### PR TITLE
LocalTest: Don't include scripts that are empty or does not exist

### DIFF
--- a/src/development/LocalTest/Views/Shared/_Layout.cshtml
+++ b/src/development/LocalTest/Views/Shared/_Layout.cshtml
@@ -33,9 +33,6 @@
             &copy; 2019 - LocalTest - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
         </div>
     </footer>
-    <script src="~/lib/jquery/dist/jquery.min.js"></script>
-    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="~/js/site.js" asp-append-version="true"></script>
     @RenderSection("Scripts", required: false)
 </body>
 </html>


### PR DESCRIPTION
* Jquery seems to never have existed.
* Bootstrap url was not moved to `/localresources` in #3394 so it does not work (I can't see where it is needed)
* js/site.js is empty

This is partially fallout from #3394 but the only thing broken seems to
be the 404 in console.