### PR TITLE
Feature/1718 refresh jwt token frontend

### DIFF
--- a/src/AltinnCore/Common/Services/Implementation/AuthenticationAppSI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/AuthenticationAppSI.cs
@@ -52,18 +52,16 @@ namespace AltinnCore.Common.Services.Implementation
         public async Task<HttpResponseMessage> RefreshToken()
         {
             string endpointUrl = $"refresh";
-            string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _cookieOptions.Cookie.Name);
+            string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, "AltinnStudioRuntime");
             JwtTokenUtil.AddTokenToRequestHeader(_client, token);
             HttpResponseMessage response = await _client.GetAsync(endpointUrl);
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
                 string refreshedToken = GetCookieValueFromResponse(response, Constants.General.RuntimeCookieName);
-                using (HttpResponseMessage result = new HttpResponseMessage(response.StatusCode))
-                {
-                    result.Content = new StringContent(refreshedToken);
-                    return result;
-                }
+                HttpResponseMessage result = new HttpResponseMessage(response.StatusCode);
+                result.Content = new StringContent(refreshedToken);
+                return result;
             }
 
             _logger.LogError($"Refreshing JwtToken failed with status code {response.StatusCode}");

--- a/src/AltinnCore/Common/Services/Implementation/AuthenticationAppSI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/AuthenticationAppSI.cs
@@ -58,9 +58,12 @@ namespace AltinnCore.Common.Services.Implementation
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
-                string refreshedToken = GetCookieValueFromResponse(response, Common.Constants.General.RuntimeCookieName);
-                HttpResponseMessage m = new HttpResponseMessage(response.StatusCode);
-                m.Content = new StringContent(refreshedToken);
+                string refreshedToken = GetCookieValueFromResponse(response, Constants.General.RuntimeCookieName);
+                using (HttpResponseMessage result = new HttpResponseMessage(response.StatusCode))
+                {
+                    result.Content = new StringContent(refreshedToken);
+                    return result;
+                }
             }
 
             _logger.LogError($"Refreshing JwtToken failed with status code {response.StatusCode}");

--- a/src/AltinnCore/Common/Services/Implementation/AuthenticationStudioSI.cs
+++ b/src/AltinnCore/Common/Services/Implementation/AuthenticationStudioSI.cs
@@ -1,0 +1,25 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using AltinnCore.Authentication.JwtCookie;
+using AltinnCore.Authentication.Utils;
+using AltinnCore.Common.Clients;
+using AltinnCore.Common.Configuration;
+using AltinnCore.Common.Services.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AltinnCore.Common.Services.Implementation
+{
+    /// <summary>
+    /// Implementation for authentication service
+    /// </summary>
+    public class AuthenticationStudioSI : IAuthentication
+    {
+        /// <inheritdoc />
+        public Task<HttpResponseMessage> RefreshToken()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/AltinnCore/Runtime/Startup.cs
+++ b/src/AltinnCore/Runtime/Startup.cs
@@ -89,6 +89,7 @@ namespace AltinnCore.Runtime
                 services.AddSingleton<IProfile, ProfileStudioSI>();
                 services.AddSingleton<IInstanceEvent, InstanceEventStudioSI>();
                 services.AddSingleton<IAuthorization, AuthorizationStudioSI>();
+                services.AddSingleton<IAuthentication, AuthenticationStudioSI>();
                 services.AddSingleton<IHttpClientAccessor, HttpClientAccessor>();
             }
             else

--- a/src/AltinnCore/Runtime/Startup.cs
+++ b/src/AltinnCore/Runtime/Startup.cs
@@ -106,6 +106,7 @@ namespace AltinnCore.Runtime
                 services.AddSingleton<IInstanceEvent, InstanceEventAppSI>();
                 services.AddSingleton<IHttpClientAccessor, HttpClientAccessor>();
                 services.AddSingleton<IAuthorization, AuthorizationAppSI>();
+                services.AddSingleton<IAuthentication, AuthenticationAppSI>();
             }
 
             services.AddSingleton<IPlatformServices, PlatformStudioSI>();
@@ -463,7 +464,7 @@ namespace AltinnCore.Runtime
                     {
                         controller = "Language",
                     });
-                
+
                 routes.MapRoute(
                   name: "authorization",
                   template: "{org}/{service}/api/{controller}/parties/{partyId}/validate",

--- a/src/react-apps/applications/runtime/src/App.tsx
+++ b/src/react-apps/applications/runtime/src/App.tsx
@@ -31,6 +31,12 @@ export default function() {
     window.addEventListener('onfocus', refreshJwtToken);
   }
 
+  function removeEventListeners() {
+    window.removeEventListener('mousemove', refreshJwtToken);
+    window.removeEventListener('scroll', refreshJwtToken);
+    window.removeEventListener('onfocus', refreshJwtToken);
+  }
+
   function refreshJwtToken() {
     const timeNow = Date.now();
     if ((timeNow - lastRefreshTokenTimestamp) > ONE_MINUTE_IN_MILLISECONDS) {
@@ -52,6 +58,9 @@ export default function() {
     ApplicationMetadataActions.getApplicationMetadata();
     PartyActions.getParties();
     setUpEventListeners();
+    return function cleanup() {
+      removeEventListeners();
+    };
   }, []);
 
   return (

--- a/src/react-apps/applications/runtime/src/App.tsx
+++ b/src/react-apps/applications/runtime/src/App.tsx
@@ -13,6 +13,7 @@ import ProfileActions from './shared/resources/profile/profileActions';
 import TextResourcesActions from './shared/resources/textResources/actions';
 import { get } from './utils/networking';
 import {
+  getEnvironmentLoginUrl,
   languageUrl,
   profileApiUrl,
   refreshJwtTokenUrl,
@@ -42,11 +43,13 @@ export default function() {
     if ((timeNow - lastRefreshTokenTimestamp) > ONE_MINUTE_IN_MILLISECONDS) {
       lastRefreshTokenTimestamp = timeNow;
       get(refreshJwtTokenUrl)
-      .then(() => {
-        console.log('token refreshed');
-      })
       .catch((err) => {
-        console.error('token not refreshed', err);
+        // Most likely the user has an expired token, so we redirect to the login-page
+        try {
+          window.location.href = getEnvironmentLoginUrl();
+        } catch (error) {
+          console.error(err, error);
+        }
       });
     }
   }

--- a/src/react-apps/applications/runtime/src/App.tsx
+++ b/src/react-apps/applications/runtime/src/App.tsx
@@ -11,15 +11,38 @@ import LanguageActions from './shared/resources/language/languageActions';
 import PartyActions from './shared/resources/party/partyActions';
 import ProfileActions from './shared/resources/profile/profileActions';
 import TextResourcesActions from './shared/resources/textResources/actions';
-
+import { get } from './utils/networking';
 import {
   languageUrl,
   profileApiUrl,
+  refreshJwtTokenUrl,
 } from './utils/urlHelper';
 
 const theme = createMuiTheme(AltinnAppTheme);
 
 export default function() {
+  const [refreshTimestamp, setRefreshTimestamp] = React.useState<number>(Date.now());
+
+  function setUpEventListeners() {
+    window.addEventListener('mousemove', refreshJwtToken);
+    window.addEventListener('scroll', refreshJwtToken);
+    window.addEventListener('onfocus', refreshJwtToken);
+  }
+
+  function refreshJwtToken(event: MouseEvent | null) {
+    console.log('Maybe update token?', (Date.now() - refreshTimestamp) > 60000);
+    if ((Date.now() - refreshTimestamp) > 60000) {
+      get(refreshJwtTokenUrl)
+      .then(() => {
+        console.log('token refreshed');
+        setRefreshTimestamp(Date.now());
+      })
+      .catch((err) => {
+        console.error('token not refreshed', err);
+        setRefreshTimestamp(Date.now());
+      });
+    }
+  }
 
   React.useEffect(() => {
     TextResourcesActions.fetchTextResources();
@@ -27,7 +50,8 @@ export default function() {
     LanguageActions.fetchLanguage(languageUrl, 'nb');
     ApplicationMetadataActions.getApplicationMetadata();
     PartyActions.getParties();
-  });
+    setUpEventListeners();
+  }, []);
 
   return (
     <MuiThemeProvider theme={theme}>

--- a/src/react-apps/applications/runtime/src/App.tsx
+++ b/src/react-apps/applications/runtime/src/App.tsx
@@ -20,8 +20,10 @@ import {
 
 const theme = createMuiTheme(AltinnAppTheme);
 
+const ONE_MINUTE_IN_MILLISECONDS: number = 60000;
+
 export default function() {
-  const [refreshTimestamp, setRefreshTimestamp] = React.useState<number>(Date.now());
+  let lastRefreshTokenTimestamp: number = 0;
 
   function setUpEventListeners() {
     window.addEventListener('mousemove', refreshJwtToken);
@@ -29,17 +31,16 @@ export default function() {
     window.addEventListener('onfocus', refreshJwtToken);
   }
 
-  function refreshJwtToken(event: MouseEvent | null) {
-    console.log('Maybe update token?', (Date.now() - refreshTimestamp) > 60000);
-    if ((Date.now() - refreshTimestamp) > 60000) {
+  function refreshJwtToken() {
+    const timeNow = Date.now();
+    if ((timeNow - lastRefreshTokenTimestamp) > ONE_MINUTE_IN_MILLISECONDS) {
+      lastRefreshTokenTimestamp = timeNow;
       get(refreshJwtTokenUrl)
       .then(() => {
         console.log('token refreshed');
-        setRefreshTimestamp(Date.now());
       })
       .catch((err) => {
         console.error('token not refreshed', err);
-        setRefreshTimestamp(Date.now());
       });
     }
   }

--- a/src/react-apps/applications/runtime/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/react-apps/applications/runtime/src/features/instantiate/containers/PartySelection.tsx
@@ -169,7 +169,7 @@ function PartySelection(props: IPartySelectionProps) {
   }
 
   function getRepresentedPartyName(): string {
-    if (selectedParty.name === null) {
+    if (!selectedParty || selectedParty.name === null) {
       return '';
     }
     return capitalizeName(selectedParty.name);

--- a/src/react-apps/applications/runtime/src/store/index.ts
+++ b/src/react-apps/applications/runtime/src/store/index.ts
@@ -18,8 +18,8 @@ function configureStore(initialState?: any): Store<any> {
   let enhancer: any;
 
   if (process.env.NODE_ENV === 'development') {
-    const { logger } = require('redux-logger');
-    middlewares.push(logger);
+    // const { logger } = require('redux-logger');
+    // middlewares.push(logger);
     enhancer = composeWithDevTools(applyMiddleware(...middlewares));
   } else {
     enhancer = compose(applyMiddleware(...middlewares));

--- a/src/react-apps/applications/runtime/src/store/index.ts
+++ b/src/react-apps/applications/runtime/src/store/index.ts
@@ -18,8 +18,8 @@ function configureStore(initialState?: any): Store<any> {
   let enhancer: any;
 
   if (process.env.NODE_ENV === 'development') {
-    // const { logger } = require('redux-logger');
-    // middlewares.push(logger);
+    const { logger } = require('redux-logger');
+    middlewares.push(logger);
     enhancer = composeWithDevTools(applyMiddleware(...middlewares));
   } else {
     enhancer = compose(applyMiddleware(...middlewares));

--- a/src/react-apps/applications/runtime/src/utils/urlHelper.ts
+++ b/src/react-apps/applications/runtime/src/utils/urlHelper.ts
@@ -18,3 +18,4 @@ export const instantiateUrl: string = `${origin}/${org}/${service}/Instance/Inst
 export const currentPartyUrl: string = `${origin}/${org}/${service}/api/authorization/parties/current`;
 export const instancesControllerUrl: string = `${origin}/${org}/${service}/instances`;
 export const partySelectionUrl: string = `${origin}/${org}/${service}/#/partyselection`;
+export const refreshJwtTokenUrl: string = `${origin}/${org}/${service}/api/authentication/keepAlive`;

--- a/src/react-apps/applications/runtime/src/utils/urlHelper.ts
+++ b/src/react-apps/applications/runtime/src/utils/urlHelper.ts
@@ -19,3 +19,17 @@ export const currentPartyUrl: string = `${origin}/${org}/${service}/api/authoriz
 export const instancesControllerUrl: string = `${origin}/${org}/${service}/instances`;
 export const partySelectionUrl: string = `${origin}/${org}/${service}/#/partyselection`;
 export const refreshJwtTokenUrl: string = `${origin}/${org}/${service}/api/authentication/keepAlive`;
+
+export const getEnvironmentLoginUrl: () => string = () => {
+  // First split away the protocol 'https://' and take the last part. Then split on dots.
+  const domainSplitted: string[] = window.location.host.split('.');
+  if (domainSplitted.length === 5) {
+    return `https://platform.${domainSplitted[2]}.${domainSplitted[3]}.${domainSplitted[4]}` +
+      `/authentication/api/v1/authentication?goto=${window.location.href}`;
+  } else if (domainSplitted.length === 4) {
+    return `https://platform${domainSplitted[2]}.${domainSplitted[3]}` +
+      `/authentication/api/v1/authentication?goto=${window.location.href}`;
+  } else {
+    throw new Error('Unknown domain');
+  }
+};


### PR DESCRIPTION
The frontend will now trigger a refresh token request if the user does one of these events:
- Moves the mouse within the application
- Focuses the window where the tab is active or switches to the tab that the app is running in
- User scrolls in the application

This request will **only** run if it has been 1 minute since it last requested a fresh token.