### PR TITLE
Revert testcafe

### DIFF
--- a/src/test/Testcafe/package-lock.json
+++ b/src/test/Testcafe/package-lock.json
@@ -2543,12 +2543,6 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
     },
-    "@miherlosev/esm": {
-      "version": "3.2.26",
-      "resolved": "https://registry.npmjs.org/@miherlosev/esm/-/esm-3.2.26.tgz",
-      "integrity": "sha512-TaW4jTGVE1/ln2VGFChnheMh589QCAZy1MVnLvjjSzZ4pEAa4WYAWPwFkDVZbSdPQdLfZy7LuTyZjWRkhX9/Gg==",
-      "dev": true
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2610,9 +2604,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.36.tgz",
-      "integrity": "sha512-+5haRZ9uzI7rYqzDznXgkuacqb6LJhAti8mzZKWxIXn/WEtvB+GHVJ7AuMwcN1HMvXOSJcrvA6PPoYHYOYYebA==",
+      "version": "12.20.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
+      "integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA==",
       "dev": true
     },
     "acorn": {
@@ -3049,9 +3043,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001276",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001276.tgz",
-      "integrity": "sha512-psUNoaG1ilknZPxi8HuhQWobuhLqtYSRUxplfVkEJdgZNB9TETVYGSBtv4YyfAdGvE6gn2eb0ztiXqHoWJcGnw==",
+      "version": "1.0.30001279",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
+      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
       "dev": true
     },
     "chai": {
@@ -3390,9 +3384,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.888",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.888.tgz",
-      "integrity": "sha512-5iD1zgyPpFER4kJ716VsA4MxQ6x405dxdFNCEK2mITL075VHO5ResjY0xzQUZguCww/KlBxCA6JmBA9sDt1PRw==",
+      "version": "1.3.892",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.892.tgz",
+      "integrity": "sha512-YDW4yIjdfMnbRoBjRZ/aNQYmT6JgQFLwmTSDRJMQdrY4MByEzppdXp3rnJ0g4LBWcsYTUvwKKClYN1ofZ0COOQ==",
       "dev": true
     },
     "elegant-spinner": {
@@ -3664,6 +3658,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
       "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
+      "dev": true
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "dev": true
     },
     "esotope-hammerhead": {
@@ -4472,9 +4472,9 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
       "dev": true
     },
     "mimic-fn": {
@@ -5263,9 +5263,9 @@
       }
     },
     "testcafe": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.17.0.tgz",
-      "integrity": "sha512-kf/y3XxuAHjQ46WbaPyZPaHOlf6c0LiEK86UI6vovnLdHknzcQoVaFSouKrCy2yt1/e4RHrFqmKBSHP8Frnhfg==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.16.1.tgz",
+      "integrity": "sha512-efb4S7YIyu8BpG4dZQBCgPE3V1YWU8J32v7/cPr1zW1yY/9F2B0y1lMTpeFJ3rUMdHSZpwYi6y00dEfEnNeN/Q==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.1",
@@ -5284,7 +5284,6 @@
         "@babel/preset-flow": "^7.12.1",
         "@babel/preset-react": "^7.12.1",
         "@babel/runtime": "^7.12.5",
-        "@miherlosev/esm": "3.2.26",
         "@types/node": "^12.20.10",
         "async-exit-hook": "^1.1.2",
         "babel-plugin-module-resolver": "^4.0.0",
@@ -5307,6 +5306,7 @@
         "emittery": "^0.4.1",
         "endpoint-utils": "^1.0.2",
         "error-stack-parser": "^1.3.6",
+        "esm": "^3.2.25",
         "execa": "^4.0.3",
         "globby": "^11.0.4",
         "graceful-fs": "^4.1.11",
@@ -5344,8 +5344,8 @@
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
         "testcafe-browser-tools": "2.0.16",
-        "testcafe-hammerhead": "24.5.7",
-        "testcafe-legacy-api": "5.1.2",
+        "testcafe-hammerhead": "24.5.4",
+        "testcafe-legacy-api": "5.1.1",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
         "testcafe-reporter-minimal": "^2.1.0",
@@ -5549,9 +5549,9 @@
       }
     },
     "testcafe-hammerhead": {
-      "version": "24.5.7",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.5.7.tgz",
-      "integrity": "sha512-4pY6GQQaCZAlOolWB2vaYZ/MIpgtmOrZeh4BVbENkbh6DDiPeOxvC0K6yZS5JfINRau5S9mzuNkm2FS7G0urSA==",
+      "version": "24.5.4",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.5.4.tgz",
+      "integrity": "sha512-ve2rgOQEh4R48L8eu945DDeLOH/Owj8ZmJL0lQBnsLrZA60vsSxpvOczuj98f2u1jtgGjcxOeRTIkNypcRZAyA==",
       "dev": true,
       "requires": {
         "acorn-hammerhead": "0.5.0",
@@ -5632,9 +5632,9 @@
       }
     },
     "testcafe-legacy-api": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/testcafe-legacy-api/-/testcafe-legacy-api-5.1.2.tgz",
-      "integrity": "sha512-vc9A4rFUdijlBFnNOVMk0hFfxnrAmtA7FMz1P/LtvNyui5JfkLmbyIQcJbxR2rjTINp0owZ2c+xQvYms/us7Fw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/testcafe-legacy-api/-/testcafe-legacy-api-5.1.1.tgz",
+      "integrity": "sha512-WRy9XvH/u+HE19oXs70xuxlcC+x4Yhydhhy5PadK/Ro9ssupSjEFxc/gzTWWcvdxAXO8JWgsXl/x4v5RMYtMow==",
       "dev": true,
       "requires": {
         "async": "0.2.6",

--- a/src/test/Testcafe/package.json
+++ b/src/test/Testcafe/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-testcafe": "^0.2.1",
     "prettier": "^2.4.1",
     "process": "^0.11.10",
-    "testcafe": "^1.17.0",
+    "testcafe": "1.16.1",
     "testcafe-browser-provider-puppeteer": "^1.5.2"
   },
   "dependencies": {


### PR DESCRIPTION


# Revert testcafe

Reverts testcafe from 1.17.0 => 1.16.1

## Description

Testcafe tests hangs against calls agains the testcafe server. Testing if patch could be a potential problem. 


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] Documentation is updated with a separate linked PR in altinn-docs (if applicable)
