### PR TITLE
App-backend  ignores errors from platform. Altinn studio issue #2655

### DIFF
--- a/src/AltinnCore/Common/Services/Implementation/PlatformClientException.cs
+++ b/src/AltinnCore/Common/Services/Implementation/PlatformClientException.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Net.Http;
+using System.Runtime.Serialization;
+
+namespace AltinnCore.Common.Services.Implementation
+{
+    /// <summary>
+    /// Exception class to hold exceptions when talking to the platform REST services
+    /// </summary>
+    [Serializable]
+    public class PlatformClientException : Exception
+    {
+        /// <summary>
+        /// the response message which is not a success.
+        /// </summary>
+        public HttpResponseMessage Response { get; }
+
+        /// <summary>
+        /// Copy the response for further investigations
+        /// </summary>
+        /// <param name="response">the response</param>
+        public PlatformClientException(HttpResponseMessage response) : base(ModifyMessage(response))
+        {
+            this.Response = response;
+        }
+
+        private static string ModifyMessage(HttpResponseMessage response)
+        {
+            string content = response.Content?.ReadAsStringAsync().Result;
+            string message = $"{(int)response.StatusCode} - {response.ReasonPhrase} - {content}";
+
+            return message;
+        }
+
+        /// <summary>
+        /// Just a single line
+        /// </summary>
+        /// <param name="message">the message</param>
+        public PlatformClientException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Inner exception
+        /// </summary>
+        public PlatformClientException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// C# stuff to what knows why
+        /// </summary>
+        protected PlatformClientException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/AltinnCore/UnitTest/Runtime/PlatformClientExceptionTest.cs
+++ b/src/AltinnCore/UnitTest/Runtime/PlatformClientExceptionTest.cs
@@ -11,6 +11,17 @@ namespace AltinnCore.UnitTest.Runtime
     public class PlatformClientExceptionTest
     {
         /// <summary>
+        /// Instantiate and format
+        /// </summary>
+        [Fact]
+        public void PlatformClientExceptionWithMessageOk()
+        {
+            PlatformClientException exception = new PlatformClientException("Something is wrong");
+
+            Assert.Equal("Something is wrong", exception.Message);
+        }
+
+        /// <summary>
         /// Instantiate and format the BadRequest message.
         /// </summary>
         [Fact]

--- a/src/AltinnCore/UnitTest/Runtime/PlatformClientExceptionTest.cs
+++ b/src/AltinnCore/UnitTest/Runtime/PlatformClientExceptionTest.cs
@@ -1,0 +1,45 @@
+using System.Net;
+using System.Net.Http;
+using AltinnCore.Common.Services.Implementation;
+using Xunit;
+
+namespace AltinnCore.UnitTest.Runtime
+{
+    /// <summary>
+    /// Tests the platformclient exception class.
+    /// </summary>
+    public class PlatformClientExceptionTest
+    {
+        /// <summary>
+        /// Instantiate and format the BadRequest message.
+        /// </summary>
+        [Fact]
+        public void PlatformClientFormatBadRequestOk()
+        {
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("content explanation"),
+            };
+
+            PlatformClientException exception = new PlatformClientException(response);
+
+            Assert.Equal("400 - Bad Request - content explanation", exception.Message);
+        }
+
+        /// <summary>
+        /// Instantiate and format the BadRequest message.
+        /// </summary>
+        [Fact]
+        public void PlatformClientFormat500Ok()
+        {
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("my error text"),
+            };
+
+            PlatformClientException exception = new PlatformClientException(response);
+
+            Assert.Equal("500 - Internal Server Error - my error text", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
When instantiating a prefill in Runtime there is a 500 error with no information: "Unable to create instance. Unknown error!"

Unfortunately we did not have any logging in place that allowed us to see what went wrong.
I haven't fixed the bug, but added better logging and throwing of exceptions.

Have added platform client exception if response code is other than success.
And added more logging.