### PR TITLE
Fix formatting of numbers in repeating tables

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -10,6 +10,8 @@ import { createRepeatingGroupComponents } from 'src/utils/formLayout';
 import { getFormDataForComponentInRepeatingGroup, getTextResource } from 'src/utils/formComponentUtils';
 import { AltinnMobileTable, AltinnMobileTableItem, AltinnTable, AltinnTableBody, AltinnTableHeader, AltinnTableRow } from 'altinn-shared/components';
 import { IMobileTableItem } from 'altinn-shared/components/molecules/AltinnMobileTableItem';
+import NumberFormat from 'react-number-format';
+import { IInputProps } from 'src/components/base/InputComponent';
 import { ILayout, ILayoutComponent, ILayoutGroup } from '../layout';
 import { setupGroupComponents } from '../../../utils/layout';
 import { ITextResource, IRepeatingGroups, IValidations, IOptions } from '../../../types';
@@ -88,8 +90,29 @@ export function RepeatingGroupTable({
     hiddenFields,
   );
 
-  const getFormDataForComponent = (component: ILayoutComponent | ILayoutGroup, index: number): string => {
-    return getFormDataForComponentInRepeatingGroup(formData, component, index, container.dataModelBindings.group, textResources, options);
+  const getFormDataForComponent = (component: ILayoutComponent | ILayoutGroup, index: number): string | React.ReactElement => {
+    const formDataValue = getFormDataForComponentInRepeatingGroup(formData, component, index, container.dataModelBindings.group, textResources, options);
+
+    // Use <NumberFormat if it is used on the field.
+    if (component.type === 'Input') {
+      const inputComponent = component as unknown as IInputProps;
+      if (inputComponent.formatting) {
+        const comp = inputComponent?.formatting?.number ? <NumberFormat
+          {...inputComponent.formatting.number}
+          displayType='text'
+          value={formDataValue}
+        /> : formDataValue;
+        if (inputComponent.formatting.align === 'right' || inputComponent.formatting.number.fixedDecimalScale) {
+          return <div style={{ textAlign: 'right' }}>{comp}</div>;
+        }
+        if (inputComponent.formatting.align === 'center') {
+          return <div style={{ textAlign: 'center' }}>{comp}</div>;
+        }
+
+        return comp;
+      }
+    }
+    return formDataValue;
   };
 
   const onClickEdit = (groupIndex: number) => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/index.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/index.ts
@@ -99,16 +99,6 @@ export interface IHeaderProps extends ILayoutComponent {
   size: HeaderSize;
 }
 
-declare enum InputFieldType {
-  text,
-  email,
-  password,
-}
-
-export interface IInputProps extends ILayoutComponent {
-  inputType: InputFieldType;
-}
-
 export interface INavigationButtonProps extends ILayoutComponent {
   next?: string;
   previous?: string;

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnMobileTableItem.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/components/molecules/AltinnMobileTableItem.tsx
@@ -4,7 +4,7 @@ import theme from '../../theme/altinnStudioTheme';
 
 export interface IMobileTableItem {
   label: string;
-  value: string;
+  value: string | React.ReactElement;
 }
 
 export interface IAltinnMobileTableItemProps {


### PR DESCRIPTION
Partially fixes #6376 (no PDF 👎 )

This is a pretty messy solution, but the best I could see how, without a
massive rewrite.

This was made much harder by react-number-format not exporting a function
for formatting numbers, so I needed to use the `<NumberFormat ` jsx
component https://github.com/s-yadav/react-number-format/issues/458

I ended up right aligning the numbers in the table if the number is
right aligned in the input field, or if it has a fixed decimal scale.
I also implemented `align: center` for no particular reason

The IInputProps in form/layout/index.ts was not in use and confused me a
lot