### PR TITLE
validating input to stateless data controller

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>4.5.1</AssemblyVersion>
-    <FileVersion>4.5.1</FileVersion>
+    <AssemblyVersion>4.5.2</AssemblyVersion>
+    <FileVersion>4.5.2</FileVersion>
     <!-- SonarCloud requires a ProjectGuid to separate projects. -->
     <ProjectGuid>{E8F29FE8-6B62-41F1-A08C-2A318DD08BB4}</ProjectGuid>
 
     <!-- NuGet package properties -->
     <PackageId>Altinn.App.Api</PackageId>
-    <PackageVersion>4.5.1-alpha</PackageVersion>
+    <PackageVersion>4.5.2-alpha</PackageVersion>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>
     <Description>
       This class library holds all the API controllers used by a standard Altinn 3 App.

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/StatelessDataController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/StatelessDataController.cs
@@ -60,6 +60,11 @@ namespace Altinn.App.Api.Controllers
         [ProducesResponseType(typeof(DataElement), 200)]
         public async Task<ActionResult> Post([FromQuery] string dataType)
         {
+            if (string.IsNullOrEmpty(dataType))
+            {
+                return BadRequest($"Invalid dataType {dataType} provided. Please provide a valid dataType as query parameter.");
+            }
+
             string classRef = _appResourcesService.GetClassRefForLogicDataType(dataType);
 
             if (string.IsNullOrEmpty(classRef))
@@ -94,11 +99,21 @@ namespace Altinn.App.Api.Controllers
         [ProducesResponseType(typeof(DataElement), 200)]
         public async Task<ActionResult> Put([FromQuery] string dataType)
         {
+            if (string.IsNullOrEmpty(dataType))
+            {
+                return BadRequest($"Invalid dataType {dataType} provided. Please provide a valid dataType as query parameter.");
+            }
+
             string classRef = _appResourcesService.GetClassRefForLogicDataType(dataType);
 
             if (string.IsNullOrEmpty(classRef))
             {
                 return BadRequest($"Invalid dataType {dataType} provided. Please provide a valid dataType as query parameter.");
+            }
+
+            if (Request.ContentLength == null || Request.ContentLength <= 0)
+            {
+                return BadRequest("No data found in content.");
             }
 
             ModelDeserializer deserializer = new ModelDeserializer(_logger, _altinnApp.GetAppModelType(classRef));

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>4.5.1</AssemblyVersion>
-    <FileVersion>4.5.1</FileVersion>
+    <AssemblyVersion>4.5.2</AssemblyVersion>
+    <FileVersion>4.5.2</FileVersion>
     <!-- SonarCloud requires a ProjectGuid to separate projects. -->
     <ProjectGuid>{7D2FF2B1-7F21-4934-9D77-DBCDC15BD8CC}</ProjectGuid>
 
     <!-- NuGet package properties -->
     <PackageId>Altinn.App.Common</PackageId>
-    <PackageVersion>4.5.1-alpha</PackageVersion>
+    <PackageVersion>4.5.2-alpha</PackageVersion>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>
     <Description>
       This class library holds classes with logic that is common for the other Altinn.App packages.

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -1,16 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>4.5.1</AssemblyVersion>
-    <FileVersion>4.5.1</FileVersion>
+    <AssemblyVersion>4.5.2</AssemblyVersion>
+    <FileVersion>4.5.2</FileVersion>
     <!-- SonarCloud requires a ProjectGuid to separate projects. -->
     <ProjectGuid>{98E6200A-ED99-418E-B30C-81BA564B509A}</ProjectGuid>
 
     <!-- NuGet package properties -->
     <PackageId>Altinn.App.PlatformServices</PackageId>
-    <PackageVersion>4.5.1-alpha</PackageVersion>
+    <PackageVersion>4.5.2-alpha</PackageVersion>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>
     <Description>
       This class library holds most of the Altinn App business logic and clients for communication with the platform.
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.0.2" />
+    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.0.3" />
     <PackageReference Include="Altinn.Common.PEP" Version="1.0.38-alpha" />
     <PackageReference Include="Altinn.Common.EFormidlingClient" Version="1.0.0-alpha" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.0.5" />

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
@@ -231,22 +231,12 @@ namespace Altinn.App.Services.Implementation
             Application application = GetApplication();
             string classRef = string.Empty;
 
-            DataType element = application.DataTypes.Single(d => d.Id.Equals(dataType));
+            DataType element = application.DataTypes.SingleOrDefault(d => d.Id.Equals(dataType));
 
             if (element != null)
             {
                 classRef = element.AppLogic.ClassRef;
-            }
-            else
-            {
-                foreach (DataType dataTypeElement in application.DataTypes)
-                {
-                    if (dataTypeElement.AppLogic != null)
-                    {
-                        classRef = dataTypeElement.AppLogic.ClassRef;
-                    }
-                }
-            }
+            }            
 
             return classRef;
         }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAppResources.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAppResources.cs
@@ -62,14 +62,14 @@ namespace Altinn.App.Services.Interface
         /// Gets the prefill json file
         /// </summary>
         /// <param name="dataModelName">the data model name</param>
-        /// <returns></returns>
+        /// <returns>The prefill json file as a string</returns>
         string GetPrefillJson(string dataModelName = "ServiceModel");
 
         /// <summary>
-        /// Returns the class ref for a given datatype. Defaults to first applogic type if not prent
+        /// Get the class ref based on data type
         /// </summary>
         /// <param name="dataType">The datatype</param>
-        /// <returns></returns>
+        /// <returns>Returns the class ref for a given datatype. An empty string is returned if no match is found.</returns>
         string GetClassRefForLogicDataType(string dataType);
 
         /// <summary>

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/StatelessDataApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/StatelessDataApiTest.cs
@@ -58,6 +58,29 @@ namespace App.IntegrationTests.ApiTests
         }
 
         [Fact]
+        public async Task StatelessData_Post_MissingDataType()
+        {
+            // Arrange
+            string org = "ttd";
+            string app = "presentationfields-app";
+
+            string token = PrincipalUtil.GetToken(1337);
+
+            HttpClient client = SetupUtil.GetTestClient(_factory, org, app);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            string requestUri = $"/{org}/{app}/v1/data";
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri);
+
+            // Act
+            HttpResponseMessage res = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+        }
+
+        [Fact]
         public async Task StatelessData_Put_CalculationsRunAndDataReturned()
         {
             // Arrange
@@ -89,6 +112,56 @@ namespace App.IntegrationTests.ApiTests
             Assert.Equal(HttpStatusCode.OK, res.StatusCode);
             Assert.NotNull(actual);
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public async Task StatelessData_Put_InvalidDataType()
+        {
+            // Arrange
+            string org = "ttd";
+            string app = "model-validation";
+
+            string token = PrincipalUtil.GetToken(1337);
+
+            HttpClient client = SetupUtil.GetTestClient(_factory, org, app);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            string requestUri = $"/{org}/{app}/v1/data?dataType=tix";
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, requestUri)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            HttpResponseMessage res = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+        }
+
+        [Fact]
+        public async Task StatelessData_Put_RequestMissingBodyBadRequest()
+        {
+            // Arrange
+            string org = "ttd";
+            string app = "model-validation";
+
+            string token = PrincipalUtil.GetToken(1337);
+
+            HttpClient client = SetupUtil.GetTestClient(_factory, org, app);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            string requestUri = $"/{org}/{app}/v1/data?dataType=default";
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, requestUri);
+
+            // Act
+            HttpResponseMessage res = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+
         }
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/StatelessDataApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/StatelessDataApiTest.cs
@@ -161,7 +161,6 @@ namespace App.IntegrationTests.ApiTests
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
-
         }
     }
 }


### PR DESCRIPTION
#6123 

- Using latest version of accessTokenClient package
- GetClassRefFromDataType now defaults to return null if no match is found
- Validation added on request body / data type for statelessdatacontroller
