### PR TITLE
"Test i testmiljø" page

### DIFF
--- a/src/AltinnCore/Common/Languages/ini/en.ini
+++ b/src/AltinnCore/Common/Languages/ini/en.ini
@@ -113,6 +113,11 @@ sharing_changes_no_access_submessage = You may still work on the service and sav
 validating_changes = Validating changes
 validation_completed = The changes are now validated and can be shared with other
 
+[testing]
+testing_in_testenv_body = Here you can test your service from A to Z in a production-like test environment.
+testing_in_testenv_title = Testing in test environment
+
+
 [ux_editor]
 api_connection_header = Api connections
 collapsable_schema_components = Schema Components

--- a/src/AltinnCore/Common/Languages/ini/nb.ini
+++ b/src/AltinnCore/Common/Languages/ini/nb.ini
@@ -114,6 +114,9 @@ sharing_changes_no_access_submessage = Du kan fortsatt arbeide med tjenesten og 
 validating_changes = Validerer endringene dine
 validation_completed = Endringene er validert og kan deles med andre
 
+[testing]
+testing_in_testenv_body = Her kan du teste tjenesten din fra a til å i et produksjonslikt testmiljø.
+testing_in_testenv_title = Test i testmiljø
 
 [ux_editor]
 api_connection_header = Api-tilkoblinger

--- a/src/react-apps/applications/service-development/src/App.tsx
+++ b/src/react-apps/applications/service-development/src/App.tsx
@@ -40,9 +40,6 @@ const styles = () => createStyles({
     width: '100%',
   },
   subApp: {
-    [theme.breakpoints.up('md')]: {
-      paddingLeft: 73,
-    },
     background: theme.altinnPalette.primary.greyLight,
     height: '100%',
     width: '100%',

--- a/src/react-apps/applications/service-development/src/config/routes.tsx
+++ b/src/react-apps/applications/service-development/src/config/routes.tsx
@@ -4,6 +4,7 @@ import { Administration } from '../features/administration/components/Administra
 import HandleMergeConflictContainer from '../features/handleMergeConflict/HandleMergeConflictContainer';
 import { IFrame } from '../features/iFrame/iFrameComponent';
 import RedirectComponent from '../features/iFrame/RedirectComponent';
+import TestingInTestenvironmentContainer from '../features/testing-in-testenvironment/testing-in-testenvironment';
 
 export const routes = [
   {
@@ -56,6 +57,14 @@ export const routes = [
       shadow: true,
       redirectUrl: 'runtime/ManualTesting/Users/',
     },
+  },
+  {
+    path: '/testingintestenvironment',
+    exact: true,
+    activeSubHeaderSelection: 'Teste',
+    activeLeftMenuSelection: 'Test i testmiljø',
+    menu: 'test',
+    subapp: TestingInTestenvironmentContainer,
   },
   {
     path: '/aboutservice',
@@ -221,7 +230,7 @@ export const routes = [
     },
   },
   {
-    path: '/productionsetting',
+    path: '/publish',
     exact: true,
     activeSubHeaderSelection: 'Publisere',
     activeLeftMenuSelection: 'Produksjonsette',

--- a/src/react-apps/applications/service-development/src/features/administration/components/Administration.tsx
+++ b/src/react-apps/applications/service-development/src/features/administration/components/Administration.tsx
@@ -51,8 +51,13 @@ const styles = createStyles({
     marginBottom: 30,
   },
   sidebar: {
-    borderLeft: '1px solid ' + theme.altinnPalette.primary.greyMedium,
-    paddingLeft: 10,
+    [theme.breakpoints.down('md')]: {
+      borderLeft: '1px solid ' + theme.altinnPalette.primary.greyMedium,
+      paddingLeft: 10,
+    },
+    [theme.breakpoints.down('sm')]: {
+      paddingLeft: 60,
+    },
   },
   sidebarHeader: {
     marginBottom: 20,
@@ -87,6 +92,7 @@ const styles = createStyles({
     [theme.breakpoints.up('md')]: {
       height: `calc(100vh - 110px)`,
       overflowY: 'auto',
+      paddingLeft: theme.sharedStyles.mainPaddingLeft,
     },
   },
   marginBottom_24: {

--- a/src/react-apps/applications/service-development/src/features/iFrame/RedirectComponent.tsx
+++ b/src/react-apps/applications/service-development/src/features/iFrame/RedirectComponent.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import AltinnButton from '../../../../shared/src/components/AltinnButton';
 
 export interface IRedirectComponentProvidedProps {
   redirectUrl: string;
@@ -8,13 +9,28 @@ export interface IRedirectComponentProvidedProps {
 export class RedirectComponent extends
   React.Component<IRedirectComponentProvidedProps, any> {
 
-  public render() {
+  public openManualTesting = () => {
     const altinnWindow: any = window;
     const { org, service } = altinnWindow;
     // tslint:disable-next-line:max-line-length
-    window.location.assign(`${altinnWindow.location.origin}/${this.props.redirectUrl}?ReturnUrl=%2Fruntime%2F${org}%2F${service}%2FManualTesting`);
+    const url = `${altinnWindow.location.origin}/${this.props.redirectUrl}?ReturnUrl=%2Fruntime%2F${org}%2F${service}%2FManualTesting`;
     // tslint:disable-next-line:jsx-self-close
-    return (<React.Fragment />);
+    window.open(url, '_newWindow');
+  }
+
+  public render() {
+
+    return (
+      <React.Fragment>
+        <div style={{ paddingLeft: 80, paddingTop: 10 }}>
+          <AltinnButton
+            id='manual-test-button'
+            btnText='Åpne manuell testing i nytt vindu'
+            onClickFunction={this.openManualTesting}
+          />
+        </div>
+      </React.Fragment>
+    );
   }
 }
 

--- a/src/react-apps/applications/service-development/src/features/iFrame/iFrameComponent.tsx
+++ b/src/react-apps/applications/service-development/src/features/iFrame/iFrameComponent.tsx
@@ -8,7 +8,7 @@ export interface IIFrameComponentProvidedProps {
 
 const theme = createMuiTheme(altinnTheme);
 
-const styles = createStyles({
+const styles = () => createStyles({
   iFrameLayout: {
     [theme.breakpoints.down('sm')]: {
       height: `calc(100vh - 55px)`,
@@ -18,6 +18,11 @@ const styles = createStyles({
     },
     width: '100%',
     border: 0,
+  },
+  mainLayout: {
+    [theme.breakpoints.up('md')]: {
+      paddingLeft: theme.sharedStyles.mainPaddingLeft,
+    },
   },
 });
 

--- a/src/react-apps/applications/service-development/src/features/testing-in-testenvironment/testing-in-testenvironment.tsx
+++ b/src/react-apps/applications/service-development/src/features/testing-in-testenvironment/testing-in-testenvironment.tsx
@@ -1,0 +1,128 @@
+import { Grid, Hidden, Paper, Typography } from '@material-ui/core';
+import { createMuiTheme, createStyles, withStyles, WithStyles } from '@material-ui/core/styles';
+import * as React from 'react';
+import { connect } from 'react-redux';
+import altinnTheme from '../../../../shared/src/theme/altinnStudioTheme';
+import { getLanguageFromKey } from '../../../../shared/src/utils/language';
+// import VersionControlHeader from '../../../../shared/src/version-control/versionControlHeader';
+
+const theme = createMuiTheme(altinnTheme);
+
+const styles = () => createStyles({
+  mainLayout: {
+    paddingTop: 20,
+    [theme.breakpoints.up('md')]: {
+      height: `calc(100vh - 110px)`,
+      overflowY: 'auto',
+      paddingLeft: theme.sharedStyles.mainPaddingLeft,
+    },
+    [theme.breakpoints.down('sm')]: {
+      height: `calc(100vh - 55px)`,
+      overflowY: 'auto',
+    },
+  },
+  ingress: {
+    paddingTop: 10,
+  },
+  deployPlaceholderStyle: {
+    marginTop: 24,
+    [theme.breakpoints.up('md')]: {
+      paddingRight: 60,
+    },
+  },
+  aboutServicePlaceholderStyle: {
+    [theme.breakpoints.up('md')]: {
+      borderLeft: '1px solid ' + theme.altinnPalette.primary.greyMedium,
+      paddingLeft: 12,
+    },
+    marginTop: 24,
+  },
+});
+
+export interface ITestingInTestenvironmentContainerProps extends WithStyles<typeof styles> {
+  language: any;
+  name?: any;
+  repoStatus: any;
+}
+
+export interface ITestingInTestenvironmentContainerState {
+}
+
+export class TestingInTestenvironmentContainer extends
+  React.Component<ITestingInTestenvironmentContainerProps, ITestingInTestenvironmentContainerState> {
+
+  constructor(_props: ITestingInTestenvironmentContainerProps, _state: ITestingInTestenvironmentContainerState) {
+    super(_props, _state);
+    this.state = {
+
+    };
+  }
+
+  // public componentDidMount() {
+  // }
+
+  // public componentWillUnmount() {
+  // }
+
+  public render() {
+    const { classes } = this.props;
+    return (
+      <React.Fragment>
+        <div className={classes.mainLayout}>
+          <Grid container={true} justify='center'>
+            <Grid item={true} xs={11} sm={10} md={11}>
+              <Typography variant='h1'>
+                {getLanguageFromKey('testing.testing_in_testenv_title', this.props.language)}
+              </Typography>
+              <Typography variant='body1' className={classes.ingress}>
+                {getLanguageFromKey('testing.testing_in_testenv_body', this.props.language)}
+              </Typography>
+            </Grid>
+
+
+            <Grid item={true} xs={11} sm={7} md={7} className={classes.deployPlaceholderStyle}>
+
+              <Paper square={true} elevation={1} style={{ padding: 24 }}>
+                Placeholder for Tjenesten er klar til å legges ut i testmiljø
+              </Paper>
+
+            </Grid>
+            <Hidden mdUp={true} xsDown={true}>
+              <Grid item={true} sm={3}>
+                {/* grid padding */}
+              </Grid>
+            </Hidden>
+
+
+            <Grid item={true} xs={11} sm={7} md={4} className={classes.aboutServicePlaceholderStyle}>
+
+              <Paper square={true} elevation={1} style={{ padding: 24 }}>
+                Placeholder for "Tjenesten i testmiljø"
+              </Paper>
+
+            </Grid>
+            <Hidden mdUp={true} xsDown={true}>
+              <Grid item={true} sm={3}>
+                {/* grid padding */}
+              </Grid>
+            </Hidden>
+          </Grid>
+
+        </div>
+      </React.Fragment >
+    );
+  }
+}
+
+const makeMapStateToProps = () => {
+  const mapStateToProps = (
+    state: IServiceDevelopmentState,
+  ) => {
+    return {
+      language: state.language,
+    };
+  };
+  return mapStateToProps;
+};
+
+export default withStyles(styles)(connect(makeMapStateToProps)(TestingInTestenvironmentContainer));

--- a/src/react-apps/applications/service-development/src/features/testing-in-testenvironment/testing-in-testenvironment.tsx
+++ b/src/react-apps/applications/service-development/src/features/testing-in-testenvironment/testing-in-testenvironment.tsx
@@ -79,7 +79,6 @@ export class TestingInTestenvironmentContainer extends
               </Typography>
             </Grid>
 
-
             <Grid item={true} xs={11} sm={7} md={7} className={classes.deployPlaceholderStyle}>
 
               <Paper square={true} elevation={1} style={{ padding: 24 }}>
@@ -92,7 +91,6 @@ export class TestingInTestenvironmentContainer extends
                 {/* grid padding */}
               </Grid>
             </Hidden>
-
 
             <Grid item={true} xs={11} sm={7} md={4} className={classes.aboutServicePlaceholderStyle}>
 

--- a/src/react-apps/applications/shared/__tests__/__snapshots__/LeftDrawerMenu.test.tsx.snap
+++ b/src/react-apps/applications/shared/__tests__/__snapshots__/LeftDrawerMenu.test.tsx.snap
@@ -509,7 +509,7 @@ exports[`LeftDrawerMenu.tsx render left drawer menu when mockmenutype is publish
         className="MuiList-root-57 MuiList-padding-58"
       >
         <a
-          href="/productionsetting"
+          href="/publish"
           onClick={[Function]}
           style={
             Object {
@@ -632,6 +632,41 @@ exports[`LeftDrawerMenu.tsx render left drawer menu when mockmenutype is test sh
               className="MuiListItemText-root-75 LeftDrawerMenu-listItemText-12"
             >
               Test
+            </div>
+          </li>
+        </a>
+        <a
+          href="/testintestenvironment"
+          onClick={[Function]}
+          style={
+            Object {
+              "borderBottom": 0,
+            }
+          }
+        >
+          <li
+            className="MuiListItem-root-61 LeftDrawerMenu-listItem-1 MuiListItem-default-64 MuiListItem-gutters-69"
+            disabled={false}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <div
+              className="MuiListItemIcon-root-73"
+            >
+              <i
+                className="fa fa-integration-test"
+                style={
+                  Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontSize": null,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiListItemText-root-75 LeftDrawerMenu-listItemText-12"
+            >
+              Test i testmiljø
             </div>
           </li>
         </a>

--- a/src/react-apps/applications/shared/__tests__/__snapshots__/appBar.test.tsx.snap
+++ b/src/react-apps/applications/shared/__tests__/__snapshots__/appBar.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`AppBarComponent - src/navigation/main-header/appBar Snapshot should mat
         >
           <a
             className="AppBarComponent-subHeaderLink-7"
-            href="/test"
+            href="/testingintestenvironment"
             onClick={[Function]}
           >
             Teste
@@ -152,7 +152,7 @@ exports[`AppBarComponent - src/navigation/main-header/appBar Snapshot should mat
         >
           <a
             className="AppBarComponent-subHeaderLink-7"
-            href="/productionsetting"
+            href="/publish"
             onClick={[Function]}
           >
             Publisere
@@ -608,7 +608,7 @@ exports[`AppBarComponent - src/navigation/main-header/appBar Snapshot should mat
         >
           <a
             className="AppBarComponent-subHeaderLink-7"
-            href="/test"
+            href="/testingintestenvironment"
             onClick={[Function]}
           >
             Teste
@@ -619,7 +619,7 @@ exports[`AppBarComponent - src/navigation/main-header/appBar Snapshot should mat
         >
           <a
             className="AppBarComponent-subHeaderLink-7 AppBarComponent-subHeaderLinkActive-8"
-            href="/productionsetting"
+            href="/publish"
             onClick={[Function]}
           >
             Publisere
@@ -772,7 +772,7 @@ exports[`AppBarComponent - src/navigation/main-header/appBar Snapshot should mat
         >
           <a
             className="AppBarComponent-subHeaderLink-7"
-            href="/test"
+            href="/testingintestenvironment"
             onClick={[Function]}
           >
             Teste
@@ -783,7 +783,7 @@ exports[`AppBarComponent - src/navigation/main-header/appBar Snapshot should mat
         >
           <a
             className="AppBarComponent-subHeaderLink-7 AppBarComponent-subHeaderLinkActive-8"
-            href="/productionsetting"
+            href="/publish"
             onClick={[Function]}
           >
             Publisere

--- a/src/react-apps/applications/shared/src/navigation/drawer/drawerMenuSettings.ts
+++ b/src/react-apps/applications/shared/src/navigation/drawer/drawerMenuSettings.ts
@@ -143,11 +143,17 @@ export const leftDrawerMenuSettings: IDrawerMenu = {
       activeLeftMenuSelection: 'Test',
       iconClass: 'fa fa-info-circle',
     },
+    {
+      displayText: 'Test i testmiljø',
+      navLink: '/testintestenvironment',
+      activeLeftMenuSelection: 'Test',
+      iconClass: 'fa fa-integration-test',
+    },
   ],
   publish: [
     {
       displayText: 'Produksjonsette',
-      navLink: '/productionsetting',
+      navLink: '/publish',
       activeLeftMenuSelection: 'Produksjonsette',
       iconClass: 'fa fa-settings',
     },

--- a/src/react-apps/applications/shared/src/navigation/main-header/appBarConfig.tsx
+++ b/src/react-apps/applications/shared/src/navigation/main-header/appBarConfig.tsx
@@ -17,11 +17,11 @@ export const menu = ([
   {
     key: 'Teste',
     activeSubHeaderSelection: 'Teste',
-    link: '/test',
+    link: '/testingintestenvironment',
   },
   {
     key: 'Publisere',
     activeSubHeaderSelection: 'Publisere',
-    link: '/productionsetting',
+    link: '/publish',
   },
 ]);

--- a/src/react-apps/applications/shared/src/theme/altinnStudioTheme.tsx
+++ b/src/react-apps/applications/shared/src/theme/altinnStudioTheme.tsx
@@ -30,6 +30,7 @@ declare module '@material-ui/core/styles/createMuiTheme' {
     };
     sharedStyles: {
       boxShadow: string,
+      mainPaddingLeft: number,
     };
   }
 }
@@ -85,6 +86,9 @@ const theme = {
       h1: {
         fontSize: 36,
       },
+      body1: {
+        fontSize: 16,
+      },
     },
   },
   palette: {
@@ -105,6 +109,7 @@ const theme = {
   },
   sharedStyles: {
     boxShadow: '0px 0px 4px rgba(0, 0, 0, 0.25)',
+    mainPaddingLeft: 73,
   },
   typography: {
     htmlFontSize: 16,

--- a/src/react-apps/applications/ux-editor/src/containers/FormDesigner.tsx
+++ b/src/react-apps/applications/ux-editor/src/containers/FormDesigner.tsx
@@ -36,6 +36,9 @@ export interface IFormDesignerState {
 
 const styles = ((theme: Theme) => createStyles({
   root: {
+    [theme.breakpoints.up('md')]: {
+      paddingLeft: theme.sharedStyles.mainPaddingLeft,
+    },
     flexGrow: 1,
     minHeight: 'calc(100vh - 69px)',
   },


### PR DESCRIPTION
- Initial "Test i testmiljø" page.
- Placeholders for deploy and about service.

Other:
- Moved the "leftPadding" for all apps in Service-Development
- Fixed "Administration" tablet view.
- Added button for opening manual testing in new window.