### PR TITLE
move sleep before check

### DIFF
--- a/src/test/K6/src/tests/app/performance/memo.js
+++ b/src/test/K6/src/tests/app/performance/memo.js
@@ -174,8 +174,8 @@ export default function () {
         addErrorCount(success);
         if (res.json('ended') != null) break;
 
-        stepSleepCounter = stepSleepCounter * 2;
         sleptSeconds = sleptSeconds + stepSleepCounter;
+        stepSleepCounter = stepSleepCounter * 2;
         if (sleptSeconds >= waitForTE) stopIterationOnFail('Instance is not archived by TE', null, null);
       }
     }


### PR DESCRIPTION
To wait for and check for at least the given wait sleep should happen before the actual check is performed