### PR TITLE
GetCertificateAsync missing vault URI parameter

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/SecretsAppSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/SecretsAppSI.cs
@@ -36,7 +36,7 @@ namespace Altinn.App.PlatformServices.Implementation
         public async Task<byte[]> GetCertificateAsync(string certificateId)
         {         
             using KeyVaultClient client = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(_azureServiceTokenProvider.KeyVaultTokenCallback));
-            CertificateBundle cert = await client.GetCertificateAsync(certificateId);
+            CertificateBundle cert = await client.GetCertificateAsync(_vaultUri, certificateId);
 
             return cert.Cer;
         }


### PR DESCRIPTION
#5803
Customer is experiencing errors when using Altinn.App.PlatformServices.Implementation.SecretsAppSI.GetCertificateAsync
Error messag: ```Unhandled exception. System.AggregateException: One or more errors occurred. (Invalid URI: The format of the URI could not be determined.)```
I suspect vaultUri is missing as an param to KeyVaultClient.GetCertificateAsync