### PR TITLE
Update lgtm to use .net core 3.1

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -4,4 +4,7 @@ extraction:
       maven:
         version: 4.0.0
       build_command: mvn -f ./src/Altinn.Platform/Altinn.Platform.PDF/pom.xml -Pprod package
-
+  csharp:
+    index:
+      dotnet:
+        version: 3.1.100


### PR DESCRIPTION
LGTM must be instructed to use 3.1. 