### PR TITLE
Platform authorization api bug fix

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/PartiesWrapper.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/PartiesWrapper.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Altinn.Platform.Authorization.Clients;
 using Altinn.Platform.Authorization.Services.Interface;
 using Authorization.Interface.Models;
+ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 namespace Altinn.Platform.Authorization.Services.Implementation
@@ -13,14 +14,16 @@ namespace Altinn.Platform.Authorization.Services.Implementation
     public class PartiesWrapper : IParties
     {
         private readonly PartyClient _partyClient;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PartiesWrapper"/> class
         /// </summary>
         /// <param name="partyClient">the client handler for actor api</param>
-        public PartiesWrapper(PartyClient partyClient)
+        public PartiesWrapper(PartyClient partyClient, ILogger<PartiesWrapper> logger)
         {
             _partyClient = partyClient;
+            _logger = logger;
         }
 
         /// <inheritdoc />
@@ -28,8 +31,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         {            
             List<Party> partiesList = null;
 
-            var request = $"/actors?userid={userId}";
-
+            var request = $"parties?userid={userId}";            
             var response = await _partyClient.Client.GetAsync(request);            
             string partiesDataList = await response.Content.ReadAsStringAsync();
             response.EnsureSuccessStatusCode();

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/appsettings.json
@@ -1,6 +1,6 @@
 {
   "GeneralSettings": {
-    "BridgeApiEndpoint": "https://at21.altinn.cloud/sblbridge/authorization/api"
+    "BridgeApiEndpoint": "https://at21.altinn.cloud/sblbridge/authorization/api/"
   },
   "Serilog": {
     "MinimumLevel": {


### PR DESCRIPTION
Added "/" to bridgeapi endpoint as the httpclient baseaddress took only the first part of the url (url before first slash) as baseaddress