### PR TITLE
Feature/4773: First part of solution for support for storing delegation policies

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Altinn.Authorization.ABAC/Utils/XacmlParser.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Altinn.Authorization.ABAC/Utils/XacmlParser.cs
@@ -8,7 +8,7 @@ using Altinn.Authorization.ABAC.Xacml;
 namespace Altinn.Authorization.ABAC.Utils
 {
     /// <summary>
-    /// Parser Responsible for parsing.
+    /// Parser Responsible for parsing XACML XML documents to XACML models.
     /// </summary>
     public static class XacmlParser
     {

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Altinn.Authorization.ABAC/Utils/XacmlSerializer.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Altinn.Authorization.ABAC/Utils/XacmlSerializer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Xml;
 using System.Xml.Linq;
 using Altinn.Authorization.ABAC.Constants;
@@ -7,7 +8,7 @@ using Altinn.Authorization.ABAC.Xacml;
 namespace Altinn.Authorization.ABAC.Utils
 {
     /// <summary>
-    /// Utility to parse XACM objects to XML or JSON.
+    /// Utility to serialize XACML objects to XML or JSON.
     /// </summary>
     public static class XacmlSerializer
     {
@@ -31,6 +32,60 @@ namespace Altinn.Authorization.ABAC.Utils
             foreach (var result in xacmlContextResponse.Results)
             {
                 WriteContextResult(writer, result);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Method to serialize a XACML Policy.
+        /// </summary>
+        /// <param name="writer">XML Writer</param>
+        /// <param name="xacmlPolicy">The XACML Policy to be serialized</param>
+        public static void WritePolicy(XmlWriter writer, XacmlPolicy xacmlPolicy)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlPolicy, nameof(xacmlPolicy));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.Policy, Xacml30Constants.NameSpaces.Policy);
+
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.PolicyId, xacmlPolicy.PolicyId.OriginalString);
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.Version, xacmlPolicy.Version);
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.RuleCombiningAlgId, xacmlPolicy.RuleCombiningAlgId.OriginalString);
+
+            if (xacmlPolicy.MaxDelegationDepth != null)
+            {
+                writer.WriteAttributeString(XacmlConstants.AttributeNames.MaxDelegationDepth, xacmlPolicy.MaxDelegationDepth.ToString());
+            }
+
+            if (xacmlPolicy.PolicyIssuer != null)
+            {
+                WriteIssuer(writer, xacmlPolicy.PolicyIssuer);
+            }
+
+            if (xacmlPolicy.Description != null)
+            {
+                WriteDescription(writer, xacmlPolicy.Description);
+            }
+
+            if (xacmlPolicy.Target != null)
+            {
+                WriteTarget(writer, xacmlPolicy.Target);
+            }
+
+            foreach (XacmlRule rule in xacmlPolicy.Rules)
+            {
+                WriteRule(writer, rule);
+            }
+
+            if (xacmlPolicy.ObligationExpressions != null && xacmlPolicy.ObligationExpressions.Count > 0)
+            {
+                WriteObligationExpressions(writer, xacmlPolicy.ObligationExpressions);
+            }
+
+            if (xacmlPolicy.AdviceExpressions != null && xacmlPolicy.AdviceExpressions.Count > 0)
+            {
+                WriteAdviceExpressions(writer, xacmlPolicy.AdviceExpressions);
             }
 
             writer.WriteEndElement();
@@ -178,6 +233,39 @@ namespace Altinn.Authorization.ABAC.Utils
             writer.WriteEndElement();
         }
 
+        private static void WriteObligationExpressions(XmlWriter writer, ICollection<XacmlObligationExpression> xacmlObligationExpressions)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlObligationExpressions, nameof(xacmlObligationExpressions));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.ObligationExpressions, Xacml30Constants.NameSpaces.Policy);
+
+            foreach (XacmlObligationExpression xacmlObligationExpression in xacmlObligationExpressions)
+            {
+                WriteObligationExpression(writer, xacmlObligationExpression);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteObligationExpression(XmlWriter writer, XacmlObligationExpression xacmlObligationExpression)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlObligationExpression, nameof(xacmlObligationExpression));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.ObligationExpression, Xacml30Constants.NameSpaces.Policy);
+
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.ObligationId, xacmlObligationExpression.ObligationId.OriginalString);
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.FulfillOn, xacmlObligationExpression.FulfillOn.ToString());
+
+            foreach (XacmlAttributeAssignmentExpression attributeAssigmentExpression in xacmlObligationExpression.AttributeAssignmentExpressions)
+            {
+                WriteAttributeAssignmentExpression(writer, attributeAssigmentExpression);
+            }
+
+            writer.WriteEndElement();
+        }
+
         private static void WriteAdvice(XmlWriter writer, XacmlAdvice xacmlAdvice)
         {
             Guard.ArgumentNotNull(writer, nameof(writer));
@@ -189,6 +277,39 @@ namespace Altinn.Authorization.ABAC.Utils
             foreach (var attributeAssigment in xacmlAdvice.AttributeAssignment)
             {
                 WriteAttributeAssignment(writer, attributeAssigment);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteAdviceExpressions(XmlWriter writer, ICollection<XacmlAdviceExpression> xacmlAdviceExpressions)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlAdviceExpressions, nameof(xacmlAdviceExpressions));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.AdviceExpressions, Xacml30Constants.NameSpaces.Policy);
+
+            foreach (XacmlAdviceExpression xacmlAdviceExpression in xacmlAdviceExpressions)
+            {
+                WriteAdviceExpression(writer, xacmlAdviceExpression);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteAdviceExpression(XmlWriter writer, XacmlAdviceExpression xacmlAdviceExpression)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlAdviceExpression, nameof(xacmlAdviceExpression));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.AdviceExpression, Xacml30Constants.NameSpaces.Policy);
+
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.AdviceId, xacmlAdviceExpression.AdviceId.OriginalString);
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.FulfillOn, xacmlAdviceExpression.AppliesTo.ToString());
+
+            foreach (XacmlAttributeAssignmentExpression attributeAssigmentExpression in xacmlAdviceExpression.AttributeAssignmentExpressions)
+            {
+                WriteAttributeAssignmentExpression(writer, attributeAssigmentExpression);
             }
 
             writer.WriteEndElement();
@@ -224,6 +345,51 @@ namespace Altinn.Authorization.ABAC.Utils
             }
 
             writer.WriteEndElement();
+        }
+
+        private static void WriteAttributeAssignmentExpression(XmlWriter writer, XacmlAttributeAssignmentExpression xacmlAttributeAssignmentExpression)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlAttributeAssignmentExpression, nameof(xacmlAttributeAssignmentExpression));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.AttributeAssignmentExpression, Xacml30Constants.NameSpaces.Policy);
+
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.AttributeId, xacmlAttributeAssignmentExpression.AttributeId.OriginalString);
+            if (xacmlAttributeAssignmentExpression.Category != null)
+            {
+                writer.WriteAttributeString(XacmlConstants.AttributeNames.Category, xacmlAttributeAssignmentExpression.Category.OriginalString);
+            }
+
+            if (!string.IsNullOrEmpty(xacmlAttributeAssignmentExpression.Issuer))
+            {
+                writer.WriteAttributeString(XacmlConstants.AttributeNames.Issuer, xacmlAttributeAssignmentExpression.Issuer);
+            }
+
+            if (xacmlAttributeAssignmentExpression.Property != null)
+            {
+                WriteExpression(writer, xacmlAttributeAssignmentExpression.Property);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteExpression(XmlWriter writer, IXacmlExpression xacmlExpression)
+        {
+            switch (xacmlExpression.GetType().Name)
+            {
+                case "XacmlAttributeValue":
+                    WriteAttributeValue(writer, (XacmlAttributeValue)xacmlExpression);
+                    break;
+                case "XacmlAttributeDesignator":
+                    WriteAttributeDesignator(writer, (XacmlAttributeDesignator)xacmlExpression);
+                    break;
+                case "XacmlAttributeSelector":
+                case "XacmlApply":
+                case "XacmlVariableReference":
+                case "XacmlFunction":
+                default:
+                    throw new NotImplementedException($"XacmlSerializer: Serialization of type {xacmlExpression.GetType().Name} currently not supported");
+            }
         }
 
         private static void WriteContextAttributes(XmlWriter writer, XacmlContextAttributes xacmlContextAttributes)
@@ -282,6 +448,53 @@ namespace Altinn.Authorization.ABAC.Utils
             else
             {
                 WriteAnyElement(writer, (XacmlAnyElement)xacmlAttributeValue);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteAttributeDesignator(XmlWriter writer, XacmlAttributeDesignator xacmlAttributeDesignator)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlAttributeDesignator, nameof(xacmlAttributeDesignator));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.AttributeDesignator, Xacml30Constants.NameSpaces.Policy);
+
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.AttributeId, xacmlAttributeDesignator.AttributeId.OriginalString);
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.Category, xacmlAttributeDesignator.Category.OriginalString);
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.DataType, xacmlAttributeDesignator.DataType.OriginalString);
+
+            if (xacmlAttributeDesignator.MustBePresent != null)
+            {
+                writer.WriteAttributeString(XacmlConstants.AttributeNames.MustBePresent, xacmlAttributeDesignator.MustBePresent.ToString().ToLower());
+            }
+
+            if (!string.IsNullOrEmpty(xacmlAttributeDesignator.Issuer))
+            {
+                writer.WriteAttributeString(XacmlConstants.AttributeNames.Issuer, xacmlAttributeDesignator.Issuer);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteAttribute(XmlWriter writer, XacmlAttribute xacmlAttribute)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlAttribute, nameof(xacmlAttribute));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.Attribute, Xacml30Constants.NameSpaces.Policy);
+
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.AttributeId, xacmlAttribute.AttributeId.OriginalString);
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.IncludeInResult, xacmlAttribute.IncludeInResult.ToString().ToLower());
+
+            if (xacmlAttribute.Issuer != null)
+            {
+                writer.WriteAttributeString(XacmlConstants.AttributeNames.Issuer, xacmlAttribute.Issuer);
+            }
+
+            foreach (XacmlAttributeValue attributeValue in xacmlAttribute.AttributeValues)
+            {
+                WriteAttributeValue(writer, attributeValue);
             }
 
             writer.WriteEndElement();
@@ -368,6 +581,144 @@ namespace Altinn.Authorization.ABAC.Utils
             {
                 elem.WriteTo(writer);
             }
+        }
+
+        private static void WriteTarget(XmlWriter writer, XacmlTarget xacmlTarget)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlTarget, nameof(xacmlTarget));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.Target, Xacml30Constants.NameSpaces.Policy);
+
+            foreach (XacmlAnyOf xacmlAnyOf in xacmlTarget.AnyOf)
+            {
+                WriteAnyOf(writer, xacmlAnyOf);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteAnyOf(XmlWriter writer, XacmlAnyOf xacmlAnyOf)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlAnyOf, nameof(xacmlAnyOf));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.AnyOf, Xacml30Constants.NameSpaces.Policy);
+
+            foreach (XacmlAllOf xacmlAllOf in xacmlAnyOf.AllOf)
+            {
+                WriteAllOf(writer, xacmlAllOf);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteAllOf(XmlWriter writer, XacmlAllOf xacmlAllOf)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlAllOf, nameof(xacmlAllOf));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.AllOf, Xacml30Constants.NameSpaces.Policy);
+
+            foreach (XacmlMatch xacmlMatch in xacmlAllOf.Matches)
+            {
+                WriteMatch(writer, xacmlMatch);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteMatch(XmlWriter writer, XacmlMatch xacmlMatch)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlMatch, nameof(xacmlMatch));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.Match, Xacml30Constants.NameSpaces.Policy);
+
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.MatchId, xacmlMatch.MatchId.OriginalString);
+
+            if (xacmlMatch.AttributeValue != null)
+            {
+                WriteAttributeValue(writer, xacmlMatch.AttributeValue);
+            }
+
+            if (xacmlMatch.AttributeDesignator != null)
+            {
+                WriteAttributeDesignator(writer, xacmlMatch.AttributeDesignator);
+            }
+
+            if (xacmlMatch.AttributeSelector != null)
+            {
+                throw new NotImplementedException($"XacmlSerializer: Serialization of type {xacmlMatch.AttributeSelector.GetType().Name} currently not supported");
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteRule(XmlWriter writer, XacmlRule xacmlRule)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlRule, nameof(xacmlRule));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.Rule, Xacml30Constants.NameSpaces.Policy);
+
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.RuleId, xacmlRule.RuleId);
+            writer.WriteAttributeString(XacmlConstants.AttributeNames.Effect, xacmlRule.Effect.ToString());
+
+            if (xacmlRule.Description != null)
+            {
+                WriteDescription(writer, xacmlRule.Description);
+            }
+
+            if (xacmlRule.Target != null)
+            {
+                WriteTarget(writer, xacmlRule.Target);
+            }
+
+            if (xacmlRule.Condition != null)
+            {
+                throw new NotImplementedException($"XacmlSerializer: Serialization of type {xacmlRule.Condition.GetType().Name} currently not supported");
+            }
+
+            if (xacmlRule.Obligations != null && xacmlRule.Obligations.Count > 0)
+            {
+                WriteObligationExpressions(writer, xacmlRule.Obligations);
+            }
+
+            if (xacmlRule.Advices != null && xacmlRule.Advices.Count > 0)
+            {
+                WriteAdviceExpressions(writer, xacmlRule.Advices);
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteIssuer(XmlWriter writer, XacmlPolicyIssuer xacmlPolicyIssuer)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(xacmlPolicyIssuer, nameof(xacmlPolicyIssuer));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.PolicyIssuer, Xacml30Constants.NameSpaces.Policy);
+
+            if (xacmlPolicyIssuer.Attributes != null)
+            {
+                foreach (XacmlAttribute attribute in xacmlPolicyIssuer.Attributes)
+                {
+                    WriteAttribute(writer, attribute);
+                }
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteDescription(XmlWriter writer, string description)
+        {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+            Guard.ArgumentNotNull(description, nameof(description));
+
+            writer.WriteStartElement(XacmlConstants.Prefixes.Xacml, XacmlConstants.ElementNames.Description, Xacml30Constants.NameSpaces.Policy);
+            writer.WriteString(description);
+            writer.WriteEndElement();
         }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/UnitTest/Utils/AssertionUtil.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/UnitTest/Utils/AssertionUtil.cs
@@ -1,5 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
-
+using System.Xml.Linq;
 using Altinn.Authorization.ABAC.Xacml;
 
 using Xunit;
@@ -18,6 +20,26 @@ namespace Altinn.Authorization.ABAC.UnitTest.Utils
             {
                 AssertEqual(expected.Results.First(), actual.Results.First());
             }
+        }
+
+        public static void AssertPolicyEqual(XacmlPolicy expected, XacmlPolicy actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+            Assert.Equal(expected.PolicyId, actual.PolicyId);
+            Assert.Equal(expected.Version, actual.Version);
+            Assert.Equal(expected.MaxDelegationDepth, actual.MaxDelegationDepth);
+            Assert.Equal(expected.Description, actual.Description);
+            Assert.Equal(expected.RuleCombiningAlgId.OriginalString, actual.RuleCombiningAlgId.OriginalString);
+
+            if (expected.XPathVersion != null)
+            {
+                Assert.Equal(expected.XPathVersion.OriginalString, actual.XPathVersion.OriginalString);
+            }
+
+            AssertTargetEqual(expected.Target, actual.Target);
+
+            AssertCollections(expected.Rules, actual.Rules, AssertRuleEqual);
         }
 
         private static void AssertEqual(XacmlContextResult expected, XacmlContextResult actual)
@@ -63,6 +85,141 @@ namespace Altinn.Authorization.ABAC.UnitTest.Utils
             Assert.Equal(expected.Category, actual.Category);
             Assert.Equal(expected.AttributeId, actual.AttributeId);
             Assert.Equal(expected.DataType, actual.DataType);
+        }
+
+        private static void AssertTargetEqual(XacmlTarget expected, XacmlTarget actual)
+        {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+            }
+            else
+            {
+                Assert.NotNull(actual);
+                AssertCollections(expected.AnyOf, actual.AnyOf, AssertAnyOfEqual);
+            }
+        }
+
+        private static void AssertRuleEqual(XacmlRule expected, XacmlRule actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+
+            Assert.Equal(expected.RuleId, actual.RuleId);
+            AssertTargetEqual(expected.Target, actual.Target);
+
+            AssertCollections(expected.Obligations, actual.Obligations, AssertObligationExpressionEqual);
+        }
+
+        private static void AssertAnyOfEqual(XacmlAnyOf expected, XacmlAnyOf actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+
+            AssertCollections(expected.AllOf, actual.AllOf, AssertAllOfEqual);
+        }
+
+        private static void AssertAllOfEqual(XacmlAllOf expected, XacmlAllOf actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+
+            AssertCollections(expected.Matches, actual.Matches, AssertMatchEqual);
+        }
+
+        private static void AssertMatchEqual(XacmlMatch expected, XacmlMatch actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+
+            Assert.Equal(expected.MatchId, actual.MatchId);
+            AssertAttributeDesignatorEqual(expected.AttributeDesignator, actual.AttributeDesignator);
+            AssertAttributeValueEqual(expected.AttributeValue, actual.AttributeValue);
+        }
+
+        private static void AssertAttributeValueEqual(XacmlAttributeValue expected, XacmlAttributeValue actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+
+            Assert.Equal(expected.DataType.OriginalString, actual.DataType.OriginalString);
+            Assert.Equal(expected.Value, actual.Value);
+            AssertCollections(expected.Attributes, actual.Attributes, AssertXAttributeEqual);
+            AssertCollections(expected.Elements, actual.Elements, AssertXElementEqual);
+        }
+
+        private static void AssertAttributeDesignatorEqual(XacmlAttributeDesignator expected, XacmlAttributeDesignator actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+
+            Assert.Equal(expected.AttributeId.OriginalString, actual.AttributeId.OriginalString);
+            Assert.Equal(expected.Category.OriginalString, actual.Category.OriginalString);
+            Assert.Equal(expected.DataType.OriginalString, actual.DataType.OriginalString);
+            Assert.Equal(expected.Issuer, actual.Issuer);
+            Assert.Equal(expected.MustBePresent, actual.MustBePresent);
+        }
+
+        private static void AssertObligationExpressionEqual(XacmlObligationExpression expected, XacmlObligationExpression actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+
+            Assert.Equal(expected.ObligationId.OriginalString, actual.ObligationId.OriginalString);
+            Assert.Equal(expected.FulfillOn, actual.FulfillOn);
+
+            AssertCollections(expected.AttributeAssignmentExpressions, actual.AttributeAssignmentExpressions, AssertAttributeAssignmentExpressionEqual);
+        }
+
+        private static void AssertAttributeAssignmentExpressionEqual(XacmlAttributeAssignmentExpression expected, XacmlAttributeAssignmentExpression actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+
+            Assert.Equal(expected.AttributeId.OriginalString, actual.AttributeId.OriginalString);
+            Assert.Equal(expected.Category.OriginalString, actual.Category.OriginalString);
+            Assert.Equal(expected.Issuer, actual.Issuer);
+
+            AssertAttributeValueEqual((XacmlAttributeValue)expected.Property, (XacmlAttributeValue)actual.Property);
+        }
+
+        private static void AssertXAttributeEqual(XAttribute expected, XAttribute actual)
+        {
+            Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.Value, actual.Value);
+        }
+
+        private static void AssertXElementEqual(XElement expected, XElement actual)
+        {
+            Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.Value, actual.Value);
+        }
+
+        private static void AssertCollections<T>(ICollection<T> expected, ICollection<T> actual, Action<T, T> assertMethod)
+        {
+            Assert.Equal(expected.Count, actual.Count);
+
+            Dictionary<int, T> expectedDict = new Dictionary<int, T>();
+            Dictionary<int, T> actualDict = new Dictionary<int, T>();
+
+            int i = 1;
+            foreach (T ex in expected)
+            {
+                expectedDict.Add(i, ex);
+                i++;
+            }
+
+            i = 1;
+            foreach (T ac in actual)
+            {
+                actualDict.Add(i, ac);
+                i++;
+            }
+
+            foreach (int key in expectedDict.Keys)
+            {
+                assertMethod(expectedDict[key], actualDict[key]);
+            }
         }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/UnitTest/Xacml30SerializerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/UnitTest/Xacml30SerializerTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using Altinn.Authorization.ABAC.UnitTest.Utils;
+using Altinn.Authorization.ABAC.Utils;
+using Altinn.Authorization.ABAC.Xacml;
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace Altinn.Authorization.ABAC.UnitTests
+{
+    public class Xacml30SerializerTests
+    {
+        [Fact]
+        public void SerializedXACMLPolicy_ShouldBeEqual()
+        {
+            XmlDocument policyDocument = new XmlDocument();
+            policyDocument.Load(Path.Combine(GetAltinnAppsPath(), "AltinnApps0001Policy.xml"));
+
+            XacmlPolicy originalPolicy;
+            using (XmlReader reader = XmlReader.Create(new StringReader(policyDocument.OuterXml)))
+            {
+               originalPolicy = XacmlParser.ParseXacmlPolicy(reader);
+            }
+
+            MemoryStream dataStream = new MemoryStream();
+            XmlWriter writer = XmlWriter.Create(dataStream);
+
+            XacmlSerializer.WritePolicy(writer, originalPolicy);
+
+            writer.Flush();
+            dataStream.Position = 0;
+
+            XacmlPolicy serializedPolicy;
+            using (XmlReader reader = XmlReader.Create(dataStream))
+            {
+                serializedPolicy = XacmlParser.ParseXacmlPolicy(reader);
+            }
+
+            AssertionUtil.AssertPolicyEqual(originalPolicy, serializedPolicy);
+        }
+
+        [Fact]
+        public void SerializeXACMLPolicy_ShouldBeUnequal()
+        {
+            XmlDocument policyDocument = new XmlDocument();
+            policyDocument.Load(Path.Combine(GetAltinnAppsPath(), "AltinnApps0001Policy.xml"));
+
+            XacmlPolicy originalPolicy;
+            using (XmlReader reader = XmlReader.Create(new StringReader(policyDocument.OuterXml)))
+            {
+                originalPolicy = XacmlParser.ParseXacmlPolicy(reader);
+            }
+
+            MemoryStream dataStream = new MemoryStream();
+            XmlWriter writer = XmlWriter.Create(dataStream);
+
+            XacmlSerializer.WritePolicy(writer, originalPolicy);
+
+            writer.Flush();
+            dataStream.Position = 0;
+
+            XacmlPolicy serializedPolicy;
+            using (XmlReader reader = XmlReader.Create(dataStream))
+            {
+                serializedPolicy = XacmlParser.ParseXacmlPolicy(reader);
+            }
+
+            // Change a bottom node value on serialized policy model to verify that Assertion should fail
+            string originalAttributeValue = originalPolicy.Rules.First().Target.AnyOf.First().AllOf.First().Matches.First().AttributeValue.Value;
+            string actualAttributeValue = "THIS IS NOT THE VALUE YOU ARE LOOKING FOR";
+            serializedPolicy.Rules.First().Target.AnyOf.First().AllOf.First().Matches.First().AttributeValue.Value = actualAttributeValue;
+
+            try
+            {
+                AssertionUtil.AssertPolicyEqual(originalPolicy, serializedPolicy);
+            }
+            catch (EqualException e)
+            {
+                Assert.Equal(e.Expected, originalAttributeValue);
+                Assert.Equal(e.Actual, actualAttributeValue);
+            }
+        }
+
+        private string GetAltinnAppsPath()
+        {
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(Xacml30ParserTests).Assembly.CodeBase).LocalPath);
+            return Path.Combine(unitTestFolder, @"..\..\..\Data\Xacml\3.0\AltinnApps");
+        }
+    }
+}


### PR DESCRIPTION
#4773
In order to store delegation policy xacml files the XacmlSerializer needs to be expanded with support for serializing the complete and complex XacmlPolicy model.

The implemention here is still not a 100% feature complete according to Xacml 3.0 standard (see for example WriteExpression where I so far have only added support for the AttributeValue and AttributeDesignator models Altinn Authorization actively use on the XacmlMatch model).

Also added unittest which reuse the existing AltinnApps0001Policy.xml files used for unittesting the XacmlParser, to test the XacmlSerializer and compare the XacmlPolicy models before and after serialization.
AssertionUtil have been expanded with needed helper operations in order to do a deep compare of the XacmlPolicy models.