### PR TITLE
Fix for deploy issue for Platform.Authorization missing migration files

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Dockerfile
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Dockerfile
@@ -12,6 +12,8 @@ EXPOSE 5030
 WORKDIR /app
 COPY --from=build /app_output .
 
+COPY /Authorization/Migration ./Migration
+
 # setup the user and group
 # the user will have no password, using shell /bin/false and using the group dotnet
 RUN addgroup -g 3000 dotnet && adduser -u 1000 -G dotnet -D -s /bin/false dotnet


### PR DESCRIPTION
#4773
PR #7097 introduced PostgreSQL database integration for Platform.Authorization, but the Migration folder containing deploy scripts is missing from dockerfile causing deploy to fail.