### PR TITLE
set contraint on app in endpoint path

### DIFF
--- a/src/studio/src/designer/backend/Startup.cs
+++ b/src/studio/src/designer/backend/Startup.cs
@@ -185,7 +185,7 @@ namespace Altinn.Studio.Designer
                         pattern: "designer/{org}/{app}",
                         defaults: new { controller = "ServiceDevelopment", action = "index" },
                         constraints: new
-                         {
+                        {
                             app = "^[a-z]+[a-zA-Z0-9-]+[a-zA-Z0-9]$",
                         });
 

--- a/src/studio/src/designer/backend/Startup.cs
+++ b/src/studio/src/designer/backend/Startup.cs
@@ -183,16 +183,20 @@ namespace Altinn.Studio.Designer
                 endpoints.MapControllerRoute(
                         name: "serviceDevelopmentRoute",
                         pattern: "designer/{org}/{app}",
-                        defaults: new { controller = "ServiceDevelopment", action = "index" });
+                        defaults: new { controller = "ServiceDevelopment", action = "index" },
+                        constraints: new
+                         {
+                            app = "^[a-z]+[a-zA-Z0-9-]+[a-zA-Z0-9]$",
+                        });
 
                 endpoints.MapControllerRoute(
-                    name: "designerApiRoute",
-                    pattern: "designerapi/{controller}/{action=Index}/{id?}",
-                    defaults: new { controller = "Repository" },
-                    constraints: new
-                    {
-                        controller = @"(Repository|Language|User)",
-                    });
+                        name: "designerApiRoute",
+                        pattern: "designerapi/{controller}/{action=Index}/{id?}",
+                        defaults: new { controller = "Repository" },
+                        constraints: new
+                        {
+                            controller = @"(Repository|Language|User)",
+                        });
                 endpoints.MapControllerRoute(
                           name: "serviceRoute",
                           pattern: "designer/{org}/{app}/{controller}/{action=Index}/{id?}",
@@ -200,7 +204,7 @@ namespace Altinn.Studio.Designer
                           constraints: new
                           {
                               controller = @"(Codelist|Config|Service|RuntimeAPI|ManualTesting|Model|Rules|ServiceMetadata|Text|UI|UIEditor|ServiceDevelopment)",
-                              app = "[a-zA-Z][a-zA-Z0-9_\\-]{2,30}",
+                              app = "^[a-z]+[a-zA-Z0-9-]+[a-zA-Z0-9]$",
                               id = "[a-zA-Z0-9_\\-]{1,30}",
                           });
 


### PR DESCRIPTION
#4716 

App must start with letter
must end with letter or number

verifying on the designer/org/app endpoint
updated for an endpoint with existing regex to match current naming rule