### PR TITLE
Added authorize header

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/ApplicationMetadataController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/ApplicationMetadataController.cs
@@ -40,6 +40,7 @@ namespace Altinn.App.Api.Controllers
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <returns>Application metadata</returns>
+        [Authorize]
         [HttpGet("{org}/{app}/api/v1/applicationmetadata")]
         public async Task<IActionResult> GetAction(string org, string app)
         {

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/AuthenticationController.cs
@@ -37,20 +37,18 @@ namespace Altinn.App.Api.Controllers
         [HttpGet("{org}/{app}/api/[controller]/keepAlive")]
         public async Task<IActionResult> KeepAlive()
         {
-            if (_settings.RuntimeMode != "AltinnStudio")
+
+            string token = await _authentication.RefreshToken();
+
+            CookieOptions runtimeCookieSetting = new CookieOptions
             {
-                string token = await _authentication.RefreshToken();
+                Domain = _settings.HostName,
+            };
 
-                CookieOptions runtimeCookieSetting = new CookieOptions
-                {
-                    Domain = _settings.HostName,
-                };
-
-                if (!string.IsNullOrWhiteSpace(token))
-                {
-                    HttpContext.Response.Cookies.Append(General.RuntimeCookieName, token, runtimeCookieSetting);
-                    return Ok();
-                }
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                HttpContext.Response.Cookies.Append(General.RuntimeCookieName, token, runtimeCookieSetting);
+                return Ok();
             }
 
             return BadRequest();

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/PartiesController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/PartiesController.cs
@@ -63,6 +63,7 @@ namespace Altinn.App.Api.Controllers
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <param name="allowedToInstantiateFilter">when set to true returns parties that are allowed to instantiate</param>
         /// <returns>parties</returns>
+        [Authorize]
         [HttpGet("{org}/{app}/api/v1/parties")]
         public async Task<IActionResult> Get(string org, string app, bool allowedToInstantiateFilter = false)
         {
@@ -86,6 +87,7 @@ namespace Altinn.App.Api.Controllers
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <param name="partyId">The selected partyId</param>
         /// <returns>A validation status</returns>
+        [Authorize]
         [HttpPost("{org}/{app}/api/v1/parties/validateInstantiation")]
         public IActionResult ValidateInstantiation(string org, string app, [FromQuery] int partyId)
         {
@@ -149,6 +151,7 @@ namespace Altinn.App.Api.Controllers
         /// Updates the party the user represents
         /// </summary>
         /// <returns>Status code</returns>
+        [Authorize]
         [HttpPut("{org}/{app}/api/v1/parties/{partyId}")]
         public async Task<IActionResult> UpdateSelectedParty(int partyId)
         {

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/ProfileController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/ProfileController.cs
@@ -38,6 +38,7 @@ namespace Altinn.App.Api.Controllers
         /// <summary>
         /// Method that returns the user information about the user that is logged in
         /// </summary>
+       [Authorize]
        [HttpGet("user")]
         public async Task<ActionResult> GetUser()
         {


### PR DESCRIPTION
Added authorize header for profile, parties, authentication and applicationmetadata so that it redirects to authentication instead of waiting until keepalive redirects it