### PR TITLE
Bump target framework to .NET 5 for localtest

### DIFF
--- a/src/development/LocalTest/LocalTest.csproj
+++ b/src/development/LocalTest/LocalTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>56f36ce2-b44b-415e-a8a5-f399a76e35b9</UserSecretsId>
   </PropertyGroup>
 


### PR DESCRIPTION
To avoid this error when .NET 3.1 is not installed locally.

```
It was not possible to find any compatible framework version
The framework 'Microsoft.AspNetCore.App', version '3.1.0' was not found.
```