### PR TITLE
Bugfix for generating repeating groups from form data runtime

### DIFF
--- a/src/react-apps/ux-editor/src/sagas/formDesigner/formDesignerSagas.ts
+++ b/src/react-apps/ux-editor/src/sagas/formDesigner/formDesignerSagas.ts
@@ -153,13 +153,13 @@ function* generateRepeatingGroupsSaga({}: FormDesignerActions.IGenerateRepeating
     const baseContainerId = Object.keys(formDesignerState.layout.order)[0];
     for (const containerId of Object.keys(containers)) {
       const container = containers[containerId];
-      if (!container.repeating) return;
+      if (!container.repeating) continue;
 
       const repeatingData = Object.keys(formFillerState.formData).filter((formDataKey) => {
         return formDataKey.includes(container.dataModelGroup + '[');
       });
 
-      if (repeatingData.length === 0) return;
+      if (repeatingData.length === 0) continue;
 
       let maxIndex = 0;
       repeatingData.forEach((data) => {


### PR DESCRIPTION
Fix bug that causes only the first container to be rendered for repeating containers with multiple groups in form data. 