### PR TITLE
feature/6766-start-from-existing-instance

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/entrypoint/Entrypoint.test.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/entrypoint/Entrypoint.test.tsx
@@ -1,13 +1,13 @@
 import 'jest';
 import * as React from 'react';
-import { IRuntimeState } from "../../../src/types";
-import { getInitialStateMock } from '../../../__mocks__/initialStateMock';
 import { Provider } from 'react-redux';
-import Entrypoint from '../../../src/features/entrypoint/Entrypoint';
 import { render, waitFor } from '@testing-library/react';
-import { IApplicationMetadata } from '../../../src/shared/resources/applicationMetadata';
 import axios from 'axios';
 import { createStore } from 'redux';
+import { IRuntimeState } from '../../../src/types';
+import { getInitialStateMock } from '../../../__mocks__/initialStateMock';
+import Entrypoint from '../../../src/features/entrypoint/Entrypoint';
+import { IApplicationMetadata } from '../../../src/shared/resources/applicationMetadata';
 
 jest.mock('axios');
 
@@ -16,15 +16,14 @@ describe('>>> features/entrypoint/Entrypoint.tsx', () => {
   let mockStore: any;
   let mockReducer: any;
 
-
   beforeEach(() => {
     mockInitialState = getInitialStateMock({});
     (axios.post as jest.Mock).mockResolvedValue({
       data: {
         valid: true,
         validParties: [],
-        message: ''
-      }
+        message: '',
+      },
     });
     mockReducer = (state: IRuntimeState, action: string): IRuntimeState => {
       if (action === 'queue/startInitialStatelessQueue') {
@@ -32,9 +31,9 @@ describe('>>> features/entrypoint/Entrypoint.tsx', () => {
           ...state,
           isLoading: {
             stateless: false,
-            dataTask: null
-          }
-        }
+            dataTask: null,
+          },
+        };
       }
       return state;
     };
@@ -46,13 +45,13 @@ describe('>>> features/entrypoint/Entrypoint.tsx', () => {
       data: {
         valid: false,
         validParties: [],
-        message: ''
-      }
+        message: '',
+      },
     });
     const rendered = render(
       <Provider store={mockStore}>
         <Entrypoint />
-      </Provider>
+      </Provider>,
     );
     await waitFor(() => {
       // validate party
@@ -67,7 +66,7 @@ describe('>>> features/entrypoint/Entrypoint.tsx', () => {
     const rendered = render(
       <Provider store={mockStore}>
         <Entrypoint />
-      </Provider>
+      </Provider>,
     );
 
     const contentLoader = await rendered.findByText('Loading...');
@@ -81,11 +80,11 @@ describe('>>> features/entrypoint/Entrypoint.tsx', () => {
     const statelessApplication: IApplicationMetadata = {
       ...mockInitialState.applicationMetadata.applicationMetadata,
       onEntry: {
-        show: 'stateless'
-      }
-    }
+        show: 'stateless',
+      },
+    };
     const mockStateWithStatelessApplication: IRuntimeState = {
-      ...mockInitialState
+      ...mockInitialState,
     };
     mockStateWithStatelessApplication.applicationMetadata.applicationMetadata = statelessApplication;
     mockStore = createStore(mockReducer, mockStateWithStatelessApplication);
@@ -94,7 +93,7 @@ describe('>>> features/entrypoint/Entrypoint.tsx', () => {
     const rendered = render(
       <Provider store={mockStore}>
         <Entrypoint />
-      </Provider>
+      </Provider>,
     );
 
     const contentLoader = await rendered.findByText('Loading...');
@@ -102,8 +101,7 @@ describe('>>> features/entrypoint/Entrypoint.tsx', () => {
 
     // should have started the initialStatelessQueue
     await waitFor(() => {
-      expect(mockStore.dispatch).toHaveBeenCalledWith({ type: 'queue/startInitialStatelessQueue'});
+      expect(mockStore.dispatch).toHaveBeenCalledWith({ type: 'queue/startInitialStatelessQueue' });
     });
   });
-
 });

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/form/components/__snapshots__/GroupContainer.test.tsx.snap
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/form/components/__snapshots__/GroupContainer.test.tsx.snap
@@ -11,13 +11,16 @@ exports[`>>> features/form/components/Group.tsx +++ should match snapshot 1`] = 
   >
     <div
       className="MuiGrid-root MuiTableContainer-root"
+      id="group-mock-container-id-table-container"
     >
       <table
-        className="MuiTable-root makeStyles-table-1"
+        className="MuiTable-root makeStyles-table-3"
+        id="group-mock-container-id-table"
         role={null}
       >
         <thead
-          className="MuiTableHead-root makeStyles-tableHeader-2"
+          className="MuiTableHead-root makeStyles-tableHeader-5"
+          id="group-mock-container-id-table-header"
           role={null}
         >
           <tr
@@ -60,7 +63,8 @@ exports[`>>> features/form/components/Group.tsx +++ should match snapshot 1`] = 
           </tr>
         </thead>
         <tbody
-          className="MuiTableBody-root makeStyles-tableBody-3"
+          className="MuiTableBody-root makeStyles-tableBody-6"
+          id="group-mock-container-id-table-body"
           role={null}
         >
           <tr
@@ -112,7 +116,8 @@ exports[`>>> features/form/components/Group.tsx +++ should match snapshot 1`] = 
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "color": "black",
+                    "color": "#0062BA",
+                    "fontWeight": 700,
                   }
                 }
                 tabIndex={0}
@@ -123,7 +128,7 @@ exports[`>>> features/form/components/Group.tsx +++ should match snapshot 1`] = 
                 >
                   Rediger
                   <i
-                    className="fa fa-editing-file makeStyles-editIcon-6"
+                    className="fa fa-edit makeStyles-editIcon-2"
                   />
                 </span>
               </button>
@@ -178,7 +183,8 @@ exports[`>>> features/form/components/Group.tsx +++ should match snapshot 1`] = 
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "color": "black",
+                    "color": "#0062BA",
+                    "fontWeight": 700,
                   }
                 }
                 tabIndex={0}
@@ -189,7 +195,7 @@ exports[`>>> features/form/components/Group.tsx +++ should match snapshot 1`] = 
                 >
                   Rediger
                   <i
-                    className="fa fa-editing-file makeStyles-editIcon-6"
+                    className="fa fa-edit makeStyles-editIcon-2"
                   />
                 </span>
               </button>
@@ -244,7 +250,8 @@ exports[`>>> features/form/components/Group.tsx +++ should match snapshot 1`] = 
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "color": "black",
+                    "color": "#0062BA",
+                    "fontWeight": 700,
                   }
                 }
                 tabIndex={0}
@@ -255,7 +262,7 @@ exports[`>>> features/form/components/Group.tsx +++ should match snapshot 1`] = 
                 >
                   Rediger
                   <i
-                    className="fa fa-editing-file makeStyles-editIcon-6"
+                    className="fa fa-edit makeStyles-editIcon-2"
                   />
                 </span>
               </button>
@@ -310,7 +317,8 @@ exports[`>>> features/form/components/Group.tsx +++ should match snapshot 1`] = 
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "color": "black",
+                    "color": "#0062BA",
+                    "fontWeight": 700,
                   }
                 }
                 tabIndex={0}
@@ -321,7 +329,7 @@ exports[`>>> features/form/components/Group.tsx +++ should match snapshot 1`] = 
                 >
                   Rediger
                   <i
-                    className="fa fa-editing-file makeStyles-editIcon-6"
+                    className="fa fa-edit makeStyles-editIcon-2"
                   />
                 </span>
               </button>
@@ -338,7 +346,7 @@ exports[`>>> features/form/components/Group.tsx +++ should match snapshot 1`] = 
     className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-center"
   >
     <div
-      className="MuiGrid-root makeStyles-addButton-12 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-center MuiGrid-grid-xs-12"
+      className="MuiGrid-root makeStyles-addButton-8 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-center MuiGrid-grid-xs-12"
       onClick={[Function]}
       onKeyPress={[Function]}
       role="button"
@@ -348,14 +356,14 @@ exports[`>>> features/form/components/Group.tsx +++ should match snapshot 1`] = 
         className="MuiGrid-root MuiGrid-item"
       >
         <i
-          className="fa fa-exit makeStyles-addIcon-14"
+          className="fa fa-exit makeStyles-addIcon-10"
         />
       </div>
       <div
         className="MuiGrid-root MuiGrid-item"
       >
         <span
-          className="makeStyles-addButtonText-13"
+          className="makeStyles-addButtonText-9"
         >
           Legg til ny
             

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/form/components/__snapshots__/RepeatingGroupsTable.test.tsx.snap
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/form/components/__snapshots__/RepeatingGroupsTable.test.tsx.snap
@@ -9,12 +9,15 @@ exports[`components/base/InputComponent.tsx feature/form/containers/RepeatingGro
   >
     <div
       class="MuiGrid-root MuiTableContainer-root"
+      id="group-mock-container-id-table-container"
     >
       <table
-        class="MuiTable-root makeStyles-table-1"
+        class="MuiTable-root makeStyles-table-3"
+        id="group-mock-container-id-table"
       >
         <thead
-          class="MuiTableHead-root makeStyles-tableHeader-2"
+          class="MuiTableHead-root makeStyles-tableHeader-5"
+          id="group-mock-container-id-table-header"
         >
           <tr
             class="MuiTableRow-root MuiTableRow-head"
@@ -50,7 +53,8 @@ exports[`components/base/InputComponent.tsx feature/form/containers/RepeatingGro
           </tr>
         </thead>
         <tbody
-          class="MuiTableBody-root makeStyles-tableBody-3"
+          class="MuiTableBody-root makeStyles-tableBody-6"
+          id="group-mock-container-id-table-body"
         >
           <tr
             class="MuiTableRow-root"
@@ -72,7 +76,7 @@ exports[`components/base/InputComponent.tsx feature/form/containers/RepeatingGro
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
-                style="color: black;"
+                style="color: rgb(0, 98, 186); font-weight: 700;"
                 tabindex="0"
                 type="button"
               >
@@ -81,7 +85,7 @@ exports[`components/base/InputComponent.tsx feature/form/containers/RepeatingGro
                 >
                   general.edit_alt
                   <i
-                    class="fa fa-editing-file makeStyles-editIcon-6"
+                    class="fa fa-edit makeStyles-editIcon-2"
                   />
                 </span>
                 <span
@@ -110,7 +114,7 @@ exports[`components/base/InputComponent.tsx feature/form/containers/RepeatingGro
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
-                style="color: black;"
+                style="color: rgb(0, 98, 186); font-weight: 700;"
                 tabindex="0"
                 type="button"
               >
@@ -119,7 +123,7 @@ exports[`components/base/InputComponent.tsx feature/form/containers/RepeatingGro
                 >
                   general.edit_alt
                   <i
-                    class="fa fa-editing-file makeStyles-editIcon-6"
+                    class="fa fa-edit makeStyles-editIcon-2"
                   />
                 </span>
                 <span
@@ -148,7 +152,7 @@ exports[`components/base/InputComponent.tsx feature/form/containers/RepeatingGro
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
-                style="color: black;"
+                style="color: rgb(0, 98, 186); font-weight: 700;"
                 tabindex="0"
                 type="button"
               >
@@ -157,7 +161,7 @@ exports[`components/base/InputComponent.tsx feature/form/containers/RepeatingGro
                 >
                   general.edit_alt
                   <i
-                    class="fa fa-editing-file makeStyles-editIcon-6"
+                    class="fa fa-edit makeStyles-editIcon-2"
                   />
                 </span>
                 <span
@@ -186,7 +190,7 @@ exports[`components/base/InputComponent.tsx feature/form/containers/RepeatingGro
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
-                style="color: black;"
+                style="color: rgb(0, 98, 186); font-weight: 700;"
                 tabindex="0"
                 type="button"
               >
@@ -195,7 +199,7 @@ exports[`components/base/InputComponent.tsx feature/form/containers/RepeatingGro
                 >
                   general.edit_alt
                   <i
-                    class="fa fa-editing-file makeStyles-editIcon-6"
+                    class="fa fa-edit makeStyles-editIcon-2"
                   />
                 </span>
                 <span

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/instantiate/InstanceSelection.test.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/instantiate/InstanceSelection.test.tsx
@@ -1,0 +1,93 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import InstanceSelection from '../../../src/features/instantiate/containers/InstanceSelection';
+import { IRuntimeState, ISimpleInstance } from '../../../src/types';
+import { getInitialStateMock } from '../../../__mocks__/initialStateMock';
+
+describe('>>> features/instantiate/InstanceSelection.tsx', () => {
+  let mockInitialState: IRuntimeState;
+  let mockStore: any;
+  let mockStartNewInstance: () => void;
+  let mockActiveInstances: ISimpleInstance[];
+
+  beforeEach(() => {
+    const createStore = configureStore();
+    mockInitialState = getInitialStateMock({});
+    mockStore = createStore(mockInitialState);
+    mockStartNewInstance = jest.fn();
+    mockActiveInstances = [
+      { id: 'some-id', lastChanged: '28-01-92', lastChangedBy: 'Navn Navnesen' },
+      { id: 'some-other-id', lastChanged: '03-05-2005', lastChangedBy: 'Kåre Nordmannsen' },
+    ];
+  });
+
+  it('should show full size table for larger devices', () => {
+    const rendered = render(
+      <Provider store={mockStore}>
+        <InstanceSelection
+          instances={mockActiveInstances}
+          onNewInstance={mockStartNewInstance}
+        />
+      </Provider>,
+    );
+    const altinnTable = rendered.container.querySelector('#instance-selection-table');
+    expect(altinnTable).not.toBeNull();
+  });
+
+  it('should display mobile table for smaller devices', () => {
+    (window as any).matchMedia = jest.fn().mockReturnValue({
+      matches: true,
+      addListener: () => {},
+      removeListener: () => {},
+    });
+    const rendered = render(
+      <Provider store={mockStore}>
+        <InstanceSelection
+          instances={mockActiveInstances}
+          onNewInstance={mockStartNewInstance}
+        />
+      </Provider>,
+    );
+    const altinnMobileTable = rendered.container.querySelector('#instance-selection-mobile-table');
+    expect(altinnMobileTable).not.toBeNull();
+  });
+
+  it('should display active instances', async () => {
+    const rendered = render(
+      <Provider store={mockStore}>
+        <InstanceSelection
+          instances={mockActiveInstances}
+          onNewInstance={mockStartNewInstance}
+        />
+      </Provider>,
+    );
+
+    const firstInstanceChangedBy = await rendered.findByText(mockActiveInstances[0].lastChangedBy);
+    const secondInstanceChangedBy = await rendered.findByText(mockActiveInstances[1].lastChangedBy);
+
+    const firstInstanceLastChanged = await rendered.findByText(mockActiveInstances[0].lastChanged);
+    const secondInstanceLastChanged = await rendered.findByText(mockActiveInstances[1].lastChanged);
+
+    expect(firstInstanceChangedBy).not.toBeNull();
+    expect(secondInstanceChangedBy).not.toBeNull();
+
+    expect(firstInstanceLastChanged).not.toBeNull();
+    expect(secondInstanceLastChanged).not.toBeNull();
+  });
+
+  it('pressing "Start på nytt" should trigger callback', () => {
+    const rendered = render(
+      <Provider store={mockStore}>
+        <InstanceSelection
+          instances={mockActiveInstances}
+          onNewInstance={mockStartNewInstance}
+        />
+      </Provider>,
+    );
+
+    rendered.getByText('Start på nytt').click();
+    expect(mockStartNewInstance).toBeCalledTimes(1);
+  });
+});

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/instantiate/index.test.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/instantiate/index.test.tsx
@@ -4,11 +4,11 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { render, waitFor } from '@testing-library/react'
 import configureStore from 'redux-mock-store';
+import { BrowserRouter } from 'react-router-dom';
 import Instantiate from '../../../src/features/instantiate/containers/index';
 import { IRuntimeState } from '../../../src/types';
 import { getInitialStateMock } from '../../../__mocks__/initialStateMock';
 import InstantiationActions from '../../../src/features/instantiate/instantiation/actions';
-import { BrowserRouter } from 'react-router-dom';
 
 describe('>>> features/instantiate/index.ts', () => {
   let mockInitialState: IRuntimeState;
@@ -45,8 +45,5 @@ describe('>>> features/instantiate/index.ts', () => {
 
     const instantiationText = await rendered.findByText('Hold deg fast, nå starter vi!');
     expect(instantiationText).not.toBeNull();
-
   });
 });
-
-

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.11.8",
+  "version": "3.12.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/entrypoint/Entrypoint.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/entrypoint/Entrypoint.tsx
@@ -5,11 +5,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import Presentation from 'src/shared/containers/Presentation';
 import { startInitialStatelessQueue } from 'src/shared/resources/queue/queueSlice';
-import { IRuntimeState, PresentationType, ProcessTaskType } from 'src/types';
+import { IRuntimeState, ISimpleInstance, PresentationType, ProcessTaskType } from 'src/types';
+import { isStatelessApp } from 'src/utils/appMetadata';
 import { HttpStatusCodes, post } from 'src/utils/networking';
 import { getPartyValidationUrl } from 'src/utils/urlHelper';
 import Form from '../form/containers/Form';
 import Instantiate from '../instantiate/containers';
+import InstanceSelection from '../instantiate/containers/InstanceSelection';
 import NoValidPartiesError from '../instantiate/containers/NoValidPartiesError';
 
 export default function Entrypoint() {
@@ -17,6 +19,7 @@ export default function Entrypoint() {
   const selectedParty = useSelector((state: IRuntimeState) => state.party.selectedParty);
   const [action, setAction] = React.useState<string>(null);
   const [partyValidation, setPartyValidation] = React.useState(null);
+  const [activeInstances, setActiveInstances] = React.useState<ISimpleInstance[]>(null);
   const statelessLoading: boolean = useSelector((state: IRuntimeState) => state.isLoading.stateless);
   const dispatch = useDispatch();
 
@@ -32,6 +35,33 @@ export default function Entrypoint() {
       throw new Error('Server did not respond with party validation');
     }
   };
+
+  const fetchExistingInstances = async () => {
+    try {
+      // const { data } = await get(getActiveInstancesUrl(selectedParty.partyId));'
+      // todo: remove this dummy api response when api has been fixed
+      const data: ISimpleInstance[] = [
+        { id: 'some-id', lastChanged: '28-01-1992', lastChangedBy: 'Steffen Ekeberg' },
+        { id: 'some-id', lastChanged: '06-03-1974', lastChangedBy: 'Marius Ekeberg' },
+        { id: 'some-id', lastChanged: '12-07-2004', lastChangedBy: 'Emma Ekeberg' },
+        { id: 'some-id', lastChanged: '19-10-1998', lastChangedBy: 'Tine Ekeberg' },
+      ];
+      setActiveInstances(data);
+    } catch (err) {
+      console.error(err);
+      throw new Error('Server did not return active instances');
+    }
+  };
+
+  const handleNewInstance = () => {
+    setAction('new-instance');
+  };
+
+  React.useEffect(() => {
+    if (action === 'instance-selection' && partyValidation?.valid) {
+      fetchExistingInstances();
+    }
+  }, [action, partyValidation]);
 
   React.useEffect(() => {
     if (selectedParty) {
@@ -66,8 +96,27 @@ export default function Entrypoint() {
     return <Instantiate />;
   }
 
+  if (action === 'instance-selection' && partyValidation?.valid && activeInstances !== null) {
+    if (activeInstances.length === 0) {
+      // no existing instances exist, we start instantiation
+      return <Instantiate />;
+    }
+    return (
+      // let user decide if continuing on existing or starting new
+      <Presentation
+        header={applicationMetadata?.title?.nb}
+        type={ProcessTaskType.Unknown}
+      >
+        <InstanceSelection
+          instances={activeInstances}
+          onNewInstance={handleNewInstance}
+        />
+      </Presentation>
+    );
+  }
+
   // stateless view
-  if (action && partyValidation?.valid) {
+  if (isStatelessApp(applicationMetadata) && partyValidation?.valid) {
     if (statelessLoading === null) {
       dispatch(startInitialStatelessQueue());
     }
@@ -91,7 +140,7 @@ export default function Entrypoint() {
       type={ProcessTaskType.Unknown}
     >
       <AltinnContentLoader width='100%' height='400'>
-        <AltinnContentIconFormData/>
+        <AltinnContentIconFormData />
       </AltinnContentLoader>
     </Presentation>
   );

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -2,12 +2,14 @@
 /* eslint-disable react/no-array-index-key */
 /* eslint-disable max-len */
 import React from 'react';
-import { Grid, makeStyles, createTheme, TableContainer, Table, TableHead, TableRow, TableBody, TableCell, IconButton, useMediaQuery } from '@material-ui/core';
+import { Grid, makeStyles, createTheme, TableRow, TableCell, IconButton, useMediaQuery } from '@material-ui/core';
 import altinnAppTheme from 'altinn-shared/theme/altinnAppTheme';
 import { getLanguageFromKey } from 'altinn-shared/utils';
 import { componentHasValidations, repeatingGroupHasValidations } from 'src/utils/validation';
 import { createRepeatingGroupComponents } from 'src/utils/formLayout';
 import { getFormDataForComponentInRepeatingGroup, getTextResource } from 'src/utils/formComponentUtils';
+import { AltinnMobileTable, AltinnMobileTableItem, AltinnTable, AltinnTableBody, AltinnTableHeader, AltinnTableRow } from 'altinn-shared/components';
+import { IMobileTableItem } from 'altinn-shared/components/molecules/AltinnMobileTableItem';
 import { ILayout, ILayoutComponent, ILayoutGroup } from '../layout';
 import { setupGroupComponents } from '../../../utils/layout';
 import { ITextResource, IRepeatingGroups, IValidations, IOptions } from '../../../types';
@@ -34,39 +36,6 @@ export interface IRepeatingGroupTableProps {
 const theme = createTheme(altinnAppTheme);
 
 const useStyles = makeStyles({
-  table: {
-    tableLayout: 'fixed',
-    marginBottom: '12px',
-    wordBreak: 'break-word',
-  },
-  tableHeader: {
-    borderBottom: `2px solid ${theme.altinnPalette.primary.blueMedium}`,
-    '& th': {
-      fontSize: '1.4rem',
-      padding: '0px',
-      paddingLeft: '6px',
-      '& p': {
-        fontWeight: 500,
-        fontSize: '1.4rem',
-        padding: '0px',
-        paddingLeft: '6px',
-      },
-    },
-  },
-  tableBody: {
-    '& td': {
-      borderBottom: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,
-      padding: '0px',
-      paddingLeft: '6px',
-      fontSize: '1.4rem',
-      whiteSpace: 'nowrap',
-      textOverflow: 'ellipsis',
-      overflow: 'hidden',
-    },
-  },
-  tableRowError: {
-    backgroundColor: '#F9CAD3;',
-  },
   errorIcon: {
     fontSize: '2em',
     minWidth: '0px',
@@ -75,39 +44,7 @@ const useStyles = makeStyles({
   },
   editIcon: {
     paddingLeft: '6px',
-  },
-  mobileGrid: {
-    borderBottom: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,
-    paddingLeft: '0.6rem',
-    paddingRight: '0.6rem',
-  },
-  mobileContainer: {
-    borderTop: `2px solid ${theme.altinnPalette.primary.blueMedium}`,
-    marginBottom: '1.2rem',
-  },
-  mobileText: {
-    fontWeight: 500,
-    float: 'left',
-    maxWidth: '50%',
-    whiteSpace: 'nowrap',
-    textOverflow: 'ellipsis',
-    overflow: 'hidden',
-    '& p': {
-      fontWeight: 500,
-    },
-  },
-  mobileValueText: {
-    whiteSpace: 'nowrap',
-    textOverflow: 'ellipsis',
-    overflow: 'hidden',
-    maxWidth: '50%',
-    minWidth: '50%',
-  },
-  textContainer: {
-    width: '100%',
-    whiteSpace: 'nowrap',
-    textOverflow: 'ellipsis',
-    overflow: 'hidden',
+    fontSize: '24px',
   },
 });
 
@@ -190,9 +127,8 @@ export function RepeatingGroupTable({
       id={`group-${id}`}
     >
       {!mobileView &&
-      <TableContainer component={Grid}>
-        <Table className={classes.table}>
-          <TableHead className={classes.tableHeader}>
+        <AltinnTable id={`group-${id}-table`}>
+          <AltinnTableHeader id={`group-${id}-table-header`}>
             <TableRow>
               {componentTitles.map((title: string) => (
                 <TableCell align='left' key={title}>
@@ -201,8 +137,8 @@ export function RepeatingGroupTable({
               ))}
               <TableCell/>
             </TableRow>
-          </TableHead>
-          <TableBody className={classes.tableBody}>
+          </AltinnTableHeader>
+          <AltinnTableBody id={`group-${id}-table-body`}>
             {(repeatingGroupIndex >= 0) && [...Array(repeatingGroupIndex + 1)].map((_x: any, index: number) => {
               const rowHasErrors = repeatingGroupDeepCopyComponents[index].some((component: ILayoutComponent | ILayoutGroup) => {
                 return childElementHasErrors(component, index);
@@ -214,7 +150,7 @@ export function RepeatingGroupTable({
               }
 
               return (
-                <TableRow className={rowHasErrors ? classes.tableRowError : ''} key={index}>
+                <AltinnTableRow valid={!rowHasErrors} key={index}>
                   {components.map((component: ILayoutComponent) => {
                     const childId = (component as any).baseComponentId || component.id;
                     if (!tableHeaderComponents.includes(childId)) {
@@ -227,75 +163,56 @@ export function RepeatingGroupTable({
                     );
                   })}
                   <TableCell align='right' key={`delete-${index}`}>
-                    <IconButton style={{ color: 'black' }} onClick={() => onClickEdit(index)}>
+                    <IconButton style={{ color: theme.altinnPalette.primary.blueDark, fontWeight: 700 }} onClick={() => onClickEdit(index)}>
                       {rowHasErrors ?
                         getLanguageFromKey('general.edit_alt_error', language) :
                         getLanguageFromKey('general.edit_alt', language)}
                       <i className={rowHasErrors ?
                         `ai ai-circle-exclamation a-icon ${classes.errorIcon} ${classes.editIcon}` :
-                        `fa fa-editing-file ${classes.editIcon}`}
+                        `fa fa-edit ${classes.editIcon}`}
                       />
                     </IconButton>
                   </TableCell>
-                </TableRow>);
+                </AltinnTableRow>);
             })}
-          </TableBody>
-        </Table>
-      </TableContainer>}
+          </AltinnTableBody>
+        </AltinnTable>}
       {mobileView &&
-      <Grid
-        container={true}
-        item={true}
-        direction='column'
-        className={classes.mobileContainer}
-      >
+      <AltinnMobileTable id={`group-${id}-table`}>
         {(repeatingGroupIndex >= 0) && [...Array(repeatingGroupIndex + 1)].map((_x: any, index: number) => {
           const rowHasErrors = repeatingGroupDeepCopyComponents[index].some((component: ILayoutComponent | ILayoutGroup) => {
             return childElementHasErrors(component, index);
           });
+          const items: IMobileTableItem[] = [];
+          components.forEach((component) => {
+            const childId = (component as any).baseComponentId || component.id;
+            if (tableHeaderComponents.includes(childId)) {
+              items.push({
+                label: getTextResource(component?.textResourceBindings?.title, textResources),
+                value: getFormDataForComponent(component, index),
+              });
+            }
+          });
           return (
-            <Grid
-              item={true} container={true}
-              justifyContent='flex-end' direction='row'
-              className={`${classes.mobileGrid} ${rowHasErrors ? classes.tableRowError : ''}`}
-            >
-              <Grid item={true}>
-                <IconButton
-                  style={{
-                    color: 'black', padding: '0px', paddingLeft: '6px',
-                  }} onClick={() => onClickEdit(index)}
-                >
+            <AltinnMobileTableItem
+              items={items}
+              valid={!rowHasErrors}
+              onClick={() => onClickEdit(index)}
+              iconNode={
+                <>
                   {rowHasErrors ?
                     getLanguageFromKey('general.edit_alt_error', language) :
                     getLanguageFromKey('general.edit_alt', language)}
                   <i className={rowHasErrors ?
                     `ai ai-circle-exclamation ${classes.errorIcon}` :
-                    `fa fa-editing-file ${classes.editIcon}`}
+                    `fa fa-edit ${classes.editIcon}`}
                   />
-                </IconButton>
-              </Grid>
-              {components.map((component: ILayoutComponent) => {
-                const childId = (component as any).baseComponentId || component.id;
-                if (!tableHeaderComponents.includes(childId)) {
-                  return null;
-                }
-                return (
-                  <Grid item={true} className={rowHasErrors ? `${classes.tableRowError} ${classes.textContainer}` : classes.textContainer}>
-                    <div className={classes.mobileText}>
-                      {getTextResource(component?.textResourceBindings?.title || '', textResources)}
-                    </div>
-                    <div
-                      className={classes.mobileValueText}
-                    >
-                      {`: ${getFormDataForComponent(component, index)}`}
-                    </div>
-                  </Grid>
-                );
-              })}
-            </Grid>
+                </>
+              }
+            />
           );
         })}
-      </Grid>
+      </AltinnMobileTable>
       }
     </Grid>
   );

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/datamodel/fetch/fetchFormDatamodelSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/datamodel/fetch/fetchFormDatamodelSagas.ts
@@ -3,7 +3,7 @@ import { SagaIterator } from 'redux-saga';
 import { call, select, all, take, put } from 'redux-saga/effects';
 import { getJsonSchemaUrl } from 'src/utils/urlHelper';
 import { IInstance } from 'altinn-shared/types';
-import { getCurrentDataTypeForApplication } from 'src/utils/appMetadata';
+import { getCurrentDataTypeForApplication, isStatelessApp } from 'src/utils/appMetadata';
 import { FETCH_APPLICATION_METADATA_FULFILLED } from 'src/shared/resources/applicationMetadata/actions/types';
 import { dataTaskQueueError } from '../../../../shared/resources/queue/queueSlice';
 import { get } from '../../../../utils/networking';
@@ -43,7 +43,7 @@ export function* watchFetchJsonSchemaSaga(): SagaIterator {
     take(fetchJsonSchema),
   ]);
   const application: IApplicationMetadata = yield select((state: IRuntimeState) => state.applicationMetadata.applicationMetadata);
-  if (application?.onEntry?.show) {
+  if (isStatelessApp(application)) {
     yield call(fetchJsonSchemaSaga);
     while (true) {
       yield take(fetchJsonSchema);

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/InstanceSelection.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/InstanceSelection.tsx
@@ -1,0 +1,109 @@
+import { Grid, IconButton, TableCell, Typography, useMediaQuery } from '@material-ui/core';
+import { AltinnButton, AltinnMobileTable, AltinnMobileTableItem, AltinnTable, AltinnTableBody, AltinnTableHeader, AltinnTableRow } from 'altinn-shared/components';
+import { getLanguageFromKey } from 'altinn-shared/utils';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { IRuntimeState, ISimpleInstance } from 'src/types';
+import { getInstanceUiUrl } from '../../../utils/urlHelper';
+
+export interface IInstanceSelectionProps {
+  instances: ISimpleInstance[];
+  onNewInstance: () => void;
+}
+
+export default function InstanceSelection({ instances, onNewInstance }: IInstanceSelectionProps) {
+  const language = useSelector((state: IRuntimeState) => state.language.language);
+  const mobileView = useMediaQuery('(max-width:992px)'); // breakpoint on altinn-modal
+
+  const openInstance = (instanceId: string) => {
+    window.location.href = getInstanceUiUrl(instanceId);
+  };
+
+  const renderMobileTable = () => {
+    return (
+      <>
+        <Typography variant='h3'>
+          {getLanguageFromKey('instance_selection.left_of', language)}
+        </Typography>
+        <AltinnMobileTable id='instance-selection-mobile-table'>
+          {instances.map((instance) => {
+            return (
+              <AltinnMobileTableItem
+                items={[
+                  { label: getLanguageFromKey('instance_selection.last_changed', language), value: instance.lastChanged },
+                  { label: getLanguageFromKey('instance_selection.changed_by', language), value: instance.lastChangedBy },
+                ]}
+                onClick={() => openInstance(instance.id)}
+                iconNode={
+                  <>
+                    <Typography variant='body1' style={{ color: '#0062BA', marginRight: '4px', fontWeight: 700 }}>
+                      {getLanguageFromKey('instance_selection.continue', language)}
+                    </Typography>
+                    <i className='fa fa-edit' style={{ color: '#0062BA', fontSize: '24px' }} />
+                  </>
+                }
+              />
+            );
+          })}
+        </AltinnMobileTable>
+      </>
+    );
+  };
+
+  const renderTable = () => {
+    return (
+      <AltinnTable id='instance-selection-table'>
+        <AltinnTableHeader id='instance-selection-table-header'>
+          <AltinnTableRow>
+            <TableCell>{getLanguageFromKey('instance_selection.last_changed', language)}</TableCell>
+            <TableCell>{getLanguageFromKey('instance_selection.changed_by', language)}</TableCell>
+          </AltinnTableRow>
+        </AltinnTableHeader>
+        <AltinnTableBody id='instance-selection-table-body'>
+          {instances.map((instance: ISimpleInstance) => {
+            return (
+              <AltinnTableRow>
+                <TableCell>{instance.lastChanged}</TableCell>
+                <TableCell>{instance.lastChangedBy}</TableCell>
+                <TableCell align='right'>
+                  <IconButton onClick={() => openInstance(instance.id)}>
+                    <Typography variant='body1' style={{ color: '#0062BA', marginRight: '4px', fontWeight: 700 }}>
+                      {getLanguageFromKey('instance_selection.continue', language)}
+                    </Typography>
+                    <i className='fa fa-edit' style={{ color: '#0062BA', fontSize: '24px' }} />
+                  </IconButton>
+                </TableCell>
+              </AltinnTableRow>
+            );
+          })}
+        </AltinnTableBody>
+      </AltinnTable>
+    );
+  };
+
+  return (
+    <Grid container id='instance-selection-container'>
+      <Grid item>
+        <Typography variant='h2' id='instance-selection-header'>
+          {getLanguageFromKey('instance_selection.header', language)}
+        </Typography>
+      </Grid>
+      <Grid item id='instance-selection-description'>
+        <Typography variant='body1' style={{ marginTop: '12px' }}>
+          {getLanguageFromKey('instance_selection.description', language)}
+        </Typography>
+      </Grid>
+      <Grid item style={{ marginTop: '26px' }}>
+        {mobileView && renderMobileTable()}
+        {!mobileView && renderTable()}
+      </Grid>
+      <Grid item style={{ marginTop: '12px' }}>
+        <AltinnButton
+          btnText={getLanguageFromKey('instance_selection.new_instance', language)}
+          onClickFunction={onNewInstance}
+          id='new-instance-button'
+        />
+      </Grid>
+    </Grid>
+  );
+}

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/types/index.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/types/index.ts
@@ -225,6 +225,12 @@ export interface ISchemaValidator {
   validator: Ajv;
 }
 
+export interface ISimpleInstance {
+  id: string;
+  lastChanged: string;
+  lastChangedBy: string;
+}
+
 export interface ITextResource {
   id: string;
   value: string;

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/appMetadata.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/appMetadata.ts
@@ -18,6 +18,15 @@ export function getDataTypeByLayoutSetId(layoutSetId: string, layoutSets: ILayou
 }
 
 /**
+ * Application metadata onEntry.show values that have a state full application
+ */
+export const onEntryValuesThatHaveState: string[] = [
+  'new-instance',
+  'instance-selection',
+  'start-page',
+];
+
+/**
  * Get the current layout set for application if it exists
  * @param application the application metadata
  * @param instance the instance if present
@@ -30,7 +39,7 @@ export function getLayoutSetIdForApplication(
   layoutSets?: ILayoutSets,
 ): string {
   const showOnEntry: string = application?.onEntry?.show;
-  if (showOnEntry && showOnEntry !== 'new-instance' && showOnEntry !== 'startpage') {
+  if (showOnEntry && !onEntryValuesThatHaveState.includes(showOnEntry)) {
     // we have a stateless app with a layout set
     return showOnEntry;
   }
@@ -57,7 +66,7 @@ export function getCurrentDataTypeForApplication(
   layoutSets?: ILayoutSets,
 ): string {
   const showOnEntry: string = application?.onEntry?.show;
-  if (showOnEntry && showOnEntry !== 'new-instance' && showOnEntry !== 'startpage') {
+  if (showOnEntry && !onEntryValuesThatHaveState.includes(showOnEntry)) {
     // we have a stateless app with a layout set
     return getDataTypeByLayoutSetId(showOnEntry, layoutSets);
   }
@@ -67,6 +76,6 @@ export function getCurrentDataTypeForApplication(
 }
 
 export function isStatelessApp(application: IApplication) {
-  const show = application.onEntry?.show;
-  return show && show !== 'new-instance';
+  const show = application?.onEntry?.show;
+  return show && !onEntryValuesThatHaveState.includes(show);
 }

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/urlHelper.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/urlHelper.ts
@@ -168,3 +168,11 @@ export function getCalculatePageOrderUrl() {
 export function getPartyValidationUrl(partyId: string) {
   return `${appPath}/api/v1/parties/validateInstantiation?partyId=${partyId}`;
 }
+
+export function getActiveInstancesUrl(partyId: string) {
+  return `${appPath}/instances/${partyId}/active`;
+}
+
+export function getInstanceUiUrl(instanceId: string) {
+  return `${appPath}#/instance/${instanceId}`;
+}

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/components/index.ts
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/components/index.ts
@@ -38,8 +38,15 @@ export { default as AltinnInformationCardForChildren } from './molecules/AltinnI
 export { default as AltinnModal } from './molecules/AltinnModal';
 export { default as AltinnPopoverSimple } from './molecules/AltinnPopoverSimple';
 export { default as AltinnSubstatusPaper } from './molecules/AltinnSubstatusPaper';
+export { AltinnTableHeader } from './molecules/AltinnTableHeader';
+export { default as AltinnTableItem } from './molecules/AltinnTableItem';
+export { default as AltinnTableBody } from './molecules/AltinnTableBody';
+export { default as AltinnTableRow } from './molecules/AltinnTableRow';
+export { default as AltinnMobileTable } from './molecules/AltinnMobileTable';
+export { default as AltinnMobileTableItem } from './molecules/AltinnMobileTableItem';
 
 // organisms
 export { default as AltinnAppHeader } from './organisms/AltinnAppHeader';
 export { default as AltinnReceipt } from './organisms/AltinnReceipt';
 export { default as AltinnReceiptSimple } from './organisms/AltinnReceiptSimple';
+export { default as AltinnTable } from './organisms/AltinnTable';

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnMobileTable.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnMobileTable.tsx
@@ -1,0 +1,31 @@
+import { Grid, makeStyles } from '@material-ui/core';
+import React from 'react';
+import theme from '../../theme/altinnStudioTheme';
+
+export interface IAltinnMobileTableProps {
+  children: React.ReactNode;
+  id: string;
+}
+
+const useStyles = makeStyles({
+  mobileContainer: {
+    borderTop: `2px solid ${theme.altinnPalette.primary.blueMedium}`,
+    marginBottom: '1.2rem',
+  },
+});
+
+export default function AltinnMobileTable({ children, id }: IAltinnMobileTableProps) {
+  const classes = useStyles();
+
+  return (
+    <Grid
+      container={true}
+      item={true}
+      direction='column'
+      className={classes.mobileContainer}
+      id={id}
+    >
+      {children}
+    </Grid>
+  );
+}

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnMobileTableItem.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnMobileTableItem.tsx
@@ -1,0 +1,103 @@
+import { Grid, IconButton, makeStyles, Table, TableCell, TableContainer, TableRow, Typography } from '@material-ui/core';
+import React from 'react';
+import theme from '../../theme/altinnStudioTheme';
+
+export interface IMobileTableItem {
+  label: string;
+  value: string;
+}
+
+export interface IAltinnMobileTableItemProps {
+  items: IMobileTableItem[];
+  valid?: boolean;
+  onClick: () => void;
+  iconNode: React.ReactNode;
+}
+
+const useStyles = makeStyles({
+  tableContainer: {
+    borderBottom: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,
+    paddingLeft: '0.6rem',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  table: {
+    tableLayout: 'fixed',
+    marginTop: '1.2rem',
+    marginBottom: '1.2rem',
+    '& tr': {
+      '& td': {
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+        maxWidth: '50%',
+        minWidth: '50%',
+        padding: 0,
+        paddingRight: '5px',
+        border: 'none',
+      },
+    },
+  },
+  tableRowError: {
+    backgroundColor: '#F9CAD3;',
+  },
+  labelText: {
+    color: theme.altinnPalette.primary.grey,
+  },
+  iconButton: {
+    color: theme.altinnPalette.primary.blueDark,
+    padding: '0px',
+    fontWeight: 700,
+  },
+  textContainer: {
+    width: '100%',
+    display: 'block',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+});
+
+export default function AltinnMobileTableItem({
+  items, valid = true, onClick, iconNode,
+}: IAltinnMobileTableItemProps) {
+  const classes = useStyles();
+
+  return (
+    <TableContainer
+      component={Grid}
+      className={`${classes.tableContainer} ${valid ? '' : classes.tableRowError}`}
+    >
+      <Table className={classes.table}>
+        {items.map((item) => {
+          return (
+            <TableRow>
+              <TableCell variant='head' width='40%'>
+                <Typography variant='body1' className={`${classes.labelText} ${classes.textContainer}`}>
+                  {item.label}
+                </Typography>
+              </TableCell>
+              <TableCell>
+                <Typography variant='body1' className={classes.textContainer}>
+                  {item.value}
+                </Typography>
+              </TableCell>
+            </TableRow>
+          );
+        })}
+        <TableRow>
+          <TableCell width='40%' />
+          <TableCell>
+            <IconButton
+              className={classes.iconButton}
+              onClick={onClick}
+            >
+              {iconNode}
+            </IconButton>
+          </TableCell>
+        </TableRow>
+      </Table>
+    </ TableContainer>
+  );
+}

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnTableBody.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnTableBody.tsx
@@ -1,0 +1,38 @@
+import { makeStyles, TableBody } from "@material-ui/core";
+import React from 'react';
+import theme from '../../theme/altinnAppTheme';
+
+export interface IAltinnTableBody {
+  children: React.ReactNode;
+  id: string;
+}
+
+const useStyles = makeStyles({
+  tableBody: {
+    '& td': {
+      borderBottom: `2px dotted ${theme.altinnPalette.primary.blueMedium}`,
+      padding: '0px',
+      paddingLeft: '6px',
+      fontSize: '1.4rem',
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
+    },
+    '& tr': {
+      '&:hover': {
+        background: theme.altinnPalette.primary.blueLighter,
+      }
+    }
+  },
+});
+
+export default function AltinnTableBody(props: IAltinnTableBody) {
+  const { children, id } = props;
+  const classes = useStyles();
+
+  return (
+    <TableBody className={classes.tableBody} id={id}>
+      { children }
+    </TableBody>
+  );
+}

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnTableHeader.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnTableHeader.tsx
@@ -1,0 +1,42 @@
+import { TableHead } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core';
+import React from 'react';
+import theme from '../../theme/altinnAppTheme';
+
+export interface IAltinnTableHeaderProps {
+  id: string;
+  children: React.ReactNode;
+}
+
+const useStyles = makeStyles({
+  table: {
+    tableLayout: 'fixed',
+    marginBottom: '12px',
+    wordBreak: 'break-word',
+  },
+  tableHeader: {
+    borderBottom: `2px solid ${theme.altinnPalette.primary.blueMedium}`,
+    '& th': {
+      fontSize: '1.4rem',
+      padding: '0px',
+      paddingLeft: '6px',
+      '& p': {
+        fontWeight: 500,
+        fontSize: '1.4rem',
+        padding: '0px',
+        paddingLeft: '6px',
+      },
+    },
+  },
+});
+
+export function AltinnTableHeader(props: IAltinnTableHeaderProps) {
+  const { children, id } = props;
+  const classes = useStyles();
+  return (
+    <TableHead id={id} className={classes.tableHeader}>
+      {children}
+    </TableHead>
+
+  );
+}

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnTableItem.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnTableItem.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+
+export default function AltinnTableItem() {
+  return (
+    <> Here comes the AltinnTableItem </>
+  );
+}

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnTableRow.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnTableRow.tsx
@@ -1,0 +1,25 @@
+import { makeStyles, TableRow } from "@material-ui/core";
+import React from "react";
+
+export interface IAltinnTableRow {
+  children: React.ReactNode;
+  id?: string;
+  valid?: boolean;
+}
+
+const useStyles = makeStyles({
+  tableRowError: {
+    backgroundColor: '#F9CAD3;',
+  },
+});
+
+export default function AltinnTableRow(props: IAltinnTableRow) {
+  const classes = useStyles();
+  const { children, id, valid } = props;
+
+  return (
+    <TableRow id={id} className={valid === false ? classes.tableRowError : ''}>
+      { children }
+    </TableRow>
+  );
+}

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/components/organisms/AltinnTable.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/components/organisms/AltinnTable.tsx
@@ -1,0 +1,29 @@
+import { Grid, makeStyles, Table, TableContainer } from '@material-ui/core';
+import React from 'react';
+
+export interface IAltinnTableProps {
+  children: React.ReactNode;
+  id: string;
+}
+
+const useStyles = makeStyles({
+  table: {
+    tableLayout: 'fixed',
+    marginBottom: '12px',
+    wordBreak: 'break-word',
+  },
+});
+
+export default function AltinnTable(props: IAltinnTableProps) {
+  const {
+    id, children,
+  } = props;
+  const classes = useStyles();
+  return (
+    <TableContainer component={Grid} id={`${id}-container`}>
+      <Table className={classes.table} id={id}>
+        {children}
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/language/texts/en.ts
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/language/texts/en.ts
@@ -121,6 +121,15 @@ export function en() {
     group: {
       row_error: 'One of the rows is incorrectly filled out. This has to bee fixed before the schema can be submitted.',
     },
+    instance_selection: {
+      changed_by: 'Changed by',
+      continue: 'Continue here',
+      description: 'Choose if you want to continue on an existing form, or if you want to start on a new one.',
+      header: 'You have already started filling out this form.',
+      last_changed: 'Last changed',
+      left_of: 'Continue where you left of',
+      new_instance: 'Start over',
+    },
     instantiate: {
       all_forms: 'all forms',
       inbox: 'inbox',

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/language/texts/nb.ts
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/language/texts/nb.ts
@@ -121,6 +121,15 @@ export function nb() {
     group: {
       row_error: 'En av radene er ikke fylt ut riktig, dette må fikses før skjema kan sendes inn',
     },
+    instance_selection: {
+      changed_by: 'Endret av',
+      continue: 'Fortsett her',
+      description: 'Velg om du vil fortsette på et skjema du har begynt på, eller om du vil starte på ny.',
+      header: 'Du har allerede startet å fylle ut dette skjemaet.',
+      last_changed: 'Sist endret',
+      left_of: 'Fortsett der du slapp',
+      new_instance: 'Start på nytt',
+    },
     instantiate: {
       all_forms: 'alle skjema',
       inbox: 'innboks',

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/language/texts/nn.ts
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/language/texts/nn.ts
@@ -117,6 +117,15 @@ export function nn() {
     group: {
       row_error: 'Ei av radene er ikkje fylt ut riktig. Dette må bli retta før skjema kan sendast inn.',
     },
+    instance_selection: {
+      changed_by: 'Endret av',
+      continue: 'Fortsett her',
+      description: 'Velg om du vil fortsette på et skjema du har begynt på, eller om du vil starte på ny.',
+      header: 'Du har allerede startet å fylle ut dette skjemaet.',
+      last_changed: 'Sist endret',
+      left_of: 'Fortsett der du slapp',
+      new_instance: 'Start på nytt',
+    },
     instantiate: {
       all_forms: 'alle skjema',
       inbox: 'innboks',

--- a/src/development/LocalTest/Services/Storage/Implementation/InstanceQueryResponse.cs
+++ b/src/development/LocalTest/Services/Storage/Implementation/InstanceQueryResponse.cs
@@ -11,12 +11,6 @@ namespace Altinn.Platform.Storage.Repository
     public class InstanceQueryResponse
     {
         /// <summary>
-        /// The total number of instances that matched the query. May be removed for performance issues.
-        /// </summary>
-        [JsonProperty(PropertyName = "totalHits")]
-        public int? TotalHits { get; set; }
-
-        /// <summary>
         /// The number of instances returned in this response.
         /// </summary>
         [JsonProperty(PropertyName = "count")]
@@ -29,7 +23,7 @@ namespace Altinn.Platform.Storage.Repository
         public string Next { get; set; }
 
         /// <summary>
-        /// The url to the query that created this page. 
+        /// The url to the query that created this page.
         /// </summary>
         [JsonProperty(PropertyName = "self")]
         public string Self { get; set; }


### PR DESCRIPTION
#6766 

- Now possible to start an existing instance from app-frontend
- Refactored `RepeatingGroupTable` to split out relevant components for easier re-use in the new `InstanceSelection`-component.

Should not be merged until #6767 is working. 