### PR TITLE
Changed Logout to be a POST

### DIFF
--- a/src/studio/src/designer/backend/Controllers/HomeController.cs
+++ b/src/studio/src/designer/backend/Controllers/HomeController.cs
@@ -181,7 +181,7 @@ namespace Altinn.Studio.Designer.Controllers
         public async Task<IActionResult> Logout()
         {
             await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-            return LocalRedirect("/repos/user/logout");
+            return LocalRedirect("/");
         }
 
         /// <summary>

--- a/src/studio/src/designer/frontend/shared/navigation/drawer/TabletDrawerMenu.tsx
+++ b/src/studio/src/designer/frontend/shared/navigation/drawer/TabletDrawerMenu.tsx
@@ -12,6 +12,7 @@ import { Link } from 'react-router-dom';
 import { IMenuItem, leftDrawerMenuSettings } from './drawerMenuSettings';
 import { mainMenuSettings } from './drawerMenuSettings';
 import { styles } from './tabletDrawerMenustyle';
+import { post } from '../../utils/networking';
 
 export interface ITabletDrawerMenuProps {
   classes: any;
@@ -61,9 +62,11 @@ class TabletDrawerMenu extends React.Component<ITabletDrawerMenuProps & WithStyl
   }
 
   public handleLogout = () => {
-    if (window) {
-      window.location.href = '/Home/Logout';
-    }
+    const altinnWindow: Window = window;
+    const url = `${altinnWindow.location.origin}/repos/user/logout`;
+    post(url).then((result: any) => {
+        window.location.assign(`${altinnWindow.location.origin}/Home/Logout`);
+    });
     return true;
   }
 

--- a/src/studio/src/designer/frontend/shared/navigation/drawer/TabletDrawerMenu.tsx
+++ b/src/studio/src/designer/frontend/shared/navigation/drawer/TabletDrawerMenu.tsx
@@ -64,8 +64,8 @@ class TabletDrawerMenu extends React.Component<ITabletDrawerMenuProps & WithStyl
   public handleLogout = () => {
     const altinnWindow: Window = window;
     const url = `${altinnWindow.location.origin}/repos/user/logout`;
-    post(url).then((result: any) => {
-        window.location.assign(`${altinnWindow.location.origin}/Home/Logout`);
+    post(url).then(() => {
+      window.location.assign(`${altinnWindow.location.origin}/Home/Logout`);
     });
     return true;
   }

--- a/src/studio/src/designer/frontend/shared/navigation/main-header/profileMenu.tsx
+++ b/src/studio/src/designer/frontend/shared/navigation/main-header/profileMenu.tsx
@@ -6,6 +6,7 @@ import AccountCircle from '@material-ui/icons/AccountCircle';
 import * as React from 'react';
 import { IAltinnWindow } from '../../types';
 import { altinnStudioDocsUrl, repositoryUrl } from '../../utils/urlHelper';
+import { post } from '../../utils/networking';
 
 export interface IProfileMenuComponentProps {
   showlogout?: boolean;
@@ -51,10 +52,11 @@ class ProfileMenuComponent extends React.Component<IProfileMenuComponentProps, I
   }
 
   public handleLogout = () => {
-    this.setState({ anchorEl: null });
-    if (window) {
-      window.location.href = '/Home/Logout';
-    }
+    const altinnWindow: Window = window;
+    const url = `${altinnWindow.location.origin}/repos/user/logout`;
+    post(url).then((result: any) => {
+        window.location.assign(`${altinnWindow.location.origin}/Home/Logout`);
+    });
     return true;
   }
 

--- a/src/studio/src/designer/frontend/shared/navigation/main-header/profileMenu.tsx
+++ b/src/studio/src/designer/frontend/shared/navigation/main-header/profileMenu.tsx
@@ -54,8 +54,8 @@ class ProfileMenuComponent extends React.Component<IProfileMenuComponentProps, I
   public handleLogout = () => {
     const altinnWindow: Window = window;
     const url = `${altinnWindow.location.origin}/repos/user/logout`;
-    post(url).then((result: any) => {
-        window.location.assign(`${altinnWindow.location.origin}/Home/Logout`);
+    post(url).then(() => {
+      window.location.assign(`${altinnWindow.location.origin}/Home/Logout`);
     });
     return true;
   }


### PR DESCRIPTION
Related to #4624 

Changed the call to the Gitea logout mechanism to be a POST. Then redirects to the Designer logout which cleans up and redirects to the front page.