### PR TITLE
servicemetadata -> modelmetadata

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>0.0.25.0</AssemblyVersion>
-    <FileVersion>0.0.25.0</FileVersion>
-    <Version>0.0.25-alpha</Version>
+    <AssemblyVersion>0.0.26.0</AssemblyVersion>
+    <FileVersion>0.0.26.0</FileVersion>
+    <Version>0.0.26-alpha</Version>
     <Description>Package that contains API controllers for the standard API for a Altinn App.</Description>
     <Company>Altinn</Company>
     <Authors>Altinn</Authors>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/ResourceController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/ResourceController.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using System.IO;
 using Altinn.App.Services.Helpers;
 using Altinn.App.Services.Interface;
-using Altinn.App.Services.ServiceMetadata;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Altinn.App.Api.Controllers
@@ -76,34 +75,31 @@ namespace Altinn.App.Api.Controllers
             byte[] fileContent = _appResourceService.GetText(org, app, id);
             if (fileContent != null)
             {
-              return new FileContentResult(fileContent, MimeTypeMap.GetMimeType(Path.GetExtension(id).ToLower()));
+                return new FileContentResult(fileContent, MimeTypeMap.GetMimeType(Path.GetExtension(id).ToLower()));
             }
 
             id = $"resource.{defaultLang}.json";
             fileContent = _appResourceService.GetText(org, app, id);
             if (fileContent != null)
             {
-              return new FileContentResult(fileContent, MimeTypeMap.GetMimeType(Path.GetExtension(id).ToLower()));
+                return new FileContentResult(fileContent, MimeTypeMap.GetMimeType(Path.GetExtension(id).ToLower()));
             }
 
             return StatusCode(404);
         }
 
         /// <summary>
-        /// Get the service metadata
+        /// Get the model metadata
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
-        /// <param name="texts">whether text is set</param>
-        /// <param name="restrictions">whether  restrictions are set</param>
-        /// <param name="attributes">whether attributes are set</param>
-        /// <returns>The service metadata</returns>
+        /// <returns>The model metadata</returns>
         [HttpGet]
         [Route("{org}/{app}/api/metadata/{id}")]
-        public ActionResult ServiceMetaData([FromRoute] string org, [FromRoute] string app, [FromRoute] string id)
+        public ActionResult ModelMetadata([FromRoute] string org, [FromRoute] string app)
         {
-            ServiceMetadata metadata = _appResourceService.GetServiceMetaData(org, app);
+            string metadata = _appResourceService.GetModelMetaDataJSON(org, app);
             return Ok(metadata);
         }
-  }
+    }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <Version>0.0.25-alpha</Version>
+    <Version>0.0.26-alpha</Version>
     <Authors>Altinn</Authors>
     <Company>Altinn</Company>
     <Description>Package with common functionality for Altinn Apps created in Altinn Studio</Description>
     <PackageProjectUrl>https://github.com/Altinn/altinn-studio</PackageProjectUrl>
-    <AssemblyVersion>0.0.25.0</AssemblyVersion>
+    <AssemblyVersion>0.0.26.0</AssemblyVersion>
     <IsPackable>true</IsPackable>
     <OutputType>Library</OutputType>
   </PropertyGroup>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -1,16 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <Version>0.0.25-alpha</Version>
+    <Version>0.0.26-alpha</Version>
     <Authors>Altinn</Authors>
     <Company>Altinn</Company>
     <Description>Common services with Altinn Platform functionality and Altinn Apps functionality</Description>
     <PackageProjectUrl>https://github.com/Altinn/altinn-studio</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>0.0.25.0</AssemblyVersion>
+    <AssemblyVersion>0.0.26.0</AssemblyVersion>
     <IsPackable>true</IsPackable>
     <OutputType>Library</OutputType>
+    <FileVersion>0.0.26.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Extentions/XmlToLinqExtensions.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Extentions/XmlToLinqExtensions.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Xml.Linq;
-using Altinn.App.Services.ServiceMetadata;
+using Altinn.App.Services.ModelMetadata;
 
 namespace Altinn.App.Services.Extensions
 {

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
@@ -120,7 +120,7 @@ namespace Altinn.App.Services.Implementation
 
 
         /// <inheritdoc/>
-        public ServiceMetadata.ServiceMetadata GetServiceMetaData(string org, string app)
+        public string GetModelMetaDataJSON(string org, string app)
         {
             Application applicationMetadata = GetApplication();
 
@@ -135,7 +135,8 @@ namespace Altinn.App.Services.Implementation
 
             string filename = _settings.AppBasePath + _settings.ModelsFolder + dataTypeId + "." + _settings.ServiceMetadataFileName;
             string filedata = File.ReadAllText(filename, Encoding.UTF8);
-            return JsonConvert.DeserializeObject<ServiceMetadata.ServiceMetadata>(filedata);
+
+            return filedata;
         }
 
         /// <inheritdoc/>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAppResources.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAppResources.cs
@@ -29,12 +29,12 @@ namespace Altinn.App.Services.Interface
 
 
         /// <summary>
-        /// Returns the ServiceMetadata for an app.
+        /// Returns the model metadata for an app.
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <returns>The ServiceMetadata for an app.</returns>
-        ServiceMetadata.ServiceMetadata GetServiceMetaData(string org, string app);
+        string GetModelMetaDataJSON(string org, string app);
 
         /// <summary>
         /// Method that fetches the runtime resources stored in wwwroot

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/BaseValueType.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/BaseValueType.cs
@@ -1,4 +1,4 @@
-namespace Altinn.App.Services.ServiceMetadata
+namespace Altinn.App.Services.ModelMetadata
 {
     /// <summary>
     /// Base value type, in XmlSchema

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/CultureDictionary.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/CultureDictionary.cs
@@ -8,7 +8,7 @@ using System.Xml.Serialization;
 
 #endregion
 
-namespace Altinn.App.Services.ServiceMetadata
+namespace Altinn.App.Services.ModelMetadata
 {
     /// <summary>
     /// A dictionary where the values have cultures

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/CultureString.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/CultureString.cs
@@ -11,7 +11,7 @@ using Altinn.App.Services.Extensions;
 
 #endregion
 
-namespace Altinn.App.Services.ServiceMetadata
+namespace Altinn.App.Services.ModelMetadata
 {
     /// <summary>
     /// Culture string

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/ElementMetadata.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/ElementMetadata.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace Altinn.App.Services.ServiceMetadata
+namespace Altinn.App.Services.ModelMetadata
 {
   /// <summary>
   /// Metadata for a given service element

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/ElementType.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/ElementType.cs
@@ -1,4 +1,4 @@
-namespace Altinn.App.Services.ServiceMetadata
+namespace Altinn.App.Services.ModelMetadata
 {
     /// <summary>
     /// Enumeration for the different type of service elements

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/Language.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/Language.cs
@@ -1,4 +1,4 @@
-namespace Altinn.App.Services.ServiceMetadata
+namespace Altinn.App.Services.ModelMetadata
 {
     /// <summary>
     /// Enumeration for language

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/ModelMetadata.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/ModelMetadata.cs
@@ -1,12 +1,12 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
-namespace Altinn.App.Services.ServiceMetadata
+namespace Altinn.App.Services.ModelMetadata
 {
     /// <summary>
     /// Class representation for the metadata for a service
     /// </summary>
-    public class ServiceMetadata
+    public class ModelMetadata
     {
         /// <summary>
         /// Gets or sets the organization the service belongs to

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/Restriction.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/Restriction.cs
@@ -1,4 +1,4 @@
-namespace Altinn.App.Services.ServiceMetadata
+namespace Altinn.App.Services.ModelMetadata
 {
     /// <summary>
     /// Class representing a service element restriction

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/ServicePackageDetails.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/ServicePackageDetails.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Altinn.App.Services.ServiceMetadata
+namespace Altinn.App.Services.ModelMetadata
 {
     /// <summary>
     /// Entity containing all details about a service package

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/TextCategoryType.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/TextCategoryType.cs
@@ -1,4 +1,4 @@
-namespace Altinn.App.Services.ServiceMetadata
+namespace Altinn.App.Services.ModelMetadata
 {
     /// <summary>
     /// Enumeration for all text categories

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/XDocName.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/ModelMetadata/XDocName.cs
@@ -1,6 +1,6 @@
 using System.Xml.Linq;
 
-namespace Altinn.App.Services.ServiceMetadata
+namespace Altinn.App.Services.ModelMetadata
 {
     /// <summary>
     /// Class containing XNamespace and XName for various xml and xsd element 

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Models/ProfileSettingPreference.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Models/ProfileSettingPreference.cs
@@ -1,4 +1,4 @@
-using Altinn.App.Services.ServiceMetadata;
+using Altinn.App.Services.ModelMetadata;
 
 namespace Altinn.App.Services.Models
 {

--- a/src/Altinn.Apps/AppTemplates/AspNet/App/App.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App/App.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="0.0.25-alpha" />
-    <PackageReference Include="Altinn.App.Common" Version="0.0.25-alpha" />
-    <PackageReference Include="Altinn.App.PlatformServices" Version="0.0.25-alpha" />
+    <PackageReference Include="Altinn.App.Api" Version="0.0.26-alpha" />
+    <PackageReference Include="Altinn.App.Common" Version="0.0.26-alpha" />
+    <PackageReference Include="Altinn.App.PlatformServices" Version="0.0.26-alpha" />
     <PackageReference Include="Altinn.Common.PEP" Version="0.0.13-alpha" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />


### PR DESCRIPTION
renamed servicemetadata to modelmetadata to match term used in designer 
returning file content in metadata instead of parsing to c# class