### PR TITLE
Test/get instance polling

### DIFF
--- a/src/test/K6/src/tests/platform/appowner/instances-poll.js
+++ b/src/test/K6/src/tests/platform/appowner/instances-poll.js
@@ -1,0 +1,60 @@
+/* 
+    Pre-reqisite for test: 
+    1. MaskinPorteTokenGenerator https://github.com/Altinn/MaskinportenTokenGenerator built
+    2. Installed appOwner certificate
+    3. Send maskinporten token as environment variable after generating the token
+
+    This test script is to poll towards get instances every x seconds (sent using env variable poll)
+    as an app owner
+    Test data required: an app that has instances in task 1 and maskinporten token for appowner
+    Command: docker-compose run k6 run --duration 10m /src/tests/platform/appowner/instances-poll.js 
+    -e env=*** -e org=*** -e app=*** -e appsaccesskey=*** -e maskinporten=token -e poll=60 (in seconds)
+*/
+
+import { check, sleep } from "k6";
+import { addErrorCount } from "../../../errorcounter.js";
+import { convertMaskinPortenToken } from "../../../api/platform/authentication.js";
+import * as instances from "../../../api/platform/storage/instances.js";
+
+const appOwner = __ENV.org;
+const appName = __ENV.app;
+const maskinPortenToken = __ENV.maskinporten;
+const pollEvery = __ENV.poll;
+
+export const options = {
+  vus: 1,
+  thresholds: {
+    errors: ["count<1"],
+  },
+};
+
+export function setup() {
+  var data = {};
+  var altinnStudioRuntimeCookie = convertMaskinPortenToken(
+    maskinPortenToken,
+    "true"
+  );
+  data.RuntimeToken = altinnStudioRuntimeCookie;
+  return data;
+}
+
+export default function (data) {
+  const runtimeToken = data["RuntimeToken"];
+  var res, success;
+
+  //Get app instances of appName that are in task1
+  var filters = {
+    appId: appOwner + "/" + appName,
+    "process.currentTask": "Task_1",
+  };
+  res = instances.getAllinstancesWithFilters(runtimeToken, filters);
+  success = check(res, {
+    "GET Instance by Current task is 200": (r) => r.status === 200,
+    "Instance current task is task_1": (r) =>
+      JSON.parse(r.body).instances[0].process.currentTask.elementId ===
+      "Task_1",
+  });
+  addErrorCount(success);
+
+  sleep(pollEvery);
+}

--- a/src/test/K6/src/tests/platform/appowner/instances-poll.js
+++ b/src/test/K6/src/tests/platform/appowner/instances-poll.js
@@ -8,7 +8,7 @@
     as an app owner
     Test data required: an app that has instances in task 1 and maskinporten token for appowner
     Command: docker-compose run k6 run --duration 10m /src/tests/platform/appowner/instances-poll.js 
-    -e env=*** -e org=*** -e app=*** -e appsaccesskey=*** -e maskinporten=token -e poll=60 (in seconds)
+    -e env=*** -e org=*** -e app=*** -e maskinporten=token -e poll=60 (in seconds)
 */
 
 import { check, sleep } from "k6";


### PR DESCRIPTION
k6 test script that send api calls to platform/storage to get instances based on appid and current process
`/storage/api/v1/instances?appId=ttd/apps-test-prod&process.currentTask=Task_1`
controls polling in seconds using param `poll` and duration using `-d` flag