### PR TITLE
bug/5849-page-order-studio

### DIFF
--- a/src/studio/src/designer/frontend/ux-editor/App.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/App.tsx
@@ -33,6 +33,7 @@ export function App() {
     dispatch(fetchRuleModel());
     dispatch(fetchLanguage({ languageCode }));
     dispatch(fetchWidgetSettings());
+    dispatch(FormLayoutActions.fetchLayoutSettings());
     dispatch(fetchWidgets());
   };
 

--- a/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formDesignerTypes.ts
+++ b/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formDesignerTypes.ts
@@ -72,6 +72,7 @@ export interface IAddLayoutAction {
 
 export interface IAddLayoutFulfilledAction {
   layouts: IFormLayouts;
+  layoutOrder: string[];
 }
 
 export interface IAddWidgetAction {

--- a/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formLayout/formLayoutSagas.ts
+++ b/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formLayout/formLayoutSagas.ts
@@ -397,7 +397,7 @@ export function* addLayoutSaga({ payload }: PayloadAction<IAddLayoutAction>): Sa
     }
     layoutsCopy[layout] = convertFromLayoutToInternalFormat(null);
 
-    yield put(FormLayoutActions.addLayoutFulfilled({ layouts: layoutsCopy }));
+    yield put(FormLayoutActions.addLayoutFulfilled({ layouts: layoutsCopy, layoutOrder: [...layoutOrder, layout] }));
 
     if (Object.keys(layoutsCopy).length > 1) {
       const NavigationButtonComponent = {

--- a/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formLayout/formLayoutSlice.ts
+++ b/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formLayout/formLayoutSlice.ts
@@ -135,9 +135,9 @@ const formLayoutSlice = createSlice({
       state.error = error;
     },
     addLayoutFulfilled: (state, action: PayloadAction<FormLayoutTypes.IAddLayoutFulfilledAction>) => {
-      const { layouts } = action.payload;
+      const { layouts, layoutOrder } = action.payload;
       state.layouts = layouts;
-      state.layoutSettings.pages.order = Object.keys(layouts);
+      state.layoutSettings.pages.order = layoutOrder;
     },
     addLayoutRejected: (state, action: PayloadAction<FormLayoutTypes.IFormDesignerActionRejected>) => {
       const { error } = action.payload;


### PR DESCRIPTION
#5849 

- Actually call get page settings
- Order is preserved in the actually wanted order and not alphabetically