### PR TITLE
removed tests storage sbl get instances by party

### DIFF
--- a/src/test/K6/src/api/platform/storage/messageboxinstances.js
+++ b/src/test/K6/src/api/platform/storage/messageboxinstances.js
@@ -10,16 +10,6 @@ export function getSblInstanceById(altinnStudioRuntimeCookie, partyId, instanceI
     return http.get(endpoint, params);
 };
 
-/**
- * Api call to Storage:SBL instances to get an instance for a partyid and return response  
- * @param {*} state the instance state; active, archived or deleted
- */
-export function getSblInstanceByParty(altinnStudioRuntimeCookie, partyId, state) {
-    var endpoint = config.platformStorage["messageBoxInstances"] + "/" + partyId + "?state=" + state + "&language=nb";
-    var params = header.buildHearderWithRuntimeforSbl(altinnStudioRuntimeCookie, "platform");
-    return http.get(endpoint, params);
-};
-
 //Api call to Storage:SBL instances to get an instance by id and return response
 export function deleteSblInstance(altinnStudioRuntimeCookie, partyId, instanceId, hardDelete) {
     var endpoint = config.buildStorageUrls(partyId, instanceId, "", "sblinstanceid") + "?hard=" + hardDelete;

--- a/src/test/K6/src/tests/platform/storage/messageboxinstances.js
+++ b/src/test/K6/src/tests/platform/storage/messageboxinstances.js
@@ -39,7 +39,7 @@ export function setup() {
 };
 
 //Tests for platform Storage: MessageBoxInstances
-export default function(data) {
+export default function (data) {
     const runtimeToken = data["RuntimeToken"];
     const partyId = data["partyId"];
     const instanceId = data["instanceId"];
@@ -50,13 +50,6 @@ export default function(data) {
     success = check(res, {
         "GET SBL Instance by Id status is 200:": (r) => r.status === 200,
         "GET SBL Instance by Id Instance Id matches:": (r) => (JSON.parse(r.body)).id === instanceId
-    });
-    addErrorCount(success);
-
-    //Test to get instances for a party from storage: SBL and validate the response
-    res = sbl.getSblInstanceByParty(runtimeToken, partyId, "active");
-    success = check(res, {
-        "GET SBL Instance by Party status is 200:": (r) => r.status === 200
     });
     addErrorCount(success);
 


### PR DESCRIPTION
after the merge of #6042, it is observed that the bruksmønster started to fail and was found that the tests of the removed endpoint was removed. 
all the tests for getting instances by party from `platform/storage/sbl` is now removed in the PR.
#595