### PR TITLE
Remove apps build and deploy badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ Read [the Altinn Studio documentation](https://docs.altinn.studio/teknologi/alti
 
 ### Apps
 
-[![App build status](https://dev.azure.com/brreg/altinn-studio/_apis/build/status/altinn-apps/altinn-studio-build-app-image?label=build)](https://dev.azure.com/brreg/altinn-studio/_build/latest?definitionId=69)
-[![App deploy status](https://dev.azure.com/brreg/altinn-studio/_apis/build/status/altinn-apps/altinn-studio-deploy-app-image?label=deploy)](https://dev.azure.com/brreg/altinn-studio/_build/latest?definitionId=81)
-
 [![KubernetesWrapper build status](https://dev.azure.com/brreg/altinn-studio/_apis/build/status/altinn-apps/altinn-kuberneteswrapper-build-master?label=apps/kuberneteswrapper)](https://dev.azure.com/brreg/altinn-studio/_build/latest?definitionId=88)
 [![Front-end build status](https://dev.azure.com/brreg/altinn-studio/_apis/build/status/altinn-apps/altinn-app-frontend-cdn-build-master?label=apps/frontend)](https://dev.azure.com/brreg/altinn-studio/_build/latest?definitionId=74)
 


### PR DESCRIPTION
Does it make any sense to show failing app owners build and deploys on our status page?