### PR TITLE
set limit on continuation token  for getInstance

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
@@ -111,6 +111,7 @@ namespace Altinn.Platform.Storage.Repository
                 {
                     EnableCrossPartitionQuery = true,
                     MaxItemCount = size - queryResponse.Count,
+                    ResponseContinuationTokenLimitInKb = 7
                 };
 
                 if (continuationToken != null)


### PR DESCRIPTION
#5602 

Consequence: end user will receive error message and no instances are returned if the conttoken cannot be compressed to 7kb. 
