### PR TITLE
Feature/4816 altinn platform models change to depend on standard21

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Models/Altinn.Platform.Models.Tests/ModelValidator.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Models/Altinn.Platform.Models.Tests/ModelValidator.cs
@@ -7,7 +7,7 @@ namespace Altinn.Platform.Models.Tests
     /// Helper methods for model validation.
     /// </summary>
     public static class ModelValidator
-    {        
+    {
         /// <summary>
         /// Perform validation of an instance of a model.
         /// </summary>

--- a/src/Altinn.Platform/Altinn.Platform.Models/Models/Altinn.Platform.Models.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Models/Models/Altinn.Platform.Models.csproj
@@ -1,14 +1,32 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Altinn.Platform</RootNamespace>
-    <Version>1.0.4-alpha</Version>
-    <Description>Shared models for Altinn Platform</Description>
+    <!-- SonarCloud needs this -->
+    <ProjectGuid>{B72A146D-719D-4E2A-B931-C2ACBA72EF4F}</ProjectGuid>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Version>1.0.5</Version>
+    <PackageId>Altinn.Platform.Models</PackageId>
+    <PackageTags>Altinn Studio, Altinn.Platform, Altinn.Platform.Models</PackageTags>
+    <Description>Altinn.Platform.Models is a package for models used by platform register and profile</Description>
+    <Product>PlatformModels</Product>
+    <Authors>Altinn Platform Contributors</Authors>
+    <Company>Altinn</Company>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <AssemblyVersion>1.0.5.0</AssemblyVersion>
+    <FileVersion>1.0.5.0</FileVersion>
+    <RepositoryUrl>https://github.com/Altinn/altinn-studio</RepositoryUrl>
+    <RepositoryType>Github</RepositoryType>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
@@ -16,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <AdditionalFiles Include="..\..\..\..\stylecop.json"/>
+    <AdditionalFiles Include="..\..\..\..\stylecop.json" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Altinn.Platform/Altinn.Platform.Models/Models/Profile/Models/ProfileSettingPreference.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Models/Models/Profile/Models/ProfileSettingPreference.cs
@@ -1,5 +1,3 @@
-using Altinn.Platform.Profile.Enums;
-
 namespace Altinn.Platform.Profile.Models
 {
     /// <summary>

--- a/src/Altinn.Platform/Altinn.Platform.Models/Models/Register/Models/PartyLookup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Models/Models/Register/Models/PartyLookup.cs
@@ -37,12 +37,12 @@ namespace Altinn.Platform.Register.Models
             {
                 if (OrgNo != null)
                 {
-                    issues.Add(new ValidationResult($"With Ssn already provided the OrgNo field should be null.", new string[] { nameof(OrgNo) } ));
+                    issues.Add(new ValidationResult($"With Ssn already provided the OrgNo field should be null.", new string[] { nameof(OrgNo) }));
                 }
             }
             else if (OrgNo == null)
             {
-                issues.Add(new ValidationResult($"At least one of the object properties must have a value", new string[] { nameof(Ssn), nameof(OrgNo) } ));
+                issues.Add(new ValidationResult($"At least one of the object properties must have a value", new string[] { nameof(Ssn), nameof(OrgNo) }));
             }
 
             return issues;

--- a/src/Altinn.Platform/Altinn.Platform.Models/Models/Register/Models/Person.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Models/Models/Register/Models/Person.cs
@@ -4,7 +4,7 @@ namespace Altinn.Platform.Register.Models
     /// Class representing a person
     /// </summary>
     public class Person
-    {        
+    {
         /// <summary>
         /// Gets or sets the social security number
         /// </summary>


### PR DESCRIPTION
Sneaky update to change Altinn.Platform.Models to depend on .Net Standard 2.1 instead of .Net core 3.1.

Sneakily related to #4816 