### PR TITLE
FileUpload should not have isSimple be true

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/utils/formComponentUtils.test.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/utils/formComponentUtils.test.ts
@@ -1,4 +1,4 @@
-import { getDisplayFormData, getFormDataForComponentInRepeatingGroup } from '../../src/utils/formComponentUtils';
+import { getDisplayFormData, getFormDataForComponentInRepeatingGroup, isSimpleComponent } from '../../src/utils/formComponentUtils';
 import { IOptions, ITextResource } from '../../src/types';
 import { IFormData } from '../../src/features/form/data/formDataReducer';
 import { ILayoutComponent, ISelectionComponentProps } from '../../src/features/form/layout';
@@ -83,5 +83,35 @@ describe('>>> utils/formComponentUtils.ts', () => {
     } as unknown as ISelectionComponentProps;
     const result = getFormDataForComponentInRepeatingGroup(mockFormData, checkboxComponent, 0, 'group', mockTextResources, mockOptions);
     expect(result).toEqual('RepValue1, RepValue2, RepValue3');
+  });
+
+  it('+++ isSimpleComponent should return false when dataModelBinding is undefined', () => {
+    const genericComponent = {
+      type: 'FileUpload',
+    }
+    const result = isSimpleComponent(undefined, genericComponent.type);
+    expect(result).toEqual(false);
+  });
+
+  it('+++ isSimpleComponent should return false when component type is Datepicker', () => {
+    const genericComponent = {
+      type: 'Datepicker',
+      dataModelBindings: {
+        simpleBinding: 'group.superdate',
+      },
+    }
+    const result = isSimpleComponent(genericComponent.dataModelBindings, genericComponent.type);
+    expect(result).toEqual(false);
+  });
+
+  it('+++ isSimpleComponent should return true when component type is Input', () => {
+    const genericComponent = {
+      type: 'Input',
+      dataModelBindings: {
+        simpleBinding: 'group.secretnumber',
+      },
+    }
+    const result = isSimpleComponent(genericComponent.dataModelBindings, genericComponent.type);
+    expect(result).toEqual(true);
   });
 });

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.6.13",
+  "version": "3.6.14",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.6.12",
+  "version": "3.6.13",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/GenericComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/GenericComponent.tsx
@@ -65,9 +65,7 @@ export function GenericComponent(props: IGenericComponentProps) {
   const componentValidations: IComponentValidations = useSelector((state: IRuntimeState) => state.formValidations.validations[currentView]?.[props.id], shallowEqual);
 
   React.useEffect(() => {
-    if (props.dataModelBindings && props.type) {
-      setIsSimple(isSimpleComponent(props.dataModelBindings, props.type));
-    }
+    setIsSimple(isSimpleComponent(props.dataModelBindings, props.type));
   }, []);
 
   React.useEffect(() => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/formComponentUtils.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/formComponentUtils.ts
@@ -3,8 +3,7 @@ import { ILayoutComponent, ILayoutGroup, ISelectionComponentProps } from 'src/fe
 import { IDataModelBindings, IComponentValidations, ITextResource, ITextResourceBindings, IOption, IOptions, IValidations } from 'src/types';
 
 export const isSimpleComponent = (dataModelBindings: any, type: string): boolean => {
-  const simpleBinding = dataModelBindings ? dataModelBindings.simpleBinding : false;
-  return simpleBinding && type !== 'FileUpload' && type !== 'Datepicker';
+  return !!dataModelBindings?.simpleBinding && type !== 'FileUpload' && type !== 'Datepicker';
 };
 
 export const componentHasValidationMessages = (componentValidations) => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/formComponentUtils.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/formComponentUtils.ts
@@ -3,7 +3,7 @@ import { ILayoutComponent, ILayoutGroup, ISelectionComponentProps } from 'src/fe
 import { IDataModelBindings, IComponentValidations, ITextResource, ITextResourceBindings, IOption, IOptions, IValidations } from 'src/types';
 
 export const isSimpleComponent = (dataModelBindings: any, type: string): boolean => {
-  const simpleBinding = dataModelBindings.simpleBinding;
+  const simpleBinding = dataModelBindings ? dataModelBindings.simpleBinding : false;
   return simpleBinding && type !== 'FileUpload' && type !== 'Datepicker';
 };
 


### PR DESCRIPTION
There was a bug in the logic that determines the value of `isSimple` in `GenericComponent`. It caused the value to be true for `FileUpload` because `dataModelBinding` is undefined. Adjusting with the assumption that no `dataModelBinding` should force `isSimple` to be `false`.

We could alternatively set it to `false` specifically for FileUpload.

#6400 