### PR TITLE
Fixed upercase not being allowed as the first character in property names.

### DIFF
--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector.tsx
@@ -94,6 +94,10 @@ export interface ISchemaInspectorProps {
   language: ILanguage;
 }
 
+export const isValidName = (name: string) => {
+  return Boolean(name.match(/^[a-zA-ZæÆøØåÅ][a-zA-Z0-9_.\-æÆøØåÅ ]*$/));
+};
+
 const SchemaInspector = ((props: ISchemaInspectorProps) => {
   const classes = useStyles();
   const dispatch = useDispatch();
@@ -415,12 +419,13 @@ const SchemaInspector = ((props: ISchemaInspectorProps) => {
   const onNameChange = (e: any) => {
     const name: string = e.target.value;
     setNodeName(name);
-    if (!name.match(/^[a-z][a-zA-Z0-9_.\-æÆøØåÅ ]*$/)) {
+    if (!isValidName(name)) {
       setNameError('Invalid character in name');
     } else {
       setNameError('');
     }
   };
+
   const renderItemData = () => (
     <div>
       <p className={classes.name}>{getTranslation('name', props.language)}</p>

--- a/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/SchemaInspector.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/SchemaInspector.test.tsx
@@ -5,10 +5,11 @@ import configureStore from 'redux-mock-store';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { Autocomplete } from '@material-ui/lab';
-import SchemaInspector from '../../src/components/SchemaInspector';
+import SchemaInspector, {isValidName} from '../../src/components/SchemaInspector';
 import { dataMock } from '../../src/mockData';
 import { buildUISchema, resetUniqueNumber } from '../../src/utils';
 import { ISchemaState, UiSchemaItem } from '../../src/types';
+import { hasExpectedRequestMetadata } from '@reduxjs/toolkit/dist/matchers';
 
 let mockStore: any = null;
 let mockInitialState: ISchemaState;
@@ -415,3 +416,16 @@ it('dispatches correctly when adding fields', () => {
     },
   });
 });
+
+it('validates name of properties', () => {
+  expect(isValidName('Melding')).toBe(true);
+  expect(isValidName('melding')).toBe(true)
+  expect(isValidName('melding1')).toBe(true)
+  expect(isValidName('melding.1')).toBe(true)
+  expect(isValidName('melding_xyz')).toBe(true)
+  expect(isValidName('melding-xyz')).toBe(true)
+  expect(isValidName('1melding')).toBe(false)
+  expect(isValidName('_melding')).toBe(false)
+  expect(isValidName('.melding')).toBe(false)
+  expect(isValidName('melding%')).toBe(false)
+})

--- a/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/SchemaInspector.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/test/__tests__/SchemaInspector.test.tsx
@@ -9,7 +9,6 @@ import SchemaInspector, {isValidName} from '../../src/components/SchemaInspector
 import { dataMock } from '../../src/mockData';
 import { buildUISchema, resetUniqueNumber } from '../../src/utils';
 import { ISchemaState, UiSchemaItem } from '../../src/types';
-import { hasExpectedRequestMetadata } from '@reduxjs/toolkit/dist/matchers';
 
 let mockStore: any = null;
 let mockInitialState: ISchemaState;


### PR DESCRIPTION
Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master.

# First character not being allowed to be uppercase
Allowing for the first character to be uppercase, including æÆøØåÅ but not numbers or other characters.

## Fixes
- #7243

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
~~- [ ] Documentation is updated with a separate linked PR in altinn-docs (if applicable)~~
