### PR TITLE
validating only if content types has entries

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/ValidationAppSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/ValidationAppSI.cs
@@ -144,7 +144,7 @@ namespace Altinn.App.Services.Implementation
             {
                 string contentTypeWithoutEncoding = dataElement.ContentType.Split(";")[0];
 
-                if (dataType.AllowedContentTypes != null && dataType.AllowedContentTypes.All(ct => !ct.Equals(contentTypeWithoutEncoding, StringComparison.OrdinalIgnoreCase)))
+                if (dataType.AllowedContentTypes.Count != 0 && dataType.AllowedContentTypes.All(ct => !ct.Equals(contentTypeWithoutEncoding, StringComparison.OrdinalIgnoreCase)))
                 {
                     ValidationIssue message = new ValidationIssue
                     {

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/ValidationAppSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/ValidationAppSI.cs
@@ -144,7 +144,7 @@ namespace Altinn.App.Services.Implementation
             {
                 string contentTypeWithoutEncoding = dataElement.ContentType.Split(";")[0];
 
-                if (dataType.AllowedContentTypes.Count != 0 && dataType.AllowedContentTypes.All(ct => !ct.Equals(contentTypeWithoutEncoding, StringComparison.OrdinalIgnoreCase)))
+                if (dataType.AllowedContentTypes?.Count > 0 && dataType.AllowedContentTypes.All(ct => !ct.Equals(contentTypeWithoutEncoding, StringComparison.OrdinalIgnoreCase)))
                 {
                     ValidationIssue message = new ValidationIssue
                     {

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/ValidationAppSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/ValidationAppSI.cs
@@ -144,7 +144,7 @@ namespace Altinn.App.Services.Implementation
             {
                 string contentTypeWithoutEncoding = dataElement.ContentType.Split(";")[0];
 
-                if (dataType.AllowedContentTypes?.Count > 0 && dataType.AllowedContentTypes.All(ct => !ct.Equals(contentTypeWithoutEncoding, StringComparison.OrdinalIgnoreCase)))
+                if (dataType.AllowedContentTypes != null && dataType.AllowedContentTypes.Count > 0 && dataType.AllowedContentTypes.All(ct => !ct.Equals(contentTypeWithoutEncoding, StringComparison.OrdinalIgnoreCase)))
                 {
                     ValidationIssue message = new ValidationIssue
                     {


### PR DESCRIPTION
Avoiding validation in the cases where allowedContent types instantiated, but doesn't have any content.