### PR TITLE
feature/3839-display-validation-errors-frontend

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/message/ErrorReport.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/message/ErrorReport.tsx
@@ -1,13 +1,40 @@
 import * as React from 'react';
 import { getLanguageFromKey } from 'altinn-shared/utils';
+import { IValidations, ITextResource } from 'src/types/global';
+import { getTextResourceByKey } from '../../utils/textResource';
+import { useRef, useEffect } from 'react';
+import ReactDOM from 'react-dom';
 
-const ErrorReport = (props: any) => {
+export interface IErrorProps {
+  language: any;
+  validations: IValidations;
+  textResources: ITextResource[];
+  formHasErrors: boolean;
+}
+
+const getUnmappedErrors = (validations: IValidations) => {
+  const messages: string[] = [];
+  if (!validations || !validations.unmapped) {
+    return messages;
+  }
+  return validations.unmapped[''].errors;
+}
+
+const ErrorReport = (props: IErrorProps) => {
+    const unmappedErrors  = getUnmappedErrors(props.validations);
+    const hasUnmappedErrors: boolean = unmappedErrors.length > 0;
+    const errorRef = useRef(null);
+
+    useEffect(() => {
+      errorRef?.current?.focus();
+    });
+
     if (!props.formHasErrors) {
       return null;
     }
 
     return (
-      <div id='errorReport' className='a-modal-content-target' style={{ marginTop: '55px' }}>
+      <div id='errorReport' className='a-modal-content-target' style={{ marginTop: '55px' }} ref={errorRef} tabIndex={0} >
         <div className='a-page a-current-page'>
           <div className='modalPage'>
             <div className='modal-content'>
@@ -32,11 +59,24 @@ const ErrorReport = (props: any) => {
                 </div>
               </div>
               <div className='modal-body a-modal-body' style={{paddingTop: '0px', paddingBottom: '24px'}}>
-                <h4 className='a-fontReg'>
-                  <span>
-                  {getLanguageFromKey('form_filler.error_report_description', props.language)}
-                  </span>
-                </h4>
+                  {hasUnmappedErrors && unmappedErrors.map((key: string) => {
+                    // List unmapped errors
+                    return (
+                      <h4 className='a-fontReg' style={{marginBottom: '12px'}}>
+                      <span>
+                        {getTextResourceByKey(key, props.textResources)}
+                      </span>
+                      </h4>
+                    )
+                  })}
+                  {!hasUnmappedErrors &&
+                    // No errors to list, show a generic error message
+                    <h4 className='a-fontReg' style={{marginBottom: '12px'}}>
+                      <span>
+                        {getLanguageFromKey('form_filler.error_report_description', props.language)}
+                      </span>
+                    </h4>
+                  }
               </div>
             </div>
           </div>

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/message/ErrorReport.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/message/ErrorReport.tsx
@@ -3,7 +3,6 @@ import { getLanguageFromKey } from 'altinn-shared/utils';
 import { IValidations, ITextResource } from 'src/types/global';
 import { getTextResourceByKey } from '../../utils/textResource';
 import { useRef, useEffect } from 'react';
-import ReactDOM from 'react-dom';
 
 export interface IErrorProps {
   language: any;

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
@@ -63,7 +63,7 @@ function* submitFormSaga({ url, apiMode }: ISubmitDataAction): SagaIterator {
         if (validationResult && validationResult.length > 0) {
           // we have validation errors, update validations and return
           const layoutState: ILayoutState = yield select(LayoutSelector);
-          const mappedValidations = mapDataElementValidationToRedux(validationResult, layoutState.layout);
+          const mappedValidations = mapDataElementValidationToRedux(validationResult, layoutState.layout, state.textResources.resources);
           FormValidationActions.updateValidations(mappedValidations);
           return yield call(FormDataActions.submitFormDataRejected, null);
         } else {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/containers/ProcessStep.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/containers/ProcessStep.tsx
@@ -8,7 +8,7 @@ import {AltinnAppTheme} from 'altinn-shared/theme';
 import { IParty } from 'altinn-shared/types';
 import { getLanguageFromKey, returnUrlToMessagebox } from 'altinn-shared/utils';
 import { IRuntimeState, ProcessSteps } from '../../types';
-import { IValidations } from '../../types/global';
+import { IValidations, ITextResource } from '../../types/global';
 import ReceiptContainer from '../../features/receipt/containers/receiptContainer';
 import ErrorReport from '../../components/message/ErrorReport';
 import Header from '../../components/process-step/Header';
@@ -24,7 +24,8 @@ const ProcessStepComponent = (props) => {
   const language: any = useSelector((state: IRuntimeState) => state.language ? state.language.language : {});
   const formHasErrors: boolean = useSelector((state: IRuntimeState) => getFormHasErrors(state.formValidations.validations));
   const userParty: IParty = useSelector((state: IRuntimeState) => state.profile.profile ? state.profile.profile.party : {} as IParty);
-
+  const validations: IValidations = useSelector((state: IRuntimeState) => state.formValidations.validations);
+  const textResources: ITextResource[] = useSelector((state: IRuntimeState) => state.textResources.resources);
   const handleModalCloseButton = () => {
     const origin = window.location.origin;
     if (window) {
@@ -34,7 +35,7 @@ const ProcessStepComponent = (props) => {
   }
 
   const isProcessStepsArchived = Boolean(props.step === ProcessSteps.Archived);
-  const backgroundColor = isProcessStepsArchived ? 
+  const backgroundColor = isProcessStepsArchived ?
     AltinnAppTheme.altinnPalette.primary.greenLight
     : AltinnAppTheme.altinnPalette.primary.blue;
   document.body.style.background = backgroundColor;
@@ -50,7 +51,12 @@ const ProcessStepComponent = (props) => {
         <div className='container'>
           <div className={classNames('row', {['d-print-none']: isProcessStepsArchived})}>
             <div className='col-xl-10 offset-xl-1 a-p-static'>
-              <ErrorReport formHasErrors={formHasErrors} language={language}/>
+              <ErrorReport
+                formHasErrors={formHasErrors}
+                language={language}
+                validations={validations}
+                textResources={textResources}
+              />
               <NavBar handleClose={handleModalCloseButton} />
               <div className='a-modal-content-target'>
                 <div className='a-page a-current-page'>

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/validation.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/validation.ts
@@ -2,11 +2,12 @@ import { getLanguageFromKey, getParsedLanguageFromKey } from 'altinn-shared/util
 import { IFormData } from '../features/form/data/formDataReducer';
 import { ILayout, ILayoutComponent } from '../features/form/layout/';
 import { IValidationIssue, Severity } from '../types';
-import { IComponentValidations, IDataModelFieldElement, IValidations, IComponentBindingValidation } from '../types/global';
+import { IComponentValidations, IDataModelFieldElement, IValidations, IComponentBindingValidation, ITextResource } from '../types/global';
 import { getKeyWithoutIndex } from './databindings';
 import moment from 'moment';
 import { DatePickerMinDateDefault, DatePickerMaxDateDefault, DatePickerFormatDefault } from '../components/base/DatepickerComponent';
 import { getFormDataForComponent } from './formComponentUtils';
+import { getTextResourceByKey } from './textResource';
 
 export function min(value: number, test: number): boolean {
   test = Number(test);
@@ -384,7 +385,7 @@ export function mapApiValidationsToRedux(
 }
 
 /* Function to map the new data element validations to our internal redux structure*/
-export function mapDataElementValidationToRedux(validations: IValidationIssue[], layout: ILayout) {
+export function mapDataElementValidationToRedux(validations: IValidationIssue[], layout: ILayout, textResources: ITextResource[]) {
   const validationResult: IValidations = {};
   if (!validations) {
     return validationResult;
@@ -398,13 +399,13 @@ export function mapDataElementValidationToRedux(validations: IValidationIssue[],
 
       if (validation.field === componentCandidate.id) {
         found = true;
-        addValidation(componentValidations, validation, 'simpleBinding');
+        addValidation(componentValidations, validation, 'simpleBinding', textResources);
       } else {
         Object.keys(componentCandidate.dataModelBindings).forEach((dataModelBindingKey) => {
           // tslint:disable-next-line: max-line-length
           if (validation.field && componentCandidate.dataModelBindings[dataModelBindingKey].toLowerCase() === validation.field.toLowerCase()) {
             found = true;
-            addValidation(componentValidations, validation, dataModelBindingKey);
+            addValidation(componentValidations, validation, dataModelBindingKey, textResources);
           }
         });
       }
@@ -447,14 +448,14 @@ export function mapDataElementValidationToRedux(validations: IValidationIssue[],
   return validationResult;
 }
 
-function addValidation(componentValidations: IComponentValidations, validation: IValidationIssue, dataModelBindingKey: string) {
+function addValidation(componentValidations: IComponentValidations, validation: IValidationIssue, dataModelBindingKey: string, textResources: ITextResource[]) {
   if (!componentValidations[dataModelBindingKey]) {
     componentValidations[dataModelBindingKey] = {errors: [], warnings: []};
   }
   if (validation.severity === Severity.Error) {
-    componentValidations[dataModelBindingKey].errors.push(validation.description);
+    componentValidations[dataModelBindingKey].errors.push(getTextResourceByKey(validation.description, textResources));
   } else {
-    componentValidations[dataModelBindingKey].warnings.push(validation.description);
+    componentValidations[dataModelBindingKey].warnings.push(getTextResourceByKey(validation.description, textResources));
   }
 }
 


### PR DESCRIPTION
#3839 

- Mapped validations are shown under their connected field as before
- Unmapped errors are shown in message box above the form
- Generic error message is shown if there are no unmapped errors
- The error box is focused on render, screen readers must read errors when they appear
- Validation messages from backend can now be returned as a textResource key. If key is not found, show the key (makes it possible to return a message as plain text if needed)