### PR TITLE
62 bug import of xsd must handle encoding

### DIFF
--- a/src/AltinnCore/Designer/Controllers/ModelController.cs
+++ b/src/AltinnCore/Designer/Controllers/ModelController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -53,6 +54,11 @@ namespace AltinnCore.Designer.Controllers
         [HttpPost]
         public ActionResult Upload(string org, string service, IFormFile thefile, IEnumerable<IFormFile> secondaryFiles)
         {
+            if (thefile == null)
+            {
+                throw new ApplicationException("Cannot upload empty file");
+            }
+
             XDocument mainXsd = null;
             var secondaryXsds = new Dictionary<string, XDocument>();
 
@@ -64,12 +70,15 @@ namespace AltinnCore.Designer.Controllers
 
             secondaryXsds.Clear();
 
-            foreach (IFormFile file in secondaryFiles)
+            if (secondaryFiles != null)
             {
-                string filename = ContentDispositionHeaderValue.Parse(new StringSegment(file.ContentDisposition)).FileName.ToString();
-                using (var reader = XmlReader.Create(file.OpenReadStream()))
+                foreach (IFormFile file in secondaryFiles)
                 {
-                    secondaryXsds.Add(filename, XDocument.Load(reader));
+                    string filename = ContentDispositionHeaderValue.Parse(new StringSegment(file.ContentDisposition)).FileName.ToString();
+                    using (var reader = XmlReader.Create(file.OpenReadStream()))
+                    {
+                        secondaryXsds.Add(filename, XDocument.Load(reader));
+                    }
                 }
             }
 

--- a/src/AltinnCore/Designer/Controllers/ModelController.cs
+++ b/src/AltinnCore/Designer/Controllers/ModelController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 using AltinnCore.Common.Factories.ModelFactory;
 using AltinnCore.Common.Services.Interfaces;
@@ -56,9 +57,9 @@ namespace AltinnCore.Designer.Controllers
             var secondaryXsds = new Dictionary<string, XDocument>();
 
             string mainFileName = ContentDispositionHeaderValue.Parse(new StringSegment(thefile.ContentDisposition)).FileName.ToString();
-            using (var reader = new StreamReader(thefile.OpenReadStream()))
+            using (var reader = XmlReader.Create(thefile.OpenReadStream()))
             {
-                mainXsd = XDocument.Parse(reader.ReadToEnd());
+                mainXsd = XDocument.Load(reader);
             }
 
             secondaryXsds.Clear();
@@ -66,9 +67,9 @@ namespace AltinnCore.Designer.Controllers
             foreach (IFormFile file in secondaryFiles)
             {
                 string filename = ContentDispositionHeaderValue.Parse(new StringSegment(file.ContentDisposition)).FileName.ToString();
-                using (var reader = new StreamReader(file.OpenReadStream()))
+                using (var reader = XmlReader.Create(file.OpenReadStream()))
                 {
-                    secondaryXsds.Add(filename, XDocument.Parse(reader.ReadToEnd()));
+                    secondaryXsds.Add(filename, XDocument.Load(reader));
                 }
             }
 
@@ -96,7 +97,7 @@ namespace AltinnCore.Designer.Controllers
         public ActionResult GetJson(string org, string service, bool texts = true, bool restrictions = true, bool attributes = true)
         {
             ServiceMetadata metadata = _repository.GetServiceMetaData(org, service);
-            return Json(metadata, new JsonSerializerSettings() { Formatting = Formatting.Indented });
+            return Json(metadata, new JsonSerializerSettings() { Formatting = Newtonsoft.Json.Formatting.Indented });
         }
 
         /// <summary>

--- a/src/AltinnCore/UnitTest/AltinnCore.UnitTest.csproj
+++ b/src/AltinnCore/UnitTest/AltinnCore.UnitTest.csproj
@@ -38,4 +38,10 @@
     <ProjectReference Include="..\Designer\AltinnCore.Designer.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Designer\Edag-latin1.xsd">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/src/AltinnCore/UnitTest/Designer/Edag-latin1.xsd
+++ b/src/AltinnCore/UnitTest/Designer/Edag-latin1.xsd
@@ -1,0 +1,674 @@
+<?xml version="1.0" encoding="iso-8859-1" standalone="no"?>
+<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:seres="http://seres.no/xsd/forvaltningsdata" 
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    xmlns:altinn="www.altinn.no/infopath-extensions">
+    <xsd:element name="melding" type="EDAG_M" />
+    <xsd:complexType name="EDAG_M">
+        <xsd:sequence>
+            <xsd:element name="LeveranseæøåÆØÅ" type="Leveranse" />
+        </xsd:sequence>
+        <xsd:attribute name="dataFormatProvider" type="xsd:string" use="required" fixed="SERES" />
+        <xsd:attribute name="dataFormatId" type="xsd:string" use="required" fixed="3940" />
+        <xsd:attribute name="dataFormatVersion" type="xsd:string" use="required" fixed="20161021" />
+        <xsd:anyAttribute />
+    </xsd:complexType>
+    <xsd:complexType name="Leveranse">
+        <xsd:sequence>
+            <xsd:element name="leveringstidspunkt" type="DatoTid" />
+            <xsd:element name="kalendermaaned" type="AArOgMaaned" />
+            <xsd:element name="kildesystem" type="TekstMedRestriksjon" />
+            <xsd:element name="meldingsId" type="Identifikator" />
+            <xsd:element name="opplysningspliktig" type="Opplysningspliktig" />
+            <xsd:element name="oppgave" type="JuridiskEntitet" />
+            <xsd:element name="spraakForTilbakemelding" type="Språk" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Opplysningspliktig">
+        <xsd:sequence>
+            <xsd:element name="norskIdentifikator" type="NorskIdentifikator" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="JuridiskEntitet">
+        <xsd:sequence>
+            <xsd:element name="betalingsinformasjon" type="Betalingsinformasjon" nillable="true" minOccurs="0" />
+            <xsd:element name="annenBagatellmessigStoette" type="Beloep" nillable="true" minOccurs="0" />
+            <xsd:element name="virksomhet" type="Virksomhet" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Betalingsinformasjon">
+        <xsd:sequence>
+            <xsd:element name="sumForskuddstrekk" type="BeloepSomHeltall" nillable="true" minOccurs="0" />
+            <xsd:element name="sumArbeidsgiveravgift" type="BeloepSomHeltall" nillable="true" minOccurs="0" />
+            <xsd:element name="sumFinansskattLoenn" type="BeloepSomHeltall" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Virksomhet">
+        <xsd:sequence>
+            <xsd:element name="norskIdentifikator" type="NorskIdentifikator" />
+            <xsd:element name="inntektsmottaker" type="Inntektsmottaker" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="arbeidsgiveravgift" type="Arbeidsgiveravgift" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:anyAttribute />
+    </xsd:complexType>
+    <xsd:complexType name="Inntektsmottaker">
+        <xsd:sequence>
+            <xsd:element name="norskIdentifikator" type="NorskIdentifikator" nillable="true" minOccurs="0" />
+            <xsd:element name="internasjonalIdentifikator" type="InternasjonalIdentifikator" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="identifiserendeInformasjon" type="IdentifiserendeInformasjon" nillable="true" minOccurs="0" />
+            <xsd:element name="arbeidsforhold" type="Arbeidsforhold" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="fradrag" type="Fradrag" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="forskuddstrekk" type="Forskuddstrekk" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="inntekt" type="Inntektsentitet" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="sjoefolksrelatertInformasjon" type="SjoefolksrelatertInformasjon" nillable="true" minOccurs="0" />
+            <xsd:element name="oppholdPaaSvalbardJanMayenOgBilandene" type="OppholdPaaSvalbardJanMayenOgBilandene" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:anyAttribute />
+    </xsd:complexType>
+    <xsd:complexType name="InternasjonalIdentifikator">
+        <xsd:sequence>
+            <xsd:element name="identifikator" type="TekstMedRestriksjon" />
+            <xsd:element name="identifikatortype" type="InternasjonalIdentifikatortype" />
+            <xsd:element name="land" type="Landkode" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:simpleType name="InternasjonalIdentifikatortype">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Landkode">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:complexType name="IdentifiserendeInformasjon">
+        <xsd:sequence>
+            <xsd:element name="navn" type="TekstMedRestriksjon" />
+            <xsd:element name="foedselsdato" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="ansattnummer" type="TekstMedRestriksjon" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Arbeidsforhold">
+        <xsd:sequence>
+            <xsd:element name="arbeidsforholdId" type="Identifikator" nillable="true" minOccurs="0" />
+            <xsd:element name="typeArbeidsforhold" type="Arbeidsforholdstype" />
+            <xsd:element name="startdato" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="sluttdato" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="antallTimerPerUkeSomEnFullStillingTilsvarer" type="Desimaltall" nillable="true" minOccurs="0" />
+            <xsd:element name="avloenningstype" type="Avloenningstype" nillable="true" minOccurs="0" />
+            <xsd:element name="yrke" type="Yrke" nillable="true" minOccurs="0" />
+            <xsd:element name="arbeidstidsordning" type="Arbeidstidsordning" nillable="true" minOccurs="0" />
+            <xsd:element name="stillingsprosent" type="Desimaltall" nillable="true" minOccurs="0" />
+            <xsd:element name="sisteLoennsendringsdato" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="loennsansiennitet" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="loennstrinn" type="TekstMedRestriksjon" nillable="true" minOccurs="0" />
+            <xsd:element name="fartoey" type="Fartoey" nillable="true" minOccurs="0" />
+            <xsd:element name="permisjon" type="Permisjon" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="sisteDatoForStillingsprosentendring" type="Dato" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:anyAttribute />
+    </xsd:complexType>
+    <xsd:simpleType name="Arbeidsforholdstype">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Avloenningstype">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Yrke">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Arbeidstidsordning">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:complexType name="Fartoey">
+        <xsd:sequence>
+            <xsd:element name="skipsregister" type="Skipsregister" />
+            <xsd:element name="skipstype" type="Skipstype" />
+            <xsd:element name="fartsomraade" type="Fartsomraade" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:simpleType name="Skipsregister">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Skipstype">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Fartsomraade">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="PermisjonsOgPermitteringsBeskrivelse">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:complexType name="Permisjon">
+        <xsd:sequence>
+            <xsd:element name="startdato" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="sluttdato" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="permisjonsprosent" type="Desimaltall" nillable="true" minOccurs="0" />
+            <xsd:element name="permisjonId" type="Identifikator" />
+            <xsd:element name="beskrivelse" type="PermisjonsOgPermitteringsBeskrivelse" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Fradrag">
+        <xsd:sequence>
+            <xsd:element name="beskrivelse" type="Fradragsbeskrivelse" />
+            <xsd:element name="beloep" type="Beloep" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:simpleType name="Fradragsbeskrivelse">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:complexType name="Forskuddstrekk">
+        <xsd:sequence>
+            <xsd:element name="beskrivelse" type="Forskuddstrekksbeskrivelse" nillable="true" minOccurs="0" />
+            <xsd:element name="beloep" type="BeloepSomHeltall" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:simpleType name="Forskuddstrekksbeskrivelse">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:complexType name="Inntekt" abstract="true">
+        <xsd:sequence>
+            <xsd:element name="skatteOgAvgiftsregel" type="SkatteOgAvgiftsregel" nillable="true" minOccurs="0" />
+            <xsd:element name="startdatoOpptjeningsperiode" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="sluttdatoOpptjeningsperiode" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="fordel" type="Fordel" nillable="true" minOccurs="0" />
+            <xsd:element name="utloeserArbeidsgiveravgift" type="Boolsk" nillable="true" minOccurs="0" />
+            <xsd:element name="inngaarIGrunnlagForTrekk" type="Boolsk" nillable="true" minOccurs="0" />
+            <xsd:element name="beloep" type="Beloep" nillable="true" minOccurs="0" />
+            <xsd:element name="arbeidsforholdId" type="Identifikator" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:simpleType name="SkatteOgAvgiftsregel">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Fordel">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:complexType name="Loennsinntekt">
+        <xsd:complexContent>
+            <xsd:extension base="Inntekt">
+                <xsd:sequence>
+                    <xsd:element name="beskrivelse" type="Loennsbeskrivelse" />
+                    <xsd:element name="spesifikasjon" type="Spesifikasjon" nillable="true" minOccurs="0" />
+                    <xsd:element name="antall" type="Desimaltall" nillable="true" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:simpleType name="Loennsbeskrivelse">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:complexType name="Periode">
+        <xsd:sequence>
+            <xsd:element name="startdato" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="sluttdato" type="Dato" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BilOgBaat">
+        <xsd:complexContent>
+            <xsd:extension base="Loennsinntekt">
+                <xsd:sequence>
+                    <xsd:element name="antallKilometer" type="Desimaltall" nillable="true" minOccurs="0" />
+                    <xsd:element name="antallReiser" type="Heltall" nillable="true" minOccurs="0" />
+                    <xsd:element name="heravAntallKilometerMellomHjemOgArbeid" type="Desimaltall" nillable="true" minOccurs="0" />
+                    <xsd:element name="listeprisForBil" type="Beloep" nillable="true" minOccurs="0" />
+                    <xsd:element name="bilregistreringsnummer" type="TekstMedRestriksjon" nillable="true" minOccurs="0" />
+                    <xsd:element name="erBilpool" type="Boolsk" nillable="true" minOccurs="0" />
+                    <xsd:element name="erAnnenBil" type="Boolsk" nillable="true" minOccurs="0" />
+                    <xsd:element name="erBilUtenforStandardregelen" type="Boolsk" nillable="true" minOccurs="0" />
+                    <xsd:element name="personklassifiseringAvBilbruker" type="PersontypeForReiseKostLosji" nillable="true" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:simpleType name="PersontypeForReiseKostLosji">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:complexType name="DagmammaIEgenBolig">
+        <xsd:complexContent>
+            <xsd:extension base="Naeringsinntekt">
+                <xsd:sequence>
+                    <xsd:element name="antallBarn" type="Heltall" nillable="true" minOccurs="0" />
+                    <xsd:element name="antallMaaneder" type="Heltall" nillable="true" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="NorskKontinentalsokkel">
+        <xsd:complexContent>
+            <xsd:extension base="Loennsinntekt">
+                <xsd:sequence>
+                    <xsd:element name="tidsrom" type="Periode" nillable="true" minOccurs="0" />
+                    <xsd:element name="gjelderLoennFoerste60Dager" type="Boolsk" nillable="true" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:simpleType name="SpesielleInntjeningsforhold">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:complexType name="Livrente">
+        <xsd:complexContent>
+            <xsd:extension base="Etterbetalingsperiode">
+                <xsd:sequence>
+                    <xsd:element name="totaltUtbetaltBeloep" type="Beloep" nillable="true" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="LottOgPartInnenFiske">
+        <xsd:complexContent>
+            <xsd:extension base="Naeringsinntekt">
+                <xsd:sequence>
+                    <xsd:element name="antallDager" type="Heltall" nillable="true" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="Nettoloennsordning">
+        <xsd:complexContent>
+            <xsd:extension base="Loennsinntekt">
+                <xsd:sequence>
+                    <xsd:element name="oppgrossingstabellnummer" type="Heltall" nillable="true" minOccurs="0" />
+                    <xsd:element name="bilinformasjon" type="BilOgBaat" nillable="true" minOccurs="0" />
+                    <xsd:element name="betaltSkattebeloepIUtlandet" type="Beloep" nillable="true" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="AldersUfoereEtterlatteAvtalefestetOgKrigspensjon">
+        <xsd:complexContent>
+            <xsd:extension base="Etterbetalingsperiode">
+                <xsd:sequence>
+                    <xsd:element name="grunnpensjonsbeloep" type="Beloep" nillable="true" minOccurs="0" />
+                    <xsd:element name="tilleggspensjonsbeloep" type="Beloep" nillable="true" minOccurs="0" />
+                    <xsd:element name="ufoeregrad" type="Heltall" nillable="true" minOccurs="0" />
+                    <xsd:element name="pensjonsgrad" type="Heltall" nillable="true" minOccurs="0" />
+                    <xsd:element name="heravEtterlattepensjon" type="Beloep" nillable="true" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="ReiseKostOgLosji">
+        <xsd:complexContent>
+            <xsd:extension base="Loennsinntekt">
+                <xsd:sequence>
+                    <xsd:element name="persontype" type="PersontypeForReiseKostLosji" nillable="true" minOccurs="0" />
+                    <xsd:element name="antallReiser" type="Heltall" nillable="true" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="UtenlandskArtist">
+        <xsd:complexContent>
+            <xsd:extension base="Loennsinntekt">
+                <xsd:sequence>
+                    <xsd:element name="inntektsaar" type="AArstall" nillable="true" minOccurs="0" />
+                    <xsd:element name="oppgrossingsgrunnlag" type="Beloep" nillable="true" minOccurs="0" />
+                    <xsd:element name="trukketArtistskatt" type="BeloepSomHeltall" nillable="true" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="BonusFraForsvaret">
+        <xsd:complexContent>
+            <xsd:extension base="Loennsinntekt">
+                <xsd:sequence>
+                    <xsd:element name="aaretUtbetalingenGjelderFor" type="AArstall" nillable="true" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="Spesifikasjon">
+        <xsd:sequence>
+            <xsd:element name="skattemessigBosattILand" type="Landkode" nillable="true" minOccurs="0" />
+            <xsd:element name="opptjeningsland" type="Landkode" nillable="true" minOccurs="0" />
+            <xsd:element name="erOpptjentPaaHjelpefartoey" type="Boolsk" nillable="true" minOccurs="0" />
+            <xsd:element name="erOpptjentPaaKontinentalsokkel" type="Boolsk" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PensjonEllerTrygd">
+        <xsd:complexContent>
+            <xsd:extension base="Inntekt">
+                <xsd:sequence>
+                    <xsd:element name="beskrivelse" type="PensjonEllerTrygdebeskrivelse" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:simpleType name="PensjonEllerTrygdebeskrivelse">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:complexType name="Naeringsinntekt">
+        <xsd:complexContent>
+            <xsd:extension base="Inntekt">
+                <xsd:sequence>
+                    <xsd:element name="beskrivelse" type="Naeringsinntektsbeskrivelse" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:simpleType name="Naeringsinntektsbeskrivelse">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="OppholdsbeskrivelseForSvalbardJanMayenOgBilandene">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:complexType name="SjoefolksrelatertInformasjon">
+        <xsd:sequence>
+            <xsd:element name="antallDoegnOmbord" type="Heltall" nillable="true" minOccurs="0" />
+            <xsd:element name="antallDoegnOmbordUtenDekkedeSmaautgifter" type="Heltall" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="OppholdPaaSvalbardJanMayenOgBilandene">
+        <xsd:sequence>
+            <xsd:element name="oppholdsId" type="Identifikator" />
+            <xsd:element name="startdato" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="sluttdato" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="beskrivelse" type="OppholdsbeskrivelseForSvalbardJanMayenOgBilandene" />
+        </xsd:sequence>
+        <xsd:anyAttribute />
+    </xsd:complexType>
+    <xsd:complexType name="Arbeidsgiveravgift">
+        <xsd:sequence>
+            <xsd:element name="loennOgGodtgjoerelse" type="Arbeidsgiveravgiftsgrunnlag" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="tilskuddOgPremieTilPensjon" type="Arbeidsgiveravgiftsgrunnlag" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="utenlandskeMedSaerskiltProsentsats" type="UtenlandskeMedSaerskiltProsentsats" nillable="true" minOccurs="0" />
+            <xsd:element name="utenlandskeMedFastAvgiftsbeloep" type="UtenlandskeMedFastAvgiftsbeloep" nillable="true" minOccurs="0" />
+            <xsd:element name="fradragIGrunnlagetForSone" type="FradragIGrunnlaget" nillable="true" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="fradragIGrunnlagetForUtenlandsk" type="FradragIGrunnlagetForUtenlandsk" nillable="true" minOccurs="0" />
+            <!--<xsd:element ref="altinn:finansskattLoenn_kr" minOccurs="0"/>--></xsd:sequence>
+        <xsd:anyAttribute />
+    </xsd:complexType>
+    <xsd:complexType name="Arbeidsgiveravgiftsgrunnlag">
+        <xsd:sequence>
+            <xsd:element name="beregningskodeForArbeidsgiveravgift" type="BeregningskodeForArbeidsgiveravgift" />
+            <xsd:element name="sone" type="Arbeidsgiveravgiftsone" />
+            <xsd:element name="avgiftsgrunnlagBeloep" type="Beloep" nillable="true" minOccurs="0" />
+            <xsd:element name="prosentsatsForAvgiftsberegning" type="Grunnlagsprosent" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:anyAttribute />
+    </xsd:complexType>
+    <xsd:simpleType name="BeregningskodeForArbeidsgiveravgift">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Arbeidsgiveravgiftsone">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Grunnlagsprosent">
+        <xsd:restriction base="xsd:decimal" />
+    </xsd:simpleType>
+    <xsd:simpleType name="GrunnlagsprosentForUtenlandske">
+        <xsd:restriction base="xsd:decimal" />
+    </xsd:simpleType>
+    <xsd:simpleType name="GrunnlagsbeloepForUtenlandske">
+        <xsd:restriction base="xsd:decimal" />
+    </xsd:simpleType>
+    <xsd:complexType name="UtenlandskeMedSaerskiltProsentsats">
+        <xsd:sequence>
+            <xsd:element name="avgiftsgrunnlagBeloep" type="Beloep" nillable="true" minOccurs="0" />
+            <xsd:element name="prosentsatsForAvgiftsberegning" type="GrunnlagsprosentForUtenlandske" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:anyAttribute />
+    </xsd:complexType>
+    <xsd:complexType name="UtenlandskeMedFastAvgiftsbeloep">
+        <xsd:sequence>
+            <xsd:element name="antallAvgiftsgrunnlagPersoner" type="Heltall" nillable="true" minOccurs="0" />
+            <xsd:element name="beloepssatsForAvgiftsberegning" type="GrunnlagsbeloepForUtenlandske" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="FradragIGrunnlaget">
+        <xsd:sequence>
+            <xsd:element name="beregningskodeForArbeidsgiveravgift" type="BeregningskodeForArbeidsgiveravgift" />
+            <xsd:element name="sone" type="Arbeidsgiveravgiftsone" />
+            <xsd:element name="avgiftsfradragBeloep" type="Beloep" nillable="true" minOccurs="0" />
+            <xsd:element name="prosentsatsForAvgiftsberegning" type="Grunnlagsprosent" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:anyAttribute />
+    </xsd:complexType>
+    <xsd:complexType name="FradragIGrunnlagetForUtenlandsk">
+        <xsd:sequence>
+            <xsd:element name="avgiftsfradragBeloep" type="Beloep" nillable="true" minOccurs="0" />
+            <xsd:element name="prosentsatsForAvgiftsberegning" type="GrunnlagsprosentForUtenlandske" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:anyAttribute />
+    </xsd:complexType>
+    <xsd:complexType name="Etterbetalingsperiode">
+        <xsd:complexContent>
+            <xsd:extension base="PensjonEllerTrygd">
+                <xsd:sequence>
+                    <xsd:element name="tidsrom" type="Periode" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:simpleType name="DatoTid">
+        <xsd:restriction base="xsd:dateTime" />
+    </xsd:simpleType>
+    <xsd:simpleType name="AArOgMaaned">
+        <xsd:restriction base="xsd:gYearMonth" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Tekst">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="NorskIdentifikator">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="BeloepSomHeltall">
+        <xsd:restriction base="xsd:integer" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Beloep">
+        <xsd:restriction base="xsd:decimal" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Dato">
+        <xsd:restriction base="xsd:date" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Desimaltall">
+        <xsd:restriction base="xsd:decimal" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Boolsk">
+        <xsd:restriction base="xsd:boolean" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Heltall">
+        <xsd:restriction base="xsd:integer" />
+    </xsd:simpleType>
+    <xsd:simpleType name="AArstall">
+        <xsd:restriction base="xsd:gYear" />
+    </xsd:simpleType>
+    <xsd:simpleType name="Språk">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="bokmaal" />
+            <xsd:enumeration value="nynorsk" />
+            <xsd:enumeration value="engelsk" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="TekstMedRestriksjon">
+        <xsd:restriction base="RestriksjonTekstfelt" />
+    </xsd:simpleType>
+    <xsd:simpleType name="RestriksjonTekstfelt">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="255" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="Identifikator">
+        <xsd:restriction base="RestriksjonIdentifikator" />
+    </xsd:simpleType>
+    <xsd:simpleType name="RestriksjonIdentifikator">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="150" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:complexType name="Inntjeningsforhold">
+        <xsd:complexContent>
+            <xsd:extension base="Loennsinntekt">
+                <xsd:sequence>
+                    <xsd:element name="inntjeningsforhold" type="SpesielleInntjeningsforhold" nillable="true" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="Inntektsentitet">
+        <xsd:sequence>
+            <xsd:element name="alleFelter" type="InntektAlle" minOccurs="0" />
+            <xsd:element name="loennsinntekt" type="Loennsinntekt" minOccurs="0" />
+            <xsd:element name="bilOgBaat" type="BilOgBaat" nillable="true" minOccurs="0" />
+            <xsd:element name="inntektPaaNorskKontinentalsokkel" type="NorskKontinentalsokkel" nillable="true" minOccurs="0" />
+            <xsd:element name="inntjeningsforhold" type="Inntjeningsforhold" nillable="true" minOccurs="0" />
+            <xsd:element name="nettoloenn" type="Nettoloennsordning" nillable="true" minOccurs="0" />
+            <xsd:element name="reiseKostOgLosji" type="ReiseKostOgLosji" nillable="true" minOccurs="0" />
+            <xsd:element name="utenlandskArtist" type="UtenlandskArtist" nillable="true" minOccurs="0" />
+            <xsd:element name="bonusFraForsvaret" type="BonusFraForsvaret" nillable="true" minOccurs="0" />
+            <xsd:element name="pensjonEllerTrygd" type="PensjonEllerTrygd" minOccurs="0" />
+            <xsd:element name="livrente" type="Livrente" nillable="true" minOccurs="0" />
+            <xsd:element name="etterbetalingsperiode" type="Etterbetalingsperiode" nillable="true" minOccurs="0" />
+            <xsd:element name="pensjon" type="AldersUfoereEtterlatteAvtalefestetOgKrigspensjon" nillable="true" minOccurs="0" />
+            <xsd:element name="naeringsinntekt" type="Naeringsinntekt" minOccurs="0" />
+            <xsd:element name="lottOgPart" type="LottOgPartInnenFiske" nillable="true" minOccurs="0" />
+            <xsd:element name="dagmammaIEgenBolig" type="DagmammaIEgenBolig" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:attribute name="valgNivaa1" type="xsd:string" />
+        <xsd:attribute name="valgNivaa2" type="xsd:string" />
+        <xsd:attribute name="valgNivaa3" type="xsd:string" />
+        <xsd:attribute name="valgNivaa4" type="xsd:string" />
+        <xsd:attribute name="tilleggsinformasjon" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation>Her fylles det inn en tekst som forteller hvilken choice i tidligere modell som vi skal mappe til. Tilsvarer teksten i kolonne tillegsinformasjon i kombinasjonsregnearket</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:anyAttribute />
+    </xsd:complexType>
+    <xsd:complexType name="InntektAlle" abstract="false">
+        <xsd:sequence>
+            <xsd:element name="tilleggsinformasjon" type="xsd:string" nillable="true" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Ikke i bruk. Her fylles det inn en tekst som forteller hvilken choice i tidligere modell som vi skal mappe til. Tilsvarer teksten i kolonne tillegsinformasjon i kombinasjonsregnearket</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:group ref="InntektGruppe" minOccurs="0" />
+            <xsd:group ref="BeskrivelseGruppe" minOccurs="0" />
+            <xsd:group ref="LoennsinntektGruppe" minOccurs="0" />
+            <xsd:group ref="BilOgBaatGruppe" minOccurs="0" />
+            <xsd:group ref="NorskKontinentalsokkelGruppe" minOccurs="0" />
+            <xsd:group ref="InntjeningsforholdGruppe" minOccurs="0" />
+            <xsd:group ref="NettoloennsordningGruppe" minOccurs="0" />
+            <xsd:group ref="ReiseKostOgLosjiGruppe" minOccurs="0" />
+            <xsd:group ref="UtenlandskArtistGruppe" minOccurs="0" />
+            <xsd:group ref="BonusFraForsvaretGruppe" minOccurs="0" />
+            <xsd:group ref="PensjonEllerTrygdGruppe" minOccurs="0" />
+            <xsd:group ref="LivrenteGruppe" minOccurs="0" />
+            <xsd:group ref="EtterbetalingsperiodeGruppe" minOccurs="0" />
+            <xsd:group ref="AldersUfoereEtterlatteAvtalefestetOgKrigspensjonGruppe" minOccurs="0" />
+            <xsd:group ref="NaeringsinntektGruppe" minOccurs="0" />
+            <xsd:group ref="LottOgPartInnenFiskeGruppe" minOccurs="0" />
+            <xsd:group ref="DagmammaIEgenBoligGruppe" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:group name="InntektGruppe">
+        <xsd:sequence>
+            <xsd:element name="skatteOgAvgiftsregel" type="SkatteOgAvgiftsregel" nillable="true" minOccurs="0" />
+            <xsd:element name="startdatoOpptjeningsperiode" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="sluttdatoOpptjeningsperiode" type="Dato" nillable="true" minOccurs="0" />
+            <xsd:element name="fordel" type="Fordel" nillable="true" minOccurs="0" />
+            <xsd:element name="utloeserArbeidsgiveravgift" type="Boolsk" nillable="true" minOccurs="0" />
+            <xsd:element name="inngaarIGrunnlagForTrekk" type="Boolsk" nillable="true" minOccurs="0" />
+            <xsd:element name="beloep" type="Beloep" nillable="true" minOccurs="0" />
+            <xsd:element name="arbeidsforholdId" type="Identifikator" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="BeskrivelseGruppe">
+        <xsd:sequence>
+            <xsd:element name="beskrivelse" type="Tekst" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="LoennsinntektGruppe">
+        <xsd:sequence>
+            <xsd:element name="spesifikasjon" type="Spesifikasjon" nillable="true" minOccurs="0" />
+            <xsd:element name="antall" type="Desimaltall" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="BilOgBaatGruppe">
+        <xsd:sequence>
+            <xsd:element name="antallKilometer" type="Desimaltall" nillable="true" minOccurs="0" />
+            <xsd:element name="antallReiser" type="Heltall" nillable="true" minOccurs="0" />
+            <xsd:element name="heravAntallKilometerMellomHjemOgArbeid" type="Desimaltall" nillable="true" minOccurs="0" />
+            <xsd:element name="listeprisForBil" type="Beloep" nillable="true" minOccurs="0" />
+            <xsd:element name="bilregistreringsnummer" type="TekstMedRestriksjon" nillable="true" minOccurs="0" />
+            <xsd:element name="erBilpool" type="Boolsk" nillable="true" minOccurs="0" />
+            <xsd:element name="erAnnenBil" type="Boolsk" nillable="true" minOccurs="0" />
+            <xsd:element name="erBilUtenforStandardregelen" type="Boolsk" nillable="true" minOccurs="0" />
+            <xsd:element name="personklassifiseringAvBilbruker" type="PersontypeForReiseKostLosji" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="NorskKontinentalsokkelGruppe">
+        <xsd:sequence>
+            <xsd:element name="gjelderLoennFoerste60Dager" type="Boolsk" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="InntjeningsforholdGruppe">
+        <xsd:sequence>
+            <xsd:element name="inntjeningsforhold" type="SpesielleInntjeningsforhold" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="NettoloennsordningGruppe">
+        <xsd:sequence>
+            <xsd:element name="oppgrossingstabellnummer" type="Heltall" nillable="true" minOccurs="0" />
+            <xsd:element name="bilinformasjon" nillable="true" minOccurs="0">
+                <xsd:complexType>
+                    <xsd:group ref="BilOgBaatGruppe" />
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="betaltSkattebeloepIUtlandet" type="Beloep" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="ReiseKostOgLosjiGruppe">
+        <xsd:sequence>
+            <xsd:element name="persontype" type="PersontypeForReiseKostLosji" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="UtenlandskArtistGruppe">
+        <xsd:sequence>
+            <xsd:element name="inntektsaar" type="AArstall" nillable="true" minOccurs="0" />
+            <xsd:element name="oppgrossingsgrunnlag" type="Beloep" nillable="true" minOccurs="0" />
+            <xsd:element name="trukketArtistskatt" type="BeloepSomHeltall" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="BonusFraForsvaretGruppe">
+        <xsd:sequence>
+            <xsd:element name="aaretUtbetalingenGjelderFor" type="AArstall" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="PensjonEllerTrygdGruppe">
+        <xsd:sequence />
+    </xsd:group>
+    <xsd:group name="EtterbetalingsperiodeGruppe">
+        <xsd:sequence>
+            <xsd:element name="tidsrom" type="Periode" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="LivrenteGruppe">
+        <xsd:sequence>
+            <xsd:element name="totaltUtbetaltBeloep" type="Beloep" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="AldersUfoereEtterlatteAvtalefestetOgKrigspensjonGruppe">
+        <xsd:sequence>
+            <xsd:element name="grunnpensjonsbeloep" type="Beloep" nillable="true" minOccurs="0" />
+            <xsd:element name="tilleggspensjonsbeloep" type="Beloep" nillable="true" minOccurs="0" />
+            <xsd:element name="ufoeregrad" type="Heltall" nillable="true" minOccurs="0" />
+            <xsd:element name="pensjonsgrad" type="Heltall" nillable="true" minOccurs="0" />
+            <xsd:element name="heravEtterlattepensjon" type="Beloep" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="NaeringsinntektGruppe">
+        <xsd:sequence />
+    </xsd:group>
+    <xsd:group name="LottOgPartInnenFiskeGruppe">
+        <xsd:sequence>
+            <xsd:element name="antallDager" type="Heltall" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="DagmammaIEgenBoligGruppe">
+        <xsd:sequence>
+            <xsd:element name="antallBarn" type="Heltall" nillable="true" minOccurs="0" />
+            <xsd:element name="antallMaaneder" type="Heltall" nillable="true" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:group>
+</xsd:schema>

--- a/src/AltinnCore/UnitTest/Designer/ModelControllerTests.cs
+++ b/src/AltinnCore/UnitTest/Designer/ModelControllerTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using AltinnCore.Common.Services.Interfaces;
+using AltinnCore.Designer.Controllers;
+using AltinnCore.ServiceLibrary.ServiceMetadata;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace AltinnCore.UnitTest.Designer
+{
+    /// <summary>
+    ///  tests
+    /// </summary>
+    public class ModelControllerTests
+    {
+        /// <summary>
+        ///  x
+        /// </summary>
+        [Fact]
+        public void CanUploadIso8859EncodedXmlFiles()
+        {
+            // Arrange
+            ServiceMetadata serviceMetadata = null;
+            XDocument xmlDocument = null;
+
+            Mock<IRepository> moqRepository = new Mock<IRepository>();
+            moqRepository.Setup(r => r.CreateModel(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ServiceMetadata>(), It.IsAny<XDocument>()))
+                .Returns(true)
+                .Callback<string, string, ServiceMetadata, XDocument>((o, s, m, d) =>
+                {
+                    serviceMetadata = m;
+                    xmlDocument = d;
+                });
+
+            ModelController controller = new ModelController(moqRepository.Object);           
+
+            IFormFile formFile = AsMockIFormFile("Designer/Edag-latin1.xsd");
+
+            ActionResult result = controller.Upload("Org", "service2", formFile, null);
+
+            Assert.NotNull(serviceMetadata);
+
+            Assert.True(serviceMetadata.Elements.ContainsKey("melding.LeveranseæøåÆØÅ"));
+        }
+
+        private IFormFile AsMockIFormFile(string file)
+        {
+            var physicalFile = new FileInfo(file);
+            var fileMock = new Mock<IFormFile>();
+            var ms = new MemoryStream();
+
+            using (FileStream fs = File.OpenRead(file))
+            {
+                fs.CopyTo(ms);
+            }
+
+            ms.Position = 0;
+            var fileName = physicalFile.Name;
+
+            // Setup mock file using info from physical file
+            fileMock.Setup(_ => _.FileName).Returns(fileName);
+            fileMock.Setup(_ => _.Length).Returns(ms.Length);
+            fileMock.Setup(m => m.OpenReadStream()).Returns(ms);
+            fileMock.Setup(m => m.ContentDisposition).Returns(string.Format("inline; filename={0}", fileName));
+
+            return fileMock.Object;           
+        }
+    }
+}


### PR DESCRIPTION
Changed how we load XML file. Now uses XmlReader instead of StreamReader.
Have compiled and tested import model of iso-8859-1 file.
Have created a test to check that iso-8859-1 file is handled ok.