### PR TITLE
Fixed some yellow warnings when building designer.

### DIFF
--- a/src/studio/src/designer/backend/Configuration/ServiceRepositorySettings.cs
+++ b/src/studio/src/designer/backend/Configuration/ServiceRepositorySettings.cs
@@ -407,6 +407,18 @@ namespace Altinn.Studio.Designer.Configuration
         [Obsolete("GetFormLayoutPath gets the path of the old form layout (ui/FormLayout.json). Use GetFormLayoutPath(org, app, developer, formLayout) for new structure.")]
         public string GetFormLayoutPath(string org, string app, string developer)
         {
+            return GetOldFormLayoutPath(org, app, developer);
+        }
+
+        /// <summary>
+        /// Method that returns the path to the form layout file
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="app">Application identifier which is unique within an organisation.</param>
+        /// <param name="developer">The current developer</param>
+        /// <returns>The full path, ending with "/"</returns>
+        public string GetOldFormLayoutPath(string org, string app, string developer)
+        {
             org = org.AsFileName();
             app = app.AsFileName();
             developer = developer.AsFileName();

--- a/src/studio/src/designer/backend/Configuration/ServiceRepositorySettings.cs
+++ b/src/studio/src/designer/backend/Configuration/ServiceRepositorySettings.cs
@@ -398,20 +398,7 @@ namespace Altinn.Studio.Designer.Configuration
         }
 
         /// <summary>
-        /// Method that returns the path to the form layout file
-        /// </summary>
-        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
-        /// <param name="app">Application identifier which is unique within an organisation.</param>
-        /// <param name="developer">The current developer</param>
-        /// <returns>The full path, ending with "/"</returns>
-        [Obsolete("GetFormLayoutPath gets the path of the old form layout (ui/FormLayout.json). Use GetFormLayoutPath(org, app, developer, formLayout) for new structure.")]
-        public string GetFormLayoutPath(string org, string app, string developer)
-        {
-            return GetOldFormLayoutPath(org, app, developer);
-        }
-
-        /// <summary>
-        /// Method that returns the path to the form layout file
+        /// Method that returns the path to the form layout file in the old format
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>

--- a/src/studio/src/designer/backend/RepositoryClient/Client/ApiClient.cs
+++ b/src/studio/src/designer/backend/RepositoryClient/Client/ApiClient.cs
@@ -324,7 +324,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Client
         /// <returns>Object representation of the JSON string.</returns>
         public object Deserialize(IRestResponse response, Type type)
         {
-            IList<Parameter> headers = response.Headers;
+            var headers = response.Headers;
 
             // return byte array
             if (type == typeof(byte[]))

--- a/src/studio/src/designer/backend/Services/Implementation/RepositorySI.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/RepositorySI.cs
@@ -594,8 +594,10 @@ namespace Altinn.Studio.Designer.Services.Implementation
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
 
             // If FormLayout.json exists in app/ui => move it to app/ui/layouts (for backwards comp)
+#pragma warning disable 0618
             string filedata = string.Empty;
             string formLayoutPath = _settings.GetFormLayoutPath(org, app, developer);
+#pragma warning restore 0618
             if (File.Exists(formLayoutPath))
             {
                 filedata = File.ReadAllText(formLayoutPath, Encoding.UTF8);
@@ -1888,6 +1890,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             return dataTypeId;
         }
 
+#pragma warning disable 0618
         private void DeleteOldFormLayoutJson(string org, string app, string developer)
         {
             string path = _settings.GetFormLayoutPath(org, app, developer);
@@ -1896,6 +1899,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 File.Delete(path);
             }
         }
+#pragma warning restore 0618
 
         /// <inheritdoc/>
         public async Task DeleteRepository(string org, string repository)

--- a/src/studio/src/designer/backend/Services/Implementation/RepositorySI.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/RepositorySI.cs
@@ -594,10 +594,8 @@ namespace Altinn.Studio.Designer.Services.Implementation
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
 
             // If FormLayout.json exists in app/ui => move it to app/ui/layouts (for backwards comp)
-#pragma warning disable 0618
             string filedata = string.Empty;
-            string formLayoutPath = _settings.GetFormLayoutPath(org, app, developer);
-#pragma warning restore 0618
+            string formLayoutPath = _settings.GetOldFormLayoutPath(org, app, developer);
             if (File.Exists(formLayoutPath))
             {
                 filedata = File.ReadAllText(formLayoutPath, Encoding.UTF8);
@@ -1890,16 +1888,14 @@ namespace Altinn.Studio.Designer.Services.Implementation
             return dataTypeId;
         }
 
-#pragma warning disable 0618
         private void DeleteOldFormLayoutJson(string org, string app, string developer)
         {
-            string path = _settings.GetFormLayoutPath(org, app, developer);
+            string path = _settings.GetOldFormLayoutPath(org, app, developer);
             if (File.Exists(path))
             {
                 File.Delete(path);
             }
         }
-#pragma warning restore 0618
 
         /// <inheritdoc/>
         public async Task DeleteRepository(string org, string repository)


### PR DESCRIPTION
Use of deprecated function was for backwards compatibility, so I fixed
the warning with `#pragma disable`

```
C:\Users\xivne\dev\altinn-studio\src\studio\src\designer\backend\RepositoryClient\Client\ApiClient.cs(327,19): warning CS0618: 'Parameter' is obsolete: 'Use Add[XXX]Parameter methods of IRestRequest instead of instantiating the Parameter class.' [C:\Users\xivne\dev\altinn-studio\src\studio\src\designer\backend\Designer.csproj]
C:\Users\xivne\dev\altinn-studio\src\studio\src\designer\backend\Services\Implementation\RepositorySI.cs(598,37): warning CS0618: 'ServiceRepositorySettings.GetFormLayoutPath(string, string, string)' is obsolete: 'GetFormLayoutPath gets the path of the old form layout (ui/FormLayout.json). Use GetFormLayoutPath(org, app, developer, formLayout) for new structure.' [C:\Users\xivne\dev\altinn-studio\src\studio\src\designer\backend\Designer.csproj]
C:\Users\xivne\dev\altinn-studio\src\studio\src\designer\backend\Services\Implementation\RepositorySI.cs(1893,27): warning CS0618: 'ServiceRepositorySettings.GetFormLayoutPath(string, string, string)' is obsolete: 'GetFormLayoutPath gets the path of the old form layout (ui/FormLayout.json). Use GetFormLayoutPath(org, app, developer, formLayout) for new structure.' [C:\Users\xivne\dev\altinn-studio\src\studio\src\designer\backend\Designer.csproj]
```