### PR TITLE
More efficient load testing cleanup

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/DataCleanup/Services/CosmosService.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/DataCleanup/Services/CosmosService.cs
@@ -158,7 +158,7 @@ namespace Altinn.Platform.Storage.DataCleanup.Services
             {
                 IDocumentQuery<Instance> query = filter.AsDocumentQuery();
 
-                while (query.HasMoreResults)
+                while (query.HasMoreResults && instances.Count < 10000)
                 {
                     FeedResponse<Instance> feedResponse = await query.ExecuteNextAsync<Instance>();
                     instances.AddRange(feedResponse.ToList());


### PR DESCRIPTION
A case in production now is that retrieving all instances of the load testing app takes too much time. 
Instead we get a lower number of instances for each trigger.

Could be set back to original implementation once this extraordinary cleanup in production is complete. 

#5305 