### PR TITLE
Added a max split of two to credential splitter for not accidentally split the password.

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Altinn.Platform.Authentication.Tests/Mocks/EnterpriseUserAuthenticationServiceMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Altinn.Platform.Authentication.Tests/Mocks/EnterpriseUserAuthenticationServiceMock.cs
@@ -34,14 +34,6 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
             
             if (credentials.UserName == "Test" && credentials.Password == "Testesen")
             {
-                string credentialsJson = JsonSerializer.Serialize(credentials);
-                var request = new HttpRequestMessage
-                {
-                    Method = HttpMethod.Post,
-                    RequestUri = new Uri(_settings.BridgeAuthnApiEndpoint + "enterpriseuser"),
-                    Content = new StringContent(credentialsJson.ToString(), Encoding.UTF8, "application/json")
-                };
-
                 result.StatusCode = HttpStatusCode.TooManyRequests;
                 RetryConditionHeaderValue retryAfter = new RetryConditionHeaderValue(DateTime.Now);
                 result.Headers.RetryAfter = retryAfter;

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Altinn.Platform.Authentication.Tests/Mocks/EnterpriseUserAuthenticationServiceMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Altinn.Platform.Authentication.Tests/Mocks/EnterpriseUserAuthenticationServiceMock.cs
@@ -30,8 +30,7 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
 
         public async Task<HttpResponseMessage> AuthenticateEnterpriseUser(EnterpriseUserCredentials credentials)
         {
-            // Just to remove warning that method will run syncronus as no await is performed
-            var result = await Task.Run(() => { return new HttpResponseMessage(); });
+            HttpResponseMessage result = new HttpResponseMessage();
             
             if (credentials.UserName == "Test" && credentials.Password == "Testesen")
             {
@@ -46,56 +45,28 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
                 result.StatusCode = HttpStatusCode.TooManyRequests;
                 RetryConditionHeaderValue retryAfter = new RetryConditionHeaderValue(DateTime.Now);
                 result.Headers.RetryAfter = retryAfter;
-                return result;
             }
             else if (credentials.UserName == "ValidUser" && credentials.Password == "ValidPassword")
             {
-                string credentialsJson = JsonSerializer.Serialize(credentials);
-                var request = new HttpRequestMessage
-                {
-                    Method = HttpMethod.Post,
-                    RequestUri = new Uri(_settings.BridgeAuthnApiEndpoint + "enterpriseuser"),
-                    Content = new StringContent(credentialsJson.ToString(), Encoding.UTF8, "application/json")
-                };
-
                 result.StatusCode = HttpStatusCode.OK;
                 result.Content = GetEnterpriseUserContent(credentials.UserName);
-
-                return result;
             }
             else if (credentials.UserName == "ValidUser2" && credentials.Password == "Valid:Password")
             {
-                string credentialsJson = JsonSerializer.Serialize(credentials);
-                var request = new HttpRequestMessage
-                {
-                    Method = HttpMethod.Post,
-                    RequestUri = new Uri(_settings.BridgeAuthnApiEndpoint + "enterpriseuser"),
-                    Content = new StringContent(credentialsJson.ToString(), Encoding.UTF8, "application/json")
-                };
-
                 result.StatusCode = HttpStatusCode.OK;
                 result.Content = GetEnterpriseUserContent(credentials.UserName);
-
-                return result;
             }
             else
             {
-                string credentialsJson = JsonSerializer.Serialize(credentials);
-                var request = new HttpRequestMessage
-                {
-                    Method = HttpMethod.Post,
-                    RequestUri = new Uri(_settings.BridgeAuthnApiEndpoint + "enterpriseuser"),
-                    Content = new StringContent(credentialsJson.ToString(), Encoding.UTF8, "application/json")
-                };
-
                 result.StatusCode = HttpStatusCode.NotFound;
-                return result;
             }
+
+            return await Task.FromResult(result);
         }
 
         private static HttpContent GetEnterpriseUserContent(string userName)
         {
-            string jsonString = string.Format("{{\r\n\t\"UserID\": 1234,\r\n\t\"Username\": \"{0}\",\r\n\t\"SSN\": null,\r\n\t\"PartyID\": 0,\r\n\t\"AuthenticateResult\": 1,\r\n\t\"AuthenticationMethod\": 9,\r\n\t\"LockedOutDate\": \"1753-01-01T00:00:00\",\r\n\t\"SmsPinUpgraded\": false,\r\n\t\"IsTestUser\": false,\r\n\t\"IDPortenNameID\": null,\r\n\t\"IDPortenSessionIndex\": null\r\n}}", userName);
+            string jsonString = $"{{\r\n\t\"UserID\": 1234,\r\n\t\"Username\": \"{userName}\",\r\n\t\"SSN\": null,\r\n\t\"PartyID\": 0,\r\n\t\"AuthenticateResult\": 1,\r\n\t\"AuthenticationMethod\": 9,\r\n\t\"LockedOutDate\": \"1753-01-01T00:00:00\",\r\n\t\"SmsPinUpgraded\": false,\r\n\t\"IsTestUser\": false,\r\n\t\"IDPortenNameID\": null,\r\n\t\"IDPortenSessionIndex\": null\r\n}}";
             HttpContent content = new StringContent(jsonString, Encoding.UTF8, "application/json");
 
             return content;

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Altinn.Platform.Authentication.Tests/Mocks/EnterpriseUserAuthenticationServiceMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Altinn.Platform.Authentication.Tests/Mocks/EnterpriseUserAuthenticationServiceMock.cs
@@ -93,7 +93,7 @@ namespace Altinn.Platform.Authentication.Tests.Mocks
             }
         }
 
-        private HttpContent GetEnterpriseUserContent(string userName)
+        private static HttpContent GetEnterpriseUserContent(string userName)
         {
             string jsonString = string.Format("{{\r\n\t\"UserID\": 1234,\r\n\t\"Username\": \"{0}\",\r\n\t\"SSN\": null,\r\n\t\"PartyID\": 0,\r\n\t\"AuthenticateResult\": 1,\r\n\t\"AuthenticationMethod\": 9,\r\n\t\"LockedOutDate\": \"1753-01-01T00:00:00\",\r\n\t\"SmsPinUpgraded\": false,\r\n\t\"IsTestUser\": false,\r\n\t\"IDPortenNameID\": null,\r\n\t\"IDPortenSessionIndex\": null\r\n}}", userName);
             HttpContent content = new StringContent(jsonString, Encoding.UTF8, "application/json");

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -505,7 +505,7 @@ namespace Altinn.Platform.Authentication.Controllers
             byte[] decodedCredentials = Convert.FromBase64String(encodedCredentials);
             string decodedString = Encoding.UTF8.GetString(decodedCredentials);
 
-            string[] decodedStringArray = decodedString.Split(":");
+            string[] decodedStringArray = decodedString.Split(":", 2);
             string usernameFromRequest = decodedStringArray[0];
             string password = decodedStringArray[1];
 


### PR DESCRIPTION
Added a max boundary to split username and password so we don't split the password containing the split character in multiple parts and only using the first part for validation.

Also added a unit test for this.

Also Removed the call to Bridge from the mock to get a HttpResponseMessage that is manipulated afterwards as this call prevented two existing unit test to run and would have prevented the additional test to work the same way.

resolve #6813 
