### PR TITLE
Bug/3106 submit form issues

### DIFF
--- a/src/react-apps/applications/runtime/src/features/form/data/sagas/submit/index.ts
+++ b/src/react-apps/applications/runtime/src/features/form/data/sagas/submit/index.ts
@@ -64,6 +64,7 @@ function* submitFormSaga({ url, apiMode }: ISubmitDataAction): SagaIterator {
       yield call(FormDataActions.submitFormDataFulfilled);
     } else {
       FormValidationActions.updateValidations(validations);
+      return yield call(FormDataActions.submitFormDataRejected, null);
     }
   } catch (err) {
     console.error(err);

--- a/src/react-apps/applications/runtime/src/features/form/data/sagas/submit/index.ts
+++ b/src/react-apps/applications/runtime/src/features/form/data/sagas/submit/index.ts
@@ -39,6 +39,7 @@ function* submitFormSaga({ url, apiMode }: ISubmitDataAction): SagaIterator {
     if (apiMode === 'Complete') {
       validations = Object.assign(validations, emptyFieldsValidations);
     }
+
     if (canFormBeSaved(validations)) {
       // updates the default data element
       const defaultDataElementGuid = state.instanceData.instance.data.find((e) => e.elementType === 'default').id;
@@ -48,7 +49,8 @@ function* submitFormSaga({ url, apiMode }: ISubmitDataAction): SagaIterator {
         // run validations against the datamodel
         const instanceId = state.instanceData.instance.id;
         const validationResult = yield call(get, getValidationUrl(instanceId, defaultDataElementGuid));
-        if (validationResult && validationResult.length > 0) {
+        if (validationResult && validationResult.length > 0
+          && !(validationResult.length === 1 && validationResult[0].field === null)) {
           // we have validation errors, update validations and return
           const layoutState: ILayoutState = yield select(LayoutSelector);
           const mappedValidations = mapDataElementValidationToRedux(validationResult, layoutState.layout);

--- a/src/react-apps/applications/runtime/src/utils/validation.ts
+++ b/src/react-apps/applications/runtime/src/utils/validation.ts
@@ -344,7 +344,7 @@ export function mapDataElementValidationToRedux(validations: IValidationIssue[],
       let found = false;
       Object.keys(componentCandidate.dataModelBindings).forEach((dataModelBindingKey) => {
         // tslint:disable-next-line: max-line-length
-        if (componentCandidate.dataModelBindings[dataModelBindingKey].toLowerCase() === validation.field.toLowerCase()) {
+        if (validation.field && componentCandidate.dataModelBindings[dataModelBindingKey].toLowerCase() === validation.field.toLowerCase()) {
           found = true;
           if (!componentValidations[dataModelBindingKey]) {
             componentValidations[dataModelBindingKey] = {errors: [], warnings: []};

--- a/src/react-apps/applications/runtime/src/utils/validation.ts
+++ b/src/react-apps/applications/runtime/src/utils/validation.ts
@@ -2,7 +2,7 @@ import { getLanguageFromKey, getParsedLanguageFromKey } from '../../../shared/sr
 import { IFormData } from '../features/form/data/reducer';
 import { ILayout, ILayoutComponent } from '../features/form/layout/';
 import { IValidationIssue, Severity } from '../types';
-import { IComponentValidations, IDataModelFieldElement, IValidations, IFormComponent } from '../types/global';
+import { IComponentValidations, IDataModelFieldElement, IValidations } from '../types/global';
 import { getKeyWithoutIndex } from './databindings';
 
 export function min(value: number, test: number): boolean {

--- a/src/react-apps/applications/runtime/src/utils/validation.ts
+++ b/src/react-apps/applications/runtime/src/utils/validation.ts
@@ -86,7 +86,6 @@ export function validateFormComponents(
   language: any,
 ) {
   const validations: any = {};
-  const numberOfAttachments = attachments ? Object.keys(attachments).length : 0;
   const fieldKey = 'simpleBinding';
   formLayout.forEach((component: any) => {
     if (!component.hidden) {

--- a/src/react-apps/applications/runtime/src/utils/validation.ts
+++ b/src/react-apps/applications/runtime/src/utils/validation.ts
@@ -2,7 +2,7 @@ import { getLanguageFromKey, getParsedLanguageFromKey } from '../../../shared/sr
 import { IFormData } from '../features/form/data/reducer';
 import { ILayout, ILayoutComponent } from '../features/form/layout/';
 import { IValidationIssue, Severity } from '../types';
-import { IComponentValidations, IDataModelFieldElement, IValidations } from '../types/global';
+import { IComponentValidations, IDataModelFieldElement, IValidations, IFormComponent } from '../types/global';
 import { getKeyWithoutIndex } from './databindings';
 
 export function min(value: number, test: number): boolean {
@@ -90,7 +90,7 @@ export function validateFormComponents(
   formLayout.forEach((component: any) => {
     if (!component.hidden) {
       if (component.type === 'FileUpload') {
-        if (attachments[component.id] && attachments[component.id].length < component.minNumberOfAttachments) {
+        if (!attachmentsValid(attachments, component)) {
           validations[component.id] = {};
           const componentValidations: IComponentValidations = {
             [fieldKey]: {
@@ -109,6 +109,15 @@ export function validateFormComponents(
     }
   });
   return validations;
+}
+
+function attachmentsValid(attachments: any, component: any): boolean {
+  return (
+    component.minNumberOfAttachments === 0 ||
+    (attachments &&
+      attachments[component.id] &&
+      attachments[component.id].length >= component.minNumberOfAttachments)
+  );
 }
 
 /*

--- a/src/react-apps/applications/runtime/src/utils/validation.ts
+++ b/src/react-apps/applications/runtime/src/utils/validation.ts
@@ -91,8 +91,7 @@ export function validateFormComponents(
   formLayout.forEach((component: any) => {
     if (!component.hidden) {
       if (component.type === 'FileUpload') {
-        if (component.minNumberOfAttachments > 0 && numberOfAttachments < 1 ||
-          attachments[component.id].length < component.minNumberOfAttachments) {
+        if (attachments[component.id] && attachments[component.id].length < component.minNumberOfAttachments) {
           validations[component.id] = {};
           const componentValidations: IComponentValidations = {
             [fieldKey]: {


### PR DESCRIPTION
Multiple small fixes for issues discovered in #3106:
- When validation fails when submitting form, the `SUBMIT_FORM_DATA_REJECTED` action should be called to make it clear that the form was not submitted. 
- Bug in validation of min number of attachments
- Mapping of server-side validation to client-side crashes