### PR TITLE
bug/5863-initial-page-order-calc-if-trigger-present

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/form/components/GroupContainer.test.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/form/components/GroupContainer.test.tsx
@@ -10,7 +10,7 @@ import * as renderer from 'react-test-renderer';
 import configureStore from 'redux-mock-store';
 import { GroupContainer } from '../../../../src/features/form/containers/GroupContainer';
 import { getInitialStateMock } from '../../../../__mocks__/mocks';
-import { ILayoutGroup } from '../../../../src/features/form/layout';
+import { IGroupTypes, ILayoutGroup } from '../../../../src/features/form/layout';
 
 describe('>>> features/form/components/Group.tsx', () => {
   let mockStore: any;
@@ -122,7 +122,7 @@ describe('>>> features/form/components/Group.tsx', () => {
 
     mockContainer = {
       id: 'mock-container-id',
-      type: 'Group',
+      type: IGroupTypes.Group,
       children: [
         'field1',
         'field2',

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/form/components/GroupContainer.test.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/form/components/GroupContainer.test.tsx
@@ -122,6 +122,7 @@ describe('>>> features/form/components/Group.tsx', () => {
 
     mockContainer = {
       id: 'mock-container-id',
+      type: 'Group',
       children: [
         'field1',
         'field2',

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/GenericComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/GenericComponent.tsx
@@ -34,8 +34,8 @@ export interface IGenericComponentProps {
   textResourceBindings: ITextResourceBindings;
   dataModelBindings: IDataModelBindings;
   componentValidations?: IComponentValidations;
-  readOnly: boolean;
-  required: boolean;
+  readOnly?: boolean;
+  required?: boolean;
   labelSettings?: ILabelSettings;
   grid?: IGrid;
   triggers?: Triggers[];

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/process-step/NavigationButtons.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/process-step/NavigationButtons.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { AltinnButton } from 'altinn-shared/components';
 import { Grid, makeStyles } from '@material-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
-import { IRuntimeState, INavigationConfig, ILayoutNavigation } from 'src/types';
+import { IRuntimeState, INavigationConfig, ILayoutNavigation, Triggers } from 'src/types';
 import classNames from 'classnames';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
 import { FormLayoutActions } from 'src/features/form/layout/formLayoutSlice';
@@ -19,7 +19,7 @@ export interface INavigationButtons {
   id: string;
   showBackButton: boolean;
   textResourceBindings: any;
-  triggers?: string[];
+  triggers?: Triggers[];
 }
 
 export function NavigationButtons(props: INavigationButtons) {
@@ -57,10 +57,10 @@ export function NavigationButtons(props: INavigationButtons) {
   };
 
   const OnClickNext = () => {
-    const runPageValidations = !returnToView && triggers && triggers.includes('validatePage');
-    const runAllValidations = returnToView || (triggers && triggers.includes('validateAllPages'));
+    const runPageValidations = !returnToView && triggers && triggers.includes(Triggers.ValidatePage);
+    const runAllValidations = returnToView || (triggers && triggers.includes(Triggers.ValidateAllPages));
     const validations = runAllValidations ? 'allPages' : (runPageValidations ? 'page' : null);
-    if (triggers?.includes('calculatePageOrder')) {
+    if (triggers?.includes(Triggers.CalculatePageOrder)) {
       dispatch(FormLayoutActions.calculatePageOrderAndMoveToNextPage({ validations }));
     } else {
       const goToView = returnToView || next || orderedLayoutKeys[orderedLayoutKeys.indexOf(currentView) + 1];

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/summary/SummaryGroupComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/summary/SummaryGroupComponent.tsx
@@ -2,7 +2,7 @@ import { Grid, makeStyles, Typography } from '@material-ui/core';
 import * as React from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import appTheme from 'altinn-shared/theme/altinnAppTheme';
-import { ILayout, ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
+import { IGroupTypes, ILayout, ILayoutComponent, ILayoutGroup } from 'src/features/form/layout';
 import { IRepeatingGroups, IRuntimeState, IValidations } from 'src/types';
 import { getDisplayFormDataForComponent, getFormDataForComponentInRepeatingGroup } from 'src/utils/formComponentUtils';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
@@ -187,7 +187,7 @@ function SummaryGroupComponent(props: ISummaryGroupComponent) {
     for (let i = 0; i <= repeatingGroupMaxIndex; i++) {
       const groupContainer: ILayoutGroup = {
         id: `${groupComponent.id}-${i}-summary`,
-        type: 'Group',
+        type: IGroupTypes.Group,
         children: [],
         maxCount: 0,
         textResourceBindings: {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/summary/SummaryGroupComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/summary/SummaryGroupComponent.tsx
@@ -187,6 +187,7 @@ function SummaryGroupComponent(props: ISummaryGroupComponent) {
     for (let i = 0; i <= repeatingGroupMaxIndex; i++) {
       const groupContainer: ILayoutGroup = {
         id: `${groupComponent.id}-${i}-summary`,
+        type: 'Group',
         children: [],
         maxCount: 0,
         textResourceBindings: {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/components/Legend.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/components/Legend.tsx
@@ -9,7 +9,7 @@ export interface IFormLegendProps {
   labelText: string;
   descriptionText: string;
   language: any;
-  required: boolean;
+  required?: boolean;
   labelSettings?: ILabelSettings;
   helpText: string;
   id: string;

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/index.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/index.ts
@@ -7,7 +7,7 @@ export interface ILayouts {
 
 export interface ILayoutEntry {
   id: string;
-  type?: string;
+  type: IGroupTypes | IComponentTypes | string;
 }
 
 export interface ILayoutGroup extends ILayoutEntry {
@@ -19,16 +19,20 @@ export interface ILayoutGroup extends ILayoutEntry {
 }
 
 export interface ILayoutComponent extends ILayoutEntry {
-  type: IComponentTypes;
   dataModelBindings: IDataModelBindings;
   isValid?: boolean;
-  readOnly: boolean;
+  readOnly?: boolean;
   disabled?: boolean;
-  required: boolean;
+  required?: boolean;
   textResourceBindings: ITextResourceBindings;
   triggers?: Triggers[];
   formData?: any;
   grid?: IGrid;
+}
+
+export enum IGroupTypes {
+  Group = 'Group',
+  group = 'group'
 }
 
 export enum IComponentTypes {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/index.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/index.ts
@@ -19,7 +19,7 @@ export interface ILayoutGroup extends ILayoutEntry {
 }
 
 export interface ILayoutComponent extends ILayoutEntry {
-  type: string;
+  type: IComponentTypes;
   dataModelBindings: IDataModelBindings;
   isValid?: boolean;
   readOnly: boolean;
@@ -30,6 +30,24 @@ export interface ILayoutComponent extends ILayoutEntry {
   formData?: any;
   grid?: IGrid;
 }
+
+export enum IComponentTypes {
+  AddressComponent = 'AddressComponent',
+  AttachmentList = 'AttachmentList',
+  Button = 'Button',
+  Checkboxes = 'Checkboxes',
+  Datepicker = 'Datepicker',
+  Dropdown = 'Dropdown',
+  FileUpload = 'FileUpload',
+  Header = 'Header',
+  Input = 'Input',
+  NavigationButtons = 'NavigationButtons',
+  Paragraph = 'Paragraph',
+  RadioButtons = 'RadioButtons',
+  Summary = 'Summary',
+  TextArea = 'TextArea'
+}
+
 export interface IDataModelBindings {
   [id: string]: string;
 }

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/index.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/index.ts
@@ -7,7 +7,7 @@ export interface ILayouts {
 
 export interface ILayoutEntry {
   id: string;
-  type: IGroupTypes | IComponentTypes | string;
+  type: IGroupTypes | IComponentTypes;
 }
 
 export interface ILayoutGroup extends ILayoutEntry {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -173,7 +173,7 @@ export function* updateCurrentViewSaga({ payload: {
   }
 }
 
-export function* calculatePageOrderAndMoveToNextPageSaga({ payload: { runValidations, skipMoveToNext } } : PayloadAction<ICalculatePageOrderAndMoveToNextPage>): SagaIterator {
+export function* calculatePageOrderAndMoveToNextPageSaga({ payload: { runValidations, skipMoveToNext } }: PayloadAction<ICalculatePageOrderAndMoveToNextPage>): SagaIterator {
   try {
     const state: IRuntimeState = yield select();
     const layoutSets = state.formLayout.layoutsets;
@@ -222,27 +222,29 @@ export function* watchCalculatePageOrderAndMoveToNextPageSaga(): SagaIterator {
 }
 
 export function* watchInitialCalculagePageOrderAndMoveToNextPageSaga(): SagaIterator {
-  yield all([
-    take(START_INITIAL_DATA_TASK_QUEUE_FULFILLED),
-    take(FormLayoutActions.fetchLayoutFulfilled),
-    take(FormLayoutActions.fetchLayoutSettingsFulfilled),
-  ]);
-  const state: IRuntimeState = yield select();
-  const layouts = state.formLayout.layouts;
-  const pageTriggers = state.formLayout.uiConfig.pageTriggers;
-  const appHasCalculateTrigger = pageTriggers?.includes(Triggers.CalculatePageOrder) || Object.keys(layouts).some((layout) => {
-    return layouts[layout].some((element) => {
-      if (element.type === IComponentTypes.NavigationButtons) {
-        const layoutComponent = element as ILayoutComponent;
-        if (layoutComponent?.triggers?.includes(Triggers.CalculatePageOrder)) {
-          return true;
+  while (true) {
+    yield all([
+      take(START_INITIAL_DATA_TASK_QUEUE_FULFILLED),
+      take(FormLayoutActions.fetchLayoutFulfilled),
+      take(FormLayoutActions.fetchLayoutSettingsFulfilled),
+    ]);
+    const state: IRuntimeState = yield select();
+    const layouts = state.formLayout.layouts;
+    const pageTriggers = state.formLayout.uiConfig.pageTriggers;
+    const appHasCalculateTrigger = pageTriggers?.includes(Triggers.CalculatePageOrder) || Object.keys(layouts).some((layout) => {
+      return layouts[layout].some((element) => {
+        if (element.type === IComponentTypes.NavigationButtons) {
+          const layoutComponent = element as ILayoutComponent;
+          if (layoutComponent?.triggers?.includes(Triggers.CalculatePageOrder)) {
+            return true;
+          }
         }
-      }
-      return false;
+        return false;
+      });
     });
-  });
-  if (appHasCalculateTrigger) {
-    yield put(FormLayoutActions.calculatePageOrderAndMoveToNextPage({ skipMoveToNext: true }));
+    if (appHasCalculateTrigger) {
+      yield put(FormLayoutActions.calculatePageOrderAndMoveToNextPage({ skipMoveToNext: true }));
+    }
   }
 }
 

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -2,7 +2,7 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import { SagaIterator } from 'redux-saga';
 import { all, call, put, select, take, takeEvery, takeLatest } from 'redux-saga/effects';
-import { IRepeatingGroups, IRuntimeState } from 'src/types';
+import { IRepeatingGroups, IRuntimeState, Triggers } from 'src/types';
 import { removeRepeatingGroupFromUIConfig } from 'src/utils/formLayout';
 import { AxiosRequestConfig } from 'axios';
 import { get, post } from 'altinn-shared/utils';
@@ -11,7 +11,7 @@ import { getCalculatePageOrderUrl, getValidationUrl } from 'src/utils/urlHelper'
 import { createValidator, validateFormData, validateFormComponents, validateEmptyFields, mapDataElementValidationToRedux, canFormBeSaved, mergeValidationObjects } from 'src/utils/validation';
 import { getLayoutsetForDataElement } from 'src/utils/layout';
 import { START_INITIAL_DATA_TASK_QUEUE_FULFILLED } from 'src/shared/resources/queue/dataTask/dataTaskQueueActionTypes';
-import { ILayoutComponent, ILayoutGroup } from '..';
+import { ILayoutComponent, IComponentTypes, ILayoutGroup } from '..';
 import ConditionalRenderingActions from '../../dynamics/formDynamicsActions';
 import { FormLayoutActions, ILayoutState } from '../formLayoutSlice';
 import { IUpdateFocus, IUpdateRepeatingGroups, IUpdateCurrentView, ICalculatePageOrderAndMoveToNextPage } from '../formLayoutTypes';
@@ -228,7 +228,20 @@ export function* watchInitialCalculagePageOrderAndMoveToNextPageSaga(): SagaIter
     take(FormLayoutActions.fetchLayoutSettingsFulfilled),
   ]);
   const state: IRuntimeState = yield select();
-  if (state.formLayout.uiConfig.layoutOrder.length > 1) {
+  const layouts = state.formLayout.layouts;
+  const pageTriggers = state.formLayout.uiConfig.pageTriggers;
+  const appHasCalculateTrigger = pageTriggers?.includes(Triggers.CalculatePageOrder) || Object.keys(layouts).some((layout) => {
+    return layouts[layout].some((element) => {
+      if (element.type === IComponentTypes.NavigationButtons) {
+        const layoutComponent = element as ILayoutComponent;
+        if (layoutComponent?.triggers?.includes(Triggers.CalculatePageOrder)) {
+          return true;
+        }
+      }
+      return false;
+    });
+  });
+  if (appHasCalculateTrigger) {
     yield put(FormLayoutActions.calculatePageOrderAndMoveToNextPage({ skipMoveToNext: true }));
   }
 }

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/types/index.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/types/index.ts
@@ -148,7 +148,7 @@ export interface ILayoutSettings {
 
 export interface IPagesSettings {
   order: string[];
-  triggers?: string[];
+  triggers?: Triggers[];
 }
 
 export interface ILayoutNavigation {
@@ -251,7 +251,7 @@ export interface IUiConfig {
   repeatingGroups?: IRepeatingGroups;
   navigationConfig?: INavigationConfig;
   layoutOrder: string[];
-  pageTriggers?: string[];
+  pageTriggers?: Triggers[];
 }
 
 export interface IValidationResult {
@@ -289,6 +289,9 @@ export enum Severity {
 
 export enum Triggers {
   Validation = 'validation',
+  CalculatePageOrder = 'calculatePageOrder',
+  ValidatePage = 'validatePage',
+  ValidateAllPages = 'validateAllPages'
 }
 
 export interface ILabelSettings {


### PR DESCRIPTION
#5863 

- Only call calculate page order if `calculatePageTrigger` is present in formlayout or layout settings.