### PR TITLE
Use VScode Tasks to quickly start everything required for local studio and LocalTest

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,20 +1,103 @@
 {
-    // See https://code.visualstudio.com/docs/editor/tasks for documentation about the tasks.json format
-    "version": "2.0.0",
-    "command": "dotnet",
-    "isShellCommand": true,
-    "args": [],
-    "tasks": [
-         {
-            "taskName": "restore",
-            "isBuildCommand": false,
-            "showOutput": "always"
-        },
-        {
-            "taskName": "build",
-            "isBuildCommand": true,
-            "showOutput": "always",
-            "problemMatcher": "$msCompile"
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "RunLocalTest",
+      "dependsOn": [
+        "docker up LocalTest",
+        "LocalTest"
+      ]
+    },
+    {
+      "label": "Run studio docker",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "compose",
+        "up",
+        "--abort-on-container-exit"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/src/studio/src/designer"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "RunStudioLocalDesigner",
+      "dependsOn": [
+        "designer frontend",
+        "designer backend",
+        "docker up no designer"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "docker up LocalTest",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "compose",
+        "up",
+        "--build",
+        "--abort-on-container-exit"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/src/development"
+      }
+    },
+    {
+      "label": "LocalTest",
+      "command": "dotnet",
+      "args": [
+        "run"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/src/development/LocalTest"
+      }
+    },
+    {
+      "label": "designer frontend",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "webpack-watch"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/src/studio/src/designer/frontend/app-development"
+      }
+    },
+    {
+      "label": "designer backend",
+      "type": "shell",
+      "command": "dotnet",
+      "args": [
+        "watch",
+        "run"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/src/studio/src/designer/backend",
+        "env": {
+          "DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER": "1"
         }
-    ]
+      }
+    },
+    {
+      "label": "docker up no designer",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "compose",
+        "-fdocker-compose.yml",
+        "-fdocker-compose.no-designer.yml",
+        "up",
+        "--build",
+        "--abort-on-container-exit"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/src/studio/"
+      },
+      "problemMatcher": []
+    }
+  ]
 }

--- a/src/studio/docker-compose.no-designer.yml
+++ b/src/studio/docker-compose.no-designer.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+
+# In order for the nginx config that references altinm_designer to not crash on startup
+# we need to have a service with the same name running but not answering on port 5000
+
+# The solution I found was an override file that runs alpine-lates on this port
+# so that nginx origin answers for DNS, but uses the backup endpoint on the host machine.
+services:
+  altinn_designer:
+    container_name: altinn-designer
+    image: alpine:latest
+    networks:
+      - altinncore_network
+    entrypoint: ["sleep","infinity"]
+    # Build is required because original config for altinn_designer is merged
+    build:
+      context: ./src/load-balancer
+      dockerfile: "Dockerfile"
+
+ 


### PR DESCRIPTION
This adds two composite tasks in `.vscode/tasks.json`
* RunStudioDesigner (runs docker containers and local versions of frontend and backend of designer with watch functionality)
* RunLocalTest (runs docker containers required for local test)

The main benefit is that this starts in three terminal sessions (in vs code) so that you can see messages from each without competing as in the old `npm run gulp-develop`. Another benefit is that they are in the root of the repo, so you don't have to remeber which directory to `cd` into.

If this is desired, we should probably add a step to run all the `npm install/ci` commands for a clean pull to work.

I had to do an ugly hack for nginx and docker to be happy with not
building-starting-stopping altinn-designer
To acheive this, I created another compose file that overwrites
altinn-designer with an empty alpine container that sleeps and
don't reply on port 5000, but still resolves DNS so that nginx can start.

https://user-images.githubusercontent.com/131616/135423641-3d01fc7c-30ee-461a-b020-0d89f72be6a1.mp4



