### PR TITLE
Remove check on required error message

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/logic/validation.test.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/logic/validation.test.ts
@@ -306,42 +306,13 @@ describe('>>> utils/validations.ts', () => {
   });
 
   it('+++ canFormBeSaved should validate correctly', () => {
-    const validationResult = {
-      validations: {
-        componentId_1: {
-          simpleBinding: {
-            errors: [
-              'Field is required',
-            ],
-            warnings: [],
-          },
-        },
-        componentId_2: {
-          customBinding: {
-            errors: [],
-            warnings: [],
-          },
-        },
-        componentId_3: {
-          simpleBinding: {
-            errors: [
-              'Field is required',
-            ],
-            warnings: [],
-          },
-        },
-      },
-      invalidDataTypes: false,
-    };
     const apiModeComplete = 'Complete';
     const falseResult = validation.canFormBeSaved(mockFormValidationResult, apiModeComplete);
     const falseResult2 = validation.canFormBeSaved(mockInvalidTypes);
-    const falseResult3 = validation.canFormBeSaved(validationResult, apiModeComplete);
     const trueResult2 = validation.canFormBeSaved(null);
     const trueResult3 = validation.canFormBeSaved(mockFormValidationResult);
     expect(falseResult).toBeFalsy();
     expect(falseResult2).toBeFalsy();
-    expect(falseResult3).toBeFalsy();
     expect(trueResult2).toBeTruthy();
     expect(trueResult3).toBeTruthy();
   });

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/logic/validation.test.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/logic/validation.test.ts
@@ -306,7 +306,7 @@ describe('>>> utils/validations.ts', () => {
   });
 
   it('+++ canFormBeSaved should validate correctly', () => {
-    const validValidationResult = {
+    const validationResult = {
       validations: {
         componentId_1: {
           simpleBinding: {
@@ -336,12 +336,12 @@ describe('>>> utils/validations.ts', () => {
     const apiModeComplete = 'Complete';
     const falseResult = validation.canFormBeSaved(mockFormValidationResult, apiModeComplete);
     const falseResult2 = validation.canFormBeSaved(mockInvalidTypes);
-    const trueResult = validation.canFormBeSaved(validValidationResult, apiModeComplete);
+    const falseResult3 = validation.canFormBeSaved(validationResult, apiModeComplete);
     const trueResult2 = validation.canFormBeSaved(null);
     const trueResult3 = validation.canFormBeSaved(mockFormValidationResult);
     expect(falseResult).toBeFalsy();
     expect(falseResult2).toBeFalsy();
-    expect(trueResult).toBeTruthy();
+    expect(falseResult3).toBeFalsy();
     expect(trueResult2).toBeTruthy();
     expect(trueResult3).toBeTruthy();
   });

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/validation.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/validation.ts
@@ -498,24 +498,12 @@ export function canFormBeSaved(validationResult: IValidationResult, apiMode?: st
     }
     const componentCanBeSaved = Object.keys(componentValidations).every((bindingKey: string) => {
       const componentErrors = componentValidations[bindingKey].errors;
-      if (componentErrors) {
-        return componentErrors.every((error) => (
-          validErrorMessages.indexOf(error) > -1
-        ));
-      }
-      return true;
+      return !componentErrors;
     });
     return componentCanBeSaved;
   });
   return layoutCanBeSaved;
 }
-
-/*
-* Validation messages we allow before saving the form
-*/
-const validErrorMessages: string[] = [
-  'Field is required',
-];
 
 /*
   Maps the API validation response to our redux format


### PR DESCRIPTION
#4818 
Remove useless check that allows user to submit form even though there are validation errors, as long as the error message is `Field is required`. 