### PR TITLE
bug/css-for-drawers

### DIFF
--- a/src/react-apps/applications/shared/src/navigation/drawer/leftDrawerMenuStyles.ts
+++ b/src/react-apps/applications/shared/src/navigation/drawer/leftDrawerMenuStyles.ts
@@ -47,7 +47,7 @@ export const styles = (theme: Theme) => createStyles({
     overflowX: 'hidden',
     width: theme.spacing.unit * 7 + 1,
     [theme.breakpoints.up('sm')]: {
-      width: theme.spacing.unit * 9 + 1,
+      width: theme.spacing.unit * 8 + 1,
     },
   },
   toolbar: {

--- a/src/react-apps/applications/shared/src/navigation/drawer/rightDrawerMenu.tsx
+++ b/src/react-apps/applications/shared/src/navigation/drawer/rightDrawerMenu.tsx
@@ -18,6 +18,7 @@ const styles = createStyles({
     background: altinnTheme.altinnPalette.primary.greyLight,
     position: 'relative',
     top: 0,
+    height: '100vh',
   },
   scrollable: {
     overflowY: 'scroll',


### PR DESCRIPTION
Fixes:
Right drawer menu (tjenestelogikk) is using the whole screen height
Left drawer menu (icons) is not showing parts of the text any more