### PR TITLE
Feature/56 archive submit

### DIFF
--- a/src/AltinnCore/Runtime/Controllers/InstanceController.cs
+++ b/src/AltinnCore/Runtime/Controllers/InstanceController.cs
@@ -465,7 +465,7 @@ namespace AltinnCore.Runtime.Controllers
             List<ServiceInstance> formInstances = _testdata.GetFormInstances(requestContext.Reportee.PartyId, org, service, edition);
             ViewBag.ServiceInstance = formInstances.Find(i => i.ServiceInstanceID == instanceId);
 
-      return View();
+            return View();
         }
 
         /// <summary>

--- a/src/AltinnCore/Runtime/Controllers/InstanceController.cs
+++ b/src/AltinnCore/Runtime/Controllers/InstanceController.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using AltinnCore.Common.Backend;
 using AltinnCore.Common.Helpers;
@@ -29,6 +30,7 @@ namespace AltinnCore.Runtime.Controllers
         private readonly IForm _form;
         private readonly IExecution _execution;
         private readonly IArchive _archive;
+        private readonly ITestdata _testdata;
         private readonly UserHelper _userHelper;
 
         /// <summary>
@@ -51,7 +53,8 @@ namespace AltinnCore.Runtime.Controllers
             IViewRepository viewRepository,
             IExecution serviceExecutionService,
             IProfile profileService,
-            IArchive archiveService)
+            IArchive archiveService,
+            ITestdata testDataService)
         {
             _authorization = authorizationService;
             _logger = logger;
@@ -62,6 +65,7 @@ namespace AltinnCore.Runtime.Controllers
             _execution = serviceExecutionService;
             _userHelper = new UserHelper(profileService, _register);
             _archive = archiveService;
+            _testdata = testDataService;
         }
 
 
@@ -78,6 +82,15 @@ namespace AltinnCore.Runtime.Controllers
         [Authorize(Policy = "InstanceRead")]
         public IActionResult EditSPA(string org, string service, string edition, int instanceId, string view, int? itemId)
         {
+            // Make sure user cannot edit an archived instance
+            RequestContext requestContext = RequestHelper.GetRequestContext(Request.Query, instanceId);
+            requestContext.UserContext = _userHelper.GetUserContext(HttpContext);
+            requestContext.Reportee = requestContext.UserContext.Reportee;
+            List<ServiceInstance> formInstances = _testdata.GetFormInstances(requestContext.Reportee.PartyId, org, service, edition);
+            if (formInstances.FirstOrDefault(i => i.ServiceInstanceID == instanceId && i.IsArchived) != null)
+            {
+                return RedirectToAction("Receipt", new { org, service, edition, instanceId });
+            }
             // TODO Add info for REACT app.
             return View();
         }
@@ -449,8 +462,10 @@ namespace AltinnCore.Runtime.Controllers
             PopulateViewBag(org, service, edition, instanceId, 0, requestContext, serviceContext, platformServices);
 
             object serviceModel = _archive.GetArchivedServiceModel(instanceId, serviceImplementation.GetServiceModelType(), org, service, edition, requestContext.Reportee.PartyId);
+            List<ServiceInstance> formInstances = _testdata.GetFormInstances(requestContext.Reportee.PartyId, org, service, edition);
+            ViewBag.ServiceInstance = formInstances.Find(i => i.ServiceInstanceID == instanceId);
 
-            return View();
+      return View();
         }
 
         /// <summary>

--- a/src/AltinnCore/Runtime/Views/Instance/Receipt.cshtml
+++ b/src/AltinnCore/Runtime/Views/Instance/Receipt.cshtml
@@ -1,6 +1,10 @@
 ﻿
 <h1>Kvittering</h1>
 
+<h4>Tjeneste: @ViewBag.Service</h4>
+<h4>Utgave: @ViewBag.Edition</h4>
+<h4>Levert: @ViewBag.ServiceInstance.LastChanged</h4>
+
 <a asp-controller="Instance"
    asp-action="ViewPrint"
    asp-route-org="@ViewBag.Org"

--- a/src/react-apps/ux-editor/src/containers/FormFiller.tsx
+++ b/src/react-apps/ux-editor/src/containers/FormFiller.tsx
@@ -8,6 +8,7 @@ import { Preview } from './Preview';
 
 export interface IFormFillerProps {
   validationErrors: any[];
+  unsavedChanges: boolean;
   connections: any;
   dataModelElements: IDataModelFieldElement[];
   designMode: boolean;
@@ -32,7 +33,7 @@ export class FormFillerComponent extends React.Component<IFormFillerProps, IForm
     }
   }
 
-  public submitFormData() {
+  public saveFormData() {
     const altinnWindow: IAltinnWindow = window as IAltinnWindow;
     const { reportee, org, service, edition, instanceId } = altinnWindow;
     if (window.location.pathname.split('/')[1].toLowerCase() === 'runtime') {
@@ -41,15 +42,37 @@ export class FormFillerComponent extends React.Component<IFormFillerProps, IForm
     }
   }
 
+  public submitForm() {
+    const altinnWindow: IAltinnWindow = window as IAltinnWindow;
+    const { org, service, edition, instanceId } = altinnWindow;
+    if (window.location.pathname.split('/')[1].toLowerCase() === 'runtime') {
+      window.location.replace(`${window.location.origin}/runtime/` +
+        `${org}/${service}/${edition}/${instanceId}/CompleteAndSendIn`);
+    }
+  }
+
+  public renderSaveButton = () => {
+    return (
+      <button
+        type='submit'
+        className={Object.keys(this.props.validationErrors).length === 0 && this.props.unsavedChanges ?
+          'a-btn a-btn-success' : 'a-btn a-btn-success disabled'}
+        onClick={this.saveFormData}
+      >
+        Save
+      </button>
+    );
+  }
+
   public renderSubmitButton = () => {
     return (
       <button
         type='submit'
-        className={Object.keys(this.props.validationErrors).length === 0 ?
+        className={Object.keys(this.props.validationErrors).length === 0 && !this.props.unsavedChanges ?
           'a-btn a-btn-success' : 'a-btn a-btn-success disabled'}
-        onClick={this.submitFormData}
+        onClick={this.submitForm}
       >
-        Submit
+        Control and submit
       </button>
     );
   }
@@ -61,7 +84,8 @@ export class FormFillerComponent extends React.Component<IFormFillerProps, IForm
           <Preview />
         </div>
         <div className='row mt-3'>
-          <div className='col'>
+          <div className='a-btn-group'>
+            {this.renderSaveButton()}
             {this.renderSubmitButton()}
           </div>
         </div>
@@ -73,9 +97,10 @@ export class FormFillerComponent extends React.Component<IFormFillerProps, IForm
 const mapStateToProps = (state: IAppState, empty: any): IFormFillerProps => {
   return {
     validationErrors: state.formFiller.validationErrors,
+    unsavedChanges: state.formFiller.unsavedChanges,
     connections: state.serviceConfigurations.APIs.connections,
     dataModelElements: state.appData.dataModel.model,
-    designMode: state.appData.appConfig.designMode
+    designMode: state.appData.appConfig.designMode,
   };
 };
 

--- a/src/react-apps/ux-editor/src/containers/FormFiller.tsx
+++ b/src/react-apps/ux-editor/src/containers/FormFiller.tsx
@@ -33,7 +33,7 @@ export class FormFillerComponent extends React.Component<IFormFillerProps, IForm
     }
   }
 
-  public saveFormData() {
+  public saveFormData = () => {
     const altinnWindow: IAltinnWindow = window as IAltinnWindow;
     const { reportee, org, service, edition, instanceId } = altinnWindow;
     if (window.location.pathname.split('/')[1].toLowerCase() === 'runtime') {
@@ -42,7 +42,7 @@ export class FormFillerComponent extends React.Component<IFormFillerProps, IForm
     }
   }
 
-  public submitForm() {
+  public submitForm = () => {
     const altinnWindow: IAltinnWindow = window as IAltinnWindow;
     const { org, service, edition, instanceId } = altinnWindow;
     if (window.location.pathname.split('/')[1].toLowerCase() === 'runtime') {

--- a/src/react-apps/ux-editor/src/containers/FormFiller.tsx
+++ b/src/react-apps/ux-editor/src/containers/FormFiller.tsx
@@ -12,6 +12,7 @@ export interface IFormFillerProps {
   connections: any;
   dataModelElements: IDataModelFieldElement[];
   designMode: boolean;
+  formDataCount: number;
 }
 
 export interface IFormFillerState { }
@@ -68,7 +69,8 @@ export class FormFillerComponent extends React.Component<IFormFillerProps, IForm
     return (
       <button
         type='submit'
-        className={Object.keys(this.props.validationErrors).length === 0 && !this.props.unsavedChanges ?
+        className={Object.keys(this.props.validationErrors).length === 0 && !this.props.unsavedChanges
+          && this.props.formDataCount > 0 ?
           'a-btn a-btn-success' : 'a-btn a-btn-success disabled'}
         onClick={this.submitForm}
       >
@@ -101,6 +103,7 @@ const mapStateToProps = (state: IAppState, empty: any): IFormFillerProps => {
     connections: state.serviceConfigurations.APIs.connections,
     dataModelElements: state.appData.dataModel.model,
     designMode: state.appData.appConfig.designMode,
+    formDataCount: Object.keys(state.formFiller.formData).length,
   };
 };
 

--- a/src/react-apps/ux-editor/src/reducers/formDesignerReducer/formLayoutReducer.ts
+++ b/src/react-apps/ux-editor/src/reducers/formDesignerReducer/formLayoutReducer.ts
@@ -7,7 +7,6 @@ export interface IFormLayoutState extends IFormDesignerLayout {
   fetching: boolean;
   fetched: boolean;
   error: Error;
-  unSavedChanges: boolean;
   saving: boolean;
 }
 
@@ -19,7 +18,6 @@ const initialState: IFormLayoutState = {
   fetched: false,
   error: null,
   saving: false,
-  unSavedChanges: false,
 };
 
 const formLayoutReducer: Reducer<IFormLayoutState> = (

--- a/src/react-apps/ux-editor/src/reducers/formFillerReducer/index.ts
+++ b/src/react-apps/ux-editor/src/reducers/formFillerReducer/index.ts
@@ -6,11 +6,13 @@ import * as FormFillerActionTypes from '../../actions/formFillerActions/formFill
 export interface IFormFillerState {
   formData: any;
   validationErrors: any;
+  unsavedChanges: boolean;
 }
 
 const initialState: IFormFillerState = {
   formData: {},
-  validationErrors: {}
+  validationErrors: {},
+  unsavedChanges: false,
 };
 
 const formFillerReducer: Reducer<IFormFillerState> = (
@@ -54,6 +56,9 @@ const formFillerReducer: Reducer<IFormFillerState> = (
               $set: validationErrors,
             },
           },
+          unsavedChanges: {
+            $set: true,
+          },
         });
       }
 
@@ -66,7 +71,10 @@ const formFillerReducer: Reducer<IFormFillerState> = (
         },
         validationErrors: {
           $unset: [componentID]
-        }
+        },
+        unsavedChanges: {
+          $set: true,
+        },
       });
     }
 
@@ -74,8 +82,19 @@ const formFillerReducer: Reducer<IFormFillerState> = (
       const { formData } = action as FormFillerActions.IFetchFormDataActionFulfilled;
       return update<IFormFillerState>(state, {
         formData: {
-          $set: formData
-        }
+          $set: formData,
+        },
+        unsavedChanges: {
+          $set: false,
+        },
+      })
+    }
+
+    case (FormFillerActionTypes.SUBMIT_FORM_DATA_FULFILLED): {
+      return update<IFormFillerState>(state, {
+        unsavedChanges: {
+          $set: false,
+        },
       })
     }
 

--- a/src/react-apps/ux-editor/src/reducers/formFillerReducer/index.ts
+++ b/src/react-apps/ux-editor/src/reducers/formFillerReducer/index.ts
@@ -87,7 +87,7 @@ const formFillerReducer: Reducer<IFormFillerState> = (
         unsavedChanges: {
           $set: false,
         },
-      })
+      });
     }
 
     case (FormFillerActionTypes.SUBMIT_FORM_DATA_FULFILLED): {
@@ -95,7 +95,7 @@ const formFillerReducer: Reducer<IFormFillerState> = (
         unsavedChanges: {
           $set: false,
         },
-      })
+      });
     }
 
     default:

--- a/src/react-apps/ux-editor/src/sagas/formFiller/formFillerSagas.ts
+++ b/src/react-apps/ux-editor/src/sagas/formFiller/formFillerSagas.ts
@@ -49,13 +49,14 @@ export function* watchUpdateFormDataSaga(): SagaIterator {
 export function* submitFormDataSaga({ url }: FormFillerActions.ISubmitFormDataAction): SagaIterator {
   try {
     const state: IAppState = yield select();
+    console.log('formData:', state.formFiller.formData);
 
     // Validating entire form before trying to commit
     const valErrors = Validator.validateFormData(state.formFiller.formData, state.appData.dataModel.model,
       state.formDesigner.layout.components);
 
     if (Object.keys(valErrors).length === 0) {
-      yield call(put, url, 'Update', yield convertDataBindingToModel(state.formFiller.formData,
+      yield call(put, url, 'Update', convertDataBindingToModel(state.formFiller.formData,
         state.appData.dataModel.model));
       yield call(FormFillerActionDispatcher.submitFormDataFulfilled);
     } else {

--- a/src/react-apps/ux-editor/src/sagas/formFiller/formFillerSagas.ts
+++ b/src/react-apps/ux-editor/src/sagas/formFiller/formFillerSagas.ts
@@ -49,7 +49,6 @@ export function* watchUpdateFormDataSaga(): SagaIterator {
 export function* submitFormDataSaga({ url }: FormFillerActions.ISubmitFormDataAction): SagaIterator {
   try {
     const state: IAppState = yield select();
-    console.log('formData:', state.formFiller.formData);
 
     // Validating entire form before trying to commit
     const valErrors = Validator.validateFormData(state.formFiller.formData, state.appData.dataModel.model,

--- a/src/react-apps/ux-editor/src/utils/databindings.ts
+++ b/src/react-apps/ux-editor/src/utils/databindings.ts
@@ -7,6 +7,7 @@ import {object} from 'dot-object';
  * @param formData the complete datamodel in store
  */
 export function convertDataBindingToModel(formData: any, dataModelElements: IDataModelFieldElement[]): any {
+  console.log('in convert to data model', JSON.parse(JSON.stringify(formData)));
   return object(formData);
 }
 


### PR DESCRIPTION
Solving issue #56 
- Added new button _control and submit_ -> redirects user to existing "CompleteAndSendIn" action, which archives the instance by placing it in _archive_-folder
- Renamed existing _submit_ button to _save_, as this action saves form data to disk.
- Added conditions to make the buttons enabled:
    - _Save_: there are unsaved changes in the form (added new parameter to formFiller-reducer)
    - _Control and submit_: there are no unsaved changes, and form data is not empty
    - _both_: there are no validation errors.
- Make sure user cannot edit an already archived form instance by redirecting to receipt for archived instances
- Added some information to the receipt page