### PR TITLE
Adds API Action and Repository logic for getting all Applications

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/ApplicationsController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/ApplicationsController.cs
@@ -40,11 +40,26 @@ namespace Altinn.Platform.Storage.Controllers
         }
 
         /// <summary>
+        /// Get all applications.
+        /// </summary>
+        /// <returns>List of all applications</returns>
+        [AllowAnonymous]
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [Produces("application/json")]
+        public async Task<ActionResult<ApplicationList>> GetAll()
+        {
+            List<Application> applications = await repository.FindAll();
+            ApplicationList applicationList = new ApplicationList { Applications = applications };
+            return Ok(applicationList);
+        }
+
+        /// <summary>
         /// Get all applications deployed by a given application owner.
         /// </summary>
         /// <param name="org">The id of the application owner.</param>
         /// <returns>List of all applications depoyed by the given owner.</returns>
-        [Authorize]
+        [AllowAnonymous]
         [HttpGet("{org}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -58,7 +73,7 @@ namespace Altinn.Platform.Storage.Controllers
 
             try
             {
-                List<Application> applications = await repository.ListApplications(org);
+                List<Application> applications = await repository.FindByOrg(org);
 
                 ApplicationList applicationList = new ApplicationList { Applications = applications };
 
@@ -82,7 +97,7 @@ namespace Altinn.Platform.Storage.Controllers
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <returns>The metadata for the identified application.</returns>
-        [Authorize]
+        [AllowAnonymous]
         [HttpGet("{org}/{app}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -199,41 +214,6 @@ namespace Altinn.Platform.Storage.Controllers
                 logger.LogError($"Unable to store application data in database. {e}");
                 return StatusCode(500, $"Unable to store application data in database. {e}");
             }
-        }
-
-        /// <summary>
-        /// Checks if an appId is valid
-        /// </summary>
-        /// <param name="appId">the id to check</param>
-        /// <returns>true if it is valid, false otherwise</returns>
-        [ApiExplorerSettings(IgnoreApi = true)]
-        public bool IsValidAppId(string appId)
-        {
-            if (string.IsNullOrEmpty(appId))
-            {
-                return false;
-            }
-
-            string[] parts = appId.Split("/");
-
-            if (parts.Length != 2)
-            {
-                return false;
-            }
-
-            string orgNamePattern = @"^[a-zæøå][a-zæåø0-9]*$";
-            if (!Regex.IsMatch(parts[0], orgNamePattern))
-            {
-                return false;
-            }
-
-            string appPattern = @"^[a-zæøå][a-zæøå0-9\-]*$";
-            if (!Regex.IsMatch(parts[1], appPattern))
-            {
-                return false;
-            }
-
-            return true;
         }
 
         /// <summary>
@@ -375,6 +355,41 @@ namespace Altinn.Platform.Storage.Controllers
                 logger.LogError($"Unable to perform request: {e}");
                 return StatusCode(500, $"Unable to perform request: {e}");
             }
+        }
+
+        /// <summary>
+        /// Checks if an appId is valid
+        /// </summary>
+        /// <param name="appId">the id to check</param>
+        /// <returns>true if it is valid, false otherwise</returns>
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public bool IsValidAppId(string appId)
+        {
+            if (string.IsNullOrEmpty(appId))
+            {
+                return false;
+            }
+
+            string[] parts = appId.Split("/");
+
+            if (parts.Length != 2)
+            {
+                return false;
+            }
+
+            string orgNamePattern = @"^[a-zæøå][a-zæåø0-9]*$";
+            if (!Regex.IsMatch(parts[0], orgNamePattern))
+            {
+                return false;
+            }
+
+            string appPattern = @"^[a-zæøå][a-zæøå0-9\-]*$";
+            if (!Regex.IsMatch(parts[1], appPattern))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private string GetUserId()

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/IApplicationRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/IApplicationRepository.cs
@@ -10,26 +10,17 @@ namespace Altinn.Platform.Storage.Repository
     public interface IApplicationRepository
     {
         /// <summary>
-        /// Creates an application metadata object in repository
+        /// Get all applications
         /// </summary>
-        /// <param name="item">the application metadata object</param>
-        /// <returns>the created application</returns>
-        Task<Application> Create(Application item);
-
-        /// <summary>
-        /// Delets an instance.
-        /// </summary>
-        /// <param name="appId">The id of the application to delete</param>
-        /// <param name="org">The application owner id</param>
-        /// <returns>if the item is deleted or not</returns>
-        Task<bool> Delete(string appId, string org);
+        /// <returns>A list of Applications</returns>
+        Task<List<Application>> FindAll();
 
         /// <summary>
         /// Get the application owners' applications
         /// </summary>
         /// <param name="org">application owner id</param>
         /// <returns>the instance for the given parameters</returns>
-        Task<List<Application>> ListApplications(string org);
+        Task<List<Application>> FindByOrg(string org);
 
         /// <summary>
         /// Get the instance based on the input parameters
@@ -40,6 +31,28 @@ namespace Altinn.Platform.Storage.Repository
         Task<Application> FindOne(string appId, string org);
 
         /// <summary>
+        /// Creates an application metadata object in repository
+        /// </summary>
+        /// <param name="item">the application metadata object</param>
+        /// <returns>the created application</returns>
+        Task<Application> Create(Application item);
+
+        /// <summary>
+        /// Update instance for a given form id
+        /// </summary>
+        /// <param name="item">the application object</param>
+        /// <returns>The updated application instance</returns>
+        Task<Application> Update(Application item);
+
+        /// <summary>
+        /// Delets an instance.
+        /// </summary>
+        /// <param name="appId">The id of the application to delete</param>
+        /// <param name="org">The application owner id</param>
+        /// <returns>if the item is deleted or not</returns>
+        Task<bool> Delete(string appId, string org);
+
+        /// <summary>
         /// Gets a dictionary of all application titles.
         /// </summary>
         /// <returns>A dictionary of application titles.</returns>
@@ -48,12 +61,5 @@ namespace Altinn.Platform.Storage.Repository
         /// The value holds the titles, each language by ';'.
         /// </remarks>
         Task<Dictionary<string, string>> GetAllAppTitles();
-
-        /// <summary>
-        /// Update instance for a given form id
-        /// </summary>
-        /// <param name="item">the application object</param>
-        /// <returns>The updated application instance</returns>
-        Task<Application> Update(Application item);
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/ApplicationRepositoryMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/ApplicationRepositoryMock.cs
@@ -27,7 +27,12 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
             return await Task.FromResult(GetTestApplication(org, appId.Split("/")[1]));
         }
 
-        public Task<List<Application>> ListApplications(string org)
+        public Task<List<Application>> FindAll()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<List<Application>> FindByOrg(string org)
         {
             throw new NotImplementedException();
         }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/ApplicationsControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/ApplicationsControllerTests.cs
@@ -433,6 +433,30 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Assert.True(string.IsNullOrEmpty(content));
         }
 
+        /// <summary>
+        /// Get all applications returns 200.
+        /// </summary>
+        [Fact]
+        public async void GetAll_ReturnsOK()
+        {
+            // Arrange
+            string requestUri = $"{BasePath}/applications";
+            List<Application> expected = new List<Application>
+            {
+                CreateApplication("testorg", "testapp")
+            };
+            Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
+            applicationRepository.Setup(s => s.FindAll()).ReturnsAsync(expected);
+            HttpClient client = GetTestClient(applicationRepository.Object);
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        }
+
         private static DocumentClientException CreateDocumentClientExceptionForTesting(string message, HttpStatusCode httpStatusCode)
         {
             Type type = typeof(DocumentClientException);

--- a/src/development/LocalTest/Controllers/Storage/ApplicationsController.cs
+++ b/src/development/LocalTest/Controllers/Storage/ApplicationsController.cs
@@ -40,11 +40,26 @@ namespace Altinn.Platform.Storage.Controllers
         }
 
         /// <summary>
+        /// Get all applications.
+        /// </summary>
+        /// <returns>List of all applications</returns>
+        [AllowAnonymous]
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [Produces("application/json")]
+        public async Task<ActionResult<ApplicationList>> GetAll()
+        {
+            List<Application> applications = await repository.FindAll();
+            ApplicationList applicationList = new ApplicationList { Applications = applications };
+            return Ok(applicationList);
+        }
+
+        /// <summary>
         /// Get all applications deployed by a given application owner.
         /// </summary>
         /// <param name="org">The id of the application owner.</param>
         /// <returns>List of all applications depoyed by the given owner.</returns>
-        [Authorize]
+        [AllowAnonymous]
         [HttpGet("{org}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -58,7 +73,7 @@ namespace Altinn.Platform.Storage.Controllers
 
             try
             {
-                List<Application> applications = await repository.ListApplications(org);
+                List<Application> applications = await repository.FindByOrg(org);
 
                 ApplicationList applicationList = new ApplicationList { Applications = applications };
 
@@ -82,7 +97,7 @@ namespace Altinn.Platform.Storage.Controllers
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <returns>The metadata for the identified application.</returns>
-        [Authorize]
+        [AllowAnonymous]
         [HttpGet("{org}/{app}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -199,41 +214,6 @@ namespace Altinn.Platform.Storage.Controllers
                 logger.LogError($"Unable to store application data in database. {e}");
                 return StatusCode(500, $"Unable to store application data in database. {e}");
             }
-        }
-
-        /// <summary>
-        /// Checks if an appId is valid
-        /// </summary>
-        /// <param name="appId">the id to check</param>
-        /// <returns>true if it is valid, false otherwise</returns>
-        [ApiExplorerSettings(IgnoreApi = true)]
-        public bool IsValidAppId(string appId)
-        {
-            if (string.IsNullOrEmpty(appId))
-            {
-                return false;
-            }
-
-            string[] parts = appId.Split("/");
-
-            if (parts.Length != 2)
-            {
-                return false;
-            }
-
-            string orgNamePattern = @"^[a-zæøå][a-zæåø0-9]*$";
-            if (!Regex.IsMatch(parts[0], orgNamePattern))
-            {
-                return false;
-            }
-
-            string appPattern = @"^[a-zæøå][a-zæøå0-9\-]*$";
-            if (!Regex.IsMatch(parts[1], appPattern))
-            {
-                return false;
-            }
-
-            return true;
         }
 
         /// <summary>
@@ -375,6 +355,41 @@ namespace Altinn.Platform.Storage.Controllers
                 logger.LogError($"Unable to perform request: {e}");
                 return StatusCode(500, $"Unable to perform request: {e}");
             }
+        }
+
+        /// <summary>
+        /// Checks if an appId is valid
+        /// </summary>
+        /// <param name="appId">the id to check</param>
+        /// <returns>true if it is valid, false otherwise</returns>
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public bool IsValidAppId(string appId)
+        {
+            if (string.IsNullOrEmpty(appId))
+            {
+                return false;
+            }
+
+            string[] parts = appId.Split("/");
+
+            if (parts.Length != 2)
+            {
+                return false;
+            }
+
+            string orgNamePattern = @"^[a-zæøå][a-zæåø0-9]*$";
+            if (!Regex.IsMatch(parts[0], orgNamePattern))
+            {
+                return false;
+            }
+
+            string appPattern = @"^[a-zæøå][a-zæøå0-9\-]*$";
+            if (!Regex.IsMatch(parts[1], appPattern))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private string GetUserId()

--- a/src/development/LocalTest/Services/Storage/Implementation/ApplicationRepository.cs
+++ b/src/development/LocalTest/Services/Storage/Implementation/ApplicationRepository.cs
@@ -60,7 +60,7 @@ namespace LocalTest.Services.Storage.Implementation
             throw new NotImplementedException();
         }
 
-        public Task<List<Application>> ListApplications(string org)
+        public Task<List<Application>> FindByOrg(string org)
         {
             throw new NotImplementedException();
         }
@@ -73,6 +73,16 @@ namespace LocalTest.Services.Storage.Implementation
         private string GetApplicationPath()
         {
            return  _localTestAppSelectionService.GetAppPath() + "config/applicationmetadata.json";
+        }
+
+        public Task<List<Application>> FindAll()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<Dictionary<string, string>> GetAllAppTitles()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/development/LocalTest/Services/Storage/Interface/IApplicationRepository.cs
+++ b/src/development/LocalTest/Services/Storage/Interface/IApplicationRepository.cs
@@ -10,26 +10,17 @@ namespace Altinn.Platform.Storage.Repository
     public interface IApplicationRepository
     {
         /// <summary>
-        /// Creates an application metadata object in repository
+        /// Get all applications
         /// </summary>
-        /// <param name="item">the application metadata object</param>
-        /// <returns>the created application</returns>
-        Task<Application> Create(Application item);
-
-        /// <summary>
-        /// Delets an instance.
-        /// </summary>
-        /// <param name="appId">The id of the application to delete</param>
-        /// <param name="org">The application owner id</param>
-        /// <returns>if the item is deleted or not</returns>
-        Task<bool> Delete(string appId, string org);
+        /// <returns>A list of Applications</returns>
+        Task<List<Application>> FindAll();
 
         /// <summary>
         /// Get the application owners' applications
         /// </summary>
         /// <param name="org">application owner id</param>
         /// <returns>the instance for the given parameters</returns>
-        Task<List<Application>> ListApplications(string org);
+        Task<List<Application>> FindByOrg(string org);
 
         /// <summary>
         /// Get the instance based on the input parameters
@@ -40,11 +31,11 @@ namespace Altinn.Platform.Storage.Repository
         Task<Application> FindOne(string appId, string org);
 
         /// <summary>
-        /// Get a list of application titles based on applicationId.
+        /// Creates an application metadata object in repository
         /// </summary>
-        /// <param name="appIds">List of application ids.</param>
-        /// <returns>A dictionary of application titles based on applicationId.</returns>
-        Task<Dictionary<string, Dictionary<string, string>>> GetAppTitles(List<string> appIds);
+        /// <param name="item">the application metadata object</param>
+        /// <returns>the created application</returns>
+        Task<Application> Create(Application item);
 
         /// <summary>
         /// Update instance for a given form id
@@ -52,5 +43,23 @@ namespace Altinn.Platform.Storage.Repository
         /// <param name="item">the application object</param>
         /// <returns>The updated application instance</returns>
         Task<Application> Update(Application item);
+
+        /// <summary>
+        /// Delets an instance.
+        /// </summary>
+        /// <param name="appId">The id of the application to delete</param>
+        /// <param name="org">The application owner id</param>
+        /// <returns>if the item is deleted or not</returns>
+        Task<bool> Delete(string appId, string org);
+
+        /// <summary>
+        /// Gets a dictionary of all application titles.
+        /// </summary>
+        /// <returns>A dictionary of application titles.</returns>
+        /// <remarks>
+        /// Key is application id formated as [org]/[app]
+        /// The value holds the titles, each language by ';'.
+        /// </remarks>
+        Task<Dictionary<string, string>> GetAllAppTitles();
     }
 }


### PR DESCRIPTION
#4798

Adds functionality to Altinn.Platform.Storage to get all applications. This includes soft deleted applications, so not only active applications which the issue (#4798) states. This is done due to two reasons: (1) consumers of the API will expect the same behavior as for the existing endpoint `GET storage/api/v1/applications/{org}`, and (2) Altinn 2 will handle logic for soft deleted apps internally, to avoid breaking delegations.

- Adds endpoint `GET storage/api/v1/applications` to get all applications
- Adds `ApplicationRepository.FindAll()` for querying CosmosDB for all applications
- Renames `ApplicationRepository.ListApplications(string org)` -> `ApplicationRepository.FindByOrg(string org)` for consistency
- Rearranges methods in ApplicationRepository for readability
- Removes `[Authorize]` from all GET-actions in ApplicationsController to make the API open for non-authenticated requests.