### PR TITLE
Removed MaxSize from Application model

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage.Interface/Models/Application.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage.Interface/Models/Application.cs
@@ -53,13 +53,6 @@ namespace Altinn.Platform.Storage.Interface.Models
         public string ProcessId { get; set; }
 
         /// <summary>
-        /// Maximum allowed size of all the data element files of an application instance in bytes.
-        /// If not set there is no limit on file size.
-        /// </summary>
-        [JsonProperty(PropertyName = "maxSize")]
-        public int? MaxSize { get; set; }
-
-        /// <summary>
         /// Gets or sets the data types, the allowed elements of an application instance.
         /// </summary>
         [JsonProperty(PropertyName = "dataTypes")]


### PR DESCRIPTION
After discussion with David and Terje it was decided not to implement validation in Storage. The validation in the Runtime shall control the amount and quality of the data.

A consequence of the decision is remove the MaxSize property is ApplcationModel, no longer needed.