### PR TITLE
Simplified entrypoint and instantiation to use Presentation.tsx

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__mocks__/initialStateMock.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__mocks__/initialStateMock.ts
@@ -60,7 +60,7 @@ export function getInitialStateMock(customStates?: Partial<IRuntimeState>): IRun
     },
     isLoading: {
       dataTask: false,
-      stateless: false,
+      stateless: null,
     },
     language: {
       language: getLanguageFromCode('nb'),

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/entrypoint/Entrypoint.test.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/entrypoint/Entrypoint.test.tsx
@@ -1,4 +1,3 @@
-import configureStore from 'redux-mock-store';
 import 'jest';
 import * as React from 'react';
 import { IRuntimeState } from "../../../src/types";
@@ -50,7 +49,7 @@ describe('>>> features/entrypoint/Entrypoint.tsx', () => {
     );
 
     const contentLoader = await rendered.findByText('Loading...');
-    expect(contentLoader).not.toBeNull();;
+    expect(contentLoader).not.toBeNull();
 
     const instantiationText = await rendered.findByText('Hold deg fast, nå starter vi!');
     expect(instantiationText).not.toBeNull();

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/entrypoint/Entrypoint.test.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/entrypoint/Entrypoint.test.tsx
@@ -1,0 +1,88 @@
+import configureStore from 'redux-mock-store';
+import 'jest';
+import * as React from 'react';
+import { IRuntimeState } from "../../../src/types";
+import { getInitialStateMock } from '../../../__mocks__/initialStateMock';
+import { Provider } from 'react-redux';
+import Entrypoint from '../../../src/features/entrypoint/Entrypoint';
+import { render, waitFor } from '@testing-library/react';
+import { IApplicationMetadata } from '../../../src/shared/resources/applicationMetadata';
+import axios from 'axios';
+import { createStore } from 'redux';
+
+jest.mock('axios');
+
+describe('>>> features/entrypoint/Entrypoint.tsx', () => {
+  let mockInitialState: IRuntimeState;
+  let mockStore: any;
+  let mockReducer: any;
+
+
+  beforeAll(() => {
+    mockInitialState = getInitialStateMock({});
+    (axios.post as jest.Mock).mockResolvedValue({
+      data: {
+        valid: true,
+        validParties: [],
+        message: ''
+      }
+    });
+    mockReducer = (state: IRuntimeState, action: string): IRuntimeState => {
+      if (action === 'queue/startInitialStatelessQueue') {
+        return {
+          ...state,
+          isLoading: {
+            stateless: false,
+            dataTask: null
+          }
+        }
+      }
+      return state;
+    };
+    mockStore = createStore(mockReducer, mockInitialState);
+  });
+
+  it('+++ should show loader while fetching data then start instantiation by default ', async () => {
+    const rendered = render(
+      <Provider store={mockStore}>
+        <Entrypoint />
+      </Provider>
+    );
+
+    const contentLoader = await rendered.findByText('Loading...');
+    expect(contentLoader).not.toBeNull();;
+
+    const instantiationText = await rendered.findByText('Hold deg fast, nå starter vi!');
+    expect(instantiationText).not.toBeNull();
+  });
+
+  it('+++ should show loader while fetching data then start statelessQueue if stateless app', async () => {
+    const statelessApplication: IApplicationMetadata = {
+      ...mockInitialState.applicationMetadata.applicationMetadata,
+      onEntry: {
+        show: 'stateless'
+      }
+    }
+    const mockStateWithStatelessApplication: IRuntimeState = {
+      ...mockInitialState
+    };
+    mockStateWithStatelessApplication.applicationMetadata.applicationMetadata = statelessApplication;
+    mockStore = createStore(mockReducer, mockStateWithStatelessApplication);
+    mockStore.dispatch = jest.fn();
+
+    const rendered = render(
+      <Provider store={mockStore}>
+        <Entrypoint />
+      </Provider>
+    );
+
+    const contentLoader = await rendered.findByText('Loading...');
+    expect(contentLoader).not.toBeNull();
+
+    // should have started the initialStatelessQueue
+    await waitFor(() => {
+      expect(mockStore.dispatch).toHaveBeenCalledWith({ type: 'queue/startInitialStatelessQueue'});
+    });
+  });
+
+});

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/instantiate/index.test.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/instantiate/index.test.tsx
@@ -1,0 +1,67 @@
+/* tslint:disable:jsx-wrap-multiline */
+import 'jest';
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import { render, waitFor } from '@testing-library/react'
+import configureStore from 'redux-mock-store';
+import Instantiate from '../../../src/features/instantiate/containers/index';
+import { IRuntimeState } from '../../../src/types';
+import { getInitialStateMock } from '../../../__mocks__/initialStateMock';
+import InstantiationActions from '../../../src/features/instantiate/instantiation/actions';
+import { BrowserRouter } from 'react-router-dom';
+import axios from 'axios';
+
+jest.mock('axios');
+
+describe('>>> features/instantiate/index.ts', () => {
+  let mockInitialState: IRuntimeState;
+  let mockStore: any;
+  const createStore = configureStore();
+
+  beforeAll(() => {
+    mockInitialState = getInitialStateMock({});
+    mockStore = createStore(mockInitialState);
+    (axios.post as jest.Mock).mockResolvedValue({
+      data: {
+        valid: true,
+        validParties: [],
+        message: ''
+      }
+    })
+    mockStore.dispatch = jest.fn();
+    InstantiationActions.instantiate = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('+++ should show content loader on initial render and start instantiation if valid party', async () => {
+    const rendered = render(
+      <BrowserRouter>
+        <Provider store={mockStore}>
+          <Instantiate />
+        </Provider>
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      // validate party
+      expect(axios.post).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      // start instantiation
+      expect(InstantiationActions.instantiate).toHaveBeenCalledTimes(1);
+    });
+
+    const contentLoader = await rendered.findByText('Loading...');
+    expect(contentLoader).not.toBeNull();;
+
+    const instantiationText = await rendered.findByText('Hold deg fast, nå starter vi!');
+    expect(instantiationText).not.toBeNull();
+
+  });
+});
+
+

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/instantiate/index.test.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/instantiate/index.test.tsx
@@ -56,7 +56,7 @@ describe('>>> features/instantiate/index.ts', () => {
     });
 
     const contentLoader = await rendered.findByText('Loading...');
-    expect(contentLoader).not.toBeNull();;
+    expect(contentLoader).not.toBeNull();
 
     const instantiationText = await rendered.findByText('Hold deg fast, nå starter vi!');
     expect(instantiationText).not.toBeNull();

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/message/ErrorPaper.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/message/ErrorPaper.tsx
@@ -29,7 +29,7 @@ export default function ErrorPaper(props: IErrorPaperProps) {
         container={true}
         alignItems='center'
         direction='row'
-        justify='flex-start'
+        justifyContent='flex-start'
         className={classes.grid}
         spacing={2}
       >

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/presentation/NavigationButtons.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/presentation/NavigationButtons.tsx
@@ -73,7 +73,7 @@ export function NavigationButtons(props: INavigationButtons) {
   return (
     <Grid
       container={true}
-      justify='space-between'
+      justifyContent='space-between'
     >
       <Grid item={true} xs={10}>
         {!disableBack && props.showBackButton &&

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/entrypoint/Entrypoint.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/entrypoint/Entrypoint.tsx
@@ -1,18 +1,14 @@
 /* eslint-disable import/no-named-as-default */
-import { AltinnAppHeader, AltinnContentIconFormData, AltinnContentLoader, AltinnModal } from 'altinn-shared/components';
-import { AltinnAppTheme } from 'altinn-shared/theme';
-import { IParty } from 'altinn-shared/types';
+import { AltinnContentIconFormData, AltinnContentLoader } from 'altinn-shared/components';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Presentation from 'src/shared/containers/Presentation';
 import { startInitialStatelessQueue } from 'src/shared/resources/queue/queueSlice';
-import { IRuntimeState, PresentationType } from 'src/types';
+import { IRuntimeState, PresentationType, ProcessTaskType } from 'src/types';
 import Form from '../form/containers/Form';
 import Instantiate from '../instantiate/containers';
 
 export default function Entrypoint() {
-  const profile = useSelector((state: IRuntimeState) => state.profile.profile);
-  const selectedParty = useSelector((state: IRuntimeState) => state.party.selectedParty);
   const applicationMetadata = useSelector((state: IRuntimeState) => state.applicationMetadata.applicationMetadata);
   const [action, setAction] = React.useState<string>(null);
   const statelessLoading: boolean = useSelector((state: IRuntimeState) => state.isLoading.stateless);
@@ -44,7 +40,7 @@ export default function Entrypoint() {
           type={PresentationType.Stateless}
         >
           <div>
-            <Form/>
+            <Form />
           </div>
         </Presentation>
       );
@@ -52,23 +48,13 @@ export default function Entrypoint() {
   }
 
   return (
-    <>
-      <AltinnAppHeader
-        logoColor={AltinnAppTheme.altinnPalette.primary.blueDarker}
-        headerBackgroundColor={AltinnAppTheme.altinnPalette.primary.blue}
-        party={selectedParty}
-        userParty={profile ? profile.party : {} as IParty}
-      />
-      <AltinnModal
-        isOpen={true}
-        onClose={null}
-        hideBackdrop={true}
-        hideCloseIcon={true}
-      >
-        <AltinnContentLoader width='100%' height='400'>
-          <AltinnContentIconFormData/>
-        </AltinnContentLoader>
-      </AltinnModal>
-    </>
+    <Presentation
+      header={applicationMetadata?.title?.nb}
+      type={ProcessTaskType.Unknown}
+    >
+      <AltinnContentLoader width='100%' height='400'>
+        <AltinnContentIconFormData/>
+      </AltinnContentLoader>
+    </Presentation>
   );
 }

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/entrypoint/Entrypoint.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/entrypoint/Entrypoint.tsx
@@ -49,7 +49,7 @@ export default function Entrypoint() {
 
   return (
     <Presentation
-      header={applicationMetadata?.title?.nb}
+      header=''
       type={ProcessTaskType.Unknown}
     >
       <AltinnContentLoader width='100%' height='400'>

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/components/RepeatingGroupAddButton.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/components/RepeatingGroupAddButton.tsx
@@ -60,7 +60,7 @@ export function RepeatingGroupAddButton({
     <Grid
       container={true}
       direction='row'
-      justify='center'
+      justifyContent='center'
     >
       <Grid
         item={true}
@@ -72,7 +72,7 @@ export function RepeatingGroupAddButton({
         tabIndex={0}
         onClick={onClickAdd}
         onKeyPress={(event) => onKeypressAdd(event)}
-        justify='center'
+        justifyContent='center'
         alignItems='center'
       >
         <Grid item={true}>

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -159,7 +159,7 @@ export function GroupContainer({
       }
       <Grid
         container={true}
-        justify='flex-end'
+        justifyContent='flex-end'
       />
       {(container.edit?.mode !== 'showAll' && (editIndex < 0 && ((repeatingGroupIndex + 1) < container.maxCount))) &&
         <RepeatingGroupAddButton

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -256,7 +256,7 @@ export function RepeatingGroupTable({
           return (
             <Grid
               item={true} container={true}
-              justify='flex-end' direction='row'
+              justifyContent='flex-end' direction='row'
               className={`${classes.mobileGrid} ${rowHasErrors ? classes.tableRowError : ''}`}
             >
               <Grid item={true}>

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/PartySelection.tsx
@@ -310,7 +310,7 @@ const PartySelectionWithRouter = withRouter((props: IPartySelectionProps) => {
       >
         <Grid
           container={true}
-          justify='space-between'
+          justifyContent='space-between'
           direction='row'
         >
           <Grid item={true}>

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/index.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/index.tsx
@@ -1,4 +1,4 @@
-import { createStyles, withStyles, WithStyles } from '@material-ui/core/styles';
+import { createStyles, withStyles } from '@material-ui/core/styles';
 import { AxiosError } from 'axios';
 import * as React from 'react';
 import { useSelector } from 'react-redux';

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/index.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/index.tsx
@@ -35,10 +35,6 @@ export interface IPartyValidation {
   validParties: IParty[];
 }
 
-export interface IServiceInfoProps extends WithStyles<typeof styles> {
-  // intentionally left empty
-}
-
 function InstantiateContainer() {
   changeBodyBackground(AltinnAppTheme.altinnPalette.primary.blue);
   const { org, app } = window as Window as IAltinnWindow;

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/index.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/index.tsx
@@ -2,13 +2,14 @@ import { createStyles, withStyles, WithStyles } from '@material-ui/core/styles';
 import { AxiosError } from 'axios';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
-import { AltinnAppHeader, AltinnModal, AltinnContentLoader, AltinnContentIconFormData } from 'altinn-shared/components';
+import { AltinnContentLoader, AltinnContentIconFormData } from 'altinn-shared/components';
 import { Redirect } from 'react-router-dom';
 import { AltinnAppTheme } from 'altinn-shared/theme';
 import { IParty } from 'altinn-shared/types';
 import { checkIfAxiosError } from 'altinn-shared/utils';
 import { getTextFromAppOrDefault } from 'src/utils/textResource';
-import { IAltinnWindow, IRuntimeState } from '../../../types';
+import Presentation from 'src/shared/containers/Presentation';
+import { IAltinnWindow, IRuntimeState, ProcessTaskType } from '../../../types';
 import { changeBodyBackground } from '../../../utils/bodyStyling';
 import { HttpStatusCodes } from '../../../utils/networking';
 import { post } from '../../../utils/networking';
@@ -38,7 +39,7 @@ export interface IServiceInfoProps extends WithStyles<typeof styles> {
   // intentionally left empty
 }
 
-function InstantiateContainer(props: IServiceInfoProps) {
+function InstantiateContainer() {
   changeBodyBackground(AltinnAppTheme.altinnPalette.primary.blue);
   const { org, app } = window as Window as IAltinnWindow;
 
@@ -46,7 +47,6 @@ function InstantiateContainer(props: IServiceInfoProps) {
   const [instantiating, setInstantiating] = React.useState(false);
 
   const instantiation = useSelector((state: IRuntimeState) => state.instantiation);
-  const profile = useSelector((state: IRuntimeState) => state.profile.profile);
   const selectedParty = useSelector((state: IRuntimeState) => state.party.selectedParty);
   const titleText: any = useSelector((state: IRuntimeState) => {
     const text = getTextFromAppOrDefault(titleKey, state.textResources.resources, state.language.language, [], true);
@@ -75,27 +75,6 @@ function InstantiateContainer(props: IServiceInfoProps) {
       console.error(err);
       throw new Error('Server did not respond with party validation');
     }
-  };
-
-  // eslint-disable-next-line no-undef
-  const renderModalAndLoader = (): JSX.Element => {
-    const { classes } = props;
-    return (
-      <>
-        <AltinnModal
-          classes={classes}
-          isOpen={true}
-          onClose={null}
-          hideBackdrop={true}
-          hideCloseIcon={true}
-          headerText={titleText}
-        >
-          <AltinnContentLoader width='100%' height='400'>
-            <AltinnContentIconFormData/>
-          </AltinnContentLoader>
-        </AltinnModal>
-      </>
-    );
   };
 
   React.useEffect(() => {
@@ -144,7 +123,7 @@ function InstantiateContainer(props: IServiceInfoProps) {
       );
     }
     return (
-      <Redirect to={`/partyselection/${HttpStatusCodes.Forbidden}`}/>
+      <Redirect to={`/partyselection/${HttpStatusCodes.Forbidden}`} />
     );
   }
 
@@ -155,15 +134,14 @@ function InstantiateContainer(props: IServiceInfoProps) {
   }
 
   return (
-    <>
-      <AltinnAppHeader
-        logoColor={AltinnAppTheme.altinnPalette.primary.blueDarker}
-        headerBackgroundColor={AltinnAppTheme.altinnPalette.primary.blue}
-        party={selectedParty}
-        userParty={profile ? profile.party : {} as IParty}
-      />
-      {renderModalAndLoader()}
-    </>
+    <Presentation
+      header={titleText}
+      type={ProcessTaskType.Unknown}
+    >
+      <AltinnContentLoader width='100%' height='400'>
+        <AltinnContentIconFormData />
+      </AltinnContentLoader>
+    </Presentation>
   );
 }
 

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
@@ -111,6 +111,7 @@ export default (props) => {
 
   return (
     <Presentation
+      header={appHeader}
       type={process.taskType}
     >
       <div>

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
@@ -111,7 +111,6 @@ export default (props) => {
 
   return (
     <Presentation
-      header={appHeader}
       type={process.taskType}
     >
       <div>

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/components/organisms/AltinnAppHeader.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/components/organisms/AltinnAppHeader.tsx
@@ -72,7 +72,7 @@ export function AltinnAppHeader(props: IAltinnAppHeaderProps) {
         </Grid>
         <Grid
           container={true}
-          justify={'flex-end'}
+          justifyContent={'flex-end'}
           alignItems={'center'}
           item={true}
           xs={6}


### PR DESCRIPTION
#6558 
Reuse existing modal to get same behaviour for entrypoint and during instantiation.
Added some unit tests to `Entrypoint.tsx `and `Instantiation.tsx`

Refactored some Grid props from the deprecated `justify `to `justifyContent`