### PR TITLE
Removing references to the AppOwner properties

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
@@ -517,7 +517,7 @@ namespace Altinn.Platform.Storage.Controllers
 
         private Instance CreateInstanceFromTemplate(Application appInfo, Instance instanceTemplate, DateTime creationTime, string userId)
         {
-            Instance createdInstance = new Instance()
+            Instance createdInstance = new Instance
             {
                 InstanceOwner = instanceTemplate.InstanceOwner,
                 CreatedBy = userId,
@@ -529,15 +529,9 @@ namespace Altinn.Platform.Storage.Controllers
                 VisibleAfter = DateTimeHelper.ConvertToUniversalTime(instanceTemplate.VisibleAfter),
                 Status = instanceTemplate.Status,
                 DueBefore = DateTimeHelper.ConvertToUniversalTime(instanceTemplate.DueBefore),
-                AppOwner = new ApplicationOwnerState
-                {
-                    Labels = instanceTemplate.AppOwner?.Labels,
-                },
+                Data = new List<DataElement>(),
+                Process = instanceTemplate.Process,
             };
-
-            createdInstance.Data = new List<DataElement>();
-
-            createdInstance.Process = instanceTemplate.Process;
 
             return createdInstance;
         }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/DataControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/DataControllerTests.cs
@@ -260,7 +260,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
         public async void Get_DataElement_Org_Ok()
         {
             // Arrange
-            DataElement dataElementBefore = TestDataUtil.GetDataElement("28023597-516b-4a71-a77c-d3736912abd5");
             string dataPathWithData = $"{_versionPrefix}/instances/1337/ca9da17c-904a-44d2-9771-a5420acfbcf3/data/28023597-516b-4a71-a77c-d3736912abd5";
 
             HttpClient client = GetTestClient();
@@ -271,7 +270,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Null(dataElementBefore.AppOwner);
         }
 
         private HttpClient GetTestClient()
@@ -279,7 +277,9 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
             Application testApp1 = new Application { Id = "test/testApp1", Org = "test" };
 
-            applicationRepository.Setup(s => s.FindOne(It.Is<string>(p => p.Equals("test/testApp1")), It.IsAny<string>())).ReturnsAsync(testApp1);
+            applicationRepository
+                .Setup(s => s.FindOne(It.Is<string>(p => p.Equals("test/testApp1")), It.IsAny<string>()))
+                .ReturnsAsync(testApp1);
 
             // No setup required for these services. They are not in use by the InstanceController
             Mock<ISasTokenProvider> sasTokenProvider = new Mock<ISasTokenProvider>();

--- a/src/development/LocalTest/Controllers/Storage/InstancesController.cs
+++ b/src/development/LocalTest/Controllers/Storage/InstancesController.cs
@@ -75,7 +75,6 @@ namespace Altinn.Platform.Storage.Controllers
         /// <param name="processEndEvent">Process end state.</param>
         /// <param name="processEnded">Process ended value.</param>
         /// <param name="instanceOwnerPartyId">Instance owner id.</param>
-        /// <param name="labels">Labels.</param>
         /// <param name="lastChanged">Last changed date.</param>
         /// <param name="created">Created time.</param>
         /// <param name="visibleAfter">The visible after date time.</param>
@@ -97,7 +96,6 @@ namespace Altinn.Platform.Storage.Controllers
             [FromQuery(Name = "process.endEvent")] string processEndEvent,
             [FromQuery(Name = "process.ended")] string processEnded,
             [FromQuery(Name = "instanceOwner.partyId")] int? instanceOwnerPartyId,
-            [FromQuery(Name = "appOwner.labels")] string labels,
             [FromQuery] string lastChanged,
             [FromQuery] string created,
             [FromQuery(Name = "visibleAfter")] string visibleAfter,
@@ -471,7 +469,7 @@ namespace Altinn.Platform.Storage.Controllers
 
         private Instance CreateInstanceFromTemplate(Application appInfo, Instance instanceTemplate, DateTime creationTime, string userId)
         {
-            Instance createdInstance = new Instance()
+            Instance createdInstance = new Instance
             {
                 InstanceOwner = instanceTemplate.InstanceOwner,
                 CreatedBy = userId,
@@ -483,15 +481,9 @@ namespace Altinn.Platform.Storage.Controllers
                 VisibleAfter = DateTimeHelper.ConvertToUniversalTime(instanceTemplate.VisibleAfter),
                 Status = instanceTemplate.Status,
                 DueBefore = DateTimeHelper.ConvertToUniversalTime(instanceTemplate.DueBefore),
-                AppOwner = new ApplicationOwnerState
-                {
-                    Labels = instanceTemplate.AppOwner?.Labels,
-                },
+                Data = new List<DataElement>(),
+                Process = instanceTemplate.Process
             };
-
-            createdInstance.Data = new List<DataElement>();
-
-            createdInstance.Process = instanceTemplate.Process;
 
             return createdInstance;
         }
@@ -557,9 +549,9 @@ namespace Altinn.Platform.Storage.Controllers
             items.RemoveAll(x => x.Key == queryParamName);
 
             var qb = new QueryBuilder(items)
-                        {
-                            { queryParamName, newParamValue }
-                        };
+            {
+                { queryParamName, newParamValue }
+            };
 
             string nextQueryString = qb.ToQueryString().Value;
 


### PR DESCRIPTION
Removed the use of Instance.AppOwner and DataElement.AppOwner properties from Storage and LocalTest. Neither was in use by App or AltinnCLI.

Related to issue #4199 