### PR TITLE
Removing add altinnParty cookie in authenticationController

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -107,14 +107,7 @@ namespace Altinn.Platform.Authentication.Controllers
                             {
                                 Response.Cookies.Append(_generalSettings.GetSBLCookieName, userAuthentication.EncryptedTicket);
                             }
-                            
-                            Response.Cookies.Append(
-                                _generalSettings.GetAltinnPartyCookieName,
-                                userAuthentication.PartyID.ToString(),
-                                new CookieOptions
-                                {
-                                    Domain = _generalSettings.HostName
-                                });
+
                             return Redirect(goTo);
                         }
                         else


### PR DESCRIPTION
Cookie set in SBL, so no need to add it here any longer. 
Will be set by runtime if cookie is updated by app frontend.