### PR TITLE
Authorize all messagebox actions individually when getting instances

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/MessageboxInstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/MessageboxInstancesController.cs
@@ -108,7 +108,7 @@ namespace Altinn.Platform.Storage.Controllers
         /// <param name="instanceGuid">the instance guid</param>
         /// <param name="language"> language id en, nb, nn-NO"</param>
         /// <returns>list of instances</returns>
-        [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_READ)]
+        [Authorize]
         [HttpGet("{instanceOwnerPartyId:int}/{instanceGuid:guid}")]
         public async Task<ActionResult> GetMessageBoxInstance(int instanceOwnerPartyId, Guid instanceGuid, [FromQuery] string language)
         {
@@ -129,16 +129,19 @@ namespace Altinn.Platform.Storage.Controllers
                 return NotFound($"Could not find instance {instanceId}");
             }
 
-            MessageBoxInstance messageBoxInstance = InstanceHelper.ConvertToMessageBoxInstance(instance);
+            List<MessageBoxInstance> authorizedInstanceList = await _authorizationHelper.AuthorizeMesseageBoxInstances(HttpContext.User, new List<Instance> { instance });
+            if (authorizedInstanceList.Count <= 0)
+            {
+                return Forbid();
+            }
 
-            // Setting these two properties could be handled by custom PEP. 
-            messageBoxInstance.AllowDelete = true;
-            messageBoxInstance.AuthorizedForWrite = true;
+            MessageBoxInstance authorizedInstance = authorizedInstanceList.First();
 
             Dictionary<string, Dictionary<string, string>> appTitle = await _applicationRepository.GetAppTitles(new List<string> { instance.AppId });
-            InstanceHelper.AddTitleToInstances(new List<MessageBoxInstance> { messageBoxInstance }, appTitle, languageId);
+            InstanceHelper.AddTitleToInstances(new List<MessageBoxInstance> { authorizedInstance }, appTitle, languageId);
 
-            return Ok(messageBoxInstance);
+            return Ok(authorizedInstance);
+
         }
 
         /// <summary>

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/AuthorizationHelper.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/AuthorizationHelper.cs
@@ -54,11 +54,8 @@ namespace Altinn.Platform.Storage.Helpers
             }
 
             List<MessageBoxInstance> authorizedInstanceeList = new List<MessageBoxInstance>();
-            List<string> actionTypes = new List<string> { "read", "write" };
+            List<string> actionTypes = new List<string> { "read", "write", "delete" };
 
-            _logger.LogInformation($"// AuthorizationHelper // AuthorizeMsgBoxInstances // User: {user}");
-            _logger.LogInformation($"// AuthorizationHelper // AuthorizeMsgBoxInstances // Instances count: {instances.Count()}");
-            _logger.LogInformation($"// AuthorizationHelper // AuthorizeMsgBoxInstances // Action types: {actionTypes}");
             XacmlJsonRequestRoot xacmlJsonRequest = CreateMultiDecisionRequest(user, instances, actionTypes);
 
             _logger.LogInformation($"// AuthorizationHelper // AuthorizeMsgBoxInstances // xacmlJsonRequest: {JsonConvert.SerializeObject(xacmlJsonRequest)}");
@@ -96,20 +93,32 @@ namespace Altinn.Platform.Storage.Helpers
                     // Checks if the instance has already been authorized
                     if (authorizedInstanceeList.Any(i => i.Id.Equals(authorizedInstance.Id.Split("/")[1])))
                     {
-                        // Only need to check if the action type is write, because read do not add any special rights to the MessageBoxInstane.
-                        if (actiontype.Equals("write"))
+                        switch (actiontype)
                         {
-                            authorizedInstanceeList.Where(i => i.Id.Equals(authorizedInstance.Id.Split("/")[1])).ToList().ForEach(i => i.AuthorizedForWrite = i.AllowDelete = true);
+                            case "write":
+                                authorizedInstanceeList.Where(i => i.Id.Equals(authorizedInstance.Id.Split("/")[1])).ToList().ForEach(i => i.AuthorizedForWrite = true);
+                                break;
+                            case "delete":
+                                authorizedInstanceeList.Where(i => i.Id.Equals(authorizedInstance.Id.Split("/")[1])).ToList().ForEach(i => i.AllowDelete = true);
+                                break;
+                            case "read":
+                                break;
                         }
                     }
                     else
                     {
                         MessageBoxInstance messageBoxInstance = InstanceHelper.ConvertToMessageBoxInstance(authorizedInstance);
 
-                        if (actiontype.Equals("write"))
+                        switch (actiontype)
                         {
-                            messageBoxInstance.AuthorizedForWrite = true;
-                            messageBoxInstance.AllowDelete = true;
+                            case "write":
+                                messageBoxInstance.AuthorizedForWrite = true;
+                                break;
+                            case "delete":
+                                messageBoxInstance.AllowDelete = true;
+                                break;
+                            case "read":
+                                break;
                         }
 
                         authorizedInstanceeList.Add(messageBoxInstance);

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/AuthorizationHelper.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/AuthorizationHelper.cs
@@ -53,7 +53,7 @@ namespace Altinn.Platform.Storage.Helpers
                 return new List<MessageBoxInstance>();
             }
 
-            List<MessageBoxInstance> authorizedInstanceeList = new List<MessageBoxInstance>();
+            List<MessageBoxInstance> authorizedInstanceList = new List<MessageBoxInstance>();
             List<string> actionTypes = new List<string> { "read", "write", "delete" };
 
             XacmlJsonRequestRoot xacmlJsonRequest = CreateMultiDecisionRequest(user, instances, actionTypes);
@@ -88,18 +88,18 @@ namespace Altinn.Platform.Storage.Helpers
                     }
 
                     // Find the instance that has been validated to add it to the list of authorized instances.
-                    Instance authorizedInstance = instances.FirstOrDefault(i => i.Id == instanceId);
+                    Instance authorizedInstance = instances.First(i => i.Id == instanceId);
 
                     // Checks if the instance has already been authorized
-                    if (authorizedInstanceeList.Any(i => i.Id.Equals(authorizedInstance.Id.Split("/")[1])))
+                    if (authorizedInstanceList.Any(i => i.Id.Equals(authorizedInstance.Id.Split("/")[1])))
                     {
                         switch (actiontype)
                         {
                             case "write":
-                                authorizedInstanceeList.Where(i => i.Id.Equals(authorizedInstance.Id.Split("/")[1])).ToList().ForEach(i => i.AuthorizedForWrite = true);
+                                authorizedInstanceList.Where(i => i.Id.Equals(authorizedInstance.Id.Split("/")[1])).ToList().ForEach(i => i.AuthorizedForWrite = true);
                                 break;
                             case "delete":
-                                authorizedInstanceeList.Where(i => i.Id.Equals(authorizedInstance.Id.Split("/")[1])).ToList().ForEach(i => i.AllowDelete = true);
+                                authorizedInstanceList.Where(i => i.Id.Equals(authorizedInstance.Id.Split("/")[1])).ToList().ForEach(i => i.AllowDelete = true);
                                 break;
                             case "read":
                                 break;
@@ -121,12 +121,12 @@ namespace Altinn.Platform.Storage.Helpers
                                 break;
                         }
 
-                        authorizedInstanceeList.Add(messageBoxInstance);
+                        authorizedInstanceList.Add(messageBoxInstance);
                     }
                 }
             }
 
-            return authorizedInstanceeList;
+            return authorizedInstanceList;
         }
 
         /// <summary>

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Altinn.Platform.Storage.UnitTest.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Altinn.Platform.Storage.UnitTest.csproj
@@ -31,6 +31,7 @@
     <Content Remove="data\Roles\user_1\party_1600\roles.json" />
     <Content Remove="data\Roles\user_1\party_50000000\roles.json" />
     <Content Remove="data\Roles\user_1\party_500\roles.json" />
+    <Content Remove="data\Roles\user_3\party_1606\roles.json" />
     <Content Remove="data\Roles\user_3\party_1600\roles.json" />
   </ItemGroup>
 
@@ -58,6 +59,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="data\Roles\user_1\party_500\roles.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="data\Roles\user_3\party_1606\roles.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="data\Roles\user_3\party_1600\roles.json">

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
@@ -178,6 +178,36 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             /// <summary>
             /// Scenario:
+            ///   Request an existing instance.
+            /// Expected:
+            ///  A converted instance is returned.
+            /// Success:
+            ///  The instance has the expected properties.
+            /// </summary>
+            [Fact]
+            public async void GetMessageBoxInstance_RequestsExistingInstanceUserCannotDelete_InstanceIsSuccessfullyMappedAndReturned()
+            {
+                // Arrange
+                string instanceId = "1606/6323a337-26e7-4d40-89e8-f5bb3d80be3a";
+
+                HttpClient client = GetTestClient();
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(3, 1606, 3));
+
+                // Act
+                HttpResponseMessage responseMessage = await client.GetAsync($"{BasePath}/sbl/instances/{instanceId}?language=en");
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+
+                string responseContent = await responseMessage.Content.ReadAsStringAsync();
+                MessageBoxInstance actual = JsonConvert.DeserializeObject<MessageBoxInstance>(responseContent);
+
+                Assert.False(actual.AllowDelete);
+                Assert.True(actual.AuthorizedForWrite);
+            }
+
+            /// <summary>
+            /// Scenario:
             ///   Request an instance the user is not authorized to see
             /// Expected:
             ///   Authorization stops the request

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
@@ -182,7 +182,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             /// Expected:
             ///  A converted instance is returned.
             /// Success:
-            ///  The instance has the expected properties.
+            ///  The instance does not have allowed to delete permissions.
             /// </summary>
             [Fact]
             public async void GetMessageBoxInstance_RequestsExistingInstanceUserCannotDelete_InstanceIsSuccessfullyMappedAndReturned()

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/Roles/user_3/party_1606/roles.json
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/Roles/user_3/party_1606/roles.json
@@ -1,0 +1,6 @@
+[
+  {
+    "Type": "altinn",
+    "value": "REGNA"
+  }
+]

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/apps/tdd/test-applikasjon-1/config/applicationmetadata.json
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/apps/tdd/test-applikasjon-1/config/applicationmetadata.json
@@ -1,0 +1,24 @@
+{
+  "id": "tdd/test-applikasjon-1",
+  "org": "tdd",
+  "created": "2019-09-24T10:02:41.0839253Z",
+  "createdBy": "Steph",
+  "lastChanged": "2019-09-24T10:02:41.0839254Z",
+  "lastChangedBy": "Steph",
+  "title": {
+    "nb": "Test applikasjon",
+    "en": "Test app"
+  },
+  "dataTypes": [
+    {
+      "id": "default",
+      "allowedContentTypes": [ "application/xml" ],
+      "maxCount": 1,
+      "appLogic": {
+        "autoCreate": true,
+        "ClassRef": "Form"
+      },
+      "taskId": "Task_1"
+    }
+  ]
+}

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/apps/tdd/test-applikasjon-1/config/authorization/policy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/apps/tdd/test-applikasjon-1/config/authorization/policy.xml
@@ -102,15 +102,9 @@
     </xacml:Target>
   </xacml:Rule>
   <xacml:Rule RuleId="urn:altinn:example:ruleid:3" Effect="Permit">
-    <xacml:Description>Rule that defines that user with role REGNA or DAGL can delete instances of tdd/test-applikasjon-1</xacml:Description>
+    <xacml:Description>Rule that defines that user with role DAGL can delete instances of tdd/test-applikasjon-1</xacml:Description>
     <xacml:Target>
       <xacml:AnyOf>
-        <xacml:AllOf>
-          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">REGNA</xacml:AttributeValue>
-            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
-          </xacml:Match>
-        </xacml:AllOf>
         <xacml:AllOf>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
             <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DAGL</xacml:AttributeValue>

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/instances/1606/6323a337-26e7-4d40-89e8-f5bb3d80be3a.json
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/instances/1606/6323a337-26e7-4d40-89e8-f5bb3d80be3a.json
@@ -1,0 +1,60 @@
+{
+  "id": "6323a337-26e7-4d40-89e8-f5bb3d80be3a",
+  "instanceOwner": {
+    "partyId": "1606",
+    "organisationNumber": "725736800"
+  },
+  "appId": "tdd/test-applikasjon-1",
+  "org": "tdd",
+  "title": {
+    "nb": "Test app"
+  },
+  "process": {
+    "started": "2020-04-29T13:53:01.7020218Z",
+    "startEvent": "StartEvent_1",
+    "currentTask": { "elementId": "Task_1" }
+  },
+  "status": {
+  },
+  "appOwner": {},
+  "data": [
+    {
+      "id": "99dc0012-89fa-4968-b928-d6cc16d18d26",
+      "instanceGuid": "ba577e7f-3dfd-4ff6-b659-350308a47348",
+      "dataType": "schema_4222_160523_forms_212_20160523",
+      "contentType": "application/xml",
+      "blobStoragePath": "ttd/rf-0002/ba577e7f-3dfd-4ff6-b659-350308a47348/data/99dc0012-89fa-4968-b928-d6cc16d18d26",
+      "selfLinks": {
+        "platform": "https://platform.yt01.altinn.cloud/storage/api/v1/instances/58621971/ba577e7f-3dfd-4ff6-b659-350308a47348/data/99dc0012-89fa-4968-b928-d6cc16d18d26"
+      },
+      "size": 1993,
+      "locked": true,
+      "refs": [],
+      "created": "2020-04-29T13:53:03.0388998Z",
+      "lastChanged": "2020-04-29T13:53:05.7829624Z",
+      "lastChangedBy": "4228869"
+    },
+    {
+      "id": "8ec413e7-2f72-4e7a-8ef4-5976f42ce88f",
+      "instanceGuid": "ba577e7f-3dfd-4ff6-b659-350308a47348",
+      "dataType": "ref-data-as-pdf",
+      "filename": "RF-0002_Skattemelding_for_merverdiavgift.pdf",
+      "contentType": "application/pdf",
+      "blobStoragePath": "ttd/rf-0002/ba577e7f-3dfd-4ff6-b659-350308a47348/data/8ec413e7-2f72-4e7a-8ef4-5976f42ce88f",
+      "size": 10326,
+      "locked": false,
+      "refs": [],
+      "created": "2020-04-29T13:53:09.0214218Z",
+      "lastChanged": "2020-04-29T13:53:09.0214218Z"
+    }
+  ],
+  "created": "2020-04-29T13:53:02.2836971Z",
+  "createdBy": "1337",
+  "lastChanged": "2020-04-29T13:53:09.1122622Z",
+  "lastChangedBy": "1337",
+  "_rid": "AnsTAK4aVt8czAIAAAAAAA==",
+  "_self": "dbs/AnsTAA==/colls/AnsTAK4aVt8=/docs/AnsTAK4aVt8czAIAAAAAAA==/",
+  "_etag": "\"1400ade0-0000-3c00-0000-5eaa8a220000\"",
+  "_attachments": "attachments/",
+  "_ts": 1588234786
+}


### PR DESCRIPTION
#2487 

Instead of handling the error when users that arent authorized to delete try to delete and instance, we are sending a multi request to pep so we can authorize all actions at once eliminating the need for this  specific error handling