### PR TITLE
Correct PDF generator language

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
@@ -119,7 +119,7 @@ public class PDFGenerator {
     String defaultAppearance = "/Helv 10 Tf 0 0 0 rg";
     form.setDefaultAppearance(defaultAppearance);
     catalog.setAcroForm(form);
-    catalog.setLanguage("Norwegian"); // hardcoded for now, will be solved by issue #1253
+    catalog.setLanguage(getLanguage());
     catalog.setMarkInfo(new PDMarkInfo());
     catalog.getMarkInfo().setMarked(true);
     catalog.setViewerPreferences(new PDViewerPreferences(new COSDictionary()));


### PR DESCRIPTION
Just a small one, The comment peaked my interest, and apparently it was solved in https://github.com/Altinn/altinn-studio/pull/4669, but the comment remained.

According to https://www.w3.org/TR/WCAG20-TECHS/PDF16.html, the language
we should set in the document catalog is the  ISO 639 language code, not
a string of the language name in english.

