### PR TITLE
Fix/7360 uncaught null in dashboard

### DIFF
--- a/src/studio/src/designer/frontend/dashboard/App.tsx
+++ b/src/studio/src/designer/frontend/dashboard/App.tsx
@@ -6,6 +6,8 @@ import { HashRouter as Router, Route } from 'react-router-dom';
 import AppBarComponent from 'app-shared/navigation/main-header/appBar';
 import altinnTheme from 'app-shared/theme/altinnStudioTheme';
 import AltinnSpinner from 'app-shared/components/AltinnSpinner';
+import { AltinnButton } from 'app-shared/components';
+import { post } from 'app-shared/utils/networking';
 import { StandaloneDataModelling } from './features';
 import { CloneService } from './features/cloneService/cloneServices';
 import { KnownIssues } from './features/knownIssues/knownIssues';
@@ -14,8 +16,6 @@ import { DashboardActions } from './resources/fetchDashboardResources/dashboardS
 import { fetchLanguage } from './resources/fetchLanguage/languageSlice';
 
 import './App.css';
-import { AltinnButton } from 'app-shared/components';
-import { post } from 'app-shared/utils/networking';
 
 const theme = createTheme(altinnTheme);
 

--- a/src/studio/src/designer/frontend/dashboard/App.tsx
+++ b/src/studio/src/designer/frontend/dashboard/App.tsx
@@ -1,11 +1,11 @@
 import { createTheme, MuiThemeProvider } from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
 import * as React from 'react';
-import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { HashRouter as Router, Route } from 'react-router-dom';
 import AppBarComponent from 'app-shared/navigation/main-header/appBar';
 import altinnTheme from 'app-shared/theme/altinnStudioTheme';
+import AltinnSpinner from 'app-shared/components/AltinnSpinner';
 import { StandaloneDataModelling } from './features';
 import { CloneService } from './features/cloneService/cloneServices';
 import { KnownIssues } from './features/knownIssues/knownIssues';
@@ -14,6 +14,8 @@ import { DashboardActions } from './resources/fetchDashboardResources/dashboardS
 import { fetchLanguage } from './resources/fetchLanguage/languageSlice';
 
 import './App.css';
+import { AltinnButton } from 'app-shared/components';
+import { post } from 'app-shared/utils/networking';
 
 const theme = createTheme(altinnTheme);
 
@@ -21,7 +23,7 @@ export const App = () => {
   const dispatch = useDispatch();
   const user = useSelector((state: any) => state.dashboard.user);
 
-  useEffect(() => {
+  React.useEffect(() => {
     dispatch(
       DashboardActions.fetchCurrentUser({
         url: `${window.location.origin}/designerapi/User/Current`,
@@ -48,10 +50,17 @@ export const App = () => {
     );
   }, [dispatch]);
 
+  const [showLogOutButton, setShowLogoutButton] = React.useState(false);
+  React.useEffect(()=> {
+    if (!user){
+      setTimeout(()=> setShowLogoutButton(true), 5000);
+    }
+  }, [user]);
+
   return (
     <MuiThemeProvider theme={theme}>
       <Router>
-        <div>
+        {user ? <div>
           <AppBarComponent
             org={user.full_name || user.login}
             app={null}
@@ -90,10 +99,25 @@ export const App = () => {
             exact={true}
             component={StandaloneDataModelling}
           />
-        </div>
+        </div> : <Grid justifyContent='center'>
+          <AltinnSpinner spinnerText='Venter på svar' />
+          {showLogOutButton && <AltinnButton
+            onClickFunction={handleLogout}
+            btnText={'Logg ut'}
+          />}
+        </Grid>
+        }
       </Router>
     </MuiThemeProvider>
   );
 };
 
 export default App;
+const handleLogout = () => {
+  const altinnWindow: Window = window;
+  const url = `${altinnWindow.location.origin}/repos/user/logout`;
+  post(url).then(() => {
+    window.location.assign(`${altinnWindow.location.origin}/Home/Logout`);
+  });
+  return true;
+}

--- a/src/studio/src/designer/frontend/dashboard/App.tsx
+++ b/src/studio/src/designer/frontend/dashboard/App.tsx
@@ -102,7 +102,9 @@ export const App = () => {
         </div> : <Grid justifyContent='center'>
           <AltinnSpinner spinnerText='Venter på svar' />
           {showLogOutButton && <AltinnButton
-            onClickFunction={handleLogout}
+            onClickFunction={() => post(`${window.location.origin}/repos/user/logout`).then(() => {
+              window.location.assign(`${window.location.origin}/Home/Logout`);
+            })}
             btnText={'Logg ut'}
           />}
         </Grid>
@@ -113,11 +115,3 @@ export const App = () => {
 };
 
 export default App;
-const handleLogout = () => {
-  const altinnWindow: Window = window;
-  const url = `${altinnWindow.location.origin}/repos/user/logout`;
-  post(url).then(() => {
-    window.location.assign(`${altinnWindow.location.origin}/Home/Logout`);
-  });
-  return true;
-}

--- a/src/studio/src/designer/frontend/dashboard/features/cloneService/cloneServices.tsx
+++ b/src/studio/src/designer/frontend/dashboard/features/cloneService/cloneServices.tsx
@@ -86,8 +86,6 @@ const styles = createStyles({
 
 // eslint-disable-next-line max-len
 export class CloneServiceComponent extends React.Component<ICloneServiceComponentProps & RouteChildrenProps, ICloneServiceComponentState> {
-  public _isMounted = false;
-
   // eslint-disable-next-line react/state-in-constructor
   public state: ICloneServiceComponentState = {
     lastChangedBy: '',
@@ -95,13 +93,13 @@ export class CloneServiceComponent extends React.Component<ICloneServiceComponen
   };
 
   public componentDidMount() {
-    this._isMounted = true;
+    this.componentMounted = true;
     const { location } = window as Window;
     const { org, serviceName } = (this.props.match.params as any);
     // eslint-disable-next-line max-len
     const url = `${location.origin}/designerapi/Repository/Branch?org=${org}&repository=${serviceName}&branch=master`;
     get(url).then((result: any) => {
-      if (result && this._isMounted) {
+      if (result && this.componentMounted) {
         this.setState({
           lastChangedBy: result.commit.author.name,
         });
@@ -110,12 +108,7 @@ export class CloneServiceComponent extends React.Component<ICloneServiceComponen
   }
 
   public componentWillUnmount() {
-    this._isMounted = false;
-  }
-
-  public redirectToCode = () => {
-    const repoInfo = this.getCurrentRepositoryInfo();
-    window.location.assign(`/repos/${repoInfo.full_name}`);
+    this.componentMounted = false;
   }
 
   public getCurrentRepositoryInfo = () => {
@@ -129,7 +122,14 @@ export class CloneServiceComponent extends React.Component<ICloneServiceComponen
     });
 
     return returnService.length === 1 ? returnService[0] : null;
-  }
+  };
+
+  public redirectToCode = () => {
+    const repoInfo = this.getCurrentRepositoryInfo();
+    window.location.assign(`/repos/${repoInfo.full_name}`);
+  };
+
+  public componentMounted = false;
 
   public cloneAndEditService = () => {
     const altinnWindow = window as Window as IAltinnWindow;
@@ -148,12 +148,12 @@ export class CloneServiceComponent extends React.Component<ICloneServiceComponen
     });
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     get(url).then((result: any) => {
-      if (this._isMounted) {
+      if (this.componentMounted) {
         // eslint-disable-next-line max-len
         window.location.assign(`${location.origin}/designer/${org}/${serviceName}`);
       }
     });
-  }
+  };
 
   public render() {
     const { classes } = this.props;

--- a/src/studio/src/designer/frontend/dashboard/features/createService/createNewService.tsx
+++ b/src/studio/src/designer/frontend/dashboard/features/createService/createNewService.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-underscore-dangle */
+/* slint-disable no-underscore-dangle */
 import { createStyles, withStyles } from '@material-ui/core/styles';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -48,9 +48,12 @@ const styles = createStyles({
 });
 
 export const appNameRegex = /^(?!datamodels$)[a-z]+[a-z0-9-]+[a-z0-9]$/;
-export class CreateNewServiceComponent extends React.Component<ICreateNewServiceProps, ICreateNewServiceState> {
-  public _isMounted = false;
 
+const validateRepoName = (repoName: string) => {
+  return appNameRegex.test(repoName);
+};
+
+export class CreateNewServiceComponent extends React.Component<ICreateNewServiceProps, ICreateNewServiceState> {
   // eslint-disable-next-line react/state-in-constructor
   public state: ICreateNewServiceState = {
     isOpen: false,
@@ -65,22 +68,22 @@ export class CreateNewServiceComponent extends React.Component<ICreateNewService
   };
 
   public componentDidMount() {
-    this._isMounted = true;
+    this.componentMounted = true;
   }
 
   public componentWillUnmount() {
-    this._isMounted = false;
+    this.componentMounted = false;
   }
 
   public handleModalOpen = () => {
+    const { selectableUser } = this.props;
+    const user = selectableUser?.length === 1 && selectableUser[0];
     this.setState({
       isOpen: true,
-      // eslint-disable-next-line max-len
-      // eslint-disable-next-line no-nested-ternary
-      selectedOrgOrUser: this.props.selectableUser.length === 1 ? this.props.selectableUser[0].full_name ? this.props.selectableUser[0].full_name : this.props.selectableUser[0].name : '',
-      selectedOrgOrUserDisabled: this.props.selectableUser.length === 1,
+      selectedOrgOrUser: user ? (user.full_name || user.name) : '',
+      selectedOrgOrUserDisabled: selectableUser.length === 1,
     });
-  }
+  };
 
   public handleModalClose = () => {
     this.setState({
@@ -92,44 +95,41 @@ export class CreateNewServiceComponent extends React.Component<ICreateNewService
       selectedOrgOrUser: '',
       repoName: '',
     });
-  }
-
-  public getListOfUsers() {
-    return this.props.selectableUser.map((user: any) => user.full_name || user.name);
-  }
-
-  public showServiceOwnerPopper = (message: string) => {
-    this.setState({
-      serviceOwnerAnchorEl: document.getElementById('service-owner'),
-      serviceOwnerPopperMessage: message,
-    });
-  }
-
-  public showRepoNamePopper = (message: string) => {
-    this.setState({
-      repoNameAnchorEl: document.getElementById('service-saved-name'),
-      repoNamePopperMessage: message,
-    });
-  }
+  };
 
   public handleUpdateDropdown = (event: any) => {
     this.setState({
       selectedOrgOrUser: event.target.value,
       serviceOwnerAnchorEl: null,
     });
-  }
+  };
 
   public handleRepoNameUpdated = (event: any) => {
     this.setState({
       repoName: event.target.value,
       repoNameAnchorEl: null,
     });
+  };
+
+  public getListOfUsers() {
+    return this.props.selectableUser.map((user: any) => user.full_name || user.name);
   }
 
-  public validateRepoName = (repoName: string) => {
-    // eslint-disable-next-line no-useless-escape
-    return appNameRegex.test(repoName);
-  }
+  public componentMounted = false;
+
+  public showServiceOwnerPopper = (message: string) => {
+    this.setState({
+      serviceOwnerAnchorEl: document.getElementById('service-owner'),
+      serviceOwnerPopperMessage: message,
+    });
+  };
+
+  public showRepoNamePopper = (message: string) => {
+    this.setState({
+      repoNameAnchorEl: document.getElementById('service-saved-name'),
+      repoNamePopperMessage: message,
+    });
+  };
 
   public validateService = () => {
     let serviceIsValid = true;
@@ -142,7 +142,7 @@ export class CreateNewServiceComponent extends React.Component<ICreateNewService
       serviceIsValid = false;
     }
 
-    if (this.state.repoName && !this.validateRepoName(this.state.repoName)) {
+    if (this.state.repoName && !validateRepoName(this.state.repoName)) {
       this.showRepoNamePopper(getLanguageFromKey('dashboard.service_name_has_illegal_characters', this.props.language));
       serviceIsValid = false;
     }
@@ -152,7 +152,7 @@ export class CreateNewServiceComponent extends React.Component<ICreateNewService
       serviceIsValid = false;
     }
     return serviceIsValid;
-  }
+  };
 
   public createNewService = () => {
     const serviceIsValid = this.validateService();
@@ -181,7 +181,7 @@ export class CreateNewServiceComponent extends React.Component<ICreateNewService
         }
       }).catch((error: Error) => {
         console.error('Unsucessful creating new app', error.message);
-        if (this._isMounted) {
+        if (this.componentMounted) {
           this.setState({
             isLoading: false,
           });
@@ -189,7 +189,7 @@ export class CreateNewServiceComponent extends React.Component<ICreateNewService
         }
       });
     }
-  }
+  };
 
   public render() {
     const { classes } = this.props;
@@ -250,10 +250,11 @@ export class CreateNewServiceComponent extends React.Component<ICreateNewService
           }
 
         </AltinnModal>
-      </div >
+      </div>
     );
   }
 }
+
 const combineCurrentUserAndOrg = (organisations: any, user: any) => {
   // eslint-disable-next-line camelcase
   const allUsers = organisations.map(({ username, full_name }: any) => ({ name: username, full_name }));

--- a/src/studio/src/designer/frontend/dashboard/features/createService/createNewService.tsx
+++ b/src/studio/src/designer/frontend/dashboard/features/createService/createNewService.tsx
@@ -1,4 +1,3 @@
-/* slint-disable no-underscore-dangle */
 import { createStyles, withStyles } from '@material-ui/core/styles';
 import * as React from 'react';
 import { connect } from 'react-redux';

--- a/src/studio/src/designer/frontend/dashboard/features/knownIssues/knownIssues.tsx
+++ b/src/studio/src/designer/frontend/dashboard/features/knownIssues/knownIssues.tsx
@@ -53,18 +53,16 @@ const styles = createStyles({
 });
 
 export class KnownIssuesComponent extends React.Component<IKnownIssuesComponentProps, IKnownIssuesComponentState> {
-  public _isMounted = false;
-
   // eslint-disable-next-line react/state-in-constructor
   public state: IKnownIssuesComponentState = {
     knownIssues: null,
   };
 
   public componentDidMount() {
-    this._isMounted = true;
+    this.componentMounted = true;
     get('https://raw.githubusercontent.com/Altinn/altinn-studio/master/KNOWNISSUES.md')
       .then((res) => {
-        if (this._isMounted) {
+        if (this.componentMounted) {
           marked.setOptions({
             headerIds: false,
           });
@@ -85,8 +83,10 @@ export class KnownIssuesComponent extends React.Component<IKnownIssuesComponentP
   }
 
   public componentWillUnmount() {
-    this._isMounted = false;
+    this.componentMounted = false;
   }
+
+  public componentMounted = false;
 
   public render() {
     const { classes } = this.props;

--- a/src/studio/src/designer/frontend/dashboard/features/serviceOverview/servicesOverview.tsx
+++ b/src/studio/src/designer/frontend/dashboard/features/serviceOverview/servicesOverview.tsx
@@ -119,8 +119,6 @@ export class ServicesOverviewComponent extends React.Component<IServicesOverview
     };
   }
 
-  public _isMounted = false;
-
   // eslint-disable-next-line react/state-in-constructor
   public state: IServicesOverviewComponentState = {
     selectedOwners: [],
@@ -129,18 +127,20 @@ export class ServicesOverviewComponent extends React.Component<IServicesOverview
   };
 
   public componentDidMount() {
-    this._isMounted = true;
+    this.componentMounted = true;
   }
 
   public componentWillUnmount() {
-    this._isMounted = false;
+    this.componentMounted = false;
   }
+
+  public componentMounted = false;
 
   public updateSearchString = (event: any) => {
     this.setState({
       searchString: event.target.value,
     });
-  }
+  };
 
   public searchAndFilterServicesIntoCategoriesCategory(hasWriteRights: any) {
     const filteredServices = this.props.services

--- a/src/studio/src/designer/frontend/dashboard/test/__tests__/components/base/cloneService.test.tsx
+++ b/src/studio/src/designer/frontend/dashboard/test/__tests__/components/base/cloneService.test.tsx
@@ -156,7 +156,7 @@ describe('>>> components/base/cloneService.tsx', () => {
     const getSpy = jest.spyOn(networking, 'get').mockImplementation(() => Promise.resolve(mockResult));
     instance.componentDidMount();
     return Promise.resolve().then(() => {
-      expect(instance._isMounted).toBe(true);
+      expect(instance.componentMounted).toBe(true);
       expect(componentDidMountSpy).toHaveBeenCalled();
       expect(getSpy).toHaveBeenCalled();
       expect(instance.state.lastChangedBy).toBe(mockResult.commit.author.name);
@@ -270,7 +270,7 @@ describe('>>> components/base/cloneService.tsx', () => {
     const componentWillUnmountSpy = jest.spyOn(instance, 'componentWillUnmount');
     instance.componentWillUnmount();
     expect(componentWillUnmountSpy).toHaveBeenCalled();
-    expect(instance._isMounted).toBe(false);
+    expect(instance.componentMounted).toBe(false);
   });
 
   it('+++ Should show correct date', () => {

--- a/src/studio/src/designer/frontend/dashboard/test/__tests__/components/base/createNewService.test.tsx
+++ b/src/studio/src/designer/frontend/dashboard/test/__tests__/components/base/createNewService.test.tsx
@@ -174,7 +174,7 @@ describe('>>> components/base/createNewService.tsx', () => {
     );
 
     const instance = mountedComponent.instance() as CreateNewServiceComponent;
-    instance._isMounted = true;
+    instance.componentMounted = true;
     instance.state.repoName = 'service-name';
     instance.state.selectedOrgOrUser = mockSelectableUser[0].name;
     const mockResult = {
@@ -188,7 +188,7 @@ describe('>>> components/base/createNewService.tsx', () => {
     expect(instance.state.isLoading).toBe(true);
     return Promise.resolve().then(() => {
       expect(getSpy).toHaveBeenCalled();
-      expect(instance._isMounted).toBe(true);
+      expect(instance.componentMounted).toBe(true);
       expect(instance.state.isLoading).toBe(false);
       expect(instance.state.repoNamePopperMessage).toBe('dashboard.app_already_exist');
     });
@@ -204,7 +204,7 @@ describe('>>> components/base/createNewService.tsx', () => {
     );
 
     const instance = mountedComponent.instance() as CreateNewServiceComponent;
-    instance._isMounted = true;
+    instance.componentMounted = true;
     instance.state.repoName = 'service-name';
     instance.state.selectedOrgOrUser = mockSelectableUser[0].name;
     const mockResult = {
@@ -219,7 +219,7 @@ describe('>>> components/base/createNewService.tsx', () => {
     expect(instance.state.isLoading).toBe(true);
     return Promise.resolve().then(() => {
       expect(getSpy).toHaveBeenCalled();
-      expect(instance._isMounted).toBe(true);
+      expect(instance.componentMounted).toBe(true);
       expect(instance.state.isLoading).toBe(false);
       expect(instance.state.repoNamePopperMessage).toBe('dashboard.error_when_creating_app');
     });
@@ -235,7 +235,7 @@ describe('>>> components/base/createNewService.tsx', () => {
     );
 
     const instance = mountedComponent.instance() as CreateNewServiceComponent;
-    instance._isMounted = true;
+    instance.componentMounted = true;
     instance.state.repoName = 'service-name';
     instance.state.selectedOrgOrUser = mockSelectableUser[0].name;
     const mockError = Error('mocked error');
@@ -248,7 +248,7 @@ describe('>>> components/base/createNewService.tsx', () => {
     // workaround to resolve promise, making test run
     await Promise.resolve();
     expect(mockPost).toHaveBeenCalled();
-    expect(instance._isMounted).toBe(true);
+    expect(instance.componentMounted).toBe(true);
     expect(instance.state.isLoading).toBe(false);
     expect(instance.state.repoNamePopperMessage).toBe('dashboard.error_when_creating_app');
     expect(consoleError).toHaveBeenCalled();
@@ -264,7 +264,7 @@ describe('>>> components/base/createNewService.tsx', () => {
     );
 
     const instance = mountedComponent.instance() as CreateNewServiceComponent;
-    instance._isMounted = true;
+    instance.componentMounted = true;
     instance.state.repoName = 'service-name';
     instance.state.selectedOrgOrUser = mockSelectableUser[0].name;
     const mockResult = {
@@ -294,9 +294,9 @@ describe('>>> components/base/createNewService.tsx', () => {
 
     const instance = mountedComponent.instance() as CreateNewServiceComponent;
     instance.componentDidMount();
-    expect(instance._isMounted).toBe(true);
+    expect(instance.componentMounted).toBe(true);
     instance.componentWillUnmount();
-    expect(instance._isMounted).toBe(false);
+    expect(instance.componentMounted).toBe(false);
   });
 
   it('+++ app name regex should return false on capital letters', () => {

--- a/src/studio/src/designer/frontend/dashboard/test/__tests__/components/base/knownIssues.test.tsx
+++ b/src/studio/src/designer/frontend/dashboard/test/__tests__/components/base/knownIssues.test.tsx
@@ -28,13 +28,13 @@ describe('>>> components/base/knownIssues.tsx', () => {
     const instance = mountedComponent.instance() as KnownIssuesComponent;
     const getSpy = jest.spyOn(networking, 'get').mockImplementation(() => Promise.resolve(mockGetResult));
     instance.componentDidMount();
-    expect(instance._isMounted).toBe(true);
+    expect(instance.componentMounted).toBe(true);
     await Promise.resolve();
     expect(getSpy).toHaveBeenCalled();
     expect(instance.state.knownIssues).not.toBe('default');
   });
 
-  it('+++ should handle updating _isMounted on componentDidMount and componentWillUnmount', () => {
+  it('+++ should handle updating componentMounted on componentDidMount and componentWillUnmount', () => {
     const mountedComponent = mount(
       (
         <KnownIssuesComponent
@@ -46,8 +46,8 @@ describe('>>> components/base/knownIssues.tsx', () => {
 
     const instance = mountedComponent.instance() as KnownIssuesComponent;
     instance.componentDidMount();
-    expect(instance._isMounted).toBe(true);
+    expect(instance.componentMounted).toBe(true);
     instance.componentWillUnmount();
-    expect(instance._isMounted).toBe(false);
+    expect(instance.componentMounted).toBe(false);
   });
 });

--- a/src/studio/src/designer/frontend/package.json
+++ b/src/studio/src/designer/frontend/package.json
@@ -13,7 +13,7 @@
     "build-dashboard": "npm run build --prefix dashboard/",
     "build-app-development": "npm run build --prefix app-development/",
     "start-dashboard": "npm start --prefix dashboard/",
-    "start-app-development": "npm start --prefix dashboard",
+    "start-app-development": "npm start --prefix app-development/",
     "update-packages": "lerna exec --concurrency 1 -- npm update --dev"
   },
   "devDependencies": {


### PR DESCRIPTION
# Fixed null crash in studio dashboard when login cookie is invalid.

## Description

This should fix #7360 and add a spinner if the app is waiting for a user object to be populated.
As a convenience, a log out button will appear if the spinner is visible for more than 5 seconds.

## Fixes
- #7360

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] Documentation is updated with a separate linked PR in altinn-docs (if applicable)
