### PR TITLE
fixed hostname for navigation links

### DIFF
--- a/src/react-apps/applications/altinn-app-frontend/src/utils/urlHelper.ts
+++ b/src/react-apps/applications/altinn-app-frontend/src/utils/urlHelper.ts
@@ -79,8 +79,10 @@ export const getHostname: () => string = () => {
   // First split away the protocol 'https://' and take the last part. Then split on dots.
   const domainSplitted: string[] = window.location.host.split('.');
   if (domainSplitted.length === 5) {
-    return domainSplitted[2];
+    return `${domainSplitted[2]}.${domainSplitted[3]}.${domainSplitted[4]}`;
   } else if (domainSplitted.length === 4) {
-    return domainSplitted[2];
+    return `${domainSplitted[2]}.${domainSplitted[3]}`;
+  } else {
+    throw new Error('Unknown domain');
   }
 };


### PR DESCRIPTION
#3409 
Links were only using first part of domain, fixed to use the whole thing.