### PR TITLE
Feature/2761 netcore30 upgrade prefillclient

### DIFF
--- a/src/Altinn.ExampleClients/PrefillClient/PrefillClient.csproj
+++ b/src/Altinn.ExampleClients/PrefillClient/PrefillClient.csproj
@@ -1,13 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="1.2.3-alpha" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
   </ItemGroup>
 </Project>

--- a/src/Altinn.ExampleClients/PrefillClient/Program.cs
+++ b/src/Altinn.ExampleClients/PrefillClient/Program.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Net.Http;
 using System.Linq;
 using Newtonsoft.Json;
-using System.Text.RegularExpressions;
 using System.Collections.Generic;
 
 namespace Altinn.Clients.PrefillClient


### PR DESCRIPTION
Ready for QA.

Updates PrefillClient to .NET Core 3.0. 

Tested successfully with local run of program and connection to API to find instances and upload data as prefill (this program is only intended as stand-a-lone project, for our clients to have something to begin with as an example application when developing Prefill).