### PR TITLE
Update .net core

### DIFF
--- a/src/Altinn.Apps/KubernetesWrapper/Dockerfile
+++ b/src/Altinn.Apps/KubernetesWrapper/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.103-alpine3.13 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.201-alpine3.13 AS build
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -10,7 +10,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.3-alpine3.13 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.4-alpine3.13 AS final
 WORKDIR /app
 COPY --from=build /app/out .
 ENTRYPOINT ["dotnet", "KubernetesWrapper.dll"]

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Dockerfile
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.103-alpine3.12 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.201-alpine3.12 AS build
 WORKDIR /Authentication
 
 COPY Authentication .
@@ -6,7 +6,7 @@ COPY Authentication .
 RUN dotnet build Altinn.Platform.Authentication.csproj -c Release -o /app_output
 RUN dotnet publish Altinn.Platform.Authentication.csproj -c Release -o /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.3-alpine3.12 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.4-alpine3.12 AS final
 EXPOSE 5040
 WORKDIR /app
 COPY --from=build /app_output .

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Dockerfile
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.103-alpine3.13 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.201-alpine3.13 AS build
 WORKDIR Authorization/
 
 COPY Authorization ./Authorization
@@ -7,7 +7,7 @@ WORKDIR Authorization/
 RUN dotnet build Altinn.Platform.Authorization.csproj -c Release -o /app_output
 RUN dotnet publish Altinn.Platform.Authorization.csproj -c Release -o /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.3-alpine3.13 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.4-alpine3.13 AS final
 EXPOSE 5030
 WORKDIR /app
 COPY --from=build /app_output .

--- a/src/Altinn.Platform/Altinn.Platform.Events/Events/Dockerfile
+++ b/src/Altinn.Platform/Altinn.Platform.Events/Events/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.103-alpine3.13 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.201-alpine3.13 AS build
 
 # Copy event backend
 COPY Events ./Events
@@ -9,7 +9,7 @@ WORKDIR Events/
 RUN dotnet build Altinn.Platform.Events.csproj -c Release -o /app_output
 RUN dotnet publish Altinn.Platform.Events.csproj -c Release -o /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.3-alpine3.13 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.4-alpine3.13 AS final
 EXPOSE 5080
 WORKDIR /app
 COPY --from=build /app_output .

--- a/src/Altinn.Platform/Altinn.Platform.Profile/Profile/Dockerfile
+++ b/src/Altinn.Platform/Altinn.Platform.Profile/Profile/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.103-alpine3.13 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.201-alpine3.13 AS build
 WORKDIR Profile/
 
 COPY Profile ./Profile
@@ -7,7 +7,7 @@ WORKDIR Profile/
 RUN dotnet build Altinn.Platform.Profile.csproj -c Release -o /app_output
 RUN dotnet publish Altinn.Platform.Profile.csproj -c Release -o /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.3-alpine3.13 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.4-alpine3.13 AS final
 EXPOSE 5030
 WORKDIR /app
 COPY --from=build /app_output .

--- a/src/Altinn.Platform/Altinn.Platform.Receipt/Receipt/Dockerfile
+++ b/src/Altinn.Platform/Altinn.Platform.Receipt/Receipt/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.103-alpine3.13 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.201-alpine3.13 AS build
 
 # Copy receipt backend
 WORKDIR /src/Altinn.Platform/Altinn.Platform.Receipt/Receipt
@@ -11,7 +11,7 @@ RUN dotnet publish Altinn.Platform.Receipt.csproj -c Release -o /app_output
 # Copy receipt frontend to public folder
 FROM altinn-receipt-react-app:latest AS generate-receipt-react-app
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.3-alpine3.13 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.4-alpine3.13 AS final
 EXPOSE 5060
 WORKDIR /app
 COPY --from=build /app_output .

--- a/src/Altinn.Platform/Altinn.Platform.Register/Register/Dockerfile
+++ b/src/Altinn.Platform/Altinn.Platform.Register/Register/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.103-alpine3.13 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.201-alpine3.13 AS build
 WORKDIR Register/
 
 COPY Register ./Register
@@ -7,7 +7,7 @@ WORKDIR Register/
 RUN dotnet build Altinn.Platform.Register.csproj -c Release -o /app_output
 RUN dotnet publish Altinn.Platform.Register.csproj -c Release -o /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.3-alpine3.13 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.4-alpine3.13 AS final
 EXPOSE 5020
 WORKDIR /app
 COPY --from=build /app_output .

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Dockerfile
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.103-alpine3.13 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.201-alpine3.13 AS build
 WORKDIR Storage/
 
 COPY Storage ./Storage
@@ -8,7 +8,7 @@ RUN dotnet build Altinn.Platform.Storage.csproj -c Release -o /app_output
 RUN dotnet publish Altinn.Platform.Storage.csproj -c Release -o /app_output
 
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.3-alpine3.13 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.4-alpine3.13 AS final
 EXPOSE 5010
 WORKDIR /app
 COPY --from=build /app_output .

--- a/src/studio/src/designer/Dockerfile
+++ b/src/studio/src/designer/Dockerfile
@@ -56,14 +56,14 @@ RUN npm ci
 COPY src/designer/backend .
 RUN npm run gulp build
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0.103-alpine3.12 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.201-alpine3.12 AS build
 COPY src/designer/backend ./designer/
 COPY --from=generate-designer-js /wwwroot ./designer/wwwroot
 
 RUN dotnet build designer/Designer.csproj -c Release -o /app_output
 RUN dotnet publish designer/Designer.csproj -c Release -o /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.3-alpine3.12 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.4-alpine3.12 AS final
 EXPOSE 80
 WORKDIR /app
 COPY --from=build /app_output .


### PR DESCRIPTION
OOB update of .net core versions. Using sdk:5.0.201-alpine3.13 instead of sdk:5.0.104-alpine3.13 since the latter is not available on Docker Hub. 
