### PR TITLE
Fixed setting currentview based on settings.json when fetched

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/formLayoutReducer.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/formLayoutReducer.ts
@@ -135,6 +135,12 @@ const LayoutReducer: Reducer<ILayoutState> = (
             }
             return settings.pages.order;
           },
+          currentView: (currentView) => {
+            if (!settings || !settings.pages || !settings.pages.order) {
+              return currentView;
+            }
+            return settings.pages.order[0];
+          },
         },
       });
     }


### PR DESCRIPTION
Found during testing of #4997 that the first alphabetical order is always set and not overwritten when Setings.json is fetched (if first element differs from alphabetical order)