### PR TITLE
Fix for NullReferenceException in ValidateInstance.

### DIFF
--- a/src/AltinnCore/Runtime/RestControllers/ValidateController.cs
+++ b/src/AltinnCore/Runtime/RestControllers/ValidateController.cs
@@ -83,7 +83,7 @@ namespace AltinnCore.Runtime.RestControllers
                 return NotFound();
             }
 
-            string taskId = instance.Process.CurrentTask.ElementId;
+            string taskId = instance.Process?.CurrentTask?.ElementId;
             if (taskId == null)
             {
                 throw new ValidationException("Unable to validate instance without a started process.");


### PR DESCRIPTION
Check that Process and Process.CurrentTask exists using the ?. accessor.