### PR TITLE
Updated url for SBLBridge  endpoints and implementation in personswrapper

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -58,7 +58,7 @@ namespace Altinn.Platform.Authentication.Controllers
             {
                 UserAuthenticationModel userAuthentication = null;
                 DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(UserAuthenticationModel));
-                Uri endpointUrl = new Uri($"{_generalSettings.GetBridgeApiEndpoint}");
+                Uri endpointUrl = new Uri($"{_generalSettings.GetBridgeApiEndpoint}/tickets");
                 using (HttpClient client = new HttpClient())
                 {
                     UserAuthenticationModel postUserValue = new UserAuthenticationModel() { EncryptedTicket = Request.Cookies[_generalSettings.GetSBLCookieName] };

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/appsettings.json
@@ -1,7 +1,7 @@
 {
   "GeneralSettings": {
     "SBLCookieName": ".ASPXAUTH",
-    "BridgeApiEndpoint": "https://at21.altinn.cloud/api/bridge/",
+    "BridgeApiEndpoint": "https://at21.altinn.cloud/sblbridge/authentication/api",
     "SBLRedirectEndpoint": "https://at21.altinn.cloud/ui/authentication",
     "PlatformEndpoint": "http://localhost:5040/",
     "ClaimsIdentity": "UserLogin",

--- a/src/Altinn.Platform/Altinn.Platform.Profile/Profile/Services/Implementation/UserProfilesWrapper.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Profile/Profile/Services/Implementation/UserProfilesWrapper.cs
@@ -36,7 +36,7 @@ namespace Altinn.Platform.Profile.Services.Implementation
         {
             UserProfile user = null;
             DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(UserProfile));
-            Uri endpointUrl = new Uri($"{_generalSettings.GetApiBaseUrl()}/userprofiles/get/{userId}");
+            Uri endpointUrl = new Uri($"{_generalSettings.GetApiBaseUrl()}/users/{userId}");
             using (HttpClient client = HttpApiHelper.GetApiClient())
             {
                 HttpResponseMessage response = await client.GetAsync(endpointUrl);

--- a/src/Altinn.Platform/Altinn.Platform.Profile/Profile/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Profile/Profile/appsettings.json
@@ -1,6 +1,6 @@
 {
   "GeneralSettings": {
-    "BridgeApiEndpoint": "https://at21.altinn.cloud/api/bridge/",
+    "BridgeApiEndpoint": "https://at21.altinn.cloud/sblbridge/profile/api",
     "ShouldUseMock": "true"
   },
   "Serilog": {

--- a/src/Altinn.Platform/Altinn.Platform.Register/Register/Services/Implementation/PersonsWrapper.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Register/Register/Services/Implementation/PersonsWrapper.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.Serialization.Json;
+using System.Text;
 using System.Threading.Tasks;
 using Altinn.Platform.Register.Configuration;
 using Altinn.Platform.Register.Helpers;
@@ -36,10 +37,10 @@ namespace Altinn.Platform.Register.Services.Implementation
         {
             Person person = null;
             DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(Person));
-            Uri endpointUrl = new Uri($"{_generalSettings.GetApiBaseUrl()}/persons/{ssn}");
+            Uri endpointUrl = new Uri($"{_generalSettings.GetApiBaseUrl()}/persons");
             using (HttpClient client = HttpApiHelper.GetApiClient())
             {
-                HttpResponseMessage response = await client.GetAsync(endpointUrl);
+                HttpResponseMessage response = await client.PostAsync(endpointUrl, new StringContent(ssn, Encoding.UTF8, "application/json"));
                 if (response.StatusCode == System.Net.HttpStatusCode.OK)
                 {
                     Stream stream = await response.Content.ReadAsStreamAsync();

--- a/src/Altinn.Platform/Altinn.Platform.Register/Register/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Register/Register/appsettings.json
@@ -1,7 +1,7 @@
 {
   "GeneralSettings": {
     "ShouldUseMock": "true",
-    "BridgeApiEndpoint": "https://at21.altinn.cloud/api/bridge/"
+    "BridgeApiEndpoint": "https://at21.altinn.cloud/sblbridge/register/api"
   },
   "Serilog": {
     "MinimumLevel": {


### PR DESCRIPTION
Updated the baseURL for SBL Bridge in appconfig for register, profile and authentication component. 

Updated requestUrl where there was a mismatch from implementation in SBL. 

Updated implementation in personswrapper as implementation in Bridge is updated to not expose SSN