### PR TITLE
bug/2427-multiple-improvements

### DIFF
--- a/deploy/kubernetes/altinncore-loadbalancer-dev-config.yaml
+++ b/deploy/kubernetes/altinncore-loadbalancer-dev-config.yaml
@@ -54,18 +54,14 @@ data:
 
         server_name dev.altinn.studio;
 
+        proxy_cookie_path ~*^/.* /;
+
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
         rewrite ^/.*/.*/staticfiles(.*)$ $1 last;
 
         location = / {
           proxy_pass 			    http://designer/;
-          proxy_set_header 	  Host dev.altinn.studio;
-          proxy_set_header 	  X-Forwarded-For $remote_addr;
-        }
-
-        location = /repos/ {
-          proxy_pass          http://designer/Redirect/FetchCookieAndRedirectHome/;
           proxy_set_header 	  Host dev.altinn.studio;
           proxy_set_header 	  X-Forwarded-For $remote_addr;
         }

--- a/deploy/kubernetes/altinncore-loadbalancer-prod-config.yaml
+++ b/deploy/kubernetes/altinncore-loadbalancer-prod-config.yaml
@@ -54,18 +54,14 @@ data:
 
         server_name altinn.studio;
 
+        proxy_cookie_path ~*^/.* /;
+
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
         rewrite ^/.*/.*/staticfiles(.*)$ $1 last;
 
         location = / {
           proxy_pass 			    http://designer/;
-          proxy_set_header 	  Host altinn.studio;
-          proxy_set_header 	  X-Forwarded-For $remote_addr;
-        }
-
-        location = /repos/ {
-          proxy_pass          http://designer/Redirect/FetchCookieAndRedirectHome/;
           proxy_set_header 	  Host altinn.studio;
           proxy_set_header 	  X-Forwarded-For $remote_addr;
         }

--- a/deploy/kubernetes/altinncore-loadbalancer-staging-config.yaml
+++ b/deploy/kubernetes/altinncore-loadbalancer-staging-config.yaml
@@ -54,18 +54,14 @@ data:
 
         server_name staging.altinn.studio;
 
+        proxy_cookie_path ~*^/.* /;
+
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
         rewrite ^/.*/.*/staticfiles(.*)$ $1 last;
 
         location = / {
           proxy_pass 			    http://designer/;
-          proxy_set_header 	  Host staging.altinn.studio;
-          proxy_set_header 	  X-Forwarded-For $remote_addr;
-        }
-
-        location = /repos/ {
-          proxy_pass          http://designer/Redirect/FetchCookieAndRedirectHome/;
           proxy_set_header 	  Host staging.altinn.studio;
           proxy_set_header 	  X-Forwarded-For $remote_addr;
         }

--- a/deploy/kubernetes/helm-charts/altinn-designer/values.yaml
+++ b/deploy/kubernetes/helm-charts/altinn-designer/values.yaml
@@ -199,14 +199,6 @@ ingress:
     paths:
       - path: /
   - metadata:
-      name: altinn-designer-cookie-fetcher
-      annotations:
-        traefik.ingress.kubernetes.io/request-modifier: "ReplacePath: /Redirect/FetchCookieAndRedirectHome/"
-        traefik.ingress.kubernetes.io/rule-type: Path
-        traefik.frontend.priority: "900"
-    paths:
-      - path: /repos/
-  - metadata:
       name: altinn-designer-home-path
       annotations:
         traefik.frontend.priority: "800"

--- a/deploy/kubernetes/loadbalancer/conf/nginx.conf
+++ b/deploy/kubernetes/loadbalancer/conf/nginx.conf
@@ -29,16 +29,11 @@ http {
 		server_name altinn.studio;
 		ssl_certificate /path/to/ssl_certificate;
 		ssl_certificate_key /path/to/ssl_certificate_key;
+    proxy_cookie_path ~*^/.* /;
 
 		location = / {
 	 		proxy_pass         http://designer/;
 		}
-
-    location = /repos/ {
-      proxy_pass          http://designer/Redirect/FetchCookieAndRedirectHome/;
-      proxy_set_header 	  Host dev.altinn.studio;
-      proxy_set_header 	  X-Forwarded-For $remote_addr;
-    }
 
     rewrite ^/.*/.*/staticfiles(.*)$ $1 last;
 

--- a/src/AltinnCore/Designer/Controllers/HomeController.cs
+++ b/src/AltinnCore/Designer/Controllers/HomeController.cs
@@ -60,7 +60,7 @@ namespace AltinnCore.Designer.Controllers
             string userName = _giteaApi.GetUserNameFromUI().Result;
 
             if (string.IsNullOrEmpty(userName))
-            {                
+            {
                 Response.Cookies.Delete(AltinnCore.Common.Constants.General.DesignerCookieName);
                 Response.Cookies.Delete(_settings.GiteaCookieName);
                 return View("StartPage");

--- a/src/AltinnCore/Designer/Controllers/RedirectController.cs
+++ b/src/AltinnCore/Designer/Controllers/RedirectController.cs
@@ -27,28 +27,5 @@ namespace Designer.Controllers
             _httpContextAccessor = httpContextAccessor;
             _settings = repositorySettings.Value;
         }
-
-        /// <summary>
-        /// Method used for setting gitea cookie without path specification and redirecting to Login Home
-        /// </summary>
-        /// <returns> Redirect to login page with gitea cookie </returns>
-        public ActionResult FetchCookieAndRedirectHome()
-        {
-            string giteaCookieKey = _settings.GiteaCookieName;
-            var giteaCookieValue = _httpContextAccessor.HttpContext.Request.Cookies[giteaCookieKey];
-
-            if (giteaCookieValue != null)
-            {
-                CookieOptions cookieOptions = new CookieOptions
-                {
-                    HttpOnly = true
-                };
-
-                Response.Cookies.Append(giteaCookieKey, giteaCookieValue, cookieOptions);
-
-            }
-
-            return RedirectToAction("Login", "Home");
-        }
     }
 }

--- a/src/AltinnCore/Designer/Views/Home/StartPage.cshtml
+++ b/src/AltinnCore/Designer/Views/Home/StartPage.cshtml
@@ -7,6 +7,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>Altinn Studio</title>
   <link rel="shortcut icon" href="~/designer/img/favicon.ico">
   <!-- CSS -->
   <link rel="stylesheet" href="~/designer/css/bootstrap.min.css" asp-append-version="true">
@@ -53,21 +54,25 @@
   <nav class="navbar navbar-default">
     <div class="container-fluid">
       <div class="navbar-header">
-        <img src="~/designer/img/altinnStudio.png" />
+        <img src="https://altinncdn.no/img/a-logo-blue.svg" alt="Altinn logo" />
       </div>
       <ul class="nav navbar-nav">
-        <li><a class="nav-link" href="repos/user/login">Logg inn <i class="fa fa-fw fa-user-circle" aria-hidden="true"></i></a></li>
+        <li><a class="nav-link" href="repos/user/login?redirect_to=/">Logg inn <i class="fa fa-fw fa-user-circle" aria-hidden="true"></i></a></li>
       </ul>
     </div>
   </nav>
   <div class="row grey-background" style="padding-top:100px">
     <div class="col-12  pt-5 pb-5 text-center">
-      <h1> Velkommen til Altinn studio. Din platform for utvikling av tjenester.</h1>
+      <h1> Velkommen til Altinn Studio!</h1>
+      Din plattform for utvikling av applikasjoner.
     </div>
   </div>
   <div class="row grey-background" style="height:50vh;padding-bottom:20px">
     <div class="col-12 pt-5 text-center">
-      <input type="button" class="btn-lg btn-primary-outline text-center" onclick="location.href='repos/user/login'" value="Logg inn" />
+      <input type="button" class="btn-lg btn-primary-outline text-center" onclick="location.href='repos/user/login?redirect_to=/'" value="Logg inn" />
+      <div>
+        <a href="https://altinn.github.io/docs/altinn-studio/first-time-setup/" target="_blank"><i class="fa fa-help" aria-hidden="true"></i> Opprette bruker?</a>
+      </div>
     </div>
   </div>
 </body>

--- a/src/AltinnRepositories/gitea-config/dev/app.ini
+++ b/src/AltinnRepositories/gitea-config/dev/app.ini
@@ -1,4 +1,4 @@
-APP_NAME = Altinn Studio Repositories
+APP_NAME = Altinn Studio Repos
 RUN_MODE = dev
 
 [repository]
@@ -91,8 +91,8 @@ SHOW_USER_EMAIL = false
 
 [ui.meta]
 AUTHOR = Altinn
-DESCRIPTION = Git for Altinn tjenesteutvikling
-KEYWORDS = altinn,tjenester,3.0,go,git,gitea
+DESCRIPTION = Repositories for Altinn Studio
+KEYWORDS = altinn,studio,apps,3.0,go,git,gitea
 
 [other]
 SHOW_FOOTER_BRANDING = false

--- a/src/AltinnRepositories/gitea-config/prod/app.ini
+++ b/src/AltinnRepositories/gitea-config/prod/app.ini
@@ -1,4 +1,4 @@
-APP_NAME = Altinn Studio Repositories
+APP_NAME = Altinn Studio Repos
 RUN_MODE = prod
 
 [repository]
@@ -91,8 +91,8 @@ SHOW_USER_EMAIL = false
 
 [ui.meta]
 AUTHOR = Altinn
-DESCRIPTION = Git for Altinn tjenesteutvikling
-KEYWORDS = altinn,tjenester,3.0,go,git,gitea
+DESCRIPTION = Repositories for Altinn Studio
+KEYWORDS = altinn,studio,apps,3.0,go,git,gitea
 
 [other]
 SHOW_FOOTER_BRANDING = false

--- a/src/AltinnRepositories/gitea-config/staging/app.ini
+++ b/src/AltinnRepositories/gitea-config/staging/app.ini
@@ -1,4 +1,4 @@
-APP_NAME = Altinn Studio Repositories
+APP_NAME = Altinn Studio Repos
 RUN_MODE = dev
 
 [repository]
@@ -91,8 +91,8 @@ SHOW_USER_EMAIL = false
 
 [ui.meta]
 AUTHOR = Altinn
-DESCRIPTION = Git for Altinn tjenesteutvikling
-KEYWORDS = altinn,tjenester,3.0,go,git,gitea
+DESCRIPTION = Repositories for Altinn Studio
+KEYWORDS = altinn,studio,apps,3.0,go,git,gitea
 
 [other]
 SHOW_FOOTER_BRANDING = false

--- a/src/AltinnRepositories/gitea-data/gitea/conf/app.ini
+++ b/src/AltinnRepositories/gitea-data/gitea/conf/app.ini
@@ -1,4 +1,4 @@
-APP_NAME = Altinn Repositories
+APP_NAME = Altinn Studio Repos
 RUN_MODE = prod
 RUN_USER = git
 
@@ -97,8 +97,8 @@ SHOW_USER_EMAIL = false
 
 [ui.meta]
 AUTHOR = Altinn
-DESCRIPTION = Git for Altinn tjenesteutvikling
-KEYWORDS = altinn,tjenester,3.0,go,git,gitea
+DESCRIPTION = Repositories for Altinn Studio
+KEYWORDS = altinn,studio,apps,3.0,go,git,gitea
 
 [other]
 SHOW_FOOTER_BRANDING = false

--- a/src/AltinnRepositories/gitea-data/gitea/templates/base/authorization_head_navbar.tmpl
+++ b/src/AltinnRepositories/gitea-data/gitea/templates/base/authorization_head_navbar.tmpl
@@ -10,8 +10,8 @@
 </style>
 <div id="navbar">
 	<div class="brand logo">
-		<a href="{{AppSubUrl}}/">
-			<img class="ui image img-logo" src="{{AppSubUrl}}/img/altinn_logo_header.png">
+		<a href="/" title="Altinn Studio {{.i18n.Tr "home"}}">
+			<img class="ui image" src="https://altinncdn.no/img/a-logo-blue.svg" alt="Altinn logo">
 		</a>
 	</div>
 </div>

--- a/src/AltinnRepositories/gitea-data/gitea/templates/base/head.tmpl
+++ b/src/AltinnRepositories/gitea-data/gitea/templates/base/head.tmpl
@@ -123,7 +123,7 @@
 {{else}}
 	<meta property="og:title" content="{{AppName}}">
 	<meta property="og:type" content="website" />
-	<meta property="og:image" content="{{AppSubUrl}}/img/altinn_logo_header.png" />
+	<meta property="og:image" content="{{AppSubUrl}}/img/favicon.png" />
 	<meta property="og:url" content="{{AppUrl}}" />
 	<meta property="og:description" content="{{MetaDescription}}">
 {{end}}
@@ -141,8 +141,8 @@
 			<div class="ui top secondary stackable main menu following bar light">
 				<div class="ui container" id="navbar">
 					<div class="item brand" style="justify-content: space-between;">
-						<a href="{{AppSubUrl}}/" href="{{AppSubUrl}}/">
-							<img class="ui mini image" src="{{AppSubUrl}}/img/altinn_logo_header.png">
+						<a href="/" title="Altinn Studio {{.i18n.Tr "home"}}">
+							<img class="ui mini image" src="{{AppSubUrl}}/img/favicon.png" alt="Altinn logo">
 						</a>
 						<div class="ui basic icon button mobile-only" id="navbar-expand-toggle">
 							<i class="sidebar icon"></i>
@@ -150,14 +150,18 @@
 					</div>
 
 					{{if .IsSigned}}
-						<a class="item{{if .PageIsDashboard}} active{{end}}" href="{{AppSubUrl}}/">{{.i18n.Tr "dashboard"}}</a>
+            <a class="item{{if .PageIsDashboard}} active{{end}}" href="{{AppSubUrl}}/">{{.i18n.Tr "dashboard"}}</a>
 						<a class="item{{if .PageIsIssues}} active{{end}}" href="{{AppSubUrl}}/issues">{{.i18n.Tr "issues"}}</a>
-						<a class="item{{if .PageIsPulls}} active{{end}}" href="{{AppSubUrl}}/pulls">{{.i18n.Tr "pull_requests"}}</a>
+            <a class="item{{if .PageIsPulls}} active{{end}}" href="{{AppSubUrl}}/pulls">{{.i18n.Tr "pull_requests"}}</a>
 					{{else}}
 						<a class="item{{if .PageIsHome}} active{{end}}" href="{{AppSubUrl}}">{{.i18n.Tr "home"}}</a>
 					{{end}}
 
-					<a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore/repos">{{.i18n.Tr "explore"}}</a>
+          <a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore/repos">{{.i18n.Tr "explore"}}</a>
+
+          {{if .Repository}}
+            <a class="item" href="/designer/{{.Repository.Owner.Name}}/{{.Repository.Name}}" title="Åpne i Designer">Designer</a>
+          {{end}}
 
 					{{template "custom/extra_links" .}}
 
@@ -231,7 +235,7 @@
 										<i class="octicon octicon-settings"></i>
 										{{.i18n.Tr "your_settings"}}<!-- Your settings -->
 									</a>
-									<a class="item" target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io">
+									<a class="item" target="_blank" rel="noopener noreferrer" href="https://docs.altinn.studio/teknologi/altinnstudio">
 										<i class="octicon octicon-question"></i>
 										{{.i18n.Tr "help"}}<!-- Help -->
 									</a>
@@ -245,7 +249,7 @@
 									{{end}}
 
 									<div class="divider"></div>
-									<a class="item" href="{{AppSubUrl}}/Home/Logout">
+									<a class="item" href="/Home/Logout">
 										<i class="octicon octicon-sign-out"></i>
 										{{.i18n.Tr "sign_out"}}<!-- Sign Out -->
 									</a>
@@ -255,7 +259,7 @@
 
 					{{else}}
 
-						<a class="item" target="_blank" rel="noopener noreferrer" href="https://docs.gitea.io">{{.i18n.Tr "help"}}</a>
+						<a class="item" target="_blank" rel="noopener noreferrer" href="https://docs.altinn.studio/teknologi/altinnstudio">{{.i18n.Tr "help"}}</a>
 						<div class="right stackable menu">
 							{{if .ShowRegistrationButton}}
 								<a class="item{{if .PageIsSignUp}} active{{end}}" href="{{AppSubUrl}}/user/sign_up">

--- a/src/AltinnRepositories/gitea-data/gitea/templates/home.tmpl
+++ b/src/AltinnRepositories/gitea-data/gitea/templates/home.tmpl
@@ -6,53 +6,50 @@
 				<img class="logo" src="{{AppSubUrl}}/img/favicon.png" />
 			</div>
 			<div class="hero">
-				<h1 class="ui icon header title">
-					Repositories
-				</h1>
-				<h2>altinn tjenester 3.0</h2>
+				<h1 class="ui header title">Altinn Studio Repos</h1>
 			</div>
 		</div>
 	</div>
-	
-    <div class="ui stackable middle very relaxed page grid">
-        <div class="eight wide center column">
-            <h1 class="hero ui icon header">
-                <i class="octicon octicon-comment-discussion"></i> Samarbeid i teams
-            </h1>
-            <p class="large">
-                <a href=/explore/users">Utviklere</a> kan samarbeide og diskutere, 
-                med tilgang til bl.a. full Git versjonshistorikk, backlog, milepæler, varsler og wiki.
-            </p>
-        </div>
-        <div class="eight wide center column">
-            <h1 class="hero ui icon header">
-                <i class="octicon octicon-organization"></i> Samarbeid på tvers
-            </h1>
-            <p class="large">
-                <a href="/explore/organizations">Organisasjoner</a> kan samarbeide med hverandre om
-                gjenbrukbare løsninger og komponenter.
-            </p>
-        </div>
-    </div>
-    <div class="ui stackable middle very relaxed page grid">
-        <div class="eight wide center column">
-            <h1 class="hero ui icon header">
-                <i class="octicon octicon-tools"></i> Enkel å integrere
-            </h1>
-            <p class="large">
-                <a href="/explore/repos">Tjenestene</a> er tilgjengelige via Git, og i tillegg så er
-                det meste av funksjonalitet tilgjengelig via et <a href="/api/swagger">REST API</a>.
-            </p>
-        </div>
-        <div class="eight wide center column">
-            <h1 class="hero ui icon header">
-                <i class="octicon octicon-code"></i> Åpen kildekode
-            </h1>
-            <p class="large">
-                Repositories vil deles som <a href="https://github.com/altinn/">åpen kildekode på Github</a>,
-                slik at alle som vil kan bidra til å forbedre løsningen.
-            </p>
-        </div>
-    </div>
+
+  <div class="ui stackable middle very relaxed page grid">
+      <div class="eight wide center column">
+          <h1 class="hero ui icon header">
+              <i class="octicon octicon-comment-discussion"></i> Samarbeid i teams
+          </h1>
+          <p class="large">
+              <a href="{{AppSubUrl}}/explore/users">Utviklere</a> kan samarbeide og diskutere,
+              med tilgang til bl.a. full Git versjonshistorikk, backlog, milepæler, varsler og wiki.
+          </p>
+      </div>
+      <div class="eight wide center column">
+          <h1 class="hero ui icon header">
+              <i class="octicon octicon-organization"></i> Samarbeid på tvers
+          </h1>
+          <p class="large">
+              <a href="{{AppSubUrl}}/explore/organizations">Organisasjoner</a> kan samarbeide med hverandre om
+              gjenbrukbare løsninger og komponenter.
+          </p>
+      </div>
+  </div>
+  <div class="ui stackable middle very relaxed page grid">
+      <div class="eight wide center column">
+          <h1 class="hero ui icon header">
+              <i class="octicon octicon-tools"></i> Enkel å integrere
+          </h1>
+          <p class="large">
+              <a href="{{AppSubUrl}}/explore/repos">Appene</a> som utvikles er tilgjengelige via Git, og i tillegg så er
+              det meste av funksjonalitet også eksponert via et <a href="{{AppSubUrl}}/api/swagger">REST API</a>.
+          </p>
+      </div>
+      <div class="eight wide center column">
+          <h1 class="hero ui icon header">
+              <i class="octicon octicon-code"></i> Åpen kildekode
+          </h1>
+          <p class="large">
+              Altinn Studio deles som <a href="https://github.com/Altinn/altinn-studio">åpen kildekode på Github</a>,
+              slik at alle som vil kan bidra til å forbedre løsningen.
+          </p>
+      </div>
+  </div>
 </div>
 {{template "base/footer" .}}

--- a/src/LoadBalancer/nginx.conf
+++ b/src/LoadBalancer/nginx.conf
@@ -22,6 +22,7 @@ http {
         listen 80;
         server_name altinn3.no localhost;
 
+        proxy_cookie_path ~*^/.* /;
         proxy_redirect     off;
         proxy_set_header   Host $host;
         proxy_set_header   X-Real-IP $remote_addr;
@@ -29,12 +30,6 @@ http {
 
         location = / {
             proxy_pass         http://designer/;
-        }
-
-        location = /repos/ {
-          proxy_pass          http://designer/Redirect/FetchCookieAndRedirectHome/;
-          proxy_set_header 	  Host altinn3.no;
-          proxy_set_header 	  X-Forwarded-For $remote_addr;
         }
 
         rewrite ^/.*/.*/staticfiles(.*)$ $1 last;


### PR DESCRIPTION
Fixes #2427 "for real", getting rid of the redirect code.
I also fixed a lot of related stuff when starting looking into this.

**Important:** @jezpoz @matsgm This fix means we can't switch to using Traefik for Studio, since it does not support rewriting cookie paths. I guess that's fine.

- A "non-hackish" way to fix the handling of login, logout and sharing of cookies.
  - Rewrite cookie-path to / using nginx instead of redirecting to an action in Redirect-controller.
  - Removed the action
  - This makes `/repos` usable for Gitea Dashboard (logged in) and Gitea homepage (when not logged in)
- Fixed UI headers in Gitea
  - Icon navigation to root works again
  - Better icons
  - Menu entry for "Designer" now pops up when navigating to a repo in Gitea
  - Navigation to Dashboard (`/repos` ) is now working
  - Logout link that does not fail
  - Accessibility fixes
- Fixed Dashboard and homepage i Gitea
- Welcome page
  - Looks a little better, new icon and now with link to help
  - Uses `redirect_to=/` for login links to be redirected back to root after login