### PR TITLE
Bug/localtest parse enum fails

### DIFF
--- a/src/development/LocalTest/Startup.cs
+++ b/src/development/LocalTest/Startup.cs
@@ -53,12 +53,12 @@ namespace LocalTest
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
-        {
+        {            
             services.Configure<Altinn.Common.PEP.Configuration.PepSettings>(Configuration.GetSection("PepSettings"));
             services.Configure<Altinn.Common.PEP.Configuration.PlatformSettings>(Configuration.GetSection("PlatformSettings"));
 
             services.Configure<LocalPlatformSettings>(Configuration.GetSection("LocalPlatformSettings"));
-            services.AddControllersWithViews();
+            services.AddControllersWithViews().AddNewtonsoftJson(); 
             services.AddSingleton(Configuration);
             services.Configure<GeneralSettings>(Configuration.GetSection("GeneralSettings"));
             services.Configure<Altinn.Platform.Authentication.Configuration.GeneralSettings>(Configuration.GetSection("AuthnGeneralSettings"));

--- a/src/development/LocalTest/Startup.cs
+++ b/src/development/LocalTest/Startup.cs
@@ -39,6 +39,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using LocalTest.Services.Localtest.Interface;
 using LocalTest.Services.Localtest.Implementation;
+using System.Text.Json.Serialization;
 
 namespace LocalTest
 {
@@ -54,7 +55,10 @@ namespace LocalTest
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddJsonOptions(opt =>
+            {
+                opt.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+            });
 
             services.Configure<Altinn.Common.PEP.Configuration.PepSettings>(Configuration.GetSection("PepSettings"));
             services.Configure<Altinn.Common.PEP.Configuration.PlatformSettings>(Configuration.GetSection("PlatformSettings"));

--- a/src/development/LocalTest/Startup.cs
+++ b/src/development/LocalTest/Startup.cs
@@ -53,12 +53,14 @@ namespace LocalTest
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
-        {            
+        {
+            services.AddControllers().AddNewtonsoftJson();
+
             services.Configure<Altinn.Common.PEP.Configuration.PepSettings>(Configuration.GetSection("PepSettings"));
             services.Configure<Altinn.Common.PEP.Configuration.PlatformSettings>(Configuration.GetSection("PlatformSettings"));
 
             services.Configure<LocalPlatformSettings>(Configuration.GetSection("LocalPlatformSettings"));
-            services.AddControllersWithViews().AddNewtonsoftJson(); 
+            services.AddControllersWithViews(); 
             services.AddSingleton(Configuration);
             services.Configure<GeneralSettings>(Configuration.GetSection("GeneralSettings"));
             services.Configure<Altinn.Platform.Authentication.Configuration.GeneralSettings>(Configuration.GetSection("AuthnGeneralSettings"));


### PR DESCRIPTION
this has the fix for the error:  
> JwtCookie was not authenticated. Failure message: IDX10501: Signature validation failed. Unable to match key: kid: 'System.String'. 

in localtest
