### PR TITLE
Prevent data breaking a 'maximum' rule from being sent to backend.

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/validation.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/validation.ts
@@ -332,7 +332,7 @@ export function validateComponentFormData(
 
   if (!valid) {
     validator.errors.forEach((error) => {
-      if (error.keyword === 'type' || error.keyword === 'format') {
+      if (error.keyword === 'type' || error.keyword === 'format' || error.keyword === 'maximum') {
         validationResult.invalidDataTypes = true;
       }
       let errorParams = error.params[errorMessageKeys[error.keyword].paramKey];


### PR DESCRIPTION
Added a check to prevent number data that is too large from being sent to backend where it would result in a BadRequest.
#4988 