### PR TITLE
bug/5381-not-possible-to-download-attachments-receipt

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/receipt/src/features/receipt/containers/Receipt.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/receipt/src/features/receipt/containers/Receipt.tsx
@@ -121,7 +121,7 @@ function Receipt(props: WithStyles<typeof styles>) {
     if (instance && application) {
       const appLogicDataTypes = application.dataTypes.filter((dataType) => !!dataType.appLogic);
 
-      const attachmentsResult = mapInstanceAttachments(instance.data, appLogicDataTypes.map((type) => type.id));
+      const attachmentsResult = mapInstanceAttachments(instance.data, appLogicDataTypes.map((type) => type.id), true);
       setAttachments(attachmentsResult);
       setPdf(getInstancePdf(instance.data, true));
     }


### PR DESCRIPTION
#5381 

- Added missing `platform` boolean for Platform receipt causing app link (which was null) to be used