### PR TITLE
Gitea 1.12.1 to 1.12.2

### DIFF
--- a/src/studio/src/repositories/Dockerfile
+++ b/src/studio/src/repositories/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM gitea/gitea:1.12.1
+FROM gitea/gitea:1.12.2
 
 # copy configuration file
 # Has to be copied to the templates-folder so parsing of environment variables is correct

--- a/src/studio/src/repositories/Dockerfile.local
+++ b/src/studio/src/repositories/Dockerfile.local
@@ -1,5 +1,5 @@
 # base image
-FROM gitea/gitea:1.12.1
+FROM gitea/gitea:1.12.2
 
 # copy configuration file
 COPY ./gitea-data/gitea/conf/app.ini data/gitea/conf/app.ini


### PR DESCRIPTION
Bump Gitea 1.12.1 => 1.12.2

https://blog.gitea.io/2020/07/gitea-1.12.2-is-released/