### PR TITLE
fixed missing initialization in seres xsd parser

### DIFF
--- a/src/AltinnCore/Common/Factories/ModelFactory/SeresXsdParser.cs
+++ b/src/AltinnCore/Common/Factories/ModelFactory/SeresXsdParser.cs
@@ -58,6 +58,8 @@ namespace AltinnCore.Common.Factories.ModelFactory
             var serviceMetadata = new ServiceMetadata
             {
                 Elements = new Dictionary<string, ElementMetadata>(),
+                RepositoryName = service,
+                Org = org,                
             };
             this.xsd = xsd;
             this.secondaryXsds = secondaryXsds;


### PR DESCRIPTION
Helper class required service metadata to have service name. This was not used before.