### PR TITLE
simplify updating component id

### DIFF
--- a/src/studio/src/designer/frontend/ux-editor/containers/EditContainer.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/EditContainer.tsx
@@ -225,14 +225,13 @@ export function EditContainer(props: IEditContainerProvidedProps) {
     setListItem(newListItem);
     setIsEditMode(false);
 
-    const { id: stateId, ...restState } = component;
-    const { id: idProps, ...restProps } = props.component;
-    if (JSON.stringify(restState) !== JSON.stringify(restProps)) {
+    if (JSON.stringify(component) !== JSON.stringify(props.component)) {
       handleSaveChange(component);
+      if (props.id !== component.id) {
+        dispatch(FormLayoutActions.updateFormComponentId({ newId: component.id, currentId: props.id }));
+      }
     }
-    if (props.id !== component.id) {
-      dispatch(FormLayoutActions.updateFormComponentId({ currentId: props.id, newId: component.id }));
-    }
+
     props.sendItemToParent(newListItem);
     dispatch(FormLayoutActions.deleteActiveList());
   };
@@ -244,8 +243,7 @@ export function EditContainer(props: IEditContainerProvidedProps) {
   };
 
   const handleSaveChange = (callbackComponent: FormComponentType): void => {
-    const { id, ...rest } = callbackComponent;
-    dispatch(FormLayoutActions.updateFormComponent({ id: props.id, updatedComponent: rest }));
+    dispatch(FormLayoutActions.updateFormComponent({ id: props.id, updatedComponent: callbackComponent }));
   };
 
   const handleKeyPress = (e: any) => {

--- a/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formDesignerSagas.ts
+++ b/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formDesignerSagas.ts
@@ -16,10 +16,9 @@ import { watchAddApplicationMetadataSaga,
   watchSaveFormLayoutSaga,
   watchSaveFormLayoutSettingSaga,
   watchUpdateApplicationMetadataSaga,
-  watchUpdateFormComponentIdSaga,
   watchUpdateFormComponentSaga,
   watchUpdateLayoutNameSaga } from './formLayout/formLayoutSagas';
-  import { watchAddWidgetSaga } from './widgets/addWidgetsSagas';
+import { watchAddWidgetSaga } from './widgets/addWidgetsSagas';
 
 export default function* formDesignerSagas(): SagaIterator {
   yield fork(watchAddActiveFormContainerSaga);
@@ -37,7 +36,6 @@ export default function* formDesignerSagas(): SagaIterator {
   yield fork(watchSaveFormLayoutSaga);
   yield fork(watchSaveFormLayoutSettingSaga);
   yield fork(watchUpdateApplicationMetadataSaga);
-  yield fork(watchUpdateFormComponentIdSaga);
   yield fork(watchUpdateFormComponentSaga);
   yield fork(watchUpdateLayoutNameSaga);
   yield fork(watchAddWidgetSaga);

--- a/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formDesignerTypes.ts
+++ b/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formDesignerTypes.ts
@@ -152,13 +152,13 @@ export interface IUpdateContainerIdFulfilled {
 }
 
 export interface IUpdateFormComponentAction {
-  updatedComponent: any;
+  updatedComponent: IFormComponent;
   id: string;
   activeContainer?: string;
 }
 
 export interface IUpdateFormComponentActionFulfilled {
-  updatedComponent: any;
+  updatedComponent: IFormComponent;
   id: string;
 }
 

--- a/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formLayout/formLayoutActions.ts
+++ b/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formLayout/formLayoutActions.ts
@@ -21,5 +21,6 @@ export const actions = {
   updateActiveList: createAction<FormDesignerTypes.IUpdateActiveListAction>(`${moduleName}/updateActiveList`),
   updateApplicationMetadata: createAction<FormDesignerTypes.IUpdateApplicationMetadaAction>(`${moduleName}/updateApplicationMetadata`),
   updateApplicationMetadataFulfilled: createAction(`${moduleName}/updateApplicationMetadataFulfilled`),
+  updateFormComponentId: createAction<FormDesignerTypes.IUpdateFormComponentIdAction>(`${moduleName}/updateFormComponentId`),
   updateLayoutName: createAction<FormDesignerTypes.IUpdateLayoutNameAction>(`${moduleName}/updateLayoutName`),
 };

--- a/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formLayout/formLayoutSlice.ts
+++ b/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formLayout/formLayoutSlice.ts
@@ -323,31 +323,33 @@ const formLayoutSlice = createSlice({
     updateFormComponent: (state, action: PayloadAction<FormLayoutTypes.IUpdateFormComponentActionFulfilled>) => {
       const { updatedComponent, id } = action.payload;
       const selectedLayoutComponents = state.layouts[state.selectedLayout].components;
-      selectedLayoutComponents[id] = {
-        ...selectedLayoutComponents[id],
-        ...updatedComponent,
-      };
+      if (id !== updatedComponent.id) {
+        const newId = updatedComponent.id;
+        selectedLayoutComponents[newId] = {
+          ...selectedLayoutComponents[id],
+          ...updatedComponent,
+        };
+        delete selectedLayoutComponents[id];
+
+        // update id in parent container order
+        const selectedLayoutOrder = state.layouts[state.selectedLayout].order;
+        const parentContainer = Object.keys(selectedLayoutOrder).find((containerId) => {
+          return (selectedLayoutOrder[containerId].indexOf(id) > -1);
+        });
+        const parentContainerOrder = selectedLayoutOrder[parentContainer];
+        const containerIndex = parentContainerOrder.indexOf(id);
+        parentContainerOrder[containerIndex] = newId;
+
+        // update id of the containers order array
+        // selectedLayoutOrder[newId] = selectedLayoutOrder[id];
+        // delete selectedLayoutOrder[id];
+      } else {
+        selectedLayoutComponents[id] = {
+          ...selectedLayoutComponents[id],
+          ...updatedComponent,
+        };
+      }
       state.unSavedChanges = true;
-    },
-    updateFormComponentId: (state, action: PayloadAction<FormLayoutTypes.IUpdateFormComponentIdAction>) => {
-      const { currentId, newId } = action.payload;
-      const currentLayout = state.layouts[state.selectedLayout];
-      // update component id
-      currentLayout.components[newId] = currentLayout.components[currentId];
-      delete currentLayout.components[currentId];
-
-      // update id in parent container order
-      const currentLayoutOrder = currentLayout.order;
-      const parentContainer = Object.keys(currentLayoutOrder).find((containerId) => {
-        return (currentLayoutOrder[containerId].indexOf(currentId) > -1);
-      });
-      const parentContainerOrder = currentLayoutOrder[parentContainer];
-      const containerIndex = parentContainerOrder.indexOf(currentId);
-      parentContainerOrder[containerIndex] = newId;
-
-      // update id of the containers order array
-      currentLayoutOrder[newId] = currentLayoutOrder[currentId];
-      delete currentLayoutOrder[currentId];
     },
     // eslint-disable-next-line max-len
     updateFormComponentOrder: (state, action: PayloadAction<FormLayoutTypes.IUpdateFormComponentOrderAction>) => {


### PR DESCRIPTION
#5705 
- Simplified updating of component id so it is part of the same call that updates a component in general
- Made updating of app metadata for fileupload component sequential, so that delete old metadata is only done _after_ adding new metadata is completed.