### PR TITLE
749 serverside validation

### DIFF
--- a/src/AltinnCore/Common/Configuration/GeneralSettings.cs
+++ b/src/AltinnCore/Common/Configuration/GeneralSettings.cs
@@ -26,6 +26,11 @@ namespace AltinnCore.Common.Configuration
         public string RuntimeMode { get; set; }
 
         /// <summary>
+        /// Gets or sets the soft validation prefix
+        /// </summary>
+        public string SoftValidationPrefix { get; set; }
+
+        /// <summary>
         /// Gets the path to the service implementation template
         /// </summary>
         public string ServiceImplementationTemplate

--- a/src/AltinnCore/Runtime/Controllers/ServiceAPIController.cs
+++ b/src/AltinnCore/Runtime/Controllers/ServiceAPIController.cs
@@ -29,6 +29,7 @@ namespace AltinnCore.Runtime.Controllers
     public class ServiceAPIController : Controller
     {
         private readonly ServiceRepositorySettings _settings;
+        private readonly GeneralSettings _generalSettings;
         private readonly ICompilation _compilation;
         private readonly IRepository _repository;
         private readonly IAuthorization _authorization;
@@ -45,6 +46,7 @@ namespace AltinnCore.Runtime.Controllers
         /// Initializes a new instance of the <see cref="ServiceAPIController"/> class
         /// </summary>
         /// <param name="settings">The repository settings (set in Startup.cs)</param>
+        /// <param name="generalSettings">The general settings (set in Startup.cs)</param>
         /// <param name="compilationService">The compilation service (set in Startup.cs)</param>
         /// <param name="authorizationService">The authorization service (set in Startup.cs)</param>
         /// <param name="logger">The logger (set in Startup.cs)</param>
@@ -57,6 +59,7 @@ namespace AltinnCore.Runtime.Controllers
         /// <param name="workflowSI">The workflow service</param>
         public ServiceAPIController(
             IOptions<ServiceRepositorySettings> settings,
+            IOptions<GeneralSettings> generalSettings,
             ICompilation compilationService,
             IAuthorization authorizationService,
             ILogger<ServiceAPIController> logger,
@@ -69,6 +72,7 @@ namespace AltinnCore.Runtime.Controllers
             IWorkflowSI workflowSI)
         {
             _settings = settings.Value;
+            _generalSettings = generalSettings.Value;
             _compilation = compilationService;
             _authorization = authorizationService;
             _logger = logger;
@@ -234,12 +238,15 @@ namespace AltinnCore.Runtime.Controllers
                 }
             }
 
-            // ServiceEvent 4: HandleValidationEvent
-            // Perform additional Validation defined by the service developer.
-            await serviceImplementation.RunServiceEvent(AltinnCore.ServiceLibrary.Enums.ServiceEventType.Validation);
-
             // Run the model Validation that handles validation defined on the model
             TryValidateModel(serviceModel);
+
+            // ServiceEvent 4: HandleValidationEvent
+            // Perform additional Validation defined by the service developer. Runs when the ApiMode is set to Validate or Complete.
+            if (apiMode.Equals(ApiMode.Validate) || apiMode.Equals(ApiMode.Complete))
+            {
+                await serviceImplementation.RunServiceEvent(AltinnCore.ServiceLibrary.Enums.ServiceEventType.Validation);
+            }
 
             // If ApiMode is only validate the instance should not be created and only return any validation errors
             if (apiMode.Equals(ApiMode.Validate) || (!ModelState.IsValid && !apiMode.Equals(ApiMode.Create)))
@@ -351,17 +358,20 @@ namespace AltinnCore.Runtime.Controllers
                 }
             }
 
-            // ServiceEvent 4: HandleValidationEvent
-            // Perform additional Validation defined by the service developer.
-            await serviceImplementation.RunServiceEvent(AltinnCore.ServiceLibrary.Enums.ServiceEventType.Validation);
-
             // Run the model Validation that handles validation defined on the model
             TryValidateModel(serviceModel);
+
+            // ServiceEvent 4: HandleValidationEvent
+            // Perform additional Validation defined by the service developer. Runs when the ApiMode is set to Validate or Complete.
+            if (apiMode.Equals(ApiMode.Validate) || apiMode.Equals(ApiMode.Complete))
+            {
+                await serviceImplementation.RunServiceEvent(AltinnCore.ServiceLibrary.Enums.ServiceEventType.Validation);
+            }
 
             // If ApiMode is only validate the instance should not be created and only return any validation errors
             if (apiMode.Equals(ApiMode.Validate) || (!ModelState.IsValid && !apiMode.Equals(ApiMode.Create)))
             {
-                MapModelStateToApiResult(ModelState, apiResult, serviceContext);
+                MapModelStateToApiResultForClient(ModelState, apiResult, serviceContext);
 
                 if (apiResult.Status.Equals(ApiStatusType.ContainsError))
                 {
@@ -513,6 +523,64 @@ namespace AltinnCore.Runtime.Controllers
         }
 
         /// <summary>
+        /// Method that maps the MVC Model state to the ApiResult for the client
+        /// </summary>
+        /// <param name="modelState">The model state</param>
+        /// <param name="apiResult">The api result</param>
+        /// <param name="serviceContext">The service context</param>
+        private void MapModelStateToApiResultForClient(ModelStateDictionary modelState, ApiResult apiResult, ServiceContext serviceContext)
+        {
+            apiResult.ValidationResult = new ApiValidationResult
+            {
+                Errors = new Dictionary<string, List<string>>(),
+                Warnings = new Dictionary<string, List<string>>(),
+            };
+            foreach (string modelKey in modelState.Keys)
+            {
+                ModelState.TryGetValue(modelKey, out ModelStateEntry entry);
+
+                if (entry != null && entry.ValidationState == ModelValidationState.Invalid)
+                {
+                    foreach (ModelError error in entry.Errors)
+                    {
+                        if (error.ErrorMessage.StartsWith(_generalSettings.SoftValidationPrefix))
+                        {
+                            string errorMesssage = error.ErrorMessage.Substring(9);
+                            if (apiResult.ValidationResult.Warnings.ContainsKey(modelKey))
+                            {
+                                apiResult.ValidationResult.Warnings[modelKey].Add(ServiceTextHelper.GetServiceText(errorMesssage, serviceContext.ServiceText, null, "nb-NO"));
+                            }
+                            else
+                            {
+                                apiResult.ValidationResult.Warnings.Add(modelKey, new List<string> { ServiceTextHelper.GetServiceText(errorMesssage, serviceContext.ServiceText, null, "nb-NO") });
+                            }
+                        }
+                        else
+                        {
+                            if (apiResult.ValidationResult.Errors.ContainsKey(modelKey))
+                            {
+                                apiResult.ValidationResult.Errors[modelKey].Add(ServiceTextHelper.GetServiceText(error.ErrorMessage, serviceContext.ServiceText, null, "nb-NO"));
+                            }
+                            else
+                            {
+                                apiResult.ValidationResult.Errors.Add(modelKey, new List<string> { ServiceTextHelper.GetServiceText(error.ErrorMessage, serviceContext.ServiceText, null, "nb-NO") });
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (apiResult.ValidationResult.Errors.Count > 0)
+            {
+                apiResult.Status = ApiStatusType.ContainsError;
+            }
+            else if (apiResult.ValidationResult.Warnings.Count > 0)
+            {
+                apiResult.Status = ApiStatusType.ContainsWarnings;
+            }
+        }
+
+        /// <summary>
         /// Method that maps the MVC Model state to the ApiResult
         /// </summary>
         /// <param name="modelState">The model state</param>
@@ -536,7 +604,7 @@ namespace AltinnCore.Runtime.Controllers
                     };
                     foreach (ModelError error in entry.Errors)
                     {
-                        apiEntry.Errors.Add(new ApiModelError() { ErrorMessage = ServiceTextHelper.GetServiceText(error.ErrorMessage, serviceContext.ServiceText, null, "nb-NO") });
+                            apiEntry.Errors.Add(new ApiModelError() { ErrorMessage = ServiceTextHelper.GetServiceText(error.ErrorMessage, serviceContext.ServiceText, null, "nb-NO") });
                     }
 
                     apiResult.ModelStateEntries.Add(apiEntry);

--- a/src/AltinnCore/Runtime/Startup.cs
+++ b/src/AltinnCore/Runtime/Startup.cs
@@ -289,10 +289,10 @@ namespace AltinnCore.Runtime
                     template: "runtime/api/{controller}/{org}/{service}/{action=Index}/{name}",
                     defaults: new { controller = "Codelist" },
                     constraints: new
-                {
-                    controller = "Codelist",
-                    service = "[a-zA-Z][a-zA-Z0-9_\\-]{2,30}",
-                });
+                    {
+                        controller = "Codelist",
+                        service = "[a-zA-Z][a-zA-Z0-9_\\-]{2,30}",
+                    });
 
                 routes.MapRoute(
                     name: "apiRoute",
@@ -305,15 +305,23 @@ namespace AltinnCore.Runtime
                     });
 
                 routes.MapRoute(
-            name: "serviceRoute",
-            template: "runtime/{org}/{service}/{controller}/{action=Index}/{id?}",
-            defaults: new { controller = "Service" },
-            constraints: new
-            {
-                controller = @"(Codelist|Config|DataSource|ManualTesting|Model|Rules|ServiceMetadata|Testing|Text|UI|Workflow|React)",
-                service = "[a-zA-Z][a-zA-Z0-9_\\-]{2,30}",
-                id = "[a-zA-Z0-9_\\-]{1,30}",
-            });
+                    name: "serviceRoute",
+                    template: "runtime/{org}/{service}/{controller}/{action=Index}/{id?}",
+                    defaults: new { controller = "Service" },
+                    constraints: new
+                    {
+                        controller = @"(Codelist|Config|DataSource|ManualTesting|Model|Rules|ServiceMetadata|Testing|Text|UI|Workflow|React)",
+                        service = "[a-zA-Z][a-zA-Z0-9_\\-]{2,30}",
+                        id = "[a-zA-Z0-9_\\-]{1,30}",
+                    });
+                routes.MapRoute(
+                    name: "languageRoute",
+                    template: "runtime/api/{controller}/{action=Index}/{id?}",
+                    defaults: new { controller = "Language" },
+                    constraints: new
+                    {
+                        controller = "Language",
+                    });
 
                 // -------------------------- DEFAULT ------------------------- //
                 routes.MapRoute(

--- a/src/AltinnCore/Runtime/appsettings.json
+++ b/src/AltinnCore/Runtime/appsettings.json
@@ -30,7 +30,8 @@
   },
   "GeneralSettings": {
     "TemplateLocation": "../Templates",
-    "RuntimeMode": "AltinnStudio"
+    "RuntimeMode": "AltinnStudio",
+    "LanguageFilesLocation": "../Common/Languages/ini/"
   },
   "ApplicationInsights": {
     "InstrumentationKey": "b1020135-1b69-4e4d-8b8e-217072c70879"

--- a/src/AltinnCore/Runtime/appsettings.json
+++ b/src/AltinnCore/Runtime/appsettings.json
@@ -31,7 +31,8 @@
   "GeneralSettings": {
     "TemplateLocation": "../Templates",
     "RuntimeMode": "AltinnStudio",
-    "LanguageFilesLocation": "../Common/Languages/ini/"
+    "LanguageFilesLocation": "../Common/Languages/ini/",
+    "SoftValidationPrefix":  "*WARNING*"
   },
   "ApplicationInsights": {
     "InstrumentationKey": "b1020135-1b69-4e4d-8b8e-217072c70879"

--- a/src/AltinnCore/ServiceLibrary/Api/ApiResult.cs
+++ b/src/AltinnCore/ServiceLibrary/Api/ApiResult.cs
@@ -18,6 +18,11 @@ namespace AltinnCore.ServiceLibrary.Api
         public List<ApiModelStateEntry> ModelStateEntries { get; set; }
 
         /// <summary>
+        /// Gets or sets the ValidationResult
+        /// </summary>
+        public ApiValidationResult ValidationResult { get; set; }
+
+        /// <summary>
         /// Gets or sets the Message
         /// </summary>
         public string Message { get; set; }

--- a/src/AltinnCore/ServiceLibrary/Api/ApiValidationResult.cs
+++ b/src/AltinnCore/ServiceLibrary/Api/ApiValidationResult.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace AltinnCore.ServiceLibrary.Api
+{
+    /// <summary>
+    /// Defines the validation result for a model state
+    /// </summary>
+    public class ApiValidationResult
+    {
+        /// <summary>
+        /// Gets or sets the collection of errors
+        /// </summary>
+        public Dictionary<string, List<string>> Errors { get; set; }
+
+        /// <summary>
+        /// Gets or sets the collection of warnings
+        /// </summary>
+        public Dictionary<string, List<string>> Warnings { get; set; }
+    }
+}

--- a/src/react-apps/applications/ux-editor/src/App.tsx
+++ b/src/react-apps/applications/ux-editor/src/App.tsx
@@ -73,6 +73,10 @@ export class App extends React.Component<IAppComponentProps, IAppCompoentState> 
       manageServiceConfigurationActionDispatcher.fetchJsonFile(
         `${altinnWindow.location.origin}/runtime/api/resource/${servicePath}/ServiceConfigurations.json`);
 
+      // Fetch language
+      appDataActionDispatcher.fetchLanguage(
+        `${altinnWindow.location.origin}/runtime/api/Language/GetLanguageAsJSON`, 'nb');
+
     } else {
       // ALTINN STUDIO
       if (window.location.hash.split('#/')[1] && window.location.hash.split('#/')[1].toLowerCase() === PREVIEW) {

--- a/src/react-apps/applications/ux-editor/src/reducers/formFillerReducer/index.ts
+++ b/src/react-apps/applications/ux-editor/src/reducers/formFillerReducer/index.ts
@@ -99,7 +99,10 @@ const formFillerReducer: Reducer<IFormFillerState> = (
         },
         apiResult: {
           $set: apiResult,
-        }
+        },
+        validationErrors: {
+          $set: {},
+        },
       });
     }
 

--- a/src/react-apps/applications/ux-editor/src/sagas/formFiller/formFillerSagas.ts
+++ b/src/react-apps/applications/ux-editor/src/sagas/formFiller/formFillerSagas.ts
@@ -70,6 +70,12 @@ export function* submitFormDataSaga({ url, apiMode }: FormFillerActions.ISubmitF
     if (err.response && err.response.status === 303) {
       yield call(FormFillerActionDispatcher.submitFormDataFulfilled, err);
       yield call(FormFillerActionDispatcher.fetchFormData, url + '/Read');
+    } else if (err.response && err.response.data &&
+        (err.response.data.status === 1 || err.response.data.status === 2)) {
+      // Update validationError state if response contains validation errors
+      const validationErrors: any = err.response.data.validationResult.errors;
+      yield call(FormFillerActionDispatcher.updateValidationErrors, validationErrors);
+      yield call(FormFillerActionDispatcher.submitFormDataRejected, err);
     } else {
       yield call(FormFillerActionDispatcher.submitFormDataRejected, err);
     }


### PR DESCRIPTION
- Updated format that is returned to the client when server side validation has errors
- Added support (serverside) for using soft validation (warnings) in service validation
- Read the errors from the response into the validationErrors state so that it appears in the error report.
- Change order of validations server side to _data model_ then _service validation_

NOT IMPLEMENTED:
- mapping from data model key in server side validation errors to client component ids (so that the validation messages appear inline/below component)