### PR TITLE
bug/5781-no-markdown-parsing-summary

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/summary/AttachmentSummaryComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/summary/AttachmentSummaryComponent.tsx
@@ -18,9 +18,16 @@ const useStyles = makeStyles({
   label: {
     fontWeight: 500,
     fontSize: '1.8rem',
+    '& p': {
+      fontWeight: 500,
+      fontSize: '1.8rem',
+    },
   },
   labelWithError: {
     color: appTheme.altinnPalette.primary.red,
+    '& p': {
+      color: appTheme.altinnPalette.primary.red,
+    },
   },
   row: {
     borderBottom: '1px dashed #008FD6',

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/summary/SingleInputSummary.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/summary/SingleInputSummary.tsx
@@ -16,9 +16,16 @@ const useStyles = makeStyles({
   label: {
     fontWeight: 500,
     fontSize: '1.8rem',
+    '& p': {
+      fontWeight: 500,
+      fontSize: '1.8rem',
+    },
   },
   labelWithError: {
     color: appTheme.altinnPalette.primary.red,
+    '& p': {
+      color: appTheme.altinnPalette.primary.red,
+    },
   },
   row: {
     borderBottom: '1px dashed #008FD6',

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/summary/SummaryComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/summary/SummaryComponent.tsx
@@ -82,7 +82,7 @@ export function SummaryComponent(props: ISummaryComponent) {
   const title = useSelector((state: IRuntimeState) => {
     const titleKey = formComponent.textResourceBindings?.title;
     if (titleKey) {
-      return getTextFromAppOrDefault(titleKey, state.textResources.resources, state.language.language, [], true);
+      return getTextFromAppOrDefault(titleKey, state.textResources.resources, state.language.language, [], false);
     }
     return undefined;
   });

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/summary/SummaryGroupComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/summary/SummaryGroupComponent.tsx
@@ -44,9 +44,16 @@ const useStyles = makeStyles({
   label: {
     fontWeight: 500,
     fontSize: '1.8rem',
+    '& p': {
+      fontWeight: 500,
+      fontSize: '1.8rem',
+    },
   },
   labelWithError: {
     color: appTheme.altinnPalette.primary.red,
+    '& p': {
+      color: appTheme.altinnPalette.primary.red,
+    },
   },
   link: {
     background: 'none',

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -12,6 +12,7 @@ import ErrorPaper from 'src/components/message/ErrorPaper';
 import { createRepeatingGroupComponents } from 'src/utils/formLayout';
 import { makeGetHidden } from 'src/selectors/getLayoutData';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
+import { getTextResource } from 'src/utils/formComponentUtils';
 import { ILayout, ILayoutComponent, ILayoutGroup, ISelectionComponentProps } from '../layout';
 import { renderGenericComponent, setupGroupComponents } from '../../../utils/layout';
 import { FormLayoutActions } from '../layout/formLayoutSlice';
@@ -71,6 +72,12 @@ const useStyles = makeStyles({
       fontSize: '1.4rem',
       padding: '0px',
       paddingLeft: '6px',
+      '& p': {
+        fontWeight: 500,
+        fontSize: '1.4rem',
+        padding: '0px',
+        paddingLeft: '6px',
+      },
     },
   },
   tableBody: {
@@ -121,6 +128,9 @@ const useStyles = makeStyles({
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
+    '& p': {
+      fontWeight: 500,
+    },
   },
   mobileValueText: {
     whiteSpace: 'nowrap',
@@ -297,7 +307,7 @@ export function GroupContainer({
               <TableRow>
                 {componentTitles.map((title: string) => (
                   <TableCell align='left' key={title}>
-                    {getTextResourceByKey(title, textResources)}
+                    {getTextResource(title, textResources)}
                   </TableCell>
                 ))}
                 <TableCell/>
@@ -373,7 +383,7 @@ export function GroupContainer({
                   return (
                     <Grid item={true} className={rowHasErrors ? `${classes.tableRowError} ${classes.textContainer}` : classes.textContainer}>
                       <div className={classes.mobileText}>
-                        {`${getTextResourceByKey(title, textResources)}`}
+                        {getTextResource(title, textResources)}
                       </div>
                       <div
                         className={classes.mobileValueText}


### PR DESCRIPTION
#5781 

We did not use markdown parsing when displaying texts in the summary component, which caused inconsistencies.

Reported bug was that a text like `1. Adresse` would be parsed as markdown and treated as a list resulting in the number being removed. This can be avoided by escaping the string: `1\\. Adresse` (double escape - once for json, once for the resulting markdown), which would result in the following output:
![image](https://user-images.githubusercontent.com/10416981/111273995-bf400f80-8634-11eb-80b9-73a725e9dd9f.png)

This did however not work in the summary (as this was never parsed as markdown), resulting in this:
![summary-felt-parsed](https://user-images.githubusercontent.com/10416981/111274092-dda60b00-8634-11eb-8bf6-d71e01c1b33d.PNG)

Now you can escape a markdown list in the texts, example: `1\\. Postnummer` and preserve the numbering in both labels and summary:
![image](https://user-images.githubusercontent.com/10416981/111274145-f1517180-8634-11eb-89ef-bbaa1ce18f7d.png)

