### PR TITLE
Added displaystring to simpleContent orid and simplify orid-names

### DIFF
--- a/src/AltinnCore/Common/Factories/ModelFactory/SeresXsdParser.cs
+++ b/src/AltinnCore/Common/Factories/ModelFactory/SeresXsdParser.cs
@@ -391,13 +391,7 @@ namespace AltinnCore.Common.Factories.ModelFactory
                 currentElementAnnotations = newElementAnnotations;
             }
 
-            var orid = string.Empty;
-            var xnameParts = elementMetadata.XName.Split('-');
-
-            if ((xnameParts.Length == 3) && ((xnameParts[1] == "grp") || (xnameParts[1] == "datadef")))
-            {
-                orid = xnameParts[2];
-            }
+            string orid = GetOrid(elementMetadata.XName);
 
             foreach (var cultureString in currentElementAnnotations)
             {
@@ -475,22 +469,41 @@ namespace AltinnCore.Common.Factories.ModelFactory
 
             if (string.IsNullOrEmpty(elementMetadata.TypeName))
             {
-                elementMetadata.TypeName = null; 
+                elementMetadata.TypeName = null;
             }
 
             if (allElements.ContainsKey(elementMetadata.ID))
             {
                 elementMetadata.ID += _randomGen.Next();
             }
-           
-            allElements.Add(elementMetadata.ID, elementMetadata);            
 
+            allElements.Add(elementMetadata.ID, elementMetadata);
             AddSchemaReferenceInformation(currentComplexType, elementMetadata);
+        }
+
+        private static string GetOrid(string xName)
+        {
+            var orid = string.Empty;
+            var xnameParts = xName.Split('-');
+
+            if ((xnameParts.Length == 3) && ((xnameParts[1] == "grp") || (xnameParts[1] == "datadef")))
+            {
+                orid = xnameParts[2];
+            }
+
+            return orid;
         }
 
         private static string SanitizeName(string name)
         {
-            return name.Replace("-", string.Empty);
+            if (!string.IsNullOrEmpty(GetOrid(name)))
+            {
+                return name.Split("-")[0]; 
+            }
+            else
+            {
+                return name.Replace("-", string.Empty);
+            }
         }
 
         private static void AddSchemaReferenceInformation(XElement currentComplexType, ElementMetadata elementMetadata)
@@ -687,6 +700,7 @@ namespace AltinnCore.Common.Factories.ModelFactory
             }
 
             allElements.Add(elementMetadata.ID, elementMetadata);
+            AddSchemaReferenceInformation(simpleContent, elementMetadata);
         }
 
         private void AddAttributeElements(XElement currentComplexType, Dictionary<string, ElementMetadata> allElements, string parentTrail)

--- a/src/AltinnCore/UnitTest/Designer/ModelControllerTests.cs
+++ b/src/AltinnCore/UnitTest/Designer/ModelControllerTests.cs
@@ -76,7 +76,7 @@ namespace AltinnCore.UnitTest.Designer
 
             Assert.NotNull(dictionary);
 
-            string lookupValue = dictionary.GetValueOrDefault("5801.Skattyterinforgrp5801.Label").GetValueOrDefault("nb-NO");
+            string lookupValue = dictionary.GetValueOrDefault("5801.Skattyterinfor.Label").GetValueOrDefault("nb-NO");
 
             // Text should be without extra withespaces
             Assert.Equal("Informasjon om skattyter", lookupValue);           


### PR DESCRIPTION
Fixed missing displaystring on simplecontent declarations with orid. 
Also simplified only OR names: now terminates name after first -