### PR TITLE
Feature/4500 metrics for cosmos

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Configuration/AzureCosmosSettings.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Configuration/AzureCosmosSettings.cs
@@ -24,5 +24,10 @@ namespace Altinn.Platform.Storage.Configuration
         /// name of the collection in the given database
         /// </summary>
         public string Collection { get; set; }
+
+        /// <summary>
+        /// boolean to indicate if query metrics should be collected.
+        /// </summary>
+        public bool CollectMetrics { get; set; }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
@@ -31,6 +31,7 @@ namespace Altinn.Platform.Storage.Repository
         private readonly IDataRepository _dataRepository;
 
         private readonly DocumentClient _client;
+        private readonly AzureCosmosSettings _settings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstanceRepository"/> class
@@ -45,6 +46,8 @@ namespace Altinn.Platform.Storage.Repository
         {
             _logger = logger;
             _dataRepository = dataRepository;
+
+            _settings = cosmosSettings.Value;
 
             CosmosDatabaseHandler database = new CosmosDatabaseHandler(cosmosSettings.Value);
 
@@ -128,7 +131,7 @@ namespace Altinn.Platform.Storage.Repository
                 }
 
                 try
-                {                    
+                {
                     IDocumentQuery<Instance> documentQuery = queryBuilder.AsDocumentQuery();
 
                     FeedResponse<Instance> feedResponse = await documentQuery.ExecuteNextAsync<Instance>();
@@ -467,6 +470,11 @@ namespace Altinn.Platform.Storage.Repository
                 PartitionKey = new PartitionKey(instanceOwnerPartyIdString)
             };
 
+            if (_settings.CollectMetrics)
+            {
+                feedOptions.PopulateQueryMetrics = true;
+            }
+
             IQueryable<Instance> filter;
 
             if (instanceState.Equals("active"))
@@ -502,6 +510,11 @@ namespace Altinn.Platform.Storage.Repository
             IDocumentQuery<Instance> query = filter.AsDocumentQuery();
 
             FeedResponse<Instance> feedResponse = await query.ExecuteNextAsync<Instance>();
+
+            if (_settings.CollectMetrics)
+            {
+                _logger.LogError($"{JsonConvert.SerializeObject(feedResponse.QueryMetrics)}");
+            }
 
             instances = feedResponse.ToList();
 

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
@@ -513,7 +513,7 @@ namespace Altinn.Platform.Storage.Repository
 
             if (_settings.CollectMetrics)
             {
-                _logger.LogError($"{JsonConvert.SerializeObject(feedResponse.QueryMetrics)}");
+                _logger.LogError($"Metrics retrieving {instanceState} instances for {instanceOwnerPartyId}: {JsonConvert.SerializeObject(feedResponse.QueryMetrics)}");
             }
 
             instances = feedResponse.ToList();

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/appsettings.json
@@ -2,7 +2,8 @@
   "AzureCosmosSettings": {
     "EndpointUri": "https://localhost:8081",
     "PrimaryKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
-    "Database": "Storage"
+    "Database": "Storage",
+    "CollectMetrics": false
   },
   "AllowedHosts": "*",
   "AzureStorageConfiguration": {


### PR DESCRIPTION
#4500

Example output from the query metrics. Would this help us narrow down what is slowing the process down? 

{"PKId([\"50002120\"])":{
"TotalTime":"00:00:00.0034900",
"RetrievedDocumentCount":36,
"RetrievedDocumentSize":48312,
"OutputDocumentCount":8,
"QueryPreparationTimes":{"CompileTime":"00:00:00.0002400",
"LogicalPlanBuildTime":"00:00:00.0000900",
"PhysicalPlanBuildTime":"00:00:00.0002000",
"QueryOptimizationTime":"00:00:00.0000300"},
"QueryEngineTimes":{"IndexLookupTime":"00:00:00.0020500",
"DocumentLoadTime":"00:00:00.0003900",
"WriteOutputTime":"00:00:00.0000300",
"RuntimeExecutionTimes":{"SystemFunctionExecutionTime":"00:00:00",
"UserDefinedFunctionExecutionTime":"00:00:00",
"TotalTime":"00:00:00.0001600"}​},
"Retries":0,
"ClientSideMetrics":{"Retries":0,
"RequestCharge":4.65,
"FetchExecutionRanges":[{"PartitionId":"PKId([\"50002120\"])",
"ActivityId":"43ee5b29-28fe-46b1-9bea-dd0c64781537",
"StartTime":"2020-10-07T09:32:32.38797Z",
"EndTime":"2020-10-07T09:32:32.397875Z",
"NumberOfDocuments":8,
"RetryCount":0}],
"PartitionSchedulingTimeSpans":[{"Item1":"PKId([\"50002120\"])",
"Item2":{"NumPreemptions":0,
"TurnaroundTime":"00:00:00.0202997",
"ResponseTime":"00:00:00.0202996",
"RunTime":"00:00:00",
"WaitTime":"00:00:00.0202998"}​}]},
"IndexHitRatio":0.19444444444444445}​}