### PR TITLE
Quick fix for demo of validation errors

### DIFF
--- a/src/react-apps/applications/shared/fallbackLanguage.tsx
+++ b/src/react-apps/applications/shared/fallbackLanguage.tsx
@@ -78,6 +78,9 @@ const fallbackLanguage = {
     toolbar_header: 'Header',
     toolbar_file_upload: 'File Upload',
   },
+  form_filler: {
+    error_report_header: 'Det er et problem',
+  }
 };
 
 export default fallbackLanguage;


### PR DESCRIPTION
Added new text key for runtime to fallbackLanguage.tsx, so that the language text is available for demo of server side validation. 
Added bug #1092 to follow up that loading of the (.ini) language files (for the platform) fails in Runtime.