### PR TITLE
Adds API Action and Repository logic for getting all Applications

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/ApplicationsController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/ApplicationsController.cs
@@ -40,6 +40,34 @@ namespace Altinn.Platform.Storage.Controllers
         }
 
         /// <summary>
+        /// Get all applications.
+        /// </summary>
+        /// <returns>List of all applications</returns>
+        [Authorize]
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [Produces("application/json")]
+        public async Task<ActionResult<ApplicationList>> GetAll()
+        {
+            try
+            {
+                List<Application> applications = await repository.FindAll();
+                ApplicationList applicationList = new ApplicationList { Applications = applications };
+                return Ok(applicationList);
+            }
+            catch (DocumentClientException dce)
+            {
+                logger.LogError($"Unable to access document database {dce}");
+                return StatusCode(500, $"Unable to access document database {dce}");
+            }
+            catch (Exception e)
+            {
+                logger.LogError($"Unable to perform query request {e}");
+                return StatusCode(500, $"Unable to perform query request {e}");
+            }
+        }
+
+        /// <summary>
         /// Get all applications deployed by a given application owner.
         /// </summary>
         /// <param name="org">The id of the application owner.</param>
@@ -58,7 +86,7 @@ namespace Altinn.Platform.Storage.Controllers
 
             try
             {
-                List<Application> applications = await repository.ListApplications(org);
+                List<Application> applications = await repository.FindByOrg(org);
 
                 ApplicationList applicationList = new ApplicationList { Applications = applications };
 

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/IApplicationRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/IApplicationRepository.cs
@@ -10,26 +10,17 @@ namespace Altinn.Platform.Storage.Repository
     public interface IApplicationRepository
     {
         /// <summary>
-        /// Creates an application metadata object in repository
+        /// Get all applications
         /// </summary>
-        /// <param name="item">the application metadata object</param>
-        /// <returns>the created application</returns>
-        Task<Application> Create(Application item);
-
-        /// <summary>
-        /// Delets an instance.
-        /// </summary>
-        /// <param name="appId">The id of the application to delete</param>
-        /// <param name="org">The application owner id</param>
-        /// <returns>if the item is deleted or not</returns>
-        Task<bool> Delete(string appId, string org);
+        /// <returns>A list of Applications</returns>
+        Task<List<Application>> FindAll();
 
         /// <summary>
         /// Get the application owners' applications
         /// </summary>
         /// <param name="org">application owner id</param>
         /// <returns>the instance for the given parameters</returns>
-        Task<List<Application>> ListApplications(string org);
+        Task<List<Application>> FindByOrg(string org);
 
         /// <summary>
         /// Get the instance based on the input parameters
@@ -40,6 +31,28 @@ namespace Altinn.Platform.Storage.Repository
         Task<Application> FindOne(string appId, string org);
 
         /// <summary>
+        /// Creates an application metadata object in repository
+        /// </summary>
+        /// <param name="item">the application metadata object</param>
+        /// <returns>the created application</returns>
+        Task<Application> Create(Application item);
+       
+        /// <summary>
+        /// Update instance for a given form id
+        /// </summary>
+        /// <param name="item">the application object</param>
+        /// <returns>The updated application instance</returns>
+        Task<Application> Update(Application item);
+
+        /// <summary>
+        /// Delets an instance.
+        /// </summary>
+        /// <param name="appId">The id of the application to delete</param>
+        /// <param name="org">The application owner id</param>
+        /// <returns>if the item is deleted or not</returns>
+        Task<bool> Delete(string appId, string org);
+
+        /// <summary>
         /// Gets a dictionary of all application titles.
         /// </summary>
         /// <returns>A dictionary of application titles.</returns>
@@ -48,12 +61,5 @@ namespace Altinn.Platform.Storage.Repository
         /// The value holds the titles, each language by ';'.
         /// </remarks>
         Task<Dictionary<string, string>> GetAllAppTitles();
-
-        /// <summary>
-        /// Update instance for a given form id
-        /// </summary>
-        /// <param name="item">the application object</param>
-        /// <returns>The updated application instance</returns>
-        Task<Application> Update(Application item);
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/ApplicationRepositoryMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/ApplicationRepositoryMock.cs
@@ -27,7 +27,12 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
             return await Task.FromResult(GetTestApplication(org, appId.Split("/")[1]));
         }
 
-        public Task<List<Application>> ListApplications(string org)
+        public Task<List<Application>> FindAll()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<List<Application>> FindByOrg(string org)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
#4798

Adds functionality to Altinn.Platform.Storage to get **all** applications. This includes soft deleted applications, so not only active applications which the issue (#4798) states. This is done due to two reasons: (1) consumers of the API will expect the same behavior as for the existing endpoint `GET storage/api/v1/applications/{org}`, and (2) Altinn 2 will handle logic for soft deleted apps internally, to avoid breaking delegations. 

- Adds endpoint `GET storage/api/v1/applications` to get all applications
- Adds `ApplicationRepository.FindAll()` for querying CosmosDB for all applications
- Renames `ApplicationRepository.ListApplications(string org)` -> `ApplicationRepository.FindByOrg(string org)` for consistency
- Rearranges methods in ApplicationRepository for readability

Topics for discussion/suggestions for improvement:
- Introducing a new strategy for handling exceptions (e.g. implementing an [ExceptionFilterAttribute ](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.filters.exceptionfilterattribute?view=aspnetcore-5.0)), to avoid catching lower level exceptions in the controllers, and avoid the controllers be cluttered with try-catch-clause catching the same exceptions in every action. 
- Let endpoints return lists of applications directly, not wrapped in an object.
- Remove required query parameter `appId` for `POST` and make the value required in the body.
- Cleanup input validation to always use same strategy, either by a general validation method, or by attribute `[RegularExpression("")]`.