### PR TITLE
order archived instanced by archived date

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
@@ -510,7 +510,8 @@ namespace Altinn.Platform.Storage.Repository
                        .Where(i => i.InstanceOwner.PartyId == instanceOwnerPartyIdString)
                        .Where(i => i.Status.Archived.HasValue)
                        .Where(i => !i.Status.SoftDeleted.HasValue)
-                       .Where(i => !i.Status.HardDeleted.HasValue);
+                       .Where(i => !i.Status.HardDeleted.HasValue)
+                       .OrderByDescending(i => i.Status.Archived);
             }
             else
             {

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/InstanceRepositoryMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/InstanceRepositoryMock.cs
@@ -96,7 +96,8 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
                        unfilteredInstances
                        .Where(i => i.Status.Archived.HasValue)
                        .Where(i => !i.Status.SoftDeleted.HasValue)
-                       .Where(i => !i.Status.HardDeleted.HasValue);
+                       .Where(i => !i.Status.HardDeleted.HasValue)
+                       .OrderByDescending(i => i.Status.Archived);
             }
             else
             {


### PR DESCRIPTION
#5188 

- Ordering archived instances by archived date. 

Considerations
- Should we order deleted instances by some property? 
- Currently, we only retrieve the 100 first instances. Should we retrieve all and create a seperate issue for how this affects performance? won't be a problem in production before we get users with many instances