### PR TITLE
feature/6118 - Add link to docs on local test @ missing env page

### DIFF
--- a/src/studio/src/designer/backend/Languages/ini/nb.ini
+++ b/src/studio/src/designer/backend/Languages/ini/nb.ini
@@ -514,9 +514,9 @@ title_submitted = Følgende er sendt inn:
 
 [app_publish]
 missing_rights = Du har ikke rettigheter til å starte en deploy til {0}-miljøet. Tilgang kan delegeres av owners i {1}.
-no_env_1 = For å opprette miljøer, slik at du kan teste og produksjonssette må du ta kontakt med <a href="mailto:tjenesteeier@altinn.no">Altinn servicedesk</a>
-no_env_2 = Det er viktig at du oppgir organisasjonnavn og hvilke miljøer du ønsker tilgang til. Du kan lese mer om de ulike miljøene i <a href="https://docs.altinn.studio/solutions/altinn-studio/functional/deployment/" target="_new" rel="noopener noreferrer">vår dokumentasjon</a>
-no_env_title = Din organisasjon har ikke bestilt test- og produksjonsmiljø
+no_env_1 = For å opprette miljøer, slik at du kan teste og produksjonssette må du ta kontakt med <a href="mailto:tjenesteeier@altinn.no">Altinn servicedesk</a>. Det er viktig at du oppgir organisasjonnavn og hvilke miljøer du ønsker tilgang til.
+no_env_2 = Fram til et miljø er på plass, husk at du kan gjøre mye <a href="https://altinn.github.io/docs/altinn-studio/testing/local/" target="_new" rel="noopener noreferrer">testing lokalt</a>.
+no_env_title = Din organisasjon har ikke test- og produksjonsmiljø
 no_versions = Du har ingen versjoner å deploye
 
 [app_release]


### PR DESCRIPTION
Note: Fix is not tested locally, but as only language file is edited, that should be fine...