### PR TITLE
remove (PDF) postfix after links to PDF

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/index.css
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/index.css
@@ -2,7 +2,6 @@
 
 /* Custom CSS for all app */
 
-
 /* Workaround to avoid (PDF) postfix from Altinn designsystem */
 a[href$=".pdf"]::after {
   content: none!important;

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/index.css
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/index.css
@@ -1,5 +1,14 @@
 @import '~altinn-designsystem/dist/css/style.dist.tjenester3.min';
 
+/* Custom CSS for all app */
+
+
+/* Workaround to avoid (PDF) postfix from Altinn designsystem */
+a[href$=".pdf"]::after {
+  content: none!important;
+  display: inline!important;
+}
+
 body {
   margin: 0;
   background-color: #1eaef7;


### PR DESCRIPTION
#4409 
update CSS to remove (PDF) postfix coming from Altinn designsystem CSS.