### PR TITLE
bugfix - designer shows created datetime

### DIFF
--- a/src/studio/src/designer/frontend/app-development/features/administration/components/Administration.tsx
+++ b/src/studio/src/designer/frontend/app-development/features/administration/components/Administration.tsx
@@ -207,7 +207,7 @@ export class AdministrationComponent extends
         {this.props.initialCommit &&
           <Typography className={classNames(classes.sidebarCreatedBy)}>
             {/* tslint:disable-next-line:max-line-length */}
-            {getLanguageFromKey('administration.created_by', this.props.language)} {formatNameAndDate(this.props.initialCommit.author.name, this.props.initialCommit.author.when)}
+            {getLanguageFromKey('administration.created_by', this.props.language)} {formatNameAndDate(this.props.initialCommit.author.name, this.props.service.created_at)}
           </Typography>
         }
     </>


### PR DESCRIPTION
Not sure if it's a bug in the gitea api or something we've done, but this seems to do the trick 

#3993