### PR TITLE
partyType -> partyTypeName

### DIFF
--- a/src/AltinnCore/Testdata/Party/10001/party.json
+++ b/src/AltinnCore/Testdata/Party/10001/party.json
@@ -1,6 +1,6 @@
 ﻿{
   "PartyId": "10001",
-  "PartyType": "Organization",
+  "PartyTypeName": "Organization",
   "Name": "Kari Consulting",
   "Organization": {
     "OrganizationId": "1",

--- a/src/AltinnCore/Testdata/Party/10002/party.json
+++ b/src/AltinnCore/Testdata/Party/10002/party.json
@@ -1,6 +1,6 @@
 ﻿{
   "PartyId": "10002",
-  "PartyType": "Organization",
+  "PartyTypeName": "Organization",
   "Name": "Frisk & Sporty Oslo",
   "Organization": {
     "OrganizationId": "2",

--- a/src/AltinnCore/Testdata/Party/10003/party.json
+++ b/src/AltinnCore/Testdata/Party/10003/party.json
@@ -1,6 +1,6 @@
 ﻿{
   "PartyId": "10003",
-  "PartyType": "Organization",
+  "PartyTypeName": "Organization",
   "Name": "Frisk & Sporty Bergen",
   "Organization": {
     "OrganizationId": "3",

--- a/src/AltinnCore/Testdata/Party/10004/party.json
+++ b/src/AltinnCore/Testdata/Party/10004/party.json
@@ -1,6 +1,6 @@
 ﻿{
   "PartyId": "10004",
-  "PartyType": "Organization",
+  "PartyTypeName": "Organization",
   "Name": "Frisk & Sporty Trondheim",
   "Organization": {
     "OrganizationId": "4",

--- a/src/AltinnCore/Testdata/Party/50001/party.json
+++ b/src/AltinnCore/Testdata/Party/50001/party.json
@@ -1,6 +1,6 @@
 ﻿{
   "PartyId": "50001",
-  "PartyType": "Person",
+  "PartyTypeName": "Person",
   "Name": "Ola Privatperson",
   "Person": {
     "PersonId": "1",

--- a/src/AltinnCore/Testdata/Party/50002/party.json
+++ b/src/AltinnCore/Testdata/Party/50002/party.json
@@ -1,6 +1,6 @@
 ﻿{
   "PartyId": "50002",
-  "PartyType": "Person",
+  "PartyTypeName": "Person",
   "Name" :  "Kari Selvstendig",
   "Person": {
     "PersonId": "2",

--- a/src/AltinnCore/Testdata/Party/50003/party.json
+++ b/src/AltinnCore/Testdata/Party/50003/party.json
@@ -1,6 +1,6 @@
 ﻿{
   "PartyId": "50003",
-  "PartyType": "Person",
+  "PartyTypeName": "Person",
   "Name": "Anne Sophie Næringslivsleder",
   "Person": {
     "PersonId": "3",

--- a/src/AltinnCore/Testdata/Party/50004/party.json
+++ b/src/AltinnCore/Testdata/Party/50004/party.json
@@ -1,6 +1,6 @@
 ﻿{
   "PartyId": "50004",
-  "PartyType": "Person",
+  "PartyTypeName": "Person",
   "Name": "Pål Revisor",
   "Person": {
     "PersonId": "4",


### PR DESCRIPTION
Parameter name in model i partyTypeName, in testdata it is simply defined as partyType. Updating the enum to start at 1 caused the studio implementation to fail as field was instantiated as 0 which happened to coincide with the correct partyType