### PR TITLE
Removing the confirmDownload and delete events endpoints

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/DataController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/DataController.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.Web;
+
 using Altinn.Platform.Storage.Configuration;
 using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Interface.Enums;
@@ -32,6 +33,7 @@ namespace Altinn.Platform.Storage.Controllers
     public class DataController : ControllerBase
     {
         private static readonly FormOptions _defaultFormOptions = new FormOptions();
+
         private readonly IDataRepository _dataRepository;
         private readonly IInstanceRepository _instanceRepository;
         private readonly IApplicationRepository _applicationRepository;
@@ -45,17 +47,17 @@ namespace Altinn.Platform.Storage.Controllers
         /// Initializes a new instance of the <see cref="DataController"/> class
         /// </summary>
         /// <param name="dataRepository">the data repository handler</param>
-        /// <param name="instanceRepository">the indtance repository</param>
+        /// <param name="instanceRepository">the instance repository</param>
         /// <param name="applicationRepository">the application repository</param>
         /// <param name="instanceEventRepository">the instance event repository</param>
-        /// <param name="generalsettings">the general settings.</param>
+        /// <param name="generalSettings">the general settings.</param>
         /// <param name="logger">The logger</param>
         public DataController(
             IDataRepository dataRepository,
             IInstanceRepository instanceRepository,
             IApplicationRepository applicationRepository,
             IInstanceEventRepository instanceEventRepository,
-            IOptions<GeneralSettings> generalsettings,
+            IOptions<GeneralSettings> generalSettings,
             ILogger<DataController> logger)
         {
             _dataRepository = dataRepository;
@@ -63,11 +65,11 @@ namespace Altinn.Platform.Storage.Controllers
             _applicationRepository = applicationRepository;
             _instanceEventRepository = instanceEventRepository;
             _logger = logger;
-            _storageBaseAndHost = $"{generalsettings.Value.Hostname}/storage/api/v1/";
+            _storageBaseAndHost = $"{generalSettings.Value.Hostname}/storage/api/v1/";
         }
 
         /// <summary>
-        /// Deletes a spesific data element.
+        /// Deletes a specific data element.
         /// </summary>
         /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
         /// <param name="instanceGuid">The id of the instance that the data element is associated with.</param>
@@ -81,7 +83,7 @@ namespace Altinn.Platform.Storage.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<DataElement>> Delete(int instanceOwnerPartyId, Guid instanceGuid, Guid dataGuid)
         {
-            _logger.LogInformation($"//DataController // Delete // Starting method");
+            _logger.LogInformation("//DataController // Delete // Starting method");
 
             string instanceId = $"{instanceOwnerPartyId}/{instanceGuid}";
 
@@ -102,7 +104,8 @@ namespace Altinn.Platform.Storage.Controllers
             try
             {
                 string storageFileName = DataElementHelper.DataFileName(instance.AppId, instanceGuid.ToString(), dataGuid.ToString());
-                _ = await _dataRepository.DeleteDataInStorage(instance.Org, storageFileName);
+
+                await _dataRepository.DeleteDataInStorage(instance.Org, storageFileName);
 
                 await _dataRepository.Delete(dataElement);
 
@@ -183,7 +186,7 @@ namespace Altinn.Platform.Storage.Controllers
                     }
                     catch (Exception e)
                     {
-                        return StatusCode(500, $"Unable to access blob storage for dataelement {e}");
+                        return StatusCode(500, $"Unable to access blob storage for data element {e}");
                     }
                 }
             }
@@ -218,9 +221,7 @@ namespace Altinn.Platform.Storage.Controllers
                 return errorResult;
             }
 
-            List<DataElement> dataElements;
-
-            dataElements = await _dataRepository.ReadAll(instanceGuid);
+            List<DataElement> dataElements = await _dataRepository.ReadAll(instanceGuid);
 
             DataElementList dataElementList = new DataElementList { DataElements = dataElements };
 
@@ -280,7 +281,7 @@ namespace Altinn.Platform.Storage.Controllers
 
             if (theStream == null)
             {
-                return BadRequest("No data attachements found");
+                return BadRequest("No data attachments found");
             }
 
             try
@@ -382,10 +383,10 @@ namespace Altinn.Platform.Storage.Controllers
                     return Ok(updatedElement);
                 }
 
-                return UnprocessableEntity($"Could not process attached file");
+                return UnprocessableEntity("Could not process attached file");
             }
 
-            return StatusCode(500, $"Storage url does not match with instance metadata");
+            return StatusCode(500, "Storage url does not match with instance metadata");
         }
 
         /// <summary>
@@ -421,105 +422,25 @@ namespace Altinn.Platform.Storage.Controllers
         }
 
         /// <summary>
-        /// Updates the data element with a new download confirmed date.
-        /// </summary>
-        /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
-        /// <param name="instanceGuid">The id of the instance that the data element is associated with.</param>
-        /// <param name="dataGuid">The id of the data element to update.</param>
-        /// <returns>The updated data element metadata</returns>
-        [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_WRITE)]
-        [HttpPut("dataelements/{dataGuid}/confirmDownload")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status409Conflict)]
-        [Produces("application/json")]
-        public async Task<ActionResult<DataElement>> ConfirmDownload(int instanceOwnerPartyId, Guid instanceGuid, Guid dataGuid)
-        {
-            DataElement dataElement = await _dataRepository.Read(instanceGuid, dataGuid);
-
-            // check if it has been downloaded
-            List<DateTime> downloaded = dataElement.AppOwner?.Downloaded;
-            if (downloaded == null || !downloaded.Any())
-            {
-                return Conflict($"Data element {instanceOwnerPartyId}/{instanceGuid}/data/{dataGuid} is not recorded downloaded by app owner. Please download first.");
-            }
-
-            DataElement updatedElement = await SetConfirmedDataAndUpdateDataElement(dataElement, DateTime.UtcNow);
-
-            return Ok(updatedElement);
-        }
-
-        /// <summary>
-        /// Updates all data elements with confirmed download date.
-        /// </summary>
-        /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
-        /// <param name="instanceGuid">The id of the instance that the data elements are associated with.</param>
-        /// <returns>A list of data elements with updated confirmed download dates.</returns>
-        [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_WRITE)]
-        [HttpPut("dataelements/confirmDownload")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status409Conflict)]
-        [Produces("application/json")]
-        public async Task<ActionResult<DataElementList>> ConfirmDownloadAll(int instanceOwnerPartyId, Guid instanceGuid)
-        {
-            List<DataElement> dataElements = await _dataRepository.ReadAll(instanceGuid);
-
-            // check if data has been downloaded
-            foreach (DataElement element in dataElements)
-            {
-                // check if it has been downloaded
-                List<DateTime> downloaded = element.AppOwner?.Downloaded;
-                if (downloaded == null || downloaded.Count == 0)
-                {
-                    return Conflict($"Data element {instanceOwnerPartyId}/{instanceGuid}/data/{element.Id} is not recorded downloaded by app owner. Please download first.");
-                }
-            }
-
-            List<DataElement> resultElements = new List<DataElement>();
-            foreach (DataElement element in dataElements)
-            {
-                DataElement updatedElement = await SetConfirmedDataAndUpdateDataElement(element, DateTime.UtcNow);
-                resultElements.Add(updatedElement);
-            }
-
-            DataElementList dataElementList = new DataElementList { DataElements = resultElements };
-
-            return Ok(dataElementList);
-        }
-
-        private async Task<DataElement> SetConfirmedDataAndUpdateDataElement(DataElement dataElement, DateTime timestamp)
-        {
-            dataElement.AppOwner ??= new ApplicationOwnerDataState();
-            dataElement.AppOwner.DownloadConfirmed ??= new List<DateTime>();
-            dataElement.AppOwner.DownloadConfirmed.Add(timestamp);
-
-            DataElement updatedElement = await _dataRepository.Update(dataElement);
-
-            return updatedElement;
-        }
-
-        /// <summary>
         /// Creates a data element by reading the first multipart element or body of the request.
         /// </summary>
         private async Task<(Stream, DataElement)> ReadRequestAndCreateDataElementAsync(HttpRequest request, string elementType, List<Guid> refs, Instance instance)
         {
             DateTime creationTime = DateTime.UtcNow;
-            Stream theStream = null;
+            Stream theStream;
 
-            string contentType = null;
+            string contentType;
             string contentFileName = null;
             long fileSize = 0;
 
             if (MultipartRequestHelper.IsMultipartContentType(request.ContentType))
             {
-                // Only read the first section of the mulitpart message.
+                // Only read the first section of the Multipart message.
                 MediaTypeHeaderValue mediaType = MediaTypeHeaderValue.Parse(request.ContentType);
                 string boundary = MultipartRequestHelper.GetBoundary(mediaType, _defaultFormOptions.MultipartBoundaryLengthLimit);
 
-                MultipartSection section = null;
-
                 MultipartReader reader = new MultipartReader(boundary, request.Body);
-                section = await reader.ReadNextSectionAsync();
+                MultipartSection section = await reader.ReadNextSectionAsync();
 
                 theStream = section.Body;
                 contentType = section.ContentType;
@@ -538,15 +459,15 @@ namespace Altinn.Platform.Storage.Controllers
                 if (request.Headers.TryGetValue("Content-Disposition", out StringValues headerValues))
                 {
                     string contentDisposition = headerValues.ToString();
-                    List<string> contenDispValues = contentDisposition.Split(';').ToList();
+                    List<string> contentDispositionValues = contentDisposition.Split(';').ToList();
 
-                    string fileNameValue = contenDispValues.FirstOrDefault(x => x.Contains("filename", StringComparison.CurrentCultureIgnoreCase));
+                    string fileNameValue = contentDispositionValues.FirstOrDefault(x => x.Contains("filename", StringComparison.CurrentCultureIgnoreCase));
 
                     if (!string.IsNullOrEmpty(fileNameValue))
                     {
                         string[] valueParts = fileNameValue.Split('=');
 
-                        if (valueParts.Count() == 2)
+                        if (valueParts.Length == 2)
                         {
                             contentFileName = HttpUtility.UrlDecode(valueParts[1]);
                         }
@@ -565,13 +486,13 @@ namespace Altinn.Platform.Storage.Controllers
 
         private async Task<(Application, ActionResult)> GetApplicationAsync(string appId, string org)
         {
-            ActionResult errorMessage = null;
+            ActionResult errorMessage;
 
             try
             {
                 Application application = await _applicationRepository.FindOne(appId, org);
 
-                return (application, errorMessage);
+                return (application, null);
             }
             catch (DocumentClientException dce)
             {
@@ -595,14 +516,13 @@ namespace Altinn.Platform.Storage.Controllers
         private async Task<(Instance, ActionResult)> GetInstanceAsync(string instanceId, int instanceOwnerPartyId)
         {
             // check if instance id exist and user is allowed to change the instance data
-            Instance instance;
-            ActionResult errorMessage = null;
+            ActionResult errorMessage;
 
             try
             {
-                instance = await _instanceRepository.GetOne(instanceId, instanceOwnerPartyId);
+                Instance instance = await _instanceRepository.GetOne(instanceId, instanceOwnerPartyId);
 
-                return (instance, errorMessage);
+                return (instance, null);
             }
             catch (DocumentClientException dce)
             {

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
@@ -90,7 +90,6 @@ namespace Altinn.Platform.Storage.Controllers
         /// <param name="processEndEvent">Process end state.</param>
         /// <param name="processEnded">Process ended value.</param>
         /// <param name="instanceOwnerPartyId">Instance owner id.</param>
-        /// <param name="labels">Labels.</param>
         /// <param name="lastChanged">Last changed date.</param>
         /// <param name="created">Created time.</param>
         /// <param name="visibleAfter">The visible after date time.</param>
@@ -112,7 +111,6 @@ namespace Altinn.Platform.Storage.Controllers
             [FromQuery(Name = "process.endEvent")] string processEndEvent,
             [FromQuery(Name = "process.ended")] string processEnded,
             [FromQuery(Name = "instanceOwner.partyId")] int? instanceOwnerPartyId,
-            [FromQuery(Name = "appOwner.labels")] string labels,
             [FromQuery] string lastChanged,
             [FromQuery] string created,
             [FromQuery(Name = "visibleAfter")] string visibleAfter,

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
@@ -209,8 +209,7 @@ namespace Altinn.Platform.Storage.Repository
                             break;
 
                         case "process.currentTask":
-                            string currentTaskId = queryValue;
-                            queryBuilder = queryBuilder.Where(i => i.Process.CurrentTask.ElementId == currentTaskId);
+                            queryBuilder = queryBuilder.Where(i => i.Process.CurrentTask.ElementId == queryValue);
                             break;
 
                         case "process.isComplete":
@@ -228,14 +227,6 @@ namespace Altinn.Platform.Storage.Repository
 
                         case "process.ended":
                             queryBuilder = QueryBuilderForEnded(queryBuilder, queryValue);
-                            break;
-
-                        case "appOwner.labels":
-                            foreach (string label in queryValue.Split(","))
-                            {
-                                queryBuilder = queryBuilder.Where(i => i.AppOwner.Labels.Contains(label));
-                            }
-
                             break;
 
                         default:
@@ -546,7 +537,7 @@ namespace Altinn.Platform.Storage.Repository
         /// </summary>
         /// <remarks>
         /// - Converts the instanceId (id) of the instance from {instanceGuid} to {instanceOwnerPartyId}/{instanceGuid} to be used outside cosmos.
-        /// - Retrieves all dataelements from data repository
+        /// - Retrieves all data elements from data repository
         /// - Sets correct LastChanged/LastChangedBy by comparing instance and data elements
         /// </remarks>
         /// <param name="instance">the instance to preprocess</param>
@@ -564,7 +555,7 @@ namespace Altinn.Platform.Storage.Repository
         }
 
         /// <summary>
-        /// Preprosesses a list of instances.
+        /// Preprocess a list of instances.
         /// </summary>
         /// <param name="instances">the list of instances</param>
         private async Task PostProcess(List<Instance> instances)

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/InstanceEventsRepositoryMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/InstanceEventsRepositoryMock.cs
@@ -24,28 +24,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
 
         public Task<InstanceEvent> InsertInstanceEvent(InstanceEvent instanceEvent)
         {
-            lock (TestDataUtil.dataLock)
-            {
-                string instanceId = instanceEvent.InstanceId;
-
-                if (instanceId.Contains("/"))
-                {
-                    instanceId = instanceEvent.InstanceId.Split("/")[1];
-                }
-
-                if (!Directory.Exists(GetInstanceEventsPath(instanceId, instanceEvent.InstanceOwnerPartyId)))
-                {
-                    Directory.CreateDirectory(GetInstanceEventsPath(instanceId, instanceEvent.InstanceOwnerPartyId));
-                }
-
-                instanceEvent.Id = Guid.NewGuid();
-
-
-                string instancePath = GetInstanceEventPath(instanceId, instanceEvent.InstanceOwnerPartyId, instanceEvent.Id.Value);
-                File.WriteAllText(instancePath, instanceEvent.ToString());
-
-                return Task.FromResult(instanceEvent);
-            }
+            return Task.FromResult(instanceEvent);
         }
 
         public Task<List<InstanceEvent>> ListInstanceEvents(string instanceId, string[] eventTypes, DateTime? fromDateTime, DateTime? toDateTime)
@@ -90,6 +69,5 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
             string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceRepositoryMock).Assembly.CodeBase).LocalPath);
             return Path.Combine(unitTestFolder, @"..\..\..\data\cosmoscollections\instances");
         }
-
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/DataControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/DataControllerTests.cs
@@ -38,7 +38,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
         /// <summary>
         /// Initializes a new instance of the <see cref="DataControllerTests"/> class.
         /// </summary>
-        /// <param name="fixture">Platform storage fixture.</param>
+        /// <param name="factory">Platform storage fixture.</param>
         public DataControllerTests(WebApplicationFactory<Startup> factory)
         {
             _factory = factory;
@@ -261,7 +261,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
         }
 
         [Fact]
-        public async void Get_DataElement_NotAuthoried()
+        public async void Get_DataElement_NotAuthorized()
         {
             TestDataUtil.DeleteInstanceAndDataAndBlobs(1337, "d91fd644-1028-4efd-924f-4ca187354514", "tdd", "endring-av-navn");
             TestDataUtil.PrepareInstance(1337, new Guid("d91fd644-1028-4efd-924f-4ca187354514"), "tdd", "endring-av-navn");
@@ -309,72 +309,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             TestDataUtil.DeleteInstanceAndDataAndBlobs(1337, "ca9da17c-904a-44d2-9771-a5420acfbcf3", "tdd", "endring-av-navn");
         }
 
-        [Fact]
-        public async void Put_ConfirmDownload_OnADataGuid_Ok()
-        {
-            TestDataUtil.DeleteInstanceAndDataAndBlobs(1337, "dd84cfe9-f875-42ea-8a96-eb725a6a8a95", "tdd", "endring-av-navn");
-            TestDataUtil.PrepareInstance(1337, new Guid("dd84cfe9-f875-42ea-8a96-eb725a6a8a95"), "tdd", "endring-av-navn");
-            string dataPathWithData = $"{_versionPrefix}/instances/1337/dd84cfe9-f875-42ea-8a96-eb725a6a8a95/dataelements/7b475791-ce2c-45a5-be2f-195f37c2646d";
-            HttpContent content = new StringContent("");
-
-            HttpClient client = GetTestClient();
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("tdd"));
-            HttpResponseMessage response = await client.PutAsync($"{dataPathWithData}/confirmDownload", content);
-
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            TestDataUtil.DeleteInstanceAndDataAndBlobs(1337, "dd84cfe9-f875-42ea-8a96-eb725a6a8a95", "tdd", "endring-av-navn");
-        }
-
-        [Fact]
-        public async void Put_ConfirmDownload_OnADataGuid_NotAuthoirzed()
-        {
-            TestDataUtil.DeleteInstanceAndDataAndBlobs(1337, "dd84cfe9-f875-42ea-8a96-eb725a6a8a95", "tdd", "endring-av-navn");
-            TestDataUtil.PrepareInstance(1337, new Guid("dd84cfe9-f875-42ea-8a96-eb725a6a8a95"), "tdd", "endring-av-navn");
-            string dataPathWithData = $"{_versionPrefix}/instances/1337/dd84cfe9-f875-42ea-8a96-eb725a6a8a95/dataelements/7b475791-ce2c-45a5-be2f-195f37c2646d";
-            HttpContent content = new StringContent("");
-
-            HttpClient client = GetTestClient();
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd"));
-            HttpResponseMessage response = await client.PutAsync($"{dataPathWithData}/confirmDownload", content);
-
-            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-            TestDataUtil.DeleteInstanceAndDataAndBlobs(1337, "dd84cfe9-f875-42ea-8a96-eb725a6a8a95", "tdd", "endring-av-navn");
-        }
-
-
-        [Fact]
-        public async void Put_ConfirmDownload_OnAllData_Ok()
-        {
-            TestDataUtil.DeleteInstanceAndDataAndBlobs(1337, "1e14b6cd-e310-4aff-aa83-720b2ec195e0", "tdd", "endring-av-navn");
-            TestDataUtil.PrepareInstance(1337, new Guid("1e14b6cd-e310-4aff-aa83-720b2ec195e0"), "tdd", "endring-av-navn");
-            string dataPathWithData = $"{_versionPrefix}/instances/1337/1e14b6cd-e310-4aff-aa83-720b2ec195e0/dataelements";
-            HttpContent content = new StringContent("");
-
-            HttpClient client = GetTestClient();
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("tdd"));
-            HttpResponseMessage response = await client.PutAsync($"{dataPathWithData}/confirmDownload", content);
-
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            TestDataUtil.DeleteInstanceAndDataAndBlobs(1337, "1e14b6cd-e310-4aff-aa83-720b2ec195e0", "tdd", "endring-av-navn");
-        }
-
-        [Fact]
-        public async void Put_ConfirmDownload_OnAllData_NotAuthorized()
-        {
-            TestDataUtil.DeleteInstanceAndDataAndBlobs(1337, "1e14b6cd-e310-4aff-aa83-720b2ec195e0", "tdd", "endring-av-navn");
-            TestDataUtil.PrepareInstance(1337, new Guid("1e14b6cd-e310-4aff-aa83-720b2ec195e0"), "tdd", "endring-av-navn");
-            string dataPathWithData = $"{_versionPrefix}/instances/1337/1e14b6cd-e310-4aff-aa83-720b2ec195e0/dataelements";
-            HttpContent content = new StringContent("");
-
-            HttpClient client = GetTestClient();
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd"));
-            HttpResponseMessage response = await client.PutAsync($"{dataPathWithData}/confirmDownload", content);
-
-            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-            TestDataUtil.DeleteInstanceAndDataAndBlobs(1337, "1e14b6cd-e310-4aff-aa83-720b2ec195e0", "tdd", "endring-av-navn");
-        }
-
-
         private HttpClient GetTestClient()
         {
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
@@ -406,6 +340,5 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             return client;
         }
-
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstanceEventsControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstanceEventsControllerTests.cs
@@ -39,6 +39,32 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             }
 
             /// <summary>
+            /// Add a new event to an instance.
+            /// </summary>
+            [Fact]
+            public async void Post_CreateNewEvent_ReturnsCreated()
+            {
+                // Arrange
+                string requestUri = "storage/api/v1/instances/1337/3c42ee2a-9464-42a8-a976-16eb926bd20a/events/";
+
+                HttpClient client = GetTestClient();
+                string token = PrincipalUtil.GetToken(3, 1337);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+                InstanceEvent instance = new InstanceEvent
+                {
+                    InstanceId = "3c42ee2a-9464-42a8-a976-16eb926bd20a"
+                };
+
+                // Act
+                StringContent content = new StringContent(JsonConvert.SerializeObject(instance), Encoding.UTF8, "application/json");
+                HttpResponseMessage response = await client.PostAsync(requestUri, content);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+            }
+
+            /// <summary>
             /// Test case: User has to low authentication level. 
             /// Expected: Returns status forbidden.
             /// </summary>
@@ -65,7 +91,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-  
             }
 
             /// <summary>

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstanceEventsControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstanceEventsControllerTests.cs
@@ -8,6 +8,7 @@ using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Storage.Clients;
 using Altinn.Platform.Storage.UnitTest.Mocks;
 using Altinn.Platform.Storage.UnitTest.Mocks.Authentication;
+using Altinn.Platform.Storage.UnitTest.Mocks.Repository;
 using Altinn.Platform.Storage.UnitTest.Utils;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Platform.Storage.Repository;
@@ -23,7 +24,6 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
-using Altinn.Platform.Storage.UnitTest.Mocks.Repository;
 
 namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 {
@@ -31,15 +31,11 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
         public class InstanceEventsControllerTests : IClassFixture<WebApplicationFactory<Startup>>
         {
-            private const string BasePath = "storage/api/v1/instances/1/cbdb00b1-4134-490d-b02b-3e33f7d8da33/events";
-
-            private readonly Mock<IInstanceEventRepository> _instanceEventRepository;
             private readonly WebApplicationFactory<Startup> _factory;
 
             public InstanceEventsControllerTests(WebApplicationFactory<Startup> factory)
             {
                 _factory = factory;
-                _instanceEventRepository = new Mock<IInstanceEventRepository>();
             }
 
             /// <summary>
@@ -52,7 +48,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 // Arrange
                 string requestUri = $"storage/api/v1/instances/1337/3c42ee2a-9464-42a8-a976-16eb926bd20a/events/";
 
-                HttpClient client = GetTestClient(_instanceEventRepository.Object);
+                HttpClient client = GetTestClient();
                 string token = PrincipalUtil.GetToken(3, 1337, 0);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
@@ -77,12 +73,12 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             /// Expected: Returns status forbidden.
             /// </summary>
             [Fact]
-            public async void Post_ReponseIsDeny_ReturnStatusForbidden()
+            public async void Post_ResponseIsDeny_ReturnStatusForbidden()
             {
                 // Arrange
                 string requestUri = $"storage/api/v1/instances/1337/3c42ee2a-9464-42a8-a976-16eb926bd20a/events/";
 
-                HttpClient client = GetTestClient(_instanceEventRepository.Object);
+                HttpClient client = GetTestClient();
                 string token = PrincipalUtil.GetToken(-1, 1);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
@@ -106,7 +102,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 string eventGuid = "c8a44353-114a-48fc-af8f-b85392793cb2";
                 string requestUri = $"storage/api/v1/instances/1337/3c42ee2a-9464-42a8-a976-16eb926bd20a/events/{eventGuid}";
 
-                HttpClient client = GetTestClient(_instanceEventRepository.Object);
+                HttpClient client = GetTestClient();
                 string token = PrincipalUtil.GetToken(3, 1337, 0);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
@@ -122,12 +118,12 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             /// Expected: Returns status forbidden.
             /// </summary>
             [Fact]
-            public async void GetOne_ReponseIsDeny_ReturnStatusForbidden()
+            public async void GetOne_ResponseIsDeny_ReturnStatusForbidden()
             {
                 string eventGuid = "9f07c256-a344-490b-b42b-1c855a83f6fc";
                 string requestUri = $"storage/api/v1/instances/1337/a6020470-2200-4448-bed9-ef46b679bdb8/events/{eventGuid}";
 
-                HttpClient client = GetTestClient(_instanceEventRepository.Object);
+                HttpClient client = GetTestClient();
                 string token = PrincipalUtil.GetToken(-1, 1337);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
@@ -146,9 +142,9 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             public async void Get_UserHasToLowAuthLv_ReturnStatusForbidden()
             {
                 // Arrange
-                string requestUri = $"storage/api/v1/instances/1337/3c42ee2a-9464-42a8-a976-16eb926bd20a/events/";
+                string requestUri = "storage/api/v1/instances/1337/3c42ee2a-9464-42a8-a976-16eb926bd20a/events/";
 
-                HttpClient client = GetTestClient(_instanceEventRepository.Object);
+                HttpClient client = GetTestClient();
                 string token = PrincipalUtil.GetToken(3, 1337, 0);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
@@ -164,12 +160,12 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             /// Expected: Returns status forbidden.
             /// </summary>
             [Fact]
-            public async void Get_ReponseIsDeny_ReturnStatusForbidden()
+            public async void Get_ResponseIsDeny_ReturnStatusForbidden()
             {
                 // Arrange
-                string requestUri = $"storage/api/v1/instances/1337/3c42ee2a-9464-42a8-a976-16eb926bd20a/events/";
+                string requestUri = "storage/api/v1/instances/1337/3c42ee2a-9464-42a8-a976-16eb926bd20a/events/";
 
-                HttpClient client = GetTestClient(_instanceEventRepository.Object);
+                HttpClient client = GetTestClient();
                 string token = PrincipalUtil.GetToken(-1, 1);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
@@ -180,7 +176,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
             }
 
-            private HttpClient GetTestClient(IInstanceEventRepository instanceEventRepository)
+            private HttpClient GetTestClient()
             {
                 Program.ConfigureSetupLogging();
                 // No setup required for these services. They are not in use by the InstanceEventController

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Reflection;
 
 using Altinn.Common.PEP.Interfaces;
 
@@ -12,6 +11,7 @@ using Altinn.Platform.Storage.Clients;
 using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.UnitTest.Mocks;
 using Altinn.Platform.Storage.UnitTest.Mocks.Authentication;
+using Altinn.Platform.Storage.UnitTest.Mocks.Repository;
 using Altinn.Platform.Storage.UnitTest.Utils;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Platform.Storage.Repository;
@@ -21,38 +21,29 @@ using AltinnCore.Authentication.JwtCookie;
 
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Azure.Documents;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
-using System.IO;
-using Altinn.Platform.Storage.UnitTest.Mocks.Repository;
 
 namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 {
     public partial class IntegrationTests
     {
-
-        public class MessageboxInstancesControllerTests : IClassFixture<WebApplicationFactory<Startup>>
+        public class MessageBoxInstancesControllerTests : IClassFixture<WebApplicationFactory<Startup>>
         {
             private const string BasePath = "/storage/api/v1";
-            private const string org = "tdd";
-            private const string app = "test-applikasjon-1";   
             private readonly WebApplicationFactory<Startup> _factory;
-            private readonly string _validToken, _validTokenUsr3;
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="MessageboxInstancesControllerTests"/> class with the given <see cref="WebApplicationFactory{TStartup}"/>.
+            /// Initializes a new instance of the <see cref="MessageBoxInstancesControllerTests"/> class with the given <see cref="WebApplicationFactory{TStartup}"/>.
             /// </summary>
             /// <param name="factory">The <see cref="WebApplicationFactory{TStartup}"/> to use when setting up the test server.</param>
-            public MessageboxInstancesControllerTests(WebApplicationFactory<Startup> factory)
+            public MessageBoxInstancesControllerTests(WebApplicationFactory<Startup> factory)
             {
                 _factory = factory;
-                _validToken = PrincipalUtil.GetToken(1, 1000);
-                _validTokenUsr3 = PrincipalUtil.GetToken(3, 1000);
             }
 
             /// <summary>
@@ -64,7 +55,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             ///   Default language is used for title, and the title contains the word "bokmål".
             /// </summary>
             [Fact]
-            public async void GetMessageBoxInstanceList_RequestAllInstancesForAnOwnerWithtoutLanguage_ReturnsAllElementsUsingDefaultLanguage()
+            public async void GetMessageBoxInstanceList_RequestAllInstancesForAnOwnerWithoutLanguage_ReturnsAllElementsUsingDefaultLanguage()
             {
                 // Arrange
                 HttpClient client = GetTestClient();
@@ -79,10 +70,9 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
                 int expectedCount = 10;
                 string expectedTitle = "Endring av navn (RF-1453)";
-                int actualCount = messageBoxInstances.Count;
-                string actualTitle = messageBoxInstances.First().Title;
-                Assert.Equal(expectedCount, actualCount);
-                Assert.Equal(expectedTitle, actualTitle);
+
+                Assert.Equal(expectedCount, messageBoxInstances?.Count);
+                Assert.Equal(expectedTitle, messageBoxInstances?.First().Title);
             }
 
             /// <summary>
@@ -393,11 +383,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             public async void Delete_UserHasTooLowAuthLv_ReturnsStatusForbidden()
             {
                 // Arrange
-                InstanceEvent instanceEvent = null;
-
                 Mock<IInstanceEventRepository> instanceEventRepository = new Mock<IInstanceEventRepository>();
-                instanceEventRepository.Setup(s => s.InsertInstanceEvent(It.IsAny<InstanceEvent>())).Callback<InstanceEvent>(p => instanceEvent = p)
-                    .ReturnsAsync((InstanceEvent r) => r);
+                instanceEventRepository.Setup(s => s.InsertInstanceEvent(It.IsAny<InstanceEvent>())).ReturnsAsync((InstanceEvent r) => r);
 
                 HttpClient client = GetTestClient();
                 string token = PrincipalUtil.GetToken(1337, 1337, 1);
@@ -487,7 +474,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
                 // Act
                 HttpResponseMessage response = await client.DeleteAsync($"{BasePath}/sbl/instances/1337/d9a586ca-17ab-453d-9fc5-35eaadb3369b?hard=true");
-                HttpStatusCode actualStatusCode = response.StatusCode;
                 string content = await response.Content.ReadAsStringAsync();
                 bool actualResult = JsonConvert.DeserializeObject<bool>(content);
 
@@ -597,30 +583,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 }).CreateClient();
 
                 return client;
-            }
-
-            /// <summary>
-            /// Create a DocumentClientException using reflection because all constructors are internal.
-            /// </summary>
-            /// <param name="message">Exception message</param>
-            /// <param name="httpStatusCode">The HttpStatus code.</param>
-            /// <returns></returns>
-            private static DocumentClientException CreateDocumentClientExceptionForTesting(string message, HttpStatusCode httpStatusCode)
-            {
-                Type type = typeof(DocumentClientException);
-
-                string fullName = type.FullName ?? "wtf?";
-
-                object documentClientExceptionInstance = type.Assembly.CreateInstance(
-                    fullName,
-                    false,
-                    BindingFlags.Instance | BindingFlags.NonPublic,
-                    null,
-                    new object[] { message, null, null, httpStatusCode, null },
-                    null,
-                    null);
-
-                return (DocumentClientException)documentClientExceptionInstance;
             }
         }
     }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
@@ -66,13 +66,14 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
                 // Assert
                 string content = await response.Content.ReadAsStringAsync();
-                List<MessageBoxInstance> messageBoxInstances = JsonConvert.DeserializeObject(content, typeof(List<MessageBoxInstance>)) as List<MessageBoxInstance>;
+                List<MessageBoxInstance> messageBoxInstances = JsonConvert.DeserializeObject<List<MessageBoxInstance>>(content);
 
                 int expectedCount = 10;
                 string expectedTitle = "Endring av navn (RF-1453)";
-
-                Assert.Equal(expectedCount, messageBoxInstances?.Count);
-                Assert.Equal(expectedTitle, messageBoxInstances?.First().Title);
+                int actualCount = messageBoxInstances.Count;
+                string actualTitle = messageBoxInstances.First().Title;
+                Assert.Equal(expectedCount, actualCount);
+                Assert.Equal(expectedTitle, actualTitle);
             }
 
             /// <summary>


### PR DESCRIPTION
Removed the two confirmDownload endpoints for dataelement.
Removed the endpoint that enabled delete of all events on an instance.
Fixed a few typos and other minor refactoring.

Related to #4484.