### PR TITLE
bug/6584-ie11-app-frontend

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/.babelrc
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/.babelrc
@@ -1,9 +1,0 @@
-{
-  "presets": [
-    "env",
-    "react"
-  ],
-  "plugins": [
-    "syntax-dynamic-import"
-  ]
-}

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/babel.config.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/babel.config.json
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-react"
+  ],
+  "ignore": [
+    "/**/*.json"
+  ]
+}

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package-lock.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "altinn-app-frontend",
-	"version": "3.9.8",
+	"version": "3.9.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -13,34 +13,196 @@
 				"@babel/highlight": "^7.10.4"
 			}
 		},
+		"@babel/compat-data": {
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+			"integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+			"dev": true
+		},
 		"@babel/core": {
-			"version": "7.12.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
-			"integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
+			"integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.1",
-				"@babel/helper-module-transforms": "^7.12.1",
-				"@babel/helpers": "^7.12.1",
-				"@babel/parser": "^7.12.3",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.1",
-				"@babel/types": "^7.12.1",
+				"@babel/code-frame": "^7.14.5",
+				"@babel/generator": "^7.15.0",
+				"@babel/helper-compilation-targets": "^7.15.0",
+				"@babel/helper-module-transforms": "^7.15.0",
+				"@babel/helpers": "^7.14.8",
+				"@babel/parser": "^7.15.0",
+				"@babel/template": "^7.14.5",
+				"@babel/traverse": "^7.15.0",
+				"@babel/types": "^7.15.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.1",
+				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.1.2",
-				"lodash": "^4.17.19",
-				"resolve": "^1.3.2",
-				"semver": "^5.4.1",
+				"semver": "^6.3.0",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+					"integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.15.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.0.tgz",
+					"integrity": "sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+					"integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.15.0",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.15.0",
+						"@babel/types": "^7.15.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				},
 				"source-map": {
@@ -48,6 +210,15 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -67,6 +238,509 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 					"dev": true
+				}
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
+			"integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.14.5.tgz",
+			"integrity": "sha512-YTA/Twn0vBXDVGJuAX6PwW7x5zQei1luDDo2Pl6q1qZ7hVNl0RZrhHCQG/ArGpR29Vl7ETiB8eJyrvpuRp300w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "^7.14.5",
+				"@babel/types": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
+			"integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.15.0",
+				"@babel/helper-validator-option": "^7.14.5",
+				"browserslist": "^4.16.6",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.16.7",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
+					"integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30001248",
+						"colorette": "^1.2.2",
+						"electron-to-chromium": "^1.3.793",
+						"escalade": "^3.1.1",
+						"node-releases": "^1.1.73"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001249",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
+					"integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.796",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.796.tgz",
+					"integrity": "sha512-agwJFgM0FUC1UPPbQ4aII3HamaaJ09fqWGAWYHmzxDWqdmTleCHyyA0kt3fJlTd5M440IaeuBfzXzXzCotnZcQ==",
+					"dev": true
+				},
+				"node-releases": {
+					"version": "1.1.73",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+					"integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-create-class-features-plugin": {
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.0.tgz",
+			"integrity": "sha512-MdmDXgvTIi4heDVX/e9EFfeGpugqm9fobBVg/iioE8kueXrOHdRDe36FAY7SnE9xXLVeYCoJR/gdrBEIHRC83Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.14.5",
+				"@babel/helper-function-name": "^7.14.5",
+				"@babel/helper-member-expression-to-functions": "^7.15.0",
+				"@babel/helper-optimise-call-expression": "^7.14.5",
+				"@babel/helper-replace-supers": "^7.15.0",
+				"@babel/helper-split-export-declaration": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.0.tgz",
+					"integrity": "sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-create-regexp-features-plugin": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.14.5.tgz",
+			"integrity": "sha512-TLawwqpOErY2HhWbGJ2nZT5wSkR192QpN+nBg1THfBfftrlvOh+WbhrxXCH4q4xJ9Gl16BGPR/48JA+Ryiho/A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.14.5",
+				"regexpu-core": "^4.7.1"
+			},
+			"dependencies": {
+				"regexpu-core": {
+					"version": "4.7.1",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+					"integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.2.0",
+						"regjsgen": "^0.5.1",
+						"regjsparser": "^0.6.4",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.2.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-define-polyfill-provider": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+			"integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-compilation-targets": "^7.13.0",
+				"@babel/helper-module-imports": "^7.12.13",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/traverse": "^7.13.0",
+				"debug": "^4.1.1",
+				"lodash.debounce": "^4.0.8",
+				"resolve": "^1.14.2",
+				"semver": "^6.1.2"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+					"integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.15.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.0.tgz",
+					"integrity": "sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+					"integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.15.0",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.15.0",
+						"@babel/types": "^7.15.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.14.5.tgz",
+			"integrity": "sha512-Htb24gnGJdIGT4vnRKMdoXiOIlqOLmdiUYpAQ0mYfgVT/GDm8GOYhgi4GL+hMKrkiPRohO4ts34ELFsGAPQLDQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -90,48 +764,302 @@
 				"@babel/types": "^7.10.4"
 			}
 		},
-		"@babel/helper-member-expression-to-functions": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-			"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+		"@babel/helper-hoist-variables": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+			"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.1"
+				"@babel/types": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+			"integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.15.0"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-			"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+			"integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.5"
+				"@babel/types": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
-			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
+			"integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.12.1",
-				"@babel/helper-replace-supers": "^7.12.1",
-				"@babel/helper-simple-access": "^7.12.1",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.1",
-				"@babel/types": "^7.12.1",
-				"lodash": "^4.17.19"
+				"@babel/helper-module-imports": "^7.14.5",
+				"@babel/helper-replace-supers": "^7.15.0",
+				"@babel/helper-simple-access": "^7.14.8",
+				"@babel/helper-split-export-declaration": "^7.14.5",
+				"@babel/helper-validator-identifier": "^7.14.9",
+				"@babel/template": "^7.14.5",
+				"@babel/traverse": "^7.15.0",
+				"@babel/types": "^7.15.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+					"integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.15.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.0.tgz",
+					"integrity": "sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+					"integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.15.0",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.15.0",
+						"@babel/types": "^7.15.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-			"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+			"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -140,25 +1068,273 @@
 			"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
 			"dev": true
 		},
-		"@babel/helper-replace-supers": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-			"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+		"@babel/helper-remap-async-to-generator": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.14.5.tgz",
+			"integrity": "sha512-rLQKdQU+HYlxBwQIj8dk4/0ENOUEhA/Z0l4hN8BexpvmSMN9oA9EagjnhnDpNsRdWCfjwa4mn/HyBXO9yhQP6A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.12.1",
-				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/traverse": "^7.12.5",
-				"@babel/types": "^7.12.5"
+				"@babel/helper-annotate-as-pure": "^7.14.5",
+				"@babel/helper-wrap-function": "^7.14.5",
+				"@babel/types": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+			"integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.15.0",
+				"@babel/helper-optimise-call-expression": "^7.14.5",
+				"@babel/traverse": "^7.15.0",
+				"@babel/types": "^7.15.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+					"integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.15.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.0.tgz",
+					"integrity": "sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+					"integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.15.0",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.15.0",
+						"@babel/types": "^7.15.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
-			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+			"version": "7.14.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
+			"integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.1"
+				"@babel/types": "^7.14.8"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.14.5.tgz",
+			"integrity": "sha512-dmqZB7mrb94PZSAOYtr+ZN5qt5owZIAgqtoTuqiFbHFtxgEcmQlRJVI+bO++fciBunXtB6MK7HrzrfcAzIz2NQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-split-export-declaration": {
@@ -176,15 +1352,381 @@
 			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
 			"dev": true
 		},
-		"@babel/helpers": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
-			"integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+		"@babel/helper-validator-option": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+			"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+			"dev": true
+		},
+		"@babel/helper-wrap-function": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.14.5.tgz",
+			"integrity": "sha512-YEdjTCq+LNuNS1WfxsDCNpgXkJaIyqco6DAelTUjT4f2KIWC1nBcaCaSdHTBqQVLnTBexBcVcFhLSU1KnYuePQ==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.5",
-				"@babel/types": "^7.12.5"
+				"@babel/helper-function-name": "^7.14.5",
+				"@babel/template": "^7.14.5",
+				"@babel/traverse": "^7.14.5",
+				"@babel/types": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+					"integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.15.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.0.tgz",
+					"integrity": "sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+					"integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.15.0",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.15.0",
+						"@babel/types": "^7.15.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.14.8",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
+			"integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.14.5",
+				"@babel/traverse": "^7.14.8",
+				"@babel/types": "^7.14.8"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+					"integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.15.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.0.tgz",
+					"integrity": "sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+					"integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.15.0",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.15.0",
+						"@babel/types": "^7.15.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/highlight": {
@@ -256,6 +1798,175 @@
 			"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
 			"dev": true
 		},
+		"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.14.5.tgz",
+			"integrity": "sha512-ZoJS2XCKPBfTmL122iP6NM9dOg+d4lc9fFk3zxc8iDjvt8Pk4+TlsHSKhIPf6X+L5ORCdBzqMZDjL/WHj7WknQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+				"@babel/plugin-proposal-optional-chaining": "^7.14.5"
+			}
+		},
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.14.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.9.tgz",
+			"integrity": "sha512-d1lnh+ZnKrFKwtTYdw320+sQWCTwgkB9fmUhNXRADA4akR6wLjaruSGnIEUjpt9HCOwTr4ynFTKu19b7rFRpmw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-remap-async-to-generator": "^7.14.5",
+				"@babel/plugin-syntax-async-generators": "^7.8.4"
+			}
+		},
+		"@babel/plugin-proposal-class-properties": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz",
+			"integrity": "sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-proposal-class-static-block": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.14.5.tgz",
+			"integrity": "sha512-KBAH5ksEnYHCegqseI5N9skTdxgJdmDoAOc0uXa+4QMYKeZD0w5IARh4FMlTNtaHhbB8v+KzMdTgxMMzsIy6Yg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-class-static-block": "^7.14.5"
+			}
+		},
+		"@babel/plugin-proposal-dynamic-import": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.14.5.tgz",
+			"integrity": "sha512-ExjiNYc3HDN5PXJx+bwC50GIx/KKanX2HiggnIUAYedbARdImiCU4RhhHfdf0Kd7JNXGpsBBBCOm+bBVy3Gb0g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-export-namespace-from": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.14.5.tgz",
+			"integrity": "sha512-g5POA32bXPMmSBu5Dx/iZGLGnKmKPc5AiY7qfZgurzrCYgIztDlHFbznSNCoQuv57YQLnQfaDi7dxCtLDIdXdA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-json-strings": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.14.5.tgz",
+			"integrity": "sha512-NSq2fczJYKVRIsUJyNxrVUMhB27zb7N7pOFGQOhBKJrChbGcgEAqyZrmZswkPk18VMurEeJAaICbfm57vUeTbQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-json-strings": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-logical-assignment-operators": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.14.5.tgz",
+			"integrity": "sha512-YGn2AvZAo9TwyhlLvCCWxD90Xq8xJ4aSgaX3G5D/8DW94L8aaT+dS5cSP+Z06+rCJERGSr9GxMBZ601xoc2taw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-nullish-coalescing-operator": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz",
+			"integrity": "sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-numeric-separator": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.14.5.tgz",
+			"integrity": "sha512-yiclALKe0vyZRZE0pS6RXgjUOt87GWv6FYa5zqj15PvhOGFO69R5DusPlgK/1K5dVnCtegTiWu9UaBSrLLJJBg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.14.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.7.tgz",
+			"integrity": "sha512-082hsZz+sVabfmDWo1Oct1u1AgbKbUAyVgmX4otIc7bdsRgHBXwTwb3DpDmD4Eyyx6DNiuz5UAATT655k+kL5g==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.14.7",
+				"@babel/helper-compilation-targets": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-transform-parameters": "^7.14.5"
+			}
+		},
+		"@babel/plugin-proposal-optional-catch-binding": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.14.5.tgz",
+			"integrity": "sha512-3Oyiixm0ur7bzO5ybNcZFlmVsygSIQgdOa7cTfOYCMY+wEPAYhZAJxi3mixKFCTCKUhQXuCTtQ1MzrpL3WT8ZQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-optional-chaining": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.5.tgz",
+			"integrity": "sha512-ycz+VOzo2UbWNI1rQXxIuMOzrDdHGrI23fRiz/Si2R4kv2XZQ1BK8ccdHwehMKBlcH/joGW/tzrUmo67gbJHlQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-private-methods": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.14.5.tgz",
+			"integrity": "sha512-838DkdUA1u+QTCplatfq4B7+1lnDa/+QMI89x5WZHBcnNv+47N8QEj2k9I2MUU9xIv8XJ4XvPCviM/Dj7Uwt9g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-proposal-private-property-in-object": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.14.5.tgz",
+			"integrity": "sha512-62EyfyA3WA0mZiF2e2IV9mc9Ghwxcg8YTu8BS4Wss4Y3PY725OmS9M0qLORbJwLqFtGh+jiE4wAmocK2CTUK2Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.14.5",
+				"@babel/helper-create-class-features-plugin": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.14.5.tgz",
+			"integrity": "sha512-6axIeOU5LnY471KenAB9vI8I5j7NQ2d652hIYwVyRfgaZT5UpiqFKCuVXCDMSrU+3VFafnu2c5m3lrWIlr6A5Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
 		"@babel/plugin-syntax-async-generators": {
 			"version": "7.8.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
@@ -283,6 +1994,33 @@
 				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
+		"@babel/plugin-syntax-class-static-block": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-syntax-dynamic-import": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+			"integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-export-namespace-from": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+			"integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
 		"@babel/plugin-syntax-import-meta": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -299,6 +2037,15 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-jsx": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+			"integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
 			}
 		},
 		"@babel/plugin-syntax-logical-assignment-operators": {
@@ -355,6 +2102,15 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
+		"@babel/plugin-syntax-private-property-in-object": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
 		"@babel/plugin-syntax-top-level-await": {
 			"version": "7.14.5",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
@@ -373,6 +2129,650 @@
 				"@babel/helper-plugin-utils": "^7.14.5"
 			}
 		},
+		"@babel/plugin-transform-arrow-functions": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.14.5.tgz",
+			"integrity": "sha512-KOnO0l4+tD5IfOdi4x8C1XmEIRWUjNRV8wc6K2vz/3e8yAOoZZvsRXRRIF/yo/MAOFb4QjtAw9xSxMXbSMRy8A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.14.5.tgz",
+			"integrity": "sha512-szkbzQ0mNk0rpu76fzDdqSyPu0MuvpXgC+6rz5rpMb5OIRxdmHfQxrktL8CYolL2d8luMCZTR0DpIMIdL27IjA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-remap-async-to-generator": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.14.5.tgz",
+			"integrity": "sha512-dtqWqdWZ5NqBX3KzsVCWfQI3A53Ft5pWFCT2eCVUftWZgjc5DpDponbIF1+c+7cSGk2wN0YK7HGL/ezfRbpKBQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-block-scoping": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.14.5.tgz",
+			"integrity": "sha512-LBYm4ZocNgoCqyxMLoOnwpsmQ18HWTQvql64t3GvMUzLQrNoV1BDG0lNftC8QKYERkZgCCT/7J5xWGObGAyHDw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-classes": {
+			"version": "7.14.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.14.9.tgz",
+			"integrity": "sha512-NfZpTcxU3foGWbl4wxmZ35mTsYJy8oQocbeIMoDAGGFarAmSQlL+LWMkDx/tj6pNotpbX3rltIA4dprgAPOq5A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.14.5",
+				"@babel/helper-function-name": "^7.14.5",
+				"@babel/helper-optimise-call-expression": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-replace-supers": "^7.14.5",
+				"@babel/helper-split-export-declaration": "^7.14.5",
+				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.0.tgz",
+					"integrity": "sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-computed-properties": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.14.5.tgz",
+			"integrity": "sha512-pWM+E4283UxaVzLb8UBXv4EIxMovU4zxT1OPnpHJcmnvyY9QbPPTKZfEj31EUvG3/EQRbYAGaYEUZ4yWOBC2xg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.14.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
+			"integrity": "sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-dotall-regex": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.14.5.tgz",
+			"integrity": "sha512-loGlnBdj02MDsFaHhAIJzh7euK89lBrGIdM9EAtHFo6xKygCUGuuWe07o1oZVk287amtW1n0808sQM99aZt3gw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-duplicate-keys": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.14.5.tgz",
+			"integrity": "sha512-iJjbI53huKbPDAsJ8EmVmvCKeeq21bAze4fu9GBQtSLqfvzj2oRuHVx4ZkDwEhg1htQ+5OBZh/Ab0XDf5iBZ7A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.14.5.tgz",
+			"integrity": "sha512-jFazJhMBc9D27o9jDnIE5ZErI0R0m7PbKXVq77FFvqFbzvTMuv8jaAwLZ5PviOLSFttqKIW0/wxNSDbjLk0tYA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-for-of": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.14.5.tgz",
+			"integrity": "sha512-CfmqxSUZzBl0rSjpoQSFoR9UEj3HzbGuGNL21/iFTmjb5gFggJp3ph0xR1YBhexmLoKRHzgxuFvty2xdSt6gTA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-function-name": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.14.5.tgz",
+			"integrity": "sha512-vbO6kv0fIzZ1GpmGQuvbwwm+O4Cbm2NrPzwlup9+/3fdkuzo1YqOZcXw26+YUJB84Ja7j9yURWposEHLYwxUfQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.0.tgz",
+					"integrity": "sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-literals": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.14.5.tgz",
+			"integrity": "sha512-ql33+epql2F49bi8aHXxvLURHkxJbSmMKl9J5yHqg4PLtdE6Uc48CH1GS6TQvZ86eoB/ApZXwm7jlA+B3kra7A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.14.5.tgz",
+			"integrity": "sha512-WkNXxH1VXVTKarWFqmso83xl+2V3Eo28YY5utIkbsmXoItO8Q3aZxN4BTS2k0hz9dGUloHK26mJMyQEYfkn/+Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.5.tgz",
+			"integrity": "sha512-3lpOU8Vxmp3roC4vzFpSdEpGUWSMsHFreTWOMMLzel2gNGfHE5UWIh/LN6ghHs2xurUp4jRFYMUIZhuFbody1g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.0.tgz",
+			"integrity": "sha512-3H/R9s8cXcOGE8kgMlmjYYC9nqr5ELiPkJn4q0mypBrjhYQoc+5/Maq69vV4xRPWnkzZuwJPf5rArxpB/35Cig==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.15.0",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-simple-access": "^7.14.8",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			}
+		},
+		"@babel/plugin-transform-modules-systemjs": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.14.5.tgz",
+			"integrity": "sha512-mNMQdvBEE5DcMQaL5LbzXFMANrQjd2W7FPzg34Y4yEz7dBgdaC+9B84dSO+/1Wba98zoDbInctCDo4JGxz1VYA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.14.5",
+				"@babel/helper-module-transforms": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-validator-identifier": "^7.14.5",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-modules-umd": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.14.5.tgz",
+			"integrity": "sha512-RfPGoagSngC06LsGUYyM9QWSXZ8MysEjDJTAea1lqRjNECE3y0qIJF/qbvJxc4oA4s99HumIMdXOrd+TdKaAAA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "7.14.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.9.tgz",
+			"integrity": "sha512-l666wCVYO75mlAtGFfyFwnWmIXQm3kSH0C3IRnJqWcZbWkoihyAdDhFm2ZWaxWTqvBvhVFfJjMRQ0ez4oN1yYA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-new-target": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.14.5.tgz",
+			"integrity": "sha512-Nx054zovz6IIRWEB49RDRuXGI4Gy0GMgqG0cII9L3MxqgXz/+rgII+RU58qpo4g7tNEx1jG7rRVH4ihZoP4esQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-object-super": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.14.5.tgz",
+			"integrity": "sha512-MKfOBWzK0pZIrav9z/hkRqIk/2bTv9qvxHzPQc12RcVkMOzpIKnFCNYJip00ssKWYkd8Sf5g0Wr7pqJ+cmtuFg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-replace-supers": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.5.tgz",
+			"integrity": "sha512-Tl7LWdr6HUxTmzQtzuU14SqbgrSKmaR77M0OKyq4njZLQTPfOvzblNKyNkGwOfEFCEx7KeYHQHDI0P3F02IVkA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.14.5.tgz",
+			"integrity": "sha512-r1uilDthkgXW8Z1vJz2dKYLV1tuw2xsbrp3MrZmD99Wh9vsfKoob+JTgri5VUb/JqyKRXotlOtwgu4stIYCmnw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-react-display-name": {
+			"version": "7.15.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.15.1.tgz",
+			"integrity": "sha512-yQZ/i/pUCJAHI/LbtZr413S3VT26qNrEm0M5RRxQJA947/YNYwbZbBaXGDrq6CG5QsZycI1VIP6d7pQaBfP+8Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-react-jsx": {
+			"version": "7.14.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
+			"integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.14.5",
+				"@babel/helper-module-imports": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-jsx": "^7.14.5",
+				"@babel/types": "^7.14.9"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-react-jsx-development": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.14.5.tgz",
+			"integrity": "sha512-rdwG/9jC6QybWxVe2UVOa7q6cnTpw8JRRHOxntG/h6g/guAOe6AhtQHJuJh5FwmnXIT1bdm5vC2/5huV8ZOorQ==",
+			"dev": true,
+			"requires": {
+				"@babel/plugin-transform-react-jsx": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-react-pure-annotations": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.14.5.tgz",
+			"integrity": "sha512-3X4HpBJimNxW4rhUy/SONPyNQHp5YRr0HhJdT2OH1BRp0of7u3Dkirc7x9FRJMKMqTBI079VZ1hzv7Ouuz///g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.14.5.tgz",
+			"integrity": "sha512-NVIY1W3ITDP5xQl50NgTKlZ0GrotKtLna08/uGY6ErQt6VEQZXla86x/CTddm5gZdcr+5GSsvMeTmWA5Ii6pkg==",
+			"dev": true,
+			"requires": {
+				"regenerator-transform": "^0.14.2"
+			}
+		},
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.14.5.tgz",
+			"integrity": "sha512-cv4F2rv1nD4qdexOGsRQXJrOcyb5CrgjUH9PKrrtyhSDBNWGxd0UIitjyJiWagS+EbUGjG++22mGH1Pub8D6Vg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.14.5.tgz",
+			"integrity": "sha512-xLucks6T1VmGsTB+GWK5Pl9Jl5+nRXD1uoFdA5TSO6xtiNjtXTjKkmPdFXVLGlK5A2/or/wQMKfmQ2Y0XJfn5g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-spread": {
+			"version": "7.14.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
+			"integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.14.5.tgz",
+			"integrity": "sha512-Z7F7GyvEMzIIbwnziAZmnSNpdijdr4dWt+FJNBnBLz5mwDFkqIXU9wmBcWWad3QeJF5hMTkRe4dAq2sUZiG+8A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.14.5.tgz",
+			"integrity": "sha512-22btZeURqiepOfuy/VkFr+zStqlujWaarpMErvay7goJS6BWwdd6BY9zQyDLDa4x2S3VugxFb162IZ4m/S/+Gg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-typeof-symbol": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.14.5.tgz",
+			"integrity": "sha512-lXzLD30ffCWseTbMQzrvDWqljvZlHkXU+CnseMhkMNqU1sASnCsz3tSzAaH3vCUXb9PHeUb90ZT1BdFTm1xxJw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-unicode-escapes": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.14.5.tgz",
+			"integrity": "sha512-crTo4jATEOjxj7bt9lbYXcBAM3LZaUrbP2uUdxb6WIorLmjNKSpHfIybgY4B8SRpbf8tEVIWH3Vtm7ayCrKocA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.14.5.tgz",
+			"integrity": "sha512-UygduJpC5kHeCiRw/xDVzC+wj8VaYSoKl5JNVmbP7MadpNinAm3SvZCxZ42H37KZBKztz46YC73i9yV34d0Tzw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
 		"@babel/polyfill": {
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
@@ -387,6 +2787,138 @@
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
 					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
 				}
+			}
+		},
+		"@babel/preset-env": {
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.0.tgz",
+			"integrity": "sha512-FhEpCNFCcWW3iZLg0L2NPE9UerdtsCR6ZcsGHUX6Om6kbCQeL5QZDqFDmeNHC6/fy6UH3jEge7K4qG5uC9In0Q==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.15.0",
+				"@babel/helper-compilation-targets": "^7.15.0",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-validator-option": "^7.14.5",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.14.5",
+				"@babel/plugin-proposal-async-generator-functions": "^7.14.9",
+				"@babel/plugin-proposal-class-properties": "^7.14.5",
+				"@babel/plugin-proposal-class-static-block": "^7.14.5",
+				"@babel/plugin-proposal-dynamic-import": "^7.14.5",
+				"@babel/plugin-proposal-export-namespace-from": "^7.14.5",
+				"@babel/plugin-proposal-json-strings": "^7.14.5",
+				"@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
+				"@babel/plugin-proposal-numeric-separator": "^7.14.5",
+				"@babel/plugin-proposal-object-rest-spread": "^7.14.7",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
+				"@babel/plugin-proposal-optional-chaining": "^7.14.5",
+				"@babel/plugin-proposal-private-methods": "^7.14.5",
+				"@babel/plugin-proposal-private-property-in-object": "^7.14.5",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.14.5",
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-class-properties": "^7.12.13",
+				"@babel/plugin-syntax-class-static-block": "^7.14.5",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+				"@babel/plugin-syntax-top-level-await": "^7.14.5",
+				"@babel/plugin-transform-arrow-functions": "^7.14.5",
+				"@babel/plugin-transform-async-to-generator": "^7.14.5",
+				"@babel/plugin-transform-block-scoped-functions": "^7.14.5",
+				"@babel/plugin-transform-block-scoping": "^7.14.5",
+				"@babel/plugin-transform-classes": "^7.14.9",
+				"@babel/plugin-transform-computed-properties": "^7.14.5",
+				"@babel/plugin-transform-destructuring": "^7.14.7",
+				"@babel/plugin-transform-dotall-regex": "^7.14.5",
+				"@babel/plugin-transform-duplicate-keys": "^7.14.5",
+				"@babel/plugin-transform-exponentiation-operator": "^7.14.5",
+				"@babel/plugin-transform-for-of": "^7.14.5",
+				"@babel/plugin-transform-function-name": "^7.14.5",
+				"@babel/plugin-transform-literals": "^7.14.5",
+				"@babel/plugin-transform-member-expression-literals": "^7.14.5",
+				"@babel/plugin-transform-modules-amd": "^7.14.5",
+				"@babel/plugin-transform-modules-commonjs": "^7.15.0",
+				"@babel/plugin-transform-modules-systemjs": "^7.14.5",
+				"@babel/plugin-transform-modules-umd": "^7.14.5",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.14.9",
+				"@babel/plugin-transform-new-target": "^7.14.5",
+				"@babel/plugin-transform-object-super": "^7.14.5",
+				"@babel/plugin-transform-parameters": "^7.14.5",
+				"@babel/plugin-transform-property-literals": "^7.14.5",
+				"@babel/plugin-transform-regenerator": "^7.14.5",
+				"@babel/plugin-transform-reserved-words": "^7.14.5",
+				"@babel/plugin-transform-shorthand-properties": "^7.14.5",
+				"@babel/plugin-transform-spread": "^7.14.6",
+				"@babel/plugin-transform-sticky-regex": "^7.14.5",
+				"@babel/plugin-transform-template-literals": "^7.14.5",
+				"@babel/plugin-transform-typeof-symbol": "^7.14.5",
+				"@babel/plugin-transform-unicode-escapes": "^7.14.5",
+				"@babel/plugin-transform-unicode-regex": "^7.14.5",
+				"@babel/preset-modules": "^0.1.4",
+				"@babel/types": "^7.15.0",
+				"babel-plugin-polyfill-corejs2": "^0.2.2",
+				"babel-plugin-polyfill-corejs3": "^0.2.2",
+				"babel-plugin-polyfill-regenerator": "^0.2.2",
+				"core-js-compat": "^3.16.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/preset-modules": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+			"integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-transform-dotall-regex": "^7.4.4",
+				"@babel/types": "^7.4.4",
+				"esutils": "^2.0.2"
+			}
+		},
+		"@babel/preset-react": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.14.5.tgz",
+			"integrity": "sha512-XFxBkjyObLvBaAvkx1Ie95Iaq4S/GUEIrejyrntQ/VCMKUYvKLoyKxOBzJ2kjA3b6rC9/KL6KXfDC2GqvLiNqQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-validator-option": "^7.14.5",
+				"@babel/plugin-transform-react-display-name": "^7.14.5",
+				"@babel/plugin-transform-react-jsx": "^7.14.5",
+				"@babel/plugin-transform-react-jsx-development": "^7.14.5",
+				"@babel/plugin-transform-react-pure-annotations": "^7.14.5"
 			}
 		},
 		"@babel/runtime": {
@@ -2566,6 +5098,15 @@
 				}
 			}
 		},
+		"babel-plugin-dynamic-import-node": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+			"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+			"dev": true,
+			"requires": {
+				"object.assign": "^4.1.0"
+			}
+		},
 		"babel-plugin-istanbul": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -2589,6 +5130,44 @@
 				"@babel/types": "^7.3.3",
 				"@types/babel__core": "^7.0.0",
 				"@types/babel__traverse": "^7.0.6"
+			}
+		},
+		"babel-plugin-polyfill-corejs2": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
+			"integrity": "sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.13.11",
+				"@babel/helper-define-polyfill-provider": "^0.2.2",
+				"semver": "^6.1.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
+		"babel-plugin-polyfill-corejs3": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
+			"integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-define-polyfill-provider": "^0.2.2",
+				"core-js-compat": "^3.14.0"
+			}
+		},
+		"babel-plugin-polyfill-regenerator": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
+			"integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-define-polyfill-provider": "^0.2.2"
 			}
 		},
 		"babel-preset-current-node-syntax": {
@@ -3927,6 +6506,55 @@
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.0.tgz",
 			"integrity": "sha512-5+5VxRFmSf97nM8Jr2wzOwLqRo6zphH2aX+7KsAUONObyzakDNq2G/bgbhinxB4PoV9L3aXQYhiDKyIKWd2c8g==",
 			"dev": true
+		},
+		"core-js-compat": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.0.tgz",
+			"integrity": "sha512-5D9sPHCdewoUK7pSUPfTF7ZhLh8k9/CoJXWUEo+F1dZT5Z1DVgcuRqUKhjeKW+YLb8f21rTFgWwQJiNw1hoZ5Q==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.16.6",
+				"semver": "7.0.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.16.7",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
+					"integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30001248",
+						"colorette": "^1.2.2",
+						"electron-to-chromium": "^1.3.793",
+						"escalade": "^3.1.1",
+						"node-releases": "^1.1.73"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001249",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
+					"integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.796",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.796.tgz",
+					"integrity": "sha512-agwJFgM0FUC1UPPbQ4aII3HamaaJ09fqWGAWYHmzxDWqdmTleCHyyA0kt3fJlTd5M440IaeuBfzXzXzCotnZcQ==",
+					"dev": true
+				},
+				"node-releases": {
+					"version": "1.1.73",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+					"integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+					"dev": true
+				}
+			}
 		},
 		"core-js-pure": {
 			"version": "3.10.1",
@@ -7341,9 +9969,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
-			"integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -10134,6 +12762,12 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
 			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
+		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
 		},
 		"lodash.escape": {
@@ -13147,9 +15781,18 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.7",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+			"version": "0.13.9",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+		},
+		"regenerator-transform": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+			"integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.8.4"
+			}
 		},
 		"regex-not": {
 			"version": "1.0.2",
@@ -13377,12 +16020,12 @@
 			"integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
 		},
 		"resolve": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.1.0",
+				"is-core-module": "^2.2.0",
 				"path-parse": "^1.0.6"
 			}
 		},

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.9.8",
+  "version": "3.9.9",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -54,6 +54,9 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
+    "@babel/core": "^7.15.0",
+    "@babel/preset-env": "^7.15.0",
+    "@babel/preset-react": "^7.14.5",
     "@testing-library/jest-dom": "~5.14.1",
     "@testing-library/react": "~12.0.0",
     "@types/dot-object": "~2.1.2",
@@ -67,13 +70,13 @@
     "@types/react-test-renderer": "~17.0.1",
     "@types/redux-mock-store": "~1.0.3",
     "@types/uuid": "8.3.1",
+    "@wojtekmaj/enzyme-adapter-react-17": "~0.6.3",
     "altinn-designsystem": "~3.1.0",
     "classnames": "~2.3.1",
     "core-js": "~3.16.0",
     "cross-env": "~7.0.3",
     "css-loader": "~5.2.6",
     "enzyme": "~3.11.0",
-    "@wojtekmaj/enzyme-adapter-react-17": "~0.6.3",
     "eslint": "~7.32.0",
     "eslint-config-airbnb-base": "~14.2.1",
     "fork-ts-checker-notifier-webpack-plugin": "3.0.0",

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/data/submit/submitFormDataSagas.ts
@@ -10,9 +10,9 @@ import ProcessDispatcher from '../../../../shared/resources/process/processDispa
 import { convertDataBindingToModel, convertModelToDataBinding, filterOutInvalidData } from '../../../../utils/databindings';
 import { dataElementUrl, getStatelessFormDataUrl, getValidationUrl } from '../../../../utils/urlHelper';
 import { canFormBeSaved,
-  createValidator,
   getNumberOfComponentsWithErrors,
   getNumberOfComponentsWithWarnings,
+  getValidator,
   mapDataElementValidationToRedux,
   mergeValidationObjects,
   validateEmptyFields,
@@ -38,8 +38,7 @@ function* submitFormSaga({ payload: { apiMode, stopWithWarnings } }: PayloadActi
     );
 
     // Run client validations
-    const schema = state.formDataModel.schemas[currentDataTaskDataTypeId];
-    const validator = createValidator(schema);
+    const validator = getValidator(currentDataTaskDataTypeId, state.formDataModel.schemas);
     const model = convertDataBindingToModel(state.formData.formData);
     const layoutOrder: string[] = state.formLayout.uiConfig.layoutOrder;
     const validationResult = validateFormData(

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/data/update/updateFormDataSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/data/update/updateFormDataSagas.ts
@@ -3,7 +3,7 @@ import { actionChannel, call, put, select, take } from 'redux-saga/effects';
 import { IRuntimeState, IValidationResult } from 'src/types';
 import { PayloadAction } from '@reduxjs/toolkit';
 import { getLayoutComponentById, getLayoutIdForComponent } from '../../../../utils/layout';
-import { createValidator, validateComponentFormData } from '../../../../utils/validation';
+import { getValidator, validateComponentFormData } from '../../../../utils/validation';
 import FormDynamicActions from '../../dynamics/formDynamicsActions';
 import { updateComponentValidations } from '../../validation/validationSlice';
 import FormDataActions from '../formDataActions';
@@ -63,8 +63,7 @@ function* runValidations(
     state.instanceData.instance,
     state.formLayout.layoutsets,
   );
-  const schema = state.formDataModel.schemas[currentDataTypeId];
-  const validator = createValidator(schema);
+  const validator = getValidator(currentDataTypeId, state.formDataModel.schemas);
   const component = getLayoutComponentById(componentId, state.formLayout.layouts);
   const layoutId = getLayoutIdForComponent(componentId, state.formLayout.layouts);
   const fieldWithoutIndex = getKeyWithoutIndex(field);

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -8,7 +8,7 @@ import { AxiosRequestConfig } from 'axios';
 import { get, getCurrentTaskDataElementId, post } from 'altinn-shared/utils';
 import { getDataTaskDataTypeId } from 'src/utils/appMetadata';
 import { getCalculatePageOrderUrl, getDataValidationUrl } from 'src/utils/urlHelper';
-import { createValidator, validateFormData, validateFormComponents, validateEmptyFields, mapDataElementValidationToRedux, canFormBeSaved, mergeValidationObjects, removeGroupValidationsByIndex, validateGroup } from 'src/utils/validation';
+import { validateFormData, validateFormComponents, validateEmptyFields, mapDataElementValidationToRedux, canFormBeSaved, mergeValidationObjects, removeGroupValidationsByIndex, validateGroup, getValidator } from 'src/utils/validation';
 import { getLayoutsetForDataElement } from 'src/utils/layout';
 import { startInitialDataTaskQueueFulfilled } from 'src/shared/resources/queue/queueSlice';
 import { updateValidations } from 'src/features/form/validation/validationSlice';
@@ -139,8 +139,7 @@ export function* updateCurrentViewSaga({ payload: {
         state.applicationMetadata.applicationMetadata.dataTypes,
       );
       const layoutOrder: string[] = state.formLayout.uiConfig.layoutOrder;
-      const schema = state.formDataModel.schemas[currentDataTaskDataTypeId];
-      const validator = createValidator(schema);
+      const validator = getValidator(currentDataTaskDataTypeId, state.formDataModel.schemas);
       const model = convertDataBindingToModel(state.formData.formData);
       const validationResult = validateFormData(
         model, state.formLayout.layouts, layoutOrder,
@@ -322,6 +321,7 @@ export function* updateRepeatingGroupEditIndexSaga({ payload: {
       yield put(FormLayoutActions.updateRepeatingGroupsEditIndexFulfilled({ group, index }));
     }
   } catch (error) {
+    console.error(error);
     yield put(FormLayoutActions.updateRepeatingGroupsEditIndexRejected({ error }));
   }
 }

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -321,7 +321,6 @@ export function* updateRepeatingGroupEditIndexSaga({ payload: {
       yield put(FormLayoutActions.updateRepeatingGroupsEditIndexFulfilled({ group, index }));
     }
   } catch (error) {
-    console.error(error);
     yield put(FormLayoutActions.updateRepeatingGroupsEditIndexRejected({ error }));
   }
 }

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/index.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/index.tsx
@@ -5,7 +5,6 @@ import { HashRouter } from 'react-router-dom';
 import App from './App';
 import { initSagas } from './sagas';
 import { store } from './store';
-import 'core-js/es';
 import './styles/index.css';
 
 import ErrorBoundary from './components/ErrorBoundary';

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/resources/orgs/fetch/fetchOrgsSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/resources/orgs/fetch/fetchOrgsSagas.ts
@@ -1,14 +1,14 @@
 import { SagaIterator } from 'redux-saga';
 import { call, takeLatest } from 'redux-saga/effects';
 import { orgsListUrl } from 'altinn-shared/utils';
-import { get } from '../../../../utils/networking';
+import axios from 'axios';
 import OrgsActions from '../orgsActions';
 import * as OrgsActionTypes from './fetchOrgsActionTypes';
 
 export function* fetchOrgsSaga(): SagaIterator {
   try {
-    const result: any = yield call(get, orgsListUrl, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
-    const orgObject = result.orgs;
+    const result: any = yield call(axios.get, orgsListUrl, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
+    const orgObject = result.data?.orgs;
     yield call(OrgsActions.fetchOrgsFulfilled, orgObject);
   } catch (err) {
     yield call(OrgsActions.fetchOrgsRejected, err);

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/networking.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/networking.ts
@@ -12,8 +12,8 @@ export async function get(url: string, options?: AxiosRequestConfig): Promise<an
   const response: AxiosResponse = await axios.get(
     url,
     {
-      headers: { Pragma: 'no-cache' },
       ...options,
+      headers: { Pragma: 'no-cache', ...options?.headers },
     },
   );
   return response.data ? response.data : null;

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/validation.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/validation.ts
@@ -27,6 +27,8 @@ export function createValidator(schema: any): ISchemaValidator {
     strict: false,
     strictTypes: false,
     strictTuples: false,
+    unicodeRegExp: false,
+    code: { es5: true },
   });
   addFormats(ajv);
   ajv.addFormat('year', /^[0-9]{4}$/);

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/webpack.config.development.js
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/webpack.config.development.js
@@ -8,9 +8,7 @@ module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
   entry: [
-    "core-js/modules/es.object.assign",
-    "core-js/modules/es.array.find-index",
-    "core-js/modules/es.array.find",
+    "core-js/es",
     "./src/index.tsx"
   ],
   output: {
@@ -45,59 +43,64 @@ module.exports = {
     hints: 'warning',
   },
   module: {
-    rules: [{
-      test: /\.jsx?/,
-      exclude: /node_modules/,
-      use: {
-        loader: "babel-loader",
-      }
-    },
-    {
-      test: /\.html$/,
-      use: [{
-        loader: "html-loader",
-        options: {
-          minimize: true
+    rules: [
+      {
+        test: /\.jsx?/,
+        include: [
+          path.resolve(__dirname, "./src"),
+          path.resolve(__dirname, "../node_modules/ajv"),
+          path.resolve(__dirname, "../node_modules/ajv-formats")
+        ],
+        use: {
+          loader: "babel-loader",
         }
-      }]
-    },
-    {
-      test: /\.scss$/,
-      use: [
-        "style-loader",
-        "css-loader"
-      ]
-    },
-    {
-      test: /\.svg$/,
-      use: {
-        loader: "svg-inline-loader",
-      }
-    },
-    {
-      test: /\.css$/,
-      use: [{
-        loader: MiniCssExtractPlugin.loader,
       },
       {
-        loader: "css-loader",
-        options: {
-          url: false
+        test: /\.html$/,
+        use: [{
+          loader: "html-loader",
+          options: {
+            minimize: true
+          }
+        }]
+      },
+      {
+        test: /\.scss$/,
+        use: [
+          "style-loader",
+          "css-loader"
+        ]
+      },
+      {
+        test: /\.svg$/,
+        use: {
+          loader: "svg-inline-loader",
         }
       },
-      ]
-    },
-    {
-      test: /\.tsx?/,
-      use: [
-        {loader: "ts-loader", options: { transpileOnly: true } }
-      ]
-    },
-    {
-      enforce: "pre",
-      test: /\.js$/,
-      loader: "source-map-loader",
-    }
+      {
+        test: /\.css$/,
+        use: [{
+          loader: MiniCssExtractPlugin.loader,
+        },
+        {
+          loader: "css-loader",
+          options: {
+            url: false
+          }
+        },
+        ]
+      },
+      {
+        test: /\.tsx?/,
+        use: [
+          { loader: "ts-loader", options: { transpileOnly: true } }
+        ]
+      },
+      {
+        enforce: "pre",
+        test: /\.js$/,
+        loader: "source-map-loader",
+      },
     ],
   },
   plugins: [

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/webpack.config.production.js
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/webpack.config.production.js
@@ -12,9 +12,7 @@ module.exports = {
   mode: 'production',
   devtool: false,
   entry: [
-    "core-js/modules/es.object.assign",
-    "core-js/modules/es.array.find-index",
-    "core-js/modules/es.array.find",
+    "core-js/es",
     "./src/index.tsx"
   ],
   output: {
@@ -55,13 +53,18 @@ module.exports = {
     ],
   },
   module: {
-    rules: [{
-      test: /\.jsx?/,
-      exclude: /node_modules/,
-      use: {
-        loader: "babel-loader",
-      }
-    },
+    rules: [
+      {
+        test: /\.jsx?/,
+        include: [
+          path.resolve(__dirname, "./src"),
+          path.resolve(__dirname, "../node_modules/ajv"),
+          path.resolve(__dirname, "../node_modules/ajv-formats")
+        ],
+        use: {
+          loader: "babel-loader",
+        }
+      },
     {
       test: /\.scss$/,
       use: [


### PR DESCRIPTION
### Make IE11 great again 
#6584 

Transpiles `ajv` and `ajv-formats`, see [this thread.](https://github.com/ajv-validator/ajv/issues/1585)
Changed from `.babelc` to `babel.config.json` in order to transpile `node_module` packages. See [docs.](https://babeljs.io/docs/en/configuration#whats-your-use-case)
Also did som refactoring to use a singleton ajv-validator object instead of creating this for each validation (...).