### PR TITLE
bugfix/6009 - hide link to datamodelling page

### DIFF
--- a/src/studio/src/designer/frontend/shared/navigation/drawer/drawerMenuSettings.ts
+++ b/src/studio/src/designer/frontend/shared/navigation/drawer/drawerMenuSettings.ts
@@ -59,12 +59,12 @@ export const leftDrawerMenuSettings: IDrawerMenu = {
       activeLeftMenuSelection: 'Datamodell',
       iconClass: 'fa fa-archive',
     },
-    {
-      displayText: 'Data-Editor',
-      navLink: '/datamodelling',
-      activeLeftMenuSelection: 'Data-Editor',
-      iconClass: 'fa fa-datamodel-object',
-    },
+    // {
+    //   displayText: 'Data-Editor',
+    //   navLink: '/datamodelling',
+    //   activeLeftMenuSelection: 'Data-Editor',
+    //   iconClass: 'fa fa-datamodel-object',
+    // },
     {
       displayText: 'UI-Editor',
       navLink: '/ui-editor',

--- a/src/studio/src/designer/frontend/shared/navigation/drawer/drawerMenuSettings.ts
+++ b/src/studio/src/designer/frontend/shared/navigation/drawer/drawerMenuSettings.ts
@@ -59,6 +59,7 @@ export const leftDrawerMenuSettings: IDrawerMenu = {
       activeLeftMenuSelection: 'Datamodell',
       iconClass: 'fa fa-archive',
     },
+    // The following link is hidden until datamodelling page is ready for production.
     // {
     //   displayText: 'Data-Editor',
     //   navLink: '/datamodelling',


### PR DESCRIPTION
Link to /datamodelling is now hidden. closes #6009 