### PR TITLE
Adding logic to support certificate rollover

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Configuration/GeneralSettings.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Configuration/GeneralSettings.cs
@@ -160,5 +160,16 @@ namespace Altinn.Platform.Authentication.Configuration
         /// Gets or sets the URL of the Altinn Open ID Connect well-known configuration endpoint.
         /// </summary>
         public string OpenIdWellKnownEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of hours to wait before a new certificate is being used to
+        /// sign new JSON Web tokens.
+        /// </summary>
+        /// <remarks>
+        /// The logic use the NotBefore property of a certificate. This means that uploading a
+        /// certificate that has been valid for a few days might cause it to be used immediately.
+        /// Take care not to upload "old" certificates.
+        /// </remarks>
+        public int JwtSigningCertificateRolloverDelayHours { get; set; }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/appsettings.json
@@ -14,7 +14,8 @@
     "MaskinportenWellKnownConfigEndpoint": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server",
     "IdPortenWellKnownConfigEndpoint": "https://oidc-ver2.difi.no/idporten-oidc-provider/.well-known/openid-configuration",
     "OpenIdWellKnownEndpoint": "http://localhost:5040/authentication/api/v1/openid",
-    "OrganisationRepositoryLocation": "https://altinncdn.no/orgs/altinn-orgs.json"
+    "OrganisationRepositoryLocation": "https://altinncdn.no/orgs/altinn-orgs.json",
+    "JwtSigningCertificateRolloverDelayHours": 48 
   },
   "CertificateSettings": {
     "CertificateName": "JWTCertificate",


### PR DESCRIPTION
Updated Platform Authentication to support certificate rollover by adding logic to download multiple versions of a certificate.

The logic will present public keys for all versions of a certificate in the OpenId Connect document "right away". The logic performing signing of new JSON Web Token will wait to use the latest until the "NotBefore" date has passed with at least 48 hours, but this is configurable.

One issue with this change is that if we upload a certificate with a NotBefore date already passed by 48 hours it will be used right away.

Related to #3374 

