### PR TITLE
Feature/6475 add metrics from system runtime

### DIFF
--- a/src/studio/src/designer/backend/Startup.cs
+++ b/src/studio/src/designer/backend/Startup.cs
@@ -93,7 +93,8 @@ namespace Altinn.Studio.Designer
             {
                 services.AddApplicationInsightsTelemetry(ApplicationInsightsKey);
                 services.ConfigureTelemetryModule<EventCounterCollectionModule>(
-                    (module, o) => {
+                    (module, o) =>
+                    {
                         module.Counters.Clear();
                         module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "threadpool-queue-length"));
                         module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "threadpool-thread-count"));
@@ -101,8 +102,7 @@ namespace Altinn.Studio.Designer
                         module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "gc-heap-size"));
                         module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "time-in-gc"));
                         module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "working-set"));
-                    }
-                );
+                    });
                 services.AddApplicationInsightsTelemetryProcessor<HealthTelemetryFilter>();
                 services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
                 Console.WriteLine($"// Program.cs // ConfigureServices // Successfully added AI config.");

--- a/src/studio/src/designer/backend/Startup.cs
+++ b/src/studio/src/designer/backend/Startup.cs
@@ -97,8 +97,10 @@ namespace Altinn.Studio.Designer
                         module.Counters.Clear();
                         module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "threadpool-queue-length"));
                         module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "threadpool-thread-count"));
-                        module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "monitor-lock-contention-count"));                        
-                        module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "time-in-gc"));                        
+                        module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "monitor-lock-contention-count"));
+                        module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "gc-heap-size"));
+                        module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "time-in-gc"));
+                        module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "working-set"));
                     }
                 );
                 services.AddApplicationInsightsTelemetryProcessor<HealthTelemetryFilter>();

--- a/src/studio/src/designer/backend/Startup.cs
+++ b/src/studio/src/designer/backend/Startup.cs
@@ -7,6 +7,7 @@ using Altinn.Studio.Designer.Infrastructure;
 using Altinn.Studio.Designer.Infrastructure.Authorization;
 using Altinn.Studio.Designer.TypedHttpClients;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.EventCounterCollector;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -91,6 +92,15 @@ namespace Altinn.Studio.Designer
             if (!string.IsNullOrEmpty(ApplicationInsightsKey))
             {
                 services.AddApplicationInsightsTelemetry(ApplicationInsightsKey);
+                services.ConfigureTelemetryModule<EventCounterCollectionModule>(
+                    (module, o) => {
+                        module.Counters.Clear();
+                        module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "threadpool-queue-length"));
+                        module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "threadpool-thread-count"));
+                        module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "monitor-lock-contention-count"));                        
+                        module.Counters.Add(new EventCounterCollectionRequest("System.Runtime", "time-in-gc"));                        
+                    }
+                );
                 services.AddApplicationInsightsTelemetryProcessor<HealthTelemetryFilter>();
                 services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
                 Console.WriteLine($"// Program.cs // ConfigureServices // Successfully added AI config.");


### PR DESCRIPTION
Export performance telemetry to Application Insights as described in #6475.
Telemetry counters added:
* threadpool-queue-length
* threadpool-thread-count
* monitor-lock-contention-count
* gc-heap-size
* time-in-gc
* working-set
