### PR TITLE
fixed file path that used windows specific syntax

### DIFF
--- a/src/development/LocalTest/Services/Authorization/Implementation/RolesWrapper.cs
+++ b/src/development/LocalTest/Services/Authorization/Implementation/RolesWrapper.cs
@@ -45,8 +45,15 @@ namespace Altinn.Platform.Authorization.Services.Implementation
 
         private string GetRolesPath(int userId, int resourcePartyId)
         {
-            string unitTestFolder = this._localPlatformSettings.LocalTestingStaticTestDataPath + this._localPlatformSettings.AuthorizationDataFolder + this._localPlatformSettings.RolesFolder;
-            return Path.Combine(unitTestFolder, @"User_" + userId + @"/party_" + resourcePartyId + @"/roles.json");
+            string[] pathArray = new string[] {
+                this._localPlatformSettings.LocalTestingStaticTestDataPath,
+                this._localPlatformSettings.AuthorizationDataFolder,
+                this._localPlatformSettings.RolesFolder,
+                $"User_{userId}/",
+                $"party_{resourcePartyId}/",
+                "roles.json"
+            };
+            return Path.Combine(pathArray);
         }
     }
 }

--- a/src/development/LocalTest/Services/Authorization/Implementation/RolesWrapper.cs
+++ b/src/development/LocalTest/Services/Authorization/Implementation/RolesWrapper.cs
@@ -46,7 +46,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         private string GetRolesPath(int userId, int resourcePartyId)
         {
             string unitTestFolder = this._localPlatformSettings.LocalTestingStaticTestDataPath + this._localPlatformSettings.AuthorizationDataFolder + this._localPlatformSettings.RolesFolder;
-            return Path.Combine(unitTestFolder, @"User_" + userId + @"\party_" + resourcePartyId + @"\roles.json");
+            return Path.Combine(unitTestFolder, @"User_" + userId + @"/party_" + resourcePartyId + @"/roles.json");
         }
     }
 }


### PR DESCRIPTION
#4848 
Path to roles file in LocalTest used Windows style syntax for file path (`\\user_<id>\\roles.json`), which does not work for mac/linux.