### PR TITLE
Add pvc to app deployment

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/deployment/templates/deployment.yaml
+++ b/src/Altinn.Apps/AppTemplates/AspNet/deployment/templates/deployment.yaml
@@ -53,4 +53,3 @@ spec:
               secretName: {{ $volume.secret.secretName }}
             {{- end }}
         {{- end }}
-        {{- end }}

--- a/src/Altinn.Apps/AppTemplates/AspNet/deployment/templates/deployment.yaml
+++ b/src/Altinn.Apps/AppTemplates/AspNet/deployment/templates/deployment.yaml
@@ -34,3 +34,23 @@ spec:
           {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
+          {{- if .Values.volumeMounts}}
+          volumeMounts:
+            {{- range $mount := .Values.volumeMounts}}
+            - name: {{ $mount.name }}
+              mountPath: {{ $mount.mountPath }}
+            {{- end }}
+          {{- end }}
+      volumes:
+        {{- range $volume := .Values.volumes }}
+          - name: {{ $volume.name }}
+            {{- if $volume.persistentVolumeClaim }}
+            persistentVolumeClaim:
+              claimName: {{ $volume.persistentVolumeClaim.claimName }}
+            {{- end }}
+            {{- if $volume.secret }}
+            secret:
+              secretName: {{ $volume.secret.secretName }}
+            {{- end }}
+        {{- end }}
+        {{- end }}

--- a/src/Altinn.Apps/AppTemplates/AspNet/deployment/values.yaml
+++ b/src/Altinn.Apps/AppTemplates/AspNet/deployment/values.yaml
@@ -31,3 +31,12 @@ ingressRoute:
     options:
       name: tls-options
     secretName: ssl-cert
+
+volumeMounts:
+  - name: datakeys
+    mountPath: /mnt/keys
+
+volumes:
+  - name : datakeys
+    persistentVolumeClaim:
+      claimName: keys


### PR DESCRIPTION
App deployment was missing the pvc volume mounts for data protection keys