### PR TITLE
remove ensuresuccesshandler for gitea client

### DIFF
--- a/src/studio/src/designer/backend/TypedHttpClients/DelegatingHandlers/EnsureSuccessHandler.cs
+++ b/src/studio/src/designer/backend/TypedHttpClients/DelegatingHandlers/EnsureSuccessHandler.cs
@@ -21,9 +21,8 @@ namespace Altinn.Studio.Designer.TypedHttpClients.DelegatingHandlers
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
-
-            // Conflict (409) from Gitea when creating existing repo
-            if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.Conflict)
+            
+            if (!response.IsSuccessStatusCode)
             {
                 throw new HttpRequestWithStatusException(response.ReasonPhrase)
                 {

--- a/src/studio/src/designer/backend/TypedHttpClients/TypedHttpClientRegistration.cs
+++ b/src/studio/src/designer/backend/TypedHttpClients/TypedHttpClientRegistration.cs
@@ -32,7 +32,6 @@ namespace Altinn.Studio.Designer.TypedHttpClients
         public static IServiceCollection RegisterTypedHttpClients(this IServiceCollection services, IConfiguration config)
         {
             services.AddHttpClient();
-            services.AddTransient<EnsureSuccessHandler>();
             services.AddTransient<PlatformBearerTokenHandler>();
             services.AddAzureDevOpsTypedHttpClient(config);
             services.AddGiteaTypedHttpClient(config);
@@ -70,7 +69,6 @@ namespace Altinn.Studio.Designer.TypedHttpClients
                         General.AuthorizationTokenHeaderName,
                         AuthenticationHelper.GetDeveloperTokenHeaderValue(httpContextAccessor.HttpContext));
                 })
-                .AddHttpMessageHandler<EnsureSuccessHandler>()
                 .ConfigurePrimaryHttpMessageHandler(() =>
                     new HttpClientHandler
                     {


### PR DESCRIPTION
#6058 

removed ensure successhandler logic for gitea client.. service handles non-success responses itself