### PR TITLE
Fix applicationmetadata to be stored correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,5 @@ coverage
 /src/Altinn.Platform/Altinn.Platform.Storage/Storage/values.dev.yaml
 /src/Altinn.Platform/Altinn.Platform.Profile/Profile/charts/profile
 /src/Altinn.Platform/Altinn.Platform.Profile/Profile/azds.yaml
+src/Altinn.ExampleClients/PrefillClient/Properties/launchSettings.json
+src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/MultipartTest.cs

--- a/src/AltinnCore/Common/Services/Implementation/RepositorySI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/RepositorySI.cs
@@ -170,14 +170,15 @@ namespace AltinnCore.Common.Services.Implementation
         /// <summary>
         /// Creates the application metadata file
         /// </summary>
-        /// <param name="org">the application owner</param>
-        /// <param name="appName">the application name</param>
-        public void CreateApplication(string org, string appName)
+        /// <param name="org">The organisation code for the application owner</param>
+        /// <param name="app">the application name, e.g. "app-name-with-spaces"</param>
+        /// <param name="appTitle">the application UI title, e.g. "App name with spaces"</param>
+        public void CreateApplication(string org, string app, string appTitle)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
             Application appMetadata = new Application
             {
-                Id = ApplicationHelper.GetFormattedApplicationId(org, appName),
+                Id = ApplicationHelper.GetFormattedApplicationId(org, app),
                 VersionId = null,
                 Org = org,
 
@@ -186,9 +187,9 @@ namespace AltinnCore.Common.Services.Implementation
                 LastChangedDateTime = DateTime.UtcNow,
                 LastChangedBy = developer
             };
-
+            
             appMetadata.Title = new Dictionary<string, string>();
-            appMetadata.Title.Add("nb", appName);
+            appMetadata.Title.Add("nb", appTitle);
 
             appMetadata.ElementTypes = new List<Altinn.Platform.Storage.Models.ElementType>();
             appMetadata.ElementTypes.Add(new Altinn.Platform.Storage.Models.ElementType
@@ -200,7 +201,7 @@ namespace AltinnCore.Common.Services.Implementation
 
             string metaDataDir = _settings.GetMetadataPath(
                                     org,
-                                    appName,
+                                    app,
                                     developer);
             DirectoryInfo metaDirectoryInfo = new DirectoryInfo(metaDataDir);
             if (!metaDirectoryInfo.Exists)
@@ -1123,7 +1124,7 @@ namespace AltinnCore.Common.Services.Implementation
                 };
 
                 CreateServiceMetadata(metadata);
-                CreateApplication(owner, serviceConfig.ServiceName);
+                CreateApplication(owner, serviceConfig.RepositoryName, serviceConfig.ServiceName);
 
                 if (!string.IsNullOrEmpty(serviceConfig.ServiceName))
                 {

--- a/src/AltinnCore/Common/Services/Implementation/RepositorySI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/RepositorySI.cs
@@ -172,8 +172,8 @@ namespace AltinnCore.Common.Services.Implementation
         /// </summary>
         /// <param name="org">The organisation code for the application owner</param>
         /// <param name="app">The application name, e.g. "app-name-with-spaces"</param>
-        /// <param name="appTitleNb">The application title, e.g. "app name with spaces", at the moment it get stored as Norwegian title ("nb")</param>
-        public void CreateApplication(string org, string app, string appTitleNb)
+        /// <param name="appTitle">The application title in default language (nb), e.g. "app name with spaces"</param>
+        public void CreateApplication(string org, string app, string appTitle)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
             Application appMetadata = new Application
@@ -189,7 +189,7 @@ namespace AltinnCore.Common.Services.Implementation
             };
 
             appMetadata.Title = new Dictionary<string, string>();
-            appMetadata.Title.Add("nb", appTitleNb ?? app);
+            appMetadata.Title.Add("nb", appTitle ?? app);
 
             appMetadata.ElementTypes = new List<Altinn.Platform.Storage.Models.ElementType>();
             appMetadata.ElementTypes.Add(new Altinn.Platform.Storage.Models.ElementType

--- a/src/AltinnCore/Common/Services/Implementation/RepositorySI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/RepositorySI.cs
@@ -189,7 +189,7 @@ namespace AltinnCore.Common.Services.Implementation
             };
 
             appMetadata.Title = new Dictionary<string, string>();
-            appMetadata.Title.Add("nb", string.IsNullOrEmpty(appTitleNb) ? app : appTitleNb);
+            appMetadata.Title.Add("nb", appTitleNb ?? app);
 
             appMetadata.ElementTypes = new List<Altinn.Platform.Storage.Models.ElementType>();
             appMetadata.ElementTypes.Add(new Altinn.Platform.Storage.Models.ElementType

--- a/src/AltinnCore/Common/Services/Implementation/RepositorySI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/RepositorySI.cs
@@ -171,9 +171,9 @@ namespace AltinnCore.Common.Services.Implementation
         /// Creates the application metadata file
         /// </summary>
         /// <param name="org">The organisation code for the application owner</param>
-        /// <param name="app">the application name, e.g. "app-name-with-spaces"</param>
-        /// <param name="appTitle">the application UI title, e.g. "App name with spaces"</param>
-        public void CreateApplication(string org, string app, string appTitle)
+        /// <param name="app">The application name, e.g. "app-name-with-spaces"</param>
+        /// <param name="appTitleNb">The application title, e.g. "app name with spaces", at the moment it get stored as Norwegian title ("nb")</param>
+        public void CreateApplication(string org, string app, string appTitleNb)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
             Application appMetadata = new Application
@@ -187,9 +187,9 @@ namespace AltinnCore.Common.Services.Implementation
                 LastChangedDateTime = DateTime.UtcNow,
                 LastChangedBy = developer
             };
-            
+
             appMetadata.Title = new Dictionary<string, string>();
-            appMetadata.Title.Add("nb", appTitle);
+            appMetadata.Title.Add("nb", string.IsNullOrEmpty(appTitleNb) ? app : appTitleNb);
 
             appMetadata.ElementTypes = new List<Altinn.Platform.Storage.Models.ElementType>();
             appMetadata.ElementTypes.Add(new Altinn.Platform.Storage.Models.ElementType

--- a/src/AltinnCore/Common/Services/Interfaces/IRepository.cs
+++ b/src/AltinnCore/Common/Services/Interfaces/IRepository.cs
@@ -463,9 +463,10 @@ namespace AltinnCore.Common.Services.Interfaces
         /// <summary>
         /// creates application  metadata for attachment
         /// </summary>
-        /// <param name="org">the organisation that owns the application</param>
-        /// <param name="appName">the application name</param>
-        void CreateApplication(string org, string appName);
+        /// <param name="org">The organisation code for the application owner</param>
+        /// <param name="app">the application name, e.g. "app-name-with-spaces"</param>
+        /// <param name="appTitle">the application UI title, e.g. "App name with spaces"</param>
+        void CreateApplication(string org, string app, string appTitle);
 
         /// <summary>
         /// Updates application metadata

--- a/src/AltinnCore/Common/Services/Interfaces/IRepository.cs
+++ b/src/AltinnCore/Common/Services/Interfaces/IRepository.cs
@@ -465,8 +465,8 @@ namespace AltinnCore.Common.Services.Interfaces
         /// </summary>
         /// <param name="org">The organisation code for the application owner</param>
         /// <param name="app">the application name, e.g. "app-name-with-spaces"</param>
-        /// <param name="appTitle">the application UI title, e.g. "App name with spaces"</param>
-        void CreateApplication(string org, string app, string appTitle);
+        /// <param name="appTitleNb">The application title, e.g. "app name with spaces", at the moment it get stored as Norwegian title ("nb")</param>
+        void CreateApplication(string org, string app, string appTitleNb);
 
         /// <summary>
         /// Updates application metadata

--- a/src/AltinnCore/Designer/Controllers/ApplicationMetadataController.cs
+++ b/src/AltinnCore/Designer/Controllers/ApplicationMetadataController.cs
@@ -85,10 +85,8 @@ namespace Designer.Controllers
             }
             else
             {
-                // At the moment we send empty string as application title until we support multiple
-                // languages (it will now get set to the "app" value in the CreateApplication method
-                // if title is undefined).
-                _repository.CreateApplication(org, app, string.Empty);
+                // TO DO: Application title handling (issue #2053/#1725)
+                _repository.CreateApplication(org, app, app);
                 Application createdApplication = _repository.GetApplication(org, app);
                 if (createdApplication == null)
                 {

--- a/src/AltinnCore/Designer/Controllers/ApplicationMetadataController.cs
+++ b/src/AltinnCore/Designer/Controllers/ApplicationMetadataController.cs
@@ -85,7 +85,7 @@ namespace Designer.Controllers
             }
             else
             {
-                _repository.CreateApplication(org, app);
+                _repository.CreateApplication(org, app, string.Empty);
                 Application createdApplication = _repository.GetApplication(org, app);
                 if (createdApplication == null)
                 {

--- a/src/AltinnCore/Designer/Controllers/ApplicationMetadataController.cs
+++ b/src/AltinnCore/Designer/Controllers/ApplicationMetadataController.cs
@@ -85,6 +85,9 @@ namespace Designer.Controllers
             }
             else
             {
+                // At the moment we send empty string as application title until we support multiple
+                // languages (it will now get set to the "app" value in the CreateApplication method
+                // if title is undefined).
                 _repository.CreateApplication(org, app, string.Empty);
                 Application createdApplication = _repository.GetApplication(org, app);
                 if (createdApplication == null)

--- a/src/AltinnCore/Designer/Controllers/DeployController.cs
+++ b/src/AltinnCore/Designer/Controllers/DeployController.cs
@@ -65,13 +65,14 @@ namespace AltinnCore.Designer.Controllers
         /// <summary>
         /// Start a new deployment
         /// </summary>
-        /// <param name="org">The Organization code for the application owner</param>
-        /// <param name="appName">The application code for the current service</param>
+        /// <param name="org">The organisation code for the application owner</param>
+        /// <param name="app">The application name</param>
+        // /// <param name="appTitle">The application title, e.g. "app name with spaces"</param>
         /// <returns>The result of trying to start a new deployment</returns>
         [HttpPost]
-        public async Task<IActionResult> StartDeployment(string org, string appName)
+        public async Task<IActionResult> StartDeployment(string org, string app)
         {
-            if (org == null || appName == null)
+            if (org == null || app == null)
             {
                 return BadRequest(new DeploymentStatus
                 {
@@ -90,7 +91,7 @@ namespace AltinnCore.Designer.Controllers
                 });
             }
 
-            Repository repository = _giteaAPI.GetRepository(org, appName).Result;
+            Repository repository = _giteaAPI.GetRepository(org, app).Result;
 
             if (repository != null && repository.Permissions != null && repository.Permissions.Push != true)
             {
@@ -105,10 +106,10 @@ namespace AltinnCore.Designer.Controllers
             string credentials = _configuration["AccessTokenDevOps"];
 
             string result = string.Empty;
-            Branch masterBranch = _giteaAPI.GetBranch(org, appName, "master").Result;
+            Branch masterBranch = _giteaAPI.GetBranch(org, app, "master").Result;
             if (masterBranch == null)
             {
-                _logger.LogWarning($"Unable to fetch branch information for app owner {org} and app {appName}");
+                _logger.LogWarning($"Unable to fetch branch information for app owner {org} and app {app}");
                 return StatusCode(500, new DeploymentResponse
                 {
                     Success = false,
@@ -117,10 +118,10 @@ namespace AltinnCore.Designer.Controllers
             }
 
             // register application in platform storage
-            bool applicationInStorage = await RegisterApplicationInStorage(org, appName, masterBranch.Commit.Id);
+            bool applicationInStorage = await RegisterApplicationInStorage(org, app, masterBranch.Commit.Id);
             if (!applicationInStorage)
             {
-                _logger.LogWarning($"Unable to deploy app {appName} for {org} to Platform Storage");
+                _logger.LogWarning($"Unable to deploy app {app} for {org} to Platform Storage");
                 return StatusCode(500, new DeploymentResponse
                 {
                     Success = false,
@@ -141,7 +142,7 @@ namespace AltinnCore.Designer.Controllers
                         {
                             id = 5,
                         },
-                        parameters = $"{{\"APP_OWNER\":\"{org}\",\"APP_REPO\":\"{appName}\",\"APP_DEPLOY_TOKEN\":\"{_sourceControl.GetDeployToken()}\",\"GITEA_ENVIRONMENT\":\"{giteaEnvironment}\", \"APP_COMMIT_ID\":\"{masterBranch.Commit.Id}\",\"should_deploy\":\"{true}\"}}\"",
+                        parameters = $"{{\"APP_OWNER\":\"{org}\",\"APP_REPO\":\"{app}\",\"APP_DEPLOY_TOKEN\":\"{_sourceControl.GetDeployToken()}\",\"GITEA_ENVIRONMENT\":\"{giteaEnvironment}\", \"APP_COMMIT_ID\":\"{masterBranch.Commit.Id}\",\"should_deploy\":\"{true}\"}}\"",
                     };
 
                     string buildjson = JsonConvert.SerializeObject(buildContent);
@@ -157,7 +158,7 @@ namespace AltinnCore.Designer.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"Unable deploy app {appName} for {org} because {ex}");
+                _logger.LogWarning($"Unable deploy app {app} for {org} because {ex}");
                 return StatusCode(500, new DeploymentResponse
                 {
                     Success = false,
@@ -229,23 +230,26 @@ namespace AltinnCore.Designer.Controllers
             });
         }
 
-        private async Task<bool> RegisterApplicationInStorage(string org, string appName, string versionId)
+        private async Task<bool> RegisterApplicationInStorage(string org, string app, string versionId)
         {
             bool applicationInStorage = false;
 
-            Application applicationFromRepository = _repository.GetApplication(org, appName);
+            Application applicationFromRepository = _repository.GetApplication(org, app);
 
-            // for old service application meta data file was not generated, so create the application meta data file
+            // for old services the application meta data file was not generated, so create the application meta data file
             // but the metadata for attachment will not be available on deployment
             if (applicationFromRepository == null)
             {
-                _repository.CreateApplication(org, appName, string.Empty);
-                applicationFromRepository = _repository.GetApplication(org, appName);
+                // At the moment we send empty string as application title until we support multiple
+                // languages (it will now get set to the "app" value in the CreateApplication method
+                // if title is undefined).
+                _repository.CreateApplication(org, app, string.Empty);
+                applicationFromRepository = _repository.GetApplication(org, app);
             }
 
             using (HttpClient client = new HttpClient())
             {
-                string appId = $"{org}/{appName}";
+                string appId = $"{org}/{app}";
                 string storageEndpoint = _platformSettings.GetApiStorageEndpoint;
                 _logger.LogInformation($"Client url {storageEndpoint}");
 

--- a/src/AltinnCore/Designer/Controllers/DeployController.cs
+++ b/src/AltinnCore/Designer/Controllers/DeployController.cs
@@ -239,7 +239,7 @@ namespace AltinnCore.Designer.Controllers
             // but the metadata for attachment will not be available on deployment
             if (applicationFromRepository == null)
             {
-                _repository.CreateApplication(org, appName);
+                _repository.CreateApplication(org, appName, string.Empty);
                 applicationFromRepository = _repository.GetApplication(org, appName);
             }
 

--- a/src/AltinnCore/Designer/Controllers/DeployController.cs
+++ b/src/AltinnCore/Designer/Controllers/DeployController.cs
@@ -67,7 +67,6 @@ namespace AltinnCore.Designer.Controllers
         /// </summary>
         /// <param name="org">The organisation code for the application owner</param>
         /// <param name="app">The application name</param>
-        // /// <param name="appTitle">The application title, e.g. "app name with spaces"</param>
         /// <returns>The result of trying to start a new deployment</returns>
         [HttpPost]
         public async Task<IActionResult> StartDeployment(string org, string app)
@@ -236,7 +235,7 @@ namespace AltinnCore.Designer.Controllers
 
             Application applicationFromRepository = _repository.GetApplication(org, app);
 
-            // for old services the application meta data file was not generated, so create the application meta data file
+            // for old apps the application meta data file was not generated, so create the application meta data file
             // but the metadata for attachment will not be available on deployment
             if (applicationFromRepository == null)
             {

--- a/src/AltinnCore/Designer/Controllers/DeployController.cs
+++ b/src/AltinnCore/Designer/Controllers/DeployController.cs
@@ -240,10 +240,8 @@ namespace AltinnCore.Designer.Controllers
             // but the metadata for attachment will not be available on deployment
             if (applicationFromRepository == null)
             {
-                // At the moment we send empty string as application title until we support multiple
-                // languages (it will now get set to the "app" value in the CreateApplication method
-                // if title is undefined).
-                _repository.CreateApplication(org, app, string.Empty);
+                // TO DO: Application title handling (issue #2053/#1725)
+                _repository.CreateApplication(org, app, app);
                 applicationFromRepository = _repository.GetApplication(org, app);
             }
 


### PR DESCRIPTION
The method CreateApplication (in RepositorySI.cs) received the wrong variable, so the applicationmetadata.json file was saved in a different folder instead of the correct and existing application folder.