### PR TITLE
added functionality for getting page order from backend

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,16 +3,16 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>3.3.0</Version>
+    <Version>3.4.0-alpha</Version>
     <Authors>Altinn</Authors>
     <Company>Altinn</Company>
     <Description>Package that contains API controllers for the standard API for a Altinn App.</Description>
     <PackageProjectUrl>https://github.com/Altinn/altinn-studio</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>3.3.0.0</AssemblyVersion>
+    <AssemblyVersion>3.4.0.0</AssemblyVersion>
     <IsPackable>true</IsPackable>
     <OutputType>Library</OutputType>
-    <FileVersion>3.3.0.0</FileVersion>
+    <FileVersion>3.4.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/PagesController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/PagesController.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Altinn.App.Services.Interface;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.App.Api.Controllers
+{
+    /// <summary>
+    /// Handles page related operations
+    /// </summary>
+    [Authorize]
+    [ApiController]
+    [Route("{org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/pages")]
+    public class PagesController : ControllerBase
+    {
+        private readonly IAltinnApp _altinnApp;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PagesController"/> class.
+        /// </summary>
+        /// <param name="altinnApp">The current App Core used to interface with custom logic</param>
+        public PagesController(IAltinnApp altinnApp)
+        {
+            _altinnApp = altinnApp;
+        }
+
+        /// <summary>
+        /// Get the page order based on the current state of the instance
+        /// </summary>
+        /// <returns>The pages sorted in the correct order</returns>
+        [HttpGet("order")]
+        public async Task<List<string>> GetPageOrder(
+            string currentPage,
+            [FromRoute] int instanceOwnerPartyId,
+            [FromRoute] Guid instanceGuid)
+        {
+          return await _altinnApp.GetPageOrder($"{instanceOwnerPartyId}/{instanceGuid}");
+        }
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/PagesController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/PagesController.cs
@@ -41,7 +41,7 @@ namespace Altinn.App.Api.Controllers
             [FromRoute] int instanceOwnerPartyId,
             [FromRoute] Guid instanceGuid)
         {
-          return await _altinnApp.GetPageOrder(currentPage,org, app, instanceOwnerPartyId, instanceGuid);
+            return await _altinnApp.GetPageOrder(currentPage, org, app, instanceOwnerPartyId, instanceGuid);
         }
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/PagesController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/PagesController.cs
@@ -38,10 +38,11 @@ namespace Altinn.App.Api.Controllers
             [FromRoute] string app,
             [FromRoute] int instanceOwnerPartyId,
             [FromRoute] Guid instanceGuid,
+            [FromQuery] string layoutSetId,
             [FromQuery] string currentPage,
             [FromQuery] string dataTypeId)
         {
-            return await _altinnApp.GetPageOrder(org, app, instanceOwnerPartyId, instanceGuid, currentPage, dataTypeId);
+            return await _altinnApp.GetPageOrder(org, app, instanceOwnerPartyId, instanceGuid, layoutSetId, currentPage, dataTypeId);
         }
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/PagesController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/PagesController.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 using Altinn.App.Services.Interface;
@@ -35,13 +34,14 @@ namespace Altinn.App.Api.Controllers
         /// <returns>The pages sorted in the correct order</returns>
         [HttpGet("order")]
         public async Task<List<string>> GetPageOrder(
-            string currentPage,
             [FromRoute] string org,
             [FromRoute] string app,
             [FromRoute] int instanceOwnerPartyId,
-            [FromRoute] Guid instanceGuid)
+            [FromRoute] Guid instanceGuid,
+            [FromQuery] string currentPage,
+            [FromQuery] string dataTypeId)
         {
-            return await _altinnApp.GetPageOrder(currentPage, org, app, instanceOwnerPartyId, instanceGuid);
+            return await _altinnApp.GetPageOrder(org, app, instanceOwnerPartyId, instanceGuid, currentPage, dataTypeId);
         }
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/PagesController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/PagesController.cs
@@ -36,10 +36,12 @@ namespace Altinn.App.Api.Controllers
         [HttpGet("order")]
         public async Task<List<string>> GetPageOrder(
             string currentPage,
+            [FromRoute] string org,
+            [FromRoute] string app,
             [FromRoute] int instanceOwnerPartyId,
             [FromRoute] Guid instanceGuid)
         {
-          return await _altinnApp.GetPageOrder($"{instanceOwnerPartyId}/{instanceGuid}");
+          return await _altinnApp.GetPageOrder(currentPage,org, app, instanceOwnerPartyId, instanceGuid);
         }
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/ResourceController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/ResourceController.cs
@@ -168,7 +168,7 @@ namespace Altinn.App.Api.Controllers
         [Route("{org}/{app}/api/layoutsettings")]
         public ActionResult GetLayoutSettings(string org, string app)
         {
-            string settings = _appResourceService.GetLayoutSettings();
+            string settings = _appResourceService.GetLayoutSettingsString();
             return Ok(settings);
         }
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/ResourceController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/ResourceController.cs
@@ -183,7 +183,7 @@ namespace Altinn.App.Api.Controllers
         [Route("{org}/{app}/api/layoutsettings/{id}")]
         public ActionResult GetLayoutSettings(string org, string app, string id)
         {
-            string settings = _appResourceService.GetLayoutSettingsForSet(id);
+            string settings = _appResourceService.GetLayoutSettingsStringForSet(id);
             return Ok(settings);
         }
 
@@ -219,28 +219,6 @@ namespace Altinn.App.Api.Controllers
             }
 
             return StatusCode(404);
-        }
-
-        /// <summary>
-        /// Get the ruleconfiguration.
-        /// </summary>
-        /// <param name="org">The application owner short name</param>
-        /// <param name="app">The application name</param>
-        /// <param name="id">The layoutset id</param>
-        /// <returns>The settings in the form of a string.</returns>
-        [HttpGet]
-        [Route("{org}/{app}/api/ruleconfiguration/{id}")]
-        public ActionResult GetRuleConfiguration(string org, string app, string id)
-        {
-            byte[] fileContent = _appResourceService.GetRuleConfigurationForSet(id);
-
-            if (fileContent == null)
-            {
-                // frontend will fail witout content
-                fileContent = new byte[0];
-            }
-
-            return new FileContentResult(fileContent, MimeTypeMap.GetMimeType(".json"));
-        }
+        }        
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,16 +3,16 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>3.3.0</Version>
+    <Version>3.4.0-alpha</Version>
     <Authors>Altinn</Authors>
     <Company>Altinn</Company>
     <Description>Package with common functionality for Altinn Apps created in Altinn Studio</Description>
     <PackageProjectUrl>https://github.com/Altinn/altinn-studio</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>3.3.0.0</AssemblyVersion>
+    <AssemblyVersion>3.4.0.0</AssemblyVersion>
     <IsPackable>true</IsPackable>
     <OutputType>Library</OutputType>
-    <FileVersion>3.3.0.0</FileVersion>
+    <FileVersion>3.4.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,16 +3,16 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>3.3.0</Version>
+    <Version>3.4.0-alpha</Version>
     <Authors>Altinn</Authors>
     <Company>Altinn</Company>
     <Description>Common services with Altinn Platform functionality and Altinn Apps functionality</Description>
     <PackageProjectUrl>https://github.com/Altinn/altinn-studio</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>3.3.0.0</AssemblyVersion>
+    <AssemblyVersion>3.4.0.0</AssemblyVersion>
     <IsPackable>true</IsPackable>
     <OutputType>Library</OutputType>
-    <FileVersion>3.3.0.0</FileVersion>
+    <FileVersion>3.4.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
@@ -240,9 +240,18 @@ namespace Altinn.App.Services.Implementation
         }
 
         /// <inheritdoc />
-        public virtual async Task<List<string>> GetPageOrder(string currentPage, string org, string app, int instanceOwnerId, Guid instanceGuid)
+        public virtual async Task<List<string>> GetPageOrder(string org, string app, int instanceOwnerId, Guid instanceGuid, string currentPage, string dataTypeId)
         {
-            LayoutSettings layoutSettings = _resourceService.GetLayoutSettings();
+            LayoutSettings layoutSettings = null;
+
+            if (string.IsNullOrEmpty(dataTypeId))
+            {
+                layoutSettings = _resourceService.GetLayoutSettings();
+            }
+            else
+            {
+                layoutSettings = _resourceService.GetLayoutSettingsForSet(dataTypeId);
+            }
 
             return await Task.FromResult(layoutSettings.Pages.Order);
         }
@@ -263,7 +272,7 @@ namespace Altinn.App.Services.Implementation
                 layoutSet = layoutSets.Sets.FirstOrDefault(t => t.DataType.Equals(dataElement.DataType) && t.Tasks.Contains(taskId));
             }
 
-            string layoutSettingsFileContent = layoutSet == null ? _resourceService.GetLayoutSettingsString() : _resourceService.GetLayoutSettingsForSet(layoutSet.Id);
+            string layoutSettingsFileContent = layoutSet == null ? _resourceService.GetLayoutSettingsString() : _resourceService.GetLayoutSettingsStringForSet(layoutSet.Id);
 
             LayoutSettings layoutSettings = null;
             if (!string.IsNullOrEmpty(layoutSettingsFileContent))

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
@@ -240,7 +240,7 @@ namespace Altinn.App.Services.Implementation
         }
 
         /// <inheritdoc />
-        public virtual async Task<List<string>> GetPageOrder(string instanceId)
+        public virtual async Task<List<string>> GetPageOrder(string currentPage, string org, string app, int instanceOwnerId, Guid instanceGuid)
         {
             LayoutSettings layoutSettings = _resourceService.GetLayoutSettings();
 
@@ -263,7 +263,7 @@ namespace Altinn.App.Services.Implementation
                 layoutSet = layoutSets.Sets.FirstOrDefault(t => t.DataType.Equals(dataElement.DataType) && t.Tasks.Contains(taskId));
             }
 
-            string layoutSettingsFileContent = layoutSet == null ? _resourceService.GetLayoutSettingsString() : _resourceService.GetLayoutSettingsStringForSet(layoutSet.Id);
+            string layoutSettingsFileContent = layoutSet == null ? _resourceService.GetLayoutSettingsString() : _resourceService.GetLayoutSettingsForSet(layoutSet.Id);
 
             LayoutSettings layoutSettings = null;
             if (!string.IsNullOrEmpty(layoutSettingsFileContent))

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
@@ -239,6 +239,14 @@ namespace Altinn.App.Services.Implementation
             await Task.CompletedTask;
         }
 
+        /// <inheritdoc />
+        public virtual async Task<List<string>> GetPageOrder(string instanceId)
+        {
+            LayoutSettings layoutSettings = _resourceService.GetLayoutSettings();
+
+            return await Task.FromResult(layoutSettings.Pages.Order);
+        }
+
         private async Task GenerateAndStoreReceiptPDF(Instance instance, string taskId, DataElement dataElement, Type dataElementModelType)
         {
             string app = instance.AppId.Split("/")[1];
@@ -255,7 +263,7 @@ namespace Altinn.App.Services.Implementation
                 layoutSet = layoutSets.Sets.FirstOrDefault(t => t.DataType.Equals(dataElement.DataType) && t.Tasks.Contains(taskId));
             }
 
-            string layoutSettingsFileContent = layoutSet == null ? _resourceService.GetLayoutSettings() : _resourceService.GetLayoutSettingsForSet(layoutSet.Id);
+            string layoutSettingsFileContent = layoutSet == null ? _resourceService.GetLayoutSettingsString() : _resourceService.GetLayoutSettingsStringForSet(layoutSet.Id);
 
             LayoutSettings layoutSettings = null;
             if (!string.IsNullOrEmpty(layoutSettingsFileContent))
@@ -385,7 +393,7 @@ namespace Altinn.App.Services.Implementation
                     }
 
                     dictionary.Add(optionsId, options);
-                }          
+                }
             }
 
             return dictionary;

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
@@ -240,17 +240,17 @@ namespace Altinn.App.Services.Implementation
         }
 
         /// <inheritdoc />
-        public virtual async Task<List<string>> GetPageOrder(string org, string app, int instanceOwnerId, Guid instanceGuid, string currentPage, string dataTypeId)
+        public virtual async Task<List<string>> GetPageOrder(string org, string app, int instanceOwnerId, Guid instanceGuid, string layoutSetId, string currentPage, string dataTypeId)
         {
             LayoutSettings layoutSettings = null;
 
-            if (string.IsNullOrEmpty(dataTypeId))
+            if (string.IsNullOrEmpty(layoutSetId))
             {
                 layoutSettings = _resourceService.GetLayoutSettings();
             }
             else
             {
-                layoutSettings = _resourceService.GetLayoutSettingsForSet(dataTypeId);
+                layoutSettings = _resourceService.GetLayoutSettingsForSet(layoutSetId);
             }
 
             return await Task.FromResult(layoutSettings.Pages.Order);

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
@@ -199,7 +199,7 @@ namespace Altinn.App.Services.Implementation
         }
 
         /// <inheritdoc />
-        public string GetLayoutSettings()
+        public string GetLayoutSettingsString()
         {
             string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, _settings.FormLayoutSettingsFileName);
             string filedata = null;
@@ -209,6 +209,20 @@ namespace Altinn.App.Services.Implementation
             }
 
             return filedata;
+        }
+        
+        /// <inheritdoc />
+        public LayoutSettings GetLayoutSettings()
+        {
+            string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, _settings.FormLayoutSettingsFileName);
+            string filedata = null;
+            if (File.Exists(filename))
+            {
+                filedata = File.ReadAllText(filename, Encoding.UTF8);
+            }
+
+            LayoutSettings layoutSettings = JsonConvert.DeserializeObject<LayoutSettings>(filedata);
+            return layoutSettings;
         }
 
         /// <inheritdoc />

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
@@ -334,9 +334,9 @@ namespace Altinn.App.Services.Implementation
         }
 
         /// <inheritdoc />
-        public string GetLayoutSettingsStringForSet(string dataTypeId)
+        public string GetLayoutSettingsStringForSet(string layoutSetId)
         {
-            string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, dataTypeId, _settings.FormLayoutSettingsFileName);
+            string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, layoutSetId, _settings.FormLayoutSettingsFileName);
             string filedata = null;
             if (File.Exists(filename))
             {
@@ -347,9 +347,9 @@ namespace Altinn.App.Services.Implementation
         }
 
         /// <inheritdoc />
-        public LayoutSettings GetLayoutSettingsForSet(string dataTypeId)
+        public LayoutSettings GetLayoutSettingsForSet(string layoutSetId)
         {
-            string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, dataTypeId, _settings.FormLayoutSettingsFileName);
+            string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, layoutSetId, _settings.FormLayoutSettingsFileName);
             string filedata = null;
             if (File.Exists(filename))
             {

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
@@ -315,11 +315,11 @@ namespace Altinn.App.Services.Implementation
         }
 
         /// <inheritdoc />
-        public string GetLayoutsForSet(string id)
+        public string GetLayoutsForSet(string layoutSetId)
         {
             Dictionary<string, object> layouts = new Dictionary<string, object>();
 
-            string layoutsPath = _settings.AppBasePath + _settings.UiFolder + id + "/layouts/";
+            string layoutsPath = _settings.AppBasePath + _settings.UiFolder + layoutSetId + "/layouts/";
             if (Directory.Exists(layoutsPath))
             {
                 foreach (string file in Directory.GetFiles(layoutsPath))

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
@@ -334,9 +334,9 @@ namespace Altinn.App.Services.Implementation
         }
 
         /// <inheritdoc />
-        public string GetLayoutSettingsForSet(string id)
+        public string GetLayoutSettingsStringForSet(string dataTypeId)
         {
-            string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, id, _settings.FormLayoutSettingsFileName);
+            string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, dataTypeId, _settings.FormLayoutSettingsFileName);
             string filedata = null;
             if (File.Exists(filename))
             {
@@ -344,6 +344,20 @@ namespace Altinn.App.Services.Implementation
             }
 
             return filedata;
+        }
+
+        /// <inheritdoc />
+        public LayoutSettings GetLayoutSettingsForSet(string dataTypeId)
+        {
+            string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, dataTypeId, _settings.FormLayoutSettingsFileName);
+            string filedata = null;
+            if (File.Exists(filename))
+            {
+                filedata = File.ReadAllText(filename, Encoding.UTF8);
+            }
+
+            LayoutSettings layoutSettings = JsonConvert.DeserializeObject<LayoutSettings>(filedata);
+            return layoutSettings;
         }
 
         /// <inheritdoc />

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
@@ -118,13 +118,14 @@ namespace Altinn.App.Services.Interface
         /// Gets the current page order of the app
         /// </summary>
         /// <param name="org">The app owner.</param>
-        /// <param name="app">The ap.</param>
+        /// <param name="app">The app.</param>
         /// <param name="instanceOwnerId">The instance owner partyId</param>
         /// <param name="instanceGuid">The instanceGuid</param>
+        /// <param name="layoutSetId">The layout set id</param>
         /// <param name="currentPage">The current page of the instance.</param>
         ///<param name="dataTypeId">The data type id of the current layout.</param>
         /// <returns> The pages in sorted order.</returns>
-        virtual async Task<List<string>> GetPageOrder(string org, string app, int instanceOwnerId, Guid instanceGuid, string currentPage, string dataTypeId)
+        virtual async Task<List<string>> GetPageOrder(string org, string app, int instanceOwnerId, Guid instanceGuid, string layoutSetId, string currentPage, string dataTypeId)
         {
             return await Task.FromResult(new List<string>());
         }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
@@ -123,7 +123,7 @@ namespace Altinn.App.Services.Interface
         /// <param name="instanceGuid">The instanceGuid</param>
         /// <param name="layoutSetId">The layout set id</param>
         /// <param name="currentPage">The current page of the instance.</param>
-        ///<param name="dataTypeId">The data type id of the current layout.</param>
+        ///¨<param name="dataTypeId">The data type id of the current layout.</param>
         /// <returns> The pages in sorted order.</returns>
         virtual async Task<List<string>> GetPageOrder(string org, string app, int instanceOwnerId, Guid instanceGuid, string layoutSetId, string currentPage, string dataTypeId)
         {

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
@@ -123,7 +123,7 @@ namespace Altinn.App.Services.Interface
         /// <param name="instanceGuid">The instanceGuid</param>
         /// <param name="layoutSetId">The layout set id</param>
         /// <param name="currentPage">The current page of the instance.</param>
-        ///¨<param name="dataTypeId">The data type id of the current layout.</param>
+        /// <param name="dataTypeId">The data type id of the current layout.</param>
         /// <returns> The pages in sorted order.</returns>
         virtual async Task<List<string>> GetPageOrder(string org, string app, int instanceOwnerId, Guid instanceGuid, string layoutSetId, string currentPage, string dataTypeId)
         {

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
@@ -117,13 +117,14 @@ namespace Altinn.App.Services.Interface
         /// <summary>
         /// Gets the current page order of the app
         /// </summary>
-        /// <param name="currentPage">The current page of the instance.</param>
         /// <param name="org">The app owner.</param>
         /// <param name="app">The ap.</param>
         /// <param name="instanceOwnerId">The instance owner partyId</param>
         /// <param name="instanceGuid">The instanceGuid</param>
+        /// <param name="currentPage">The current page of the instance.</param>
+        ///<param name="dataTypeId">The data type id of the current layout.</param>
         /// <returns> The pages in sorted order.</returns>
-        virtual async Task<List<string>> GetPageOrder(string currentPage, string org, string app, int instanceOwnerId, Guid instanceGuid)
+        virtual async Task<List<string>> GetPageOrder(string org, string app, int instanceOwnerId, Guid instanceGuid, string currentPage, string dataTypeId)
         {
             return await Task.FromResult(new List<string>());
         }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
@@ -117,8 +117,13 @@ namespace Altinn.App.Services.Interface
         /// <summary>
         /// Gets the current page order of the app
         /// </summary>
+        /// <param name="currentPage">The current page of the instance.</param>
+        /// <param name="org">The app owner.</param>
+        /// <param name="app">The ap.</param>
+        /// <param name="instanceOwnerId">The instance owner partyId</param>
+        /// <param name="instanceGuid">The instanceGuid</param>
         /// <returns>A list of the pages in sorted order.</returns>
-        virtual async Task<List<string>> GetPageOrder(string instanceId)
+        virtual async Task<List<string>> GetPageOrder(string currentPage, string org, string app, int instanceOwnerId, Guid instanceGuid)
         {
             return await Task.FromResult(new List<string>());
         }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
@@ -122,7 +122,7 @@ namespace Altinn.App.Services.Interface
         /// <param name="app">The ap.</param>
         /// <param name="instanceOwnerId">The instance owner partyId</param>
         /// <param name="instanceGuid">The instanceGuid</param>
-        /// <returns>A list of the pages in sorted order.</returns>
+        /// <returns> The pages in sorted order.</returns>
         virtual async Task<List<string>> GetPageOrder(string currentPage, string org, string app, int instanceOwnerId, Guid instanceGuid)
         {
             return await Task.FromResult(new List<string>());

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAltinnApp.cs
@@ -115,6 +115,15 @@ namespace Altinn.App.Services.Interface
         Task<AppOptions> GetOptions(string id, AppOptions options);
 
         /// <summary>
+        /// Gets the current page order of the app
+        /// </summary>
+        /// <returns>A list of the pages in sorted order.</returns>
+        virtual async Task<List<string>> GetPageOrder(string instanceId)
+        {
+            return await Task.FromResult(new List<string>());
+        }
+
+        /// <summary>
         /// Event where app developers can add logic. 
         /// </summary>
         /// <param name="taskId">The taskId</param>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAppResources.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAppResources.cs
@@ -88,8 +88,14 @@ namespace Altinn.App.Services.Interface
         /// <summary>
         /// Gets the the layouts settings
         /// </summary>
+        /// <returns>The layout settings as a JSON string</returns>
+        string GetLayoutSettingsString();
+
+        /// <summary>
+        /// Gets the layout settings
+        /// </summary>
         /// <returns>The layout settings</returns>
-        string GetLayoutSettings();
+        LayoutSettings GetLayoutSettings();
 
         /// <summary>
         /// Gets the the layout sets

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAppResources.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAppResources.cs
@@ -106,14 +106,22 @@ namespace Altinn.App.Services.Interface
         /// <summary>
         /// Gets the layouts for av given layoutset
         /// </summary>
+        /// <param name="dataTypeId">The data type id</param>
         /// <returns>A dictionary of FormLayout objects serialized to JSON</returns>
-        string GetLayoutsForSet(string id);
+        string GetLayoutsForSet(string dataTypeId);
+
+        /// <summary>
+        /// Gets the the layouts settings for a layoutset
+        /// </summary>
+        /// <param name="dataTypeId">The data type id</param>
+        /// <returns>The layout settings as a JSON string</returns>
+        string GetLayoutSettingsStringForSet(string dataTypeId);
 
         /// <summary>
         /// Gets the the layouts settings for a layoutset
         /// </summary>
         /// <returns>The layout settings</returns>
-        string GetLayoutSettingsForSet(string id);
+        LayoutSettings GetLayoutSettingsForSet(string id);
 
         /// <summary>
         /// Gets the ruleconfiguration for av given layoutset

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAppResources.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAppResources.cs
@@ -106,22 +106,22 @@ namespace Altinn.App.Services.Interface
         /// <summary>
         /// Gets the layouts for av given layoutset
         /// </summary>
-        /// <param name="dataTypeId">The data type id</param>
+        /// <param name="layoutSetId">The layot set id</param>
         /// <returns>A dictionary of FormLayout objects serialized to JSON</returns>
-        string GetLayoutsForSet(string dataTypeId);
+        string GetLayoutsForSet(string layoutSetId);
 
         /// <summary>
         /// Gets the the layouts settings for a layoutset
         /// </summary>
-        /// <param name="dataTypeId">The data type id</param>
+        /// <param name="layoutSetId">The layot set id</param>
         /// <returns>The layout settings as a JSON string</returns>
-        string GetLayoutSettingsStringForSet(string dataTypeId);
+        string GetLayoutSettingsStringForSet(string layoutSetId);
 
         /// <summary>
         /// Gets the the layouts settings for a layoutset
         /// </summary>
         /// <returns>The layout settings</returns>
-        LayoutSettings GetLayoutSettingsForSet(string id);
+        LayoutSettings GetLayoutSettingsForSet(string layoutSetId);
 
         /// <summary>
         /// Gets the ruleconfiguration for av given layoutset

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/PagesApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/PagesApiTest.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+using Altinn.App.IntegrationTests;
+
+using App.IntegrationTests.Utils;
+using App.IntegrationTestsRef.Utils;
+
+using Newtonsoft.Json;
+
+using Xunit;
+
+namespace App.IntegrationTestsRef.ApiTests
+{
+    /// <summary>
+    /// Test clas for PagesController
+    /// </summary>
+    public class PagesApiTest : IClassFixture<CustomWebApplicationFactory<Altinn.App.Startup>>
+    {
+        private readonly CustomWebApplicationFactory<Altinn.App.Startup> _factory;
+
+        public PagesApiTest(CustomWebApplicationFactory<Altinn.App.Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        /// <summary>
+        /// Scenario: Request to get pages order, but user is not authorized.
+        /// Successful: Access to the api is not granted. Unauthorized response.
+        /// </summary>
+        [Fact]
+        public async Task GetPageOrder_NoTokenIncluded_NotAuthorizedResponse()
+        {
+            HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
+            HttpRequestMessage httpRequestMessage =
+                new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/instances/1001/26133fb5-a9f2-45d4-90b1-f6d93ad40713/pages/order");
+
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        /// <summary>
+        /// Scenario: Get page order for an app without layout set. No custom implementation in app.
+        /// Successful: Pages retrieved from layout settings and returned without manipulation.
+        /// </summary>
+        [Fact]
+        public async Task GetPageOrder_NoCustomConfiguration_PageOrderIsRetrievedFromAppBaseAndReturned()
+        {
+            string org = "ttd";
+            string app = "events";
+            List<string> expected = new List<string> { "FormLayout", "Side2" };
+
+            // Using default app here to not reference App.cs in the app repo.
+            HttpClient client = SetupUtil.GetTestClient(_factory, org, app);
+            string token = PrincipalUtil.GetToken(1337);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            HttpRequestMessage httpRequestMessage =
+                new HttpRequestMessage(HttpMethod.Get, $"/{org}/{app}/instances/1001/26133fb5-a9f2-45d4-90b1-f6d93ad40713/pages/order");
+
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            List<string> actual = JsonConvert.DeserializeObject<List<string>>(responseContent);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(expected, actual);
+        }
+
+        /// <summary>
+        /// Scenario: Get page order for an app without layout set. Custom implementation in app.cs should override AppBase.
+        /// Successful: Pages retrieved from custom app code. 
+        /// </summary>
+        [Fact]
+        public async Task GetPageOrder_CustomConfiguration_PageOrderIsRetrievedFromAppAndReturned()
+        {
+            string org = "ttd";
+            string app = "issue-5740";
+            List<string> expected = new List<string> { "Side4", "Side2", "Side1", "Side3" };
+
+            HttpClient client = SetupUtil.GetTestClient(_factory, org, app);
+            string token = PrincipalUtil.GetToken(1337);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            HttpRequestMessage httpRequestMessage =
+                new HttpRequestMessage(HttpMethod.Get, $"/{org}/{app}/instances/1001/26133fb5-a9f2-45d4-90b1-f6d93ad40713/pages/order");
+
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            List<string> actual = JsonConvert.DeserializeObject<List<string>>(responseContent);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/PagesApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/PagesApiTest.cs
@@ -96,5 +96,31 @@ namespace App.IntegrationTestsRef.ApiTests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(expected, actual);
         }
+        /// <summary>
+        /// Scenario: Get page order for an app with layout set. No custom implementation in app.
+        /// Successful: Pages retrieved from correct layout settings and returned without manipulation.
+        /// </summary>
+        [Fact]
+        public async Task GetPageOrder_NoCustomConfigurationLayoutSet_PageOrderIsRetrievedFromAppBaseAndReturned()
+        {
+            string org = "ttd";
+            string app = "frontend-test";
+            List<string> expected = new List<string> { "formLayout", "summary" };
+
+            // Using default app here to not reference App.cs in the app repo.
+            HttpClient client = SetupUtil.GetTestClient(_factory, org, app);
+            string token = PrincipalUtil.GetToken(1337);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            HttpRequestMessage httpRequestMessage =
+                new HttpRequestMessage(HttpMethod.Get, $"/{org}/{app}/instances/1001/26133fb5-a9f2-45d4-90b1-f6d93ad40713/pages/order?layoutSetId=changename");
+
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            List<string> actual = JsonConvert.DeserializeObject<List<string>>(responseContent);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/App.IntegrationTestsRef.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/App.IntegrationTestsRef.csproj
@@ -192,6 +192,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Data\apps\ttd\issue-5740\logic\Validation\" />
     <Folder Include="Data\Instances\ttd\model-validation\1337\8fab6615-3c57-484b-bd32-3065be958a1e\blob\" />
   </ItemGroup>
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/task-validation/logic/AltinnApp.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/task-validation/logic/AltinnApp.cs
@@ -94,6 +94,7 @@ namespace App.IntegrationTests.Mocks.Apps.tdd.task_validation
 
         public override async Task RunProcessTaskEnd(string taskId, Instance instance)
         {
+            await Task.CompletedTask;
             return;
         }
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/events/ui/Settings.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/events/ui/Settings.json
@@ -1,0 +1,9 @@
+﻿{
+  "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": [
+      "FormLayout",
+      "Side2"
+    ]
+  }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/appsettings.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/appsettings.json
@@ -1,0 +1,33 @@
+{
+  "Kestrel": {
+    "EndPoints": {
+      "Http": {
+        "Url": "http://*:5005"
+      }
+    }
+  },
+  "AppSettings": {
+    "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
+    "Hostname": "altinn3local.no",
+    "RuntimeCookieName": "AltinnStudioRuntime",
+    "RegisterEventsWithEventsComponent": false
+  },
+  "GeneralSettings": {
+    "HostName": "altinn3local.no",
+    "SoftValidationPrefix": "*WARNING*",
+    "AltinnPartyCookieName": "AltinnPartyId"
+  },
+  "PlatformSettings": {
+    "ApiStorageEndpoint": "http://localhost:5101/storage/api/v1/",
+    "ApiRegisterEndpoint": "http://localhost:5101/register/api/v1/",
+    "ApiProfileEndpoint": "http://localhost:5101/profile/api/v1/",
+    "ApiAuthenticationEndpoint": "http://localhost:5101/authentication/api/v1/",
+    "ApiAuthorizationEndpoint": "http://localhost:5101/authorization/api/v1/",
+    "ApiEventsEndpoint": "http://localhost:5101/events/api/v1/",
+    "ApiPdfEndpoint": "http://localhost:5070/api/v1/",
+    "SubscriptionKey": "retrieved from environment at runtime"
+  },
+  "ApplicationInsights": {
+    "InstrumentationKey": "retrieved from environment at runtime"
+  }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/config/applicationmetadata.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/config/applicationmetadata.json
@@ -1,0 +1,67 @@
+﻿{
+  "id": "ttd/frontend-test",
+  "org": "ttd",
+  "title": {
+    "nb": "frontend-test"
+  },
+  "dataTypes": [{
+      "id": "message",
+      "allowedContentTypes": [
+        "application/xml"
+      ],
+      "appLogic": {
+        "autoCreate": true,
+        "classRef": "Altinn.App.Models.MessageV1"
+      },
+      "taskId": "Task_1",
+      "maxCount": 1,
+      "minCount": 1
+    },
+    {
+      "id": "fileUpload-message",
+      "taskId": "Task_1",
+      "maxSize": 5,
+      "maxCount": 3,
+      "minCount": 0
+    },
+    {
+      "id": "ServiceModel-test",
+      "allowedContentTypes": [
+        "application/xml"
+      ],
+      "appLogic": {
+        "autoCreate": true,
+        "classRef": "Altinn.App.Models.Skjema"
+      },
+      "taskId": "Task_2",
+      "maxCount": 1,
+      "minCount": 1
+    },
+    {
+      "id": "fileUpload-changename",
+      "taskId": "Task_2",
+      "maxSize": 5,
+      "maxCount": 3,
+      "minCount": 0
+    },
+    {
+      "id": "ref-data-as-pdf",
+      "allowedContentTypes": [
+        "application/pdf"
+      ],
+      "maxCount": 0,
+      "minCount": 0
+    }
+  ],
+  "partyTypesAllowed": {
+    "bankruptcyEstate": false,
+    "organisation": false,
+    "person": false,
+    "subUnit": false
+  },
+  "autoDeleteOnProcessEnd": false,
+  "created": "2021-02-06T15:18:12.2060944Z",
+  "createdBy": "jeeva",
+  "lastChanged": "2021-02-06T15:18:12.2062288Z",
+  "lastChangedBy": "jeeva"
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/config/authorization/policy.xml
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/config/authorization/policy.xml
@@ -1,0 +1,293 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy xmlns:xsl="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="urn:altinn:example:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides">
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:1" Effect="Permit">
+    <xacml:Description>A rule giving user with role REGNA or DAGL and the app owner ttd the right to instantiate a instance of a given app of ttd/frontend-test</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">REGNA</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DAGL</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">instantiate</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:2" Effect="Permit">
+    <xacml:Description>Rule that defines that user with role REGNA or DAGL can read and write for ttd/frontend-test when it is in Task_1</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">REGNA</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DAGL</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_2</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">EndEvent_1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:end-event" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:3" Effect="Permit">
+    <xacml:Description>Rule that defines that user with role REGNA or DAGL can delete instances of ttd/frontend-test</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">REGNA</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DAGL</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">delete</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:4" Effect="Permit">
+    <xacml:Description>Rule that defines that org can write to instances of ttd/frontend-test for any states</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:5" Effect="Permit">
+    <xacml:Description>Rule that defines that org can complete an instance of ttd/frontend-test which state is at the end event.</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">EndEvent_1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:end-event" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">complete</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:6" Effect="Permit">
+    <xacml:Description>A rule giving user with role REGNA or DAGL and the app owner ttd the right to read the appresource events of a given app of ttd/frontend-test</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">REGNA</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DAGL</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">frontend-test</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">events</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:appresource" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:ObligationExpressions>
+    <xacml:ObligationExpression FulfillOn="Permit" ObligationId="urn:altinn:obligation:authenticationLevel1">
+      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel">
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue>
+      </xacml:AttributeAssignmentExpression>
+    </xacml:ObligationExpression>
+  </xacml:ObligationExpressions>
+</xacml:Policy>

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/config/process/process.bpmn
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/config/process/process.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions id="Altinn_SingleDataTask_Process_Definition"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:altinn="http://altinn.no"
+	xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+	xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+	xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+	xmlns:di="http://www.omg.org/spec/DD/20100524/DI" targetNamespace="http://bpmn.io/schema/bpmn">
+	<bpmn:process id="SingleDataTask" isExecutable="false">
+		<bpmn:startEvent id="StartEvent_1">
+			<bpmn:outgoing>SequenceFlow_1n56yn5</bpmn:outgoing>
+		</bpmn:startEvent>
+		<bpmn:task id="Task_1" name="Utfylling" altinn:tasktype="data">
+			<bpmn:incoming>SequenceFlow_1n56yn5</bpmn:incoming>
+			<bpmn:outgoing>SequenceFlow_1oot28q</bpmn:outgoing>
+		</bpmn:task>
+		<bpmn:task id="Task_2" name="Utfylling" altinn:tasktype="data">
+			<bpmn:incoming>SequenceFlow_1n56yn5</bpmn:incoming>
+			<bpmn:outgoing>SequenceFlow_1oot28q</bpmn:outgoing>
+		</bpmn:task>
+		<bpmn:endEvent id="EndEvent_1">
+			<bpmn:incoming>SequenceFlow_1oot28q</bpmn:incoming>
+		</bpmn:endEvent>
+		<bpmn:sequenceFlow id="SequenceFlow_1n56yn5" sourceRef="StartEvent_1" targetRef="Task_1" />
+		<bpmn:sequenceFlow id="SequenceFlow_1ooth8q" sourceRef="Task_1" targetRef="Task_2" />
+		<bpmn:sequenceFlow id="SequenceFlow_1oot28q" sourceRef="Task_2" targetRef="EndEvent_1" />
+	</bpmn:process>
+</bpmn:definitions>

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/config/texts/resource.nb.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/config/texts/resource.nb.json
@@ -1,0 +1,131 @@
+{
+  "language": "nb",
+  "resources": [{
+      "id": "ServiceName",
+      "value": "frontend-test"
+    },
+    { "id": "messageTitle", "value": "## Appen for test av app frontend", "variables": null },
+    { "id": "messageBody", "value": "Bruke dette app for å teste app frontend <br/> 1. Melding <br/> 2. Endring-av-navn-v2", "variables": null },
+    { "id": "messageAttachments", "value": "Vedlegg", "variables": null },
+    {
+      "id": "BegrunnelseAnnet",
+      "value": "Forklar hvorfor du ønsker å ta navnet, og eventuelt hvilken tilknytning du har til navnet:"
+    },
+    {
+      "id": "BegrunnelseGard1",
+      "value": "Gårdsbruk du vil ta navnet fra"
+    },
+    {
+      "id": "BegrunnelseGard2",
+      "value": "Kommune gårdsbruket ligger i"
+    },
+    {
+      "id": "BegrunnelseGard3",
+      "value": "Gårdsnummer"
+    },
+    {
+      "id": "BegrunnelseGard4",
+      "value": "Bruksnummer"
+    },
+    {
+      "id": "BegrunnelseGard5",
+      "value": "Forklar din tilknytning til gårdsbruket"
+    },
+    {
+      "id": "BegrunnelseNyttNavn",
+      "value": "Du ønsker å ta et navn som du tror er nytt i Norge. Forklar hvorfor du ønsker dette navnet:"
+    },
+    {
+      "id": "BegrunnelseSamboer1",
+      "value": "Etternavn på samboer"
+    },
+    {
+      "id": "BegrunnelseSamboer2",
+      "value": "Fødselsnummer på samboer"
+    },
+    {
+      "id": "BegrunnelseSlektskap",
+      "value": "Forklar hvem du tar navnet fra, og hvilken side slektskapet ligger"
+    },
+    {
+      "id": "BegrunnelseSteforeldre",
+      "value": "Etternavn på ste- eller fosterforeldre du ønsker å ta navnet til"
+    },
+    {
+      "id": "BegrunnelseValgNavn",
+      "value": "Vennligst oppgi begrunnelse for endring av navn"
+    },
+    {
+      "id": "BekreftNavnTittel",
+      "value": "Bekreftelse av navn"
+    },
+    {
+      "id": "DineEndringer",
+      "value": "Dine endringer"
+    },
+    {
+      "id": "EndreNavnFra",
+      "value": "Du har valgt å endre:"
+    },
+    {
+      "id": "EndreNavnTil",
+      "value": "Til:"
+    },
+    {
+      "id": "Epost",
+      "value": "E-post"
+    },
+    {
+      "id": "Fodselsnummer",
+      "value": "Fødselsnummer"
+    },
+    {
+      "id": "HintEtternavn",
+      "value": "Bindestrek må benyttes dersom du ønsker to etternavn."
+    },
+    {
+      "id": "HintMellomnavn",
+      "value": "Mellomnavn må være et navn som kan benyttes som etternavn. "
+    },
+    {
+      "id": "Kontaktinformasjon",
+      "value": "Kontaktinformasjon"
+    },
+    {
+      "id": "NavarendeNavn",
+      "value": "Nåværende navn"
+    },
+    {
+      "id": "PersonNyttEtternavn",
+      "value": "Nytt etternavn"
+    },
+    {
+      "id": "PersonNyttFornavn",
+      "value": "Nytt fornavn"
+    },
+    {
+      "id": "PersonNyttMellomnavn",
+      "value": "Nytt mellomnavn"
+    },
+    {
+      "id": "datofeltet",
+      "value": "Når vil du at navnendringen skal skje?"
+    },
+    {
+      "id": "kontaktinfoBeskrivelse",
+      "value": "Denne kontaktinformasjonen brukes til å kontakte deg hvis det er noen spørsmål rundt informasjonen du har sendt inn."
+    },
+    {
+      "id": "vedlegg",
+      "value": "Last opp eventuell dokumentasjon for ditt nye navn"
+    },
+    {
+      "id": "PersonNyttFornavn.helptext",
+      "value": "Tenk deg godt om, det tar 10 år før du kan endre navn igjen"
+    },
+    {
+      "id": "summaryTitle",
+      "value": "## Oppsummering"
+    }
+  ]
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/App.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/App.cs
@@ -91,7 +91,6 @@ namespace App.IntegrationTests.Mocks.Apps.tdd.frontendtest
         /// <summary>
         /// Run data validation event to perform custom validations on data
         /// </summary>
-        /// <param name="validationResults">Object to contain any validation errors/warnings</param>
         /// <returns>Value indicating if the form is valid or not</returns>
         public override async Task RunDataValidation(object data, ModelStateDictionary validationResults)
         {
@@ -101,7 +100,6 @@ namespace App.IntegrationTests.Mocks.Apps.tdd.frontendtest
         /// <summary>
         /// Run task validation event to perform custom validations on instance
         /// </summary>
-        /// <param name="validationResults">Object to contain any validation errors/warnings</param>
         /// <returns>Value indicating if the form is valid or not</returns>
         public override async Task RunTaskValidation(Instance instance, string taskId, ModelStateDictionary validationResults)
         {
@@ -129,7 +127,6 @@ namespace App.IntegrationTests.Mocks.Apps.tdd.frontendtest
         /// <summary>
         /// Is called to run data creation (custom prefill) defined by app developer.
         /// </summary>
-        /// <param name="instance">The data to perform data creation on</param>
         public override async Task RunDataCreation(Instance instance, object data)
         {
            await _instantiationHandler.DataCreation(instance, data);

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/App.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/App.cs
@@ -1,30 +1,22 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-
-using Altinn.App.AppLogic.Calculation;
 using Altinn.App.AppLogic.Print;
-using Altinn.App.AppLogic.Validation;
-using Altinn.App.Common.Enums;
-using Altinn.App.Common.Models;
-using Altinn.App.Services.Configuration;
-using Altinn.App.Services.Implementation;
 using Altinn.App.Services.Interface;
+using Microsoft.Extensions.Logging;
+using Altinn.App.Services.Implementation;
+using Altinn.App.Common.Enums;
+using Altinn.App.AppLogic.Validation;
+using Altinn.App.AppLogic.Calculation;
 using Altinn.App.Services.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
-
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.Extensions.Logging;
+using Altinn.App.Common.Models;
 using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Http;
+using Altinn.App.Services.Configuration;
 
-#pragma warning disable SA1300 // Element should begin with upper-case letter
-namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
-#pragma warning restore SA1300 // Element should begin with upper-case letter
+namespace App.IntegrationTests.Mocks.Apps.tdd.frontendtest
 {
-    /// <summary>
-    /// Represents the core logic of an App
-    /// </summary>
     public class App : AppBase, IAltinnApp
     {
         private readonly ILogger<App> _logger;
@@ -33,62 +25,39 @@ namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
         private readonly InstantiationHandler _instantiationHandler;
         private readonly PdfHandler _pdfHandler;
 
-        /// <summary>
-        /// Initialize a new instance of the <see cref="App"/> class.
-        /// </summary>
-        /// <param name="appResourcesService">A service with access to local resources.</param>
-        /// <param name="logger">A logger from the built in LoggingFactory.</param>
-        /// <param name="dataService">A service with access to data storage.</param>
-        /// <param name="processService">A service with access to the process.</param>
-        /// <param name="pdfService">A service with access to the PDF generator.</param>
-        /// <param name="profileService">A service with access to profile information.</param>
-        /// <param name="registerService">A service with access to register information.</param>
-        /// <param name="prefillService">A service with access to prefill mechanisms.</param>
-        /// <param name="instanceService">A service with access to instances</param>
-        /// <param name="settings">General settings</param>
-        /// <param name="textService">A service with access to text</param>
-        /// <param name="httpContextAccessor">A context accessor</param>
         public App(
-            IAppResources appResourcesService,
-            ILogger<App> logger,
-            IData dataService,
-            IProcess processService,
-            IPDF pdfService,
-            IProfile profileService,
-            IRegister registerService,
-            IPrefill prefillService,
-            IInstance instanceService,
-            IOptions<GeneralSettings> settings,
-            IText textService,
-            IHttpContextAccessor httpContextAccessor) : base(
-                appResourcesService,
-                logger,
-                dataService,
-                processService,
-                pdfService,
-                prefillService,
-                instanceService,
-                registerService,
-                settings,
-                profileService,
-                textService,
-                httpContextAccessor)
-        {
-            _logger = logger;
-            _validationHandler = new ValidationHandler(httpContextAccessor);
-            _calculationHandler = new CalculationHandler();
-            _instantiationHandler = new InstantiationHandler(profileService, registerService);
-            _pdfHandler = new PdfHandler();
-        }
+        IAppResources appResourcesService,
+        ILogger<App> logger,
+        IData dataService,
+        IProcess processService,
+        IPDF pdfService,
+        IProfile profileService,
+        IRegister registerService,
+        IPrefill prefillService,
+        IInstance instanceService,
+        IOptions<GeneralSettings> settings,
+        IText textService,
+        IHttpContextAccessor httpContextAccessor) : base(
+            appResourcesService,
+            logger,
+            dataService,
+            processService,
+            pdfService,
+            prefillService,
+            instanceService,
+            registerService,
+            settings,
+            profileService,
+            textService,
+            httpContextAccessor)
+            {
+                _logger = logger;
+                _validationHandler = new ValidationHandler(httpContextAccessor);
+                _calculationHandler = new CalculationHandler();
+                _instantiationHandler = new InstantiationHandler(profileService, registerService);
+                _pdfHandler = new PdfHandler();
+            }
 
-        /// <inheritdoc />
-        public override async Task<List<string>> GetPageOrder(string org, string app, int instanceOwnerId, Guid instanceGuid, string layoutSetId, string currentPage, string dataTypeId)
-        {
-            await Task.CompletedTask;
-            return new List<string> { "Side4", "Side2", "Side1", "Side3" };
-        }
-
-        /// <inheritdoc />
         public override object CreateNewAppModel(string classRef)
         {
             _logger.LogInformation($"CreateNewAppModel {classRef}");
@@ -97,7 +66,6 @@ namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
             return Activator.CreateInstance(appType);
         }
 
-        /// <inheritdoc />
         public override Type GetAppModelType(string classRef)
         {
             _logger.LogInformation($"GetAppModelType {classRef}");
@@ -112,8 +80,8 @@ namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
         /// <param name="appEvent">The app event type</param>
         /// <param name="model">The service model</param>
         /// <param name="modelState">The model state</param>
-        /// <returns>True if the event was handled</returns>
-        public override async Task<bool> RunAppEvent(AppEventType appEvent, object model, ModelStateDictionary modelState = null)
+        /// <returns></returns>
+        public override async Task<bool> RunAppEvent(AppEventType appEvent, object model, ModelStateDictionary modelState)
         {
             _logger.LogInformation($"RunAppEvent {appEvent}");
 
@@ -123,21 +91,18 @@ namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
         /// <summary>
         /// Run data validation event to perform custom validations on data
         /// </summary>
-        /// <param name="data">An instance of the data to be validated.</param>
         /// <param name="validationResults">Object to contain any validation errors/warnings</param>
         /// <returns>Value indicating if the form is valid or not</returns>
         public override async Task RunDataValidation(object data, ModelStateDictionary validationResults)
         {
-            await _validationHandler.ValidateData(data, validationResults);
+           await _validationHandler.ValidateData(data, validationResults);
         }
 
         /// <summary>
         /// Run task validation event to perform custom validations on instance
         /// </summary>
-        /// <param name="instance">A reference to the current instance.</param>
-        /// <param name="taskId">The name of the process step to validate based on.</param>
-        /// <param name="validationResults">Object to contain any validation errors/warnings.</param>
-        /// <returns>A task supporting the async await pattern.</returns>
+        /// <param name="validationResults">Object to contain any validation errors/warnings</param>
+        /// <returns>Value indicating if the form is valid or not</returns>
         public override async Task RunTaskValidation(Instance instance, string taskId, ModelStateDictionary validationResults)
         {
             await _validationHandler.ValidateTask(instance, taskId, validationResults);
@@ -165,13 +130,11 @@ namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
         /// Is called to run data creation (custom prefill) defined by app developer.
         /// </summary>
         /// <param name="instance">The data to perform data creation on</param>
-        /// <param name="data">The data object being created</param>
         public override async Task RunDataCreation(Instance instance, object data)
         {
-            await _instantiationHandler.DataCreation(instance, data);
+           await _instantiationHandler.DataCreation(instance, data);
         }
 
-        /// <inheritdoc />
         public override Task<AppOptions> GetOptions(string id, AppOptions options)
         {
             return Task.FromResult(options);
@@ -182,10 +145,10 @@ namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
         /// </summary>
         /// <param name="taskId">The current TaskId</param>
         /// <param name="instance">The instance where task is ended</param>
-        /// <returns>A task supporting the async await pattern.</returns>
+        /// <returns></returns>
         public override async Task RunProcessTaskEnd(string taskId, Instance instance)
         {
-            await Task.CompletedTask;
+            return;
         }
 
         /// <summary>

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/App.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/App.cs
@@ -145,6 +145,7 @@ namespace App.IntegrationTests.Mocks.Apps.tdd.frontendtest
         /// <returns></returns>
         public override async Task RunProcessTaskEnd(string taskId, Instance instance)
         {
+            await Task.CompletedTask;
             return;
         }
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/Calculation/CalculationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/Calculation/CalculationHandler.cs
@@ -1,14 +1,14 @@
 using System.Threading.Tasks;
+//using Altinn.App.Models; // <-- Uncomment this line to refer to app model(s)
 
-//// using Altinn.App.Models; // <-- Uncomment this line to refer to app model(s)
-
-namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
+namespace App.IntegrationTests.Mocks.Apps.tdd.frontendtest
 {
-    /// <summary>
-    /// Represents a business logic class responsible for running calculations on an instance.
-    /// </summary>
     public class CalculationHandler
     {
+        public CalculationHandler()
+        {
+        }
+
         /// <summary>
         /// Perform calculations and update data model
         /// </summary>

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/InstantiationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/InstantiationHandler.cs
@@ -1,26 +1,22 @@
-using System.Threading.Tasks;
+using Altinn.App.Models;
 using Altinn.App.Services.Interface;
 using Altinn.App.Services.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
+using System.Threading.Tasks;
+using Altinn.Platform.Register.Models;
 
-//// using Altinn.App.Models; // Uncomment this line to refer to app model(s)
-
-namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
+namespace App.IntegrationTests.Mocks.Apps.tdd.frontendtest
 {
-    /// <summary>
-    /// Represents a business logic class responsible for running logic related to instantiation.
-    /// </summary>
     public class InstantiationHandler
     {
         private IProfile _profileService;
         private IRegister _registerService;
 
         /// <summary>
-        /// Initialize a new instance of the <see cref="InstantiationHandler"/> class with services
-        /// that can be used to access profile and register information.
+        /// Set up access to profile and register services
         /// </summary>
-        /// <param name="profileService">A service with access to profile information</param>
-        /// <param name="registerService">A service with access to register information</param>
+        /// <param name="profileService"></param>
+        /// <param name="registerService"></param>
         public InstantiationHandler(IProfile profileService, IRegister registerService)
         {
             _profileService = profileService;
@@ -37,7 +33,8 @@ namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
         /// }
         /// return null;
         /// </example>
-        /// <param name="instance">The instance being validated</param>
+        /// <param name="instance"></param>
+        /// <param name="validationResults"></param>
         /// <returns>The validation result object (null if no errors) </returns>
         public async Task<InstantiationValidationResult> RunInstantiationValidation(Instance instance)
         {
@@ -54,6 +51,26 @@ namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
         /// <param name="data">The data object created</param>
         public async Task DataCreation(Instance instance, object data)
         {
+           if (data.GetType() == typeof(Skjema))
+            {
+                Skjema model = (Skjema)data;
+                int partyId;
+                if (int.TryParse(instance.InstanceOwner.PartyId, out partyId))
+                {
+                    Party party = await _registerService.GetParty(partyId);
+                    model.Innledninggrp9309 = new Innledninggrp9309()
+                    {
+                        Kontaktinformasjongrp9311 = new Kontaktinformasjongrp9311()
+                        {
+                            MelderFultnavn = new MelderFultnavn()
+                            {
+                                value = party.Name
+                            }
+                        }
+                    };
+                }
+            }
+
             await Task.CompletedTask;
         }
     }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/InstantiationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/InstantiationHandler.cs
@@ -34,7 +34,6 @@ namespace App.IntegrationTests.Mocks.Apps.tdd.frontendtest
         /// return null;
         /// </example>
         /// <param name="instance"></param>
-        /// <param name="validationResults"></param>
         /// <returns>The validation result object (null if no errors) </returns>
         public async Task<InstantiationValidationResult> RunInstantiationValidation(Instance instance)
         {

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/Print/PdfHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/Print/PdfHandler.cs
@@ -1,0 +1,120 @@
+using System.Threading.Tasks;
+using Altinn.App.Common.Models;
+using Altinn.App.Models;
+using System.Collections.Generic;
+
+namespace App.IntegrationTests.Mocks.Apps.tdd.frontendtest{
+    /// <summary>
+    /// Handler for formatting PDF. 
+    /// </summary>
+    public class PdfHandler
+    {
+        /// <summary>
+        /// Method to format PDF dynamic
+        /// </summary>
+        /// <example>
+        ///     if (data.GetType() == typeof(Skjema)
+        ///     {
+        ///     // need to create object if not there
+        ///     layoutSettings.Components.ExcludeFromPdf.Add("a23234234");
+        ///     }
+        /// </example>
+        /// <param name="layoutSettings">the layoutsettings</param>
+        /// <param name="data">data object</param>
+        public async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data)
+        {
+            if (data is Skjema)
+            {
+                Skjema skjema = (Skjema)data;
+
+                if (skjema.Radioknapp == "1")
+                {
+                    layoutSettings.Components.ExcludeFromPdf.AddRange(new List<string>()
+                    {"reasonParents",
+                    "reasonSSN",
+                    "reasonCohabitant1",
+                    "reasonCohabitant2",
+                    "reasonFarm1",
+                    "reasonFarm2",
+                    "reasonFarm3",
+                    "reasonFarm4",
+                    "reasonFarm5",
+                    "reasonNewName",
+                    "reasonOthers"});
+                }
+
+                if (skjema.Radioknapp == "3")
+                {
+                    layoutSettings.Components.ExcludeFromPdf.AddRange(new List<string>() {"reasonRelationship",
+                    "reasonCohabitant1",
+                    "reasonCohabitant2",
+                    "reasonFarm1",
+                    "reasonFarm2",
+                    "reasonFarm3",
+                    "reasonFarm4",
+                    "reasonFarm5",
+                    "reasonNewName",
+                    "reasonOthers"});
+                }
+
+                if (skjema.Radioknapp == "5")
+                {
+                    layoutSettings.Components.ExcludeFromPdf.AddRange(new List<string>() {"reasonRelationship",
+                    "reasonParents",
+                    "reasonSSN",
+                    "reasonFarm1",
+                    "reasonFarm2",
+                    "reasonFarm3",
+                    "reasonFarm4",
+                    "reasonFarm5",
+                    "reasonNewName",
+                    "reasonOthers"});
+                }
+
+                if (skjema.Radioknapp == "7")
+                {
+
+                    layoutSettings.Components.ExcludeFromPdf.AddRange(new List<string>() {
+                    "reasonRelationship",
+                    "reasonParents",
+                    "reasonSSN",
+                    "reasonCohabitant1",
+                    "reasonCohabitant2",
+                    "reasonNewName",
+                    "reasonOthers"});
+                }
+
+                if (skjema.Radioknapp == "8")
+                {
+                 layoutSettings.Components.ExcludeFromPdf.AddRange(new List<string>() {   "reasonRelationship",
+                    "reasonParents",
+                    "reasonSSN",
+                    "reasonCohabitant1",
+                    "reasonCohabitant2",
+                    "reasonFarm1",
+                    "reasonFarm2",
+                    "reasonFarm3",
+                    "reasonFarm4",
+                    "reasonFarm5",
+                    "reasonOthers"});
+                }
+
+                if (skjema.Radioknapp == "9")
+                {
+                   layoutSettings.Components.ExcludeFromPdf.AddRange(new List<string>() { "reasonRelationship",
+                    "reasonParents",
+                    "reasonSSN",
+                    "reasonCohabitant1",
+                    "reasonCohabitant2",
+                    "reasonFarm1",
+                    "reasonFarm2",
+                    "reasonFarm3",
+                    "reasonFarm4",
+                    "reasonFarm5",
+                    "reasonNewName"});
+                }
+            }
+            return await Task.FromResult(layoutSettings);
+        }
+    }   
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/Validation/ValidationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/Validation/ValidationHandler.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Altinn.App.Models; // Uncomment this line to refer to app model(s)
+
+namespace App.IntegrationTests.Mocks.Apps.tdd.frontendtest
+{
+    public class ValidationHandler
+    {
+        private IHttpContextAccessor _httpContextAccessor;
+
+        public ValidationHandler(IHttpContextAccessor httpContextAccessor = null)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async Task ValidateData(object data, ModelStateDictionary validationResults)
+        {
+            if (data.GetType() == typeof(Skjema))
+            {
+                Skjema model = (Skjema)data;
+                string middleName = model?.NyttNavngrp9313?.NyttNavngrp9314?.PersonMellomnavnNyttdatadef34759?.value;
+                string firstName = model?.NyttNavngrp9313?.NyttNavngrp9314?.PersonFornavnNyttdatadef34758?.value;
+                if (!string.IsNullOrEmpty(middleName) && middleName.Contains("test"))
+                {
+                    validationResults.AddModelError("NyttNavn-grp-9313.NyttNavn-grp-9314.PersonMellomnavnNytt-datadef-34759.value", "*WARNING*test er ikke en gyldig verdi");
+                }
+                if (!string.IsNullOrEmpty(firstName) && firstName.Contains("test"))
+                {
+                    validationResults.AddModelError("NyttNavn-grp-9313.NyttNavn-grp-9314.PersonFornavnNytt-datadef-34758.value", "test er ikke en gyldig verdi");
+                }
+            }
+            await Task.CompletedTask;
+        }
+
+        public async Task ValidateTask(Instance instance, string taskId, ModelStateDictionary validationResults)
+        {
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/models/ServiceModel-test.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/models/ServiceModel-test.cs
@@ -1,0 +1,1538 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
+
+namespace App.IntegrationTests.Mocks.Apps.tdd.frontendtest
+{
+public class Skjema{
+[Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlAttribute("skjemanummer")]
+    [BindNever]
+public decimal skjemanummer {get; set;} = 1533;
+[Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlAttribute("spesifikasjonsnummer")]
+    [BindNever]
+public decimal spesifikasjonsnummer {get; set;} = 11172;
+    [XmlAttribute("blankettnummer")]
+    [BindNever]
+public  string blankettnummer {get; set; } = "RF-1453";
+    [XmlAttribute("tittel")]
+    [BindNever]
+public  string tittel {get; set; } = "Endring av navn";
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9308;
+    [XmlAttribute("etatid")]
+public string etatid { get; set; }
+    [XmlElement("Innledning-grp-9309")]
+    [JsonProperty("Innledning-grp-9309")]
+    [JsonPropertyName("Innledning-grp-9309")]
+public Innledninggrp9309 Innledninggrp9309 { get; set; }
+    [XmlElement("NyttNavn-grp-9313")]
+    [JsonProperty("NyttNavn-grp-9313")]
+    [JsonPropertyName("NyttNavn-grp-9313")]
+public NyttNavngrp9313 NyttNavngrp9313 { get; set; }
+    [XmlElement("Tilknytning-grp-9315")]
+    [JsonProperty("Tilknytning-grp-9315")]
+    [JsonPropertyName("Tilknytning-grp-9315")]
+public Tilknytninggrp9315 Tilknytninggrp9315 { get; set; }
+    [XmlElement("Begrunnelse-grp-9317")]
+    [JsonProperty("Begrunnelse-grp-9317")]
+    [JsonPropertyName("Begrunnelse-grp-9317")]
+public Begrunnelsegrp9317 Begrunnelsegrp9317 { get; set; }
+    [XmlElement("Radioknapp")]
+    [JsonProperty("Radioknapp")]
+    [JsonPropertyName("Radioknapp")]
+public string Radioknapp { get; set; }
+}
+public class Innledninggrp9309{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9309;
+    [XmlElement("NavneendringenGjelderFor-grp-9310")]
+    [JsonProperty("NavneendringenGjelderFor-grp-9310")]
+    [JsonPropertyName("NavneendringenGjelderFor-grp-9310")]
+public NavneendringenGjelderForgrp9310 NavneendringenGjelderForgrp9310 { get; set; }
+    [XmlElement("Signerer-grp-9320")]
+    [JsonProperty("Signerer-grp-9320")]
+    [JsonPropertyName("Signerer-grp-9320")]
+public Signerergrp9320 Signerergrp9320 { get; set; }
+    [XmlElement("TredjeSignerer-grp-9349")]
+    [JsonProperty("TredjeSignerer-grp-9349")]
+    [JsonPropertyName("TredjeSignerer-grp-9349")]
+public TredjeSignerergrp9349 TredjeSignerergrp9349 { get; set; }
+    [XmlElement("Kontaktinformasjon-grp-9311")]
+    [JsonProperty("Kontaktinformasjon-grp-9311")]
+    [JsonPropertyName("Kontaktinformasjon-grp-9311")]
+public Kontaktinformasjongrp9311 Kontaktinformasjongrp9311 { get; set; }
+    [XmlElement("SamtykkeTilElektroniskKommunikasjon-grp-9312")]
+    [JsonProperty("SamtykkeTilElektroniskKommunikasjon-grp-9312")]
+    [JsonPropertyName("SamtykkeTilElektroniskKommunikasjon-grp-9312")]
+public SamtykkeTilElektroniskKommunikasjongrp9312 SamtykkeTilElektroniskKommunikasjongrp9312 { get; set; }
+}
+public class NavneendringenGjelderForgrp9310{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9310;
+    [XmlElement("MeldingMeldingsmottakerFodselsnummer-datadef-33548")]
+    [JsonProperty("MeldingMeldingsmottakerFodselsnummer-datadef-33548")]
+    [JsonPropertyName("MeldingMeldingsmottakerFodselsnummer-datadef-33548")]
+public MeldingMeldingsmottakerFodselsnummerdatadef33548 MeldingMeldingsmottakerFodselsnummerdatadef33548 { get; set; }
+    [XmlElement("SubjektFodselsnummer-datadef-34727")]
+    [JsonProperty("SubjektFodselsnummer-datadef-34727")]
+    [JsonPropertyName("SubjektFodselsnummer-datadef-34727")]
+public SubjektFodselsnummerdatadef34727 SubjektFodselsnummerdatadef34727 { get; set; }
+    [XmlElement("SubjektFornavnFolkeregistrert-datadef-34730")]
+    [JsonProperty("SubjektFornavnFolkeregistrert-datadef-34730")]
+    [JsonPropertyName("SubjektFornavnFolkeregistrert-datadef-34730")]
+public SubjektFornavnFolkeregistrertdatadef34730 SubjektFornavnFolkeregistrertdatadef34730 { get; set; }
+    [XmlElement("SubjektMellomnavnFolkeregistrert-datadef-34731")]
+    [JsonProperty("SubjektMellomnavnFolkeregistrert-datadef-34731")]
+    [JsonPropertyName("SubjektMellomnavnFolkeregistrert-datadef-34731")]
+public SubjektMellomnavnFolkeregistrertdatadef34731 SubjektMellomnavnFolkeregistrertdatadef34731 { get; set; }
+    [XmlElement("SubjektEtternavnFolkeregistrert-datadef-34729")]
+    [JsonProperty("SubjektEtternavnFolkeregistrert-datadef-34729")]
+    [JsonPropertyName("SubjektEtternavnFolkeregistrert-datadef-34729")]
+public SubjektEtternavnFolkeregistrertdatadef34729 SubjektEtternavnFolkeregistrertdatadef34729 { get; set; }
+}
+public class MeldingMeldingsmottakerFodselsnummerdatadef33548{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 33548;
+    [XmlText()]
+public string value { get; set; }
+}
+public class SubjektFodselsnummerdatadef34727{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34727;
+    [XmlText()]
+public string value { get; set; }
+}
+public class SubjektFornavnFolkeregistrertdatadef34730{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34730;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SubjektMellomnavnFolkeregistrertdatadef34731{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34731;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SubjektEtternavnFolkeregistrertdatadef34729{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34729;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class Signerergrp9320{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9320;
+    [XmlElement("SignererEkstraFodselsnummer-datadef-34744")]
+    [JsonProperty("SignererEkstraFodselsnummer-datadef-34744")]
+    [JsonPropertyName("SignererEkstraFodselsnummer-datadef-34744")]
+public SignererEkstraFodselsnummerdatadef34744 SignererEkstraFodselsnummerdatadef34744 { get; set; }
+    [XmlElement("SignererEkstraEtternavn-datadef-34745")]
+    [JsonProperty("SignererEkstraEtternavn-datadef-34745")]
+    [JsonPropertyName("SignererEkstraEtternavn-datadef-34745")]
+public SignererEkstraEtternavndatadef34745 SignererEkstraEtternavndatadef34745 { get; set; }
+    [XmlElement("SignererEkstraFornavn-datadef-34746")]
+    [JsonProperty("SignererEkstraFornavn-datadef-34746")]
+    [JsonPropertyName("SignererEkstraFornavn-datadef-34746")]
+public SignererEkstraFornavndatadef34746 SignererEkstraFornavndatadef34746 { get; set; }
+    [XmlElement("SignererEkstraMellomnavn-datadef-34747")]
+    [JsonProperty("SignererEkstraMellomnavn-datadef-34747")]
+    [JsonPropertyName("SignererEkstraMellomnavn-datadef-34747")]
+public SignererEkstraMellomnavndatadef34747 SignererEkstraMellomnavndatadef34747 { get; set; }
+    [XmlElement("SignererEkstraEpost-datadef-34749")]
+    [JsonProperty("SignererEkstraEpost-datadef-34749")]
+    [JsonPropertyName("SignererEkstraEpost-datadef-34749")]
+public SignererEkstraEpostdatadef34749 SignererEkstraEpostdatadef34749 { get; set; }
+    [XmlElement("SignererEkstraMobiltelefonsnummer-datadef-34750")]
+    [JsonProperty("SignererEkstraMobiltelefonsnummer-datadef-34750")]
+    [JsonPropertyName("SignererEkstraMobiltelefonsnummer-datadef-34750")]
+public SignererEkstraMobiltelefonsnummerdatadef34750 SignererEkstraMobiltelefonsnummerdatadef34750 { get; set; }
+    [XmlElement("SignererEkstraReferanseAltinn-datadef-34751")]
+    [JsonProperty("SignererEkstraReferanseAltinn-datadef-34751")]
+    [JsonPropertyName("SignererEkstraReferanseAltinn-datadef-34751")]
+public SignererEkstraReferanseAltinndatadef34751 SignererEkstraReferanseAltinndatadef34751 { get; set; }
+    [XmlElement("SignererEkstraArkivDato-datadef-34752")]
+    [JsonProperty("SignererEkstraArkivDato-datadef-34752")]
+    [JsonPropertyName("SignererEkstraArkivDato-datadef-34752")]
+public SignererEkstraArkivDatodatadef34752 SignererEkstraArkivDatodatadef34752 { get; set; }
+    [XmlElement("SignererEkstraTidspunkt-datadef-34753")]
+    [JsonProperty("SignererEkstraTidspunkt-datadef-34753")]
+    [JsonPropertyName("SignererEkstraTidspunkt-datadef-34753")]
+public SignererEkstraTidspunktdatadef34753 SignererEkstraTidspunktdatadef34753 { get; set; }
+    [XmlElement("SignererEkstraAksept-datadef-34754")]
+    [JsonProperty("SignererEkstraAksept-datadef-34754")]
+    [JsonPropertyName("SignererEkstraAksept-datadef-34754")]
+public SignererEkstraAkseptdatadef34754 SignererEkstraAkseptdatadef34754 { get; set; }
+    [XmlElement("SignererEkstraMalform-datadef-34895")]
+    [JsonProperty("SignererEkstraMalform-datadef-34895")]
+    [JsonPropertyName("SignererEkstraMalform-datadef-34895")]
+public SignererEkstraMalformdatadef34895 SignererEkstraMalformdatadef34895 { get; set; }
+}
+public class SignererEkstraFodselsnummerdatadef34744{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34744;
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererEkstraEtternavndatadef34745{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34745;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererEkstraFornavndatadef34746{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34746;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererEkstraMellomnavndatadef34747{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34747;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererEkstraEpostdatadef34749{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34749;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererEkstraMobiltelefonsnummerdatadef34750{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34750;
+[MinLength(1)]
+[MaxLength(15)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererEkstraReferanseAltinndatadef34751{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34751;
+[MinLength(1)]
+[MaxLength(10)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererEkstraArkivDatodatadef34752{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34752;
+    [XmlText()]
+public DateTime value { get; set; }
+}
+public class SignererEkstraTidspunktdatadef34753{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34753;
+[RegularExpression(@"^([0,1][0-9]|[2][0-3]):[0-5][0-9]:[0-5][0-9](Z|(\+|-)([0,1][0-9]|[2][0-3]):[0-5][0-9])?$")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererEkstraAkseptdatadef34754{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34754;
+[RegularExpression(@"(J|N)")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererEkstraMalformdatadef34895{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34895;
+[MinLength(1)]
+[MaxLength(10)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class TredjeSignerergrp9349{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9349;
+    [XmlElement("SignererTredjeFodselsnummer-datadef-34884")]
+    [JsonProperty("SignererTredjeFodselsnummer-datadef-34884")]
+    [JsonPropertyName("SignererTredjeFodselsnummer-datadef-34884")]
+public SignererTredjeFodselsnummerdatadef34884 SignererTredjeFodselsnummerdatadef34884 { get; set; }
+    [XmlElement("SignererTredjeEtternavn-datadef-34885")]
+    [JsonProperty("SignererTredjeEtternavn-datadef-34885")]
+    [JsonPropertyName("SignererTredjeEtternavn-datadef-34885")]
+public SignererTredjeEtternavndatadef34885 SignererTredjeEtternavndatadef34885 { get; set; }
+    [XmlElement("SignererTredjeFornavn-datadef-34886")]
+    [JsonProperty("SignererTredjeFornavn-datadef-34886")]
+    [JsonPropertyName("SignererTredjeFornavn-datadef-34886")]
+public SignererTredjeFornavndatadef34886 SignererTredjeFornavndatadef34886 { get; set; }
+    [XmlElement("SignererTredjeMellomnavn-datadef-34887")]
+    [JsonProperty("SignererTredjeMellomnavn-datadef-34887")]
+    [JsonPropertyName("SignererTredjeMellomnavn-datadef-34887")]
+public SignererTredjeMellomnavndatadef34887 SignererTredjeMellomnavndatadef34887 { get; set; }
+    [XmlElement("SignererTredjeEpost-datadef-34889")]
+    [JsonProperty("SignererTredjeEpost-datadef-34889")]
+    [JsonPropertyName("SignererTredjeEpost-datadef-34889")]
+public SignererTredjeEpostdatadef34889 SignererTredjeEpostdatadef34889 { get; set; }
+    [XmlElement("SignererTredjeMobiltelefonnummer-datadef-34890")]
+    [JsonProperty("SignererTredjeMobiltelefonnummer-datadef-34890")]
+    [JsonPropertyName("SignererTredjeMobiltelefonnummer-datadef-34890")]
+public SignererTredjeMobiltelefonnummerdatadef34890 SignererTredjeMobiltelefonnummerdatadef34890 { get; set; }
+    [XmlElement("SignererTredjeReferanseAltinn-datadef-34891")]
+    [JsonProperty("SignererTredjeReferanseAltinn-datadef-34891")]
+    [JsonPropertyName("SignererTredjeReferanseAltinn-datadef-34891")]
+public SignererTredjeReferanseAltinndatadef34891 SignererTredjeReferanseAltinndatadef34891 { get; set; }
+    [XmlElement("SignererTredjeArkivDato-datadef-34892")]
+    [JsonProperty("SignererTredjeArkivDato-datadef-34892")]
+    [JsonPropertyName("SignererTredjeArkivDato-datadef-34892")]
+public SignererTredjeArkivDatodatadef34892 SignererTredjeArkivDatodatadef34892 { get; set; }
+    [XmlElement("SignererTredjeTidspunkt-datadef-34893")]
+    [JsonProperty("SignererTredjeTidspunkt-datadef-34893")]
+    [JsonPropertyName("SignererTredjeTidspunkt-datadef-34893")]
+public SignererTredjeTidspunktdatadef34893 SignererTredjeTidspunktdatadef34893 { get; set; }
+    [XmlElement("SignererTredjeAksept-datadef-34894")]
+    [JsonProperty("SignererTredjeAksept-datadef-34894")]
+    [JsonPropertyName("SignererTredjeAksept-datadef-34894")]
+public SignererTredjeAkseptdatadef34894 SignererTredjeAkseptdatadef34894 { get; set; }
+    [XmlElement("SignererTredjeMalform-datadef-34883")]
+    [JsonProperty("SignererTredjeMalform-datadef-34883")]
+    [JsonPropertyName("SignererTredjeMalform-datadef-34883")]
+public SignererTredjeMalformdatadef34883 SignererTredjeMalformdatadef34883 { get; set; }
+}
+public class SignererTredjeFodselsnummerdatadef34884{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34884;
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererTredjeEtternavndatadef34885{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34885;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererTredjeFornavndatadef34886{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34886;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererTredjeMellomnavndatadef34887{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34887;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererTredjeEpostdatadef34889{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34889;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererTredjeMobiltelefonnummerdatadef34890{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34890;
+[MinLength(1)]
+[MaxLength(15)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererTredjeReferanseAltinndatadef34891{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34891;
+[MinLength(1)]
+[MaxLength(10)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererTredjeArkivDatodatadef34892{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34892;
+    [XmlText()]
+public DateTime value { get; set; }
+}
+public class SignererTredjeTidspunktdatadef34893{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34893;
+[RegularExpression(@"^([0,1][0-9]|[2][0-3]):[0-5][0-9]:[0-5][0-9](Z|(\+|-)([0,1][0-9]|[2][0-3]):[0-5][0-9])?$")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererTredjeAkseptdatadef34894{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34894;
+[RegularExpression(@"(J|N)")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SignererTredjeMalformdatadef34883{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34883;
+[MinLength(1)]
+[MaxLength(10)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class Kontaktinformasjongrp9311{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9311;
+    [XmlElement("MeldingFodselsnummer-datadef-34734")]
+    [JsonProperty("MeldingFodselsnummer-datadef-34734")]
+    [JsonPropertyName("MeldingFodselsnummer-datadef-34734")]
+public MeldingFodselsnummerdatadef34734 MeldingFodselsnummerdatadef34734 { get; set; }
+    [XmlElement("MelderFornavn-datadef-34736")]
+    [JsonProperty("MelderFornavn-datadef-34736")]
+    [JsonPropertyName("MelderFornavn-datadef-34736")]
+public MelderFornavndatadef34736 MelderFornavndatadef34736 { get; set; }
+    [XmlElement("MelderMellomnavn-datadef-34737")]
+    [JsonProperty("MelderMellomnavn-datadef-34737")]
+    [JsonPropertyName("MelderMellomnavn-datadef-34737")]
+public MelderMellomnavndatadef34737 MelderMellomnavndatadef34737 { get; set; }
+    [XmlElement("MelderEtternavn-datadef-34735")]
+    [JsonProperty("MelderEtternavn-datadef-34735")]
+    [JsonPropertyName("MelderEtternavn-datadef-34735")]
+public MelderEtternavndatadef34735 MelderEtternavndatadef34735 { get; set; }
+    [XmlElement("MelderFultnavn")]
+    [JsonProperty("MelderFultnavn")]
+    [JsonPropertyName("MelderFultnavn")]
+public MelderFultnavn MelderFultnavn { get; set; }
+    [XmlElement("MelderEpost-datadef-34739")]
+    [JsonProperty("MelderEpost-datadef-34739")]
+    [JsonPropertyName("MelderEpost-datadef-34739")]
+public MelderEpostdatadef34739 MelderEpostdatadef34739 { get; set; }
+    [XmlElement("MelderMobiltelefonnummer-datadef-34740")]
+    [JsonProperty("MelderMobiltelefonnummer-datadef-34740")]
+    [JsonPropertyName("MelderMobiltelefonnummer-datadef-34740")]
+public MelderMobiltelefonnummerdatadef34740 MelderMobiltelefonnummerdatadef34740 { get; set; }
+    [XmlElement("MelderArkivDato-datadef-34741")]
+    [JsonProperty("MelderArkivDato-datadef-34741")]
+    [JsonPropertyName("MelderArkivDato-datadef-34741")]
+public MelderArkivDatodatadef34741 MelderArkivDatodatadef34741 { get; set; }
+    [XmlElement("MelderArkivTidspunkt-datadef-34742")]
+    [JsonProperty("MelderArkivTidspunkt-datadef-34742")]
+    [JsonPropertyName("MelderArkivTidspunkt-datadef-34742")]
+public MelderArkivTidspunktdatadef34742 MelderArkivTidspunktdatadef34742 { get; set; }
+    [XmlElement("MelderReferanseAltinn-datadef-34743")]
+    [JsonProperty("MelderReferanseAltinn-datadef-34743")]
+    [JsonPropertyName("MelderReferanseAltinn-datadef-34743")]
+public MelderReferanseAltinndatadef34743 MelderReferanseAltinndatadef34743 { get; set; }
+    [XmlElement("MelderMalform-datadef-34882")]
+    [JsonProperty("MelderMalform-datadef-34882")]
+    [JsonPropertyName("MelderMalform-datadef-34882")]
+public MelderMalformdatadef34882 MelderMalformdatadef34882 { get; set; }
+}
+public class MeldingFodselsnummerdatadef34734{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34734;
+    [XmlText()]
+public string value { get; set; }
+}
+public class MelderFornavndatadef34736{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34736;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class MelderMellomnavndatadef34737{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34737;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class MelderEtternavndatadef34735{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34735;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class MelderFultnavn{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34735;
+[MinLength(1)]
+[MaxLength(60)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class MelderEpostdatadef34739{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34739;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class MelderMobiltelefonnummerdatadef34740{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34740;
+[MinLength(1)]
+[MaxLength(15)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class MelderArkivDatodatadef34741{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34741;
+    [XmlText()]
+public DateTime value { get; set; }
+}
+public class MelderArkivTidspunktdatadef34742{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34742;
+[RegularExpression(@"^([0,1][0-9]|[2][0-3]):[0-5][0-9]:[0-5][0-9](Z|(\+|-)([0,1][0-9]|[2][0-3]):[0-5][0-9])?$")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class MelderReferanseAltinndatadef34743{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34743;
+[MinLength(1)]
+[MaxLength(10)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class MelderMalformdatadef34882{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34882;
+[MinLength(1)]
+[MaxLength(10)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class SamtykkeTilElektroniskKommunikasjongrp9312{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9312;
+    [XmlElement("AvgiverSkattSamtykke-datadef-34755")]
+    [JsonProperty("AvgiverSkattSamtykke-datadef-34755")]
+    [JsonPropertyName("AvgiverSkattSamtykke-datadef-34755")]
+public AvgiverSkattSamtykkedatadef34755 AvgiverSkattSamtykkedatadef34755 { get; set; }
+    [XmlElement("AvgiverFolkeregisterSamtykke-datadef-34756")]
+    [JsonProperty("AvgiverFolkeregisterSamtykke-datadef-34756")]
+    [JsonPropertyName("AvgiverFolkeregisterSamtykke-datadef-34756")]
+public AvgiverFolkeregisterSamtykkedatadef34756 AvgiverFolkeregisterSamtykkedatadef34756 { get; set; }
+}
+public class AvgiverSkattSamtykkedatadef34755{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34755;
+[RegularExpression(@"(J|N|D)")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class AvgiverFolkeregisterSamtykkedatadef34756{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34756;
+[RegularExpression(@"(J|N|D)")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class NyttNavngrp9313{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9313;
+    [XmlElement("NyttNavn-grp-9314")]
+    [JsonProperty("NyttNavn-grp-9314")]
+    [JsonPropertyName("NyttNavn-grp-9314")]
+public NyttNavngrp9314 NyttNavngrp9314 { get; set; }
+}
+public class NyttNavngrp9314{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9314;
+    [XmlElement("PersonEtternavnNytt-datadef-34757")]
+    [JsonProperty("PersonEtternavnNytt-datadef-34757")]
+    [JsonPropertyName("PersonEtternavnNytt-datadef-34757")]
+public PersonEtternavnNyttdatadef34757 PersonEtternavnNyttdatadef34757 { get; set; }
+    [XmlElement("PersonFornavnNytt-datadef-34758")]
+    [JsonProperty("PersonFornavnNytt-datadef-34758")]
+    [JsonPropertyName("PersonFornavnNytt-datadef-34758")]
+public PersonFornavnNyttdatadef34758 PersonFornavnNyttdatadef34758 { get; set; }
+    [XmlElement("PersonMellomnavnNytt-datadef-34759")]
+    [JsonProperty("PersonMellomnavnNytt-datadef-34759")]
+    [JsonPropertyName("PersonMellomnavnNytt-datadef-34759")]
+public PersonMellomnavnNyttdatadef34759 PersonMellomnavnNyttdatadef34759 { get; set; }
+    [XmlElement("PersonBekrefterNyttNavn")]
+    [JsonProperty("PersonBekrefterNyttNavn")]
+    [JsonPropertyName("PersonBekrefterNyttNavn")]
+public PersonBekrefterNyttNavn PersonBekrefterNyttNavn { get; set; }
+}
+public class PersonEtternavnNyttdatadef34757{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34757;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonFornavnNyttdatadef34758{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34758;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnNyttdatadef34759{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34759;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonBekrefterNyttNavn{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34760;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class Tilknytninggrp9315{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9315;
+    [XmlElement("TilknytningTilNavnet-grp-9316")]
+    [JsonProperty("TilknytningTilNavnet-grp-9316")]
+    [JsonPropertyName("TilknytningTilNavnet-grp-9316")]
+public TilknytningTilNavnetgrp9316 TilknytningTilNavnetgrp9316 { get; set; }
+}
+public class TilknytningTilNavnetgrp9316{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9316;
+    [XmlElement("TilknytningEtternavn1-grp-9350")]
+    [JsonProperty("TilknytningEtternavn1-grp-9350")]
+    [JsonPropertyName("TilknytningEtternavn1-grp-9350")]
+public TilknytningEtternavn1grp9350 TilknytningEtternavn1grp9350 { get; set; }
+    [XmlElement("TilknytningEtternavn2-grp-9351")]
+    [JsonProperty("TilknytningEtternavn2-grp-9351")]
+    [JsonPropertyName("TilknytningEtternavn2-grp-9351")]
+public TilknytningEtternavn2grp9351 TilknytningEtternavn2grp9351 { get; set; }
+    [XmlElement("TilknytningMellomnavn1-grp-9352")]
+    [JsonProperty("TilknytningMellomnavn1-grp-9352")]
+    [JsonPropertyName("TilknytningMellomnavn1-grp-9352")]
+public TilknytningMellomnavn1grp9352 TilknytningMellomnavn1grp9352 { get; set; }
+    [XmlElement("TilknytningMellomnavn2-grp-9353")]
+    [JsonProperty("TilknytningMellomnavn2-grp-9353")]
+    [JsonPropertyName("TilknytningMellomnavn2-grp-9353")]
+public TilknytningMellomnavn2grp9353 TilknytningMellomnavn2grp9353 { get; set; }
+    [XmlElement("TilknytningMellomnavn3-grp-9354")]
+    [JsonProperty("TilknytningMellomnavn3-grp-9354")]
+    [JsonPropertyName("TilknytningMellomnavn3-grp-9354")]
+public TilknytningMellomnavn3grp9354 TilknytningMellomnavn3grp9354 { get; set; }
+    [XmlElement("TilknytningMellomnavnEkstra-grp-9355")]
+    [JsonProperty("TilknytningMellomnavnEkstra-grp-9355")]
+    [JsonPropertyName("TilknytningMellomnavnEkstra-grp-9355")]
+public TilknytningMellomnavnEkstragrp9355 TilknytningMellomnavnEkstragrp9355 { get; set; }
+}
+public class TilknytningEtternavn1grp9350{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9350;
+    [XmlElement("PersonEtternavnForste-datadef-34896")]
+    [JsonProperty("PersonEtternavnForste-datadef-34896")]
+    [JsonPropertyName("PersonEtternavnForste-datadef-34896")]
+public PersonEtternavnForstedatadef34896 PersonEtternavnForstedatadef34896 { get; set; }
+    [XmlElement("PersonEtternavnForsteTilknytningstype-datadef-34897")]
+    [JsonProperty("PersonEtternavnForsteTilknytningstype-datadef-34897")]
+    [JsonPropertyName("PersonEtternavnForsteTilknytningstype-datadef-34897")]
+public PersonEtternavnForsteTilknytningstypedatadef34897 PersonEtternavnForsteTilknytningstypedatadef34897 { get; set; }
+    [XmlElement("PersonEtternavnForsteTilknytningBeskrivelse-datadef-34898")]
+    [JsonProperty("PersonEtternavnForsteTilknytningBeskrivelse-datadef-34898")]
+    [JsonPropertyName("PersonEtternavnForsteTilknytningBeskrivelse-datadef-34898")]
+public PersonEtternavnForsteTilknytningBeskrivelsedatadef34898 PersonEtternavnForsteTilknytningBeskrivelsedatadef34898 { get; set; }
+    [XmlElement("PersonEtternavnForsteTilknyttetPersonsFodselsnummer-datadef-34899")]
+    [JsonProperty("PersonEtternavnForsteTilknyttetPersonsFodselsnummer-datadef-34899")]
+    [JsonPropertyName("PersonEtternavnForsteTilknyttetPersonsFodselsnummer-datadef-34899")]
+public PersonEtternavnForsteTilknyttetPersonsFodselsnummerdatadef34899 PersonEtternavnForsteTilknyttetPersonsFodselsnummerdatadef34899 { get; set; }
+    [XmlElement("PersonEtternavnForsteTilknyttetPersonsEtternavn-datadef-34900")]
+    [JsonProperty("PersonEtternavnForsteTilknyttetPersonsEtternavn-datadef-34900")]
+    [JsonPropertyName("PersonEtternavnForsteTilknyttetPersonsEtternavn-datadef-34900")]
+public PersonEtternavnForsteTilknyttetPersonsEtternavndatadef34900 PersonEtternavnForsteTilknyttetPersonsEtternavndatadef34900 { get; set; }
+    [XmlElement("PersonEtternavnForsteTilknyttetGardNavn-datadef-34901")]
+    [JsonProperty("PersonEtternavnForsteTilknyttetGardNavn-datadef-34901")]
+    [JsonPropertyName("PersonEtternavnForsteTilknyttetGardNavn-datadef-34901")]
+public PersonEtternavnForsteTilknyttetGardNavndatadef34901 PersonEtternavnForsteTilknyttetGardNavndatadef34901 { get; set; }
+    [XmlElement("PersonEtternavnForsteTilknyttetGardKommunenummer-datadef-34902")]
+    [JsonProperty("PersonEtternavnForsteTilknyttetGardKommunenummer-datadef-34902")]
+    [JsonPropertyName("PersonEtternavnForsteTilknyttetGardKommunenummer-datadef-34902")]
+public PersonEtternavnForsteTilknyttetGardKommunenummerdatadef34902 PersonEtternavnForsteTilknyttetGardKommunenummerdatadef34902 { get; set; }
+    [XmlElement("PersonEtternavnForsteTilknyttetGardGardsnummer-datadef-34903")]
+    [JsonProperty("PersonEtternavnForsteTilknyttetGardGardsnummer-datadef-34903")]
+    [JsonPropertyName("PersonEtternavnForsteTilknyttetGardGardsnummer-datadef-34903")]
+public PersonEtternavnForsteTilknyttetGardGardsnummerdatadef34903 PersonEtternavnForsteTilknyttetGardGardsnummerdatadef34903 { get; set; }
+    [XmlElement("PersonEtternavnForsteTilknyttetGardBruksnummer-datadef-34904")]
+    [JsonProperty("PersonEtternavnForsteTilknyttetGardBruksnummer-datadef-34904")]
+    [JsonPropertyName("PersonEtternavnForsteTilknyttetGardBruksnummer-datadef-34904")]
+public PersonEtternavnForsteTilknyttetGardBruksnummerdatadef34904 PersonEtternavnForsteTilknyttetGardBruksnummerdatadef34904 { get; set; }
+    [XmlElement("PersonEtternavnForsteTilknyttetGardFesteavgift-datadef-34905")]
+    [JsonProperty("PersonEtternavnForsteTilknyttetGardFesteavgift-datadef-34905")]
+    [JsonPropertyName("PersonEtternavnForsteTilknyttetGardFesteavgift-datadef-34905")]
+public PersonEtternavnForsteTilknyttetGardFesteavgiftdatadef34905 PersonEtternavnForsteTilknyttetGardFesteavgiftdatadef34905 { get; set; }
+}
+public class PersonEtternavnForstedatadef34896{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34896;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnForsteTilknytningstypedatadef34897{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34897;
+[MinLength(1)]
+[MaxLength(2)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnForsteTilknytningBeskrivelsedatadef34898{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34898;
+[MinLength(1)]
+[MaxLength(500)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnForsteTilknyttetPersonsFodselsnummerdatadef34899{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34899;
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnForsteTilknyttetPersonsEtternavndatadef34900{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34900;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnForsteTilknyttetGardNavndatadef34901{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34901;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnForsteTilknyttetGardKommunenummerdatadef34902{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34902;
+[RegularExpression(@"[0-9]{4}")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnForsteTilknyttetGardGardsnummerdatadef34903{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34903;
+[MinLength(1)]
+[MaxLength(5)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnForsteTilknyttetGardBruksnummerdatadef34904{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34904;
+[MinLength(1)]
+[MaxLength(4)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnForsteTilknyttetGardFesteavgiftdatadef34905{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34905;
+[MinLength(1)]
+[MaxLength(4)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class TilknytningEtternavn2grp9351{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9351;
+    [XmlElement("PersonEtternavnAndre-datadef-34906")]
+    [JsonProperty("PersonEtternavnAndre-datadef-34906")]
+    [JsonPropertyName("PersonEtternavnAndre-datadef-34906")]
+public PersonEtternavnAndredatadef34906 PersonEtternavnAndredatadef34906 { get; set; }
+    [XmlElement("PersonEtternavnAndreTilknytningstype-datadef-34907")]
+    [JsonProperty("PersonEtternavnAndreTilknytningstype-datadef-34907")]
+    [JsonPropertyName("PersonEtternavnAndreTilknytningstype-datadef-34907")]
+public PersonEtternavnAndreTilknytningstypedatadef34907 PersonEtternavnAndreTilknytningstypedatadef34907 { get; set; }
+    [XmlElement("PersonEtternavnAndreTilknytningBeskrivelse-datadef-34908")]
+    [JsonProperty("PersonEtternavnAndreTilknytningBeskrivelse-datadef-34908")]
+    [JsonPropertyName("PersonEtternavnAndreTilknytningBeskrivelse-datadef-34908")]
+public PersonEtternavnAndreTilknytningBeskrivelsedatadef34908 PersonEtternavnAndreTilknytningBeskrivelsedatadef34908 { get; set; }
+    [XmlElement("PersonEtternavnAndreTilknyttetPersonsFodselsnummer-datadef-34909")]
+    [JsonProperty("PersonEtternavnAndreTilknyttetPersonsFodselsnummer-datadef-34909")]
+    [JsonPropertyName("PersonEtternavnAndreTilknyttetPersonsFodselsnummer-datadef-34909")]
+public PersonEtternavnAndreTilknyttetPersonsFodselsnummerdatadef34909 PersonEtternavnAndreTilknyttetPersonsFodselsnummerdatadef34909 { get; set; }
+    [XmlElement("PersonEtternavnAndreTilknyttetPersonsEtternavn-datadef-34910")]
+    [JsonProperty("PersonEtternavnAndreTilknyttetPersonsEtternavn-datadef-34910")]
+    [JsonPropertyName("PersonEtternavnAndreTilknyttetPersonsEtternavn-datadef-34910")]
+public PersonEtternavnAndreTilknyttetPersonsEtternavndatadef34910 PersonEtternavnAndreTilknyttetPersonsEtternavndatadef34910 { get; set; }
+    [XmlElement("PersonEtternavnAndreTilknyttetGardNavn-datadef-34911")]
+    [JsonProperty("PersonEtternavnAndreTilknyttetGardNavn-datadef-34911")]
+    [JsonPropertyName("PersonEtternavnAndreTilknyttetGardNavn-datadef-34911")]
+public PersonEtternavnAndreTilknyttetGardNavndatadef34911 PersonEtternavnAndreTilknyttetGardNavndatadef34911 { get; set; }
+    [XmlElement("PersonEtternavnAndreTilknyttetGardKommunenummer-datadef-34912")]
+    [JsonProperty("PersonEtternavnAndreTilknyttetGardKommunenummer-datadef-34912")]
+    [JsonPropertyName("PersonEtternavnAndreTilknyttetGardKommunenummer-datadef-34912")]
+public PersonEtternavnAndreTilknyttetGardKommunenummerdatadef34912 PersonEtternavnAndreTilknyttetGardKommunenummerdatadef34912 { get; set; }
+    [XmlElement("PersonEtternavnAndreTilknyttetGardGardsnummer-datadef-34913")]
+    [JsonProperty("PersonEtternavnAndreTilknyttetGardGardsnummer-datadef-34913")]
+    [JsonPropertyName("PersonEtternavnAndreTilknyttetGardGardsnummer-datadef-34913")]
+public PersonEtternavnAndreTilknyttetGardGardsnummerdatadef34913 PersonEtternavnAndreTilknyttetGardGardsnummerdatadef34913 { get; set; }
+    [XmlElement("PersonEtternavnAndreTilknyttetGardBruksnummer-datadef-34914")]
+    [JsonProperty("PersonEtternavnAndreTilknyttetGardBruksnummer-datadef-34914")]
+    [JsonPropertyName("PersonEtternavnAndreTilknyttetGardBruksnummer-datadef-34914")]
+public PersonEtternavnAndreTilknyttetGardBruksnummerdatadef34914 PersonEtternavnAndreTilknyttetGardBruksnummerdatadef34914 { get; set; }
+    [XmlElement("PersonEtternavnAndreTilknyttetGardFesteavgift-datadef-34915")]
+    [JsonProperty("PersonEtternavnAndreTilknyttetGardFesteavgift-datadef-34915")]
+    [JsonPropertyName("PersonEtternavnAndreTilknyttetGardFesteavgift-datadef-34915")]
+public PersonEtternavnAndreTilknyttetGardFesteavgiftdatadef34915 PersonEtternavnAndreTilknyttetGardFesteavgiftdatadef34915 { get; set; }
+}
+public class PersonEtternavnAndredatadef34906{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34906;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnAndreTilknytningstypedatadef34907{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34907;
+[MinLength(1)]
+[MaxLength(2)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnAndreTilknytningBeskrivelsedatadef34908{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34908;
+[MinLength(1)]
+[MaxLength(500)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnAndreTilknyttetPersonsFodselsnummerdatadef34909{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34909;
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnAndreTilknyttetPersonsEtternavndatadef34910{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34910;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnAndreTilknyttetGardNavndatadef34911{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34911;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnAndreTilknyttetGardKommunenummerdatadef34912{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34912;
+[RegularExpression(@"[0-9]{4}")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnAndreTilknyttetGardGardsnummerdatadef34913{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34913;
+[MinLength(1)]
+[MaxLength(5)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnAndreTilknyttetGardBruksnummerdatadef34914{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34914;
+[MinLength(1)]
+[MaxLength(4)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonEtternavnAndreTilknyttetGardFesteavgiftdatadef34915{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34915;
+[MinLength(1)]
+[MaxLength(4)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class TilknytningMellomnavn1grp9352{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9352;
+    [XmlElement("PersonMellomnavnForste-datadef-34916")]
+    [JsonProperty("PersonMellomnavnForste-datadef-34916")]
+    [JsonPropertyName("PersonMellomnavnForste-datadef-34916")]
+public PersonMellomnavnForstedatadef34916 PersonMellomnavnForstedatadef34916 { get; set; }
+    [XmlElement("PersonMellomnavnForsteTilknytningstype-datadef-34917")]
+    [JsonProperty("PersonMellomnavnForsteTilknytningstype-datadef-34917")]
+    [JsonPropertyName("PersonMellomnavnForsteTilknytningstype-datadef-34917")]
+public PersonMellomnavnForsteTilknytningstypedatadef34917 PersonMellomnavnForsteTilknytningstypedatadef34917 { get; set; }
+    [XmlElement("PersonMellomnavnForsteTilknytningBeskrivelse-datadef-34918")]
+    [JsonProperty("PersonMellomnavnForsteTilknytningBeskrivelse-datadef-34918")]
+    [JsonPropertyName("PersonMellomnavnForsteTilknytningBeskrivelse-datadef-34918")]
+public PersonMellomnavnForsteTilknytningBeskrivelsedatadef34918 PersonMellomnavnForsteTilknytningBeskrivelsedatadef34918 { get; set; }
+    [XmlElement("PersonMellomnavnForsteTilknyttetPersonsFodselsnummer-datadef-34919")]
+    [JsonProperty("PersonMellomnavnForsteTilknyttetPersonsFodselsnummer-datadef-34919")]
+    [JsonPropertyName("PersonMellomnavnForsteTilknyttetPersonsFodselsnummer-datadef-34919")]
+public PersonMellomnavnForsteTilknyttetPersonsFodselsnummerdatadef34919 PersonMellomnavnForsteTilknyttetPersonsFodselsnummerdatadef34919 { get; set; }
+    [XmlElement("PersonMellomnavnForsteTilknyttetPersonsEtternavn-datadef-34920")]
+    [JsonProperty("PersonMellomnavnForsteTilknyttetPersonsEtternavn-datadef-34920")]
+    [JsonPropertyName("PersonMellomnavnForsteTilknyttetPersonsEtternavn-datadef-34920")]
+public PersonMellomnavnForsteTilknyttetPersonsEtternavndatadef34920 PersonMellomnavnForsteTilknyttetPersonsEtternavndatadef34920 { get; set; }
+    [XmlElement("PersonMellomnavnForsteTilknyttetGardNavn-datadef-34921")]
+    [JsonProperty("PersonMellomnavnForsteTilknyttetGardNavn-datadef-34921")]
+    [JsonPropertyName("PersonMellomnavnForsteTilknyttetGardNavn-datadef-34921")]
+public PersonMellomnavnForsteTilknyttetGardNavndatadef34921 PersonMellomnavnForsteTilknyttetGardNavndatadef34921 { get; set; }
+    [XmlElement("PersonMellomnavnForsteTilknyttetGardKommunenummer-datadef-34922")]
+    [JsonProperty("PersonMellomnavnForsteTilknyttetGardKommunenummer-datadef-34922")]
+    [JsonPropertyName("PersonMellomnavnForsteTilknyttetGardKommunenummer-datadef-34922")]
+public PersonMellomnavnForsteTilknyttetGardKommunenummerdatadef34922 PersonMellomnavnForsteTilknyttetGardKommunenummerdatadef34922 { get; set; }
+    [XmlElement("PersonMellomnavnForsteTilknyttetGardGardsnummer-datadef-34923")]
+    [JsonProperty("PersonMellomnavnForsteTilknyttetGardGardsnummer-datadef-34923")]
+    [JsonPropertyName("PersonMellomnavnForsteTilknyttetGardGardsnummer-datadef-34923")]
+public PersonMellomnavnForsteTilknyttetGardGardsnummerdatadef34923 PersonMellomnavnForsteTilknyttetGardGardsnummerdatadef34923 { get; set; }
+    [XmlElement("PersonMellomnavnForsteTilknyttetGardBruksnummer-datadef-34924")]
+    [JsonProperty("PersonMellomnavnForsteTilknyttetGardBruksnummer-datadef-34924")]
+    [JsonPropertyName("PersonMellomnavnForsteTilknyttetGardBruksnummer-datadef-34924")]
+public PersonMellomnavnForsteTilknyttetGardBruksnummerdatadef34924 PersonMellomnavnForsteTilknyttetGardBruksnummerdatadef34924 { get; set; }
+    [XmlElement("PersonMellomnavnForsteTilknyttetGardFestenummer-datadef-34925")]
+    [JsonProperty("PersonMellomnavnForsteTilknyttetGardFestenummer-datadef-34925")]
+    [JsonPropertyName("PersonMellomnavnForsteTilknyttetGardFestenummer-datadef-34925")]
+public PersonMellomnavnForsteTilknyttetGardFestenummerdatadef34925 PersonMellomnavnForsteTilknyttetGardFestenummerdatadef34925 { get; set; }
+}
+public class PersonMellomnavnForstedatadef34916{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34916;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnForsteTilknytningstypedatadef34917{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34917;
+[MinLength(1)]
+[MaxLength(2)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnForsteTilknytningBeskrivelsedatadef34918{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34918;
+[MinLength(1)]
+[MaxLength(500)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnForsteTilknyttetPersonsFodselsnummerdatadef34919{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34919;
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnForsteTilknyttetPersonsEtternavndatadef34920{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34920;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnForsteTilknyttetGardNavndatadef34921{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34921;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnForsteTilknyttetGardKommunenummerdatadef34922{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34922;
+[RegularExpression(@"[0-9]{4}")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnForsteTilknyttetGardGardsnummerdatadef34923{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34923;
+[MinLength(1)]
+[MaxLength(5)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnForsteTilknyttetGardBruksnummerdatadef34924{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34924;
+[MinLength(1)]
+[MaxLength(4)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnForsteTilknyttetGardFestenummerdatadef34925{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34925;
+[MinLength(1)]
+[MaxLength(4)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class TilknytningMellomnavn2grp9353{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9353;
+    [XmlElement("PersonMellomnavnAndre-datadef-34926")]
+    [JsonProperty("PersonMellomnavnAndre-datadef-34926")]
+    [JsonPropertyName("PersonMellomnavnAndre-datadef-34926")]
+public PersonMellomnavnAndredatadef34926 PersonMellomnavnAndredatadef34926 { get; set; }
+    [XmlElement("PersonMellomnavnAndreTilknytningstype-datadef-34927")]
+    [JsonProperty("PersonMellomnavnAndreTilknytningstype-datadef-34927")]
+    [JsonPropertyName("PersonMellomnavnAndreTilknytningstype-datadef-34927")]
+public PersonMellomnavnAndreTilknytningstypedatadef34927 PersonMellomnavnAndreTilknytningstypedatadef34927 { get; set; }
+    [XmlElement("PersonMellomnavnAndreTilknytningBeskrivelse-datadef-34928")]
+    [JsonProperty("PersonMellomnavnAndreTilknytningBeskrivelse-datadef-34928")]
+    [JsonPropertyName("PersonMellomnavnAndreTilknytningBeskrivelse-datadef-34928")]
+public PersonMellomnavnAndreTilknytningBeskrivelsedatadef34928 PersonMellomnavnAndreTilknytningBeskrivelsedatadef34928 { get; set; }
+    [XmlElement("PersonMellomnavnAndreTilknyttetPersonsFodselsnummer-datadef-34929")]
+    [JsonProperty("PersonMellomnavnAndreTilknyttetPersonsFodselsnummer-datadef-34929")]
+    [JsonPropertyName("PersonMellomnavnAndreTilknyttetPersonsFodselsnummer-datadef-34929")]
+public PersonMellomnavnAndreTilknyttetPersonsFodselsnummerdatadef34929 PersonMellomnavnAndreTilknyttetPersonsFodselsnummerdatadef34929 { get; set; }
+    [XmlElement("PersonMellomnavnAndreTilknyttetPersonsEtternavn-datadef-34930")]
+    [JsonProperty("PersonMellomnavnAndreTilknyttetPersonsEtternavn-datadef-34930")]
+    [JsonPropertyName("PersonMellomnavnAndreTilknyttetPersonsEtternavn-datadef-34930")]
+public PersonMellomnavnAndreTilknyttetPersonsEtternavndatadef34930 PersonMellomnavnAndreTilknyttetPersonsEtternavndatadef34930 { get; set; }
+    [XmlElement("PersonMellomnavnAndreTilknyttetGardNavn-datadef-34931")]
+    [JsonProperty("PersonMellomnavnAndreTilknyttetGardNavn-datadef-34931")]
+    [JsonPropertyName("PersonMellomnavnAndreTilknyttetGardNavn-datadef-34931")]
+public PersonMellomnavnAndreTilknyttetGardNavndatadef34931 PersonMellomnavnAndreTilknyttetGardNavndatadef34931 { get; set; }
+    [XmlElement("PersonMellomnavnAndreTilknyttetGardKommunenummer-datadef-34932")]
+    [JsonProperty("PersonMellomnavnAndreTilknyttetGardKommunenummer-datadef-34932")]
+    [JsonPropertyName("PersonMellomnavnAndreTilknyttetGardKommunenummer-datadef-34932")]
+public PersonMellomnavnAndreTilknyttetGardKommunenummerdatadef34932 PersonMellomnavnAndreTilknyttetGardKommunenummerdatadef34932 { get; set; }
+    [XmlElement("PersonMellomnavnAndreTilknyttetGardGardsnummer-datadef-34933")]
+    [JsonProperty("PersonMellomnavnAndreTilknyttetGardGardsnummer-datadef-34933")]
+    [JsonPropertyName("PersonMellomnavnAndreTilknyttetGardGardsnummer-datadef-34933")]
+public PersonMellomnavnAndreTilknyttetGardGardsnummerdatadef34933 PersonMellomnavnAndreTilknyttetGardGardsnummerdatadef34933 { get; set; }
+    [XmlElement("PersonMellomnavnAndreTilknyttetGardBruksnummer-datadef-34934")]
+    [JsonProperty("PersonMellomnavnAndreTilknyttetGardBruksnummer-datadef-34934")]
+    [JsonPropertyName("PersonMellomnavnAndreTilknyttetGardBruksnummer-datadef-34934")]
+public PersonMellomnavnAndreTilknyttetGardBruksnummerdatadef34934 PersonMellomnavnAndreTilknyttetGardBruksnummerdatadef34934 { get; set; }
+    [XmlElement("PersonMellomnavnAndreTilknyttetGardFestenummer-datadef-34935")]
+    [JsonProperty("PersonMellomnavnAndreTilknyttetGardFestenummer-datadef-34935")]
+    [JsonPropertyName("PersonMellomnavnAndreTilknyttetGardFestenummer-datadef-34935")]
+public PersonMellomnavnAndreTilknyttetGardFestenummerdatadef34935 PersonMellomnavnAndreTilknyttetGardFestenummerdatadef34935 { get; set; }
+}
+public class PersonMellomnavnAndredatadef34926{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34926;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnAndreTilknytningstypedatadef34927{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34927;
+[MinLength(1)]
+[MaxLength(2)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnAndreTilknytningBeskrivelsedatadef34928{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34928;
+[MinLength(1)]
+[MaxLength(500)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnAndreTilknyttetPersonsFodselsnummerdatadef34929{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34929;
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnAndreTilknyttetPersonsEtternavndatadef34930{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34930;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnAndreTilknyttetGardNavndatadef34931{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34931;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnAndreTilknyttetGardKommunenummerdatadef34932{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34932;
+[RegularExpression(@"[0-9]{4}")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnAndreTilknyttetGardGardsnummerdatadef34933{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34933;
+[MinLength(1)]
+[MaxLength(5)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnAndreTilknyttetGardBruksnummerdatadef34934{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34934;
+[MinLength(1)]
+[MaxLength(4)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnAndreTilknyttetGardFestenummerdatadef34935{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34935;
+[MinLength(1)]
+[MaxLength(4)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class TilknytningMellomnavn3grp9354{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9354;
+    [XmlElement("PersonMellomnavnTredje-datadef-34936")]
+    [JsonProperty("PersonMellomnavnTredje-datadef-34936")]
+    [JsonPropertyName("PersonMellomnavnTredje-datadef-34936")]
+public PersonMellomnavnTredjedatadef34936 PersonMellomnavnTredjedatadef34936 { get; set; }
+    [XmlElement("PersonMellomnavnTredjeTilknytningstype-datadef-34937")]
+    [JsonProperty("PersonMellomnavnTredjeTilknytningstype-datadef-34937")]
+    [JsonPropertyName("PersonMellomnavnTredjeTilknytningstype-datadef-34937")]
+public PersonMellomnavnTredjeTilknytningstypedatadef34937 PersonMellomnavnTredjeTilknytningstypedatadef34937 { get; set; }
+    [XmlElement("PersonMellomnavnTredjeTilknytningBeskrivelse-datadef-34938")]
+    [JsonProperty("PersonMellomnavnTredjeTilknytningBeskrivelse-datadef-34938")]
+    [JsonPropertyName("PersonMellomnavnTredjeTilknytningBeskrivelse-datadef-34938")]
+public PersonMellomnavnTredjeTilknytningBeskrivelsedatadef34938 PersonMellomnavnTredjeTilknytningBeskrivelsedatadef34938 { get; set; }
+    [XmlElement("PersonMellomnavnTredjeTilknyttetPersonsFodselsnummer-datadef-34939")]
+    [JsonProperty("PersonMellomnavnTredjeTilknyttetPersonsFodselsnummer-datadef-34939")]
+    [JsonPropertyName("PersonMellomnavnTredjeTilknyttetPersonsFodselsnummer-datadef-34939")]
+public PersonMellomnavnTredjeTilknyttetPersonsFodselsnummerdatadef34939 PersonMellomnavnTredjeTilknyttetPersonsFodselsnummerdatadef34939 { get; set; }
+    [XmlElement("PersonMellomnavnTredjeTilknyttetPersonsEtternavn-datadef-34940")]
+    [JsonProperty("PersonMellomnavnTredjeTilknyttetPersonsEtternavn-datadef-34940")]
+    [JsonPropertyName("PersonMellomnavnTredjeTilknyttetPersonsEtternavn-datadef-34940")]
+public PersonMellomnavnTredjeTilknyttetPersonsEtternavndatadef34940 PersonMellomnavnTredjeTilknyttetPersonsEtternavndatadef34940 { get; set; }
+    [XmlElement("PersonMellomnavnTredjeTilknyttetGardNavn-datadef-34941")]
+    [JsonProperty("PersonMellomnavnTredjeTilknyttetGardNavn-datadef-34941")]
+    [JsonPropertyName("PersonMellomnavnTredjeTilknyttetGardNavn-datadef-34941")]
+public PersonMellomnavnTredjeTilknyttetGardNavndatadef34941 PersonMellomnavnTredjeTilknyttetGardNavndatadef34941 { get; set; }
+    [XmlElement("PersonMellomnavnTredjeTilknyttetGardKommunenummer-datadef-34942")]
+    [JsonProperty("PersonMellomnavnTredjeTilknyttetGardKommunenummer-datadef-34942")]
+    [JsonPropertyName("PersonMellomnavnTredjeTilknyttetGardKommunenummer-datadef-34942")]
+public PersonMellomnavnTredjeTilknyttetGardKommunenummerdatadef34942 PersonMellomnavnTredjeTilknyttetGardKommunenummerdatadef34942 { get; set; }
+    [XmlElement("PersonMellomnavnTredjeTilknyttetGardGardsnummer-datadef-34943")]
+    [JsonProperty("PersonMellomnavnTredjeTilknyttetGardGardsnummer-datadef-34943")]
+    [JsonPropertyName("PersonMellomnavnTredjeTilknyttetGardGardsnummer-datadef-34943")]
+public PersonMellomnavnTredjeTilknyttetGardGardsnummerdatadef34943 PersonMellomnavnTredjeTilknyttetGardGardsnummerdatadef34943 { get; set; }
+    [XmlElement("PersonMellomnavnTredjeTilknyttetGardBruksnummer-datadef-34944")]
+    [JsonProperty("PersonMellomnavnTredjeTilknyttetGardBruksnummer-datadef-34944")]
+    [JsonPropertyName("PersonMellomnavnTredjeTilknyttetGardBruksnummer-datadef-34944")]
+public PersonMellomnavnTredjeTilknyttetGardBruksnummerdatadef34944 PersonMellomnavnTredjeTilknyttetGardBruksnummerdatadef34944 { get; set; }
+    [XmlElement("PersonMellomnavnTredjeTilknyttetGardFestenummer-datadef-34945")]
+    [JsonProperty("PersonMellomnavnTredjeTilknyttetGardFestenummer-datadef-34945")]
+    [JsonPropertyName("PersonMellomnavnTredjeTilknyttetGardFestenummer-datadef-34945")]
+public PersonMellomnavnTredjeTilknyttetGardFestenummerdatadef34945 PersonMellomnavnTredjeTilknyttetGardFestenummerdatadef34945 { get; set; }
+}
+public class PersonMellomnavnTredjedatadef34936{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34936;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnTredjeTilknytningstypedatadef34937{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34937;
+[MinLength(1)]
+[MaxLength(2)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnTredjeTilknytningBeskrivelsedatadef34938{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34938;
+[MinLength(1)]
+[MaxLength(500)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnTredjeTilknyttetPersonsFodselsnummerdatadef34939{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34939;
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnTredjeTilknyttetPersonsEtternavndatadef34940{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34940;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnTredjeTilknyttetGardNavndatadef34941{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34941;
+[MinLength(1)]
+[MaxLength(50)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnTredjeTilknyttetGardKommunenummerdatadef34942{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34942;
+[RegularExpression(@"[0-9]{4}")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnTredjeTilknyttetGardGardsnummerdatadef34943{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34943;
+[MinLength(1)]
+[MaxLength(5)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnTredjeTilknyttetGardBruksnummerdatadef34944{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34944;
+[MinLength(1)]
+[MaxLength(4)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonMellomnavnTredjeTilknyttetGardFestenummerdatadef34945{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34945;
+[MinLength(1)]
+[MaxLength(4)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class TilknytningMellomnavnEkstragrp9355{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9355;
+    [XmlElement("PersonMellomnavnBeskrivelse-datadef-34946")]
+    [JsonProperty("PersonMellomnavnBeskrivelse-datadef-34946")]
+    [JsonPropertyName("PersonMellomnavnBeskrivelse-datadef-34946")]
+public PersonMellomnavnBeskrivelsedatadef34946 PersonMellomnavnBeskrivelsedatadef34946 { get; set; }
+}
+public class PersonMellomnavnBeskrivelsedatadef34946{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34946;
+[MinLength(1)]
+[MaxLength(500)]
+    [XmlText()]
+public string value { get; set; }
+}
+public class Begrunnelsegrp9317{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9317;
+    [XmlElement("BegrunnelseForNyttNavn-grp-9318")]
+    [JsonProperty("BegrunnelseForNyttNavn-grp-9318")]
+    [JsonPropertyName("BegrunnelseForNyttNavn-grp-9318")]
+public BegrunnelseForNyttNavngrp9318 BegrunnelseForNyttNavngrp9318 { get; set; }
+}
+public class BegrunnelseForNyttNavngrp9318{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+public decimal gruppeid {get; set;} = 9318;
+    [XmlElement("PersonForrigeFornavnValgt-datadef-34947")]
+    [JsonProperty("PersonForrigeFornavnValgt-datadef-34947")]
+    [JsonPropertyName("PersonForrigeFornavnValgt-datadef-34947")]
+public PersonForrigeFornavnValgtdatadef34947 PersonForrigeFornavnValgtdatadef34947 { get; set; }
+    [XmlElement("PersonFornavnAnnetBegrunnelse-datadef-34948")]
+    [JsonProperty("PersonFornavnAnnetBegrunnelse-datadef-34948")]
+    [JsonPropertyName("PersonFornavnAnnetBegrunnelse-datadef-34948")]
+public PersonFornavnAnnetBegrunnelsedatadef34948 PersonFornavnAnnetBegrunnelsedatadef34948 { get; set; }
+}
+public class PersonForrigeFornavnValgtdatadef34947{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34947;
+[RegularExpression(@"(0|1)")]
+    [XmlText()]
+public string value { get; set; }
+}
+public class PersonFornavnAnnetBegrunnelsedatadef34948{
+[Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+public decimal orid {get; set;} = 34948;
+[MinLength(1)]
+[MaxLength(500)]
+    [XmlText()]
+public string value { get; set; }
+}
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/models/message.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/models/message.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
+namespace Altinn.App.Models
+{
+  public class MessageV1{
+    [XmlElement("ProcessTask")]
+    [JsonProperty("ProcessTask")]
+    [JsonPropertyName("ProcessTask")]
+    public string ProcessTask { get; set; }
+
+    [XmlElement("Title")]
+    [JsonProperty("Title")]
+    [JsonPropertyName("Title")]
+    public string Title { get; set; }
+
+    [XmlElement("Body")]
+    [JsonProperty("Body")]
+    [JsonPropertyName("Body")]
+    public string Body { get; set; }
+
+    [XmlElement("Reference")]
+    [JsonProperty("Reference")]
+    [JsonPropertyName("Reference")]
+    public string Reference { get; set; }
+
+    [XmlElement("Sender")]
+    [JsonProperty("Sender")]
+    [JsonPropertyName("Sender")]
+    public string Sender { get; set; }
+
+  }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/ui/changename/Settings.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/ui/changename/Settings.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
+    "pages": {
+        "order": [
+            "formLayout",
+            "summary"
+        ],        
+        "excludeFromPdf": [
+            "summary"          
+        ]
+    },
+    "components": {
+        "excludeFromPdf": [    
+            "confirmChangeName"        
+        ]
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/ui/message/Settings.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/ui/message/Settings.json
@@ -1,0 +1,8 @@
+﻿{
+  "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": [
+      "formLayout"
+    ]
+  }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/appsettings.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/appsettings.json
@@ -1,0 +1,33 @@
+{
+  "Kestrel": {
+    "EndPoints": {
+      "Http": {
+        "Url": "http://*:5005"
+      }
+    }
+  },
+  "AppSettings": {
+    "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
+    "Hostname": "altinn3local.no",
+    "RuntimeCookieName": "AltinnStudioRuntime",
+    "RegisterEventsWithEventsComponent": false
+  },
+  "GeneralSettings": {
+    "HostName": "altinn3local.no",
+    "SoftValidationPrefix": "*WARNING*",
+    "AltinnPartyCookieName": "AltinnPartyId"
+  },
+  "PlatformSettings": {
+    "ApiStorageEndpoint": "http://localhost:5101/storage/api/v1/",
+    "ApiRegisterEndpoint": "http://localhost:5101/register/api/v1/",
+    "ApiProfileEndpoint": "http://localhost:5101/profile/api/v1/",
+    "ApiAuthenticationEndpoint": "http://localhost:5101/authentication/api/v1/",
+    "ApiAuthorizationEndpoint": "http://localhost:5101/authorization/api/v1/",
+    "ApiEventsEndpoint": "http://localhost:5101/events/api/v1/",
+    "ApiPdfEndpoint": "http://localhost:5070/api/v1/",
+    "SubscriptionKey": "retrieved from environment at runtime"
+  },
+  "ApplicationInsights": {
+    "InstrumentationKey": "retrieved from environment at runtime"
+  }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/config/applicationmetadata.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/config/applicationmetadata.json
@@ -1,0 +1,41 @@
+﻿{
+  "id": "ttd/issue-5740",
+  "org": "ttd",
+  "title": {
+    "nb": "issue-5740"
+  },
+  "dataTypes": [
+    {
+      "id": "ref-data-as-pdf",
+      "allowedContentTypes": [
+        "application/pdf"
+      ],
+      "maxCount": 0,
+      "minCount": 0
+    },
+    {
+      "id": "default",
+      "allowedContentTypes": [
+        "application/xml"
+      ],
+      "appLogic": {
+        "autoCreate": true,
+        "classRef": "Altinn.App.Models.Skjema"
+      },
+      "taskId": "Task_1",
+      "maxCount": 1,
+      "minCount": 1
+    }
+  ],
+  "partyTypesAllowed": {
+    "bankruptcyEstate": false,
+    "organisation": false,
+    "person": false,
+    "subUnit": false
+  },
+  "autoDeleteOnProcessEnd": false,
+  "created": "2021-03-03T16:16:59.6023111Z",
+  "createdBy": "steph",
+  "lastChanged": "2021-03-03T16:16:59.6024412Z",
+  "lastChangedBy": "steph"
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/config/authorization/policy.xml
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/config/authorization/policy.xml
@@ -1,0 +1,279 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy xmlns:xsl="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="urn:altinn:example:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides">
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:1" Effect="Permit">
+    <xacml:Description>A rule giving user with role REGNA or DAGL and the app owner ttd the right to instantiate a instance of a given app of ttd/issue-5740</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">REGNA</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DAGL</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">issue-5740</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">instantiate</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:2" Effect="Permit">
+    <xacml:Description>Rule that defines that user with role REGNA or DAGL can read and write for ttd/issue-5740 when it is in Task_1</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">REGNA</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DAGL</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">issue-5740</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">issue-5740</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">EndEvent_1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:end-event" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:3" Effect="Permit">
+    <xacml:Description>Rule that defines that user with role REGNA or DAGL can delete instances of ttd/issue-5740</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">REGNA</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DAGL</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">issue-5740</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">delete</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:4" Effect="Permit">
+    <xacml:Description>Rule that defines that org can write to instances of ttd/issue-5740 for any states</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">issue-5740</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:5" Effect="Permit">
+    <xacml:Description>Rule that defines that org can complete an instance of ttd/issue-5740 which state is at the end event.</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">issue-5740</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">EndEvent_1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:end-event" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">complete</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:6" Effect="Permit">
+    <xacml:Description>A rule giving user with role REGNA or DAGL and the app owner ttd the right to read the appresource events of a given app of ttd/issue-5740</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">REGNA</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DAGL</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ttd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">issue-5740</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">events</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:appresource" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:ObligationExpressions>
+    <xacml:ObligationExpression FulfillOn="Permit" ObligationId="urn:altinn:obligation:authenticationLevel1">
+      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel">
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue>
+      </xacml:AttributeAssignmentExpression>
+    </xacml:ObligationExpression>
+  </xacml:ObligationExpressions>
+</xacml:Policy>

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/config/process/process.bpmn
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/config/process/process.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions id="Altinn_SingleDataTask_Process_Definition" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  
+xmlns:altinn="http://altinn.no"
+xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" 
+xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" 
+xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" 
+xmlns:di="http://www.omg.org/spec/DD/20100524/DI" 
+targetNamespace="http://bpmn.io/schema/bpmn" >
+	<bpmn:process id="SingleDataTask" isExecutable="false">
+		<bpmn:startEvent id="StartEvent_1">
+			<bpmn:outgoing>SequenceFlow_1n56yn5</bpmn:outgoing>
+		</bpmn:startEvent>
+		<bpmn:task id="Task_1" name="Utfylling" altinn:tasktype="data">
+			<bpmn:incoming>SequenceFlow_1n56yn5</bpmn:incoming>
+			<bpmn:outgoing>SequenceFlow_1oot28q</bpmn:outgoing>
+		</bpmn:task>
+		<bpmn:endEvent id="EndEvent_1">
+			<bpmn:incoming>SequenceFlow_1oot28q</bpmn:incoming>
+		</bpmn:endEvent>
+		<bpmn:sequenceFlow id="SequenceFlow_1n56yn5" sourceRef="StartEvent_1" targetRef="Task_1" />
+		<bpmn:sequenceFlow id="SequenceFlow_1oot28q" sourceRef="Task_1" targetRef="EndEvent_1" />
+	</bpmn:process>
+	<bpmndi:BPMNDiagram id="BPMNDiagram_1">
+		<bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="SingleDataTask">
+			<bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+				<dc:Bounds x="156" y="81" width="36" height="36" />
+			</bpmndi:BPMNShape>
+			<bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+				<dc:Bounds x="300" y="59" width="100" height="80" />
+			</bpmndi:BPMNShape>
+			<bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+				<dc:Bounds x="512" y="81" width="36" height="36" />
+			</bpmndi:BPMNShape>
+			<bpmndi:BPMNEdge id="SequenceFlow_1n56yn5_di" bpmnElement="SequenceFlow_1n56yn5">
+				<di:waypoint x="192" y="99" />
+				<di:waypoint x="300" y="99" />
+			</bpmndi:BPMNEdge>
+			<bpmndi:BPMNEdge id="SequenceFlow_1oot28q_di" bpmnElement="SequenceFlow_1oot28q">
+				<di:waypoint x="400" y="99" />
+				<di:waypoint x="512" y="99" />
+			</bpmndi:BPMNEdge>
+		</bpmndi:BPMNPlane>
+	</bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/config/texts/resource.nb.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/config/texts/resource.nb.json
@@ -1,0 +1,241 @@
+{
+  "language": "nb",
+  "resources": [
+    {
+      "id": "ServiceName",
+      "value": "issue-5740"
+    },
+    {
+      "id": "33316.Journalnummerdatadef33316.Label",
+      "value": "Journalnummer"
+    },
+    {
+      "id": "33317.IdentifikasjonsnummerKravdatadef33317.Label",
+      "value": "KravID"
+    },
+    {
+      "id": "1223.AnsattNavndatadef1223.Label",
+      "value": "Navn"
+    },
+    {
+      "id": "1224.AnsattFodselsnummerdatadef1224.Label",
+      "value": "Fødselsnummer"
+    },
+    {
+      "id": "27335.OppgavegiverTelefonnummerdatadef27335.Label",
+      "value": "Telefonnummer"
+    },
+    {
+      "id": "27334.OppgavegiverEPostdatadef27334.Label",
+      "value": "E-post"
+    },
+    {
+      "id": "33282.AnsattSoknadAFPDatodatadef33282.Label",
+      "value": "Tidspunkt AFP søkes fra"
+    },
+    {
+      "id": "1387.AnsattTiltredelseDatodatadef1387.Label",
+      "value": "Når ble arbeidstakeren ansatt?"
+    },
+    {
+      "id": "33267.AnsattSammenhengendeAnsattAnsettelsedatadef33267.Label",
+      "value": "Har arbeidstakeren vært sammenhengende ansatt fra denne dato?"
+    },
+    {
+      "id": "33268.AnsattArbeidsforholdPabegyntdatadef33268.Label",
+      "value": "Oppgi når nåværende arbeidsforhold begynte"
+    },
+    {
+      "id": "33269.AnsattArbeidsforholdOpphortdatadef33269.Label",
+      "value": "Er det bestemt når arbeidsforholdet skal opphøre?"
+    },
+    {
+      "id": "33261.AnsattArbeidsforholdOpphortDatodatadef33261.Label",
+      "value": "Oppgi opphørsdato"
+    },
+    {
+      "id": "33262.AnsattLonnUtbetaltDatodatadef33262.Label",
+      "value": "Oppgi siste dag arbeidstakeren mottar lønn"
+    },
+    {
+      "id": "33270.AnsattArbeidsforholdOpphortDatodatadef33270.Label",
+      "value": "Hvis arbeidsforholdet allerede er avsluttet, oppgi siste arbeidsdag"
+    },
+    {
+      "id": "33271.AnsattArbeidsforholdOpphortArsakdatadef33271.Label",
+      "value": "Hva var grunnen til at arbeidsforholdet ble avsluttet?"
+    },
+    {
+      "id": "33263.AnsattLonnSpesifisertManeddatadef33263.Label",
+      "value": "Oppgi arbeidstakerens nåværende pensjonsgivende inntekt pr. måned"
+    },
+    {
+      "id": "33264.AnsattLonnBelopPeriodedatadef33264.Label",
+      "value": "Oppgi samlet pensjonsgivende inntekt (kode 111-A SKD) arbeidstaker har  mottatt siste 15 måneder"
+    },
+    {
+      "id": "33273.AnsattHeltidDeltidSesongdatadef33273.Label",
+      "value": "Er arbeidstaker heltidsansatt, deltidsansatt eller sesongarbeidstaker?"
+    },
+    {
+      "id": "31808.AnsattStillingsprosentdatadef31808.Label",
+      "value": "Oppgi stillingsbrøk/-grad"
+    },
+    {
+      "id": "33272.AnsattPabegyntStillingDatodatadef33272.Label",
+      "value": "Fra dato"
+    },
+    {
+      "id": "33274.AnsattHeltidDeltidSesongArbeidetIkkeIForetaketTidligeredatadef33274.Label",
+      "value": "Arbeidstakers tidligere stilling"
+    },
+    {
+      "id": "33277.AnsattStillingsbrokTidligereProsentdatadef33277.Label",
+      "value": "Oppgi stillingsbrøk/-grad"
+    },
+    {
+      "id": "33275.AnsattStillingTidligereFradatadef33275.Label",
+      "value": "Fra dato"
+    },
+    {
+      "id": "33276.AnsattStillingTidligereTildatadef33276.Label",
+      "value": "Til dato"
+    },
+    {
+      "id": "33265.AnsattSykemeldtdatadef33265.Label",
+      "value": "Har arbeidstakeren i løpet av de siste tre år til sammen vært  sykemeldt mer enn 26 uker?"
+    },
+    {
+      "id": "33265.AnsattSykemeldtdatadef33265.Help",
+      "value": "Hvis arbeidstakeren ikke har vært ansatt i bedriften i hele  treårsperioden, er spørsmålet om arbeidstaker har vært sykemeldt mer  enn 52 uker siden vedkommende begynte i foretaket."
+    },
+    {
+      "id": "33278.AnsattPermittertdatadef33278.Label",
+      "value": "Har arbeidstakeren i løpet av de siste tre år vært permittert?"
+    },
+    {
+      "id": "33278.AnsattPermittertdatadef33278.Help",
+      "value": "Hvis arbeidstakeren ikke har vært ansatt i bedriften i hele  treårsperioden, er spørsmålet om arbeidstaker har vært permittert  siden vedkommende begynte i foretaket."
+    },
+    {
+      "id": "33279.AnsattPermittertPermiteringsgraddatadef33279.Label",
+      "value": "Permitteringsgrad"
+    },
+    {
+      "id": "33283.AnsattPermittertDatodatadef33283.Label",
+      "value": "Fra dato"
+    },
+    {
+      "id": "33280.AnsattPermisjondatadef33280.Label",
+      "value": "Har arbeidstakeren i løpet av de siste tre år til sammen hatt  permisjon i mer enn 26 uker?"
+    },
+    {
+      "id": "33280.AnsattPermisjondatadef33280.Help",
+      "value": "Hvis arbeidstakeren ikke har vært ansatt i bedriften i hele  treårsperioden, er spørsmålet om arbeidstaker har hatt permisjon mer  enn 26 uker siden vedkommende begynte i foretaket"
+    },
+    {
+      "id": "33281.AnsattPermisjonTypedatadef33281.Label",
+      "value": "Oppgi type permisjon"
+    },
+    {
+      "id": "33293.AnsattYtelserMottattUtenArbeidspliktdatadef33293.Label",
+      "value": "Har arbeidstakeren i løpet av de siste tre år fått utbetalt pensjon,  ventelønn eller annen ytelse uten motsvarende arbeidsplikt, fra  nåværende eller tidligere arbeidsforhold?"
+    },
+    {
+      "id": "33293.AnsattYtelserMottattUtenArbeidspliktdatadef33293.Help",
+      "value": "Svar ja også dersom arbeidstakeren har mottatt pensjon eller fått  redusert stillingsbrøken/-graden, men opprettholdt tidligere lønn.  Hvis arbeidstakeren ikke har vært ansatt i bedriften i hele  treårsperioden, er\n                                    spørsmålet om arbeidstakeren har mottatt ytelser  uten motsvarende arbeidsplikt siden vedkommende begynte i foretaket."
+    },
+    {
+      "id": "33294.AnsattEierandel20EllerMerdatadef33294.Label",
+      "value": "Har arbeidstakeren etter fylte 53 år hatt en eierandel på 20 % eller  mer i foretaket eller i annet selskap i samme konsern?"
+    },
+    {
+      "id": "33284.AnsattIForetaketHovedbeskjeftigelsedatadef33284.Label",
+      "value": "Har arbeidstakeren hatt arbeidet i foretaket som sin  hovedbeskjeftigelse?"
+    },
+    {
+      "id": "33284.AnsattIForetaketHovedbeskjeftigelsedatadef33284.Help",
+      "value": "Svar nei dersom arbeidsgiver kjenner til at arbeidstaker har brukt mer  enn halvparten av arbeidstiden i annet foretak."
+    },
+    {
+      "id": "33285.AnsattStillingsbrokUnder20datadef33285.Label",
+      "value": "Har arbeidstakeren etter fylte 53 år hatt stillingsbrøk/-grad på under  20 %?"
+    },
+    {
+      "id": "3443.InnsenderNavndatadef3443.Label",
+      "value": "Enhetens navn"
+    },
+    {
+      "id": "33286.EnhetNavnEndringdatadef33286.Label",
+      "value": "Oppgi tidligere navn på foretaket dersom det har skiftet navn de siste  10 år"
+    },
+    {
+      "id": "3445.InnsenderAdressedatadef3445.Label",
+      "value": "Postadresse"
+    },
+    {
+      "id": "11339.InnsenderPostnummerdatadef11339.Label",
+      "value": "Postnummer"
+    },
+    {
+      "id": "11340.InnsenderPoststeddatadef11340.Label",
+      "value": "Poststed"
+    },
+    {
+      "id": "755.EnhetTelefonnummerdatadef755.Label",
+      "value": "Telefon"
+    },
+    {
+      "id": "1816.EnhetTelefaksnummerdatadef1816.Label",
+      "value": "Telefaks"
+    },
+    {
+      "id": "21591.EnhetEPostdatadef21591.Label",
+      "value": "E-post"
+    },
+    {
+      "id": "33552.ForetakOrganisasjonsnummerdatadef33552.Label",
+      "value": "Organisasjonsnummer"
+    },
+    {
+      "id": "22684.EnhetOrganisasjonsnummerNydatadef22684.Label",
+      "value": "Hvis ovennevnte organisasjonsnummer ikke stemmer, fyll ut riktig  nummer"
+    },
+    {
+      "id": "33287.EnhetOrganisasjonsnummerEndringArsakdatadef33287.Label",
+      "value": "Oppgi grunn til endring av organisasjonsnummer"
+    },
+    {
+      "id": "19.BedriftOrganisasjonsnummerdatadef19.Label",
+      "value": "Undernummer hvor arbeidstakeren er registrert i Arbeidsgiver- og  arbeidstakerregisteret"
+    },
+    {
+      "id": "33292.BedriftOrganisasjonsnummerNydatadef33292.Label",
+      "value": "Hvis ovennevnte undernummer ikke stemmer, fyll ut riktig nummer"
+    },
+    {
+      "id": "33288.BedriftOrganisasjonsnummerEndringArsakdatadef33288.Label",
+      "value": "Oppgi grunn til endring av undernummer"
+    },
+    {
+      "id": "33289.AnsattAnsettelsePgaFusjonFisjonOverdragelsedatadef33289.Label",
+      "value": "Har arbeidstakeren blitt ansatt i foretaket i forbindelse med  sammenslåing (fusjon), deling (fisjon) eller overdragelse av  virksomhet?"
+    },
+    {
+      "id": "31.EnhetNavnEndringdatadef31.Label",
+      "value": "Navn på foretaket som har vært omfattet av foretaksendringen"
+    },
+    {
+      "id": "33290.Merknaddatadef33290.Label",
+      "value": "Merknad"
+    },
+    {
+      "id": "Skjema.Label",
+      "value": "Arbeidsgiverskjema AFP"
+    },
+    {
+      "id": "8854.Skjemainstansgrp8854.Label",
+      "value": "Skjemainstans"
+    }
+  ]
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/App.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/App.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Altinn.App.AppLogic.Calculation;
+using Altinn.App.AppLogic.Print;
+using Altinn.App.AppLogic.Validation;
+using Altinn.App.Common.Enums;
+using Altinn.App.Common.Models;
+using Altinn.App.Services.Configuration;
+using Altinn.App.Services.Implementation;
+using Altinn.App.Services.Interface;
+using Altinn.App.Services.Models.Validation;
+using Altinn.Platform.Storage.Interface.Models;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+{
+    /// <summary>
+    /// Represents the core logic of an App
+    /// </summary>
+    public class App : AppBase, IAltinnApp
+    {
+        private readonly ILogger<App> _logger;
+        private readonly ValidationHandler _validationHandler;
+        private readonly CalculationHandler _calculationHandler;
+        private readonly InstantiationHandler _instantiationHandler;
+        private readonly PdfHandler _pdfHandler;
+
+        /// <summary>
+        /// Initialize a new instance of the <see cref="App"/> class.
+        /// </summary>
+        /// <param name="appResourcesService">A service with access to local resources.</param>
+        /// <param name="logger">A logger from the built in LoggingFactory.</param>
+        /// <param name="dataService">A service with access to data storage.</param>
+        /// <param name="processService">A service with access to the process.</param>
+        /// <param name="pdfService">A service with access to the PDF generator.</param>
+        /// <param name="profileService">A service with access to profile information.</param>
+        /// <param name="registerService">A service with access to register information.</param>
+        /// <param name="prefillService">A service with access to prefill mechanisms.</param>
+        /// <param name="instanceService">A service with access to instances</param>
+        /// <param name="settings">General settings</param>
+        /// <param name="textService">A service with access to text</param>
+        /// <param name="httpContextAccessor">A context accessor</param>
+        public App(
+            IAppResources appResourcesService,
+            ILogger<App> logger,
+            IData dataService,
+            IProcess processService,
+            IPDF pdfService,
+            IProfile profileService,
+            IRegister registerService,
+            IPrefill prefillService,
+            IInstance instanceService,
+            IOptions<GeneralSettings> settings,
+            IText textService,
+            IHttpContextAccessor httpContextAccessor) : base(
+                appResourcesService,
+                logger,
+                dataService,
+                processService,
+                pdfService,
+                prefillService,
+                instanceService,
+                registerService,
+                settings,
+                profileService,
+                textService,
+                httpContextAccessor)
+        {
+            _logger = logger;
+            _validationHandler = new ValidationHandler(httpContextAccessor);
+            _calculationHandler = new CalculationHandler();
+            _instantiationHandler = new InstantiationHandler(profileService, registerService);
+            _pdfHandler = new PdfHandler();
+        }
+
+        /// <inheritdoc />
+        public override async Task<List<string>> GetPageOrder(string org, string app, int instanceOwnerId, Guid instanceGuid, string currentPage, string dataTypeId)
+        {
+            await Task.CompletedTask;
+            return new List<string> { "Side4", "Side2", "Side1", "Side3" };
+        }
+
+        /// <inheritdoc />
+        public override object CreateNewAppModel(string classRef)
+        {
+            _logger.LogInformation($"CreateNewAppModel {classRef}");
+
+            Type appType = Type.GetType(classRef);
+            return Activator.CreateInstance(appType);
+        }
+
+        /// <inheritdoc />
+        public override Type GetAppModelType(string classRef)
+        {
+            _logger.LogInformation($"GetAppModelType {classRef}");
+
+            return Type.GetType(classRef);
+        }
+
+        /// <summary>
+        /// Run app event
+        /// </summary>
+        /// <remarks>DEPRECATED METHOD, USE EVENT SPECIFIC METHOD INSTEAD</remarks>
+        /// <param name="appEvent">The app event type</param>
+        /// <param name="model">The service model</param>
+        /// <param name="modelState">The model state</param>
+        /// <returns>True if the event was handled</returns>
+        public override async Task<bool> RunAppEvent(AppEventType appEvent, object model, ModelStateDictionary modelState = null)
+        {
+            _logger.LogInformation($"RunAppEvent {appEvent}");
+
+            return await Task.FromResult(true);
+        }
+
+        /// <summary>
+        /// Run data validation event to perform custom validations on data
+        /// </summary>
+        /// <param name="data">An instance of the data to be validated.</param>
+        /// <param name="validationResults">Object to contain any validation errors/warnings</param>
+        /// <returns>Value indicating if the form is valid or not</returns>
+        public override async Task RunDataValidation(object data, ModelStateDictionary validationResults)
+        {
+            await _validationHandler.ValidateData(data, validationResults);
+        }
+
+        /// <summary>
+        /// Run task validation event to perform custom validations on instance
+        /// </summary>
+        /// <param name="instance">A reference to the current instance.</param>
+        /// <param name="taskId">The name of the process step to validate based on.</param>
+        /// <param name="validationResults">Object to contain any validation errors/warnings.</param>
+        /// <returns>A task supporting the async await pattern.</returns>
+        public override async Task RunTaskValidation(Instance instance, string taskId, ModelStateDictionary validationResults)
+        {
+            await _validationHandler.ValidateTask(instance, taskId, validationResults);
+        }
+
+        /// <summary>
+        /// Is called to run custom calculation events defined by app developer.
+        /// </summary>
+        /// <param name="data">The data to perform calculations on</param>
+        public override async Task<bool> RunCalculation(object data)
+        {
+            return await _calculationHandler.Calculate(data);
+        }
+
+        /// <summary>
+        /// Is called to run custom instantiation validation defined by app developer.
+        /// </summary>
+        /// <returns>Task with validation results</returns>
+        public override async Task<InstantiationValidationResult> RunInstantiationValidation(Instance instance)
+        {
+            return await _instantiationHandler.RunInstantiationValidation(instance);
+        }
+
+        /// <summary>
+        /// Is called to run data creation (custom prefill) defined by app developer.
+        /// </summary>
+        /// <param name="instance">The data to perform data creation on</param>
+        /// <param name="data">The data object being created</param>
+        public override async Task RunDataCreation(Instance instance, object data)
+        {
+            await _instantiationHandler.DataCreation(instance, data);
+        }
+
+        /// <inheritdoc />
+        public override Task<AppOptions> GetOptions(string id, AppOptions options)
+        {
+            return Task.FromResult(options);
+        }
+
+        /// <summary>
+        /// Hook to run code when process tasks is ended. 
+        /// </summary>
+        /// <param name="taskId">The current TaskId</param>
+        /// <param name="instance">The instance where task is ended</param>
+        /// <returns>A task supporting the async await pattern.</returns>
+        public override async Task RunProcessTaskEnd(string taskId, Instance instance)
+        {
+            await Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Hook to run logic to hide pages or components when generatring PDF
+        /// </summary>
+        /// <param name="layoutSettings">The layoutsettings. Can be null and need to be created in method</param>
+        /// <param name="data">The data that there is generated PDF from</param>
+        /// <returns>Layoutsetting with possible hidden fields or pages</returns>
+        public override async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data)
+        {
+            return await _pdfHandler.FormatPdf(layoutSettings, data);
+        }
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/Calculation/CalculationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/Calculation/CalculationHandler.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+
+//// using Altinn.App.Models; // <-- Uncomment this line to refer to app model(s)
+
+namespace Altinn.App.AppLogic.Calculation
+{
+    /// <summary>
+    /// Represents a business logic class responsible for running calculations on an instance.
+    /// </summary>
+    public class CalculationHandler
+    {
+        /// <summary>
+        /// Perform calculations and update data model
+        /// </summary>
+        /// <example>
+        /// if (instance.GetType() == typeof(Skjema)
+        /// {
+        ///     Skjema model = (Skjema)instance;
+        ///     // Perform calculations and manipulation of data model here
+        /// }
+        /// </example>
+        /// <param name="instance">The data</param>
+        public async Task<bool> Calculate(object instance)
+        {
+            return await Task.FromResult(false);
+        }
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/InstantiationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/InstantiationHandler.cs
@@ -1,0 +1,61 @@
+using System.Threading.Tasks;
+using Altinn.App.Services.Interface;
+using Altinn.App.Services.Models.Validation;
+using Altinn.Platform.Storage.Interface.Models;
+
+//// using Altinn.App.Models; // Uncomment this line to refer to app model(s)
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+{
+    /// <summary>
+    /// Represents a business logic class responsible for running logic related to instantiation.
+    /// </summary>
+    public class InstantiationHandler
+    {
+        private IProfile _profileService;
+        private IRegister _registerService;
+
+        /// <summary>
+        /// Initialize a new instance of the <see cref="InstantiationHandler"/> class with services
+        /// that can be used to access profile and register information.
+        /// </summary>
+        /// <param name="profileService">A service with access to profile information</param>
+        /// <param name="registerService">A service with access to register information</param>
+        public InstantiationHandler(IProfile profileService, IRegister registerService)
+        {
+            _profileService = profileService;
+            _registerService = registerService;
+        }
+
+        /// <summary>
+        /// Run validations related to instantiation
+        /// </summary>
+        /// <example>
+        /// if ([some condition])
+        /// {
+        ///     return new ValidationResult("[error message]");
+        /// }
+        /// return null;
+        /// </example>
+        /// <param name="instance">The instance being validated</param>
+        /// <returns>The validation result object (null if no errors) </returns>
+        public async Task<InstantiationValidationResult> RunInstantiationValidation(Instance instance)
+        {
+            return await Task.FromResult((InstantiationValidationResult)null);
+        }
+
+        /// <summary>
+        /// Run events related to instantiation
+        /// </summary>
+        /// <remarks>
+        /// For example custom prefill.
+        /// </remarks>
+        /// <param name="instance">Instance information</param>
+        /// <param name="data">The data object created</param>
+        public async Task DataCreation(Instance instance, object data)
+        {
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/Print/PdfHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/Print/PdfHandler.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Altinn.App.Common.Models;
+
+namespace Altinn.App.AppLogic.Print
+{
+    /// <summary>
+    /// Handler for formatting PDF. 
+    /// </summary>
+    public class PdfHandler
+    {
+        /// <summary>
+        /// Method to format PDF dynamic
+        /// </summary>
+        /// <example>
+        ///     if (data.GetType() == typeof(Skjema)
+        ///     {
+        ///     // need to create object if not there
+        ///     layoutSettings.Components.ExcludeFromPdf.Add("a23234234");
+        ///     }
+        /// </example>
+        /// <param name="layoutSettings">the layoutsettings</param>
+        /// <param name="data">data object</param>
+        public async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data)
+        {
+            return await Task.FromResult(layoutSettings);
+        }
+    }   
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/Print/PdfHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/Print/PdfHandler.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
 using Altinn.App.Common.Models;
 
-namespace Altinn.App.AppLogic.Print
+namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
 {
     /// <summary>
     /// Handler for formatting PDF. 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/Validation/ValidationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/Validation/ValidationHandler.cs
@@ -1,0 +1,78 @@
+using System.Threading.Tasks;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+//// using Altinn.App.Models; // Uncomment this line to refer to app model(s)
+
+namespace Altinn.App.AppLogic.Validation
+{
+    /// <summary>
+    /// Represents a business logic class responsible for running validation at different steps of a process.
+    /// </summary>
+    public class ValidationHandler
+    {
+        private IHttpContextAccessor _httpContextAccessor;
+
+        /// <summary>
+        /// Initialize a new instance of the <see cref="ValidationHandler"/> class with access to the Http Context.
+        /// </summary>
+        /// <param name="httpContextAccessor">An http context accessor.</param>
+        public ValidationHandler(IHttpContextAccessor httpContextAccessor = null)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <summary>
+        /// Handles all custom validations that are not covered by the data model validation.
+        /// </summary>
+        /// <remarks>
+        /// Validations that fail should be handled by updating the validation result object,
+        /// see example.
+        /// </remarks>
+        /// <param name="data">The data object to validate</param>
+        /// <param name="validationResults">An object with the result of the validation.</param>
+        /// <example>
+        /// if (instance.GetType() == typeof([model class name])
+        /// {
+        ///     // Explicitly cast instance to correct model type
+        ///     [model class name] model = ([model class name])object;
+        ///
+        ///     // Perform validations
+        ///     if ([some condition])
+        ///     {
+        ///       validationResults.Add(new ValidationResult([error message], new List{string}() {[affected field id]} ));
+        ///     }
+        /// }
+        /// </example>
+        public async Task ValidateData(object data, ModelStateDictionary validationResults)
+        {
+            await Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Handles all custom validation regarding the state of the instance in a given task
+        /// </summary>
+        /// <remarks>
+        /// Validations that fail should be handled by updating the validation result object,
+        /// see example.
+        /// </remarks>
+        /// <param name="instance">The current instance.</param>
+        /// <param name="taskId">The process task id to validate the instance against.</param>
+        /// <param name="validationResults">An object with the result of the validation.</param>
+        /// <example>
+        ///  if (taskId.Equals("Task_2"))
+        ///  {
+        ///     DateTime deadline = ((DateTime)instance.Created).AddDays(3);
+        ///     if (DateTime.UtcNow &lt; deadline)
+        ///     {
+        ///       validationResults.AddModelError("flyttemelding", $"Avslutting av task 2 er kun gyldig mellom 08-15 på hverdager.");
+        ///     }
+        ///   }
+        /// </example>
+        public async Task ValidateTask(Instance instance, string taskId, ModelStateDictionary validationResults)
+        {
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/Validation/ValidationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/logic/Validation/ValidationHandler.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 //// using Altinn.App.Models; // Uncomment this line to refer to app model(s)
 
-namespace Altinn.App.AppLogic.Validation
+namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
 {
     /// <summary>
     /// Represents a business logic class responsible for running validation at different steps of a process.

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/models/default.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/models/default.cs
@@ -1,0 +1,1013 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
+
+namespace App.IntegrationTests.Mocks.Apps.ttd.issue5740
+{
+    public class Skjema{
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlAttribute("skjemanummer")]
+    [BindNever]
+    public decimal skjemanummer {get; set;} = 1472;
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlAttribute("spesifikasjonsnummer")]
+    [BindNever]
+    public decimal spesifikasjonsnummer {get; set;} = 9812;
+
+    [XmlAttribute("blankettnummer")]
+    [BindNever]
+    public  string blankettnummer {get; set; } = "AFP-01";
+
+    [XmlAttribute("tittel")]
+    [BindNever]
+    public  string tittel {get; set; } = "Arbeidsgiverskjema AFP";
+
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+    public decimal gruppeid {get; set;} = 8818;
+
+    [XmlAttribute("etatid")]
+    public string etatid { get; set; }
+
+    [XmlElement("OpplysningerOmArbeidstakeren-grp-8819")]
+    [JsonProperty("OpplysningerOmArbeidstakeren-grp-8819")]
+    [JsonPropertyName("OpplysningerOmArbeidstakeren-grp-8819")]
+    public OpplysningerOmArbeidstakerengrp8819 OpplysningerOmArbeidstakerengrp8819 { get; set; }
+
+    [XmlElement("StillingsbrokGrad-grp-8821")]
+    [JsonProperty("StillingsbrokGrad-grp-8821")]
+    [JsonPropertyName("StillingsbrokGrad-grp-8821")]
+    public StillingsbrokGradgrp8821 StillingsbrokGradgrp8821 { get; set; }
+
+    [XmlElement("Permisjonsopplysninger-grp-8822")]
+    [JsonProperty("Permisjonsopplysninger-grp-8822")]
+    [JsonPropertyName("Permisjonsopplysninger-grp-8822")]
+    public Permisjonsopplysningergrp8822 Permisjonsopplysningergrp8822 { get; set; }
+
+    [XmlElement("Foretak-grp-8820")]
+    [JsonProperty("Foretak-grp-8820")]
+    [JsonPropertyName("Foretak-grp-8820")]
+    public Foretakgrp8820 Foretakgrp8820 { get; set; }
+
+  }
+  public class OpplysningerOmArbeidstakerengrp8819{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+    public decimal gruppeid {get; set;} = 8819;
+
+    [XmlElement("Skjemainstans-grp-8854")]
+    [JsonProperty("Skjemainstans-grp-8854")]
+    [JsonPropertyName("Skjemainstans-grp-8854")]
+    public Skjemainstansgrp8854 Skjemainstansgrp8854 { get; set; }
+
+    [XmlElement("OpplysningerOmArbeidstakeren-grp-8855")]
+    [JsonProperty("OpplysningerOmArbeidstakeren-grp-8855")]
+    [JsonPropertyName("OpplysningerOmArbeidstakeren-grp-8855")]
+    public OpplysningerOmArbeidstakerengrp8855 OpplysningerOmArbeidstakerengrp8855 { get; set; }
+
+    [XmlElement("Arbeidsforhold-grp-8856")]
+    [JsonProperty("Arbeidsforhold-grp-8856")]
+    [JsonPropertyName("Arbeidsforhold-grp-8856")]
+    public Arbeidsforholdgrp8856 Arbeidsforholdgrp8856 { get; set; }
+
+  }
+  public class Skjemainstansgrp8854{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+    public decimal gruppeid {get; set;} = 8854;
+
+    [XmlElement("Journalnummer-datadef-33316")]
+    [JsonProperty("Journalnummer-datadef-33316")]
+    [JsonPropertyName("Journalnummer-datadef-33316")]
+    public Journalnummerdatadef33316 Journalnummerdatadef33316 { get; set; }
+
+    [XmlElement("IdentifikasjonsnummerKrav-datadef-33317")]
+    [JsonProperty("IdentifikasjonsnummerKrav-datadef-33317")]
+    [JsonPropertyName("IdentifikasjonsnummerKrav-datadef-33317")]
+    public IdentifikasjonsnummerKravdatadef33317 IdentifikasjonsnummerKravdatadef33317 { get; set; }
+
+  }
+  public class Journalnummerdatadef33316{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33316;
+
+    [Range(-7.766279631452242E+18, 7.766279631452242E+18)]
+    [XmlText()]
+    public decimal value { get; set; }
+
+  }
+  public class IdentifikasjonsnummerKravdatadef33317{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33317;
+
+    [MinLength(1)]
+    [MaxLength(20)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class OpplysningerOmArbeidstakerengrp8855{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+    public decimal gruppeid {get; set;} = 8855;
+
+    [XmlElement("AnsattNavn-datadef-1223")]
+    [JsonProperty("AnsattNavn-datadef-1223")]
+    [JsonPropertyName("AnsattNavn-datadef-1223")]
+    public AnsattNavndatadef1223 AnsattNavndatadef1223 { get; set; }
+
+    [XmlElement("AnsattFodselsnummer-datadef-1224")]
+    [JsonProperty("AnsattFodselsnummer-datadef-1224")]
+    [JsonPropertyName("AnsattFodselsnummer-datadef-1224")]
+    public AnsattFodselsnummerdatadef1224 AnsattFodselsnummerdatadef1224 { get; set; }
+
+    [XmlElement("OppgavegiverTelefonnummer-datadef-27335")]
+    [JsonProperty("OppgavegiverTelefonnummer-datadef-27335")]
+    [JsonPropertyName("OppgavegiverTelefonnummer-datadef-27335")]
+    public OppgavegiverTelefonnummerdatadef27335 OppgavegiverTelefonnummerdatadef27335 { get; set; }
+
+    [XmlElement("OppgavegiverEPost-datadef-27334")]
+    [JsonProperty("OppgavegiverEPost-datadef-27334")]
+    [JsonPropertyName("OppgavegiverEPost-datadef-27334")]
+    public OppgavegiverEPostdatadef27334 OppgavegiverEPostdatadef27334 { get; set; }
+
+    [XmlElement("AnsattSoknadAFPDato-datadef-33282")]
+    [JsonProperty("AnsattSoknadAFPDato-datadef-33282")]
+    [JsonPropertyName("AnsattSoknadAFPDato-datadef-33282")]
+    public AnsattSoknadAFPDatodatadef33282 AnsattSoknadAFPDatodatadef33282 { get; set; }
+
+  }
+  public class AnsattNavndatadef1223{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 1223;
+
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattFodselsnummerdatadef1224{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 1224;
+
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class OppgavegiverTelefonnummerdatadef27335{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 27335;
+
+    [MinLength(1)]
+    [MaxLength(11)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class OppgavegiverEPostdatadef27334{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 27334;
+
+    [MinLength(1)]
+    [MaxLength(50)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattSoknadAFPDatodatadef33282{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33282;
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1,2][0-9]|3[0,1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class Arbeidsforholdgrp8856{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+    public decimal gruppeid {get; set;} = 8856;
+
+    [XmlElement("AnsattTiltredelseDato-datadef-1387")]
+    [JsonProperty("AnsattTiltredelseDato-datadef-1387")]
+    [JsonPropertyName("AnsattTiltredelseDato-datadef-1387")]
+    public AnsattTiltredelseDatodatadef1387 AnsattTiltredelseDatodatadef1387 { get; set; }
+
+    [XmlElement("AnsattSammenhengendeAnsattAnsettelse-datadef-33267")]
+    [JsonProperty("AnsattSammenhengendeAnsattAnsettelse-datadef-33267")]
+    [JsonPropertyName("AnsattSammenhengendeAnsattAnsettelse-datadef-33267")]
+    public AnsattSammenhengendeAnsattAnsettelsedatadef33267 AnsattSammenhengendeAnsattAnsettelsedatadef33267 { get; set; }
+
+    [XmlElement("AnsattArbeidsforholdPabegynt-datadef-33268")]
+    [JsonProperty("AnsattArbeidsforholdPabegynt-datadef-33268")]
+    [JsonPropertyName("AnsattArbeidsforholdPabegynt-datadef-33268")]
+    public AnsattArbeidsforholdPabegyntdatadef33268 AnsattArbeidsforholdPabegyntdatadef33268 { get; set; }
+
+    [XmlElement("AnsattArbeidsforholdOpphort-datadef-33269")]
+    [JsonProperty("AnsattArbeidsforholdOpphort-datadef-33269")]
+    [JsonPropertyName("AnsattArbeidsforholdOpphort-datadef-33269")]
+    public AnsattArbeidsforholdOpphortdatadef33269 AnsattArbeidsforholdOpphortdatadef33269 { get; set; }
+
+    [XmlElement("AnsattArbeidsforholdOpphortDato-datadef-33261")]
+    [JsonProperty("AnsattArbeidsforholdOpphortDato-datadef-33261")]
+    [JsonPropertyName("AnsattArbeidsforholdOpphortDato-datadef-33261")]
+    public AnsattArbeidsforholdOpphortDatodatadef33261 AnsattArbeidsforholdOpphortDatodatadef33261 { get; set; }
+
+    [XmlElement("AnsattLonnUtbetaltDato-datadef-33262")]
+    [JsonProperty("AnsattLonnUtbetaltDato-datadef-33262")]
+    [JsonPropertyName("AnsattLonnUtbetaltDato-datadef-33262")]
+    public AnsattLonnUtbetaltDatodatadef33262 AnsattLonnUtbetaltDatodatadef33262 { get; set; }
+
+    [XmlElement("AnsattArbeidsforholdOpphortDato-datadef-33270")]
+    [JsonProperty("AnsattArbeidsforholdOpphortDato-datadef-33270")]
+    [JsonPropertyName("AnsattArbeidsforholdOpphortDato-datadef-33270")]
+    public AnsattArbeidsforholdOpphortDatodatadef33270 AnsattArbeidsforholdOpphortDatodatadef33270 { get; set; }
+
+    [XmlElement("AnsattArbeidsforholdOpphortArsak-datadef-33271")]
+    [JsonProperty("AnsattArbeidsforholdOpphortArsak-datadef-33271")]
+    [JsonPropertyName("AnsattArbeidsforholdOpphortArsak-datadef-33271")]
+    public AnsattArbeidsforholdOpphortArsakdatadef33271 AnsattArbeidsforholdOpphortArsakdatadef33271 { get; set; }
+
+    [XmlElement("AnsattLonnSpesifisertManed-datadef-33263")]
+    [JsonProperty("AnsattLonnSpesifisertManed-datadef-33263")]
+    [JsonPropertyName("AnsattLonnSpesifisertManed-datadef-33263")]
+    public AnsattLonnSpesifisertManeddatadef33263 AnsattLonnSpesifisertManeddatadef33263 { get; set; }
+
+    [XmlElement("AnsattLonnBelopPeriode-datadef-33264")]
+    [JsonProperty("AnsattLonnBelopPeriode-datadef-33264")]
+    [JsonPropertyName("AnsattLonnBelopPeriode-datadef-33264")]
+    public AnsattLonnBelopPeriodedatadef33264 AnsattLonnBelopPeriodedatadef33264 { get; set; }
+
+  }
+  public class AnsattTiltredelseDatodatadef1387{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 1387;
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1,2][0-9]|3[0,1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattSammenhengendeAnsattAnsettelsedatadef33267{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33267;
+
+    [MinLength(1)]
+    [MaxLength(3)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattArbeidsforholdPabegyntdatadef33268{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33268;
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1,2][0-9]|3[0,1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattArbeidsforholdOpphortdatadef33269{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33269;
+
+    [MinLength(1)]
+    [MaxLength(3)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattArbeidsforholdOpphortDatodatadef33261{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33261;
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1,2][0-9]|3[0,1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattLonnUtbetaltDatodatadef33262{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33262;
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1,2][0-9]|3[0,1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattArbeidsforholdOpphortDatodatadef33270{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33270;
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1,2][0-9]|3[0,1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattArbeidsforholdOpphortArsakdatadef33271{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33271;
+
+    [MinLength(1)]
+    [MaxLength(10)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattLonnSpesifisertManeddatadef33263{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33263;
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlText()]
+    public decimal value { get; set; }
+
+  }
+  public class AnsattLonnBelopPeriodedatadef33264{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33264;
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlText()]
+    public decimal value { get; set; }
+
+  }
+  public class StillingsbrokGradgrp8821{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+    public decimal gruppeid {get; set;} = 8821;
+
+    [XmlElement("NavarendeStillingsbrokGrad-grp-8857")]
+    [JsonProperty("NavarendeStillingsbrokGrad-grp-8857")]
+    [JsonPropertyName("NavarendeStillingsbrokGrad-grp-8857")]
+    public NavarendeStillingsbrokGradgrp8857 NavarendeStillingsbrokGradgrp8857 { get; set; }
+
+    [XmlElement("ForhenvarendeStillingsbrokGrad-grp-8858")]
+    [JsonProperty("ForhenvarendeStillingsbrokGrad-grp-8858")]
+    [JsonPropertyName("ForhenvarendeStillingsbrokGrad-grp-8858")]
+    public ForhenvarendeStillingsbrokGradgrp8858 ForhenvarendeStillingsbrokGradgrp8858 { get; set; }
+
+  }
+  public class NavarendeStillingsbrokGradgrp8857{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+    public decimal gruppeid {get; set;} = 8857;
+
+    [XmlElement("AnsattHeltidDeltidSesong-datadef-33273")]
+    [JsonProperty("AnsattHeltidDeltidSesong-datadef-33273")]
+    [JsonPropertyName("AnsattHeltidDeltidSesong-datadef-33273")]
+    public AnsattHeltidDeltidSesongdatadef33273 AnsattHeltidDeltidSesongdatadef33273 { get; set; }
+
+    [XmlElement("AnsattStillingsprosent-datadef-31808")]
+    [JsonProperty("AnsattStillingsprosent-datadef-31808")]
+    [JsonPropertyName("AnsattStillingsprosent-datadef-31808")]
+    public AnsattStillingsprosentdatadef31808 AnsattStillingsprosentdatadef31808 { get; set; }
+
+    [XmlElement("NarBegynteArbeidstakerenINavarendeStillingsbrokGrad-grp-8860")]
+    [JsonProperty("NarBegynteArbeidstakerenINavarendeStillingsbrokGrad-grp-8860")]
+    [JsonPropertyName("NarBegynteArbeidstakerenINavarendeStillingsbrokGrad-grp-8860")]
+    public NarBegynteArbeidstakerenINavarendeStillingsbrokGradgrp8860 NarBegynteArbeidstakerenINavarendeStillingsbrokGradgrp8860 { get; set; }
+
+  }
+  public class AnsattHeltidDeltidSesongdatadef33273{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33273;
+
+    [MinLength(1)]
+    [MaxLength(20)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattStillingsprosentdatadef31808{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 31808;
+
+    [Range(1, 999)]
+    [XmlText()]
+    public decimal value { get; set; }
+
+  }
+  public class NarBegynteArbeidstakerenINavarendeStillingsbrokGradgrp8860{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+    public decimal gruppeid {get; set;} = 8860;
+
+    [XmlElement("AnsattPabegyntStillingDato-datadef-33272")]
+    [JsonProperty("AnsattPabegyntStillingDato-datadef-33272")]
+    [JsonPropertyName("AnsattPabegyntStillingDato-datadef-33272")]
+    public AnsattPabegyntStillingDatodatadef33272 AnsattPabegyntStillingDatodatadef33272 { get; set; }
+
+  }
+  public class AnsattPabegyntStillingDatodatadef33272{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33272;
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1,2][0-9]|3[0,1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class ForhenvarendeStillingsbrokGradgrp8858{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+    public decimal gruppeid {get; set;} = 8858;
+
+    [XmlElement("AnsattHeltidDeltidSesongArbeidetIkkeIForetaketTidligere-datadef-33274")]
+    [JsonProperty("AnsattHeltidDeltidSesongArbeidetIkkeIForetaketTidligere-datadef-33274")]
+    [JsonPropertyName("AnsattHeltidDeltidSesongArbeidetIkkeIForetaketTidligere-datadef-33274")]
+    public AnsattHeltidDeltidSesongArbeidetIkkeIForetaketTidligeredatadef33274 AnsattHeltidDeltidSesongArbeidetIkkeIForetaketTidligeredatadef33274 { get; set; }
+
+    [XmlElement("AnsattStillingsbrokTidligereProsent-datadef-33277")]
+    [JsonProperty("AnsattStillingsbrokTidligereProsent-datadef-33277")]
+    [JsonPropertyName("AnsattStillingsbrokTidligereProsent-datadef-33277")]
+    public AnsattStillingsbrokTidligereProsentdatadef33277 AnsattStillingsbrokTidligereProsentdatadef33277 { get; set; }
+
+    [XmlElement("TidsromForDenneStillingsbrokenGraden-grp-8859")]
+    [JsonProperty("TidsromForDenneStillingsbrokenGraden-grp-8859")]
+    [JsonPropertyName("TidsromForDenneStillingsbrokenGraden-grp-8859")]
+    public TidsromForDenneStillingsbrokenGradengrp8859 TidsromForDenneStillingsbrokenGradengrp8859 { get; set; }
+
+  }
+  public class AnsattHeltidDeltidSesongArbeidetIkkeIForetaketTidligeredatadef33274{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33274;
+
+    [MinLength(1)]
+    [MaxLength(30)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattStillingsbrokTidligereProsentdatadef33277{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33277;
+
+    [Range(1, 999)]
+    [XmlText()]
+    public decimal value { get; set; }
+
+  }
+  public class TidsromForDenneStillingsbrokenGradengrp8859{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+    public decimal gruppeid {get; set;} = 8859;
+
+    [XmlElement("AnsattStillingTidligereFra-datadef-33275")]
+    [JsonProperty("AnsattStillingTidligereFra-datadef-33275")]
+    [JsonPropertyName("AnsattStillingTidligereFra-datadef-33275")]
+    public AnsattStillingTidligereFradatadef33275 AnsattStillingTidligereFradatadef33275 { get; set; }
+
+    [XmlElement("AnsattStillingTidligereTil-datadef-33276")]
+    [JsonProperty("AnsattStillingTidligereTil-datadef-33276")]
+    [JsonPropertyName("AnsattStillingTidligereTil-datadef-33276")]
+    public AnsattStillingTidligereTildatadef33276 AnsattStillingTidligereTildatadef33276 { get; set; }
+
+  }
+  public class AnsattStillingTidligereFradatadef33275{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33275;
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1,2][0-9]|3[0,1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattStillingTidligereTildatadef33276{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33276;
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1,2][0-9]|3[0,1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class Permisjonsopplysningergrp8822{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+    public decimal gruppeid {get; set;} = 8822;
+
+    [XmlElement("AnsattSykemeldt-datadef-33265")]
+    [JsonProperty("AnsattSykemeldt-datadef-33265")]
+    [JsonPropertyName("AnsattSykemeldt-datadef-33265")]
+    public AnsattSykemeldtdatadef33265 AnsattSykemeldtdatadef33265 { get; set; }
+
+    [XmlElement("AnsattPermittert-datadef-33278")]
+    [JsonProperty("AnsattPermittert-datadef-33278")]
+    [JsonPropertyName("AnsattPermittert-datadef-33278")]
+    public AnsattPermittertdatadef33278 AnsattPermittertdatadef33278 { get; set; }
+
+    [XmlElement("AnsattPermittertPermiteringsgrad-datadef-33279")]
+    [JsonProperty("AnsattPermittertPermiteringsgrad-datadef-33279")]
+    [JsonPropertyName("AnsattPermittertPermiteringsgrad-datadef-33279")]
+    public AnsattPermittertPermiteringsgraddatadef33279 AnsattPermittertPermiteringsgraddatadef33279 { get; set; }
+
+    [XmlElement("AnsattPermittertDato-datadef-33283")]
+    [JsonProperty("AnsattPermittertDato-datadef-33283")]
+    [JsonPropertyName("AnsattPermittertDato-datadef-33283")]
+    public AnsattPermittertDatodatadef33283 AnsattPermittertDatodatadef33283 { get; set; }
+
+    [XmlElement("AnsattPermisjon-datadef-33280")]
+    [JsonProperty("AnsattPermisjon-datadef-33280")]
+    [JsonPropertyName("AnsattPermisjon-datadef-33280")]
+    public AnsattPermisjondatadef33280 AnsattPermisjondatadef33280 { get; set; }
+
+    [XmlElement("AnsattPermisjonType-datadef-33281")]
+    [JsonProperty("AnsattPermisjonType-datadef-33281")]
+    [JsonPropertyName("AnsattPermisjonType-datadef-33281")]
+    public AnsattPermisjonTypedatadef33281 AnsattPermisjonTypedatadef33281 { get; set; }
+
+    [XmlElement("AnsattYtelserMottattUtenArbeidsplikt-datadef-33293")]
+    [JsonProperty("AnsattYtelserMottattUtenArbeidsplikt-datadef-33293")]
+    [JsonPropertyName("AnsattYtelserMottattUtenArbeidsplikt-datadef-33293")]
+    public AnsattYtelserMottattUtenArbeidspliktdatadef33293 AnsattYtelserMottattUtenArbeidspliktdatadef33293 { get; set; }
+
+    [XmlElement("AnsattEierandel20EllerMer-datadef-33294")]
+    [JsonProperty("AnsattEierandel20EllerMer-datadef-33294")]
+    [JsonPropertyName("AnsattEierandel20EllerMer-datadef-33294")]
+    public AnsattEierandel20EllerMerdatadef33294 AnsattEierandel20EllerMerdatadef33294 { get; set; }
+
+    [XmlElement("AnsattIForetaketHovedbeskjeftigelse-datadef-33284")]
+    [JsonProperty("AnsattIForetaketHovedbeskjeftigelse-datadef-33284")]
+    [JsonPropertyName("AnsattIForetaketHovedbeskjeftigelse-datadef-33284")]
+    public AnsattIForetaketHovedbeskjeftigelsedatadef33284 AnsattIForetaketHovedbeskjeftigelsedatadef33284 { get; set; }
+
+    [XmlElement("AnsattStillingsbrokUnder20-datadef-33285")]
+    [JsonProperty("AnsattStillingsbrokUnder20-datadef-33285")]
+    [JsonPropertyName("AnsattStillingsbrokUnder20-datadef-33285")]
+    public AnsattStillingsbrokUnder20datadef33285 AnsattStillingsbrokUnder20datadef33285 { get; set; }
+
+  }
+  public class AnsattSykemeldtdatadef33265{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33265;
+
+    [MinLength(1)]
+    [MaxLength(3)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattPermittertdatadef33278{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33278;
+
+    [MinLength(1)]
+    [MaxLength(3)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattPermittertPermiteringsgraddatadef33279{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33279;
+
+    [Range(1, 999)]
+    [XmlText()]
+    public decimal value { get; set; }
+
+  }
+  public class AnsattPermittertDatodatadef33283{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33283;
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1,2][0-9]|3[0,1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattPermisjondatadef33280{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33280;
+
+    [MinLength(1)]
+    [MaxLength(3)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattPermisjonTypedatadef33281{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33281;
+
+    [MinLength(1)]
+    [MaxLength(100)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattYtelserMottattUtenArbeidspliktdatadef33293{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33293;
+
+    [MinLength(1)]
+    [MaxLength(3)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattEierandel20EllerMerdatadef33294{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33294;
+
+    [MinLength(1)]
+    [MaxLength(2)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattIForetaketHovedbeskjeftigelsedatadef33284{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33284;
+
+    [MinLength(1)]
+    [MaxLength(2)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattStillingsbrokUnder20datadef33285{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33285;
+
+    [MinLength(1)]
+    [MaxLength(3)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class Foretakgrp8820{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("gruppeid")]
+    [BindNever]
+    public decimal gruppeid {get; set;} = 8820;
+
+    [XmlElement("InnsenderNavn-datadef-3443")]
+    [JsonProperty("InnsenderNavn-datadef-3443")]
+    [JsonPropertyName("InnsenderNavn-datadef-3443")]
+    public InnsenderNavndatadef3443 InnsenderNavndatadef3443 { get; set; }
+
+    [XmlElement("EnhetNavnEndring-datadef-33286")]
+    [JsonProperty("EnhetNavnEndring-datadef-33286")]
+    [JsonPropertyName("EnhetNavnEndring-datadef-33286")]
+    public EnhetNavnEndringdatadef33286 EnhetNavnEndringdatadef33286 { get; set; }
+
+    [XmlElement("InnsenderAdresse-datadef-3445")]
+    [JsonProperty("InnsenderAdresse-datadef-3445")]
+    [JsonPropertyName("InnsenderAdresse-datadef-3445")]
+    public InnsenderAdressedatadef3445 InnsenderAdressedatadef3445 { get; set; }
+
+    [XmlElement("InnsenderPostnummer-datadef-11339")]
+    [JsonProperty("InnsenderPostnummer-datadef-11339")]
+    [JsonPropertyName("InnsenderPostnummer-datadef-11339")]
+    public InnsenderPostnummerdatadef11339 InnsenderPostnummerdatadef11339 { get; set; }
+
+    [XmlElement("InnsenderPoststed-datadef-11340")]
+    [JsonProperty("InnsenderPoststed-datadef-11340")]
+    [JsonPropertyName("InnsenderPoststed-datadef-11340")]
+    public InnsenderPoststeddatadef11340 InnsenderPoststeddatadef11340 { get; set; }
+
+    [XmlElement("EnhetTelefonnummer-datadef-755")]
+    [JsonProperty("EnhetTelefonnummer-datadef-755")]
+    [JsonPropertyName("EnhetTelefonnummer-datadef-755")]
+    public EnhetTelefonnummerdatadef755 EnhetTelefonnummerdatadef755 { get; set; }
+
+    [XmlElement("EnhetTelefaksnummer-datadef-1816")]
+    [JsonProperty("EnhetTelefaksnummer-datadef-1816")]
+    [JsonPropertyName("EnhetTelefaksnummer-datadef-1816")]
+    public EnhetTelefaksnummerdatadef1816 EnhetTelefaksnummerdatadef1816 { get; set; }
+
+    [XmlElement("EnhetEPost-datadef-21591")]
+    [JsonProperty("EnhetEPost-datadef-21591")]
+    [JsonPropertyName("EnhetEPost-datadef-21591")]
+    public EnhetEPostdatadef21591 EnhetEPostdatadef21591 { get; set; }
+
+    [XmlElement("ForetakOrganisasjonsnummer-datadef-33552")]
+    [JsonProperty("ForetakOrganisasjonsnummer-datadef-33552")]
+    [JsonPropertyName("ForetakOrganisasjonsnummer-datadef-33552")]
+    public ForetakOrganisasjonsnummerdatadef33552 ForetakOrganisasjonsnummerdatadef33552 { get; set; }
+
+    [XmlElement("EnhetOrganisasjonsnummerNy-datadef-22684")]
+    [JsonProperty("EnhetOrganisasjonsnummerNy-datadef-22684")]
+    [JsonPropertyName("EnhetOrganisasjonsnummerNy-datadef-22684")]
+    public EnhetOrganisasjonsnummerNydatadef22684 EnhetOrganisasjonsnummerNydatadef22684 { get; set; }
+
+    [XmlElement("EnhetOrganisasjonsnummerEndringArsak-datadef-33287")]
+    [JsonProperty("EnhetOrganisasjonsnummerEndringArsak-datadef-33287")]
+    [JsonPropertyName("EnhetOrganisasjonsnummerEndringArsak-datadef-33287")]
+    public EnhetOrganisasjonsnummerEndringArsakdatadef33287 EnhetOrganisasjonsnummerEndringArsakdatadef33287 { get; set; }
+
+    [XmlElement("BedriftOrganisasjonsnummer-datadef-19")]
+    [JsonProperty("BedriftOrganisasjonsnummer-datadef-19")]
+    [JsonPropertyName("BedriftOrganisasjonsnummer-datadef-19")]
+    public BedriftOrganisasjonsnummerdatadef19 BedriftOrganisasjonsnummerdatadef19 { get; set; }
+
+    [XmlElement("BedriftOrganisasjonsnummerNy-datadef-33292")]
+    [JsonProperty("BedriftOrganisasjonsnummerNy-datadef-33292")]
+    [JsonPropertyName("BedriftOrganisasjonsnummerNy-datadef-33292")]
+    public BedriftOrganisasjonsnummerNydatadef33292 BedriftOrganisasjonsnummerNydatadef33292 { get; set; }
+
+    [XmlElement("BedriftOrganisasjonsnummerEndringArsak-datadef-33288")]
+    [JsonProperty("BedriftOrganisasjonsnummerEndringArsak-datadef-33288")]
+    [JsonPropertyName("BedriftOrganisasjonsnummerEndringArsak-datadef-33288")]
+    public BedriftOrganisasjonsnummerEndringArsakdatadef33288 BedriftOrganisasjonsnummerEndringArsakdatadef33288 { get; set; }
+
+    [XmlElement("AnsattAnsettelsePgaFusjonFisjonOverdragelse-datadef-33289")]
+    [JsonProperty("AnsattAnsettelsePgaFusjonFisjonOverdragelse-datadef-33289")]
+    [JsonPropertyName("AnsattAnsettelsePgaFusjonFisjonOverdragelse-datadef-33289")]
+    public AnsattAnsettelsePgaFusjonFisjonOverdragelsedatadef33289 AnsattAnsettelsePgaFusjonFisjonOverdragelsedatadef33289 { get; set; }
+
+    [XmlElement("EnhetNavnEndring-datadef-31")]
+    [JsonProperty("EnhetNavnEndring-datadef-31")]
+    [JsonPropertyName("EnhetNavnEndring-datadef-31")]
+    public EnhetNavnEndringdatadef31 EnhetNavnEndringdatadef31 { get; set; }
+
+    [XmlElement("Merknad-datadef-33290")]
+    [JsonProperty("Merknad-datadef-33290")]
+    [JsonPropertyName("Merknad-datadef-33290")]
+    public Merknaddatadef33290 Merknaddatadef33290 { get; set; }
+
+  }
+  public class InnsenderNavndatadef3443{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 3443;
+
+    [MinLength(1)]
+    [MaxLength(175)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class EnhetNavnEndringdatadef33286{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33286;
+
+    [MinLength(1)]
+    [MaxLength(175)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class InnsenderAdressedatadef3445{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 3445;
+
+    [MinLength(1)]
+    [MaxLength(105)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class InnsenderPostnummerdatadef11339{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 11339;
+
+    [RegularExpression(@"[0-9]{4}")]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class InnsenderPoststeddatadef11340{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 11340;
+
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class EnhetTelefonnummerdatadef755{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 755;
+
+    [MinLength(1)]
+    [MaxLength(13)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class EnhetTelefaksnummerdatadef1816{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 1816;
+
+    [MinLength(1)]
+    [MaxLength(13)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class EnhetEPostdatadef21591{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 21591;
+
+    [MinLength(1)]
+    [MaxLength(100)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class ForetakOrganisasjonsnummerdatadef33552{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33552;
+
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class EnhetOrganisasjonsnummerNydatadef22684{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 22684;
+
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class EnhetOrganisasjonsnummerEndringArsakdatadef33287{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33287;
+
+    [MinLength(1)]
+    [MaxLength(500)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class BedriftOrganisasjonsnummerdatadef19{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 19;
+
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class BedriftOrganisasjonsnummerNydatadef33292{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33292;
+
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class BedriftOrganisasjonsnummerEndringArsakdatadef33288{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33288;
+
+    [MinLength(1)]
+    [MaxLength(500)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class AnsattAnsettelsePgaFusjonFisjonOverdragelsedatadef33289{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33289;
+
+    [MinLength(1)]
+    [MaxLength(3)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class EnhetNavnEndringdatadef31{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 31;
+
+    [MinLength(1)]
+    [MaxLength(175)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+  public class Merknaddatadef33290{
+    [Range(1,Int32.MaxValue)]
+    [XmlAttribute("orid")]
+    [BindNever]
+    public decimal orid {get; set;} = 33290;
+
+    [MinLength(1)]
+    [MaxLength(500)]
+    [XmlText()]
+    public string value { get; set; }
+
+  }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/ui/Settings.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/issue-5740/ui/Settings.json
@@ -1,0 +1,9 @@
+﻿{
+  "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": [
+      "FormLayout",
+      "Side2"
+    ]
+  }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Utils/SetupUtil.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Utils/SetupUtil.cs
@@ -107,6 +107,9 @@ namespace App.IntegrationTestsRef.Utils
                         case "klareringsportalen":
                             services.AddSingleton<IAltinnApp, IntegrationTests.Mocks.Apps.nsm.klareringsportalen.AppLogic.App>();
                             break;
+                        case "issue-5740":
+                            services.AddSingleton<IAltinnApp, IntegrationTests.Mocks.Apps.ttd.issue5740.App>();
+                            break;
                         default:
                             services.AddSingleton<IAltinnApp, IntegrationTests.Mocks.Apps.tdd.endring_av_navn.AltinnApp>();
                             break;


### PR DESCRIPTION
It's not a breaking change in the app template ❤️  We should use this implementation  more widely to avoid breaking changes where possible.

QUESTIONS: 
- Is Settings.json always placed under app/ui ? 
- Tried going with a pages/order as we aren't explicity getting the next page, only the updated order.
- Seems like a lot of parameters to send from the controller to the app, but I guess it's cheaper than getting the instance every time if we don't need it. 
- Did we need the current page order being used by the app as well as input? This has not been included for now. 
