### PR TITLE
removed not found ProducesResponseType for get instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To run Altinn Studio locally, follow the [Altinn Studio instructions](/src/studi
 
 #### Develop or run Apps
 
-First make sure to [follow the prerequisites for Altinn Studio](/src/studio/README.md#prerequisites)  
+First make sure to [follow the prerequisites for Altinn Studio](/src/studio/README.md#prerequisites).  
 _If you only need to develop and debug App-Frontend, you can follow the description in **step #5** (only) and deploy the app to any test environment. The App-Frontend will be loaded from your local webpack-dev-server._
 
 It's possible to run an app locally in order to test and debug it. It needs a local version of the platform services to work.  

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.14.0</Version>
-    <AssemblyVersion>4.14.0.0</AssemblyVersion>
+    <Version>4.14.1</Version>
+    <AssemblyVersion>4.14.1.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>
     <Description>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/InstancesController.cs
@@ -105,7 +105,6 @@ namespace Altinn.App.Api.Controllers
         [HttpGet("{instanceOwnerPartyId:int}/{instanceGuid:guid}")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(Instance), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult> Get(
             [FromRoute] string org,

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.14.0</Version>
-    <AssemblyVersion>4.14.0.0</AssemblyVersion>
+    <Version>4.14.1</Version>
+    <AssemblyVersion>4.14.1.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>
     <Description>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.14.0</Version>
-    <AssemblyVersion>4.14.0.0</AssemblyVersion>
+    <Version>4.14.1</Version>
+    <AssemblyVersion>4.14.1.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>
     <Description>

--- a/src/Altinn.Apps/AppTemplates/AspNet/App/App.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App/App.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="4.14.0">
+    <PackageReference Include="Altinn.App.Api" Version="4.14.1">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Common" Version="4.14.0" />
-    <PackageReference Include="Altinn.App.PlatformServices" Version="4.14.0" />
+    <PackageReference Include="Altinn.App.Common" Version="4.14.1" />
+    <PackageReference Include="Altinn.App.PlatformServices" Version="4.14.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.1" />
   </ItemGroup>

--- a/src/studio/AppTemplates/AspNet/App/App.csproj
+++ b/src/studio/AppTemplates/AspNet/App/App.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="4.14.0">
+    <PackageReference Include="Altinn.App.Api" Version="4.14.1">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Common" Version="4.14.0" />
-    <PackageReference Include="Altinn.App.PlatformServices" Version="4.14.0" />
+    <PackageReference Include="Altinn.App.Common" Version="4.14.1" />
+    <PackageReference Include="Altinn.App.PlatformServices" Version="4.14.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.1" />
   </ItemGroup>


### PR DESCRIPTION
#6681

Bug related to swagger not matching response. As 404 is not a response it is possible to get from this endpoint atm, I'm removing the tag on the endpoint. 

Seperate issue for more extensive problem details.