### PR TITLE
Fix PR labeler for forks

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -6,7 +6,7 @@
 # https://github.com/actions/labeler/blob/master/README.md
 
 name: Pull Request Labeler
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   label:


### PR DESCRIPTION
Ref. https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

This should make the PR labeler github action run for PR from forks without failing, like #6105 did.