### PR TITLE
Trucation input #262

### DIFF
--- a/src/react-apps/ux-editor/src/components/config/EditModalContent.tsx
+++ b/src/react-apps/ux-editor/src/components/config/EditModalContent.tsx
@@ -377,12 +377,20 @@ export class EditModalContent extends React.Component<IEditModalContentProps, IE
 
     return (
       this.props.textResources.map((resource, index) => {
+        const option = this.truncate(resource.value);
         return (
           <option key={index} value={resource.id}>
-            {resource.value}
+            {option}
           </option>
         );
       }));
+  }
+
+  public truncate = (s: string) => {
+    if (s.length > 60)
+      return s.substring(0, 60);
+    else
+      return s;
   }
 
   public render(): JSX.Element {

--- a/src/react-apps/ux-editor/src/components/config/EditModalContent.tsx
+++ b/src/react-apps/ux-editor/src/components/config/EditModalContent.tsx
@@ -379,7 +379,7 @@ export class EditModalContent extends React.Component<IEditModalContentProps, IE
       this.props.textResources.map((resource, index) => {
         const option = this.truncate(resource.value);
         return (
-          <option key={index} value={resource.id}>
+          <option key={index} value={resource.id} title={resource.value}>
             {option}
           </option>
         );


### PR DESCRIPTION
#262 was not solved. Truncation of the option-text was in fact needed in order to prevent select options from taking the space of about 860 characters.