### PR TITLE
Repeating group open by default

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/GroupContainer.tsx
@@ -88,6 +88,10 @@ export function GroupContainer({
     if (container.edit?.multiPage) {
       setMultiPageIndex(0);
     }
+
+    if (container.openDefault == true && repeatingGroupIndex == -1) {
+      onClickAdd();
+    }
   }, [container]);
 
   const onClickAdd = () => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/index.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/index.ts
@@ -18,6 +18,7 @@ export interface ILayoutGroup extends ILayoutEntry {
   textResourceBindings?: ITextResourceBindings;
   tableHeaders?: string[];
   edit?: IGroupEditProperties;
+  openDefault?: boolean;
 }
 
 export interface ILayoutComponent extends ILayoutEntry {


### PR DESCRIPTION
The functionality has been requested in the following issue: https://github.com/Altinn/altinn-studio/issues/4870
If the property "openDefault" is set to "true" and the repeating group is empty, it will be displayed as open by default. Here is an example of how it's used in the application layout: 
![image](https://user-images.githubusercontent.com/17925860/131632721-400bc0aa-b445-4edb-831a-be4675eb8170.png)
