### PR TITLE
provide component id for component updated by rule

### DIFF
--- a/src/react-apps/applications/runtime/src/features/form/rules/sagas/rule/index.ts
+++ b/src/react-apps/applications/runtime/src/features/form/rules/sagas/rule/index.ts
@@ -18,6 +18,7 @@ const selectFormdataModelConnection = (state: IRuntimeState): IDataModelState =>
 export interface IResponse {
   ruleShouldRun: boolean;
   dataBindingName: string;
+  componentId: string;
   result: string;
 }
 
@@ -41,11 +42,10 @@ function* checkIfRuleShouldRunSaga({
       repeatingContainerId,
       lastUpdatedDataBinding,
     );
-    if (rules.length > 0) {
-      const component = formLayoutState.layout.find((comp: any) => comp.id === lastUpdatedComponentId);
 
+    if (rules.length > 0) {
       yield all(rules.map((rule) => call(FormDataActions.updateFormData, rule.dataBindingName, rule.result,
-        component.id)));
+        rule.componentId)));
     }
 
   } catch (err) {

--- a/src/react-apps/applications/runtime/src/utils/rules/index.ts
+++ b/src/react-apps/applications/runtime/src/utils/rules/index.ts
@@ -77,7 +77,7 @@ export function checkIfRuleShouldRun(
             }
             if (layoutComponent.dataModelBindings[dataBindingKey] ===
               connectionDef.outParams.outParam0) {
-              updatedComponent = component;
+              updatedComponent = layoutElement.id;
               break;
             }
           }
@@ -96,6 +96,7 @@ export function checkIfRuleShouldRun(
             rules.push({
               ruleShouldRun: true,
               dataBindingName: updatedDataBinding.DataBindingName,
+              componentId: updatedComponent,
               result: result.toString(),
             });
           }


### PR DESCRIPTION
#2431 
The issue was that when running the updateFormData-action, the component id of the field that _triggered_ the validation was used, not the id of the updated component. This caused the validation to be run on the wrong field, and validation was therefore never triggered for the updated field.