### PR TITLE
set content type to actual file type

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/resources/attachments/upload/uploadAttachmentSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/resources/attachments/upload/uploadAttachmentSagas.ts
@@ -24,7 +24,7 @@ export function* uploadAttachmentSaga(
     const fileUploadLink = fileUploadUrl(attachmentType, file.name);
     const config: AxiosRequestConfig = {
       headers: {
-        'Content-Type': 'application/octet-stream',
+        'Content-Type': file.type,
         'Content-Disposition': `attachment; filename=${encodeURI(file.name)}`
       }
     }


### PR DESCRIPTION
#1925 
Fix hard-coding frontend that set Content-Type to application/octet-stream, and set it to the actual type of the file. Tested locally, seems to work.