### PR TITLE
Version update of dependencies in JwtCookieAuthentication++

### DIFF
--- a/src/AltinnCore/Altinn.Process.UnitTest/Altinn.Process.UnitTest.csproj
+++ b/src/AltinnCore/Altinn.Process.UnitTest/Altinn.Process.UnitTest.csproj
@@ -36,8 +36,6 @@
     <PackageReference Include="Manatee.Json" Version="10.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="NJsonSchema" Version="9.13.37" />
-    <PackageReference Include="NJsonSchema.CodeGeneration.CSharp" Version="9.13.37" />
     <PackageReference Include="XmlDiffPatch.Core" Version="1.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/src/AltinnCore/Authentication/AltinnCore.Authentication.csproj
+++ b/src/AltinnCore/Authentication/AltinnCore.Authentication.csproj
@@ -11,21 +11,21 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.0.5" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.4" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.6.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.6.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>2.2.0-alpha</Version>
+    <Version>2.2.1-alpha</Version>
     <Description>JWTCookieAuthentication is a package for usage of JWT token for authentication both as bearer token and inside cookie</Description>
     <PackageTags>altinn studio, authentication, jwt, JWTCookieAuthentication</PackageTags>
     <PackageId>JWTCookieAuthentication</PackageId>
     <Company>Altinn</Company>
     <Product>JWTCookieAuthentication</Product>
-    <AssemblyVersion>2.2.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
+    <AssemblyVersion>2.2.1.0</AssemblyVersion>
+    <FileVersion>2.2.1.0</FileVersion>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />


### PR DESCRIPTION
JwtCookieAuthentication depends on older version of Microsoft.IdentityModel.Clients.ActiveDirectory. Fix for2905. Also removed unnecessary dependencies in the unit test project for Process.