### PR TITLE
Added ShouldFetchFromDatabase as config to runtime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - ServiceRepositorySettings:ForceGiteaAuthentication=true
       - ServiceRepositorySettings:ApiEndPoint=http://altinn-repositories:3000/api/v1
       - ServiceRepositorySettings:ApiEndPointHost=altinn-repositories
+      - ServiceRepositorySettings:ShouldFetchFromDatabase=false
       - TestdataRepositorySettings:RepositoryLocation=/app/Testdata
     ports:
       - "5005:5005"

--- a/src/AltinnCore/Common/Configuration/ServiceRepositorySettings.cs
+++ b/src/AltinnCore/Common/Configuration/ServiceRepositorySettings.cs
@@ -67,6 +67,11 @@ namespace AltinnCore.Common.Configuration
     public bool ForceGiteaAuthentication { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating if runtime should fetch service information from database or from disk
+    /// </summary>
+    public bool ShouldFetchFromDatabase { get; set; }
+
+    /// <summary>
     /// Gets or sets the url for the API Endpoint
     /// </summary>
     public string ApiEndPoint { get; set; }

--- a/src/AltinnCore/Runtime/appsettings.json
+++ b/src/AltinnCore/Runtime/appsettings.json
@@ -19,7 +19,8 @@
     "EnableGitAutentication": true,
     "ForceGiteaAuthentication": true,
     "GiteaCookieName": "i_like_gitea",
-    "GiteaLoginUrl": "http://altinn3.no/user/login"
+    "GiteaLoginUrl": "http://altinn3.no/user/login",
+    "ShouldFetchFromDatabase":  false
   },
   "TestdataRepositorySettings": {
     "RepositoryLocation": "../Testdata"


### PR DESCRIPTION
Added a config value ServiceRepositorySettings:ShouldFetchFromDatabase that should be used for runtime to fetch from database instead of disk once the database is in place