### PR TITLE
// eslint-disable-next-line react/jsx-no-bind

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/PartySelection.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-nested-ternary */
+/* eslint-disable react/jsx-no-bind */
 /* eslint-disable implicit-arrow-linebreak */
 import { createStyles, Grid, Typography, withStyles, WithStyles } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/components/altinnPartySearch.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/components/altinnPartySearch.tsx
@@ -42,6 +42,7 @@ function AltinnPartySearch(props: IAltinnPartySearchProps) {
             language.party_selection.search_placeholder
         }
         showLabel={false}
+        // eslint-disable-next-line react/jsx-no-bind
         onChange={onChangeSearchString}
         placeholder={
           !language.party_selection ?

--- a/src/Altinn.Apps/AppTemplates/react/altinn-app-frontend/src/components/altinnPartySearch.tsx
+++ b/src/Altinn.Apps/AppTemplates/react/altinn-app-frontend/src/components/altinnPartySearch.tsx
@@ -44,6 +44,7 @@ function AltinnPartySearch(props: IAltinnPartySearchProps) {
             language.party_selection.search_placeholder
         }
         showLabel={false}
+        // eslint-disable-next-line react/jsx-no-bind
         onChange={onChangeSearchString}
         placeholder={
           !language.party_selection ?


### PR DESCRIPTION
Theese are ignored in PartySelection.tsx as well, and are really annoying when they break

```
altinn-studio\src\Altinn.Apps\AppFrontend\react\altinn-app-frontend> npm start
```

Not sure if these should be fixed instead of ignored, but such changes tend to have unintended consequences and some testing to ensure unchanged behaviour would be required.