### PR TITLE
bug/4916-receipt-not-showing

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "2.1.27",
+  "version": "2.1.28",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
@@ -1,15 +1,17 @@
+/* eslint-disable max-len */
 import * as React from 'react';
 import { RouteChildrenProps, withRouter } from 'react-router';
 import { useSelector } from 'react-redux';
 import { createMuiTheme } from '@material-ui/core';
 import { makeStyles } from '@material-ui/styles';
 import { AltinnReceipt, AltinnContentLoader, AltinnContentIconReceipt, AltinnButton, AltinnLoader } from 'altinn-shared/components';
-import { IInstance, IParty, IProfile } from 'altinn-shared/types';
+import { IInstance, IParty } from 'altinn-shared/types';
 import { getLanguageFromKey } from 'altinn-shared/utils/language';
 import { getCurrentTaskData, mapInstanceAttachments } from 'altinn-shared/utils';
 import { AltinnAppTheme } from 'altinn-shared/theme';
 import { IValidations } from 'src/types';
 import { getAttachmentGroupings } from 'altinn-shared/utils/attachmentsUtils';
+import { getTextResource } from 'src/utils/formComponentUtils';
 import ProcessDispatcher from '../../../shared/resources/process/processDispatcher';
 import { IAltinnWindow, IRuntimeState } from '../../../types';
 import { get } from '../../../utils/networking';
@@ -71,19 +73,15 @@ export const returnConfirmSummaryObject = (data: ISummaryData): {} => {
 const Confirm = (props: IConfirmProps) => {
   const classes = useStyles();
 
-  const [appName, setAppName] = React.useState('');
   const [attachments, setAttachments] = React.useState([]);
   const [lastChangedDateTime, setLastChangedDateTime] = React.useState('');
   const [instanceMetaObject, setInstanceMetaObject] = React.useState({});
-  const [userLanguage, setUserLanguage] = React.useState('nb');
   const [isSubmitting, setIsSubmitting] = React.useState<boolean>(false);
-
   const applicationMetadata: IApplicationMetadata = useSelector((state: IRuntimeState) => state.applicationMetadata.applicationMetadata);
   const instance: IInstance = useSelector((state: IRuntimeState) => state.instanceData.instance);
   const language: any = useSelector((state: IRuntimeState) => state.language.language);
   const parties: IParty[] = useSelector((state: IRuntimeState) => state.party.parties);
   const validations: IValidations = useSelector((state: IRuntimeState) => state.formValidations.validations);
-  const profile: IProfile = useSelector((state: IRuntimeState) => state.profile.profile);
 
   const routeParams: any = props.match.params;
 
@@ -95,7 +93,6 @@ const Confirm = (props: IConfirmProps) => {
     !attachments ||
     !instanceMetaObject ||
     !lastChangedDateTime ||
-    !appName ||
     !instance ||
     !lastChangedDateTime ||
     !parties
@@ -105,12 +102,6 @@ const Confirm = (props: IConfirmProps) => {
     OrgsActions.fetchOrgs();
     InstanceDataActions.getInstanceData(routeParams.partyId, routeParams.instanceGuid);
   }, []);
-
-  React.useEffect(() => {
-    if (profile && profile.profileSettingPreference) {
-      setUserLanguage(profile.profileSettingPreference.language);
-    }
-  }, [profile]);
 
   React.useEffect(() => {
     if (instance && instance.org && parties && applicationMetadata) {
@@ -125,12 +116,6 @@ const Confirm = (props: IConfirmProps) => {
       setInstanceMetaObject(obj);
     }
   }, [parties, instance, lastChangedDateTime, applicationMetadata]);
-
-  React.useEffect(() => {
-    if (applicationMetadata && applicationMetadata.title) {
-      setAppName(applicationMetadata.title[userLanguage]);
-    }
-  }, [applicationMetadata, userLanguage]);
 
   React.useEffect(() => {
     if (instance && instance.data && applicationMetadata) {
@@ -174,7 +159,7 @@ const Confirm = (props: IConfirmProps) => {
       <>
         <AltinnReceipt
           attachmentGroupings={getAttachmentGroupings(attachments, applicationMetadata, textResources)}
-          body={getTextFromAppOrDefault('confirm.body', textResources, language, [appName])}
+          body={getTextFromAppOrDefault('confirm.body', textResources, language, [getTextResource('ServiceName', textResources)])}
           collapsibleTitle={getTextFromAppOrDefault('confirm.attachments', textResources, language, null, true)}
           hideCollapsibleCount={true}
           instanceMetaDataObject={instanceMetaObject}

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/receipt/containers/receiptContainer.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/receipt/containers/receiptContainer.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import moment from 'moment';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { RouteChildrenProps, withRouter } from 'react-router';
-import { AltinnContentIconReceipt, AltinnContentLoader, AltinnReceipt as ReceiptComponent} from 'altinn-shared/components';
+import { AltinnContentIconReceipt, AltinnContentLoader, AltinnReceipt as ReceiptComponent } from 'altinn-shared/components';
 import { IInstance, IParty, ITextResource, IProfile } from 'altinn-shared/types';
 import { getCurrentTaskData,
   mapInstanceAttachments,

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/receipt/containers/receiptContainer.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/receipt/containers/receiptContainer.tsx
@@ -9,7 +9,8 @@ import { IInstance, IParty, ITextResource, IProfile } from 'altinn-shared/types'
 import { getCurrentTaskData,
   mapInstanceAttachments,
   getLanguageFromKey,
-  returnUrlToMessagebox } from 'altinn-shared/utils';
+  returnUrlToMessagebox,
+  getTextResourceByKey } from 'altinn-shared/utils';
 import { getAttachmentGroupings } from 'altinn-shared/utils/attachmentsUtils';
 import InstanceDataActions from '../../../shared/resources/instanceData/instanceDataActions';
 import OrgsActions from '../../../shared/resources/orgs/orgsActions';
@@ -52,7 +53,6 @@ export const returnInstanceMetaDataObject = (
 };
 
 const ReceiptContainer = (props: IReceiptContainerProps) => {
-  const [appName, setAppName] = React.useState('');
   const [attachments, setAttachments] = useState([]);
   const [lastChangedDateTime, setLastChangedDateTime] = useState('');
   const [instanceMetaObject, setInstanceMetaObject] = useState({});
@@ -73,7 +73,6 @@ const ReceiptContainer = (props: IReceiptContainerProps) => {
     !attachments ||
     !instanceMetaObject ||
     !lastChangedDateTime ||
-    !appName ||
     !allOrgs ||
     !instance ||
     !lastChangedDateTime ||
@@ -111,12 +110,6 @@ const ReceiptContainer = (props: IReceiptContainerProps) => {
   }, [allOrgs, parties, instance, lastChangedDateTime]);
 
   React.useEffect(() => {
-    if (applicationMetadata && applicationMetadata.title) {
-      setAppName(applicationMetadata.title[userLanguage]);
-    }
-  }, [applicationMetadata, userLanguage]);
-
-  React.useEffect(() => {
     if (instance && instance.data && applicationMetadata) {
       const defaultElement = getCurrentTaskData(applicationMetadata, instance);
 
@@ -145,7 +138,7 @@ const ReceiptContainer = (props: IReceiptContainerProps) => {
           instanceMetaDataObject={instanceMetaObject}
           subtitle={getLanguageFromKey('receipt.subtitle', language)}
           subtitleurl={returnUrlToMessagebox(origin)}
-          title={`${appName} ${getLanguageFromKey('receipt.title_part_is_submitted', language)}`}
+          title={`${getTextResourceByKey('ServiceName', textResources)} ${getLanguageFromKey('receipt.title_part_is_submitted', language)}`}
           titleSubmitted={getLanguageFromKey('receipt.title_submitted', language)}
         />
       }

--- a/src/Altinn.Apps/AppFrontend/react/receipt/src/features/receipt/containers/Receipt.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/receipt/src/features/receipt/containers/Receipt.tsx
@@ -104,7 +104,7 @@ function Receipt(props: WithStyles<typeof styles>) {
   };
 
   const getTitle = (): string => {
-    const applicationTitle = application ? application.title.nb : '';
+    const applicationTitle = getTextResourceByKey('ServiceName', textResources);
     return `${applicationTitle} ${getLanguageFromKey('receipt_platform.is_sent', language)}`;
   };
 


### PR DESCRIPTION
#4916 

Fixed bug where receipt and confirm would get stuck loading if the app title for the users language was not defined in the app-metdata. Now fetches the app name from app text resources.