### PR TITLE
Expose substatus to messagebox

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Configuration/GeneralSettings.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Configuration/GeneralSettings.cs
@@ -28,8 +28,8 @@ namespace Altinn.Platform.Storage.Configuration
         public Uri BridgeApiAuthorizationEndpoint { get; set; }
 
         /// <summary>
-        /// Gets or sets the cache resource lifetime.
+        /// Gets or sets the cache lifetime for text resources.
         /// </summary>
-        public int CacheResourceLifeTimeInSeconds { get; set; }
+        public int TextResourceCacheLifeTimeInSeconds { get; set; }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Configuration/GeneralSettings.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Configuration/GeneralSettings.cs
@@ -26,5 +26,10 @@ namespace Altinn.Platform.Storage.Configuration
         /// Gets or sets the URI for the SBL Bridge Authorization API.
         /// </summary>
         public Uri BridgeApiAuthorizationEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cache resource lifetime.
+        /// </summary>
+        public int CacheResourceLifeTimeInSeconds { get; set; }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
@@ -26,6 +26,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
+using Substatus = Altinn.Platform.Storage.Interface.Models.Substatus;
 
 namespace Altinn.Platform.Storage.Controllers
 {

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/MessageboxInstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/MessageboxInstancesController.cs
@@ -25,7 +25,7 @@ namespace Altinn.Platform.Storage.Controllers
     {
         private readonly IInstanceRepository _instanceRepository;
         private readonly IInstanceEventRepository _instanceEventRepository;
-        private readonly IApplicationRepository _applicationRepository;
+        private readonly ITextRepository _textRepository;
         private readonly AuthorizationHelper _authorizationHelper;
 
         /// <summary>
@@ -33,19 +33,19 @@ namespace Altinn.Platform.Storage.Controllers
         /// </summary>
         /// <param name="instanceRepository">the instance repository handler</param>
         /// <param name="instanceEventRepository">the instance event repository service</param>
-        /// <param name="applicationRepository">the application repository handler</param>
+        /// <param name="textRepository">the text repository handler</param>
         /// <param name="pdp">the policy decision point</param>
         /// <param name="logger">The logger to be used to perform logging from the controller.</param>
         public MessageBoxInstancesController(
             IInstanceRepository instanceRepository,
             IInstanceEventRepository instanceEventRepository,
-            IApplicationRepository applicationRepository,
+            ITextRepository textRepository,
             IPDP pdp,
             ILogger<AuthorizationHelper> logger)
         {
             _instanceRepository = instanceRepository;
             _instanceEventRepository = instanceEventRepository;
-            _applicationRepository = applicationRepository;
+            _textRepository = textRepository;
             _authorizationHelper = new AuthorizationHelper(pdp, logger);
         }
 
@@ -95,10 +95,12 @@ namespace Altinn.Platform.Storage.Controllers
 
             List<MessageBoxInstance> autorizedInstances = await _authorizationHelper.AuthorizeMesseageBoxInstances(HttpContext.User, allInstances);
             List<string> appIds = autorizedInstances.Select(i => InstanceHelper.GetAppId(i)).Distinct().ToList();
-            Dictionary<string, Dictionary<string, string>> appTitles = await _applicationRepository.GetAppTitles(appIds);
-            List<MessageBoxInstance> messageBoxInstances = InstanceHelper.AddTitleToInstances(autorizedInstances, appTitles, languageId);
 
-            return Ok(messageBoxInstances);
+            // get app texts and exchange all text keys.
+            List<TextResource> texts = await _textRepository.Get(appIds, languageId);
+            InstanceHelper.ReplaceTextKeys(autorizedInstances, texts, languageId);
+
+            return Ok(autorizedInstances);
         }
 
         /// <summary>
@@ -137,8 +139,9 @@ namespace Altinn.Platform.Storage.Controllers
 
             MessageBoxInstance authorizedInstance = authorizedInstanceList.First();
 
-            Dictionary<string, Dictionary<string, string>> appTitle = await _applicationRepository.GetAppTitles(new List<string> { instance.AppId });
-            InstanceHelper.AddTitleToInstances(new List<MessageBoxInstance> { authorizedInstance }, appTitle, languageId);
+            // get app texts and exchange all text keys.
+            List<TextResource> texts = await _textRepository.Get(new List<string> { instance.AppId }, languageId);
+            InstanceHelper.ReplaceTextKeys(new List<MessageBoxInstance> { authorizedInstance }, texts, languageId);
 
             return Ok(authorizedInstance);
         }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/MessageboxInstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/MessageboxInstancesController.cs
@@ -96,7 +96,6 @@ namespace Altinn.Platform.Storage.Controllers
             List<MessageBoxInstance> autorizedInstances = await _authorizationHelper.AuthorizeMesseageBoxInstances(HttpContext.User, allInstances);
             List<string> appIds = autorizedInstances.Select(i => InstanceHelper.GetAppId(i)).Distinct().ToList();
 
-            // get app texts and exchange all text keys.
             List<TextResource> texts = await _textRepository.Get(appIds, languageId);
             InstanceHelper.ReplaceTextKeys(autorizedInstances, texts, languageId);
 

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/MessageBoxInstance.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/MessageBoxInstance.cs
@@ -66,6 +66,11 @@ namespace Altinn.Platform.Storage.Helpers
         public ReadStatus ReadStatus { get; set; }
 
         /// <summary>
+        /// The substatus of the instance.
+        /// </summary>
+        public Substatus Substatus { get; set; }
+
+        /// <summary>
         /// Boolean indicating if user is allowed to delete instance.
         /// </summary>
         public bool AllowDelete { get; set; }
@@ -107,5 +112,21 @@ namespace Altinn.Platform.Storage.Helpers
         /// </summary>
         [EnumMember]
         SoftDeleted = 1
+    }
+
+    /// <summary>
+    /// Status containing label and description.
+    /// </summary>
+    public class Substatus
+    {
+        /// <summary>
+        /// A text key pointing to a short description of the substatus.
+        /// </summary>
+        public string Label { get; set; }
+
+        /// <summary>
+        /// A text key pointing to a longer description of the substatus.
+        /// </summary>
+        public string Description { get; set; }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/ITextRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/ITextRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 
@@ -16,6 +17,14 @@ namespace Altinn.Platform.Storage.Repository
         /// <param name="language">the language. Must be a two letter ISO name.</param>
         /// <returns>the text resource</returns>
         Task<TextResource> Get(string org, string app, string language);
+
+        /// <summary>
+        /// Gets a list of text resource
+        /// </summary>
+        /// <param name="appIds">List of application ids e.g. ttd/apps-test</param>
+        /// <param name="language">the language. Must be a two letter ISO name.</param>
+        /// <returns>the list of text resource</returns>
+        Task<List<TextResource>> Get(List<string> appIds, string language);
 
         /// <summary>
         /// Creates a text resource

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/ITextRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/ITextRepository.cs
@@ -19,7 +19,7 @@ namespace Altinn.Platform.Storage.Repository
         Task<TextResource> Get(string org, string app, string language);
 
         /// <summary>
-        /// Gets a list of text resource
+        /// Gets a list of text resources based on appId.
         /// </summary>
         /// <param name="appIds">List of application ids e.g. ttd/apps-test</param>
         /// <param name="language">the language. Must be a two letter ISO name.</param>

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/TextRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/TextRepository.cs
@@ -9,6 +9,7 @@ namespace Altinn.Platform.Storage.Repository
     using Altinn.Platform.Storage.Interface.Models;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Client;
+    using Microsoft.Extensions.Caching.Memory;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
     using Newtonsoft.Json;
@@ -24,13 +25,21 @@ namespace Altinn.Platform.Storage.Repository
         private readonly string _partitionKey = "/org";
         private readonly DocumentClient _client;
         private readonly ILogger<ITextRepository> _logger;
+        private readonly IMemoryCache _memoryCache;
+        private readonly MemoryCacheEntryOptions _cacheEntryOptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TextRepository"/> class
         /// </summary>
         /// <param name="cosmosettings">the configuration settings for cosmos database</param>
+        /// <param name="generalSettings">the general configurations settings</param>
         /// <param name="logger">the logger</param>
-        public TextRepository(IOptions<AzureCosmosSettings> cosmosettings, ILogger<ITextRepository> logger)
+        /// <param name="memoryCache">the memory cache</param>
+        public TextRepository(
+            IOptions<AzureCosmosSettings> cosmosettings,
+            IOptions<GeneralSettings> generalSettings,
+            ILogger<ITextRepository> logger,
+            IMemoryCache memoryCache)
         {
             var database = new CosmosDatabaseHandler(cosmosettings.Value);
             _logger = logger;
@@ -45,31 +54,43 @@ namespace Altinn.Platform.Storage.Repository
                 documentCollection).GetAwaiter().GetResult();
 
             _client.OpenAsync();
+
+            _memoryCache = memoryCache;
+            _cacheEntryOptions = new MemoryCacheEntryOptions()
+                .SetPriority(CacheItemPriority.High)
+                .SetAbsoluteExpiration(new TimeSpan(0, 0, generalSettings.Value.CacheResourceLifeTimeInSeconds));
         }
 
         /// <inheritdoc/>
         public async Task<TextResource> Get(string org, string app, string language)
         {
             ValidateArguments(org, app, language);
-            try
+            string id = GetTextId(org, app, language);
+            if (!_memoryCache.TryGetValue(id, out TextResource textResource))
             {
-                string id = GetTextId(org, app, language);
-                Uri uri = UriFactory.CreateDocumentUri(_databaseId, _collectionId, id);
-                TextResource result = await _client
-                    .ReadDocumentAsync<TextResource>(
-                        uri,
-                        new RequestOptions { PartitionKey = new PartitionKey(org) });
-                return result;
-            }
-            catch (DocumentClientException dce)
-            {
-                if (dce.StatusCode == HttpStatusCode.NotFound)
+                try
                 {
-                    return null;
-                }
+                    Uri uri = UriFactory.CreateDocumentUri(_databaseId, _collectionId, id);
+                    textResource = await _client
+                        .ReadDocumentAsync<TextResource>(
+                            uri,
+                            new RequestOptions { PartitionKey = new PartitionKey(org) });
 
-                throw;
+                    _memoryCache.Set(id, textResource, _cacheEntryOptions);
+                    return textResource;
+                }
+                catch (DocumentClientException dce)
+                {
+                    if (dce.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        return null;
+                    }
+
+                    throw;
+                }
             }
+
+            return textResource;
         }
 
         /// <inheritdoc/>

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/TextRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/TextRepository.cs
@@ -58,7 +58,7 @@ namespace Altinn.Platform.Storage.Repository
             _memoryCache = memoryCache;
             _cacheEntryOptions = new MemoryCacheEntryOptions()
                 .SetPriority(CacheItemPriority.High)
-                .SetAbsoluteExpiration(new TimeSpan(0, 0, generalSettings.Value.CacheResourceLifeTimeInSeconds));
+                .SetAbsoluteExpiration(new TimeSpan(0, 0, generalSettings.Value.TextResourceCacheLifeTimeInSeconds));
         }
 
         /// <inheritdoc/>
@@ -113,7 +113,7 @@ namespace Altinn.Platform.Storage.Repository
                 }
                 catch (Exception e)
                 {
-                    _logger.LogError($"Error occured when retriecing text resources for {org}-{app} in language {language}. Exception: {e}");
+                    _logger.LogError($"Error occured when retrieving text resources for {org}-{app} in language {language}. Exception: {e}");
                 }
             }
 

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/appsettings.json
@@ -20,7 +20,8 @@
     "OpenIdWellKnownEndpoint": "http://localhost:5040/authentication/api/v1/openid/",
     "Hostname": "at22.altinn.cloud",
     "RuntimeCookieName": "AltinnStudioRuntime",
-    "BridgeApiAuthorizationEndpoint": "http://localhost:5055/sblbridge/authorization/api/"
+    "BridgeApiAuthorizationEndpoint": "http://localhost:5055/sblbridge/authorization/api/",
+    "CacheResourceLifeTimeInSeconds":  600
   },
   "PlatformSettings": {
     "ApiAuthorizationEndpoint": "http://localhost:5050/authorization/api/v1/"

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/appsettings.json
@@ -21,7 +21,7 @@
     "Hostname": "at22.altinn.cloud",
     "RuntimeCookieName": "AltinnStudioRuntime",
     "BridgeApiAuthorizationEndpoint": "http://localhost:5055/sblbridge/authorization/api/",
-    "CacheResourceLifeTimeInSeconds":  600
+    "TextResourceCacheLifeTimeInSeconds": 3600
   },
   "PlatformSettings": {
     "ApiAuthorizationEndpoint": "http://localhost:5050/authorization/api/v1/"

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/TextRepositoryMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/TextRepositoryMock.cs
@@ -47,7 +47,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
                 string org = appId.Split("/")[0];
                 string app = appId.Split("/")[1];
 
-                TextResource resource = Get(org, app, language).Result;
+                TextResource resource = await Get(org, app, language);
                 if (resource != null)
                 {
                     result.Add(resource);

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/TextRepositoryMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/TextRepositoryMock.cs
@@ -54,7 +54,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
                 }
             }
 
-            return result;
+            return await Task.FromResult(result);
         }
 
         public Task<bool> Delete(string org, string app, string language)

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/TextRepositoryMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/TextRepositoryMock.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Net;
-using System.Reflection;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Platform.Storage.Repository;
-using Newtonsoft.Json;
+
 
 namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
 {
@@ -32,7 +30,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
             if (File.Exists(textResourcePath))
             {
                 string content = File.ReadAllText(textResourcePath);
-                TextResource textResource = (TextResource)JsonConvert.DeserializeObject(content, typeof(TextResource));
+                TextResource textResource = JsonSerializer.Deserialize<TextResource>(content, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase});
                 return Task.FromResult(textResource);
             }
 
@@ -47,7 +45,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
                 string org = appId.Split("/")[0];
                 string app = appId.Split("/")[1];
 
-                TextResource resource = await Get(org, app, language);
+                TextResource resource = Get(org, app, language).Result;
                 if (resource != null)
                 {
                     result.Add(resource);

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/TextRepositoryMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/TextRepositoryMock.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Threading.Tasks;
+using Altinn.Platform.Storage.Helpers;
+using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Platform.Storage.Repository;
+using Newtonsoft.Json;
+
+namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
+{
+    public class TextRepositoryMock : ITextRepository
+    {
+        public Task<TextResource> Create(string org, string app, TextResource textResource)
+        {
+            string language = textResource.Language;
+            ValidateArguments(org, app, language);
+            PreProcess(org, app, language, textResource);
+
+            return Task.FromResult(textResource);
+        }
+
+        public Task<TextResource> Get(string org, string app, string language)
+        {
+            ValidateArguments(org, app, language);
+
+            string id = GetTextId(org, app, language);
+            string textResourcePath = GetTextsPath(id);
+            if (File.Exists(textResourcePath))
+            {
+                string content = File.ReadAllText(textResourcePath);
+                TextResource textResource = (TextResource)JsonConvert.DeserializeObject(content, typeof(TextResource));
+                return Task.FromResult(textResource);
+            }
+
+            return Task.FromResult<TextResource>(null);
+        }
+
+        public async Task<List<TextResource>> Get(List<string> appIds, string language)
+        {
+            List<TextResource> result = new List<TextResource>();
+            foreach (string appId in appIds)
+            {
+                string org = appId.Split("/")[0];
+                string app = appId.Split("/")[1];
+
+                TextResource resource = Get(org, app, language).Result;
+                if (resource != null)
+                {
+                    result.Add(resource);
+                }
+            }
+
+            return result;
+        }
+
+        public Task<bool> Delete(string org, string app, string language)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<TextResource> Update(string org, string app, TextResource textResource)
+        {
+            throw new NotImplementedException();
+        }
+        private string GetTextId(string org, string app, string language)
+        {
+            return $"{org}-{app}-{language}";
+        }
+
+        /// <summary>
+        /// Pre processes the text resource. Creates id and adds partition key org
+        /// </summary>
+        private void PreProcess(string org, string app, string language, TextResource textResource)
+        {
+            textResource.Id = GetTextId(org, app, language);
+            textResource.Org = org;
+        }
+
+        private void ValidateArguments(string org, string app, string language)
+        {
+            if (string.IsNullOrEmpty(org))
+            {
+                throw new ArgumentException("Org can not be null or empty");
+            }
+
+            if (string.IsNullOrEmpty(app))
+            {
+                throw new ArgumentException("App can not be null or empty");
+            }
+
+            if (!LanguageHelper.IsTwoLetters(language))
+            {
+                throw new ArgumentException("Language must be a two letter ISO name");
+            }
+        }
+
+        private string GetTextsPath(string id)
+        {
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(TextRepositoryMock).Assembly.CodeBase).LocalPath);
+            return Path.Combine(unitTestFolder, @"..\..\..\data\cosmoscollections\texts\" + id + ".json");
+        }
+
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
@@ -149,6 +149,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 // Arrange
                 string instanceId = "1337/6323a337-26e7-4d40-89e8-f5bb3d80be3a";
                 string expectedTitle = "Name change";
+                string expectedSubstatusLabel = "Application approved";
 
                 HttpClient client = GetTestClient();
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(3, 1337, 3));
@@ -165,6 +166,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 Assert.Equal(expectedTitle, actual.Title);
                 Assert.True(actual.AllowDelete);
                 Assert.True(actual.AuthorizedForWrite);
+                Assert.Equal(expectedSubstatusLabel, actual.Substatus.Label);
             }
 
             /// <summary>
@@ -558,6 +560,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                         services.AddSingleton<IApplicationRepository, ApplicationRepositoryMock>();
                         services.AddSingleton<IInstanceEventRepository, InstanceEventRepositoryMock>();
                         services.AddSingleton<IInstanceRepository, InstanceRepositoryMock>();
+                        services.AddSingleton<ITextRepository, TextRepositoryMock>();
                         services.AddSingleton(sasTokenProvider.Object);
                         services.AddSingleton(keyVaultWrapper.Object);
                         services.AddSingleton(partiesWrapper.Object);

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/instances/1337/17ad1851-f6cb-4573-bfcb-a17d145307b3.json
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/instances/1337/17ad1851-f6cb-4573-bfcb-a17d145307b3.json
@@ -16,7 +16,10 @@
     "endEvent": "EndEvent_1"
   },
   "status": {
-    "archived": "2020-04-29T13:53:06.117891Z"
+    "archived": "2020-04-29T13:53:06.117891Z",
+    "substatus": {
+      "label": "substatus.declined.label"
+    }
   },
   "appOwner": {},
   "data": [

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/instances/1337/6323a337-26e7-4d40-89e8-f5bb3d80be3a.json
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/instances/1337/6323a337-26e7-4d40-89e8-f5bb3d80be3a.json
@@ -15,6 +15,10 @@
     "currentTask": { "elementId": "Task_1" }
   },
   "status": {
+    "substatus": {
+      "label": "substatus.accepted.label",
+      "description": "substatus.accepted.description"
+    }
   },
   "appOwner": {},
   "data": [

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/texts/tdd-endring-av-navn-en.json
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/texts/tdd-endring-av-navn-en.json
@@ -1,0 +1,34 @@
+{
+  "id": "tdd-endring-av-navn-en",
+  "org": "tdd",
+  "language": "en",
+  "resources": [
+    {
+      "id": "11339.InnsenderPostnummerdatadef11339.Label",
+      "value": "Post code",
+      "variables": null
+    },
+    {
+      "id": "34891.SignererTredjeReferanseAltinndatadef34891.Label",
+      "value": "Reference number Altinn",
+      "variables": null
+    },
+    {
+      "id": "ServiceName",
+      "value": "Name change",
+      "variables": null
+    },
+    {
+      "id": "substatus.accepted.description",
+      "value": "Application approved by all instances.",
+      "variables": null
+    },
+    {
+      "id": "substatus.accepted.label",
+      "value": "Application approved",
+      "variables": null
+    },
+
+    
+  ]
+}

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/texts/tdd-endring-av-navn-en.json
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/texts/tdd-endring-av-navn-en.json
@@ -27,8 +27,6 @@
       "id": "substatus.accepted.label",
       "value": "Application approved",
       "variables": null
-    },
-
-    
+    }    
   ]
 }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/texts/tdd-endring-av-navn-nb.json
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/texts/tdd-endring-av-navn-nb.json
@@ -1,0 +1,55 @@
+{
+  "id": "tdd-endring-av-navn-nb",
+  "org": "tdd",
+  "language": "nb",
+  "resources": [
+    {
+      "id": "11339.InnsenderPostnummerdatadef11339.Label",
+      "value": "Postnummer",
+      "variables": null
+    },
+    {
+      "id": "34891.SignererTredjeReferanseAltinndatadef34891.Label",
+      "value": "Referansenummer Altinn",
+      "variables": null
+    },
+    {
+      "id": "755.EnhetTelefonnummerdatadef755.Label",
+      "value": "Telefon",
+      "variables": null
+    },
+    {
+      "id": "BegrunnelseSamboer1",
+      "value": "Etternavn på samboer",
+      "variables": null
+    },
+    {
+      "id": "BegrunnelseSamboer2",
+      "value": "Fødselsnummer på samboer",
+      "variables": null
+    },
+    {
+      "id": "BegrunnelseSlektskap",
+      "value": "Forklar hvem du tar navnet fra, og hvilken side slektskapet ligger",
+      "variables": null
+    },
+    {
+      "id": "BegrunnelseSteforeldre",
+      "value": "Etternavn på ste- eller fosterforeldre du ønsker å ta navnet til",
+      "variables": null
+    },
+    {
+      "id": "ServiceName",
+      "value": "Endring av navn (RF-1453)",
+      "variables": null
+    },
+
+    {
+      "id": "substatus.declined.label",
+      "value": "Søknad avvist",
+      "variables": null
+    }
+
+    
+  ]
+}


### PR DESCRIPTION
- Extended msgboxInstance with substatus properties
- Getting all texts (title + substatus) from textrepository for messageboxinstances
- Caching in textrepository 


Impossible to test textrepository.. Could we make CosmosDBHandler a service? Maybe this should be a seperate issue ?
Could also be solved by using tests with an emulator.. 
