### PR TITLE
Fix handling of duplicate options when collecting data for PDF

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="LocalNuGet" value="C:\LocalNuGet" />
   </packageSources>
   <disabledPackageSources>
     <add key="aspnet-contrib" value="true" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="LocalNuGet" value="C:\LocalNuGet" />
   </packageSources>
   <disabledPackageSources>
     <add key="aspnet-contrib" value="true" />

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,27 +3,23 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>4.6.1</AssemblyVersion>
-    <FileVersion>4.6.1</FileVersion>
-    <!-- SonarCloud requires a ProjectGuid to separate projects. -->
-    <ProjectGuid>{E8F29FE8-6B62-41F1-A08C-2A318DD08BB4}</ProjectGuid>
-
-    <!-- NuGet package properties -->
+    <Version>4.6.2-alpha.0</Version>
+    <AssemblyVersion>4.6.2.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
-    <PackageVersion>4.6.1</PackageVersion>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>
     <Description>
       This class library holds all the API controllers used by a standard Altinn 3 App.
     </Description>
-    <PackageReleaseNotes>
-      https://docs.altinn.studio/teknologi/altinnstudio/changelog/app-nuget/
-    </PackageReleaseNotes>
+    <PackageReleaseNotes>https://docs.altinn.studio/teknologi/altinnstudio/changelog/app-nuget/</PackageReleaseNotes>
     <Authors>Altinn Platform Contributors</Authors>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Altinn/altinn-studio</RepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IsPackable>true</IsPackable>
+
+    <!-- SonarCloud requires a ProjectGuid to separate projects. -->
+    <ProjectGuid>{E8F29FE8-6B62-41F1-A08C-2A318DD08BB4}</ProjectGuid>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,26 +3,23 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>4.6.1</AssemblyVersion>
-    <FileVersion>4.6.1</FileVersion>
-    <!-- SonarCloud requires a ProjectGuid to separate projects. -->
-    <ProjectGuid>{7D2FF2B1-7F21-4934-9D77-DBCDC15BD8CC}</ProjectGuid>
-
-    <!-- NuGet package properties -->
+    <Version>4.6.2-alpha.0</Version>
+    <AssemblyVersion>4.6.2.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
-    <PackageVersion>4.6.1</PackageVersion>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>
     <Description>
       This class library holds classes with logic that is common for the other Altinn.App packages.
     </Description>
-    <PackageReleaseNotes>
-      https://docs.altinn.studio/teknologi/altinnstudio/changelog/app-nuget/
-    </PackageReleaseNotes>
+    <PackageReleaseNotes>https://docs.altinn.studio/teknologi/altinnstudio/changelog/app-nuget/</PackageReleaseNotes>
     <Authors>Altinn Platform Contributors</Authors>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Altinn/altinn-studio</RepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IsPackable>true</IsPackable>
+    
+    <!-- SonarCloud requires a ProjectGuid to separate projects. -->
+    <ProjectGuid>{7D2FF2B1-7F21-4934-9D77-DBCDC15BD8CC}</ProjectGuid>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,26 +3,23 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>4.6.1</AssemblyVersion>
-    <FileVersion>4.6.1</FileVersion>
-    <!-- SonarCloud requires a ProjectGuid to separate projects. -->
-    <ProjectGuid>{98E6200A-ED99-418E-B30C-81BA564B509A}</ProjectGuid>
-
-    <!-- NuGet package properties -->
+    <Version>4.6.2-alpha.0</Version>
+    <AssemblyVersion>4.6.2.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
-    <PackageVersion>4.6.1</PackageVersion>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>
     <Description>
       This class library holds most of the Altinn App business logic and clients for communication with the platform.
     </Description>
-    <PackageReleaseNotes>
-      https://docs.altinn.studio/teknologi/altinnstudio/changelog/app-nuget/
-    </PackageReleaseNotes>
+    <PackageReleaseNotes>https://docs.altinn.studio/teknologi/altinnstudio/changelog/app-nuget/</PackageReleaseNotes>
     <Authors>Altinn Platform Contributors</Authors>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Altinn/altinn-studio</RepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IsPackable>true</IsPackable>
+
+    <!-- SonarCloud requires a ProjectGuid to separate projects. -->
+    <ProjectGuid>{98E6200A-ED99-418E-B30C-81BA564B509A}</ProjectGuid>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
@@ -498,7 +498,10 @@ namespace Altinn.App.Services.Implementation
                     Dictionary<string, string> options = new Dictionary<string, string>();
                     foreach (AppOption item in appOptions.Options)
                     {
-                        options.Add(item.Label, item.Value);
+                        if (!options.ContainsKey(item.Label))
+                        {
+                            options.Add(item.Label, item.Value);
+                        }
                     }
 
                     dictionary.Add(optionsId, options);

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/DataApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/DataApiTest.cs
@@ -28,7 +28,7 @@ namespace App.IntegrationTests.ApiTests
         
         public DataApiTest(CustomWebApplicationFactory<Altinn.App.Startup> factory)
         {
-            _factory = factory;            
+            _factory = factory;
         }
 
         [Fact]
@@ -87,9 +87,7 @@ namespace App.IntegrationTests.ApiTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/endring-av-navn/instances/1337/36133fb5-a9f2-45d4-90b1-f6d93ad40713/data?dataType=default")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/endring-av-navn/instances/1337/36133fb5-a9f2-45d4-90b1-f6d93ad40713/data?dataType=default");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             await response.Content.ReadAsStringAsync();
@@ -111,9 +109,7 @@ namespace App.IntegrationTests.ApiTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/instances/1337/46133fb5-a9f2-45d4-90b1-f6d93ad40713/data/4b9b5802-861b-4ca3-b757-e6bd5f582bf9")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/instances/1337/46133fb5-a9f2-45d4-90b1-f6d93ad40713/data/4b9b5802-861b-4ca3-b757-e6bd5f582bf9");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             TestDataUtil.DeleteInstance("tdd", "endring-av-navn", 1337, new Guid("46133fb5-a9f2-45d4-90b1-f6d93ad40713"));
@@ -134,9 +130,7 @@ namespace App.IntegrationTests.ApiTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/instances/1337/46133fb5-a9f2-45d4-90b1-f6d93ad40713/data/4b9b5802-861b-4ca3-b757-e6bd5f582bf9")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/instances/1337/46133fb5-a9f2-45d4-90b1-f6d93ad40713/data/4b9b5802-861b-4ca3-b757-e6bd5f582bf9");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             await response.Content.ReadAsStringAsync();
@@ -155,9 +149,7 @@ namespace App.IntegrationTests.ApiTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/instances/1000/46133fb5-a9f2-45d4-90b1-f6d93ad40713/data/4b9b5802-861b-4ca3-b757-e6bd5f582bf9")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/instances/1000/46133fb5-a9f2-45d4-90b1-f6d93ad40713/data/4b9b5802-861b-4ca3-b757-e6bd5f582bf9");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             await response.Content.ReadAsStringAsync();
@@ -174,9 +166,7 @@ namespace App.IntegrationTests.ApiTests
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "custom-validation");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/custom-validation/instances/1337/182e053b-3c74-46d4-92ec-a2828289a877/data/7dfeffd1-1750-4e4a-8107-c6741e05d2a9")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/custom-validation/instances/1337/182e053b-3c74-46d4-92ec-a2828289a877/data/7dfeffd1-1750-4e4a-8107-c6741e05d2a9");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             TestDataUtil.DeleteInstance("tdd", "custom-validation", 1337, new Guid("182e053b-3c74-46d4-92ec-a2828289a877"));
@@ -194,9 +184,7 @@ namespace App.IntegrationTests.ApiTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "custom-validation");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/custom-validation/instances/1337/182e053b-3c74-46d4-92ec-a2828289a877/data/7dfeffd1-1750-4e4a-8107-c6741e05d2a9")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/custom-validation/instances/1337/182e053b-3c74-46d4-92ec-a2828289a877/data/7dfeffd1-1750-4e4a-8107-c6741e05d2a9");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -226,18 +214,14 @@ namespace App.IntegrationTests.ApiTests
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "custom-validation");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/custom-validation/instances/1337/609efc9d-4496-4f0b-9d20-808dc2c1876d/data?dataType=default")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/custom-validation/instances/1337/609efc9d-4496-4f0b-9d20-808dc2c1876d/data?dataType=default");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
 
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             DataElement dataElement = JsonConvert.DeserializeObject<DataElement>(responseContent);
-            httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, $"/tdd/custom-validation/instances/1337/609efc9d-4496-4f0b-9d20-808dc2c1876d/data/{dataElement.Id}")
-            {
-            };
+            httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, $"/tdd/custom-validation/instances/1337/609efc9d-4496-4f0b-9d20-808dc2c1876d/data/{dataElement.Id}");
 
             response = await client.SendAsync(httpRequestMessage);
             responseContent = await response.Content.ReadAsStringAsync();
@@ -905,7 +889,10 @@ namespace App.IntegrationTests.ApiTests
 
             string dataRequestUri = $"{instanceUri}/data/{dataGuid}?dataType=default";
             string dataRequestBody = "{\"skjemanummer\":\"1472\",\"spesifikasjonsnummer\":\"9812\",\"blankettnummer\":\"AFP-01\",\"tittel\":\"ArbeidsgiverskjemaAFP\",\"gruppeid\":\"8818\",\"OpplysningerOmArbeidstakerengrp8819\":{\"Arbeidsforholdgrp8856\":{\"AnsattSammenhengendeAnsattAnsettelsedatadef33267\":{\"value\":\"12\",\"orid\":\"33267\"},},\"Skjemainstansgrp8854\":{\"Journalnummerdatadef33316\":{\"value\":\"160694\"}}}}";
-            HttpRequestMessage dataHttpRequestMessage = new HttpRequestMessage(HttpMethod.Put, dataRequestUri) { Content = new StringContent(dataRequestBody, Encoding.UTF8, "application/json") };
+            HttpRequestMessage dataHttpRequestMessage = new HttpRequestMessage(HttpMethod.Put, dataRequestUri)
+            {
+                Content = new StringContent(dataRequestBody, Encoding.UTF8, "application/json")
+            };
 
             await client.SendAsync(dataHttpRequestMessage);
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/InstanceApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/InstanceApiTest.cs
@@ -248,7 +248,6 @@ namespace App.IntegrationTests
 
             Assert.Equal("1337", createdInstance.InstanceOwner.PartyId);
             TestDataUtil.DeleteInstanceAndData("tdd", "endring-av-navn", 1337, new Guid(createdInstance.Id.Split('/')[1]));
-
         }
 
         /// <summary>
@@ -305,7 +304,7 @@ namespace App.IntegrationTests
         /// create a multipart request with instance and xml prefil for both form and message for nabovarsel
         /// </summary>
         [Fact]
-        public async void Instance_Post_NabovarselWithMessageAndForm ()
+        public async void Instance_Post_NabovarselWithMessageAndForm()
         {
             // Arrange
             string instanceOwnerPartyId = "1337";

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/OptionsApiTests.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/OptionsApiTests.cs
@@ -28,9 +28,7 @@ namespace App.IntegrationTestsRef.ApiTests
             string token = PrincipalUtil.GetToken(1337);
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/options/weekdays")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/options/weekdays");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -46,9 +44,7 @@ namespace App.IntegrationTestsRef.ApiTests
             string token = PrincipalUtil.GetToken(1337);
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/options/carbrands")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/options/carbrands");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/OptionsApiTests.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/OptionsApiTests.cs
@@ -55,7 +55,7 @@ namespace App.IntegrationTestsRef.ApiTests
 
             Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
             List<AppOption> options = JsonConvert.DeserializeObject<List<AppOption>>(responseContent);
-            Assert.Equal(3, options.Count);
+            Assert.Equal(5, options.Count);
         }
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/ProcessApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/ProcessApiTest.cs
@@ -37,9 +37,7 @@ namespace App.IntegrationTests.ApiTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/instances/1337/26133fb5-a9f2-45d4-90b1-f6d93ad40713/process")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/instances/1337/26133fb5-a9f2-45d4-90b1-f6d93ad40713/process");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             TestDataUtil.DeleteInstance("tdd", "endring-av-navn", 1337, new Guid("26133fb5-a9f2-45d4-90b1-f6d93ad40713"));
@@ -60,9 +58,7 @@ namespace App.IntegrationTests.ApiTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/instances/1337/26133fb5-a9f2-45d4-90b1-f6d93ad40713/process/next")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/instances/1337/26133fb5-a9f2-45d4-90b1-f6d93ad40713/process/next");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             TestDataUtil.DeleteInstance("tdd", "endring-av-navn", 1337, new Guid("26133fb5-a9f2-45d4-90b1-f6d93ad40713"));
@@ -84,9 +80,7 @@ namespace App.IntegrationTests.ApiTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/endring-av-navn/instances/1337/26233fb5-a9f2-45d4-90b1-f6d93ad40713/process/start")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/endring-av-navn/instances/1337/26233fb5-a9f2-45d4-90b1-f6d93ad40713/process/start");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -104,7 +98,7 @@ namespace App.IntegrationTests.ApiTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/endring-av-navn/instances/1337/26233fb5-a9f2-45d4-90b1-f6d93ad40713/process/start"){};
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/endring-av-navn/instances/1337/26233fb5-a9f2-45d4-90b1-f6d93ad40713/process/start");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -117,7 +111,7 @@ namespace App.IntegrationTests.ApiTests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // fetch actual data and compare to expected prefill
-            httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, $"/tdd/endring-av-navn/instances/1337/26233fb5-a9f2-45d4-90b1-f6d93ad40713/data/{dataElement.Id}"){};
+            httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, $"/tdd/endring-av-navn/instances/1337/26233fb5-a9f2-45d4-90b1-f6d93ad40713/data/{dataElement.Id}");
             response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -182,7 +176,7 @@ namespace App.IntegrationTests.ApiTests
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            //// Commented out the Asserts as another test might clear the Requests list and then fail these
+            // Commented out the Asserts as another test might clear the Requests list and then fail these
             ////Assert.Equal("app.instance.process.completed", EventsMockSI.Requests.First().eventType);
             ////Assert.NotNull(EventsMockSI.Requests.First().instance);
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/ProcessApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/ProcessApiTest.cs
@@ -43,7 +43,7 @@ namespace App.IntegrationTests.ApiTests
             TestDataUtil.DeleteInstance("tdd", "endring-av-navn", 1337, new Guid("26133fb5-a9f2-45d4-90b1-f6d93ad40713"));
 
             string responseContent = await response.Content.ReadAsStringAsync();
-            ProcessState processState= (ProcessState)JsonConvert.DeserializeObject(responseContent, typeof(ProcessState));
+            ProcessState processState = (ProcessState)JsonConvert.DeserializeObject(responseContent, typeof(ProcessState));
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("Task_1", processState.CurrentTask.ElementId);
@@ -104,7 +104,7 @@ namespace App.IntegrationTests.ApiTests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // fetch instance and get data element id
-            httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, $"/tdd/endring-av-navn/instances/1337/26233fb5-a9f2-45d4-90b1-f6d93ad40713/"){};
+            httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, $"/tdd/endring-av-navn/instances/1337/26233fb5-a9f2-45d4-90b1-f6d93ad40713/");
             response = await client.SendAsync(httpRequestMessage);
             Instance instance = JsonConvert.DeserializeObject<Instance>(await response.Content.ReadAsStringAsync());
             DataElement dataElement = instance.Data.First();

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/ProcessApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/ProcessApiTest.cs
@@ -116,9 +116,9 @@ namespace App.IntegrationTests.ApiTests
             string responseContent = await response.Content.ReadAsStringAsync();
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var skjema = JsonConvert.DeserializeObject<App.IntegrationTests.Mocks.Apps.tdd.endring_av_navn.Skjema>(responseContent);
-            Assert.Equal(skjema.Tilknytninggrp9315.TilknytningTilNavnetgrp9316.TilknytningMellomnavn2grp9353.PersonMellomnavnAndreTilknyttetGardNavndatadef34931.value, "01039012345");
-            Assert.Equal(skjema.Tilknytninggrp9315.TilknytningTilNavnetgrp9316.TilknytningMellomnavn2grp9353.PersonMellomnavnAndreTilknyttetPersonsEtternavndatadef34930.value, "Oslo");
-            Assert.Equal(skjema.Tilknytninggrp9315.TilknytningTilNavnetgrp9316.TilknytningMellomnavn2grp9353.PersonMellomnavnAndreTilknytningBeskrivelsedatadef34928.value, "Grev Wedels Plass");
+            Assert.Equal("01039012345", skjema.Tilknytninggrp9315.TilknytningTilNavnetgrp9316.TilknytningMellomnavn2grp9353.PersonMellomnavnAndreTilknyttetGardNavndatadef34931.value);
+            Assert.Equal("Oslo", skjema.Tilknytninggrp9315.TilknytningTilNavnetgrp9316.TilknytningMellomnavn2grp9353.PersonMellomnavnAndreTilknyttetPersonsEtternavndatadef34930.value);
+            Assert.Equal("Grev Wedels Plass", skjema.Tilknytninggrp9315.TilknytningTilNavnetgrp9316.TilknytningMellomnavn2grp9353.PersonMellomnavnAndreTilknytningBeskrivelsedatadef34928.value);
             TestDataUtil.DeleteInstanceAndData("tdd", "endring-av-navn", 1337, new System.Guid("26233fb5-a9f2-45d4-90b1-f6d93ad40713"));
         }
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/ProfileApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/ProfileApiTest.cs
@@ -34,9 +34,7 @@ namespace App.IntegrationTestsRef.ApiTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/v1/profile/user/")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/v1/profile/user/");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/ResourceApiTests.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/ResourceApiTests.cs
@@ -25,9 +25,7 @@ namespace App.IntegrationTestsRef.ApiTests
             string token = PrincipalUtil.GetToken(1337);
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/resource/FormLayout.json")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/resource/FormLayout.json");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -41,9 +39,7 @@ namespace App.IntegrationTestsRef.ApiTests
             string token = PrincipalUtil.GetToken(1337);
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/metadata/ServiceMetaData")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/metadata/ServiceMetaData");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -57,9 +53,7 @@ namespace App.IntegrationTestsRef.ApiTests
             string token = PrincipalUtil.GetToken(1337);
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/textresources/")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/textresources/");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -73,9 +67,7 @@ namespace App.IntegrationTestsRef.ApiTests
             string token = PrincipalUtil.GetToken(1337);
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/resource/RuleHandler.js")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/resource/RuleHandler.js");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -89,9 +81,7 @@ namespace App.IntegrationTestsRef.ApiTests
             string token = PrincipalUtil.GetToken(1337);
             HttpClient client = SetupUtil.GetTestClient(_factory, "ttd", "frontend-test");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/ttd/frontend-test/api/ruleconfiguration/message")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/ttd/frontend-test/api/ruleconfiguration/message");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/SiriusApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/SiriusApiTest.cs
@@ -37,9 +37,7 @@ namespace App.IntegrationTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "sirius");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/sirius/instances?instanceOwnerPartyId=1337")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/sirius/instances?instanceOwnerPartyId=1337");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
@@ -63,9 +61,7 @@ namespace App.IntegrationTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "sirius");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/sirius/instances?instanceOwnerPartyId=1337")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/sirius/instances?instanceOwnerPartyId=1337");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
@@ -143,9 +139,7 @@ namespace App.IntegrationTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "sirius");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/sirius/instances?instanceOwnerPartyId=1337")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/sirius/instances?instanceOwnerPartyId=1337");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
@@ -216,9 +210,7 @@ namespace App.IntegrationTests
             // Setup client and calls Instance controller on the App that instansiates a new instances of the app
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "sirius");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/sirius/instances?instanceOwnerPartyId=1337")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/tdd/sirius/instances?instanceOwnerPartyId=1337");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
@@ -289,9 +281,7 @@ namespace App.IntegrationTests
             Assert.Empty(messages);
 
             // Handle first next go from data to confirmation
-            HttpRequestMessage httpRequestMessageFirstNext = new HttpRequestMessage(HttpMethod.Put, "/tdd/sirius/instances/" + instance.Id + "/process/next")
-            {
-            };
+            HttpRequestMessage httpRequestMessageFirstNext = new HttpRequestMessage(HttpMethod.Put, "/tdd/sirius/instances/" + instance.Id + "/process/next");
 
             HttpResponseMessage responseFirstNext = await client.SendAsync(httpRequestMessageFirstNext);
             string responseContentFirstNext = await responseFirstNext.Content.ReadAsStringAsync();
@@ -306,9 +296,7 @@ namespace App.IntegrationTests
             Assert.Empty(messagesTask2);
 
             // Move process from Task_2 (Confirmation) to Task_3  (Feedback). 
-            HttpRequestMessage httpRequestMessageSecondNext = new HttpRequestMessage(HttpMethod.Put, "/tdd/sirius/instances/" + instance.Id + "/process/next")
-            {
-            };
+            HttpRequestMessage httpRequestMessageSecondNext = new HttpRequestMessage(HttpMethod.Put, "/tdd/sirius/instances/" + instance.Id + "/process/next");
 
             HttpResponseMessage responseSecondNext = await client.SendAsync(httpRequestMessageSecondNext);
             string responseContentSecondNext = await responseSecondNext.Content.ReadAsStringAsync();

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/SiriusApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/SiriusApiTest.cs
@@ -247,7 +247,6 @@ namespace App.IntegrationTests
 
             byte[] byteArray = Encoding.UTF8.GetBytes(næringsppgave);
 
-            //byte[] byteArray = Encoding.ASCII.GetBytes(contents);
             MemoryStream næringsoppgavestream = new MemoryStream(byteArray);
 
             StreamContent streamContentNæring = new StreamContent(næringsoppgavestream);
@@ -262,7 +261,6 @@ namespace App.IntegrationTests
 
             byte[] byteArraySkattemelding = Encoding.UTF8.GetBytes(skattemelding);
 
-            //byte[] byteArray = Encoding.ASCII.GetBytes(contents);
             MemoryStream skattemeldingstream = new MemoryStream(byteArraySkattemelding);
 
             HttpContent streamContentSkattemelding = new StreamContent(skattemeldingstream);
@@ -287,7 +285,7 @@ namespace App.IntegrationTests
             string responseContentFirstNext = await responseFirstNext.Content.ReadAsStringAsync();
 
             ProcessState stateAfterFirstNext = (ProcessState)JsonConvert.DeserializeObject(responseContentFirstNext, typeof(ProcessState));
-            Assert.Equal("Task_2",stateAfterFirstNext.CurrentTask.ElementId);
+            Assert.Equal("Task_2", stateAfterFirstNext.CurrentTask.ElementId);
 
             // Validate instance in Task_2. This validates that PDF for nærings is in place
             HttpResponseMessage responseValidationTask2 = await client.GetAsync(url);

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/TextApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/TextApiTest.cs
@@ -29,9 +29,7 @@ namespace App.IntegrationTestsRef.ApiTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/v1/texts/nb")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/api/v1/texts/nb");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ControllerTests/HomeControllerTests.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ControllerTests/HomeControllerTests.cs
@@ -29,9 +29,7 @@ namespace App.IntegrationTests.ControllerTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -51,9 +49,7 @@ namespace App.IntegrationTests.ControllerTests
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/36133fb5-a9f2-45d4-90b1-f6d93ad40713")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/36133fb5-a9f2-45d4-90b1-f6d93ad40713");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -67,9 +63,7 @@ namespace App.IntegrationTests.ControllerTests
             string token = PrincipalUtil.GetToken(1337);
 
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/")
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/tdd/endring-av-navn/");
 
             SetupUtil.AddAuthCookie(httpRequestMessage, token);
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/dibk/nabovarsel/logic/Validation/ValidationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/dibk/nabovarsel/logic/Validation/ValidationHandler.cs
@@ -21,7 +21,7 @@ namespace App.IntegrationTests.Mocks.Apps.dibk.nabovarsel
         {
             if (instance.GetType().Equals(typeof(SvarPaaNabovarselType)))
             {
-                SvarPaaNabovarselType skjema = (SvarPaaNabovarselType) instance;
+                SvarPaaNabovarselType skjema = (SvarPaaNabovarselType)instance;
                 if (skjema.nabo == null)
                 {
                     validationResults.AddModelError("nabo.epost",  "Error: Epost required");

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/dibk/nabovarsel/models/SvarPaaNabovarselType.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/dibk/nabovarsel/models/SvarPaaNabovarselType.cs
@@ -247,7 +247,6 @@ namespace App.IntegrationTestsRef.Data.apps.dibk.nabovarsel
 
         [XmlElement("signeringssteg")]
         public string signeringssteg { get; set; }
-
     }
 }
 #pragma warning restore SA1300 // Element should begin with upper-case letter

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/nsm/klareringsportalen/logic/Calculation/CalculationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/nsm/klareringsportalen/logic/Calculation/CalculationHandler.cs
@@ -28,25 +28,17 @@ namespace App.IntegrationTests.Mocks.Apps.nsm.klareringsportalen.AppLogic.calcul
             {
                 ePOB_M model = (ePOB_M)instance;
                 if (model.PersonInformasjon.harpostadrsammesombosted != null)
-                {                    
+                {
                     model.PersonInformasjon.postadresse.land = model.PersonInformasjon.bostedsadresse.land;
                     model.PersonInformasjon.postadresse.adressebeskrivelse = model.PersonInformasjon.bostedsadresse.adressebeskrivelse;
                     model.PersonInformasjon.postadresse.postnummer = model.PersonInformasjon.bostedsadresse.postnummer;
                     model.PersonInformasjon.postadresse.poststed = model.PersonInformasjon.bostedsadresse.poststed;
-                    
                 }
 
-                if
-                (model?.PersonInformasjon?.person?.naavaandestatsborgerskap?.statsborgerfrafodsel == "Ja")
+                if (model?.PersonInformasjon?.person?.naavaandestatsborgerskap?.statsborgerfrafodsel == "Ja")
                 {
                     model.PersonInformasjon.person.naavaandestatsborgerskap.fraDato = model.PersonInformasjon.person.foedselsdato;
                 }
-
-                //TODO: må lage generics av dette.
-                /*if(model?.FlereGjeldendeStatsborgerskap?.statsborgerfrafodsel == "Ja")
-                {
-                    model.FlereGjeldendeStatsborgerskap.fraDato = model.PersonInformasjon.person.foedselsdato;
-                }*/
                 
                 return true;
             }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/nsm/klareringsportalen/logic/InstantiationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/nsm/klareringsportalen/logic/InstantiationHandler.cs
@@ -74,39 +74,39 @@ namespace App.IntegrationTests.Mocks.Apps.nsm.klareringsportalen.AppLogic
               model.PersonInformasjon.postadresse = new Adresse();
             }
 
-            if(model.DeusRequest == null) {
+            if (model.DeusRequest == null) {
               model.DeusRequest = new Deusrequest();
             }
 
-            if(model.PersonRelasjoner == null) {
+            if (model.PersonRelasjoner == null) {
               model.PersonRelasjoner = new Relasjoner();
             }
 
-            if(model.Samboerellerektefelle == null) {
+            if (model.Samboerellerektefelle == null) {
               model.Samboerellerektefelle = new Samboerektefelle();
             }
 
-            if(model.PersonligOkonomi == null) {
+            if (model.PersonligOkonomi == null) {
               model.PersonligOkonomi = new OEkonomi();
             }
 
-            if(model.HelsePerson == null) {
+            if (model.HelsePerson == null) {
               model.HelsePerson = new Helse();
             }
 
-            if(model.PersonRusmidler == null) {
+            if (model.PersonRusmidler == null) {
               model.PersonRusmidler = new Rusmidler();
             }
 
-            if(model.Straff == null) {
+            if (model.Straff == null) {
               model.Straff = new Strafferettslig();
             }
 
-            if(model.StatsTilknytning == null) {
+            if (model.StatsTilknytning == null) {
               model.StatsTilknytning = new Statstilknytning();
             }
 
-            if(model.SikkerhetsOpplysninger == null) {
+            if (model.SikkerhetsOpplysninger == null) {
               model.SikkerhetsOpplysninger = new Sikkerhetsopplysninger();
             }
 
@@ -175,12 +175,12 @@ namespace App.IntegrationTests.Mocks.Apps.nsm.klareringsportalen.AppLogic
           if (foedselsnummer != null)
           {
             string century = "20";
-            int year = int.Parse(foedselsnummer.Substring(4,2));
-            if (year >= 20 && year <= 99){
+            int year = int.Parse(foedselsnummer.Substring(4, 2));
+            if (year >= 20 && year <= 99) {
               century = "19";
             }
 
-            model.PersonInformasjon.person.foedselsdato = century + foedselsnummer.Substring(4,2) + "-" + foedselsnummer.Substring(2,2) + "-" + foedselsnummer.Substring(0,2);
+            model.PersonInformasjon.person.foedselsdato = century + foedselsnummer.Substring(4, 2) + "-" + foedselsnummer.Substring(2, 2) + "-" + foedselsnummer.Substring(0, 2);
           }
         }
     }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/nsm/klareringsportalen/logic/Validation/ValidationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/nsm/klareringsportalen/logic/Validation/ValidationHandler.cs
@@ -49,18 +49,6 @@ namespace App.IntegrationTests.Mocks.Apps.nsm.klareringsportalen.AppLogic.Valida
         /// </example>
         public async Task ValidateData(object data, ModelStateDictionary validationResults)
         {
-        //_httpContextAccessor.HttpContext.Request.Headers.TryGetValue("ValidationTriggerField", out StringValues value);
-
-            /*if (data is ePOB_M testModel)
-            {
-                string firstName = testModel?.PersonInformasjon?.harpostadrsammesombosted;
-                if (firstName != null && firstName.Contains("1337")) 
-                {
-                    validationResults.AddModelError(
-                    "Person.FirstName", 
-                    "*WARNING*Are you sure your first name contains 1337?");
-                }
-            }*/
             await Task.CompletedTask;
         }
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/nsm/klareringsportalen/models/epob.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/nsm/klareringsportalen/models/epob.cs
@@ -192,7 +192,6 @@ namespace App.IntegrationTests.Mocks.Apps.nsm.klareringsportalen.models
     [JsonProperty("samtykkepersonkontroll")]
     [JsonPropertyName("samtykkepersonkontroll")]
     public string samtykkepersonkontroll { get; set; }
-
   }
 
     public class Adresse
@@ -216,7 +215,6 @@ namespace App.IntegrationTests.Mocks.Apps.nsm.klareringsportalen.models
     [JsonProperty("land")]
     [JsonPropertyName("land")]
     public string land { get; set; }
-
   }
 
     public class Iddokumenter
@@ -235,7 +233,6 @@ namespace App.IntegrationTests.Mocks.Apps.nsm.klareringsportalen.models
     [JsonProperty("land")]
     [JsonPropertyName("land")]
     public string land { get; set; }
-
   }
 
     public class Person
@@ -1077,7 +1074,6 @@ namespace App.IntegrationTests.Mocks.Apps.nsm.klareringsportalen.models
     [JsonProperty("requestid")]
     [JsonPropertyName("requestid")]
     public string requestid { get; set; }
-
   }
 #pragma warning restore SA1300 // Element should begin with upper-case letter
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/custom-validation/logic/Calculation/CalculationHandler.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/custom-validation/logic/Calculation/CalculationHandler.cs
@@ -51,7 +51,6 @@ namespace App.IntegrationTests.Mocks.Apps.tdd.custom_validation
                     model.OpplysningerOmArbeidstakerengrp8819.Skjemainstansgrp8854.IdentifikasjonsnummerKravdatadef33317 = null;
                     changed = true;
                 }
-
             }
 
             return changed;

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/endring-av-navn/options/carbrands.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/endring-av-navn/options/carbrands.json
@@ -1,11 +1,19 @@
- [
-    {
-      "value": "01",
-      "label": "Audi"
-    },
-    {
-      "value": "02",
-      "label": "BMW"
-    }
- ]
+[
+  {
+    "value": "03",
+    "label": "Tesla"
+  },
+  {
+    "value": "01",
+    "label": "Audi"
+  },
+  {
+    "value": "02",
+    "label": "BMW"
+  },
+  {
+    "value": "03",
+    "label": "Tesla"
+  }
+]
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/endring-av-navn/ui/FormLayout.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/endring-av-navn/ui/FormLayout.json
@@ -372,6 +372,18 @@
         "dataModelBindings": {},
         "textResourceId": "Standard.Button.Button",
         "customType": "Standard"
+      },
+      {
+        "id": "61e8044f-5dbd-4285-8536-5781c32d2105",
+        "type": "Dropdown",
+        "textResourceBindings": {
+          "title": "carbrands"
+        },
+        "dataModelBindings": {
+          "simpleBinding": "carbrands"
+        },
+        "required": true,
+        "optionsId": "carbrands"
       }
     ]
   }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/sirius/logic/App.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/sirius/logic/App.cs
@@ -101,7 +101,7 @@ namespace App.IntegrationTests.Mocks.Apps.tdd.sirius
                 {
                     Stream næringsStream = await _dataService.GetBinaryData(instance.Org, instance.AppId, Convert.ToInt32(instance.InstanceOwner.PartyId), new Guid(instance.Id.Split("/")[1]), new Guid(dataElement.Id));
                     bool isValidNæring = await _siriusApi.IsValidNæring(næringsStream);
-                    if(!isValidNæring)
+                    if (!isValidNæring)
                     {
                         validationResults.AddModelError(string.Empty, "invalid.næring");
                     }
@@ -148,7 +148,7 @@ namespace App.IntegrationTests.Mocks.Apps.tdd.sirius
                 if (dataElement != null)
                 {
                     Stream næringsStream = await _dataService.GetBinaryData(instance.Org, instance.AppId, Convert.ToInt32(instance.InstanceOwner.PartyId), new Guid(instance.Id.Split("/")[1]), new Guid(dataElement.Id));
-                    Stream næringsPDF =  await _siriusApi.GetNæringPDF(næringsStream);
+                    Stream næringsPDF = await _siriusApi.GetNæringPDF(næringsStream);
                     await _dataService.InsertBinaryData(instance.Id, "næringsoppgavepdf", "application/pdf", "NæringPDF", næringsPDF);
                 }
             }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/sirius/services/SiriusAPI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/sirius/services/SiriusAPI.cs
@@ -12,7 +12,7 @@ namespace App.IntegrationTestsRef.Data.apps.tdd.sirius.services
     {
         public Task<Stream> GetNæringPDF(Stream næringsoppgave)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.Location).LocalPath);
             string pdfPath = Path.Combine(unitTestFolder, @"..\..\..\Data\Files\cat.pdf");
 
             Stream fs = File.OpenRead(pdfPath);

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/App.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/logic/App.cs
@@ -20,7 +20,6 @@ using Microsoft.Extensions.Options;
 #pragma warning disable SA1300 // Element should begin with upper-case letter
 namespace App.IntegrationTests.Mocks.Apps.Tdd.Frontendtest
 #pragma warning restore SA1300 // Element should begin with upper-case letter
-
 {
     public class App : AppBase, IAltinnApp
     {

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/models/message.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/frontend-test/models/message.cs
@@ -38,6 +38,5 @@ namespace Altinn.App.Models
     [JsonProperty("Sender")]
     [JsonPropertyName("Sender")]
     public string Sender { get; set; }
-
   }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/EndToEndTests/EndToEndTests.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/EndToEndTests/EndToEndTests.cs
@@ -274,7 +274,7 @@ namespace App.IntegrationTestsRef.EndToEndTests
 
             WebApplicationFactory<Startup> factory = _factory.WithWebHostBuilder(builder =>
             {
-                string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.CodeBase).LocalPath);
+                string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.Location).LocalPath);
                 string path = Path.Combine(unitTestFolder, $"../../../Data/Apps/{org}/{app}/");
 
                 builder.ConfigureAppConfiguration((context, conf) => { conf.AddJsonFile(path + "appsettings.json"); });

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/EndToEndTests/EndToEndTests.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/EndToEndTests/EndToEndTests.cs
@@ -151,7 +151,7 @@ namespace App.IntegrationTestsRef.EndToEndTests
             response = await client.GetAsync(url);
             string responseContent = await response.Content.ReadAsStringAsync();
             List<ValidationIssue> messages =
-                (List<ValidationIssue>) JsonConvert.DeserializeObject(responseContent, typeof(List<ValidationIssue>));
+                (List<ValidationIssue>)JsonConvert.DeserializeObject(responseContent, typeof(List<ValidationIssue>));
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Single(messages);
@@ -168,7 +168,7 @@ namespace App.IntegrationTestsRef.EndToEndTests
             Thread.Sleep(new TimeSpan(0, 0, 12));
             response = await client.GetAsync(url);
             responseContent = await response.Content.ReadAsStringAsync();
-            messages = (List<ValidationIssue>) JsonConvert.DeserializeObject(
+            messages = (List<ValidationIssue>)JsonConvert.DeserializeObject(
                 responseContent,
                 typeof(List<ValidationIssue>));
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/EndToEndTests/NabovarselEndToEnd.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/EndToEndTests/NabovarselEndToEnd.cs
@@ -198,9 +198,7 @@ namespace App.IntegrationTestsRef.EndToEndTests
 
             DataElement dataElementForm = instance.Data.FirstOrDefault(r => r.DataType.Equals(dataType.Id));
 
-            httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, instancePath + "/data/" + dataElementForm.Id)
-            {
-            };
+            httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, instancePath + "/data/" + dataElementForm.Id);
 
             response = await client.SendAsync(httpRequestMessage);
             responseContent = await response.Content.ReadAsStringAsync();

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/JwtTokenMock.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/JwtTokenMock.cs
@@ -44,7 +44,7 @@ namespace Altinn.App.IntegrationTests
         /// <returns>ClaimsPrincipal</returns>
         public static ClaimsPrincipal ValidateToken(string token)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(JwtTokenMock).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(JwtTokenMock).Assembly.Location).LocalPath);
 
             string certPath = Path.Combine(unitTestFolder, @"..\..\..\JWTValidationCert.cer");
 
@@ -68,7 +68,7 @@ namespace Altinn.App.IntegrationTests
 
         private static SigningCredentials GetSigningCredentials()
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(JwtTokenMock).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(JwtTokenMock).Assembly.Location).LocalPath);
 
             string certPath = Path.Combine(unitTestFolder, @"..\..\..\jwtselfsignedcert.pfx");
             X509Certificate2 cert = new X509Certificate2(certPath, "qwer1234");

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/ApplicationMockSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/ApplicationMockSI.cs
@@ -31,7 +31,7 @@ namespace App.IntegrationTests.Mocks.Services
 
         private string GetMetadataPath()
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, @"..\..\..\Data\Metadata");
         }
     }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/DSFMockSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/DSFMockSI.cs
@@ -26,7 +26,7 @@ namespace App.IntegrationTests.Mocks.Services
 
         private string GetPersonPath(string ssn)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(DSFMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(DSFMockSI).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, @"..\..\..\Data\Register\Person", ssn + ".json");
         }
     }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/DataMockSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/DataMockSI.cs
@@ -178,13 +178,13 @@ namespace App.IntegrationTests.Mocks.Services
 
         private string GetDataPath(string org, string app, int instanceOwnerId, Guid instanceGuid)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, @"..\..\..\Data\Instances\", org + @"\", app + @"\", instanceOwnerId + @"\", instanceGuid.ToString() + @"\");
         }
 
         private string GetDataBlobPath(string org, string app, int instanceOwnerId, Guid instanceGuid, Guid dataId)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, @"..\..\..\Data\Instances\", org + @"\", app + @"\", instanceOwnerId + @"\", instanceGuid.ToString() + @"\blob\" + dataId.ToString());
         }
 
@@ -204,7 +204,7 @@ namespace App.IntegrationTests.Mocks.Services
 
         private string GetInstancePath()
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, @"..\..\..\Data\Instances");
         }
 
@@ -298,7 +298,7 @@ namespace App.IntegrationTests.Mocks.Services
 
         private string GetInstancePath(string app, string org)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, @"..\..\..\Data\Instances\", org + @"\", app + @"\");
         }
     }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/ERMockSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/ERMockSI.cs
@@ -26,7 +26,7 @@ namespace App.IntegrationTests.Mocks.Services
 
         private string GetOrganizationPath(string OrgNr)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(ERMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(ERMockSI).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, @"..\..\..\Data\Register\Org", OrgNr + ".json");
         }
     }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/PDFMockSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/PDFMockSI.cs
@@ -12,7 +12,7 @@ namespace App.IntegrationTestsRef.Mocks.Services
     {
         public Task<Stream> GeneratePDF(PDFContext pdfContext)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PDFMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PDFMockSI).Assembly.Location).LocalPath);
             string dataPath = Path.Combine(unitTestFolder, @"..\..\..\Data\Files\print.pdf");
 
             Stream ms = new MemoryStream();

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/PepWithPDPAuthorizationMockSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/PepWithPDPAuthorizationMockSI.cs
@@ -335,7 +335,7 @@ namespace App.IntegrationTests.Mocks.Services
 
         private string GetAltinnAppsPolicyPath(string org, string app)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PepWithPDPAuthorizationMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PepWithPDPAuthorizationMockSI).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, @"..\..\..\Data\apps\" + org + @"\" + app + @"\config\authorization\");
         }
     }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/ProfileMockSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/ProfileMockSI.cs
@@ -35,7 +35,7 @@ namespace App.IntegrationTestsRef.Mocks.Services
 
         private string GetProfilePath(int userId)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(RegisterMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(RegisterMockSI).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, @"..\..\..\Data\Profile\User", userId.ToString() + ".json");
         }
     }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/RegisterMockSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/RegisterMockSI.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json;
 
 namespace App.IntegrationTests.Mocks.Services
 {
-    class RegisterMockSI : IRegister
+    public class RegisterMockSI : IRegister
     {
         private readonly IDSF _dsfService;
         private readonly IER _erService;

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/RegisterMockSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/RegisterMockSI.cs
@@ -77,7 +77,7 @@ namespace App.IntegrationTests.Mocks.Services
 
         private string GetPartyPath(int partyId)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(RegisterMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(RegisterMockSI).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, @"..\..\..\Data\Register\Party", partyId.ToString() + ".json");
         }
     }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/TextMockSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Mocks/Services/TextMockSI.cs
@@ -30,7 +30,7 @@ namespace App.IntegrationTestsRef.Mocks.Services
 
         private string GetTextPath(string org, string app, string language)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(TextMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(TextMockSI).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, @"..\..\..\Data\apps\", org + @"\", app + @$"\config\texts\resource.{language}.json");
         }
     }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Utils/PrincipalUtil.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Utils/PrincipalUtil.cs
@@ -14,7 +14,7 @@ namespace App.IntegrationTests.Utils
             List<Claim> claims = new List<Claim>();
             string issuer = "www.altinn.no"; 
             claims.Add(new Claim(ClaimTypes.NameIdentifier, userId.ToString(), ClaimValueTypes.String, issuer));
-            claims.Add(new Claim(AltinnCoreClaimTypes.UserId, userId.ToString() , ClaimValueTypes.String, issuer));
+            claims.Add(new Claim(AltinnCoreClaimTypes.UserId, userId.ToString(), ClaimValueTypes.String, issuer));
             claims.Add(new Claim(AltinnCoreClaimTypes.UserName, "UserOne", ClaimValueTypes.String, issuer));
             claims.Add(new Claim(AltinnCoreClaimTypes.PartyID, userId.ToString(), ClaimValueTypes.Integer32, issuer));
             claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticateMethod, "Mock", ClaimValueTypes.String, issuer));

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Utils/SetupUtil.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Utils/SetupUtil.cs
@@ -164,7 +164,7 @@ namespace App.IntegrationTestsRef.Utils
 
         private static string GetAppPath(string org, string app)
         {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.CodeBase).LocalPath);
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, $"../../../Data/Apps/{org}/{app}/");
         }
     }


### PR DESCRIPTION
The important fix is in the first commit. "Ignore duplicate option..."
The other commits are fixes to code smells and compile warnings.
The last commit is trying to correct the mess I've made of versions in previous changes.

Related issue #5887