### PR TITLE
Added sub claim for CSRF

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -101,6 +101,7 @@ namespace Altinn.Platform.Authentication.Controllers
             {
                 List<Claim> claims = new List<Claim>();
                 string issuer = _generalSettings.PlatformEndpoint;
+                claims.Add(new Claim("sub", userAuthentication.UserID.ToString(), ClaimValueTypes.String, issuer));
                 claims.Add(new Claim(AltinnCoreClaimTypes.UserId, userAuthentication.UserID.ToString(), ClaimValueTypes.String, issuer));
                 claims.Add(new Claim(AltinnCoreClaimTypes.UserName, userAuthentication.Username, ClaimValueTypes.String, issuer));
                 claims.Add(new Claim(AltinnCoreClaimTypes.PartyID, userAuthentication.PartyID.ToString(), ClaimValueTypes.Integer32, issuer));

--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -101,6 +101,7 @@ namespace LocalTest.Controllers
 
             List<Claim> claims = new List<Claim>();
             string issuer = "altinn3local.no";
+            claims.Add(new Claim("sub", profile.UserId.ToString(), ClaimValueTypes.String, issuer));
             claims.Add(new Claim(AltinnCoreClaimTypes.UserId, profile.UserId.ToString(), ClaimValueTypes.String, issuer));
             claims.Add(new Claim(AltinnCoreClaimTypes.UserName, profile.UserName, ClaimValueTypes.String, issuer));
             claims.Add(new Claim(AltinnCoreClaimTypes.PartyID, profile.PartyId.ToString(), ClaimValueTypes.Integer32, issuer));


### PR DESCRIPTION
Added sub claim to prevent CSRF token to be based on all other claims.

This based on findings in CSRF Code. https://github.com/dotnet/aspnetcore/blob/master/src/Antiforgery/src/Internal/DefaultClaimUidExtractor.cs