### PR TITLE
Adding default repo Dockerfile to new editions in Gitea.

### DIFF
--- a/src/AltinnCore/Common/Configuration/GeneralSettings.cs
+++ b/src/AltinnCore/Common/Configuration/GeneralSettings.cs
@@ -113,5 +113,17 @@
                 return TemplateLocation + "/_ViewImports.cshtml";
             }
         }
+
+        
+        /// <summary>
+        /// Gets the path to the default Dockerfile file
+        /// </summary>
+        public string DefaultRepoDockerfile
+        {
+            get
+            {
+                return TemplateLocation + "/Dockerfile";
+            }
+        }
     }
 }

--- a/src/AltinnCore/Common/Configuration/ServiceRepositorySettings.cs
+++ b/src/AltinnCore/Common/Configuration/ServiceRepositorySettings.cs
@@ -214,6 +214,11 @@ namespace AltinnCore.Common.Configuration
     public string RulesFileName { get; set; } = "Rules.json";
 
     /// <summary>
+    /// Gets or sets the filename for the Dockerfile file
+    /// </summary>
+    public string DockerfileFileName { get; set; } = "Dockerfile";
+
+    /// <summary>
     /// Gets or sets the filename for the generated methods class
     /// </summary>
     public string GeneratedMethodsFileName { get; set; } = GENERATED_METHODS_FILENAME;

--- a/src/AltinnCore/Common/Services/Implementation/RepositorySI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/RepositorySI.cs
@@ -866,13 +866,13 @@ namespace AltinnCore.Common.Services.Implementation
     public bool CreateEdition(string org, string service, EditionConfiguration editionConfig)
     {
       string serviceEditionPath = _settings.GetEditionPath(org, service, editionConfig.Code, AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext)) + "/config.json";
-
+      
       if (Directory.Exists(serviceEditionPath))
       {
         return false;
       }
 
-        (new FileInfo(serviceEditionPath)).Directory.Create();
+      (new FileInfo(serviceEditionPath)).Directory.Create();
       using (Stream fileStream = new FileStream(serviceEditionPath, FileMode.Create, FileAccess.ReadWrite))
       using (StreamWriter streamWriter = new StreamWriter(fileStream))
       {
@@ -1624,6 +1624,10 @@ namespace AltinnCore.Common.Services.Implementation
       // Copy default view start to the service view directory
       File.Copy(_generalSettings.DefaultViewStart, defaultViewFilePath + _settings.DefaultViewStartFileName);
       File.Copy(_generalSettings.DefaultViewImports, defaultViewFilePath + _settings.DefaultViewImportsFileName);
+
+      // Copy default Dockerfile
+      string editionPath = _settings.GetEditionPath(org, service, edition, AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext));
+      File.Copy(_generalSettings.DefaultRepoDockerfile, editionPath + "/" + _settings.DockerfileFileName);
 
       // Copy All default template files
       IEnumerable<string> templates = Directory.EnumerateFiles(_generalSettings.TemplateLocation);

--- a/src/AltinnCore/Templates/Dockerfile
+++ b/src/AltinnCore/Templates/Dockerfile
@@ -1,0 +1,21 @@
+#altinn-runtime with sdk
+FROM altinntjenestercontainerregistry.azurecr.io/altinn-runtime:333 AS build
+WORKDIR /AltinnService/
+COPY Implementation/*.cs ./
+COPY Model/*.cs ./
+RUN dotnet publish -o publish/
+
+FROM microsoft/dotnet:2.1-aspnetcore-runtime AS final
+WORKDIR /app
+
+#copy altinn-runtime app
+COPY --from=build /app .
+
+#copy service
+WORKDIR /AltinnService/bin/
+COPY --from=build /AltinnService/publish/AltinnService* ./
+WORKDIR /AltinnService/
+COPY . .
+
+#entrypoint
+ENTRYPOINT ["dotnet", "AltinnCore.Runtime.dll"]


### PR DESCRIPTION
Related to #35 (How and what to deploy)

The Dockerfile is used in AzureDevops AltinnService build pipeline, and for Service Owners to define their Altinn-Runtime version.