### PR TITLE
Documentation fix for local development on macOS

### DIFF
--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -29,7 +29,7 @@ localhost altinn3.no
 
 7. Make sure your C drive is shared with docker, Docker Settings -> Shared Drives <br />
    On MacOS: Change docker-compose.yml (both)
-    ```json
+    ```yaml
       volumes:
         - "C:/AltinnCore/Repos:/AltinnCore/Repos"
     ```
@@ -91,7 +91,7 @@ npm run gulp-install-deps
 On MacOS you need two extra steps:
   1. change the RepositoryLocation in src/studio/src/designer/backend/appsettings.json to
 
-      ```cmd
+      ```json
       "ServiceRepositorySettings": {
         "RepositoryLocation": "/Users/<yourname>/AltinnCore/Repos/",
       ````

--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -88,7 +88,7 @@ npm ci
 npm run gulp-install-deps
 ```
 
-If you are using mac change the RepositoryLocation in src/studio/src/designer/backend/appsettings.json to
+On MacOS change the RepositoryLocation in src/studio/src/designer/backend/appsettings.json to
 
 ```cmd
   "ServiceRepositorySettings": {

--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -29,12 +29,12 @@ localhost altinn3.no
 
 7. Make sure your C drive is shared with docker, Docker Settings -> Shared Drives <br />
    On MacOS: Change docker-compose.yml (both)
-    ```cmd
+    ```json
       volumes:
         - "C:/AltinnCore/Repos:/AltinnCore/Repos"
     ```
     to:
-    ```cmd
+    ```yaml
       volumes:
         - "/Users/<yourname>/AltinnCore/Repos:/AltinnCore/Repos"
     ```

--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -88,6 +88,13 @@ npm ci
 npm run gulp-install-deps
 ```
 
+If you are using mac change the RepositoryLocation in src/studio/src/designer/backend/appsettings.json to
+
+```cmd
+  "ServiceRepositorySettings": {
+    "RepositoryLocation": "/Users/<yourname>/AltinnCore/Repos/",
+````
+
 Build and run the code.
 
 ```cmd

--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -27,7 +27,8 @@ localhost altinn3.no
 127.0.0.1 altinn3.no
 ```
 
-7. Make sure your C drive is shared with docker, Docker Settings -> Shared Drives <br />
+7. Make sure your C drive is shared with docker, Docker Settings -> Shared Drives
+
    On MacOS: Change docker-compose.yml (both)
     ```yaml
       volumes:

--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -15,7 +15,7 @@ These instructions will get you a copy of Altinn Studio up and running on your l
 ### Prerequisites
 
 1. Latest [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1)
-2. [Node.js](https://nodejs.org) (Version 12.*)
+2. [Node.js](https://nodejs.org) (Version 14.*)
 3. Newest [Git](https://git-scm.com/downloads)
 4. A code editor - we like [Visual Studio Code](https://code.visualstudio.com/Download)
     - Also install [recommended extensions](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions) (f.ex. [C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) and [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome))

--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -88,12 +88,19 @@ npm ci
 npm run gulp-install-deps
 ```
 
-On MacOS change the RepositoryLocation in src/studio/src/designer/backend/appsettings.json to
+On MacOS you need two extra steps:
+ 1. change the RepositoryLocation in src/studio/src/designer/backend/appsettings.json to
 
 ```cmd
   "ServiceRepositorySettings": {
     "RepositoryLocation": "/Users/<yourname>/AltinnCore/Repos/",
 ````
+
+ 2. Change location where the application stores the DataProtectionKeys
+
+ ```cmd
+ export ALTINN_KEYS_DIRECTORY=/Users/<yourname>/studio/keys
+ ```
 
 Build and run the code.
 

--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -27,8 +27,7 @@ localhost altinn3.no
 127.0.0.1 altinn3.no
 ```
 
-7. Make sure your C drive is shared with docker, Docker Settings -> Shared Drives
-
+7. Make sure your C drive is shared with docker, Docker Settings -> Shared Drives  
    On MacOS: Change docker-compose.yml (both)
     ```yaml
       volumes:

--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -89,18 +89,18 @@ npm run gulp-install-deps
 ```
 
 On MacOS you need two extra steps:
- 1. change the RepositoryLocation in src/studio/src/designer/backend/appsettings.json to
+  1. change the RepositoryLocation in src/studio/src/designer/backend/appsettings.json to
 
-```cmd
-  "ServiceRepositorySettings": {
-    "RepositoryLocation": "/Users/<yourname>/AltinnCore/Repos/",
-````
+      ```cmd
+      "ServiceRepositorySettings": {
+        "RepositoryLocation": "/Users/<yourname>/AltinnCore/Repos/",
+      ````
 
- 2. Change location where the application stores the DataProtectionKeys
+  2. Change location where the application stores the DataProtectionKeys
 
- ```cmd
- export ALTINN_KEYS_DIRECTORY=/Users/<yourname>/studio/keys
- ```
+      ```cmd
+      export ALTINN_KEYS_DIRECTORY=/Users/<yourname>/studio/keys
+      ```
 
 Build and run the code.
 


### PR DESCRIPTION
Document extra steps needed to run designer locally on macOS with ```npm``` or ```dotnet```.
This should close #1400 and also "fix a bug" when trying to run designer locally on macOS (```System.IO.IOException: Read-only file system```)
Updated documented version of nodejs to reflect version used in Dockerfile