### PR TITLE
Added lock on instanceGuid to IData app and studio.  

### DIFF
--- a/src/AltinnCore/Common/Services/Implementation/DataStudioSI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/DataStudioSI.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Runtime.Serialization.Json;
 using System.Text;
 using System.Threading.Tasks;
@@ -31,6 +30,9 @@ namespace AltinnCore.Common.Services.Implementation
         private readonly ILogger _logger;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private const string FORM_ID = "default";
+
+        private static readonly Dictionary<Guid, object> InstanceGuard = new Dictionary<Guid, object>();
+        private static object instanceGuardLock = new object();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DataStudioSI"/> class.
@@ -66,25 +68,33 @@ namespace AltinnCore.Common.Services.Implementation
             }
 
             string instanceFilePath = $"{testDataForParty}{instanceOwnerId}/{instanceGuid}/{instanceGuid}.json";
-            string instanceData = File.ReadAllText(instanceFilePath);
-            Instance instance = JsonConvert.DeserializeObject<Instance>(instanceData);
-            string dataId = Guid.NewGuid().ToString();
-            DataElement data = new DataElement
-            {
-                Id = dataId,
-                ElementType = FORM_ID,
-                ContentType = "application/Xml",
-                FileName = $"{dataId}.xml",
-                StorageUrl = $"{appName}/{instanceGuid}/data/{dataId}",
-                CreatedBy = instanceOwnerId.ToString(),
-                CreatedDateTime = DateTime.UtcNow,
-                LastChangedBy = instanceOwnerId.ToString(),
-                LastChangedDateTime = DateTime.UtcNow,
-            };
 
-            instance.Data = new List<DataElement> { data };
-            string instanceDataAsString = JsonConvert.SerializeObject(instance);
-            File.WriteAllText(instanceFilePath, instanceDataAsString);
+            string dataId = Guid.NewGuid().ToString();
+            Instance instance = null;
+
+            lock (Guard(instanceGuid))
+            {
+                string instanceData = File.ReadAllText(instanceFilePath);
+                instance = JsonConvert.DeserializeObject<Instance>(instanceData);
+
+                DataElement data = new DataElement
+                {
+                    Id = dataId,
+                    ElementType = FORM_ID,
+                    ContentType = "application/Xml",
+                    FileName = $"{dataId}.xml",
+                    StorageUrl = $"{appName}/{instanceGuid}/data/{dataId}",
+                    CreatedBy = instanceOwnerId.ToString(),
+                    CreatedDateTime = DateTime.UtcNow,
+                    LastChangedBy = instanceOwnerId.ToString(),
+                    LastChangedDateTime = DateTime.UtcNow,
+                };
+
+                instance.Data = new List<DataElement> { data };
+                string instanceDataAsString = JsonConvert.SerializeObject(instance);
+
+                File.WriteAllText(instanceFilePath, instanceDataAsString);
+            }
 
             string formDataFilePath = $"{dataPath}/{dataId}";
             try
@@ -101,6 +111,23 @@ namespace AltinnCore.Common.Services.Implementation
             }
 
             return Task.FromResult(instance);
+        }
+
+        private static object Guard(Guid instanceGuid)
+        {
+            object result;
+
+            lock (instanceGuardLock)
+            {
+                if (!InstanceGuard.ContainsKey(instanceGuid))
+                {
+                    InstanceGuard.Add(instanceGuid, new object());
+                }
+
+                result = InstanceGuard[instanceGuid];
+            }
+
+            return result;             
         }
 
         /// <inheritdoc/>
@@ -161,8 +188,12 @@ namespace AltinnCore.Common.Services.Implementation
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
             string testDataForParty = _settings.GetTestdataForPartyPath(org, appName, developer);
             string formDataFilePath = $"{testDataForParty}{instanceOwnerId}/{instanceGuid}/{instanceGuid}.json";
-            string instanceData = File.ReadAllText(formDataFilePath, Encoding.UTF8);
-            instance = JsonConvert.DeserializeObject<Instance>(instanceData);
+
+            lock (Guard(instanceGuid))
+            {
+                string instanceData = File.ReadAllText(formDataFilePath, Encoding.UTF8);
+                instance = JsonConvert.DeserializeObject<Instance>(instanceData);
+            }
 
             if (instance == null)
             {
@@ -203,15 +234,19 @@ namespace AltinnCore.Common.Services.Implementation
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
             string testDataForParty = _settings.GetTestdataForPartyPath(org, appName, developer);
             string instanceFilePath = $"{testDataForParty}{instanceOwnerId}/{instanceId}/{instanceId}.json";
-            string instanceData = File.ReadAllText(instanceFilePath);
 
-            Instance instance = JsonConvert.DeserializeObject<Instance>(instanceData);
-            DataElement removeFile = instance.Data.Find(m => m.Id == attachmentId);
+            lock (Guard(instanceId))
+            {
+                string instanceData = File.ReadAllText(instanceFilePath);
 
-            instance.Data.Remove(removeFile);
+                Instance instance = JsonConvert.DeserializeObject<Instance>(instanceData);
+                DataElement removeFile = instance.Data.Find(m => m.Id == attachmentId);
 
-            string instanceDataAsString = JsonConvert.SerializeObject(instance);
-            File.WriteAllText(instanceFilePath, instanceDataAsString);
+                instance.Data.Remove(removeFile);
+
+                string instanceDataAsString = JsonConvert.SerializeObject(instance);
+                File.WriteAllText(instanceFilePath, instanceDataAsString);
+            }
 
             string pathToDelete = $"{_settings.GetTestdataForPartyPath(org, appName, developer)}{instanceOwnerId}/{instanceId}/data/{attachmentId}";
             File.Delete(pathToDelete);
@@ -235,35 +270,40 @@ namespace AltinnCore.Common.Services.Implementation
 
             string testDataForParty = _settings.GetTestdataForPartyPath(org, appName, developer);
             string instanceFilePath = $"{testDataForParty}{instanceOwnerId}/{instanceId}/{instanceId}.json";
-            string instanceData = File.ReadAllText(instanceFilePath);
-
             FileExtensionContentTypeProvider provider = new FileExtensionContentTypeProvider();
             provider.TryGetContentType(attachmentName, out string contentType);
 
-            Instance instance = JsonConvert.DeserializeObject<Instance>(instanceData);
-
-            DataElement data = new DataElement
+            lock (Guard(instanceId))
             {
-                Id = dataId.ToString(),
-                ElementType = attachmentType,
-                ContentType = contentType,
-                FileName = attachmentName,
-                StorageUrl = $"{appName}/{instanceId}/data/{dataId}",
-                CreatedBy = instanceOwnerId.ToString(),
-                CreatedDateTime = DateTime.UtcNow,
-                LastChangedBy = instanceOwnerId.ToString(),
-                LastChangedDateTime = DateTime.UtcNow,
-                FileSize = filesize
-            };
-            if (instance.Data == null)
-            {
-                instance.Data = new List<DataElement>();
-            }
+                string instanceData = File.ReadAllText(instanceFilePath);
 
-            instance.Data.Add(data);
+                Instance instance = JsonConvert.DeserializeObject<Instance>(instanceData);
 
-            string instanceDataAsString = JsonConvert.SerializeObject(instance);
-            File.WriteAllText(instanceFilePath, instanceDataAsString);
+                DataElement data = new DataElement
+                {
+                    Id = dataId.ToString(),
+                    ElementType = attachmentType,
+                    ContentType = contentType,
+                    FileName = attachmentName,
+                    StorageUrl = $"{appName}/{instanceId}/data/{dataId}",
+                    CreatedBy = instanceOwnerId.ToString(),
+                    CreatedDateTime = DateTime.UtcNow,
+                    LastChangedBy = instanceOwnerId.ToString(),
+                    LastChangedDateTime = DateTime.UtcNow,
+                    FileSize = filesize
+                };
+                if (instance.Data == null)
+                {
+                    instance.Data = new List<DataElement>();
+                }
+
+                instance.Data.Add(data);
+
+                string instanceDataAsString = JsonConvert.SerializeObject(instance);
+
+                File.WriteAllText(instanceFilePath, instanceDataAsString);
+            }          
+
             return dataId;
         }
     }

--- a/src/AltinnCore/Runtime/Controllers/InstanceController.cs
+++ b/src/AltinnCore/Runtime/Controllers/InstanceController.cs
@@ -606,9 +606,14 @@ namespace AltinnCore.Runtime.Controllers
         [Authorize]
         [DisableFormValueModelBinding]
         [RequestSizeLimit(REQUEST_SIZE_LIMIT)]
-        public async System.Threading.Tasks.Task<IActionResult> SaveFormAttachment(string org, string service, int partyId, Guid instanceGuid, string attachmentType, string attachmentName)
+        public async Task<IActionResult> SaveFormAttachment(string org, string service, int partyId, Guid instanceGuid, string attachmentType, string attachmentName)
         {
             Guid guid = await _data.SaveFormAttachment(org, service, partyId, instanceGuid, attachmentType, attachmentName, Request);
+
+            if (guid == Guid.Empty)
+            {
+                return StatusCode(500, $"Cannot store form attachment on instance {partyId}/{instanceGuid}");
+            }
 
             return Ok(new { id = guid });
         }


### PR DESCRIPTION
Problem: multiple parallel updates (saveAttachment) on same instance object failed occasionally, both in studio and app. The locking mechanism forces multiple requests in parallel to the same instanceGuid to wait until the lock is lifted. 