### PR TITLE
bug/1785--gitea-user-repos-instead-of-search

### DIFF
--- a/src/AltinnCore/Common/Services/Implementation/GiteaAPIWrapper.cs
+++ b/src/AltinnCore/Common/Services/Implementation/GiteaAPIWrapper.cs
@@ -91,6 +91,19 @@ namespace AltinnCore.Common.Services.Implementation
         }
 
         /// <inheritdoc/>
+        public async Task<IList<Repository>> GetUserRepos() {
+            IList<Repository> repos = new List<Repository>();
+
+            HttpResponseMessage response = await _httpClient.GetAsync("user/repos");
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                repos = await response.Content.ReadAsAsync<IList<Repository>>();
+            }
+
+            return repos;
+        }
+
+        /// <inheritdoc/>
         public async Task<SearchResults> SearchRepository(bool onlyAdmin, string keyWord, int page)
         {
             User user = GetCurrentUser().Result;

--- a/src/AltinnCore/Common/Services/Implementation/GiteaAPIWrapper.cs
+++ b/src/AltinnCore/Common/Services/Implementation/GiteaAPIWrapper.cs
@@ -91,7 +91,8 @@ namespace AltinnCore.Common.Services.Implementation
         }
 
         /// <inheritdoc/>
-        public async Task<IList<Repository>> GetUserRepos() {
+        public async Task<IList<Repository>> GetUserRepos()
+        {
             IList<Repository> repos = new List<Repository>();
 
             HttpResponseMessage response = await _httpClient.GetAsync("user/repos");

--- a/src/AltinnCore/Common/Services/Interfaces/IGitea.cs
+++ b/src/AltinnCore/Common/Services/Interfaces/IGitea.cs
@@ -17,6 +17,12 @@ namespace AltinnCore.Common.Services.Interfaces
         Task<User> GetCurrentUser();
 
         /// <summary>
+        /// List the repos that the authenticated user owns or has access to
+        /// </summary>
+        /// <returns>List of repos</returns>
+        Task<IList<Repository>> GetUserRepos();
+
+        /// <summary>
         /// Create repository for the org.
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
@@ -68,7 +74,7 @@ namespace AltinnCore.Common.Services.Interfaces
         /// This method screen scrapes the user from the profile ui in GITEA.
         /// This was needed when GITEA changed their API policy in 1.5.2 and requiring
         /// only API calls with token. This is currently the only known way to get
-        /// info about the logged in user in GITEA. 
+        /// info about the logged in user in GITEA.
         /// </summary>
         /// <returns>Returns the logged in user</returns>
         Task<string> GetUserNameFromUI();
@@ -76,7 +82,7 @@ namespace AltinnCore.Common.Services.Interfaces
         /// <summary>
         /// This method generates a application key in GITEA with
         /// help of screen scraping the Application form in GITEA
-        /// This is the only  way (currently) to generate a APP key without involving the user in 
+        /// This is the only  way (currently) to generate a APP key without involving the user in
         /// </summary>
         /// <returns>A newly generated token</returns>
         Task<KeyValuePair<string, string>?> GetSessionAppKey(string keyName = null);

--- a/src/AltinnCore/Designer/Controllers/RepositoryController.cs
+++ b/src/AltinnCore/Designer/Controllers/RepositoryController.cs
@@ -47,6 +47,16 @@ namespace AltinnCore.Designer.Controllers
         }
 
         /// <summary>
+        /// List the repos that the authenticated user owns or has access to
+        /// </summary>
+        /// <returns>List of repos</returns>
+        [HttpGet]
+        public Task<IList<RepositoryModel>> UserRepos()
+        {
+            return _giteaApi.GetUserRepos();
+        }
+
+        /// <summary>
         /// Returns a list over repositories
         /// </summary>
         /// <param name="repositorySearch">The search params</param>
@@ -314,7 +324,7 @@ namespace AltinnCore.Designer.Controllers
                 RepositoryName = repository,
                 ServiceName = appTitle,
             };
-            
+
             IList<ServiceConfiguration> apps = _repository.GetServices(org);
             List<string> appNames = apps.Select(c => c.RepositoryName.ToLower()).ToList();
             bool appAlreadyExist = appNames.Contains(serviceConfiguration.RepositoryName.ToLower());

--- a/src/react-apps/applications/dashboard/src/App.tsx
+++ b/src/react-apps/applications/dashboard/src/App.tsx
@@ -37,7 +37,7 @@ class App extends React.Component<IDashboardProps, IMainDashboardState> {
       `${altinnWindow.location.origin}/designerapi/Language/GetLanguageAsJSON`, 'nb');
 
     fetchServicesActionDispatchers.fetchServices(
-      `${altinnWindow.location.origin}/designerapi/Repository/Search`);
+      `${altinnWindow.location.origin}/designerapi/Repository/UserRepos`);
 
     fetchServicesActionDispatchers.fetchCurrentUser(
       `${altinnWindow.location.origin}/designerapi/User/Current`);


### PR DESCRIPTION
Getting sick and tired of the extremely lousy performance in the studio dashboard.

This PR changes the API used for fething repos from Gitea, and will cause better performance because of three tings:

- Will only retrieve repos that the user has been granted access to (instead of _everything_). This will also improve the user experience.
- No need for designer to do multiple calls because of paging
- user/repos is faster than repos/search

The search API-call today in dev.altinn.studio takes 9 sec for my user. Will wait with updating #1785 till after I can test the impact.
![image](https://user-images.githubusercontent.com/6088624/70515831-464f2f80-1b36-11ea-9cf3-de021526cbcb.png)
