### PR TITLE
Feature/5579 exclude active elements in archiveref search

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/MessageboxInstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/MessageboxInstancesController.cs
@@ -148,6 +148,24 @@ namespace Altinn.Platform.Storage.Controllers
 
             Dictionary<string, StringValues> queryParams = QueryHelpers.ParseQuery(Request.QueryString.Value);
 
+            if (!string.IsNullOrEmpty(archiveReference))
+            {
+                if ((includeActive == includeArchived) && (includeActive == includeDeleted))
+                {
+                    includeActive = false;
+                    includeDeleted = true;
+                    includeArchived = true;
+                }
+                else if (includeActive && !includeArchived && !includeDeleted)
+                {
+                    return Ok(new List<MessageBoxInstance>());
+                }
+                else if (includeActive && (includeArchived || includeDeleted))
+                {
+                    includeActive = false;
+                }
+            }
+
             GetStatusFromQueryParams(includeActive, includeArchived, includeDeleted, queryParams);
             queryParams.Add("sortBy", "desc:lastChanged");
 

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
@@ -983,16 +983,11 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             HttpClient client = GetTestClient(instanceRepositoryMock);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1, 1600, 3));
 
-            int expectedCount = 1;
-
             // Act
             HttpResponseMessage responseMessage = await client.GetAsync($"{BasePath}/sbl/instances/search?instanceOwner.partyId=1600&archiveReference=bdb2a09da7ea");
-            string content = await responseMessage.Content.ReadAsStringAsync();
-            List<MessageBoxInstance> messageBoxInstances = JsonConvert.DeserializeObject<List<MessageBoxInstance>>(content);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
-            Assert.Equal(expectedCount, messageBoxInstances.Count);
             Assert.True(actual.ContainsKey("instanceOwner.partyId"));
             actual.TryGetValue("status.isArchivedOrSoftDeleted", out StringValues actualIsArchivedOrSoftDeleted);
             Assert.True(bool.Parse(actualIsArchivedOrSoftDeleted.First()));
@@ -1000,14 +995,14 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
         /// <summary>
         /// Scenario:
-        ///  Search instances based on archive reference. Include active and archived selected.
+        ///  Search instances based on archive reference. Include active and soft deleted selected.
         /// Expected:
         ///  Query parameters are mapped to parameters that instanceRepository can handle. Excluding all active instances.
         /// Success:
         ///  isArchived is set to true. isSoftDeleted is set to false.
         /// </summary>
         [Fact]
-        public async void Search_ArchiveReferenceIncludeActiveAndArchived_OriginalQuerySuccesfullyConverted()
+        public async void Search_ArchiveReferenceIncludeActiveAndSoftDeleted_OriginalQuerySuccesfullyConverted()
         {
             // Arrange
             Dictionary<string, StringValues> actual = new Dictionary<string, StringValues>();
@@ -1020,21 +1015,14 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             HttpClient client = GetTestClient(instanceRepositoryMock);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1, 1600, 3));
 
-            int expectedCount = 1;
-
             // Act
-            HttpResponseMessage responseMessage = await client.GetAsync($"{BasePath}/sbl/instances/search?instanceOwner.partyId=1600&archiveReference=bdb2a09da7ea&includeActive=true&includeArchived=true");
-            string content = await responseMessage.Content.ReadAsStringAsync();
-            List<MessageBoxInstance> messageBoxInstances = JsonConvert.DeserializeObject<List<MessageBoxInstance>>(content);
+            HttpResponseMessage responseMessage = await client.GetAsync($"{BasePath}/sbl/instances/search?instanceOwner.partyId=1600&archiveReference=bdb2a09da7ea&includeActive=true&includeDeleted=true");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
-            Assert.Equal(expectedCount, messageBoxInstances.Count);
             Assert.True(actual.ContainsKey("instanceOwner.partyId"));
-            actual.TryGetValue("status.isArchived", out StringValues actualIsArchived);
+            actual.TryGetValue("status.isSoftDeleted", out StringValues actualIsArchived);
             Assert.True(bool.Parse(actualIsArchived.First()));
-            actual.TryGetValue("status.isSoftDeleted", out StringValues actualIsSoftDeleted);
-            Assert.False(bool.Parse(actualIsSoftDeleted.First()));
         }
 
         private HttpClient GetTestClient(Mock<IInstanceRepository> instanceRepositoryMock = null)

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
@@ -961,6 +961,82 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             instanceRepositoryMock.VerifyAll();
         }
 
+        /// <summary>
+        /// Scenario:
+        ///  Search instances based on archive reference. No state filter included.
+        /// Expected:
+        ///  Query parameters are mapped to parameters that instanceRepository can handle. Excluding all active instances.
+        /// Success:
+        ///  isArchivedOrSoftDeleted is set to true.
+        /// </summary>
+        [Fact]
+        public async void Search_ArchiveReferenceNoStateFilter_OriginalQuerySuccesfullyConverted()
+        {
+            // Arrange
+            Dictionary<string, StringValues> actual = new Dictionary<string, StringValues>();
+            Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
+            instanceRepositoryMock
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
+                .Callback<Dictionary<string, StringValues>, string, int>((query, cont, size) => { actual = query; })
+                .ReturnsAsync((InstanceQueryResponse)null);
+
+            HttpClient client = GetTestClient(instanceRepositoryMock);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1, 1600, 3));
+
+            int expectedCount = 1;
+
+            // Act
+            HttpResponseMessage responseMessage = await client.GetAsync($"{BasePath}/sbl/instances/search?instanceOwner.partyId=1600&archiveReference=bdb2a09da7ea");
+            string content = await responseMessage.Content.ReadAsStringAsync();
+            List<MessageBoxInstance> messageBoxInstances = JsonConvert.DeserializeObject<List<MessageBoxInstance>>(content);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+            Assert.Equal(expectedCount, messageBoxInstances.Count);
+            Assert.True(actual.ContainsKey("instanceOwner.partyId"));
+            actual.TryGetValue("status.isArchivedOrSoftDeleted", out StringValues actualIsArchivedOrSoftDeleted);
+            Assert.True(bool.Parse(actualIsArchivedOrSoftDeleted.First()));
+        }
+
+        /// <summary>
+        /// Scenario:
+        ///  Search instances based on archive reference. Include active and archived selected.
+        /// Expected:
+        ///  Query parameters are mapped to parameters that instanceRepository can handle. Excluding all active instances.
+        /// Success:
+        ///  isArchived is set to true. isSoftDeleted is set to false.
+        /// </summary>
+        [Fact]
+        public async void Search_ArchiveReferenceIncludeActiveAndArchived_OriginalQuerySuccesfullyConverted()
+        {
+            // Arrange
+            Dictionary<string, StringValues> actual = new Dictionary<string, StringValues>();
+            Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
+            instanceRepositoryMock
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
+                .Callback<Dictionary<string, StringValues>, string, int>((query, cont, size) => { actual = query; })
+                .ReturnsAsync((InstanceQueryResponse)null);
+
+            HttpClient client = GetTestClient(instanceRepositoryMock);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1, 1600, 3));
+
+            int expectedCount = 1;
+
+            // Act
+            HttpResponseMessage responseMessage = await client.GetAsync($"{BasePath}/sbl/instances/search?instanceOwner.partyId=1600&archiveReference=bdb2a09da7ea&includeActive=true&includeArchived=true");
+            string content = await responseMessage.Content.ReadAsStringAsync();
+            List<MessageBoxInstance> messageBoxInstances = JsonConvert.DeserializeObject<List<MessageBoxInstance>>(content);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+            Assert.Equal(expectedCount, messageBoxInstances.Count);
+            Assert.True(actual.ContainsKey("instanceOwner.partyId"));
+            actual.TryGetValue("status.isArchived", out StringValues actualIsArchived);
+            Assert.True(bool.Parse(actualIsArchived.First()));
+            actual.TryGetValue("status.isSoftDeleted", out StringValues actualIsSoftDeleted);
+            Assert.False(bool.Parse(actualIsSoftDeleted.First()));
+        }
+
         private HttpClient GetTestClient(Mock<IInstanceRepository> instanceRepositoryMock = null)
         {
             // No setup required for these services. They are not in use by the MessageBoxInstancesController


### PR DESCRIPTION
#5579 

Added logic to ensure that active instances are not included in the results when archive reference is provided