### PR TITLE
Increment ABAC package/file/assembly version for new nuget release

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Altinn.Authorization.ABAC/Altinn.Authorization.ABAC.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Altinn.Authorization.ABAC/Altinn.Authorization.ABAC.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>0.0.0.4</AssemblyVersion>
-    <FileVersion>0.0.0.4</FileVersion>
+    <AssemblyVersion>0.0.0.5</AssemblyVersion>
+    <FileVersion>0.0.0.5</FileVersion>
     <!-- SonarCloud requires a ProjectGuid to separate projects. -->
     <ProjectGuid>{C9ABF5DB-928C-4280-B587-13E6DCE010BC}</ProjectGuid>
     
     <!-- NuGet package properties -->
     <PackageId>Altinn.Authorization.ABAC</PackageId>
-    <PackageVersion>0.0.4-alpha</PackageVersion>
+    <PackageVersion>0.0.5-alpha</PackageVersion>
     <PackageTags>Altinn;Authorization;ABAC</PackageTags>
     <Description>
       Attribute Based Access Control library for .Net Core implementing XACML 3.0 xml and JSON Profile.


### PR DESCRIPTION
#6729 introduced changes to XacmlSerializer in order to be able to serialize a complete XACML Policy model.

Forgot in the process to increment package/file/assembly version in order to prepare new nuget package release, needed in order to use the changes from Platform.Authorization.