### PR TITLE
Repeating group edit label

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/containers/RepeatingGroupTable.tsx
@@ -230,7 +230,7 @@ export function RepeatingGroupTable({
                     <IconButton style={{ color: 'black' }} onClick={() => onClickEdit(index)}>
                       {rowHasErrors ?
                         getLanguageFromKey('general.edit_alt_error', language) :
-                        getLanguageFromKey('general.edit_alt', language)}
+                        editIndex === index ? getLanguageFromKey('general.save', language) : getLanguageFromKey('general.edit_alt', language)}
                       <i className={rowHasErrors ?
                         `ai ai-circle-exclamation a-icon ${classes.errorIcon} ${classes.editIcon}` :
                         `fa fa-editing-file ${classes.editIcon}`}
@@ -267,7 +267,7 @@ export function RepeatingGroupTable({
                 >
                   {rowHasErrors ?
                     getLanguageFromKey('general.edit_alt_error', language) :
-                    getLanguageFromKey('general.edit_alt', language)}
+                    editIndex === index ? getLanguageFromKey('general.save', language) : getLanguageFromKey('general.edit_alt', language)}
                   <i className={rowHasErrors ?
                     `ai ai-circle-exclamation ${classes.errorIcon}` :
                     `fa fa-editing-file ${classes.editIcon}`}


### PR DESCRIPTION
The functionality has been requested in the following issue: https://github.com/Altinn/altinn-studio/issues/6432
When an item is selected for editing in a repeating group, the label will change to "Save" ("Lagre" in norwegian).
Here is a screenshot:
![image](https://user-images.githubusercontent.com/17925860/139820386-5d3b39c9-ffc4-49af-88ad-0a61e648c7d1.png)