### PR TITLE
Use version 2.2.0 of Storage.Interfaces.

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,21 +3,21 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.1.1.0</AssemblyVersion>
-    <FileVersion>1.1.1.0</FileVersion>
-    <Version>1.1.1-alpha</Version>
-    <Description>Package that contains API controllers for the standard API for a Altinn App.</Description>
-    <Company>Altinn</Company>
+    <Version>1.1.2-alpha</Version>
     <Authors>Altinn</Authors>
-    <PackageTags>Altinn Studio</PackageTags>
+    <Company>Altinn</Company>
+    <Description>Package that contains API controllers for the standard API for a Altinn App.</Description>
+    <PackageProjectUrl>https://github.com/Altinn/altinn-studio</PackageProjectUrl>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <AssemblyVersion>1.1.2.0</AssemblyVersion>
     <IsPackable>true</IsPackable>
     <OutputType>Library</OutputType>
+    <FileVersion>1.1.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Altinn.Common.PEP" Version="1.0.33-alpha" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.1.18" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,15 +3,16 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>1.1.1-alpha</Version>
+    <Version>1.1.2-alpha</Version>
     <Authors>Altinn</Authors>
     <Company>Altinn</Company>
     <Description>Package with common functionality for Altinn Apps created in Altinn Studio</Description>
     <PackageProjectUrl>https://github.com/Altinn/altinn-studio</PackageProjectUrl>
-    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <AssemblyVersion>1.1.2.0</AssemblyVersion>
     <IsPackable>true</IsPackable>
     <OutputType>Library</OutputType>
-    <FileVersion>1.1.1.0</FileVersion>
+    <FileVersion>1.1.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.1.18" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,16 +3,16 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>1.1.1-alpha</Version>
+    <Version>1.1.2-alpha</Version>
     <Authors>Altinn</Authors>
     <Company>Altinn</Company>
     <Description>Common services with Altinn Platform functionality and Altinn Apps functionality</Description>
     <PackageProjectUrl>https://github.com/Altinn/altinn-studio</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <AssemblyVersion>1.1.2.0</AssemblyVersion>
     <IsPackable>true</IsPackable>
     <OutputType>Library</OutputType>
-    <FileVersion>1.1.1.0</FileVersion>
+    <FileVersion>1.1.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Altinn.Common.AccessTokenClient" Version="0.5.4" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.0.4-alpha" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.1.18" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.2.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.4.0-alpha" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.2.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.4.0-alpha" />
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.6.0" />

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/App.IntegrationTestsRef.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/App.IntegrationTestsRef.csproj
@@ -7,6 +7,21 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Altinn.Platform\Altinn.Platform.Authorization\Altinn.Authorization.ABAC\Altinn.Authorization.ABAC.csproj" />
+    <ProjectReference Include="..\Altinn.App.Common\Altinn.App.Common.csproj" />
+    <ProjectReference Include="..\Altinn.App.PlatformServices\Altinn.App.PlatformServices.csproj" />
+    <ProjectReference Include="..\App\AppRef.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="Data\Instances\tdd\complex-process-1\**" />
     <Compile Remove="Data\Instances\tdd\endring-av-navn\1337\26133fb5-a9f2-45d4-90b1-f6d93ad40713\**" />
     <EmbeddedResource Remove="Data\Instances\tdd\complex-process-1\**" />
@@ -104,21 +119,6 @@
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\Altinn.Platform\Altinn.Platform.Authorization\Altinn.Authorization.ABAC\Altinn.Authorization.ABAC.csproj" />
-    <ProjectReference Include="..\Altinn.App.Common\Altinn.App.Common.csproj" />
-    <ProjectReference Include="..\Altinn.App.PlatformServices\Altinn.App.PlatformServices.csproj" />
-    <ProjectReference Include="..\App\AppRef.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.Apps/AppTemplates/AspNet/App/AppRef.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App/AppRef.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.6" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Update Altinn.App projects to use version 2.2.0 of Storage.Interfaces
Increased patch version of the affected projects.
Updated Altinn.App.Api project to generate with the same setting as the other two projects.
Updated a few other Package references.