### PR TITLE
Added some exception handling to file access in DataRepository

### DIFF
--- a/src/development/LocalTest/Configuration/LocalPlatformSettings.cs
+++ b/src/development/LocalTest/Configuration/LocalPlatformSettings.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace LocalTest.Configuration
 {
     /// <summary>
@@ -18,7 +13,7 @@ namespace LocalTest.Configuration
         /// <summary>
         /// The folder where the app that is tested is located. Used to retrieve app configuration
         /// </summary>
-        public string AppRepsitoryBasePath { get; set; }
+        public string AppRepositoryBasePath { get; set; }
 
         public string BlobStorageFolder { get; set; } = "blobs/";
 

--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using AltinnCore.Authentication.Constants;
@@ -63,7 +62,7 @@ namespace LocalTest.Controllers
             model.TestApps = await GetAppsList();
             Application app = await _applicationRepository.FindOne("", "");
             model.TestUsers = await GetTestUsersForList();
-            model.AppPath = _localPlatformSettings.AppRepsitoryBasePath;
+            model.AppPath = _localPlatformSettings.AppRepositoryBasePath;
             model.StaticTestDataPath = _localPlatformSettings.LocalTestingStaticTestDataPath;
 
             if (!model.TestApps.Any())
@@ -229,7 +228,7 @@ namespace LocalTest.Controllers
         {
             List<SelectListItem> apps = new List<SelectListItem>();
 
-            string path = this._localPlatformSettings.AppRepsitoryBasePath;
+            string path = this._localPlatformSettings.AppRepositoryBasePath;
 
             if (!Directory.Exists(path))
             {
@@ -246,7 +245,7 @@ namespace LocalTest.Controllers
                 }
             }
 
-           string[] directories =  Directory.GetDirectories(path);
+            string[] directories =  Directory.GetDirectories(path);
 
             foreach(string directory in directories)
             {

--- a/src/development/LocalTest/Services/Storage/Implementation/DataRepository.cs
+++ b/src/development/LocalTest/Services/Storage/Implementation/DataRepository.cs
@@ -191,7 +191,7 @@ namespace LocalTest.Services.Storage.Implementation
             }
             finally
             {
-                await memStream.DisposeAsync();
+                memStream.Dispose();
             }
         }
 

--- a/src/development/LocalTest/Services/Storage/Implementation/DataRepository.cs
+++ b/src/development/LocalTest/Services/Storage/Implementation/DataRepository.cs
@@ -23,13 +23,16 @@ namespace LocalTest.Services.Storage.Implementation
             _localPlatformSettings = localPlatformSettings.Value;
         }
 
-        public Task<DataElement> Create(DataElement dataElement)
+        public async Task<DataElement> Create(DataElement dataElement)
         {
             string path = GetDataPath(dataElement.InstanceGuid, dataElement.Id);
+
             Directory.CreateDirectory(GetDataCollectionFolder());
             Directory.CreateDirectory(GetDataForInstanceFolder(dataElement.InstanceGuid));
-            File.WriteAllText(path, dataElement.ToString());
-            return Task.FromResult(dataElement);
+
+            await WriteToFile(path, dataElement.ToString());
+
+            return dataElement;
         }
 
         public Task<bool> Delete(DataElement dataElement)
@@ -46,46 +49,48 @@ namespace LocalTest.Services.Storage.Implementation
             return Task.FromResult(true);
         }
 
-        public Task<DataElement> Read(Guid instanceGuid, Guid dataElementId)
+        public async Task<DataElement> Read(Guid instanceGuid, Guid dataElementId)
         {
             string dataPath = GetDataPath(instanceGuid.ToString(), dataElementId.ToString());
-            string content = File.ReadAllText(dataPath);
+            string content = await ReadFileAsString(dataPath);
             DataElement dataElement = (DataElement)JsonConvert.DeserializeObject(content, typeof(DataElement));
-            return Task.FromResult(dataElement);
+            return dataElement;
         }
 
-        public Task<List<DataElement>> ReadAll(Guid instanceGuid)
+        public async Task<List<DataElement>> ReadAll(Guid instanceGuid)
         {
             List<DataElement> dataElements = new List<DataElement>();
             string path = GetDataForInstanceFolder(instanceGuid.ToString());
             if (Directory.Exists(path))
             {
                 string[] files = Directory.GetFiles(path);
-                for (int i = 0; i < files.Length; i++)
+                foreach (string filePath in files)
                 {
-                    string content = File.ReadAllText(files[i]);
+                    string content = await ReadFileAsString(filePath);
                     DataElement instance = (DataElement)JsonConvert.DeserializeObject(content, typeof(DataElement));
                     dataElements.Add(instance);
                 }
             }
-            return Task.FromResult(dataElements);
+            return dataElements;
         }
 
-        public Task<Stream> ReadDataFromStorage(string org, string blobStoragePath)
+        public async Task<Stream> ReadDataFromStorage(string org, string blobStoragePath)
         {
             string filePath = GetFilePath(blobStoragePath);
-            Stream fs = File.OpenRead(filePath);
 
-            return Task.FromResult(fs);
+            return await ReadFileAsStream(filePath);
         }
 
-        public Task<DataElement> Update(DataElement dataElement)
+        public async Task<DataElement> Update(DataElement dataElement)
         {
             string path = GetDataPath(dataElement.InstanceGuid, dataElement.Id);
+
             Directory.CreateDirectory(GetDataCollectionFolder());
             Directory.CreateDirectory(GetDataForInstanceFolder(dataElement.InstanceGuid));
-            File.WriteAllText(path, dataElement.ToString());
-            return Task.FromResult(dataElement);
+
+            await WriteToFile(path, dataElement.ToString());
+
+            return dataElement;
         }
 
         public async Task<long> WriteDataToStorage(string org, Stream stream, string blobStoragePath)
@@ -96,16 +101,7 @@ namespace LocalTest.Services.Storage.Implementation
                 Directory.CreateDirectory(Path.GetDirectoryName(filePath));
             }
 
-            long fileSize;
-
-            using (Stream streamToWriteTo = File.Open(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite))
-            {
-                await stream.CopyToAsync(streamToWriteTo);
-                streamToWriteTo.Flush();
-                fileSize = streamToWriteTo.Length;
-            }
-
-            return fileSize;
+            return await WriteToFile(filePath, stream);
         }
 
         private string GetFilePath(string fileName)
@@ -123,10 +119,88 @@ namespace LocalTest.Services.Storage.Implementation
             return Path.Combine(GetDataCollectionFolder() + instanceId.Replace("/", "_") + "/"); 
         }
 
-
         private string GetDataCollectionFolder()
         {
             return this._localPlatformSettings.LocalTestingStorageBasePath + this._localPlatformSettings.DocumentDbFolder + this._localPlatformSettings.DataCollectionFolder;
+        }
+
+        private async Task<string> ReadFileAsString(string path)
+        {
+            Stream stream = await ReadFileAsStream(path);
+            using StreamReader reader = new StreamReader(stream);
+            return await reader.ReadToEndAsync();
+        }
+
+        private async Task<Stream> ReadFileAsStream(string path)
+        {
+            try
+            {
+                return ReadFileAsStreamInternal(path);
+            }
+            catch (IOException ioException)
+            {
+                if (ioException.Message.Contains("used by another process"))
+                {
+                    await Task.Delay(400);
+                    return ReadFileAsStreamInternal(path);
+                }
+
+                throw;
+            }
+        }
+
+        private Stream ReadFileAsStreamInternal(string path)
+        {
+            return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        }
+
+        private async Task WriteToFile(string path, string content)
+        {
+            MemoryStream stream = new MemoryStream();
+            StreamWriter writer = new StreamWriter(stream);
+            writer.Write(content);
+            writer.Flush();
+            stream.Position = 0;
+            await WriteToFile(path, stream);
+        }
+
+        private async Task<long> WriteToFile(string path, Stream stream)
+        {
+            if (!(stream is MemoryStream memStream))
+            {
+                memStream = new MemoryStream();
+                await stream.CopyToAsync(memStream);
+                memStream.Position = 0;
+            }
+
+            try
+            {
+                return await WriteToFileInternal(path, memStream);
+            }
+            catch (IOException ioException)
+            {
+                if (ioException.Message.Contains("used by another process"))
+                {
+                    await Task.Delay(400);
+                    memStream.Position = 0;
+                    return await WriteToFileInternal(path, memStream);
+                }
+
+                throw;
+            }
+        }
+
+        private async Task<long> WriteToFileInternal(string path, MemoryStream stream)
+        {
+            long fileSize;
+            await using (FileStream streamToWriteTo = File.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+            {
+                await stream.CopyToAsync(streamToWriteTo);
+                streamToWriteTo.Flush();
+                fileSize = streamToWriteTo.Length;
+            }
+
+            return fileSize;
         }
     }
 }

--- a/src/development/LocalTest/Services/Storage/Implementation/DataRepository.cs
+++ b/src/development/LocalTest/Services/Storage/Implementation/DataRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 
 using Altinn.Platform.Storage.Interface.Models;
@@ -156,8 +157,8 @@ namespace LocalTest.Services.Storage.Implementation
 
         private async Task WriteToFile(string path, string content)
         {
-            MemoryStream stream = new MemoryStream();
-            StreamWriter writer = new StreamWriter(stream);
+            await using MemoryStream stream = new MemoryStream();
+            await using StreamWriter writer = new StreamWriter(stream, Encoding.Default);
             writer.Write(content);
             writer.Flush();
             stream.Position = 0;
@@ -187,6 +188,10 @@ namespace LocalTest.Services.Storage.Implementation
                 }
 
                 throw;
+            }
+            finally
+            {
+                await memStream.DisposeAsync();
             }
         }
 

--- a/src/development/LocalTest/Services/Storage/Implementation/DataRepository.cs
+++ b/src/development/LocalTest/Services/Storage/Implementation/DataRepository.cs
@@ -169,7 +169,7 @@ namespace LocalTest.Services.Storage.Implementation
         {
             if (!(stream is MemoryStream memStream))
             {
-                memStream = new MemoryStream();
+                memStream = new MemoryStream(); // lgtm [cs/local-not-disposed]
                 await stream.CopyToAsync(memStream);
                 memStream.Position = 0;
             }
@@ -191,7 +191,7 @@ namespace LocalTest.Services.Storage.Implementation
             }
             finally
             {
-                memStream.Dispose();
+                await memStream.DisposeAsync();
             }
         }
 

--- a/src/development/LocalTest/appsettings.json
+++ b/src/development/LocalTest/appsettings.json
@@ -36,7 +36,7 @@
   "AllowedHosts": "*",
   "LocalPlatformSettings": {
     "LocalTestingStorageBasePath": "c:/AltinnPlatformLocal/",
-    "AppRepsitoryBasePath": "<Path to your repos folder where you have cloned the Altinn Studio application repositories>",
+    "AppRepositoryBasePath": "<Path to your repos folder where you have cloned the Altinn Studio application repositories>",
     "LocalTestingStaticTestDataPath": "<Path to altinn-studio repo>/src/development/TestData/"
   },
   "PlatformSettings": {


### PR DESCRIPTION
Adding some simple exception handling and retry mechanism if a file is locked by an other process. A more advanced solution would be some form of locking where threads would need to stand in line, but I don't think this issue is frequent enough to justify that. 

If this works it is a pattern that we can reuse for the other repository classes with file access.

#5000 