### PR TITLE
Removed authorization config that messed up authorization

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Startup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Startup.cs
@@ -77,14 +77,7 @@ namespace Altinn.Platform.Storage
         {
             _logger.Information("Startup // ConfigureServices");
 
-            services.AddControllers(config =>
-            {
-                AuthorizationPolicy policy = new AuthorizationPolicyBuilder()
-                    .AddAuthenticationSchemes(JwtCookieDefaults.AuthenticationScheme)
-                    .RequireAuthenticatedUser()
-                    .Build();
-                config.Filters.Add(new AuthorizeFilter(policy));
-            }).AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson();
 
             services.AddHttpClient<AuthorizationApiClient>();
 

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Startup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Startup.cs
@@ -22,7 +22,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerTests.cs
@@ -324,7 +324,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 Assert.Equal("111111111", updatedInstance.LastChangedBy);
                 
                 // GetOne is called more than once because of Authorization.
-                instanceRepository.Verify(s => s.GetOne(It.IsAny<string>(), It.IsAny<int>()), Times.Exactly(3));
+                instanceRepository.Verify(s => s.GetOne(It.IsAny<string>(), It.IsAny<int>()), Times.Exactly(2));
                 instanceRepository.Verify(s => s.Update(It.IsAny<Instance>()), Times.Once);
                 instanceEventRepository.Verify(s => s.InsertInstanceEvent(It.IsAny<InstanceEvent>()), Times.Once);
             }
@@ -372,7 +372,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
                 
                 // GetOne is called more than once because of Authorization.
-                instanceRepository.Verify(s => s.GetOne(It.IsAny<string>(), It.IsAny<int>()), Times.Exactly(3));
+                instanceRepository.Verify(s => s.GetOne(It.IsAny<string>(), It.IsAny<int>()), Times.Exactly(2));
                 instanceRepository.Verify(s => s.Update(It.IsAny<Instance>()), Times.Once);
             }
 
@@ -428,7 +428,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 Assert.Equal(confirmedOn, updatedInstance.CompleteConfirmations[0].ConfirmedOn);
 
                 // GetOne is called more than once because of Authorization.
-                instanceRepository.Verify(s => s.GetOne(It.IsAny<string>(), It.IsAny<int>()), Times.Exactly(3));
+                instanceRepository.Verify(s => s.GetOne(It.IsAny<string>(), It.IsAny<int>()), Times.Exactly(2));
                 instanceRepository.Verify(s => s.Update(It.IsAny<Instance>()), Times.Never);
             }
 


### PR DESCRIPTION
Makes authorization be called twice for every API request where [Authorize(Policy="xxx")] tag is used