### PR TITLE
Updated structure of instanceId in IAltinnWindow frontend

### DIFF
--- a/src/AltinnCore/Common/Services/Implementation/DataAppSI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/DataAppSI.cs
@@ -57,9 +57,9 @@ namespace AltinnCore.Common.Services.Implementation
         }
 
         /// <inheritdoc />
-        public async Task<Instance> InsertData<T>(T dataToSerialize, Guid instanceId, Type type, string org, string appName, int instanceOwnerId)
+        public async Task<Instance> InsertData<T>(T dataToSerialize, Guid instanceGuid, Type type, string org, string appName, int instanceOwnerId)
         {
-            string instanceIdentifier = $"{instanceOwnerId}/{instanceId}";
+            string instanceIdentifier = $"{instanceOwnerId}/{instanceGuid}";
             string apiUrl = $"instances/{instanceIdentifier}/data?elementType={FORM_ID}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _cookieOptions.Cookie.Name);
             JwtTokenUtil.AddTokenToRequestHeader(_client, token);
@@ -75,7 +75,7 @@ namespace AltinnCore.Common.Services.Implementation
                 Task<HttpResponseMessage> response = _client.PostAsync(apiUrl, streamContent);
                 if (!response.Result.IsSuccessStatusCode)
                 {
-                    _logger.Log(LogLevel.Error, "unable to save form data for instance{0} due to response {1}", instanceId, response.Result.StatusCode);
+                    _logger.Log(LogLevel.Error, "unable to save form data for instance{0} due to response {1}", instanceGuid, response.Result.StatusCode);
                     return null;
                 }
 
@@ -87,9 +87,9 @@ namespace AltinnCore.Common.Services.Implementation
         }
 
         /// <inheritdoc />
-        public void UpdateData<T>(T dataToSerialize, Guid instanceId, Type type, string org, string appName, int instanceOwnerId, Guid dataId)
+        public void UpdateData<T>(T dataToSerialize, Guid instanceGuid, Type type, string org, string appName, int instanceOwnerId, Guid dataId)
         {
-            string instanceIdentifier = $"{instanceOwnerId}/{instanceId}";
+            string instanceIdentifier = $"{instanceOwnerId}/{instanceGuid}";
             string apiUrl = $"instances/{instanceIdentifier}/data/{dataId}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _cookieOptions.Cookie.Name);
             JwtTokenUtil.AddTokenToRequestHeader(_client, token);
@@ -111,15 +111,15 @@ namespace AltinnCore.Common.Services.Implementation
                 Task<HttpResponseMessage> response = _client.PutAsync(apiUrl, streamContent);
                 if (!response.Result.IsSuccessStatusCode)
                 {
-                    _logger.LogError($"Unable to save form model for instance {instanceId}");
+                    _logger.LogError($"Unable to save form model for instance {instanceGuid}");
                 }
             }
         }
 
         /// <inheritdoc />
-        public object GetFormData(Guid instanceId, Type type, string org, string appName, int instanceOwnerId, Guid dataId)
+        public object GetFormData(Guid instanceGuid, Type type, string org, string appName, int instanceOwnerId, Guid dataId)
         {
-            string instanceIdentifier = $"{instanceOwnerId}/{instanceId}";
+            string instanceIdentifier = $"{instanceOwnerId}/{instanceGuid}";
             string apiUrl = $"instances/{instanceIdentifier}/data/{dataId}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _cookieOptions.Cookie.Name);
             JwtTokenUtil.AddTokenToRequestHeader(_client, token);
@@ -147,9 +147,9 @@ namespace AltinnCore.Common.Services.Implementation
         }
 
         /// <inheritdoc />
-        public async Task<List<AttachmentList>> GetFormAttachments(string org, string appName, int instanceOwnerId, Guid instanceId)
+        public async Task<List<AttachmentList>> GetFormAttachments(string org, string appName, int instanceOwnerId, Guid instanceGuid)
         {
-            string instanceIdentifier = $"{instanceOwnerId}/{instanceId}";
+            string instanceIdentifier = $"{instanceOwnerId}/{instanceGuid}";
             string apiUrl = $"instances/{instanceIdentifier}/data";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _cookieOptions.Cookie.Name);
             JwtTokenUtil.AddTokenToRequestHeader(_client, token);
@@ -207,9 +207,9 @@ namespace AltinnCore.Common.Services.Implementation
         }
 
         /// <inheritdoc />
-        public void DeleteFormAttachment(string org, string appName, int instanceOwnerId, Guid instanceId, string attachmentType, string attachmentId)
+        public void DeleteFormAttachment(string org, string appName, int instanceOwnerId, Guid instanceGuid, string attachmentType, string attachmentId)
         {
-            string instanceIdentifier = $"{instanceOwnerId}/{instanceId}";
+            string instanceIdentifier = $"{instanceOwnerId}/{instanceGuid}";
             List<AttachmentList> attachmentList = new List<AttachmentList>();
             string apiUrl = $"instances/{instanceIdentifier}/data/{attachmentId}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _cookieOptions.Cookie.Name);
@@ -220,9 +220,9 @@ namespace AltinnCore.Common.Services.Implementation
         }
 
         /// <inheritdoc />
-        public async Task<Guid> SaveFormAttachment(string org, string appName, int instanceOwnerId, Guid instanceId, string attachmentType, string attachmentName, HttpRequest attachment)
+        public async Task<Guid> SaveFormAttachment(string org, string appName, int instanceOwnerId, Guid instanceGuid, string attachmentType, string attachmentName, HttpRequest attachment)
         {
-            string instanceIdentifier = $"{instanceOwnerId}/{instanceId}";
+            string instanceIdentifier = $"{instanceOwnerId}/{instanceGuid}";
             string apiUrl = $"{_platformSettings.GetApiStorageEndpoint}instances/{instanceIdentifier}/data?elementType={attachmentType}&attachmentName={attachmentName}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _cookieOptions.Cookie.Name);
             Instance instance;

--- a/src/AltinnCore/Common/Services/Implementation/DataAppSI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/DataAppSI.cs
@@ -250,7 +250,6 @@ namespace AltinnCore.Common.Services.Implementation
                         header.FileName = attachmentName;
                         header.Size = attachment.ContentLength;
                         formData.Headers.ContentDisposition = header;
-                        formData.Headers.Add("Authorization", "Bearer " + token);
                         formData.Add(fileStreamContent, attachmentType, attachmentName);
                         HttpResponseMessage response = client.PostAsync(apiUrl, formData).Result;
 

--- a/src/AltinnCore/Common/Services/Implementation/DataAppSI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/DataAppSI.cs
@@ -102,12 +102,6 @@ namespace AltinnCore.Common.Services.Implementation
                 StreamContent streamContent = new StreamContent(stream);
                 streamContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/xml");
 
-                if (streamContent.Headers.Contains("Authorization"))
-                {
-                    streamContent.Headers.Remove("Authorization");
-                }
-
-                streamContent.Headers.Add("Authorization", "Bearer " + token);
                 Task<HttpResponseMessage> response = _client.PutAsync(apiUrl, streamContent);
                 if (!response.Result.IsSuccessStatusCode)
                 {

--- a/src/AltinnCore/Common/Services/Implementation/DataStudioSI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/DataStudioSI.cs
@@ -55,17 +55,17 @@ namespace AltinnCore.Common.Services.Implementation
         }
 
         /// <inheritdoc/>
-        public Task<Instance> InsertData<T>(T dataToSerialize, Guid instanceId, Type type, string org, string appName, int instanceOwnerId)
+        public Task<Instance> InsertData<T>(T dataToSerialize, Guid instanceGuid, Type type, string org, string appName, int instanceOwnerId)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
             string testDataForParty = _settings.GetTestdataForPartyPath(org, appName, developer);
-            string dataPath = $"{testDataForParty}{instanceOwnerId}/{instanceId}/data";
+            string dataPath = $"{testDataForParty}{instanceOwnerId}/{instanceGuid}/data";
             if (!Directory.Exists(dataPath))
             {
                 Directory.CreateDirectory(dataPath);
             }
 
-            string instanceFilePath = $"{testDataForParty}{instanceOwnerId}/{instanceId}/{instanceId}.json";
+            string instanceFilePath = $"{testDataForParty}{instanceOwnerId}/{instanceGuid}/{instanceGuid}.json";
             string instanceData = File.ReadAllText(instanceFilePath);
             Instance instance = JsonConvert.DeserializeObject<Instance>(instanceData);
             string dataId = Guid.NewGuid().ToString();
@@ -75,7 +75,7 @@ namespace AltinnCore.Common.Services.Implementation
                 ElementType = FORM_ID,
                 ContentType = "application/Xml",
                 FileName = $"{dataId}.xml",
-                StorageUrl = $"{appName}/{instanceId}/data/{dataId}",
+                StorageUrl = $"{appName}/{instanceGuid}/data/{dataId}",
                 CreatedBy = instanceOwnerId.ToString(),
                 CreatedDateTime = DateTime.UtcNow,
                 LastChangedBy = instanceOwnerId.ToString(),
@@ -104,10 +104,10 @@ namespace AltinnCore.Common.Services.Implementation
         }
 
         /// <inheritdoc/>
-        public void UpdateData<T>(T dataToSerialize, Guid instanceId, Type type, string org, string appName, int instanceOwnerId, Guid dataId)
+        public void UpdateData<T>(T dataToSerialize, Guid instanceGuid, Type type, string org, string appName, int instanceOwnerId, Guid dataId)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
-            string dataPath = $"{_settings.GetTestdataForPartyPath(org, appName, developer)}{instanceOwnerId}/{instanceId}/data";
+            string dataPath = $"{_settings.GetTestdataForPartyPath(org, appName, developer)}{instanceOwnerId}/{instanceGuid}/data";
             string formDataFilePath = $"{dataPath}/{dataId}";
             try
             {
@@ -124,10 +124,10 @@ namespace AltinnCore.Common.Services.Implementation
         }
 
         /// <inheritdoc/>
-        public object GetFormData(Guid instanceId, Type type, string org, string appName, int instanceOwnerId, Guid dataId)
+        public object GetFormData(Guid instanceGuid, Type type, string org, string appName, int instanceOwnerId, Guid dataId)
         {
             string testDataForParty = _settings.GetTestdataForPartyPath(org, appName, AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext));
-            string formDataFilePath = $"{testDataForParty}{instanceOwnerId}/{instanceId}/data/{dataId}";
+            string formDataFilePath = $"{testDataForParty}{instanceOwnerId}/{instanceGuid}/data/{dataId}";
             XmlSerializer serializer = new XmlSerializer(type);
             try
             {
@@ -143,7 +143,7 @@ namespace AltinnCore.Common.Services.Implementation
         }
 
         /// <inheritdoc/>
-        public Task<List<AttachmentList>> GetFormAttachments(string org, string appName, int instanceOwnerId, Guid instanceId)
+        public Task<List<AttachmentList>> GetFormAttachments(string org, string appName, int instanceOwnerId, Guid instanceGuid)
         {
             Instance instance;
             List<AttachmentList> attachmentList = new List<AttachmentList>();
@@ -151,13 +151,13 @@ namespace AltinnCore.Common.Services.Implementation
             DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(Instance));
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
             string testDataForParty = _settings.GetTestdataForPartyPath(org, appName, developer);
-            string formDataFilePath = $"{testDataForParty}{instanceOwnerId}/{instanceId}/{instanceId}.json";
+            string formDataFilePath = $"{testDataForParty}{instanceOwnerId}/{instanceGuid}/{instanceGuid}.json";
             string instanceData = File.ReadAllText(formDataFilePath, Encoding.UTF8);
             instance = JsonConvert.DeserializeObject<Instance>(instanceData);
 
             if (instance == null)
             {
-                _logger.Log(LogLevel.Error, "Instance not found for instanceid {0}", instanceId);
+                _logger.Log(LogLevel.Error, "Instance not found for instanceGuid {0}", instanceGuid);
                 return Task.FromResult(attachmentList);
             }
 

--- a/src/AltinnCore/Common/Services/Interfaces/IData.cs
+++ b/src/AltinnCore/Common/Services/Interfaces/IData.cs
@@ -18,36 +18,36 @@ namespace AltinnCore.Common.Services.Interfaces
         /// </summary>
         /// <typeparam name="T">The type</typeparam>
         /// <param name="dataToSerialize">The app model to serialize</param>
-        /// <param name="instanceId">The instance id</param>
+        /// <param name="instanceGuid">The instance id</param>
         /// <param name="type">The type for serialization</param>
         /// <param name="org">The application owner id</param>
         /// <param name="appName">The application name</param>
         /// <param name="instanceOwnerId">The instance owner id</param>
-        Task<Instance> InsertData<T>(T dataToSerialize, Guid instanceId, Type type, string org, string appName, int instanceOwnerId);
+        Task<Instance> InsertData<T>(T dataToSerialize, Guid instanceGuid, Type type, string org, string appName, int instanceOwnerId);
 
         /// <summary>
         /// updates the form data
         /// </summary>
         /// <typeparam name="T">The type</typeparam>
         /// <param name="dataToSerialize">The form data to serialize</param>
-        /// <param name="instanceId">The instanceid</param>
+        /// <param name="instanceGuid">The instanceid</param>
         /// <param name="type">The type for serialization</param>
         /// <param name="org">The application owner id</param>
         /// <param name="appName">The application name</param>
         /// <param name="instanceOwnerId">The instance owner id</param>
         /// <param name="dataId">the data id</param>
-        void UpdateData<T>(T dataToSerialize, Guid instanceId, Type type, string org, string appName, int instanceOwnerId, Guid dataId);
+        void UpdateData<T>(T dataToSerialize, Guid instanceGuid, Type type, string org, string appName, int instanceOwnerId, Guid dataId);
 
         /// <summary>
         /// Gets the form data
         /// </summary>
-        /// <param name="instanceId">The instanceid</param>
+        /// <param name="instanceGuid">The instanceid</param>
         /// <param name="type">The type for serialization</param>
         /// <param name="org">The application owner id</param>
         /// <param name="appName">The application name</param>
         /// <param name="instanceOwnerId">The instance owner id</param>
         /// <param name="dataId">the data id</param>
-        object GetFormData(Guid instanceId, Type type, string org, string appName, int instanceOwnerId, Guid dataId);
+        object GetFormData(Guid instanceGuid, Type type, string org, string appName, int instanceOwnerId, Guid dataId);
 
         /// <summary>
         /// Method that gets metadata on form attachments ordered by attachmentType
@@ -55,9 +55,9 @@ namespace AltinnCore.Common.Services.Interfaces
         /// <param name="org">The organization for the service</param>
         /// <param name="appName">The application name</param>
         /// <param name="instanceOwnerId">The instance owner id</param>
-        /// <param name="instanceId">The instance id</param>
+        /// <param name="instanceGuid">The instance id</param>
         /// <returns>A list with attachments metadata ordered by attachmentType</returns>
-        Task<List<AttachmentList>> GetFormAttachments(string org, string appName, int instanceOwnerId, Guid instanceId);
+        Task<List<AttachmentList>> GetFormAttachments(string org, string appName, int instanceOwnerId, Guid instanceGuid);
 
         /// <summary>
         /// Method that removes a form attachments from disk/storage
@@ -65,10 +65,10 @@ namespace AltinnCore.Common.Services.Interfaces
         /// <param name="org">The organization for the service</param>
         /// <param name="appName">The application name</param>
         /// <param name="instanceOwnerId">The instance owner id</param>
-        /// <param name="instanceId">The instance id</param>
+        /// <param name="instanceGuid">The instance id</param>
         /// <param name="attachmentType">The attachment type</param>
         /// <param name="attachmentId">The attachment id</param>
-        void DeleteFormAttachment(string org, string appName, int instanceOwnerId, Guid instanceId, string attachmentType, string attachmentId);
+        void DeleteFormAttachment(string org, string appName, int instanceOwnerId, Guid instanceGuid, string attachmentType, string attachmentId);
 
         /// <summary>
         /// Method that saves a form attachments to disk/storage and returns its id
@@ -76,10 +76,10 @@ namespace AltinnCore.Common.Services.Interfaces
         /// <param name="org">The organization for the service</param>
         /// <param name="appName">The application name</param>
         /// <param name="instanceOwnerId">The instance owner id</param>
-        /// <param name="instanceId">The instance id</param>
+        /// <param name="instanceGuid">The instance id</param>
         /// <param name="attachmentType">The attachment type</param>
         /// <param name="attachmentName">The attachment name</param>
         /// <param name="attachment">The attachment to be saved</param>
-        Task<Guid> SaveFormAttachment(string org, string appName, int instanceOwnerId, Guid instanceId, string attachmentType, string attachmentName, HttpRequest attachment);
+        Task<Guid> SaveFormAttachment(string org, string appName, int instanceOwnerId, Guid instanceGuid, string attachmentType, string attachmentName, HttpRequest attachment);
     }
 }

--- a/src/AltinnCore/Runtime/Controllers/InstanceController.cs
+++ b/src/AltinnCore/Runtime/Controllers/InstanceController.cs
@@ -117,12 +117,12 @@ namespace AltinnCore.Runtime.Controllers
         /// </summary>
         /// <param name="org">the organisation</param>
         /// <param name="service">the service</param>
-        /// <param name="instanceId">the instance id</param>
+        /// <param name="instanceGuid">the instance guid</param>
         /// <param name="view">name of the view</param>
         /// <param name="itemId">the item id</param>
         /// <returns>The react view or the receipt</returns>
         [Authorize]
-        public async Task<IActionResult> EditSPA(string org, string service, Guid instanceId, string view, int? itemId)
+        public async Task<IActionResult> EditSPA(string org, string service, Guid instanceGuid, string view, int? itemId)
         {
             ViewBag.Org = org;
             ViewBag.App = service;
@@ -137,12 +137,13 @@ namespace AltinnCore.Runtime.Controllers
         /// </summary>
         /// <param name="org">The Organization code for the service owner.</param>
         /// <param name="service">The service code for the current service.</param>
-        /// <param name="instanceId">The instanceId.</param>
+        /// <param name="partyId">The partyId.</param>
+        /// <param name="instanceGuid">The instanceGuid.</param>
         /// <param name="view">The ViewName.</param>
         /// <returns>Redirect user to the receipt page.</returns>
         [Authorize]
         [HttpPost]
-        public async Task<IActionResult> CompleteAndSendIn(string org, string service, Guid instanceId, string view)
+        public async Task<IActionResult> CompleteAndSendIn(string org, string service, int partyId, Guid instanceGuid, string view)
         {
             // Dependency Injection: Getting the Service Specific Implementation based on the service parameter data store
             // Will compile code and load DLL in to memory for AltinnCore
@@ -154,20 +155,20 @@ namespace AltinnCore.Runtime.Controllers
             // Create and populate the RequestContext object and make it available for the service implementation so
             // service developer can implement logic based on information about the request and the user performing
             // the request
-            RequestContext requestContext = await PopulateRequestContext(instanceId);
+            RequestContext requestContext = await PopulateRequestContext(instanceGuid);
 
             serviceImplementation.SetPlatformServices(_platformSI);
 
             // Assign data to the ViewBag so it is available to the service views or service implementation
-            PopulateViewBag(org, service, instanceId, 0, requestContext, serviceContext, _platformSI);
+            PopulateViewBag(org, service, instanceGuid, 0, requestContext, serviceContext, _platformSI);
 
             // Getting the Form Data
-            Instance instance = await _instance.GetInstance(service, org, requestContext.UserContext.ReporteeId, instanceId);
+            Instance instance = await _instance.GetInstance(service, org, requestContext.UserContext.ReporteeId, instanceGuid);
             Guid.TryParse(instance.Data.Find(m => m.ElementType == FORM_ID).Id, out Guid dataId);
-            object serviceModel = _data.GetFormData(instanceId, serviceImplementation.GetServiceModelType(), org, service, requestContext.UserContext.ReporteeId, dataId);
+            object serviceModel = _data.GetFormData(instanceGuid, serviceImplementation.GetServiceModelType(), org, service, requestContext.UserContext.ReporteeId, dataId);
             serviceImplementation.SetServiceModel(serviceModel);
 
-            ViewBag.FormID = instanceId;
+            ViewBag.FormID = instanceGuid;
             ViewBag.ServiceContext = serviceContext;
 
             serviceImplementation.SetContext(requestContext, serviceContext, null, ModelState);
@@ -176,11 +177,11 @@ namespace AltinnCore.Runtime.Controllers
             ApiResult apiResult = new ApiResult();
             if (ModelState.IsValid)
             {
-                ServiceState currentState = _workflowSI.MoveServiceForwardInWorkflow(instanceId, org, service, requestContext.UserContext.ReporteeId);
+                ServiceState currentState = _workflowSI.MoveServiceForwardInWorkflow(instanceGuid, org, service, requestContext.UserContext.ReporteeId);
 
                 if (currentState.State == WorkflowStep.Archived)
                 {
-                    await _instance.ArchiveInstance(serviceModel, serviceImplementation.GetServiceModelType(), service, org, requestContext.UserContext.ReporteeId, instanceId);
+                    await _instance.ArchiveInstance(serviceModel, serviceImplementation.GetServiceModelType(), service, org, requestContext.UserContext.ReporteeId, instanceGuid);
                     apiResult.NextState = currentState.State;
                 }
 
@@ -217,9 +218,10 @@ namespace AltinnCore.Runtime.Controllers
         /// </summary>
         /// <param name="org">The Organization code for the service owner.</param>
         /// <param name="service">The service code for the current service.</param>
-        /// <param name="instanceId">The instanceId.</param>
+        /// <param name="partyId">The partyId.</param>
+        /// <param name="instanceGuid">The instanceGuid.</param>
         /// <returns>The receipt view.</returns>
-        public async Task<IActionResult> Receipt(string org, string service, Guid instanceId)
+        public async Task<IActionResult> Receipt(string org, string service, int partyId, Guid instanceGuid)
         {
             // Dependency Injection: Getting the Service Specific Implementation based on the service parameter data store
             // Will compile code and load DLL in to memory for AltinnCore
@@ -231,18 +233,18 @@ namespace AltinnCore.Runtime.Controllers
             // Create and populate the RequestContext object and make it available for the service implementation so
             // service developer can implement logic based on information about the request and the user performing
             // the request
-            RequestContext requestContext = RequestHelper.GetRequestContext(Request.Query, instanceId);
+            RequestContext requestContext = RequestHelper.GetRequestContext(Request.Query, instanceGuid);
             requestContext.UserContext = await _userHelper.GetUserContext(HttpContext);
             requestContext.Reportee = requestContext.UserContext.Reportee;
 
             serviceImplementation.SetPlatformServices(_platformSI);
 
             // Assign data to the ViewBag so it is available to the service views or service implementation
-            PopulateViewBag(org, service, instanceId, 0, requestContext, serviceContext, _platformSI);
+            PopulateViewBag(org, service, instanceGuid, 0, requestContext, serviceContext, _platformSI);
 
-            object serviceModel = _archive.GetArchivedServiceModel(instanceId, serviceImplementation.GetServiceModelType(), org, service, requestContext.Reportee.PartyId);
+            object serviceModel = _archive.GetArchivedServiceModel(instanceGuid, serviceImplementation.GetServiceModelType(), org, service, requestContext.Reportee.PartyId);
             List<ServiceInstance> formInstances = _testdata.GetFormInstances(requestContext.Reportee.PartyId, org, service);
-            string properInstanceId = $"{requestContext.Reportee}/{instanceId}";
+            string properInstanceId = $"{requestContext.Reportee}/{instanceGuid}";
 
             ViewBag.ServiceInstance = formInstances.Find(i => i.ServiceInstanceID == properInstanceId);
 
@@ -283,14 +285,10 @@ namespace AltinnCore.Runtime.Controllers
         [HttpPost]
         public async Task<dynamic> InstantiateApp(StartServiceModel startServiceModel)
         {
-            _logger.LogInformation($"//InstanceController  // InstanciateApp // Starting function");
-
             // Dependency Injection: Getting the Service Specific Implementation based on the service parameter data store
             // Will compile code and load DLL in to memory for AltinnCore
             bool startService = true;
             IServiceImplementation serviceImplementation = _execution.GetServiceImplementation(startServiceModel.Org, startServiceModel.Service, startService);
-
-            _logger.LogInformation($"//InstanceController  // InstanciateApp // Completefd GetServiceImplementation");
 
             // Get the service context containing metadata about the service
             ServiceContext serviceContext = _execution.GetServiceContext(startServiceModel.Org, startServiceModel.Service, startService);
@@ -357,8 +355,6 @@ namespace AltinnCore.Runtime.Controllers
 
                 // Create a new instance document
                 Instance instance = await _instance.InstantiateInstance(startServiceModel, serviceModel, serviceImplementation);
-
-                _logger.LogInformation($"//InstanceController // InstantiateApp // instance is null =  {instance == null}");
 
                 // Create and store the instance created event
                 InstanceEvent instanceEvent = new InstanceEvent
@@ -499,7 +495,6 @@ namespace AltinnCore.Runtime.Controllers
                }).ToList();
 
             HttpContext.Response.Cookies.Append("altinncorereportee", startServiceModel.PartyId.ToString());
-            _logger.LogInformation($" // 404 // Setting startService Model view: {startServiceModel} ");
             return View(startServiceModel);
         }
 
@@ -508,14 +503,14 @@ namespace AltinnCore.Runtime.Controllers
         /// </summary>
         /// <param name="org">The Organization code for the service owner.</param>
         /// <param name="service">The service code for the current service.</param>
-        /// <param name="instanceId">The instance id.</param>
+        /// <param name="instanceGuid">The instance id.</param>
         /// <param name="reporteeId">The reportee id.</param>
         /// <returns>An api response containing the current ServiceState.</returns>
         [Authorize]
         [HttpGet]
-        public IActionResult GetCurrentState(string org, string service, Guid instanceId, int reporteeId)
+        public IActionResult GetCurrentState(string org, string service, Guid instanceGuid, int reporteeId)
         {
-            return new ObjectResult(_workflowSI.GetCurrentState(instanceId, org, service, reporteeId));
+            return new ObjectResult(_workflowSI.GetCurrentState(instanceGuid, org, service, reporteeId));
         }
 
         /// <summary>
@@ -523,9 +518,10 @@ namespace AltinnCore.Runtime.Controllers
         /// </summary>
         /// <param name="org">the organisation.</param>
         /// <param name="service">the service.</param>
-        /// <param name="instanceId">the instance id.</param>
+        /// <param name="partyId">The partyId.</param>
+        /// <param name="instanceGuid">The instanceGuid.</param>
         /// <returns>The api response.</returns>
-        public async Task<IActionResult> ModelValidation(string org, string service, Guid instanceId)
+        public async Task<IActionResult> ModelValidation(string org, string service, int partyId, Guid instanceGuid)
         {
             // Dependency Injection: Getting the Service Specific Implementation based on the service parameter data store
             // Will compile code and load DLL in to memory for AltinnCore
@@ -534,7 +530,7 @@ namespace AltinnCore.Runtime.Controllers
             // Create and populate the RequestContext object and make it available for the service implementation so
             // service developer can implement logic based on information about the request and the user performing
             // the request
-            RequestContext requestContext = RequestHelper.GetRequestContext(Request.Query, instanceId);
+            RequestContext requestContext = RequestHelper.GetRequestContext(Request.Query, instanceGuid);
             requestContext.UserContext = await _userHelper.GetUserContext(HttpContext);
             requestContext.Reportee = requestContext.UserContext.Reportee;
             requestContext.Form = Request.Form;
@@ -549,12 +545,12 @@ namespace AltinnCore.Runtime.Controllers
             // Set the platform services to the ServiceImplementation so the AltinnCore service can take
             // use of the plattform services
             serviceImplementation.SetPlatformServices(_platformSI);
-            Instance instance = await _instance.GetInstance(service, org, requestContext.UserContext.ReporteeId, instanceId);
+            Instance instance = await _instance.GetInstance(service, org, requestContext.UserContext.ReporteeId, instanceGuid);
             Guid.TryParse(instance.Data.Find(m => m.ElementType == FORM_ID).Id, out Guid dataId);
 
             // Getting the populated form data from disk
             dynamic serviceModel = _data.GetFormData(
-                instanceId,
+                instanceGuid,
                 serviceImplementation.GetServiceModelType(),
                 org,
                 service,
@@ -591,16 +587,16 @@ namespace AltinnCore.Runtime.Controllers
         /// <param name="org">The organization for the service</param>
         /// <param name="service">The name of the service</param>
         /// <param name="partyId">The party id of the test user</param>
-        /// <param name="instanceId">The instance id</param>
+        /// <param name="instanceGuid">The instance guid</param>
         /// <param name="attachmentType">The attachment type id</param>
         /// <param name="attachmentName">The name of the attachment</param>
         /// <returns>The status of the upload and guid of attachment</returns>
         [HttpPost]
         [Authorize]
         [DisableFormValueModelBinding]
-        public async System.Threading.Tasks.Task<IActionResult> SaveFormAttachment(string org, string service, int partyId, Guid instanceId, string attachmentType, string attachmentName)
+        public async System.Threading.Tasks.Task<IActionResult> SaveFormAttachment(string org, string service, int partyId, Guid instanceGuid, string attachmentType, string attachmentName)
         {
-            Guid guid = await _data.SaveFormAttachment(org, service, partyId, instanceId, attachmentType, attachmentName, Request);
+            Guid guid = await _data.SaveFormAttachment(org, service, partyId, instanceGuid, attachmentType, attachmentName, Request);
 
             return Ok(new { id = guid });
         }
@@ -611,16 +607,16 @@ namespace AltinnCore.Runtime.Controllers
         /// <param name="org">The organization for the service</param>
         /// <param name="service">The name of the service</param>
         /// <param name="partyId">The party id of the test user</param>
-        /// <param name="instanceId">The instance id</param>
+        /// <param name="instanceGuid">The instance guid</param>
         /// <param name="attachmentType">The attachment type id</param>
         /// <param name="attachmentId">The attachment id</param>
         /// <returns>The status of the deletion</returns>
         [HttpPost]
         [Authorize]
         [DisableFormValueModelBinding]
-        public IActionResult DeleteFormAttachment(string org, string service, int partyId, Guid instanceId, string attachmentType, string attachmentId)
+        public IActionResult DeleteFormAttachment(string org, string service, int partyId, Guid instanceGuid, string attachmentType, string attachmentId)
         {
-            _data.DeleteFormAttachment(org, service, partyId, instanceId, attachmentType, attachmentId);
+            _data.DeleteFormAttachment(org, service, partyId, instanceGuid, attachmentType, attachmentId);
             return Ok();
         }
 
@@ -630,23 +626,23 @@ namespace AltinnCore.Runtime.Controllers
         /// <param name="org">The organization for the service</param>
         /// <param name="service">The name of the service</param>
         /// <param name="partyId">The party id of the test user</param>
-        /// <param name="instanceId">The instance id</param>
+        /// <param name="instanceGuid">The instance guid</param>
         /// <returns>A list with attachments metadata ordered by attachmentType</returns>
         [HttpGet]
         [Authorize]
         [DisableFormValueModelBinding]
-        public async Task<IActionResult> GetFormAttachments(string org, string service, int partyId, Guid instanceId)
+        public async Task<IActionResult> GetFormAttachments(string org, string service, int partyId, Guid instanceGuid)
         {
-            List<AttachmentList> allAttachments = await _data.GetFormAttachments(org, service, partyId, instanceId);
+            List<AttachmentList> allAttachments = await _data.GetFormAttachments(org, service, partyId, instanceGuid);
             return Ok(allAttachments);
         }
 
-        private async Task<RequestContext> PopulateRequestContext(Guid instanceId)
+        private async Task<RequestContext> PopulateRequestContext(Guid instanceGuid)
         {
             // Create and populate the RequestContext object and make it available for the service implementation so
             // service developer can implement logic based on information about the request and the user performing
             // the request
-            RequestContext requestContext = RequestHelper.GetRequestContext(Request.Query, instanceId);
+            RequestContext requestContext = RequestHelper.GetRequestContext(Request.Query, instanceGuid);
             requestContext.UserContext = await _userHelper.GetUserContext(HttpContext);
             requestContext.Reportee = requestContext.UserContext.Reportee;
             if (Request.Method.Equals("post"))
@@ -657,13 +653,13 @@ namespace AltinnCore.Runtime.Controllers
             return requestContext;
         }
 
-        private void PopulateViewBag(string org, string service, Guid instanceId, int? itemId, RequestContext requestContext, ServiceContext serviceContext, IPlatformServices platformServices)
+        private void PopulateViewBag(string org, string service, Guid instanceGuid, int? itemId, RequestContext requestContext, ServiceContext serviceContext, IPlatformServices platformServices)
         {
             ViewBag.RequestContext = requestContext;
             ViewBag.ServiceContext = serviceContext;
             ViewBag.Org = org;
             ViewBag.Service = service;
-            ViewBag.FormID = instanceId;
+            ViewBag.FormID = instanceGuid;
             ViewBag.PlatformServices = platformServices;
 
             if (itemId.HasValue)

--- a/src/AltinnCore/Runtime/Startup.cs
+++ b/src/AltinnCore/Runtime/Startup.cs
@@ -292,14 +292,14 @@ namespace AltinnCore.Runtime
                     });
                 routes.MapRoute(
                     name: "uiRoute",
-                    template: "{org}/{service}/{instanceId}/{action}/{view|validation?}/{itemId?}",
+                    template: "{org}/{service}/{partyId}/{instanceGuid}/{action}/{view|validation?}/{itemId?}",
                     defaults: new { controller = "Instance" },
                     constraints: new
                     {
                         action = "CompleteAndSendIn|Lookup|ModelValidation|Receipt|StartService|ViewPrint|edit",
                         controller = "Instance",
                         service = "[a-zA-Z][a-zA-Z0-9_\\-]{2,30}",
-                        instanceId = @"^(\{{0,1}([0-9a-fA-F]){8}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){12}\}{0,1})$",
+                        instanceGuid = @"^(\{{0,1}([0-9a-fA-F]){8}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){12}\}{0,1})$",
                     });
 
                 routes.MapRoute(
@@ -399,13 +399,13 @@ namespace AltinnCore.Runtime
 
                 routes.MapRoute(
                     name: "apiAttachmentRoute",
-                    template: "{org}/{service}/api/attachment/{partyId}/{instanceId}/{action}",
+                    template: "{org}/{service}/api/attachment/{partyId}/{instanceGuid}/{action}",
                     defaults: new { controller = "Instance" },
                     constraints: new
                     {
                         controller = "Instance",
                         service = "[a-zA-Z][a-zA-Z0-9_\\-]{2,30}",
-                        instanceId = @"^(\{{0,1}([0-9a-fA-F]){8}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){12}\}{0,1})$",
+                        instanceGuid = @"^(\{{0,1}([0-9a-fA-F]){8}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){12}\}{0,1})$",
                     });
 
                 routes.MapRoute(

--- a/src/react-apps/applications/runtime/src/App.tsx
+++ b/src/react-apps/applications/runtime/src/App.tsx
@@ -9,7 +9,7 @@ export default function() {
     <>
       <Route path={'/'} exact={true} component={ServiceInfo} />
       <Route path={'/instantiate'} exact={true} component={Instantiate} />
-      <Route path={'/instance/:instanceId'} component={FormFiller} />
+      <Route path={'/instance/:partyId/:instanceGuid'} component={FormFiller} />
     </>
   );
 }

--- a/src/react-apps/applications/runtime/src/App.tsx
+++ b/src/react-apps/applications/runtime/src/App.tsx
@@ -9,7 +9,7 @@ export default function() {
     <>
       <Route path={'/'} exact={true} component={ServiceInfo} />
       <Route path={'/instantiate'} exact={true} component={Instantiate} />
-      <Route path={'/instance/:partyId/:instanceId'} component={FormFiller} />
+      <Route path={'/instance/:instanceId'} component={FormFiller} />
     </>
   );
 }

--- a/src/react-apps/applications/runtime/src/components/GenericComponent.tsx
+++ b/src/react-apps/applications/runtime/src/components/GenericComponent.tsx
@@ -43,8 +43,8 @@ export class GenericComponentClass extends React.Component<IGenericComponentProp
     const component = this.props.layoutElement as ILayoutComponent;
     if (component && component.triggerValidation) {
       const altinnWindow: IAltinnWindow = window as IAltinnWindow;
-      const { org, service, instanceId, reportee } = altinnWindow;
-      const url = `${window.location.origin}/${org}/${service}/api/${reportee}/${instanceId}`;
+      const { org, service, instanceId } = altinnWindow;
+      const url = `${window.location.origin}/${org}/${service}/api/${instanceId}`;
       ValidationActions.runSingleFieldValidation(url, dataModelField);
     }
     const dataModelElement = this.props.dataModel.find(

--- a/src/react-apps/applications/runtime/src/components/base/ButtonComponent.tsx
+++ b/src/react-apps/applications/runtime/src/components/base/ButtonComponent.tsx
@@ -55,16 +55,16 @@ export class ButtonComponentClass extends React.Component<IButtonProps, IButtonS
 
   public saveFormData = () => {
     const altinnWindow: IAltinnWindow = window as IAltinnWindow;
-    const { reportee, org, service, instanceId } = altinnWindow;
+    const { org, service, instanceId } = altinnWindow;
     FormDataActions.submitFormData(
-      `${window.location.origin}/${org}/${service}/api/${reportee}/${instanceId}`,
+      `${window.location.origin}/${org}/${service}/api/${instanceId}`,
     );
   }
 
   public submitForm = () => {
-    const { reportee, org, service, instanceId } = window as IAltinnWindow;
+    const {org, service, instanceId } = window as IAltinnWindow;
     FormDataActions.submitFormData(
-      `${window.location.origin}/${org}/${service}/api/${reportee}/${instanceId}`,
+      `${window.location.origin}/${org}/${service}/api/${instanceId}`,
       'Complete',
     );
   }

--- a/src/react-apps/applications/runtime/src/features/form/containers/index.tsx
+++ b/src/react-apps/applications/runtime/src/features/form/containers/index.tsx
@@ -17,9 +17,13 @@ export default (props) => {
   const {
     match: {
       params: {
+        partyId,
+        instanceGuid,
       },
     },
   } = props;
+
+  (window as IAltinnWindow).instanceId = partyId  + '/' + instanceGuid;
 
   React.useEffect(() => {
     const { org, service, instanceId } = window as IAltinnWindow;

--- a/src/react-apps/applications/runtime/src/features/form/containers/index.tsx
+++ b/src/react-apps/applications/runtime/src/features/form/containers/index.tsx
@@ -17,16 +17,12 @@ export default (props) => {
   const {
     match: {
       params: {
-        instanceId,
-        partyId,
       },
     },
   } = props;
 
-  (window as IAltinnWindow).instanceId = instanceId;
-  (window as IAltinnWindow).partyId = partyId;
   React.useEffect(() => {
-    const { org, service } = window as IAltinnWindow;
+    const { org, service, instanceId } = window as IAltinnWindow;
     LanguageActions.fetchLanguage(
       `${window.location.origin}/${org}/${service}/api/Language/GetLanguageAsJSON`,
       'nb',
@@ -38,14 +34,14 @@ export default (props) => {
       `${window.location.origin}/${org}/${service}/api/resource/FormLayout.json`,
     );
     FormDataActions.fetchFormData(
-      `${window.location.origin}/${org}/${service}/api/${partyId}/${instanceId}`,
+      `${window.location.origin}/${org}/${service}/api/${instanceId}`,
     );
     FormRuleActions.fetchRuleModel(
       `${window.location.origin}/${org}/${service}/api/resource/RuleHandler.js`,
     );
     FormWorkflowActions.getCurrentState(
       // tslint:disable-next-line:max-line-length
-      `${window.location.origin}/${org}/${service}/api/workflow/${partyId}/${instanceId}/GetCurrentState`,
+      `${window.location.origin}/${org}/${service}/api/workflow/${instanceId}/GetCurrentState`,
     );
 
     FormDynamicActions.fetchFormDynamics(

--- a/src/react-apps/applications/runtime/src/features/instantiate/containers/index.tsx
+++ b/src/react-apps/applications/runtime/src/features/instantiate/containers/index.tsx
@@ -44,6 +44,7 @@ function ServiceInfo(props) {
 
       if (response.data.instanceId) {
         setInstanceId(response.data.instanceId);
+        (window as any).instanceId = response.data.instanceId;
       } else {
         setInstantiationError(new Error(
           'Server responded without instanceId',

--- a/src/react-apps/applications/runtime/src/shared/resources/attachments/delete/deleteAttachmentSagas.ts
+++ b/src/react-apps/applications/runtime/src/shared/resources/attachments/delete/deleteAttachmentSagas.ts
@@ -24,7 +24,7 @@ export function* deleteAttachmentSaga(
     const altinnWindow: IAltinnWindow = window as IAltinnWindow;
     const { org, service, instanceId, reportee } = altinnWindow;
     const servicePath = `${org}/${service}`;
-    const deleteUrl = `${altinnWindow.location.origin}/${servicePath}/api/attachment/${reportee}/` +
+    const deleteUrl = `${altinnWindow.location.origin}/${servicePath}/api/attachment/` +
     `${instanceId}/DeleteFormAttachment?attachmentType=${attachmentType}&attachmentId=${attachment.id}`;
     const response = yield call(post, deleteUrl);
     if (response.status === 200) {

--- a/src/react-apps/applications/runtime/src/shared/resources/attachments/fetch/fetchAttachmentsSagas.ts
+++ b/src/react-apps/applications/runtime/src/shared/resources/attachments/fetch/fetchAttachmentsSagas.ts
@@ -16,7 +16,7 @@ export function* fetchAttachments(): SagaIterator {
     const altinnWindow: IAltinnWindow = window as IAltinnWindow;
     const { org, service, instanceId } = altinnWindow;
     const servicePath = `${org}/${service}`;
-    const attachmentListUrl = `${altinnWindow.location.origin}/${servicePath}/api/attachment/`+
+    const attachmentListUrl = `${altinnWindow.location.origin}/${servicePath}/api/attachment/` +
     `${instanceId}/GetFormAttachments`;
     const response = yield call(get, attachmentListUrl);
     const attachments: IAttachments = mapAttachmentListApiResponseToAttachments(response);

--- a/src/react-apps/applications/runtime/src/shared/resources/attachments/fetch/fetchAttachmentsSagas.ts
+++ b/src/react-apps/applications/runtime/src/shared/resources/attachments/fetch/fetchAttachmentsSagas.ts
@@ -1,6 +1,7 @@
 import { SagaIterator } from 'redux-saga';
 import { call, takeLatest } from 'redux-saga/effects';
-import { IAltinnWindow, IAttachments } from '..';
+import { IAttachments } from '..';
+import { IAltinnWindow } from '../../../../types';
 import { mapAttachmentListApiResponseToAttachments } from '../../../../utils/attachment';
 import { get } from '../../../../utils/networking';
 import AttachmentDispatcher from '../attachmentActions';
@@ -13,9 +14,9 @@ export function* watchFetchAttachmentsSaga(): SagaIterator {
 export function* fetchAttachments(): SagaIterator {
   try {
     const altinnWindow: IAltinnWindow = window as IAltinnWindow;
-    const { org, service, instanceId, reportee } = altinnWindow;
+    const { org, service, instanceId } = altinnWindow;
     const servicePath = `${org}/${service}`;
-    const attachmentListUrl = `${altinnWindow.location.origin}/${servicePath}/api/attachment/${reportee}/` +
+    const attachmentListUrl = `${altinnWindow.location.origin}/${servicePath}/api/attachment/`+
     `${instanceId}/GetFormAttachments`;
     const response = yield call(get, attachmentListUrl);
     const attachments: IAttachments = mapAttachmentListApiResponseToAttachments(response);

--- a/src/react-apps/applications/runtime/src/shared/resources/attachments/upload/uploadAttachmentSagas.ts
+++ b/src/react-apps/applications/runtime/src/shared/resources/attachments/upload/uploadAttachmentSagas.ts
@@ -22,7 +22,7 @@ export function* uploadAttachmentSaga(
     const servicePath = `${org}/${service}`;
     const data = new FormData();
     data.append('file', file);
-    const fileUploadLink = `${altinnWindow.location.origin}/${servicePath}/api/attachment/${reportee}/` +
+    const fileUploadLink = `${altinnWindow.location.origin}/${servicePath}/api/attachment/` +
       `${instanceId}/SaveFormAttachment?attachmentType=${attachmentType}&attachmentName=${file.name}`;
     const response = yield call(post, fileUploadLink, null, data);
     if (response.status === 200) {

--- a/src/react-apps/applications/ux-editor/src/containers/Container.tsx
+++ b/src/react-apps/applications/ux-editor/src/containers/Container.tsx
@@ -93,9 +93,9 @@ export class ContainerComponent extends React.Component<IContainerProps, IContai
     const component = this.props.components[id];
     if (component && component.triggerValidation) {
       const altinnWindow: IAltinnWindow = window as IAltinnWindow;
-      const { org, service, instanceId, reportee } = altinnWindow;
+      const { org, service, instanceId } = altinnWindow;
       FormFillerActionDispatchers.runSingleFieldValidation(
-        `${window.location.origin}/${org}/${service}/api/${reportee}/${instanceId}`,
+        `${window.location.origin}/${org}/${service}/api/${instanceId}`,
         dataBindingName,
       );
     }

--- a/src/react-apps/applications/ux-editor/src/containers/FormFiller.tsx
+++ b/src/react-apps/applications/ux-editor/src/containers/FormFiller.tsx
@@ -63,16 +63,16 @@ export class FormFillerComponent extends React.Component<IFormFillerProps, IForm
 
   public saveFormData = () => {
     const altinnWindow: IAltinnWindow = window as IAltinnWindow;
-    const { reportee, org, service, instanceId } = altinnWindow;
+    const { org, service, instanceId } = altinnWindow;
     FormFillerActionDispatchers.submitFormData(`
-        ${window.location.origin}/${org}/${service}/api/${reportee}/${instanceId}`);
+        ${window.location.origin}/${org}/${service}/api/${instanceId}`);
   }
 
   public submitForm = () => {
     const altinnWindow: IAltinnWindow = window as IAltinnWindow;
-    const { reportee, org, service, instanceId } = altinnWindow;
+    const { org, service, instanceId } = altinnWindow;
     FormFillerActionDispatchers.submitFormData(`
-      ${window.location.origin}/${org}/${service}/api/${reportee}/${instanceId}`, 'Complete');
+      ${window.location.origin}/${org}/${service}/api/${instanceId}`, 'Complete');
   }
 
   public renderSaveButton = () => {


### PR DESCRIPTION
Changes frontend
-  Updated structure of instanceId in IAltinnWindow frontend. InstanceGuid was used as instanceId consistently. Terms have been updated, and requestes as well.

Changes backend
- IData, DataAppSI and DataStudioSI updated to differ between instanceId and instanceGuid
- Removed authentication header on request content for requests related to attachments
- Updated routing in Runtime to split instanceId into partyId and instanceGuid, but only for routes that were failing. 