### PR TITLE
bug/2429-receipt-app-show-modal-as-printview

### DIFF
--- a/src/react-apps/applications/altinn-app-frontend/src/features/instantiate/containers/index.tsx
+++ b/src/react-apps/applications/altinn-app-frontend/src/features/instantiate/containers/index.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import ContentLoader from 'react-content-loader';
 import { useSelector } from 'react-redux';
 import { Redirect } from 'react-router-dom';
-import AltinnModal from '../../../../../shared/src/components/AltinnModal';
+import AltinnModal from '../../../../../shared/src/components/molecules/AltinnModal';
 import AltinnAppHeader from '../../../../../shared/src/components/organisms/AltinnAppHeader';
 import AltinnAppTheme from '../../../../../shared/src/theme/altinnAppTheme';
 import { IParty } from '../../../../../shared/src/types';

--- a/src/react-apps/applications/dashboard/src/features/createService/createNewService.tsx
+++ b/src/react-apps/applications/dashboard/src/features/createService/createNewService.tsx
@@ -5,11 +5,12 @@ import AltinnButton from '../../../../shared/src/components/AltinnButton';
 import AltinnDropdown from '../../../../shared/src/components/AltinnDropdown';
 import AltinnIconButton from '../../../../shared/src/components/AltinnIconButton';
 import AltinnInputField from '../../../../shared/src/components/AltinnInputField';
-import AltinnModal from '../../../../shared/src/components/AltinnModal';
 import AltinnPopper from '../../../../shared/src/components/AltinnPopper';
 import AltinnSpinner from '../../../../shared/src/components/AltinnSpinner';
+import AltinnModal from '../../../../shared/src/components/molecules/AltinnModal';
 import { getLanguageFromKey } from '../../../../shared/src/utils/language';
 import { post } from '../../../../shared/src/utils/networking';
+
 export interface ICreateNewServiceProvidedProps {
   classes: any;
 }

--- a/src/react-apps/applications/receipt/src/features/receipt/containers/Receipt.tsx
+++ b/src/react-apps/applications/receipt/src/features/receipt/containers/Receipt.tsx
@@ -2,8 +2,8 @@ import { createStyles, WithStyles, withStyles } from '@material-ui/core';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import Axios from 'axios';
 import * as React from 'react';
-import AltinnModal from '../../../../../shared/src/components/AltinnModal';
 import AltinnContentLoader from '../../../../../shared/src/components/molecules/AltinnContentLoader';
+import AltinnModal from '../../../../../shared/src/components/molecules/AltinnModal';
 import AltinnAppHeader from '../../../../../shared/src/components/organisms/AltinnAppHeader';
 import AltinnReceipt from '../../../../../shared/src/components/organisms/AltinnReceipt';
 import theme from '../../../../../shared/src/theme/altinnStudioTheme';
@@ -132,15 +132,15 @@ function Receipt(props: WithStyles<typeof styles>) {
         party={party ? party : {} as IParty}
         userParty={user ? user.party : {} as IParty}
       />
-        <AltinnModal
-          classes={props.classes}
-          isOpen={true}
-          onClose={handleModalClose}
-          hideBackdrop={true}
-          hideCloseIcon={isPrint}
-          printView={isPrint}
-          headerText={getLanguageFromKey('receipt_platform.receipt', language)}
-        >
+      <AltinnModal
+        classes={props.classes}
+        isOpen={true}
+        onClose={handleModalClose}
+        hideBackdrop={true}
+        hideCloseIcon={isPrint}
+        printView={true}
+        headerText={getLanguageFromKey('receipt_platform.receipt', language)}
+      >
         {isLoading() &&
           <AltinnContentLoader/>
         }
@@ -155,7 +155,7 @@ function Receipt(props: WithStyles<typeof styles>) {
             titleSubmitted={getLanguageFromKey('receipt_platform.sent_content', language)}
           />
         }
-        </AltinnModal>
+      </AltinnModal>
     </>
   );
 }

--- a/src/react-apps/applications/shared/src/components/molecules/AltinnModal.md
+++ b/src/react-apps/applications/shared/src/components/molecules/AltinnModal.md
@@ -31,3 +31,31 @@ function PreviewModal({classes}) {
 }
 ;<PreviewModal/>
 ```
+
+### Printview "looks like modal"
+
+This variant displays the modal design, without the modal function.
+
+This can be used in "print view" or to be staticly shown without any "Modal function".
+
+```jsx
+import Typography from '@material-ui/core/Typography';
+
+function PreviewModal({classes}) {
+  return (
+    <>
+      <AltinnModal
+        classes={null}
+        isOpen={null}
+        onClose={null}
+        headerText={'Printview "looks like modal"'}
+        printView={true}
+      >
+        <Typography>Content</Typography>
+      </AltinnModal>
+    </>
+  )
+};
+
+<PreviewModal/>
+```

--- a/src/react-apps/applications/shared/src/components/molecules/AltinnModal.tsx
+++ b/src/react-apps/applications/shared/src/components/molecules/AltinnModal.tsx
@@ -2,7 +2,7 @@ import { createMuiTheme, createStyles, IconButton, Modal, Typography } from '@ma
 import { withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 import * as React from 'react';
-import altinnTheme from '../theme/altinnStudioTheme';
+import altinnTheme from './../../theme/altinnStudioTheme';
 
 export interface IAltinnModalComponentProvidedProps {
   /** @ignore */


### PR DESCRIPTION
Receipt App show modal as printview.
Relocated AltinnModal to Molecules.
Documented AltinnModal printview variant.