### PR TITLE
feature/3723-appinsight-plattform-update

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Altinn.Platform.Authentication.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Altinn.Platform.Authentication.csproj
@@ -12,7 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.1.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.6.0" />

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Configuration/CustomTelemetryInitializer.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Configuration/CustomTelemetryInitializer.cs
@@ -1,0 +1,22 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Altinn.Platform.Telemetry
+{
+    /// <summary>
+    /// Set up custom telemetry for Application Insights
+    /// </summary>
+    public class CustomTelemetryInitializer : ITelemetryInitializer
+    {
+        /// <summary>
+        /// Custom TelemetryInitializer that sets some specific values for the component
+        /// </summary>
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+            {
+                telemetry.Context.Cloud.RoleName = "platform-authentication";
+            }
+        }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Startup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Startup.cs
@@ -5,9 +5,11 @@ using System.Reflection;
 using Altinn.Platform.Authentication.Configuration;
 using Altinn.Platform.Authentication.Repositories;
 using Altinn.Platform.Authentication.Services;
+using Altinn.Platform.Telemetry;
 using AltinnCore.Authentication.Constants;
 using AltinnCore.Authentication.JwtCookie;
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -29,7 +31,7 @@ namespace Altinn.Platform.Authentication
         /// <summary>
         /// The key vault key which application insights is stored.
         /// </summary>
-        public static readonly string VaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey--Authentication";
+        public static readonly string VaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey";
 
         /// <summary>
         /// The application insights key.
@@ -101,7 +103,9 @@ namespace Altinn.Platform.Authentication
             if (!string.IsNullOrEmpty(ApplicationInsightsKey))
             {
                 services.AddSingleton(typeof(ITelemetryChannel), new ServerTelemetryChannel() { StorageFolder = "/tmp/logtelemetry" });
-                services.AddApplicationInsightsTelemetry(ApplicationInsightsKey);
+                services.AddApplicationInsightsTelemetry(ApplicationInsightsKey);   
+                services.AddApplicationInsightsKubernetesEnricher();
+                services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
 
                 _logger.LogInformation($"Startup // ApplicationInsightsTelemetryKey = {ApplicationInsightsKey}");
             }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Altinn.Platform.Authorization.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Altinn.Platform.Authorization.csproj
@@ -9,10 +9,11 @@
 
  <ItemGroup>
     <PackageReference Include="Altinn.Platform.Models" Version="1.0.1-alpha" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.0" />
     <PackageReference Include="Altinn.Authorization.ABAC" Version="0.0.3-alpha" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.0.0" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.0.0-alpha" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.1.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.2" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0" />

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Configuration/CustomTelemetryInitializer.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Configuration/CustomTelemetryInitializer.cs
@@ -1,0 +1,22 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Altinn.Platform.Telemetry
+{
+    /// <summary>
+    /// Set up custom telemetry for Application Insights
+    /// </summary>
+    public class CustomTelemetryInitializer : ITelemetryInitializer
+    {
+        /// <summary>
+        /// Custom TelemetryInitializer that sets some specific values for the component
+        /// </summary>
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+            {
+                telemetry.Context.Cloud.RoleName = "platform-authorization";
+            }
+        }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Startup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Startup.cs
@@ -7,7 +7,9 @@ using Altinn.Platform.Authorization.Repositories;
 using Altinn.Platform.Authorization.Repositories.Interface;
 using Altinn.Platform.Authorization.Services.Implementation;
 using Altinn.Platform.Authorization.Services.Interface;
+using Altinn.Platform.Telemetry;
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -30,7 +32,7 @@ namespace Altinn.Platform.Authorization
         /// <summary>
         /// The key valt key for application insights.
         /// </summary>
-        internal static readonly string VaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey--Authorization";
+        internal static readonly string VaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey";
 
         /// <summary>
         /// The application insights key.
@@ -86,6 +88,8 @@ namespace Altinn.Platform.Authorization
             {
                 services.AddSingleton(typeof(ITelemetryChannel), new ServerTelemetryChannel() { StorageFolder = "/tmp/logtelemetry" });
                 services.AddApplicationInsightsTelemetry(ApplicationInsightsKey);
+                services.AddApplicationInsightsKubernetesEnricher();
+                services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
 
                 _logger.LogInformation($"Startup // ApplicationInsightsTelemetryKey = {ApplicationInsightsKey}");
             }

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/App.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/App.java
@@ -22,7 +22,7 @@ import java.util.logging.Level;
 @SpringBootApplication
 public class App {
 
-  private static String vaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey--Pdf";
+  private static String vaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey";
 
   public static void main(String[] args) {
     AltinnOrgUtils.initAltinnOrgsHarvesting();

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/ApplicationInsights.xml
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/ApplicationInsights.xml
@@ -3,6 +3,8 @@
 
   <InstrumentationKey>This key is added in App.java</InstrumentationKey>
 
+  <RoleName>platform-pdf</RoleName>
+
   <TelemetryModules>
     <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebRequestTrackingTelemetryModule"/>
     <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebSessionTrackingTelemetryModule"/>

--- a/src/Altinn.Platform/Altinn.Platform.Profile/Profile/Altinn.Platform.Profile.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Profile/Profile/Altinn.Platform.Profile.csproj
@@ -9,8 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Platform.Models" Version="1.0.1-alpha" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.12.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.0" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.3.0-alpha" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.1.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" />

--- a/src/Altinn.Platform/Altinn.Platform.Profile/Profile/Configuration/CustomTelemetryInitializer.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Profile/Profile/Configuration/CustomTelemetryInitializer.cs
@@ -1,0 +1,22 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Altinn.Platform.Telemetry
+{
+    /// <summary>
+    /// Set up custom telemetry for Application Insights
+    /// </summary>
+    public class CustomTelemetryInitializer : ITelemetryInitializer
+    {
+        /// <summary>
+        /// Custom TelemetryInitializer that sets some specific values for the component
+        /// </summary>
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+            {
+                telemetry.Context.Cloud.RoleName = "platform-profile";
+            }
+        }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Profile/Profile/Startup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Profile/Profile/Startup.cs
@@ -4,8 +4,10 @@ using System.Reflection;
 using Altinn.Platform.Profile.Configuration;
 using Altinn.Platform.Profile.Services.Implementation;
 using Altinn.Platform.Profile.Services.Interfaces;
+using Altinn.Platform.Telemetry;
 using AltinnCore.Authentication.JwtCookie;
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -26,7 +28,7 @@ namespace Altinn.Platform.Profile
         /// <summary>
         /// The key valt key for application insights.
         /// </summary>
-        internal static readonly string VaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey--Profile";
+        internal static readonly string VaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey";
 
         /// <summary>
         /// The application insights key.
@@ -92,6 +94,8 @@ namespace Altinn.Platform.Profile
             {
                 services.AddSingleton(typeof(ITelemetryChannel), new ServerTelemetryChannel() { StorageFolder = "/tmp/logtelemetry" });
                 services.AddApplicationInsightsTelemetry(ApplicationInsightsKey);
+                services.AddApplicationInsightsKubernetesEnricher();
+                services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
 
                 _logger.LogInformation($"Startup // ApplicationInsightsTelemetryKey = {ApplicationInsightsKey}");
             }

--- a/src/Altinn.Platform/Altinn.Platform.Receipt/Receipt/Altinn.Platform.Receipt.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Receipt/Receipt/Altinn.Platform.Receipt.csproj
@@ -7,13 +7,14 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Platform.Models" Version="1.0.0-alpha" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.13.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.4" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.0.4" />

--- a/src/Altinn.Platform/Altinn.Platform.Receipt/Receipt/Configuration/CustomTelemetryInitializer.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Receipt/Receipt/Configuration/CustomTelemetryInitializer.cs
@@ -1,0 +1,22 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Altinn.Platform.Telemetry
+{
+    /// <summary>
+    /// Set up custom telemetry for Application Insights
+    /// </summary>
+    public class CustomTelemetryInitializer : ITelemetryInitializer
+    {
+        /// <summary>
+        /// Custom TelemetryInitializer that sets some specific values for the component
+        /// </summary>
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+            {
+                telemetry.Context.Cloud.RoleName = "platform-receipt";
+            }
+        }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Receipt/Receipt/Startup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Receipt/Receipt/Startup.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Net;
 using Altinn.Platform.Receipt.Configuration;
+using Altinn.Platform.Telemetry;
 using AltinnCore.Authentication.JwtCookie;
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -23,7 +25,7 @@ namespace Altinn.Platform.Receipt
         /// <summary>
         /// The key valt key for application insights.
         /// </summary>
-        internal static readonly string VaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey--Receipt";
+        internal static readonly string VaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey";
 
         /// <summary>
         /// The application insights key.
@@ -90,6 +92,8 @@ namespace Altinn.Platform.Receipt
             {
                 services.AddSingleton(typeof(ITelemetryChannel), new ServerTelemetryChannel() { StorageFolder = "/tmp/logtelemetry" });
                 services.AddApplicationInsightsTelemetry(ApplicationInsightsKey);
+                services.AddApplicationInsightsKubernetesEnricher();
+                services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
 
                 _logger.Information($"Startup // ApplicationInsightsTelemetryKey = {ApplicationInsightsKey}");
             }

--- a/src/Altinn.Platform/Altinn.Platform.Register/Register/Altinn.Platform.Register.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Register/Register/Altinn.Platform.Register.csproj
@@ -11,7 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Altinn.Platform.Models" Version="1.0.2-alpha" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.3.0-alpha" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.12.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.1.1" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.4" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.1" />

--- a/src/Altinn.Platform/Altinn.Platform.Register/Register/Configuration/CustomTelemetryInitializer.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Register/Register/Configuration/CustomTelemetryInitializer.cs
@@ -1,0 +1,22 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Altinn.Platform.Telemetry
+{
+    /// <summary>
+    /// Set up custom telemetry for Application Insights
+    /// </summary>
+    public class CustomTelemetryInitializer : ITelemetryInitializer
+    {
+        /// <summary>
+        /// Custom TelemetryInitializer that sets some specific values for the component
+        /// </summary>
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+            {
+                telemetry.Context.Cloud.RoleName = "platform-register";
+            }
+        }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Register/Register/Startup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Register/Register/Startup.cs
@@ -5,8 +5,10 @@ using System.Reflection;
 using Altinn.Platform.Register.Configuration;
 using Altinn.Platform.Register.Services.Implementation;
 using Altinn.Platform.Register.Services.Interfaces;
+using Altinn.Platform.Telemetry;
 using AltinnCore.Authentication.JwtCookie;
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -30,7 +32,7 @@ namespace Altinn.Platform.Register
         /// <summary>
         /// The key valt key for application insights.
         /// </summary>
-        internal static readonly string VaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey--Register";
+        internal static readonly string VaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey";
 
         /// <summary>
         /// The application insights key.
@@ -105,6 +107,8 @@ namespace Altinn.Platform.Register
             {
                 services.AddSingleton(typeof(ITelemetryChannel), new ServerTelemetryChannel() { StorageFolder = "/tmp/logtelemetry" });
                 services.AddApplicationInsightsTelemetry(ApplicationInsightsKey);
+                services.AddApplicationInsightsKubernetesEnricher();
+                services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
 
                 _logger.Information($"Startup // ApplicationInsightsTelemetryKey = {ApplicationInsightsKey}");
             }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Altinn.Platform.Storage.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Altinn.Platform.Storage.csproj
@@ -13,7 +13,8 @@
     <PackageReference Include="Altinn.Common.PEP" Version="1.0.18-alpha" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.1.2" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.3.0-alpha" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.2" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
@@ -21,7 +22,7 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.13.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="2.0.0" />

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Configuration/CustomTelemetryInitializer.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Configuration/CustomTelemetryInitializer.cs
@@ -1,0 +1,22 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Altinn.Platform.Telemetry
+{
+    /// <summary>
+    /// Set up custom telemetry for Application Insights
+    /// </summary>
+    public class CustomTelemetryInitializer : ITelemetryInitializer
+    {
+        /// <summary>
+        /// Custom TelemetryInitializer that sets some specific values for the component
+        /// </summary>
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+            {
+                telemetry.Context.Cloud.RoleName = "platform-storage";
+            }
+        }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Startup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Startup.cs
@@ -11,11 +11,12 @@ using Altinn.Platform.Storage.Configuration;
 using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Repository;
 using Altinn.Platform.Storage.Wrappers;
-
+using Altinn.Platform.Telemetry;
 using AltinnCore.Authentication.Constants;
 using AltinnCore.Authentication.JwtCookie;
 
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -41,7 +42,7 @@ namespace Altinn.Platform.Storage
         /// <summary>
         /// application insights key in keyvault
         /// </summary>
-        public static readonly string VaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey--Storage";
+        public static readonly string VaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey";
 
         /// <summary>
         /// The application insights key.
@@ -139,6 +140,8 @@ namespace Altinn.Platform.Storage
             {
                 services.AddSingleton(typeof(ITelemetryChannel), new ServerTelemetryChannel() { StorageFolder = "/tmp/logtelemetry" });
                 services.AddApplicationInsightsTelemetry(ApplicationInsightsKey);
+                services.AddApplicationInsightsKubernetesEnricher();
+                services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
 
                 _logger.Information($"Startup // ApplicationInsightsTelemetryKey = {ApplicationInsightsKey}");
             }


### PR DESCRIPTION
Updated Application Insight packages, also added package for kubernetes: Microsoft.ApplicationInsights.Kubernetes.
Update the key vault reference for AI so that all platform components use the same.
Added and registered a custom telemetry initializer that sets the RoleName as this is not captured by AI when running in the cluster.