### PR TITLE
added endpoint for updating presentation field

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage.Interface/Altinn.Platform.Storage.Interface.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage.Interface/Altinn.Platform.Storage.Interface.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
     <Description>Altinn.Platform.Storage.Interface is a package for models used by platform storage</Description>
     <PackageTags>Altinn Studio, Altinn.Platform, Altinn.Platform.Storage.Interface</PackageTags>
     <PackageId>Altinn.Platform.Storage.Interface</PackageId>
@@ -17,8 +17,8 @@
     <Authors>Altinn Platform Contributors</Authors>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>2.5.5.0</AssemblyVersion>
-    <FileVersion>2.5.5.0</FileVersion>
+    <AssemblyVersion>2.5.6.0</AssemblyVersion>
+    <FileVersion>2.5.6.0</FileVersion>
     <RepositoryUrl>https://github.com/Altinn/altinn-studio</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>
   </PropertyGroup>

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage.Interface/Models/Instance.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage.Interface/Models/Instance.cs
@@ -81,7 +81,8 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// <summary>
         /// Gets or sets the presentation fields of the instance.
         /// </summary>
-        public Dictionary<string, string> PresentationFields { get; set; }
+        [JsonProperty(PropertyName = "presentationFields")]
+        public PresentationFields PresentationFields { get; set; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage.Interface/Models/PresentationFields.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage.Interface/Models/PresentationFields.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Altinn.Platform.Storage.Interface.Models
+{
+    /// <summary>
+    /// Dictionary containing presentation fields
+    /// </summary>
+    public class PresentationFields : Dictionary<string, string>
+    {
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Altinn.Platform.Storage.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Altinn.Platform.Storage.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.5.4" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="2.5.5" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
     <PackageReference Include="Altinn.Common.PEP" Version="1.0.38-alpha" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.4.1-alpha" />

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
@@ -589,7 +589,6 @@ namespace Altinn.Platform.Storage.Controllers
         [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_WRITE)]
         [HttpPut("{instanceOwnerPartyId:int}/{instanceGuid:guid}/presentationFields")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [HttpPut]
         public async Task<Instance> UpdatePresentationFields(
             [FromRoute] int instanceOwnerPartyId,

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
@@ -589,7 +589,6 @@ namespace Altinn.Platform.Storage.Controllers
         [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_WRITE)]
         [HttpPut("{instanceOwnerPartyId:int}/{instanceGuid:guid}/presentationFields")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        [HttpPut]
         public async Task<Instance> UpdatePresentationFields(
             [FromRoute] int instanceOwnerPartyId,
             [FromRoute] Guid instanceGuid,
@@ -597,9 +596,8 @@ namespace Altinn.Platform.Storage.Controllers
         {
             string instanceId = $"{instanceOwnerPartyId}/{instanceGuid}";
             Instance instance = await _instanceRepository.GetOne(instanceId, instanceOwnerPartyId);
-            Dictionary<string, string> existing = instance.PresentationFields;
 
-            if (existing == null)
+            if (instance.PresentationFields == null)
             {
                 instance.PresentationFields = new Dictionary<string, string>();
             }
@@ -616,8 +614,8 @@ namespace Altinn.Platform.Storage.Controllers
                 }
             }
 
-            await _instanceRepository.Update(instance);
-            return instance;
+            Instance updatedInstance = await _instanceRepository.Update(instance);
+            return updatedInstance;
         }
 
         private Instance CreateInstanceFromTemplate(Application appInfo, Instance instanceTemplate, DateTime creationTime, string userId)

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
@@ -589,6 +589,8 @@ namespace Altinn.Platform.Storage.Controllers
         [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_WRITE)]
         [HttpPut("{instanceOwnerPartyId:int}/{instanceGuid:guid}/presentationFields")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [Consumes("application/json")]
+        [Produces("application/json")]
         public async Task<Instance> UpdatePresentationFields(
             [FromRoute] int instanceOwnerPartyId,
             [FromRoute] Guid instanceGuid,

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerTests.cs
@@ -988,10 +988,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, string> actual = updatedInstance.PresentationFields;
 
             // Assert
-            const int expectedCount = 2;
-
             Assert.NotNull(actual);
-            Assert.Equal(expectedCount, actual.Keys.Count);
+            Assert.Equal(2, actual.Keys.Count);
         }
 
         /// <summary>
@@ -1029,13 +1027,9 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, string> actual = updatedInstance.PresentationFields;
 
             // Assert
-            const int expectedCount = 2;
-            const string expectedValue = "updatedvalue1";
-            const string expectedContainingKey = "key2";
-
-            Assert.Equal(expectedCount, actual.Keys.Count);
-            Assert.True(actual.ContainsKey(expectedContainingKey));
-            Assert.Equal(expectedValue, actual["key1"]);
+            Assert.Equal(2, actual.Keys.Count);
+            Assert.True(actual.ContainsKey("key2"));
+            Assert.Equal("updatedvalue1", actual["key1"]);
         }
 
         /// <summary>
@@ -1075,10 +1069,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, string> actual = updatedInstance.PresentationFields;
 
             // Assert
-            const string expectedContainingKey = "key2";
-
             Assert.Single(actual.Keys);
-            Assert.True(actual.ContainsKey(expectedContainingKey));
+            Assert.True(actual.ContainsKey("key2"));
             Assert.False(actual.ContainsKey(removedKey));
         }
 
@@ -1094,8 +1086,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             // Arrange
             int instanceOwnerPartyId = 1337;
             string instanceGuid = "20a1353e-91cf-44d6-8ff7-f68993638ffe";
-
-            const int expectedCount = 3;
 
             Dictionary<string, string> presentationFields = new Dictionary<string, string>
             {
@@ -1119,7 +1109,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, string> actual = updatedInstance.PresentationFields;
 
             // Assert
-            Assert.Equal(expectedCount, actual.Keys.Count);
+            Assert.Equal(3, actual.Keys.Count);
         }
 
         private HttpClient GetTestClient()

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerTests.cs
@@ -965,8 +965,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             int instanceOwnerPartyId = 1337;
             string instanceGuid = "20a1353e-91cf-44d6-8ff7-f68993638ffe";
 
-            int expectedCount = 2;
-
             Dictionary<string, string> presentationFields = new Dictionary<string, string>
             {
                 { "key1", "value1" },
@@ -990,6 +988,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, string> actual = updatedInstance.PresentationFields;
 
             // Assert
+            const int expectedCount = 2;
+
             Assert.NotNull(actual);
             Assert.Equal(expectedCount, actual.Keys.Count);
         }
@@ -1006,10 +1006,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             // Arrange
             int instanceOwnerPartyId = 1337;
             string instanceGuid = "20a1353e-91cf-44d6-8ff7-f68993638ffe";
-
-            int expectedCount = 2;
-            string expectedValue = "updatedvalue1";
-            string expectedContainingKey = "key2";
 
             Dictionary<string, string> presentationFields = new Dictionary<string, string>
             {
@@ -1033,6 +1029,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, string> actual = updatedInstance.PresentationFields;
 
             // Assert
+            const int expectedCount = 2;
+            const string expectedValue = "updatedvalue1";
+            const string expectedContainingKey = "key2";
+
             Assert.Equal(expectedCount, actual.Keys.Count);
             Assert.True(actual.ContainsKey(expectedContainingKey));
             Assert.Equal(expectedValue, actual["key1"]);
@@ -1051,10 +1051,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             int instanceOwnerPartyId = 1337;
             string instanceGuid = "20a1353e-91cf-44d6-8ff7-f68993638ffe";
 
-            int expectedCount = 1;
-            string removedKey = "key1";
-
-            string expectedContainingKey = "key2";
+            const string removedKey = "key1";
 
             Dictionary<string, string> presentationFields = new Dictionary<string, string>
             {
@@ -1078,7 +1075,9 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, string> actual = updatedInstance.PresentationFields;
 
             // Assert
-            Assert.Equal(expectedCount, actual.Keys.Count);
+            const string expectedContainingKey = "key2";
+
+            Assert.Single(actual.Keys);
             Assert.True(actual.ContainsKey(expectedContainingKey));
             Assert.False(actual.ContainsKey(removedKey));
         }
@@ -1096,7 +1095,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             int instanceOwnerPartyId = 1337;
             string instanceGuid = "20a1353e-91cf-44d6-8ff7-f68993638ffe";
 
-            int expectedCount = 3;
+            const int expectedCount = 3;
 
             Dictionary<string, string> presentationFields = new Dictionary<string, string>
             {

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/instances/1337/20a1353e-91cf-44d6-8ff7-f68993638ffe.json
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/data/cosmoscollections/instances/1337/20a1353e-91cf-44d6-8ff7-f68993638ffe.json
@@ -55,6 +55,10 @@
       "lastChanged": "2020-04-29T13:53:09.0214218Z"
     }
   ],
+  "presentationFields": {
+    "key1": "value1",
+    "key2": "value2"
+  },
   "visibleAfter": "2020-04-29T13:53:02.2836971Z",
   "created": "2020-04-29T13:53:02.2836971Z",
   "createdBy": "1337",


### PR DESCRIPTION
#5638 
No validation of the input is implemented.. should the presentation field befiltered against the ids defined in app metadata, or should we leave it up to the app to ensure that only valid presentation fields are forwarded to storage?

TODO: push new storage interface and update refs
