### PR TITLE
Add a version query parameter for JS files in designer

### DIFF
--- a/src/studio/src/designer/backend/Views/ServiceDevelopment/index.cshtml
+++ b/src/studio/src/designer/backend/Views/ServiceDevelopment/index.cshtml
@@ -27,8 +27,8 @@
 <link rel="stylesheet" href="~/designer/css/react/app-development.css">
 
 <div id="root" class="media-body flex-column d-flex"></div>
-<script src="~/designer/js/react/app-development.js" type="text/javascript"></script>
-<script src="~/designer/js/react/1.app-development.js" type="text/javascript"></script>
-<script src="~/designer/js/react/2.app-development.js" type="text/javascript"></script>
-<script src="~/designer/js/react/3.app-development.js" type="text/javascript"></script>
-<script src="~/designer/js/react/4.app-development.js" type="text/javascript"></script>
+<script src="~/designer/js/react/app-development.js" asp-append-version="true" type="text/javascript"></script>
+<script src="~/designer/js/react/1.app-development.js" asp-append-version="true" type="text/javascript"></script>
+<script src="~/designer/js/react/2.app-development.js" asp-append-version="true" type="text/javascript"></script>
+<script src="~/designer/js/react/3.app-development.js" asp-append-version="true" type="text/javascript"></script>
+<script src="~/designer/js/react/4.app-development.js" asp-append-version="true" type="text/javascript"></script>


### PR DESCRIPTION
Our webpack setup does not generate a unique hash in the name of the
compilled js files, and this causes issues for developers that need to
do a `hard reload` `Ctrl + Shift + R` in order to see their changes

This asp-append-version="true" is already used for bootstrap/jquery/monaco
on this same page.