### PR TITLE
added data properties to the cloud event

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Models/CloudEvent.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Models/CloudEvent.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Net.Mime;
 using System.Text.Json.Serialization;
 
 namespace Altinn.App.PlatformServices.Models
 {
     /// <summary>
-    /// Represents an event. Based on CloudEvent: https://github.com/cloudevents/spec/blob/v1.0/spec.md.
+    /// Represents a cloud event. Based on CloudEvent: https://github.com/cloudevents/spec/blob/v1.0/spec.md.
     /// </summary>
     public class CloudEvent
     {
@@ -37,7 +38,7 @@ namespace Altinn.App.PlatformServices.Models
         /// </summary>
         [JsonPropertyName("subject")]
         public string Subject { get; set; }
-    
+
         /// <summary>
         /// Gets or sets the time of the event.
         /// </summary>
@@ -49,5 +50,26 @@ namespace Altinn.App.PlatformServices.Models
         /// </summary>
         [JsonPropertyName("alternativesubject")]
         public string AlternativeSubject { get; set; }
+
+         /// <summary>
+        /// Gets or sets the cloudEvent data content. The event payload.
+        /// The payload depends on the type and the dataschema.
+        /// </summary>
+        [JsonPropertyName("data")]
+        public object Data { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cloudEvent dataschema attribute.
+        /// A link to the schema that the data attribute adheres to.
+        /// </summary>
+        [JsonPropertyName("dataschema")]
+        public Uri DataSchema { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cloudEvent datacontenttype attribute.
+        /// Content type of the data attribute value.
+        /// </summary>
+        [JsonPropertyName("contenttype")]
+        public ContentType DataContentType { get; set; }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Events/Events/Controllers/EventsController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Events/Events/Controllers/EventsController.cs
@@ -41,7 +41,7 @@ namespace Altinn.Platform.Events.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<string>> Post([FromBody] CloudEvent cloudEvent)
         {
-            if (string.IsNullOrEmpty(cloudEvent.Source.OriginalString) || string.IsNullOrEmpty(cloudEvent.Specversion) ||
+            if (string.IsNullOrEmpty(cloudEvent.Source.OriginalString) || string.IsNullOrEmpty(cloudEvent.SpecVersion) ||
             string.IsNullOrEmpty(cloudEvent.Type) || string.IsNullOrEmpty(cloudEvent.Subject))
             {
                 return BadRequest("Missing parameter values: source, subject, type, id or time cannot be null");

--- a/src/Altinn.Platform/Altinn.Platform.Events/Events/Models/CloudEvent.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Events/Events/Models/CloudEvent.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Net.Mime;
 using Newtonsoft.Json;
 
 namespace Altinn.Platform.Events.Models
 {
     /// <summary>
-    /// Class describing a CloudEvent
+    /// Represents a cloud event. Based on CloudEvent: https://github.com/cloudevents/spec/blob/v1.0/spec.md.
     /// </summary>
     [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public class CloudEvent
@@ -38,7 +39,7 @@ namespace Altinn.Platform.Events.Models
         /// </summary>
         [JsonProperty(PropertyName = "subject")]
         public string Subject { get; set; }
-    
+
         /// <summary>
         /// Gets or sets the Time of the event
         /// </summary>
@@ -49,6 +50,27 @@ namespace Altinn.Platform.Events.Models
         /// Gets or sets the alternativesubject of the event
         /// </summary>
         [JsonProperty(PropertyName = "alternativesubject")]
-        public string Alternativesubject { get; set; }
+        public string AlternativeSubject { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cloudEvent data content. The event payload.
+        /// The payload depends on the type and the dataschema.
+        /// </summary>
+        [JsonProperty(PropertyName = "data")]
+        public object Data { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cloudEvent dataschema attribute.
+        /// A link to the schema that the data attribute adheres to.
+        /// </summary>
+        [JsonProperty(PropertyName = "dataschema")]
+        public Uri DataSchema { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cloudEvent datacontenttype attribute.
+        /// Content type of the data attribute value.
+        /// </summary>
+        [JsonProperty(PropertyName = "contenttype")]
+        public ContentType DataContentType { get; set; }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Events/Events/Models/CloudEvent.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Events/Events/Models/CloudEvent.cs
@@ -1,76 +1,75 @@
 using System;
 using System.Net.Mime;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Altinn.Platform.Events.Models
 {
     /// <summary>
     /// Represents a cloud event. Based on CloudEvent: https://github.com/cloudevents/spec/blob/v1.0/spec.md.
     /// </summary>
-    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public class CloudEvent
     {
         /// <summary>
-        /// Gets or sets the Id of the event
+        /// Gets or sets the id of the event.
         /// </summary>
-        [JsonProperty(PropertyName = "id")]
+        [JsonPropertyName("id")]
         public string Id { get; set; }
 
         /// <summary>
-        /// Gets or sets the Source of the event
+        /// Gets or sets the source of the event.
         /// </summary>
-        [JsonProperty(PropertyName = "source")]
+        [JsonPropertyName("source")]
         public Uri Source { get; set; }
 
         /// <summary>
-        /// Gets or sets the Specversion of the event
+        /// Gets or sets the specification version of the event.
         /// </summary>
-        [JsonProperty(PropertyName = "specversion")]
-        public string Specversion { get; set; }
+        [JsonPropertyName("specversion")]
+        public string SpecVersion { get; set; }
 
         /// <summary>
-        /// Gets or sets the Type of the event
+        /// Gets or sets the type of the event.
         /// </summary>
-        [JsonProperty(PropertyName = "type")]
+        [JsonPropertyName("type")]
         public string Type { get; set; }
 
         /// <summary>
-        /// Gets or sets the Subject of the event
+        /// Gets or sets the subject of the event.
         /// </summary>
-        [JsonProperty(PropertyName = "subject")]
+        [JsonPropertyName("subject")]
         public string Subject { get; set; }
 
         /// <summary>
-        /// Gets or sets the Time of the event
+        /// Gets or sets the time of the event.
         /// </summary>
-        [JsonProperty(PropertyName = "time")]
-        public DateTime? Time { get; set; }
+        [JsonPropertyName("time")]
+        public DateTime Time { get; set; }
 
         /// <summary>
-        /// Gets or sets the alternativesubject of the event
+        /// Gets or sets the alternative subject of the event.
         /// </summary>
-        [JsonProperty(PropertyName = "alternativesubject")]
+        [JsonPropertyName("alternativesubject")]
         public string AlternativeSubject { get; set; }
 
         /// <summary>
         /// Gets or sets the cloudEvent data content. The event payload.
         /// The payload depends on the type and the dataschema.
         /// </summary>
-        [JsonProperty(PropertyName = "data")]
+        [JsonPropertyName("data")]
         public object Data { get; set; }
 
         /// <summary>
         /// Gets or sets the cloudEvent dataschema attribute.
         /// A link to the schema that the data attribute adheres to.
         /// </summary>
-        [JsonProperty(PropertyName = "dataschema")]
+        [JsonPropertyName("dataschema")]
         public Uri DataSchema { get; set; }
 
         /// <summary>
         /// Gets or sets the cloudEvent datacontenttype attribute.
         /// Content type of the data attribute value.
         /// </summary>
-        [JsonProperty(PropertyName = "contenttype")]
+        [JsonPropertyName("contenttype")]
         public ContentType DataContentType { get; set; }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Events/Tests/Altinn.Platform.Events.Tests.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Events/Tests/Altinn.Platform.Events.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <Content Include="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>

--- a/src/Altinn.Platform/Altinn.Platform.Events/Tests/TestingControllers/EventsControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Events/Tests/TestingControllers/EventsControllerTests.cs
@@ -141,7 +141,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             {
                 CloudEvent cloudEvent = new CloudEvent();
                 cloudEvent.Id = Guid.NewGuid().ToString();
-                cloudEvent.Specversion = "1.0";
+                cloudEvent.SpecVersion = "1.0";
                 cloudEvent.Type = "instance.created";
                 cloudEvent.Source = new Uri("http://www.brreg.no/brg/something/232243423");
                 cloudEvent.Time = DateTime.Now;


### PR DESCRIPTION
#4550

Added the missing data fields. 
As we won't be using them ourselves in our standard app events, I don't see the need to extend the existng tests for EventAppSI. 