### PR TITLE
Added orgToken and appToken that generates a jwt token 

### DIFF
--- a/src/development/LocalTest/Controllers/Authentication/AuthenticationController.cs
+++ b/src/development/LocalTest/Controllers/Authentication/AuthenticationController.cs
@@ -49,5 +49,52 @@ namespace LocalTest.Controllers.Authentication
             logger.LogInformation($"End of refreshing token");
             return Ok(token);
         }
+
+        [HttpGet("orgToken")]
+        public ActionResult GenerateOrgToken(
+            [FromQuery] string org = "ttd",
+            [FromQuery] int orgNumber = 111111111,
+            [FromQuery] string scope = "altinn:instances.read altinn:instances.write")
+        {
+            List<Claim> claims = new List<Claim>
+            {
+                new Claim("urn:altinn:org", org, ClaimValueTypes.String),
+                new Claim("urn:altinn:orgNumber", orgNumber.ToString(), ClaimValueTypes.Integer32),
+                new Claim(AltinnCoreClaimTypes.AuthenticateMethod, "fake-local-maskinporten", ClaimValueTypes.String),
+                new Claim(AltinnCoreClaimTypes.AuthenticationLevel, "3", ClaimValueTypes.Integer32),
+                new Claim("urn:altinn:scope", scope, ClaimValueTypes.String)
+            };
+
+            ClaimsIdentity identity = new ClaimsIdentity("OrganisationLogin");
+
+            identity.AddClaims(claims);
+            ClaimsPrincipal principal = new ClaimsPrincipal(identity);
+
+            string token = jwtHandler.GenerateToken(principal, new TimeSpan(0, Convert.ToInt32(generalSettings.GetJwtCookieValidityTime), 0));
+
+            return Ok(token);
+        }
+
+        [HttpGet("appToken")]
+        public ActionResult GenerateAppToken(
+            [FromQuery] int authenticationLevel = 3,
+            [FromQuery] int userId = 500000)
+        {
+            List<Claim> claims = new List<Claim>
+            {
+                new Claim(AltinnCoreClaimTypes.AuthenticateMethod, "fake-local-test", ClaimValueTypes.String),
+                new Claim(AltinnCoreClaimTypes.AuthenticationLevel, authenticationLevel.ToString(), ClaimValueTypes.Integer32),
+                new Claim(AltinnCoreClaimTypes.UserId, userId.ToString(), ClaimValueTypes.Integer32)
+            };
+
+            ClaimsIdentity identity = new ClaimsIdentity("PersonLogin");
+
+            identity.AddClaims(claims);
+            ClaimsPrincipal principal = new ClaimsPrincipal(identity);
+
+            string token = jwtHandler.GenerateToken(principal, new TimeSpan(0, Convert.ToInt32(generalSettings.GetJwtCookieValidityTime), 0));
+
+            return Ok(token);
+        }
     }
 }

--- a/src/development/LocalTest/Properties/launchSettings.json
+++ b/src/development/LocalTest/Properties/launchSettings.json
@@ -11,6 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "applicationUrl": "http://localhost:5101",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -18,9 +19,11 @@
     "LocalTest": {
       "commandName": "Project",
       "launchBrowser": true,
+      "launchUrl": "authentication/swagger",
       "applicationUrl": "http://localhost:5101",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "http://localhost:5101/"
       }
     }
   }


### PR DESCRIPTION
for test purposes

/authentication/api/v1/orgToken - simulate org as user
/authentication/api/v1/appToken - simulate app against storage