### PR TITLE
Service overview navigation

### DIFF
--- a/src/react-apps/ux-editor/src/containers/FormDesigner.tsx
+++ b/src/react-apps/ux-editor/src/containers/FormDesigner.tsx
@@ -4,6 +4,7 @@ import FormDesignerActionDispatchers from '../actions/formDesignerActions/formDe
 import ManageServiceConfigurationDispatchers from '../actions/manageServiceConfigurationActions/manageServiceConfigurationActionDispatcher';
 import { Preview } from './Preview';
 import { Toolbar } from './Toolbar';
+import { NavMenu } from '../navigation/NavMenu';
 
 export interface IFormDesignerProps { }
 export interface IFormDesignerState { }
@@ -45,22 +46,26 @@ class FormDesigner extends React.Component<
 
   public render() {
     return (
-      <div className='container mb-3'>
-        <div className='row mt-3'>
-          <h1>Form designer</h1>
-        </div>
-        <div className='row bigger-container mt-3'>
-          <Toolbar />
-          <div className='col'>
-            <Preview />
-            <div className='col-12 justify-content-center d-flex mt-3'>
-              {this.renderSaveButton()}
+      <div style={{display: 'flex', width: '100%', alignItems: 'stretch'}}>
+          <NavMenu/>
+        <div className={'content'}>
+          <div className='container mb-3'>
+            <div className='row mt-3'>
+              <h1>Form designer</h1>
+            </div>
+            <div className='row bigger-container mt-3'>
+              <Toolbar />
+              <div className='col'>
+                <Preview />
+                <div className='col-12 justify-content-center d-flex mt-3'>
+                  {this.renderSaveButton()}
+                </div>
+              </div>
+            </div>
+            <div className='row'>
+              <div className='col-3' />
             </div>
           </div>
-        </div>
-        <div className='row'>
-          <div className='col-3' />
-
         </div>
       </div>
     );

--- a/src/react-apps/ux-editor/src/containers/FormDesigner.tsx
+++ b/src/react-apps/ux-editor/src/containers/FormDesigner.tsx
@@ -4,7 +4,7 @@ import FormDesignerActionDispatchers from '../actions/formDesignerActions/formDe
 import ManageServiceConfigurationDispatchers from '../actions/manageServiceConfigurationActions/manageServiceConfigurationActionDispatcher';
 import { Preview } from './Preview';
 import { Toolbar } from './Toolbar';
-import { NavMenu } from '../navigation/NavMenu';
+import  NavMenu  from '../navigation/NavMenu';
 
 export interface IFormDesignerProps { }
 export interface IFormDesignerState { }
@@ -48,7 +48,7 @@ class FormDesigner extends React.Component<
     return (
       <div style={{display: 'flex', width: '100%', alignItems: 'stretch'}}>
           <NavMenu/>
-        <div className={'content'}>
+        <div style={{paddingLeft: 72}}>
           <div className='container mb-3'>
             <div className='row mt-3'>
               <h1>Form designer</h1>

--- a/src/react-apps/ux-editor/src/navigation/NavMenu.tsx
+++ b/src/react-apps/ux-editor/src/navigation/NavMenu.tsx
@@ -1,0 +1,75 @@
+//import Drawer from '@material-ui/core/Drawer';
+import * as React from 'react';
+import '../styles/NavMenu';
+import {leftNavMenuSettings} from './leftNavMenuSettings';
+import {NavMenuItem} from './NavMenuItem';
+
+export interface INavMenuState {
+  open: boolean;
+  openItems: number[];
+  activeItem?: number;
+}
+
+export interface INavMenuProps { }
+
+export class NavMenu extends React.Component<INavMenuProps, INavMenuState> {
+  constructor(_props: INavMenuProps, _state: INavMenuState) {
+    super(_props, _state);
+
+    this.state = {
+      open: true,
+      openItems: [],
+    };
+  }
+
+  public handleDrawerOpen = () => {
+    this.setState({open: true});
+  }
+
+  public handleDrawerClose = () => {
+    this.setState({open: false});
+  }
+
+  public toggleMenu = () => {
+    this.state.open ? this.handleDrawerClose() : this.handleDrawerOpen();
+  }
+
+  public toggleItemActive = (id: number) => {
+    this.setState((state: INavMenuState) => {
+      return {
+        activeItem: id,
+      };
+    });
+  }
+
+  public render() {
+    return (
+      <div id={'sidebar'} className={this.state.open ? 'container sidebar sidebar-open' : 'container sidebar sidebar-closed'}>
+        <div className={'row'}>
+          {leftNavMenuSettings.menuHierarchy.map((menuList: any, index: number) => {
+            return (
+              <NavMenuItem
+                key={index}
+                id={index}
+                listItems={menuList.items}
+                name={menuList.displayText}
+                navLink={menuList.navLink}
+                show={this.state.open}
+                active={this.state.activeItem === index}
+                toggleActive={this.toggleItemActive}
+              />
+            );
+          })}
+        </div>
+        <div className={this.state.open ? 'toggle-menu-row hide-menu-row' : 'toggle-menu-row show-menu-row'}>
+          <button className={'nav-menu-item toggle-menu'} onClick={this.toggleMenu}>
+          {this.state.open ?
+          <span><i className='fas fa-angle-double-left'/>Skjul meny</span>
+          :  <i className='fas fa-angle-double-right'/>}
+          
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/react-apps/ux-editor/src/navigation/NavMenu.tsx
+++ b/src/react-apps/ux-editor/src/navigation/NavMenu.tsx
@@ -1,75 +1,241 @@
-//import Drawer from '@material-ui/core/Drawer';
+import Collapse from '@material-ui/core/Collapse';
+import Divider from '@material-ui/core/Divider';
+import Drawer from '@material-ui/core/Drawer';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import { createStyles, withStyles, WithStyles, Theme } from '@material-ui/core/styles';
+import classNames from 'classnames';
 import * as React from 'react';
-import '../styles/NavMenu';
 import {leftNavMenuSettings} from './leftNavMenuSettings';
-import {NavMenuItem} from './NavMenuItem';
+
+const drawerWidth = 250;
+
+const styles = (theme: Theme) => createStyles({
+  root: {
+    display: 'flex'
+  },
+  menuButton: {
+    marginLeft: 12,
+    marginRight: 36,
+  },
+  hide: {
+    display: 'none'
+  },
+  drawer: {
+    width: drawerWidth,
+    flexShrink: 0,
+    whiteSpace: 'nowrap',
+    top: '64 !important',
+  },
+  drawerOpen: {
+    width: drawerWidth,
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen
+    })
+  },
+  drawerClose: {
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen
+    }),
+    overflowX: 'hidden',
+    width: theme.spacing.unit * 7 + 1,
+    [theme.breakpoints.up('sm')]: {
+      width: theme.spacing.unit * 9 + 1
+    }
+  },
+  paper: {
+    top: 69,
+    position: 'absolute',
+    background: 'lightgrey',
+  },
+  toggleButton: {
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+  },
+  toggleButtonClosed: {
+    width: theme.spacing.unit * 7 + 1,
+    [theme.breakpoints.up('sm')]: {
+      width: theme.spacing.unit * 9 + 1,
+    }
+  },
+  toggleButtonOpen: {
+    width: drawerWidth,
+  },
+  nested: {
+    paddingLeft: theme.spacing.unit * 4,
+    fontSize: '20px',
+  },
+  menuItemText: {
+    fontSize: '1.5rem',
+  },
+  menuSubItemText: {
+    fontSize: '1.2rem',
+  },
+  toggleMenuText: {
+    color: 'white',
+  },
+  toggleMenu: {
+    background: 'grey',
+  },
+  menuItemTextClosed: {
+    visibility: 'hidden',
+  },
+  selectedMenuItem: {
+    color: 'white',
+    textDecoration: 'underline',
+    background: 'grey',
+  },
+  selectedMenuItemText: {
+    color: 'white',
+    fontWeight: 'bold',
+  },
+});
 
 export interface INavMenuState {
   open: boolean;
-  openItems: number[];
-  activeItem?: number;
+  openSubMenus: number[];
 }
 
-export interface INavMenuProps { }
+export interface INavMenuProps extends WithStyles<typeof styles> {}
 
-export class NavMenu extends React.Component<INavMenuProps, INavMenuState> {
-  constructor(_props: INavMenuProps, _state: INavMenuState) {
-    super(_props, _state);
-
-    this.state = {
-      open: true,
-      openItems: [],
-    };
+class NavMenu extends React.Component<any, any> {
+  public state = {
+    open: false,
+    openSubMenus: [] as number[],
+    selectedMenuItem: '',
   }
 
-  public handleDrawerOpen = () => {
-    this.setState({open: true});
-  }
+  public handleNavMenuOpen = () => {
+    this.setState({ open: true });
+  };
 
-  public handleDrawerClose = () => {
-    this.setState({open: false});
-  }
+  public handleNavMenuClose = () => {
+    this.setState({ open: false });
+  };
 
-  public toggleMenu = () => {
-    this.state.open ? this.handleDrawerClose() : this.handleDrawerOpen();
-  }
+  public toggleNavMenu = () => {
+    if (this.state.open) {
+      this.handleNavMenuClose();
+    } else {
+      this.handleNavMenuOpen();
+    }
+  };
 
-  public toggleItemActive = (id: number) => {
-    this.setState((state: INavMenuState) => {
+  public handleSubmenuClicked = (id: number) => {
+    const openIdIndex = this.state.openSubMenus.indexOf(id);
+    this.setState((state: any) => {
+      if (openIdIndex > -1) {
+        state.openSubMenus.splice(openIdIndex, 1);
+      } else {
+        state.openSubMenus.push(id);
+      }
       return {
-        activeItem: id,
+        openSubMenus: state.openSubMenus,
       };
     });
   }
 
+  public handleMenuItemClicked = (menuItem: any, id: number) => {
+    console.log('Menu item clicked: ', menuItem.displayText);
+    this.setState((state: any) => {
+      return {
+        selectedMenuItem: menuItem.displayText,
+      }
+    })
+    if (menuItem.items && menuItem.items.length > 0) {
+      this.handleSubmenuClicked(id);
+    }
+  }
+
   public render() {
+    const { classes } = this.props;
+
     return (
-      <div id={'sidebar'} className={this.state.open ? 'container sidebar sidebar-open' : 'container sidebar sidebar-closed'}>
-        <div className={'row'}>
-          {leftNavMenuSettings.menuHierarchy.map((menuList: any, index: number) => {
-            return (
-              <NavMenuItem
-                key={index}
-                id={index}
-                listItems={menuList.items}
-                name={menuList.displayText}
-                navLink={menuList.navLink}
-                show={this.state.open}
-                active={this.state.activeItem === index}
-                toggleActive={this.toggleItemActive}
-              />
-            );
+      <div style={{top: 64}}>
+        <Drawer
+          variant='permanent'
+          className={classNames(classes.drawer, {
+            [classes.drawerOpen]: this.state.open,
+            [classes.drawerClose]: !this.state.open,
           })}
-        </div>
-        <div className={this.state.open ? 'toggle-menu-row hide-menu-row' : 'toggle-menu-row show-menu-row'}>
-          <button className={'nav-menu-item toggle-menu'} onClick={this.toggleMenu}>
-          {this.state.open ?
-          <span><i className='fas fa-angle-double-left'/>Skjul meny</span>
-          :  <i className='fas fa-angle-double-right'/>}
-          
-          </button>
-        </div>
+          classes={{
+            paper: classNames(classes.paper, {
+              [classes.drawerOpen]: this.state.open,
+              [classes.drawerClose]: !this.state.open,
+            }),
+          }}
+          open={this.state.open}
+        >
+          <List>
+            {leftNavMenuSettings.menuHierarchy.map((menuItem: any, index: number) => {
+              return (
+              <div key={index}>
+                <ListItem 
+                  button
+                  onClick={this.handleMenuItemClicked.bind(this, menuItem, index)}
+                  classes={{root: classNames({
+                    [classes.selectedMenuItem]: this.state.selectedMenuItem === menuItem.displayText})}}
+                >
+                  {/* <ListItemIcon>
+                    <i className={menuItem.iconName}/>
+                  </ListItemIcon> */}
+                  <ListItemText 
+                    classes={{
+                      primary: classNames(classes.menuItemText, {
+                        [classes.menuItemTextClosed]: !this.state.open,
+                        [classes.selectedMenuItemText]: this.state.selectedMenuItem === menuItem.displayText,
+                      }),
+                    }}
+                    primary={menuItem.displayText}
+                  />
+                </ListItem>
+                {menuItem.items && menuItem.items.length > 0 ?
+                  <Collapse 
+                    in={this.state.openSubMenus.indexOf(index) > -1}
+                  >
+                    <List component='div' disablePadding>
+                      {menuItem.items.map((item: any, i: number) => {
+                      return (
+                        <ListItem button className={classes.nested} key={i}>
+                        <ListItemText
+                          inset
+                          classes={{primary: classNames(classes.menuSubItemText)}} primary={item.name}
+                        />
+                        </ListItem>
+                      );
+                      })}
+                    </List>
+                  </Collapse>
+                : null}
+                <Divider />
+              </div>
+              );
+            }
+            )}
+          </List>
+          <List classes={{root: classNames(classes.toggleMenu, classes.toggleButton, {
+            [classes.toggleButtonOpen]: this.state.open,
+            [classes.toggleButtonClosed]: !this.state.open,
+          })}}>
+            <ListItem
+              button
+              onClick={this.toggleNavMenu}
+            >
+              <ListItemIcon classes={{root: classNames(classes.toggleMenuText)}}>
+                {this.state.open ? <i className='ai ai-back'/> : <i className='ai ai-expand'/>}
+              </ListItemIcon>
+              <ListItemText classes={{primary: classNames(classes.menuItemText, classes.toggleMenuText)}} primary={'Skjul meny'} />
+            </ListItem>
+          </List>
+        </Drawer>
       </div>
     );
   }
 }
+
+export default withStyles(styles)(NavMenu);

--- a/src/react-apps/ux-editor/src/navigation/NavMenuItem.tsx
+++ b/src/react-apps/ux-editor/src/navigation/NavMenuItem.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import {INavMenuSubItemProps, NavMenuSubItem} from './NavMenuSubItem';
+
+export interface INavMenuItemState {
+  open: boolean;
+}
+
+export interface INavMenuItemProps {
+  listItems: INavMenuSubItemProps[];
+  name: string;
+  navLink: string;
+  show: boolean;
+  id: number;
+  active: boolean;
+  toggleActive: (id: number) => void;
+}
+
+export class NavMenuItem extends React.Component<INavMenuItemProps, INavMenuItemState> {
+  constructor(_props: INavMenuItemProps, _state: INavMenuItemState) {
+    super(_props, _state);
+    this.state = {
+      open: false,
+    };
+  }
+
+  public handleItemOpen = () => {
+    this.setState({open: true});
+  }
+
+  public handleItemClose = () => {
+    this.setState({open: false});
+  }
+
+  public toggleItem = (id: number) => {
+    this.state.open ? this.handleItemClose() : this.handleItemOpen();
+    this.props.toggleActive(id);
+  }
+
+  public render() {
+    return (
+      <div className={'col col-lg-12'}>
+        <button
+          type={'button'}
+          onClick={this.toggleItem.bind(this, this.props.id)}
+          className={this.props.active ? 'nav-menu-item active-item' : 'nav-menu-item'}
+        >
+          {this.props.show ? this.props.name : null}
+        </button>
+        <ul>
+          {this.props.show && this.state.open ?
+            this.props.listItems.map((itemProps: INavMenuSubItemProps, index: number) => {
+            return (
+            <NavMenuSubItem
+              key={index}
+              name={itemProps.name}
+              navLink={itemProps.navLink}
+              topLevel={itemProps.topLevel}
+            />);
+          }) : null}
+        </ul>
+      </div>
+    );
+  }
+}

--- a/src/react-apps/ux-editor/src/navigation/NavMenuSubItem.tsx
+++ b/src/react-apps/ux-editor/src/navigation/NavMenuSubItem.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+export interface INavMenuSubItemState {}
+
+export interface INavMenuSubItemProps {
+  navLink: string;
+  name: string;
+  topLevel: boolean;
+}
+
+export class NavMenuSubItem extends React.Component<INavMenuSubItemProps, INavMenuSubItemState> {
+  public render() {
+    return(
+      <li>
+        <a href={this.props.navLink}>{this.props.name}</a>
+      </li>
+    );
+  }
+}

--- a/src/react-apps/ux-editor/src/navigation/leftNavMenuSettings.ts
+++ b/src/react-apps/ux-editor/src/navigation/leftNavMenuSettings.ts
@@ -4,11 +4,13 @@ export const leftNavMenuSettings: any = {
     {
       displayText: 'Tjenesteoversikt',
       navLink: '#',
+      iconName: 'ai ai-archive',
       items: [],
     },
     {
       displayText: 'Tjenesteflyt',
       navLink: '#',
+      iconName: 'ai ai-archive',
       items: [
         {
           navLink: '#',
@@ -30,6 +32,7 @@ export const leftNavMenuSettings: any = {
     {
       displayText: 'Tjenestelogikk',
       navLink: '#',
+      iconName: 'ai ai-archive',
       items: [
         {
           name: 'Valideringer',
@@ -46,16 +49,19 @@ export const leftNavMenuSettings: any = {
     {
       displayText: 'Datamodell',
       navLink: '#',
+      iconName: 'ai ai-archive',
       items: [],
     },
     {
       displayText: 'Oversettelse',
       navLink: '#',
+      iconName: 'ai ai-archive',
       items: [],
     },
     {
       displayText: 'Tekst',
       navLink: '#',
+      iconName: 'ai ai-archive',
       items: [],
     },
   ],

--- a/src/react-apps/ux-editor/src/navigation/leftNavMenuSettings.ts
+++ b/src/react-apps/ux-editor/src/navigation/leftNavMenuSettings.ts
@@ -1,0 +1,62 @@
+export const leftNavMenuSettings: any = {
+  menuTitle: 'Tjenesteoversikt',
+  menuHierarchy: [
+    {
+      displayText: 'Tjenesteoversikt',
+      navLink: '#',
+      items: [],
+    },
+    {
+      displayText: 'Tjenesteflyt',
+      navLink: '#',
+      items: [
+        {
+          navLink: '#',
+          name: 'Steg 1',
+          topLevel: false,
+        },
+        {
+          navLink: '#',
+          name: 'Steg 2',
+          topLevel: false,
+        },
+        {
+          navLink: '#',
+          name: 'Steg 3',
+          topLevel: false,
+        },
+      ],
+    },
+    {
+      displayText: 'Tjenestelogikk',
+      navLink: '#',
+      items: [
+        {
+          name: 'Valideringer',
+          navLink: '#',
+          topLevel: false,
+        },
+        {
+          name: 'Kalkuleringer',
+          navLink: '#',
+          topLevel: false,
+        },
+      ],
+    },
+    {
+      displayText: 'Datamodell',
+      navLink: '#',
+      items: [],
+    },
+    {
+      displayText: 'Oversettelse',
+      navLink: '#',
+      items: [],
+    },
+    {
+      displayText: 'Tekst',
+      navLink: '#',
+      items: [],
+    },
+  ],
+};

--- a/src/react-apps/ux-editor/src/styles/NavMenu.css
+++ b/src/react-apps/ux-editor/src/styles/NavMenu.css
@@ -1,0 +1,81 @@
+.drawer {
+  width: 340px;
+  background-color: aqua;
+  display: fixed;
+  left: 0px;
+  height: 100%;
+}
+
+.drawerOpen {
+  width: 240px;
+}
+
+.drawerClose {
+  overflow-x: hidden;
+  width: 30px;
+}
+
+.content {
+  flex-grow: 1;
+  padding: 10px;
+}
+
+.root {
+  display: flex;
+}
+
+.sidebar {
+  min-width: 250px;
+  max-width: 250px;
+  min-height: 100vh;
+  background-color: lightgray;
+}
+
+.sidebar.active {
+  margin-left: -250px;
+}
+
+.sidebar-open {
+  width: 250px !important;
+}
+
+.sidebar-closed {
+  min-width: 50px !important;
+  max-width: 50px !important;
+  overflow: hidden;
+}
+
+.nav-menu-item {
+  border: 1px solid black;
+  width: 100%;
+  line-height: 1.5em;
+  min-height: 50px;
+  margin-bottom: 0;
+  text-align: center;
+  background: 0 0;
+}
+
+
+.active-item {
+  background-color: darkgrey;
+}
+
+.hide-menu-row {
+  width: 250px;
+}
+
+.show-menu-row {
+  width: 50px;
+}
+
+.toggle-menu {
+  color: white;
+  border: none;
+}
+
+.toggle-menu-row {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  background: darkgrey;
+}


### PR DESCRIPTION
Added basic service overview navigation menu, using material-ui components. 
Very little styling applied due to changes in styling coming soon.
Nav currently does not link anywhere (as not all pages exist yet).
See sketches in #230 