### PR TITLE
Add custom pages for 502 Bad Gateway pages

### DIFF
--- a/src/development/loadbalancer/502App.html
+++ b/src/development/loadbalancer/502App.html
@@ -9,7 +9,7 @@
 <body>
   <h1>502 Bad Gateway</h1>
   <h2>Your local APP is not running on port 5005</h2>
-  <p>Please ensure that your app is running on port 5000</p>
+  <p>Please ensure that your app is running on port 5005</p>
   <pre>
     > dotnet run --project App/App.csproj
   </pre>

--- a/src/development/loadbalancer/502App.html
+++ b/src/development/loadbalancer/502App.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your local Altinn app is not running</title>
+</head>
+<body>
+  <h1>502 Bad Gateway</h1>
+  <h2>Your local APP is not running on port 5005</h2>
+  <p>Please ensure that your app is running on port 5000</p>
+  <pre>
+    > dotnet run --project App/App.csproj
+  </pre>
+</body>
+</html>

--- a/src/development/loadbalancer/502LocalTest.html
+++ b/src/development/loadbalancer/502LocalTest.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Localtest is not running</title>
+</head>
+<body>
+  <h1>502 Bad Gateway</h1>
+  <h2>Localtest is not running</h2>
+  <p>Please ensure that LocalTest is running on port 5101</p>
+  <pre>
+    > cd src/development/LocalTest
+    > dotnet run
+  </pre>
+</body>
+</html>

--- a/src/development/loadbalancer/Dockerfile
+++ b/src/development/loadbalancer/Dockerfile
@@ -1,3 +1,5 @@
 FROM nginx:1.21.3-alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
+
+COPY *.html /www/

--- a/src/development/loadbalancer/nginx.conf
+++ b/src/development/loadbalancer/nginx.conf
@@ -8,7 +8,7 @@ http {
 
     sendfile on;
 
-	upstream localtest {
+	  upstream localtest {
         server host.docker.internal:5101;
     }
 
@@ -25,6 +25,7 @@ http {
         proxy_set_header    X-Real-IP $remote_addr;
         proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
 
+    error_page 502 /502LocalTest.html;
 
 		location = / {
         proxy_pass          http://localtest/Home/;
@@ -32,15 +33,22 @@ http {
 
 		location / {
         proxy_pass          http://app/;
+        error_page 502 /502App.html;
 		}
 
 		location /Home/ {
 			  proxy_pass		      http://localtest/Home/;
 		}
 
-    		location /localtestresources/ {
+    location /localtestresources/ {
 			  proxy_pass		      http://localtest/localtestresources/;
 		}
+    location /502LocalTest.html {
+      root /www;
+    }
+    location /502App.html {
+      root /www;
+    }
 
 	}
 }

--- a/src/studio/src/load-balancer/502Designer.html
+++ b/src/studio/src/load-balancer/502Designer.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Designer not running</title>
+</head>
+<body>
+  <h1>502 Bad Gateway</h1>
+  <h2>Altinn designer is not running</h2>
+  <p>Please ensure that altinn designer is running on port 5000</p>
+</body>
+</html>

--- a/src/studio/src/load-balancer/502Repo.html
+++ b/src/studio/src/load-balancer/502Repo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Repo not loaded</title>
+</head>
+<body>
+  <h1>502 Bad Gateway</h1>
+  <h2>Altinn repositories is not running</h2>
+  <p>Please ensure that the docker container <strong>altinn-repositories</strong> is running</p>
+</body>
+</html>

--- a/src/studio/src/load-balancer/Dockerfile
+++ b/src/studio/src/load-balancer/Dockerfile
@@ -2,3 +2,5 @@
 FROM nginx:1.21.3-alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
+
+COPY *.html /www/

--- a/src/studio/src/load-balancer/nginx.conf
+++ b/src/studio/src/load-balancer/nginx.conf
@@ -27,6 +27,8 @@ http {
         proxy_set_header   Host $host;
         proxy_set_header   X-Real-IP $remote_addr;
         proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        
+        error_page 502 /502Designer.html;
 
         location = / {
             proxy_pass         http://designer/;
@@ -53,7 +55,13 @@ http {
 
         location /repos/ {
             proxy_pass         http://repositories/;
+            error_page 502 /502Repo.html;
         }
-
+        location /502Designer.html {
+          root /www;
+        }
+        location /502Repo.html {
+          root /www;
+        }
     }
 }


### PR DESCRIPTION
This makes it easier for inexperienced developers to know what they didn't
start when they get an error.

Please suggest changes that makes the HTML pages even clearer.

### Testing
Note that these changes requires a rebuild of loadbalancer.

Just stop the various services and see that you get a reasonable error page
* stop LocalTest
* stop App
* stop designer (local and docer)
* stop repository (docker container)