### PR TITLE
GetMany instances authorized based on scope and org claim.

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/IntegrationTest/Clients/InstanceClient.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/IntegrationTest/Clients/InstanceClient.cs
@@ -66,6 +66,9 @@ namespace Altinn.Platform.Storage.IntegrationTest.Clients
         {
             string requestUri = $"{_versionPrefix}/instances?org={org}&size={size}";
 
+            string token = PrincipalUtil.GetOrgToken(org: org, scope: "altinn:instances.read");
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
             HttpResponseMessage response = await _client.GetAsync(_hostName + requestUri);
 
             if (response.IsSuccessStatusCode)
@@ -104,7 +107,7 @@ namespace Altinn.Platform.Storage.IntegrationTest.Clients
                         Name = "FormFilling",
                     }
                 }
-            }.AsJson()); 
+            }.AsJson());
             if (response.IsSuccessStatusCode)
             {
                 string json = await response.Content.ReadAsStringAsync();

--- a/src/Altinn.Platform/Altinn.Platform.Storage/IntegrationTest/InstanceStorageTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/IntegrationTest/InstanceStorageTests.cs
@@ -37,6 +37,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
         private CloudBlobContainer _blobContainer;
         private bool blobSetup = false;
         private readonly string _validToken;
+        private readonly string _validOrgToken;
 
         private readonly string versionPrefix = "/storage/api/v1";
 
@@ -59,6 +60,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             _blobContainer = _blobClient.GetContainerReference("servicedata");
 
             _validToken = PrincipalUtil.GetToken(1);
+            _validOrgToken = PrincipalUtil.GetOrgToken(org: testOrg, scope: "altinn:instances.read");
             CreateTestApplication();
         }
 
@@ -166,7 +168,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             await _instanceClient.PostInstances(testAppId, testInstanceOwnerId);
 
             string url = $"{versionPrefix}/instances?org={testOrg}&appId={testAppId}&instanceOwner.partyId={testInstanceOwnerId}";
-            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
             HttpResponseMessage response = await _client.GetAsync(url);
 
             response.EnsureSuccessStatusCode();

--- a/src/Altinn.Platform/Altinn.Platform.Storage/IntegrationTest/InstancesQueryTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/IntegrationTest/InstancesQueryTests.cs
@@ -9,6 +9,7 @@ using Altinn.Platform.Storage.IntegrationTest.Clients;
 using Altinn.Platform.Storage.IntegrationTest.Fixtures;
 using Altinn.Platform.Storage.IntegrationTest.Utils;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.OpenApi.Writers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -27,6 +28,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
         private readonly string _testAppId = "tdd/m1000";
         private readonly string _versionPrefix = "/storage/api/v1";
         private readonly string _validToken;
+        private readonly string _validOrgToken;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstanceStorageTests"/> class.
@@ -37,6 +39,8 @@ namespace Altinn.Platform.Storage.IntegrationTest
             _fixture = fixture;
             _instanceClient = new InstanceClient(_fixture.CreateClient());
             _validToken = PrincipalUtil.GetToken(1);
+            _validOrgToken = PrincipalUtil.GetOrgToken(org: _testOrg, scope: "altinn:instances.read");
+
             LoadTestData();
             CreateTestApplication(_testAppId);
         }        
@@ -50,7 +54,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=100&process.currentTask=Submit_1";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -71,7 +75,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=100&visibleAfter=gt:2019-05-01";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -93,7 +97,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=100&appOwner.labels=zero";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -115,7 +119,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=100&appOwner.labels=one&appOwner.labels=two";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -137,7 +141,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=1000&appOwner.labels=one";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -159,7 +163,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=1000&appOwner.labels=one,two";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -181,7 +185,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=100&visibleAfter=2019-50-01";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -196,7 +200,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=100&visibleAfter=gt:2022-12-31";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
 
@@ -216,7 +220,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=1000&visibleAfter=2019-07-10T00:00:00Z";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -238,7 +242,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=1000&visibleAfter=2019-03-25T02:00:00%2B02:00";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -260,7 +264,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=1000&visibleAfter=gt:2019-07-01&visibleAfter=lt:2019-08-01";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -282,7 +286,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?instanceOwnerId=500";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
 
@@ -298,7 +302,10 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?org={_testOrg}";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
+
+            string token = PrincipalUtil.GetOrgToken(org: _testOrg, scope: "altinn:instances.read");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -322,7 +329,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=500";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -392,7 +399,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
 
             // client.DefaultRequestHeaders.Clear();
             client.DefaultRequestHeaders.Add("Accept", "application/json");
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
 
@@ -416,7 +423,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&process.ended=lt:2019-02-01";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = await client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -452,7 +459,7 @@ namespace Altinn.Platform.Storage.IntegrationTest
             HttpClient client = _fixture.CreateClient();
 
             string url = $"{_versionPrefix}/instances?appId={_testAppId}&size=1000";
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validToken);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _validOrgToken);
 
             HttpResponseMessage response = client.GetAsync(url).Result;
             response.EnsureSuccessStatusCode();

--- a/src/Altinn.Platform/Altinn.Platform.Storage/IntegrationTest/InstancesQueryTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/IntegrationTest/InstancesQueryTests.cs
@@ -27,7 +27,6 @@ namespace Altinn.Platform.Storage.IntegrationTest
         private readonly string _testOrg = "tdd";
         private readonly string _testAppId = "tdd/m1000";
         private readonly string _versionPrefix = "/storage/api/v1";
-        private readonly string _validToken;
         private readonly string _validOrgToken;
 
         /// <summary>
@@ -38,7 +37,6 @@ namespace Altinn.Platform.Storage.IntegrationTest
         {
             _fixture = fixture;
             _instanceClient = new InstanceClient(_fixture.CreateClient());
-            _validToken = PrincipalUtil.GetToken(1);
             _validOrgToken = PrincipalUtil.GetOrgToken(org: _testOrg, scope: "altinn:instances.read");
 
             LoadTestData();

--- a/src/Altinn.Platform/Altinn.Platform.Storage/IntegrationTest/TestingControllers/InstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/IntegrationTest/TestingControllers/InstancesControllerTests.cs
@@ -138,111 +138,6 @@ namespace Altinn.Platform.Storage.IntegrationTest.TestingControllers
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
-        /* This tests are no longer needed because put has no policy defined in the Authorize tag,
-         * but the tests can be used later if we add authorization rules to the methode later. 
-        /// <summary>
-        /// Test case: User has to low authentication level. 
-        /// Expected: Returns status forbidden.
-        /// </summary>
-        [Fact]
-        public async void Put_UserHasTooLowAuthLv_ReturnsStatusForbidden()
-        {
-            // Arrange
-            int instanceOwnerPartyId = 1;
-            string instanceGuid = "cbdb00b1-4134-490d-b02b-3e33f7d8da33";
-            string requestUri = $"{BasePath}/{instanceOwnerPartyId}/{instanceGuid}";
-
-            HttpClient client = GetTestClient(_instanceRepository.Object);
-            string token = PrincipalUtil.GetToken(1, 0);
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-            Instance instance = new Instance();
-
-            // Act
-            HttpResponseMessage response = await client.PutAsync(requestUri, new StringContent(JsonConvert.SerializeObject(instance), Encoding.UTF8, "application/json"));
-
-            // Assert
-            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-        }
-
-        /// <summary>
-        /// Test case: User has to low authentication level. 
-        /// Expected: Returns status forbidden.
-        /// </summary>
-        [Fact]
-        public async void Put_ToProcess_ReturnsStatusForbidden()
-        {
-            // Arrange
-            int instanceOwnerPartyId = 1;
-            string instanceGuid = "cbdb00b1-4134-490d-b02b-3e33f7d8da33";
-            string requestUri = $"{BasePath}/{instanceOwnerPartyId}/{instanceGuid}/process";
-            string instanceId = $"{instanceOwnerPartyId}/{instanceGuid}";
-
-            Instance instance = new Instance
-            {
-                Id = instanceId,
-                AppId = "tdd/app",
-                Org = "tdd",
-                Process = new ProcessState
-                {
-                    Started = DateTime.UtcNow,
-                    StartEvent = "StartEvent_1",
-                    CurrentTask = new ProcessElementInfo
-                    {
-                        ElementId = "Task_1",
-                        AltinnTaskType = "data"
-                    },
-                },
-            };
-
-            _instanceRepository
-                .Setup(r => r.GetOne(instanceId, instanceOwnerPartyId))
-                .Returns(Task.FromResult(instance));
-
-            HttpClient client = GetTestClient(_instanceRepository.Object);
-            string token = PrincipalUtil.GetToken(1, 0);
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-            ProcessState processState = new ProcessState
-            {
-                StartEvent = "StartEvent_1",
-                CurrentTask = null,
-                EndEvent = "EndEvent_1",
-                Ended = DateTime.UtcNow,                 
-            };
-
-            // Act
-            HttpResponseMessage response = await client.PutAsync(requestUri, new StringContent(JsonConvert.SerializeObject(processState), Encoding.UTF8, "application/json"));
-
-            // Assert
-            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-        }
-
-        /// <summary>
-        /// Test case: Response is deny. 
-        /// Expected: Returns status forbidden.
-        /// </summary>
-        [Fact]
-        public async void Put_ReponseIsDeny_ReturnsStatusForbidden()
-        {
-            // Arrange
-            int instanceOwnerPartyId = 1;
-            string instanceGuid = "cbdb00b1-4134-490d-b02b-3e33f7d8da33";
-            string requestUri = $"{BasePath}/{instanceOwnerPartyId}/{instanceGuid}";
-
-            HttpClient client = GetTestClient(_instanceRepository.Object);
-            string token = PrincipalUtil.GetToken(2);
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-            Instance instance = new Instance();
-
-            // Act
-            HttpResponseMessage response = await client.PutAsync(requestUri, new StringContent(JsonConvert.SerializeObject(instance), Encoding.UTF8, "application/json"));
-
-            // Assert
-            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-        }*/
-
         /// <summary>
         /// Test case: User has to low authentication level. 
         /// Expected: Returns status forbidden.
@@ -289,6 +184,69 @@ namespace Altinn.Platform.Storage.IntegrationTest.TestingControllers
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
+        /// <summary>
+        /// Test case: Get Multiple instances without specifying org.
+        /// Expected: Returns status bad request.
+        /// </summary>
+        [Fact]
+        public async void GetMany_NoOrgDefined_ReturnsBadRequest()
+        {
+            // Arrange
+            string requestUri = $"{BasePath}";
+
+            HttpClient client = GetTestClient(_instanceRepository.Object);
+            string token = PrincipalUtil.GetOrgToken("testOrg", scope: "altinn:instances.read");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        /// <summary>
+        /// Test case: Get Multiple instances using client with incorrect scope.
+        /// Expected: Returns status forbidden.
+        /// </summary>
+        [Fact]
+        public async void GetMany_IncorrectScope_ReturnsForbidden()
+        {
+            // Arrange
+            string requestUri = $"{BasePath}?org=testOrg";
+
+            HttpClient client = GetTestClient(_instanceRepository.Object);
+            string token = PrincipalUtil.GetOrgToken("testOrg", scope: "altinn:instances.write");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        /// <summary>
+        /// Test case: Response is deny. 
+        /// Expected: Returns status forbidden.
+        /// </summary>
+        [Fact]
+        public async void GetMany_QueryingDifferentOrgThanInClaims_ReturnsForbidden()
+        {
+            // Arrange
+            string requestUri = $"{BasePath}?org=paradiseHotelOrg";
+
+            HttpClient client = GetTestClient(_instanceRepository.Object);
+            string token = PrincipalUtil.GetOrgToken("testOrg", scope: "altinn:instances.read");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+        
         private HttpClient GetTestClient(IInstanceRepository instanceRepository)
         {
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
@@ -34,7 +34,6 @@ namespace Altinn.Platform.Storage.Controllers
         private readonly IApplicationRepository _applicationRepository;
         private readonly ILogger _logger;
         private readonly IPDP _pdp;
-        private readonly AuthorizationHelper _authorizationHelper;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstancesController"/> class
@@ -56,7 +55,6 @@ namespace Altinn.Platform.Storage.Controllers
             _applicationRepository = applicationRepository;
             _pdp = pdp;
             _logger = logger;
-            _authorizationHelper = new AuthorizationHelper(pdp);
         }
 
         /// <summary>
@@ -78,11 +76,12 @@ namespace Altinn.Platform.Storage.Controllers
         /// <param name="size">the page size</param>
         /// <returns>list of all instances for given instance owner</returns>
         /// <!-- GET /instances?org=tdd or GET /instances?appId=tdd/app2 -->
+        [Authorize(Policy = AuthzConstants.POLICY_SCOPE_INSTANCE_READ)]
         [HttpGet]
         [ProducesResponseType(typeof(QueryResponse<Instance>), 200)]
         public async Task<ActionResult> GetInstances(
-            string org,
-            string appId,
+            [FromQuery] string org,
+            [FromQuery] string appId,
             [FromQuery(Name = "process.currentTask")] string currentTaskId,
             [FromQuery(Name = "process.isComplete")] bool? processIsComplete,
             [FromQuery(Name = "process.endEvent")] string processEndEvent,
@@ -98,6 +97,18 @@ namespace Altinn.Platform.Storage.Controllers
         {
             int pageSize = size ?? 100;
             string selfContinuationToken = null;
+
+            if (string.IsNullOrEmpty(org) && string.IsNullOrEmpty(appId))
+            {
+                return BadRequest("Org or AppId must be defined.");
+            }
+
+            org = string.IsNullOrEmpty(org) ? appId.Split('/')[0] : org;
+
+            if (!AuthorizationHelper.VerifyOrgInClaimPrincipal(org, HttpContext.User))
+            {
+                return Forbid();
+            }
 
             if (!string.IsNullOrEmpty(continuationToken))
             {
@@ -116,7 +127,7 @@ namespace Altinn.Platform.Storage.Controllers
             try
             {
                 InstanceQueryResponse result = await _instanceRepository.GetInstancesOfApplication(queryParams, continuationToken, pageSize);
-                
+
                 if (!string.IsNullOrEmpty(result.Exception))
                 {
                     return BadRequest(result.Exception);
@@ -125,11 +136,9 @@ namespace Altinn.Platform.Storage.Controllers
                 string nextContinuationToken = HttpUtility.UrlEncode(result.ContinuationToken);
                 result.ContinuationToken = null;
 
-                List<Instance> authorizedInstances = await _authorizationHelper.AuthorizeInstances(HttpContext.User, result.Instances);
-
                 QueryResponse<Instance> response = new QueryResponse<Instance>
                 {
-                    Instances = authorizedInstances,
+                    Instances = result.Instances,
                     Count = result.Instances.Count,
                     TotalHits = result.TotalHits ?? 0
                 };
@@ -312,7 +321,7 @@ namespace Altinn.Platform.Storage.Controllers
 
             DateTime? visibleAfter = DateTimeHelper.ConvertToUniversalTime(instance.VisibleAfter);
             existingInstance.VisibleAfter ??= visibleAfter;
-            
+
             existingInstance.LastChangedBy = GetUserId();
             existingInstance.LastChanged = DateTime.UtcNow;
 
@@ -385,7 +394,7 @@ namespace Altinn.Platform.Storage.Controllers
             try
             {
                 result = await _instanceRepository.Update(existingInstance);
-               
+
                 AddSelfLinks(Request, result);
             }
             catch (Exception e)
@@ -484,7 +493,7 @@ namespace Altinn.Platform.Storage.Controllers
 
             string org = instance.Org;
             string app = instance.AppId.Split("/")[1];
-            
+
             XacmlJsonRequestRoot request = DecisionHelper.CreateDecisionRequest(org, app, HttpContext.User, actionType, null, instance.Id);
             XacmlJsonResponse response = await _pdp.GetDecisionForRequest(request);
             if (response?.Response == null)
@@ -565,7 +574,7 @@ namespace Altinn.Platform.Storage.Controllers
                 AppOwner = new ApplicationOwnerState
                 {
                     Labels = instanceTemplate.AppOwner?.Labels,
-                },                               
+                },
             };
 
             // copy applications title to presentation field if not set by instance template
@@ -631,7 +640,7 @@ namespace Altinn.Platform.Storage.Controllers
                     AuthenticationLevel = User.GetAuthenticationLevel(),
                     OrgId = User.GetOrg(),
                 },
-                
+
                 ProcessInfo = instance.Process,
                 Created = DateTime.UtcNow,
             };

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
@@ -42,7 +42,7 @@ namespace Altinn.Platform.Storage.Controllers
         /// <param name="instanceEventRepository">the instance event repository service</param>
         /// <param name="applicationRepository">the application repository handler</param>
         /// <param name="logger">the logger</param>
-        /// <param name="pdp">the policy desicion point.</param>
+        /// <param name="pdp">the policy decision point.</param>
         public InstancesController(
             IInstanceRepository instanceRepository,
             IInstanceEventRepository instanceEventRepository,

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/AuthorizationHelper.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/AuthorizationHelper.cs
@@ -186,7 +186,7 @@ namespace Altinn.Platform.Storage.Helpers
         /// <returns></returns>
         public static bool VerifyOrgInClaimPrincipal(string org, ClaimsPrincipal user)
         {
-            string orgClaim = user?.Claims.Where(c => c.Type.Equals("urn:altinn:org")).Select(c => c.Value).FirstOrDefault();
+            string orgClaim = user?.Claims.Where(c => c.Type.Equals(AltinnXacmlUrns.OrgId)).Select(c => c.Value).FirstOrDefault();
 
             if (org.Equals(orgClaim, StringComparison.CurrentCultureIgnoreCase))
             {

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/AuthorizationHelper.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/AuthorizationHelper.cs
@@ -8,6 +8,7 @@ using Altinn.Common.PEP.Constants;
 using Altinn.Common.PEP.Helpers;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.AspNetCore.Http;
 
 namespace Altinn.Platform.Storage.Helpers
 {
@@ -162,8 +163,11 @@ namespace Altinn.Platform.Storage.Helpers
                 throw new ArgumentNullException("user");
             }
 
-            XacmlJsonRequest request = new XacmlJsonRequest();
-            request.AccessSubject = new List<XacmlJsonCategory>();
+            XacmlJsonRequest request = new XacmlJsonRequest
+            {
+                AccessSubject = new List<XacmlJsonCategory>()
+            };
+
             request.AccessSubject.Add(CreateMultipleSubjectCategory(user.Claims));
             request.Action = CreateMultipleActionCategory(actionTypes);
             request.Resource = CreateMultipleResourceCategory(instances);
@@ -172,6 +176,24 @@ namespace Altinn.Platform.Storage.Helpers
             XacmlJsonRequestRoot jsonRequest = new XacmlJsonRequestRoot() { Request = request };
 
             return jsonRequest;
+        }
+
+        /// <summary>
+        /// Verifies that org string matches org in user claims.
+        /// </summary>
+        /// <param name="org">Organisation to match in claims.</param>
+        /// <param name="user">Claim principal from http context.</param>
+        /// <returns></returns>
+        public static bool VerifyOrgInClaimPrincipal(string org, ClaimsPrincipal user)
+        {
+            string orgClaim = user?.Claims.Where(c => c.Type.Equals("urn:altinn:org")).Select(c => c.Value).FirstOrDefault();
+
+            if (org.Equals(orgClaim, StringComparison.CurrentCultureIgnoreCase))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static XacmlJsonCategory CreateMultipleSubjectCategory(IEnumerable<Claim> claims)
@@ -206,8 +228,7 @@ namespace Altinn.Platform.Storage.Helpers
 
             foreach (Instance instance in instances)
             {
-                XacmlJsonCategory resourceCategory = new XacmlJsonCategory();
-                resourceCategory.Attribute = new List<XacmlJsonAttribute>();
+                XacmlJsonCategory resourceCategory = new XacmlJsonCategory { Attribute = new List<XacmlJsonAttribute>() };
 
                 string instanceId = instance.Id.Split("/")[1];
                 string task = instance.Process?.CurrentTask?.ElementId;
@@ -247,8 +268,10 @@ namespace Altinn.Platform.Storage.Helpers
             List<string> actionIds = actions.Select(a => a.Id).ToList();
             List<string> resourceIds = resources.Select(r => r.Id).ToList();
 
-            XacmlJsonMultiRequests multiRequests = new XacmlJsonMultiRequests();
-            multiRequests.RequestReference = CreateRequestReference(subjectIds, actionIds, resourceIds);
+            XacmlJsonMultiRequests multiRequests = new XacmlJsonMultiRequests
+            {
+                RequestReference = CreateRequestReference(subjectIds, actionIds, resourceIds)
+            };
 
             return multiRequests;
         }
@@ -264,10 +287,12 @@ namespace Altinn.Platform.Storage.Helpers
                     foreach (string subjectId in subjectIds)
                     {
                         XacmlJsonRequestReference reference = new XacmlJsonRequestReference();
-                        List<string> referenceId = new List<string>();
-                        referenceId.Add(subjectId);
-                        referenceId.Add(actionId);
-                        referenceId.Add(resourceId);
+                        List<string> referenceId = new List<string>
+                        {
+                            subjectId,
+                            actionId,
+                            resourceId
+                        };
                         reference.ReferenceId = referenceId;
                         references.Add(reference);
                     }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/AuthorizationHelper.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/AuthorizationHelper.cs
@@ -8,7 +8,6 @@ using Altinn.Common.PEP.Constants;
 using Altinn.Common.PEP.Helpers;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Storage.Interface.Models;
-using Microsoft.AspNetCore.Http;
 
 namespace Altinn.Platform.Storage.Helpers
 {

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/AuthzConstants.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/AuthzConstants.cs
@@ -19,5 +19,10 @@ namespace Altinn.Platform.Storage.Helpers
         /// Policy tag for authorizing client scope.
         /// </summary>
         public const string POLICY_SCOPE_APPDEPLOY = "ScopeAppDeploy";
+
+        /// <summary>
+        /// Policy tag for authorizing client scope.
+        /// </summary>
+        public const string POLICY_SCOPE_INSTANCE_READ = "ScopeInstanceRead"; 
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Startup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Startup.cs
@@ -216,7 +216,6 @@ namespace Altinn.Platform.Storage
             app.UseRouting();
             app.UseAuthentication();
             app.UseAuthorization();
-
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Startup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Startup.cs
@@ -113,6 +113,7 @@ namespace Altinn.Platform.Storage
                 options.AddPolicy(AuthzConstants.POLICY_INSTANCE_READ, policy => policy.Requirements.Add(new AppAccessRequirement("read")));
                 options.AddPolicy(AuthzConstants.POLICY_INSTANCE_WRITE, policy => policy.Requirements.Add(new AppAccessRequirement("write")));
                 options.AddPolicy(AuthzConstants.POLICY_SCOPE_APPDEPLOY, policy => policy.Requirements.Add(new ScopeAccessRequirement("altinn:appdeploy")));
+                options.AddPolicy(AuthzConstants.POLICY_SCOPE_INSTANCE_READ, policy => policy.Requirements.Add(new ScopeAccessRequirement("altinn:instances.read")));
             });
 
             services.AddSingleton<IDataRepository, DataRepository>();
@@ -215,6 +216,7 @@ namespace Altinn.Platform.Storage
             app.UseRouting();
             app.UseAuthentication();
             app.UseAuthorization();
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();


### PR DESCRIPTION
- org or appId must be set when querying multiple instances 
- authorization based on org claim + client scope. 