### PR TITLE
retrieve token from Gitea before each build

### DIFF
--- a/src/studio/src/designer/backend/Configuration/ServiceRepositorySettings.cs
+++ b/src/studio/src/designer/backend/Configuration/ServiceRepositorySettings.cs
@@ -161,11 +161,6 @@ namespace Altinn.Studio.Designer.Configuration
         public string GiteaLoginUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the DeployCookieName
-        /// </summary>
-        public string DeployCookieName { get; set; }
-
-        /// <summary>
         /// Gets or sets the BaseResourceFolderContainer that identifes where in the docker container the runtime can find files needed
         /// </summary>
         public string BaseResourceFolderContainer { get; set; }

--- a/src/studio/src/designer/backend/Services/Implementation/SourceControlSI.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/SourceControlSI.cs
@@ -490,16 +490,12 @@ namespace Altinn.Studio.Designer.Services.Implementation
         /// <returns>The deploy app token</returns>
         public async Task<string> GetDeployToken()
         {
-            string deployToken = _httpContextAccessor.HttpContext.Request.Cookies[_settings.DeployCookieName];
-            if (deployToken == null)
-            {
-                KeyValuePair<string, string> deployKeyValuePair = await _gitea.GetSessionAppKey("AltinnDeployToken") ?? default(KeyValuePair<string, string>);
-                if (!deployKeyValuePair.Equals(default(KeyValuePair<string, string>)))
-                {
-                    deployToken = deployKeyValuePair.Value;
-                }
+            string deployToken = string.Empty;
 
-                _httpContextAccessor.HttpContext.Response.Cookies.Append(_settings.DeployCookieName, deployToken);
+            KeyValuePair<string, string> deployKeyValuePair = await _gitea.GetSessionAppKey("AltinnDeployToken") ?? default(KeyValuePair<string, string>);
+            if (!deployKeyValuePair.Equals(default(KeyValuePair<string, string>)))
+            {
+                deployToken = deployKeyValuePair.Value;
             }
 
             return deployToken;

--- a/src/studio/src/designer/backend/appsettings.json
+++ b/src/studio/src/designer/backend/appsettings.json
@@ -8,8 +8,7 @@
     "ApiEndPointHost": "altinn3.no",
     "RepositoryBaseURL": "http://altinn3.no/repos",
     "GiteaCookieName": "i_like_gitea",
-    "GiteaLoginUrl": "http://altinn3.no/repos/user/login",
-    "DeployCookieName": "app_deploy_token"
+    "GiteaLoginUrl": "http://altinn3.no/repos/user/login"
   },
   "TestdataRepositorySettings": {
     "RepositoryLocation": "../Testdata"


### PR DESCRIPTION
Removed app_deploy_token cookie. 
Retrieving token from Gitea before build is triggered instead.

Difficult to see how it affects performance from metadata in AI, 
but the extra cost in time seems worth it to avoid people not being able to queue a build.