### PR TITLE
Bugfix/updatedatamodel 500

### DIFF
--- a/src/studio/src/designer/frontend/app-development/features/dataModeling/containers/DataModelingContainer.tsx
+++ b/src/studio/src/designer/frontend/app-development/features/dataModeling/containers/DataModelingContainer.tsx
@@ -61,7 +61,6 @@ export default function DataModelingContainer(props: IDataModelingContainerProps
     fetchModel(schema.id);
   };
   const onSaveSchema = (schema: any) => {
-    console.log(schema);
     dispatch(saveDataModel({ schema }));
   };
   const onCreateClick = (event: any) => {

--- a/src/studio/src/designer/frontend/app-development/features/dataModeling/containers/DataModelingContainer.tsx
+++ b/src/studio/src/designer/frontend/app-development/features/dataModeling/containers/DataModelingContainer.tsx
@@ -61,6 +61,7 @@ export default function DataModelingContainer(props: IDataModelingContainerProps
     fetchModel(schema.id);
   };
   const onSaveSchema = (schema: any) => {
+    console.log(schema);
     dispatch(saveDataModel({ schema }));
   };
   const onCreateClick = (event: any) => {

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector.tsx
@@ -103,6 +103,11 @@ const SchemaInspector = ((props: ISchemaInspectorProps) => {
       path, oldKey, newKey,
     }));
   };
+  const onChangPropertyName = (path: string, oldKey: string, newKey: string) => {
+    dispatch(setPropertyName({
+      path, name: newKey,
+    }));
+  };
   const onDeleteFieldClick = (path: string, key: string) => {
     dispatch(deleteField({ path, key }));
   };
@@ -110,7 +115,9 @@ const SchemaInspector = ((props: ISchemaInspectorProps) => {
     dispatch(deleteProperty({ path }));
   };
   const onChangeNodeName = (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-    dispatch(setPropertyName({ path: selectedItem?.id, name: e.target.value }));
+    dispatch(setPropertyName({
+      path: selectedItem?.id, name: e.target.value, navigate: true,
+    }));
   };
 
   const onAddPropertyClicked = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -207,7 +214,7 @@ const SchemaInspector = ((props: ISchemaInspectorProps) => {
         fullPath={p.id}
         onChangeValue={onChangeValue}
         onChangeRef={onChangeRef}
-        onChangeKey={onChangeKey}
+        onChangeKey={onChangPropertyName}
         onDeleteField={onDeleteObjectClick}
       />;
     }

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector.tsx
@@ -77,7 +77,7 @@ const SchemaInspector = ((props: ISchemaInspectorProps) => {
   const onChangeValue = (path: string, value: any, key?: string) => {
     const data = {
       path,
-      value,
+      value: Number.isNaN(value) ? value : +value,
       key,
     };
     dispatch(setFieldValue(data));

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaItem.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaItem.tsx
@@ -266,9 +266,7 @@ function SchemaItem(props: SchemaItemProps) {
           <MenuItem onClick={handleAddProperty}><i className={`${classes.menuItem} fa fa-plus`}/> Add property</MenuItem>
         }
         <MenuItem><i className='fa fa-clone'/> Import</MenuItem>
-        { (item.keywords || item.properties || item.$ref) &&
-          <MenuItem onClick={handleDeleteClick}><i className='fa fa-trash'/> Delete</MenuItem>
-        }
+        <MenuItem onClick={handleDeleteClick}><i className='fa fa-trash'/> Delete</MenuItem>
       </Menu>
     </div>
   );

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
@@ -95,7 +95,7 @@ const schemaEditorSlice = createSlice({
           removeFromItem.properties = newProperties;
         }
       } else {
-        // delete definition
+        // delete definition, here we need to find all references to this definition, and remove them (?)
         const index = state.uiSchema.findIndex((e: UiSchemaItem) => e.id === path);
         if (index >= 0) {
           state.uiSchema.splice(index, 1);

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
@@ -147,20 +147,18 @@ const schemaEditorSlice = createSlice({
       if (path.includes('/properties')) {
         // #/definitions/Foretak/properties/organisasjonsnummerForetak
         const [rootPath, propertyName] = path.split('/properties/');
-        if (rootPath && propertyName) {
-          const rootItem = state.uiSchema.find((item) => item.id === rootPath);
-          const propertyItem = rootItem?.properties?.find((property: any) => property.name === propertyName);
-          if (propertyItem) {
-            propertyItem.name = name;
-            propertyItem.id = `${rootPath}/properties/${name}`;
-            if (navigate) {
-              state.selectedId = propertyItem.id;
-            }
+        const rootItem = state.uiSchema.find((item) => item.id === rootPath);
+        const propertyItem = rootItem?.properties?.find((property: any) => property.name === propertyName);
+        if (propertyItem) {
+          propertyItem.name = name;
+          propertyItem.id = `${rootPath}/properties/${name}`;
+          if (navigate) {
+            state.selectedId = propertyItem.id;
           }
         }
-        // also update definition item ?
-      } else if (path.includes('/definitions')) {
-        // just update definition id/name
+        return;
+      }
+      if (path.includes('/definitions')) {
         const propertyName = path.split('/definitions/')[1];
         if (propertyName) {
           const rootItem = state.uiSchema.find((item) => item.id === path);

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
@@ -77,9 +77,9 @@ const schemaEditorSlice = createSlice({
       const removeFromItem = getUiSchemaItem(state.uiSchema, path);
       if (removeFromItem) {
         const removeIndex = removeFromItem.keywords?.findIndex((v: any) => v.key === key) ?? -1;
-        const newValue = removeFromItem
-          .keywords?.slice(0, removeIndex).concat(removeFromItem.keywords.slice(removeIndex + 1));
-        removeFromItem.keywords = newValue;
+        if (removeIndex >= 0) {
+          removeFromItem.keywords?.splice(removeIndex, 1);
+        }
       }
     },
     deleteProperty(state, action) {

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
@@ -94,6 +94,14 @@ const schemaEditorSlice = createSlice({
             .properties?.slice(0, removeIndex).concat(removeFromItem.properties.slice(removeIndex + 1));
           removeFromItem.properties = newProperties;
         }
+      } else {
+        // delete definition
+        const index = state.uiSchema.findIndex((e: UiSchemaItem) => e.id === path);
+        if (index >= 0) {
+          // todo: delete all references to this item.
+
+          state.uiSchema.splice(index, 1);
+        }
       }
     },
     setFieldValue(state, action) {
@@ -105,6 +113,7 @@ const schemaEditorSlice = createSlice({
       if (schemaItem.keywords) {
         const fieldItem = schemaItem.keywords.find((field) => field.key === key);
         if (fieldItem) {
+          console.log(`${fieldItem.value} -> ${value}`);
           fieldItem.value = value;
         }
       }
@@ -135,7 +144,9 @@ const schemaEditorSlice = createSlice({
       state.schema = schema;
     },
     setPropertyName(state, action) {
-      const { path, name } = action.payload;
+      const {
+        path, name, navigate,
+      } = action.payload;
       if (path.includes('/properties')) {
         // #/definitions/Foretak/properties/organisasjonsnummerForetak
         const [rootPath, propertyName] = path.split('/properties/');
@@ -145,7 +156,9 @@ const schemaEditorSlice = createSlice({
           if (propertyItem) {
             propertyItem.name = name;
             propertyItem.id = `${rootPath}/properties/${name}`;
-            state.selectedId = propertyItem.id;
+            if (navigate) {
+              state.selectedId = propertyItem.id;
+            }
           }
         }
         // also update definition item ?
@@ -157,7 +170,9 @@ const schemaEditorSlice = createSlice({
           if (rootItem) {
             rootItem.name = name;
             rootItem.id = `#/definitions/${propertyName}`;
-            state.selectedId = rootItem.id;
+            if (navigate) {
+              state.selectedId = rootItem.id;
+            }
           }
         }
       }

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
@@ -98,8 +98,6 @@ const schemaEditorSlice = createSlice({
         // delete definition
         const index = state.uiSchema.findIndex((e: UiSchemaItem) => e.id === path);
         if (index >= 0) {
-          // todo: delete all references to this item.
-
           state.uiSchema.splice(index, 1);
         }
       }
@@ -113,7 +111,6 @@ const schemaEditorSlice = createSlice({
       if (schemaItem.keywords) {
         const fieldItem = schemaItem.keywords.find((field) => field.key === key);
         if (fieldItem) {
-          console.log(`${fieldItem.value} -> ${value}`);
           fieldItem.value = value;
         }
       }

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
@@ -90,16 +90,16 @@ const schemaEditorSlice = createSlice({
         if (removeFromItem) {
           const removeIndex = removeFromItem
             .properties?.findIndex((property: any) => property.name === propertyName) ?? -1;
-          const newProperties = removeFromItem
-            .properties?.slice(0, removeIndex).concat(removeFromItem.properties.slice(removeIndex + 1));
-          removeFromItem.properties = newProperties;
+          if (removeIndex >= 0) {
+            removeFromItem.properties?.splice(removeIndex, 1);
+          }
         }
-      } else {
-        // delete definition, here we need to find all references to this definition, and remove them (?)
-        const index = state.uiSchema.findIndex((e: UiSchemaItem) => e.id === path);
-        if (index >= 0) {
-          state.uiSchema.splice(index, 1);
-        }
+        return;
+      }
+      // delete definition, here we need to find all references to this definition, and remove them (?)
+      const index = state.uiSchema.findIndex((e: UiSchemaItem) => e.id === path);
+      if (index >= 0) {
+        state.uiSchema.splice(index, 1);
       }
     },
     setFieldValue(state, action) {
@@ -144,31 +144,15 @@ const schemaEditorSlice = createSlice({
       const {
         path, name, navigate,
       } = action.payload;
-      if (path.includes('/properties')) {
-        // #/definitions/Foretak/properties/organisasjonsnummerForetak
-        const [rootPath, propertyName] = path.split('/properties/');
-        const rootItem = state.uiSchema.find((item) => item.id === rootPath);
-        const propertyItem = rootItem?.properties?.find((property: any) => property.name === propertyName);
-        if (propertyItem) {
-          propertyItem.name = name;
-          propertyItem.id = `${rootPath}/properties/${name}`;
-          if (navigate) {
-            state.selectedId = propertyItem.id;
-          }
-        }
-        return;
-      }
-      if (path.includes('/definitions')) {
-        const propertyName = path.split('/definitions/')[1];
-        if (propertyName) {
-          const rootItem = state.uiSchema.find((item) => item.id === path);
-          if (rootItem) {
-            rootItem.name = name;
-            rootItem.id = `#/definitions/${propertyName}`;
-            if (navigate) {
-              state.selectedId = rootItem.id;
-            }
-          }
+
+      const item = getUiSchemaItem(state.uiSchema, path);
+      if (item) {
+        item.name = name;
+        const arr = item.id.split('/');
+        arr[arr.length - 1] = name;
+        item.id = arr.join('/');
+        if (navigate) {
+          state.selectedId = item.id;
         }
       }
     },

--- a/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/SchemaInspector.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/SchemaInspector.test.tsx
@@ -98,6 +98,38 @@ it('dispatches correctly when changing key', (done) => {
   });
 });
 
+it('dispatches correctly when changing property name', (done) => {
+  mockStore = createStore({
+    ...mockInitialState,
+    schema: dataMock,
+    uiSchema: mockUiSchema,
+    selectedId: '#/definitions/RA-0678_M',
+  });
+  mockStore.dispatch = jest.fn(dispatchMock);
+  let wrapper: any = null;
+  act(() => {
+    wrapper = mountComponent();
+  });
+  expect(wrapper).not.toBeNull();
+  const input = wrapper.find('#input-RA-0678_M-properties-InternInformasjon-key-InternInformasjon').last();
+  input.simulate('change', { target: { value: 'Test' } });
+
+  setImmediate(() => {
+    wrapper.update();
+    input.simulate('blur');
+
+    expect(mockStore.dispatch).toHaveBeenCalledWith({
+      type: 'schemaEditor/setPropertyName',
+      payload: {
+        name: 'Test',
+        path: '#/definitions/RA-0678_M/properties/InternInformasjon',
+      },
+    });
+
+    done();
+  });
+});
+
 it('dispatches correctly when changing ref', () => {
   mockStore = createStore({
     ...mockInitialState,

--- a/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/SchemaInspector.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/SchemaInspector.test.tsx
@@ -66,7 +66,7 @@ it('dispatches correctly when changing value', () => {
       payload: {
         key: 'minLength',
         path: '#/definitions/Kommentar2000Restriksjon',
-        value: '666',
+        value: 666,
       },
     });
   });

--- a/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/schemaEditorSlice.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/schemaEditorSlice.test.ts
@@ -105,7 +105,17 @@ describe('SchemaEditorSlice', () => {
       fail('item not found');
     }
 
-    expect(item.properties).not.toContainEqual({ id: '#/definitions/Kontaktperson/properties/navn' });
+    expect(item.properties).not.toContainEqual({ id: '#/definitions/Kontaktperson/properties/navn' });    
+  });
+
+  it('handles deleteProperty (root definition)', () => {
+    const payload = {
+      path: '#/definitions/Kontaktperson',
+    };
+    const nextState = reducer(state, deleteProperty(payload));
+
+    const item = nextState.uiSchema.find((f) => f.id === '#/definitions/Kontaktperson');
+    expect(item).toBeUndefined();
   });
 
   it('handles addProperty', () => {

--- a/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/schemaEditorSlice.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/schemaEditorSlice.test.ts
@@ -130,13 +130,18 @@ describe('SchemaEditorSlice', () => {
     };
     const nextState = reducer(state, addProperty(payload));
 
-    const item = nextState.uiSchema.find((f) => f.id === '#/definitions/Kontaktperson');
-    if (!item || !item.properties) {
-      fail('item not found');
-    }
-
-    expect(item.properties).toContainEqual({
+    let item = nextState.uiSchema.find((f) => f.id === '#/definitions/Kontaktperson');
+    expect(item && item.properties).toContainEqual({
       $ref: '#/definitions/test', id: '#/definitions/Kontaktperson/properties/test', name: 'test',
+    });
+
+    // test add second time to get more case coverage.
+    payload.newKey = 'test2';
+    payload.content = [{ id: '#/definitions/test2' }];
+    const state2 = reducer(nextState, addProperty(payload));
+    item = state2.uiSchema.find((f) => f.id === '#/definitions/Kontaktperson');
+    expect(item && item.properties).toContainEqual({
+      $ref: '#/definitions/test2', id: '#/definitions/Kontaktperson/properties/test2', name: 'test2',
     });
   });
 
@@ -146,15 +151,19 @@ describe('SchemaEditorSlice', () => {
       key: 'key',
       value: 'value',
     };
-    const nextState = reducer(state, addField(payload));
+    let nextState = reducer(state, addField(payload));
 
-    const item = nextState.uiSchema.find((f) => f.id === '#/definitions/Kontaktperson');
-    if (!item || !item.properties) {
-      fail('item not found');
-    }
-
-    expect(item.keywords).toContainEqual({
+    let item = nextState.uiSchema.find((f) => f.id === '#/definitions/Kontaktperson');
+    expect(item && item.keywords).toContainEqual({
       key: 'key', value: 'value',
+    });
+
+    payload.key = 'test';
+    payload.value = 'test';
+    nextState = reducer(nextState, addField(payload));
+    item = nextState.uiSchema.find((f) => f.id === '#/definitions/Kontaktperson');
+    expect(item && item.keywords).toContainEqual({
+      key: 'test', value: 'test',
     });
   });
 

--- a/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/schemaEditorSlice.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/schemaEditorSlice.test.ts
@@ -105,7 +105,7 @@ describe('SchemaEditorSlice', () => {
       fail('item not found');
     }
 
-    expect(item.properties).not.toContainEqual({ id: '#/definitions/Kontaktperson/properties/navn' });    
+    expect(item.properties).not.toContainEqual({ id: '#/definitions/Kontaktperson/properties/navn' });
   });
 
   it('handles deleteProperty (root definition)', () => {


### PR DESCRIPTION
Fixed 500 error on saving datamodel.

- Fixed number value saved as string
- Fixed renaming properties not always working
- Enabled delete button on all context menus
- Fixed deletion of root definitions