### PR TITLE
Rollback .net core upgrade on designer

### DIFF
--- a/src/studio/src/designer/Dockerfile
+++ b/src/studio/src/designer/Dockerfile
@@ -53,14 +53,14 @@ RUN npm ci
 COPY src/designer/backend .
 RUN npm run gulp build
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.301-alpine AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1.300-alpine AS build
 COPY src/designer/backend ./designer/
 COPY --from=generate-designer-js /wwwroot ./designer/wwwroot
 
 RUN dotnet build designer/Designer.csproj -c Release -o /app_output
 RUN dotnet publish designer/Designer.csproj -c Release -o /app_output
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.5-alpine AS final
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.4-alpine AS final
 EXPOSE 80
 WORKDIR /app
 COPY --from=build /app_output .


### PR DESCRIPTION
Designer restarts when accessed. Rollback to see if the upgrade is related.
Related to #4369 