### PR TITLE
Test/fix flaky test

### DIFF
--- a/src/test/cypress/e2e/integration/app-frontend/mobile.js
+++ b/src/test/cypress/e2e/integration/app-frontend/mobile.js
@@ -25,8 +25,8 @@ describe('Mobile', () => {
         width = Math.round(width);
         expect(width).to.be.gt(292);
         expect(width).to.be.lt(296);
-      })
-      .click();
+      });
+    cy.get(appFrontend.sendinButton).click();
     cy.wait('@getLayoutGroup');
     cy.get(appFrontend.group.showGroupToContinue).then((checkbox) => {
       cy.get(checkbox).should('be.visible').find('input').check();

--- a/src/test/cypress/e2e/integration/app-frontend/mobile.js
+++ b/src/test/cypress/e2e/integration/app-frontend/mobile.js
@@ -8,7 +8,7 @@ import * as texts from '../../fixtures/texts.json';
 const appFrontend = new AppFrontend();
 const mui = new Common();
 
-describe.only('Mobile', () => {
+describe('Mobile', () => {
   beforeEach(() => {
     cy.viewport('samsung-s10');
   });

--- a/src/test/cypress/e2e/integration/app-frontend/mobile.js
+++ b/src/test/cypress/e2e/integration/app-frontend/mobile.js
@@ -8,7 +8,7 @@ import * as texts from '../../fixtures/texts.json';
 const appFrontend = new AppFrontend();
 const mui = new Common();
 
-describe('Mobile', () => {
+describe.only('Mobile', () => {
   beforeEach(() => {
     cy.viewport('samsung-s10');
   });
@@ -18,7 +18,14 @@ describe('Mobile', () => {
     cy.get(appFrontend.changeOfName.oldFullName).parents().eq(2).should('have.css', 'max-width', '100%');
     cy.completeChangeNameForm('a', 'a');
     cy.intercept('**/api/layoutsettings/group').as('getLayoutGroup');
-    cy.get(appFrontend.sendinButton).should('be.visible').and('have.css', 'width', '293px').click();
+    cy.get(appFrontend.sendinButton)
+      .should('be.visible')
+      .invoke('outerWidth')
+      .then((width) => {
+        width = Math.round(width);
+        expect(width).to.be.gt(292);
+        expect(width).to.be.lt(296);
+      });
     cy.wait('@getLayoutGroup');
     cy.get(appFrontend.group.showGroupToContinue).then((checkbox) => {
       cy.get(checkbox).should('be.visible').find('input').check();

--- a/src/test/cypress/e2e/integration/app-frontend/mobile.js
+++ b/src/test/cypress/e2e/integration/app-frontend/mobile.js
@@ -25,7 +25,8 @@ describe('Mobile', () => {
         width = Math.round(width);
         expect(width).to.be.gt(292);
         expect(width).to.be.lt(296);
-      });
+      })
+      .click();
     cy.wait('@getLayoutGroup');
     cy.get(appFrontend.group.showGroupToContinue).then((checkbox) => {
       cy.get(checkbox).should('be.visible').find('input').check();


### PR DESCRIPTION
# Fix failing app frontend test

The new test for mobile view is failing in headless mode, where there is a pixel difference when compared to the headed mode.
