### PR TITLE
bug/2933 Add "not previously used" as clause for version number

### DIFF
--- a/src/AltinnCore/Common/Languages/ini/en.ini
+++ b/src/AltinnCore/Common/Languages/ini/en.ini
@@ -430,8 +430,8 @@ local_changes_cant_build = All changes are not pushed to master. You have to pus
 application_builds_based_on = The application build is based on
 build_version = Build version
 release_description = Describe the build
-release_versionnumber = Versionsnumber
-release_versionnumber_validation = May only contain numbers, lowercased letters (a-z) and special characters (.) and (-).
+release_versionnumber = Version number
+release_versionnumber_validation = May only contain numbers, lowercased letters (a-z) and special characters (.) and (-), and cannot have been previously used for this app.
 release_creating = Building a new version of the application, started by
 
 [app_create_release_errors]

--- a/src/AltinnCore/Common/Languages/ini/nb.ini
+++ b/src/AltinnCore/Common/Languages/ini/nb.ini
@@ -435,7 +435,7 @@ local_changes_cant_build = Alle endringer er ikke pushet til master. Du må push
 release_creating = Bygger en ny versjon av applikasjonen, startet av
 release_description = Beskriv innholdet i versjonen
 release_versionnumber = Versjonsnummer
-release_versionnumber_validation = Kan kun inneholde tall, små bokstaver (a-z) og spesialtegnene (.) og (-).
+release_versionnumber_validation = Kan kun inneholde tall, små bokstaver (a-z) og spesialtegnene (.) og (-), og kan ikke være brukt tidligere for denne applikasjonen.
 
 [app_create_release_errors]
 check_status_on_build_error = Oi! Vi opplever en teknisk feil og får derfor ikke oppdatert status på bygget. Vi forsøker å sjekke status på nytt...


### PR DESCRIPTION
Simple way of solving lack of information about version number needing to be unique.