### PR TITLE
Have Storage use latest version of Storage.Interface

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Altinn.Platform.Storage.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Altinn.Platform.Storage.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Common.PEP" Version="1.0.21-alpha" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.1.10" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.1.12" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.3.0-alpha" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerTests.cs
@@ -400,8 +400,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                     InstanceOwner = new InstanceOwner { PartyId = instanceOwnerPartyId.ToString() },
                     CompleteConfirmations = new List<CompleteConfirmation> { new CompleteConfirmation { ConfirmedOn = confirmedOn, StakeholderId = org } },
                     Org = org,
-                    Process = new ProcessState { EndEvent = "Success" }
+                    Process = new ProcessState { EndEvent = "Success" },
+                    Title = new LanguageString()
                 };
+                originalInstance.Title.Add("nb", "norwegian");
 
                 Mock<IInstanceRepository> instanceRepository = new Mock<IInstanceRepository>();
                 instanceRepository.Setup(r => r.GetOne(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync(originalInstance);


### PR DESCRIPTION
I did some testing with the help of an existing unit test. Looked at the response returned by the server before the upgrade and after. This way I could see the bug in effect and see that the change removed it. 