### PR TITLE
feature/4497-cleanup-formlayout-designer

### DIFF
--- a/src/studio/src/designer/frontend/ux-editor/components/index.ts
+++ b/src/studio/src/designer/frontend/ux-editor/components/index.ts
@@ -4,7 +4,6 @@ export interface IComponentIcon {
 
 export interface IComponent {
   name: string;
-  Type: ComponentTypes;
   customProperties?: any;
   Icon: string;
 }
@@ -12,20 +11,19 @@ export interface IComponent {
 // The order here should be the same as
 // the exported 'components' list (drag and drop)
 export enum ComponentTypes {
-  Header,
-  Paragraph,
-  Input,
-  Datepicker,
-  DropDown,
-  CheckBox,
-  RadioButton,
-  TextArea,
-  FileUpload,
-  Button,
-  Container,
-  AddressComponent,
-  Group,
-  NavigationButtons,
+  Header = 'Header',
+  Paragraph = 'Paragraph',
+  Input = 'Input',
+  Datepicker = 'Datepicker',
+  Dropdown = 'Dropdown',
+  Checkboxes = 'Checkboxes',
+  RadioButtons = 'RadioButtons',
+  TextArea = 'TextArea',
+  FileUpload = 'FileUpload',
+  Button = 'Button',
+  AddressComponent = 'AddressComponent',
+  Group = 'Group',
+  NavigationButtons = 'NavigationButtons'
 }
 
 export const componentIcons: IComponentIcon = {
@@ -46,21 +44,18 @@ export const componentIcons: IComponentIcon = {
 
 export const textComponents: IComponent[] = [
   {
-    name: 'Header',
-    Type: ComponentTypes.Header,
+    name: ComponentTypes.Header,
     Icon: componentIcons.Header,
   },
   {
-    name: 'Paragraph',
-    Type: ComponentTypes.Paragraph,
+    name: ComponentTypes.Paragraph,
     Icon: componentIcons.Paragraph,
   },
 ];
 
 export const schemaComponents: IComponent[] = [
   {
-    name: 'Input',
-    Type: ComponentTypes.Input,
+    name: ComponentTypes.Input,
     customProperties: {
       required: true,
       readOnly: false,
@@ -68,8 +63,7 @@ export const schemaComponents: IComponent[] = [
     Icon: componentIcons.Input,
   },
   {
-    name: 'TextArea',
-    Type: ComponentTypes.TextArea,
+    name: ComponentTypes.TextArea,
     customProperties: {
       required: true,
       readOnly: false,
@@ -77,8 +71,7 @@ export const schemaComponents: IComponent[] = [
     Icon: componentIcons.TextArea,
   },
   {
-    name: 'Checkboxes',
-    Type: ComponentTypes.CheckBox,
+    name: ComponentTypes.Checkboxes,
     Icon: componentIcons.Checkboxes,
     customProperties: {
       options: [],
@@ -86,8 +79,7 @@ export const schemaComponents: IComponent[] = [
     },
   },
   {
-    name: 'RadioButtons',
-    Type: ComponentTypes.RadioButton,
+    name: ComponentTypes.RadioButtons,
     Icon: componentIcons.RadioButtons,
     customProperties: {
       options: [],
@@ -95,13 +87,11 @@ export const schemaComponents: IComponent[] = [
     },
   },
   {
-    name: 'Dropdown',
-    Type: ComponentTypes.DropDown,
+    name: ComponentTypes.Dropdown,
     Icon: componentIcons.Dropdown,
   },
   {
-    name: 'FileUpload',
-    Type: ComponentTypes.FileUpload,
+    name: ComponentTypes.FileUpload,
     Icon: componentIcons.FileUpload,
     customProperties: {
       maxFileSizeInMB: 25,
@@ -112,8 +102,7 @@ export const schemaComponents: IComponent[] = [
     },
   },
   {
-    name: 'Datepicker',
-    Type: ComponentTypes.Datepicker,
+    name: ComponentTypes.Datepicker,
     customProperties: {
       readOnly: false,
       minDate: '1900-01-01T12:00:00.000Z',
@@ -122,20 +111,14 @@ export const schemaComponents: IComponent[] = [
     Icon: componentIcons.Datepicker,
   },
   {
-    name: 'Button',
-    Type: ComponentTypes.Button,
+    name: ComponentTypes.Button,
     Icon: componentIcons.Button,
-    customProperties: {
-      textResourceId: 'Standard.Button.Button',
-      customType: 'Standard',
-    },
   },
 ];
 
 export const advancedComponents: IComponent[] = [
   {
-    name: 'AddressComponent',
-    Type: ComponentTypes.AddressComponent,
+    name: ComponentTypes.AddressComponent,
     Icon: componentIcons.AddressComponent,
     customProperties: {
       simplified: true,
@@ -143,8 +126,7 @@ export const advancedComponents: IComponent[] = [
     },
   },
   {
-    name: 'Group',
-    Type: ComponentTypes.Group,
+    name: ComponentTypes.Group,
     Icon: componentIcons.Group,
     customProperties: {
       maxCount: 0,

--- a/src/studio/src/designer/frontend/ux-editor/components/toolbar/ToolbarItemComponent.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/components/toolbar/ToolbarItemComponent.tsx
@@ -2,13 +2,12 @@ import { createStyles, ListItem, ListItemIcon, ListItemText, Paper, withStyles }
 import classNames from 'classnames';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { ComponentTypes } from '..';
 // eslint-disable-next-line import/no-cycle
 import { getComponentTitleByComponentType } from '../../utils/language';
 
 export interface IToolbarItemProvidedProps {
   classes: any;
-  componentType: ComponentTypes;
+  componentType: string;
   onClick: any;
   thirdPartyLabel?: string;
   icon: string;

--- a/src/studio/src/designer/frontend/ux-editor/containers/EditContainer.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/EditContainer.tsx
@@ -394,7 +394,7 @@ export class Edit extends React.Component<IEditContainerProps, IEditContainerSta
                           getTextResource(this.state.component.textResourceBindings.title,
                             this.props.textResources), 80,
                         )
-                        : getComponentTitleByComponentType(this.state.component.componentType, this.props.language)}
+                        : getComponentTitleByComponentType(this.state.component.type, this.props.language)}
                     </div>
                   }
                 </ListItem>

--- a/src/studio/src/designer/frontend/ux-editor/containers/Toolbar.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/Toolbar.tsx
@@ -16,8 +16,6 @@ import { ToolbarItem } from './ToolbarItem';
 
 import '../styles/toolBar.css';
 
-const THIRD_PARTY_COMPONENT: string = 'ThirdParty';
-
 export interface IToolbarElement {
   label: string;
   icon?: string;
@@ -115,38 +113,6 @@ class ToolbarClass extends React.Component<IToolbarProps, IToolbarState> {
           this.updateActiveListOrder();
         },
     } as IToolbarElement;
-  }
-
-  public getThirdPartyComponents = (): IToolbarElement[] => {
-    const { thirdPartyComponents } = this.props;
-    if (!thirdPartyComponents) {
-      return [];
-    }
-    const thirdPartyComponentArray: IToolbarElement[] = [];
-    for (const packageName in thirdPartyComponents) {
-      if (thirdPartyComponents.hasOwnProperty(packageName)) {
-        for (const componentName in thirdPartyComponents[packageName]) {
-          if (thirdPartyComponents[packageName].hasOwnProperty(componentName)) {
-            thirdPartyComponentArray.push({
-              label: `${packageName} - ${componentName}`,
-              componentType: null,
-              actionMethod: (containerId: string, position: number) => FormDesignerActionDispatchers.addFormComponent({
-                type: THIRD_PARTY_COMPONENT,
-                itemType: LayoutItemType.Component,
-                textResourceBindings: {
-                  title: `${packageName} - ${componentName}`,
-                },
-                dataModelBindings: {},
-                ...JSON.parse(JSON.stringify({})),
-              },
-              position,
-              containerId),
-            });
-          }
-        }
-      }
-    }
-    return thirdPartyComponentArray;
   }
 
   public handleSaveChange = (callbackComponent: FormComponentType): void => {

--- a/src/studio/src/designer/frontend/ux-editor/containers/Toolbar.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/Toolbar.tsx
@@ -21,7 +21,7 @@ const THIRD_PARTY_COMPONENT: string = 'ThirdParty';
 export interface IToolbarElement {
   label: string;
   icon?: string;
-  componentType: ComponentTypes;
+  type: string;
   actionMethod: (containerId: string, index: number) => void;
 }
 
@@ -77,7 +77,7 @@ class ToolbarClass extends React.Component<IToolbarProps, IToolbarState> {
       selectedComp: {},
       selectedCompId: '',
       componentInformationPanelOpen: false,
-      componentSelectedForInformationPanel: -1,
+      componentSelectedForInformationPanel: null,
       anchorElement: null,
       componentListOpen: true,
       componentListCloseAnimationDone: false,
@@ -94,19 +94,18 @@ class ToolbarClass extends React.Component<IToolbarProps, IToolbarState> {
   public mapComponentToToolbarElement = (c: IComponent): IToolbarElement => {
     const customProperties = c.customProperties ? c.customProperties : {};
     return {
-      componentType: c.Type,
       label: c.name,
       icon: c.Icon,
-      actionMethod: (c.Type === ComponentTypes.Group) ? this.addContainerToLayout :
+      type: c.name,
+      actionMethod: (c.name === ComponentTypes.Group) ? this.addContainerToLayout :
         (containerId: string, position: number) => {
           FormDesignerActionDispatchers.addFormComponent({
             type: c.name,
-            componentType: c.Type,
             itemType: LayoutItemType.Component,
             textResourceBindings: {
               title: c.name === 'Button' ?
                 getLanguageFromKey('ux_editor.modal_properties_button_type_submit', this.props.language)
-                : getComponentTitleByComponentType(c.Type, this.props.language),
+                : getComponentTitleByComponentType(c.name, this.props.language),
             },
             dataModelBindings: {},
             ...JSON.parse(JSON.stringify(customProperties)),
@@ -188,7 +187,7 @@ class ToolbarClass extends React.Component<IToolbarProps, IToolbarState> {
   public handleComponentInformationClose = () => {
     this.setState({
       componentInformationPanelOpen: false,
-      componentSelectedForInformationPanel: -1,
+      componentSelectedForInformationPanel: null,
       anchorElement: null,
     });
   }
@@ -291,27 +290,16 @@ class ToolbarClass extends React.Component<IToolbarProps, IToolbarState> {
             >
               {this.components.map((component: IToolbarElement) => (
                 <ToolbarItem
-                  text={getComponentTitleByComponentType(component.componentType, this.props.language)
+                  text={getComponentTitleByComponentType(component.type, this.props.language)
                     || component.label}
                   icon={component.icon}
-                  componentType={component.componentType}
+                  componentType={component.type}
                   onDropAction={component.actionMethod}
                   onClick={this.handleComponentInformationOpen}
-                  key={component.componentType}
+                  key={component.type}
                 />
               ))
               }
-
-              {this.getThirdPartyComponents().map((component: IToolbarElement) => (
-                <ToolbarItem
-                  text={component.label}
-                  icon={component.icon}
-                  componentType={component.componentType}
-                  onDropAction={component.actionMethod}
-                  onClick={this.handleComponentInformationOpen}
-                  key={`${component.componentType}-${component.label}`}
-                />
-              ))}
               {/*
 
               Commented out since we're disabling containers until design is done.
@@ -346,13 +334,13 @@ class ToolbarClass extends React.Component<IToolbarProps, IToolbarState> {
             >
               {this.textComponents.map((component: IToolbarElement) => (
                 <ToolbarItem
-                  text={getComponentTitleByComponentType(component.componentType, this.props.language)
+                  text={getComponentTitleByComponentType(component.type, this.props.language)
                     || component.label}
                   icon={component.icon}
-                  componentType={component.componentType}
+                  componentType={component.type}
                   onClick={this.handleComponentInformationOpen}
                   onDropAction={component.actionMethod}
-                  key={component.componentType}
+                  key={component.type}
                 />
               ))}
             </List>
@@ -378,13 +366,13 @@ class ToolbarClass extends React.Component<IToolbarProps, IToolbarState> {
             >
               {this.advancedComponents.map((component: IToolbarElement) => (
                 <ToolbarItem
-                  text={getComponentTitleByComponentType(component.componentType, this.props.language)
+                  text={getComponentTitleByComponentType(component.type, this.props.language)
                     || component.label}
                   icon={component.icon}
-                  componentType={component.componentType}
+                  componentType={component.type}
                   onClick={this.handleComponentInformationOpen}
                   onDropAction={component.actionMethod}
-                  key={component.componentType}
+                  key={component.type}
                 />
               ))}
             </List>

--- a/src/studio/src/designer/frontend/ux-editor/containers/ToolbarItem.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/ToolbarItem.tsx
@@ -3,7 +3,6 @@ import {
   DragSourceMonitor,
   DragSourceSpec,
 } from 'react-dnd';
-import { ComponentTypes } from '../components';
 import { ToolbarItemComponent } from '../components/toolbar/ToolbarItemComponent';
 import createDraggable, {
   IDraggableProps,
@@ -14,7 +13,7 @@ interface IToolbarItemProps {
   onDropAction: (...args: any) => void;
   notDraggable?: boolean;
   onClick: (...args: any) => void;
-  componentType: ComponentTypes;
+  componentType: string;
   icon: string;
 }
 

--- a/src/studio/src/designer/frontend/ux-editor/test/__tests__/containers/EditContainer.test.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/test/__tests__/containers/EditContainer.test.tsx
@@ -56,7 +56,6 @@ describe('>>> containers/EditContainer', () => {
               components: {
                 '4a66b4ea-13f1-4187-864a-fd4bb6e8cf88': {
                   id: '4a66b4ea-13f1-4187-864a-fd4bb6e8cf88',
-                  componentType: 2,
                   dataModelBindings: {},
                   readOnly: false,
                   required: false,
@@ -85,7 +84,6 @@ describe('>>> containers/EditContainer', () => {
     mockId = '4a66b4ea-13f1-4187-864a-fd4bb6e8cf88';
     mockComponent = {
       id: '4a66b4ea-13f1-4187-864a-fd4bb6e8cf88',
-      componentType: 2,
       dataModelBindings: {},
       readOnly: false,
       required: false,
@@ -170,7 +168,6 @@ describe('>>> containers/EditContainer', () => {
     /* Click on checkBtn */
     instance.setState({component: {
       id: '4a66b4ea-13f1-4187-864a-fd4bb6e8cf88',
-      componentType: 2,
       dataModelBindings: {},
       readOnly: false,
       required: true,
@@ -207,7 +204,6 @@ describe('>>> containers/EditContainer', () => {
       isEditMode: true,
       component: {
         id: '4a66b4ea-13f1-4187-864a-fd4bb6e8cf88',
-        componentType: 2,
         dataModelBindings: {
           simpleBinding: 'skattyterinforgrp5801.infogrp5802.oppgavegiverNavnPreutfyltdatadef25795.value',
         },

--- a/src/studio/src/designer/frontend/ux-editor/types/global.ts
+++ b/src/studio/src/designer/frontend/ux-editor/types/global.ts
@@ -59,7 +59,6 @@ declare global {
 
   export interface ICreateFormComponent {
     component?: string;
-    componentType: ComponentTypes;
     itemType?: string;
     type?: string;
     name?: string;

--- a/src/studio/src/designer/frontend/ux-editor/utils/language.ts
+++ b/src/studio/src/designer/frontend/ux-editor/utils/language.ts
@@ -1,18 +1,19 @@
+/* eslint-disable import/no-cycle */
 import { ComponentTypes } from '../components';
 import { CollapsableMenus } from '../containers/Toolbar';
 
-export function getComponentHelperTextByComponentType(componentType: ComponentTypes, language: any): string {
-  switch (componentType) {
+export function getComponentHelperTextByComponentType(type: string, language: any): string {
+  switch (type) {
     case ComponentTypes.Header: {
       return language.ux_editor.helper_text_for_header;
     }
     case ComponentTypes.Input: {
       return language.ux_editor.helper_text_for_input;
     }
-    case ComponentTypes.CheckBox: {
+    case ComponentTypes.Checkboxes: {
       return language.ux_editor.helper_text_for_check_box;
     }
-    case ComponentTypes.RadioButton: {
+    case ComponentTypes.RadioButtons: {
       return language.ux_editor.helper_text_for_radio_button;
     }
     default: {
@@ -22,15 +23,12 @@ export function getComponentHelperTextByComponentType(componentType: ComponentTy
   }
 }
 
-export function getComponentTitleByComponentType(componentType: ComponentTypes, language: any): string {
-  switch (componentType) {
-    case ComponentTypes.CheckBox: {
+export function getComponentTitleByComponentType(type: string, language: any): string {
+  switch (type) {
+    case ComponentTypes.Checkboxes: {
       return language.ux_editor.component_checkbox;
     }
-    case ComponentTypes.Container: {
-      return language.ux_editor.component_container;
-    }
-    case ComponentTypes.DropDown: {
+    case ComponentTypes.Dropdown: {
       return language.ux_editor.component_dropdown;
     }
     case ComponentTypes.FileUpload: {
@@ -51,7 +49,7 @@ export function getComponentTitleByComponentType(componentType: ComponentTypes, 
     case ComponentTypes.TextArea: {
       return language.ux_editor.component_text_area;
     }
-    case ComponentTypes.RadioButton: {
+    case ComponentTypes.RadioButtons: {
       return language.ux_editor.component_radio_button;
     }
     case ComponentTypes.Paragraph: {


### PR DESCRIPTION
Related to cleanup identified in #4497 

- Removed unused types form formlayout.json that was only used in designer
- Removed unused code related to third party components (no longer used)