### PR TITLE
remove redirect if no currently selected party

### DIFF
--- a/src/react-apps/applications/runtime/src/features/instantiate/containers/index.tsx
+++ b/src/react-apps/applications/runtime/src/features/instantiate/containers/index.tsx
@@ -139,13 +139,6 @@ function InstantiateContainer(props: IServiceInfoProps) {
     }
   }, [selectedParty, partyValidation, subscriptionHookValid, instantiating]);
 
-  if (selectedParty === undefined) {
-    return (
-      // Since a party is not selected, we shouldn't redirect with an error
-      <Redirect to={`/partyselection`}/>
-    );
-  }
-
   if (partyValidation !== null && !partyValidation.valid) {
     if (partyValidation.validParties.length === 0) {
       return (


### PR DESCRIPTION
Since the API in at21 is quite slower than in studio when it comes to fetching the current user based on cookie. And we only use it to check if the user has a selected party when instantiating (which is handled also by the backend) we shouldn't redirect if the value is undefined (before it gets fetched).

Bug issue #2637 