### PR TITLE
setting dataVals and presentationTexts

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.19.0-alpha</Version>
+    <Version>4.19.0-alpha.1</Version>
     <AssemblyVersion>4.19.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/InstancesController.cs
@@ -539,7 +539,7 @@ namespace Altinn.App.Api.Controllers
 
                     await _dataClient.InsertFormData(
                         data,
-                       Guid.Parse(targetInstance.Id.Split("/")[1]),
+                        Guid.Parse(targetInstance.Id.Split("/")[1]),
                         type,
                         org,
                         app,

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/InstancesController.cs
@@ -320,7 +320,7 @@ namespace Altinn.App.Api.Controllers
         }
 
         /// <summary>
-        /// Simplified Instanciation with support for fieldprefill 
+        /// Simplified Instanciation with support for fieldprefill
         /// </summary>
         /// <param name="org">unique identifier of the organisation responsible for the app</param>
         /// <param name="app">application identifier which is unique within an organisation</param>
@@ -403,7 +403,12 @@ namespace Altinn.App.Api.Controllers
                 return StatusCode((int)HttpStatusCode.Forbidden, $"Party {party.PartyId} is not allowed to instantiate this application {org}/{app}");
             }
 
-            Instance instanceTemplate = new Instance() { InstanceOwner = instansiationInstance.InstanceOwner };
+            Instance instanceTemplate = new Instance()
+            {
+                InstanceOwner = instansiationInstance.InstanceOwner,
+                VisibleAfter = instansiationInstance.VisibleAfter,
+                DueBefore = instansiationInstance.DueBefore
+            };
 
             // Run custom app logic to validate instantiation
             InstantiationValidationResult validationResult = await _altinnApp.RunInstantiationValidation(instanceTemplate);
@@ -534,12 +539,15 @@ namespace Altinn.App.Api.Controllers
 
                     await _dataClient.InsertFormData(
                         data,
-                        Guid.Parse(targetInstance.Id.Split("/")[1]),
+                       Guid.Parse(targetInstance.Id.Split("/")[1]),
                         type,
                         org,
                         app,
                         instanceOwnerPartyId,
                         dt.Id);
+
+                    await UpdatePresentationTextsOnInstance(application.PresentationFields, targetInstance, dt.Id, data);
+                    await UpdateDataValuesOnInstance(application.DataFields, targetInstance, dt.Id, data);
                 }
             }
         }
@@ -928,5 +936,40 @@ namespace Altinn.App.Api.Controllers
 
             return StatusCode((int)HttpStatusCode.Forbidden);
         }
+
+        private async Task UpdatePresentationTextsOnInstance(List<DataField> presentationFields, Instance instance, string dataType, object data)
+        {
+            var updatedValues = DataHelper.GetUpdatedDataValues(
+                presentationFields,
+                instance.PresentationTexts,
+                dataType,
+                data);
+
+            if (updatedValues.Count > 0)
+            {
+                await _instanceClient.UpdatePresentationTexts(
+                    int.Parse(instance.Id.Split("/")[0]),
+                    Guid.Parse(instance.Id.Split("/")[1]),
+                    new PresentationTexts { Texts = updatedValues });
+            }
+        }
+
+        private async Task UpdateDataValuesOnInstance(List<DataField> dataFields, Instance instance, string dataType, object data)
+        {
+            var updatedValues = DataHelper.GetUpdatedDataValues(
+                dataFields,
+                instance.DataValues,
+                dataType,
+                data);
+
+            if (updatedValues.Count > 0)
+            {
+                await _instanceClient.UpdateDataValues(
+                    int.Parse(instance.Id.Split("/")[0]),
+                    Guid.Parse(instance.Id.Split("/")[1]),
+                    new DataValues { Values = updatedValues });
+            }
+        }
+
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/InstancesController.cs
@@ -970,6 +970,5 @@ namespace Altinn.App.Api.Controllers
                     new DataValues { Values = updatedValues });
             }
         }
-
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.19.0-alpha</Version>
+    <Version>4.19.0-alpha.1</Version>
     <AssemblyVersion>4.19.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.19.0-alpha</Version>
+    <Version>4.19.0-alpha.1</Version>
     <AssemblyVersion>4.19.0.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/InstanceApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/InstanceApiTest.cs
@@ -1157,7 +1157,7 @@ namespace App.IntegrationTests
             string org = "ttd";
             string app = "presentationfields-app";
 
-            int instanceOwnerPartyId = 1337;
+            int instanceOwnerPartyId = 1401;
 
             HttpClient client = SetupUtil.GetTestClient(_factory, org, app);
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/InstanceApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/InstanceApiTest.cs
@@ -407,7 +407,10 @@ namespace App.IntegrationTests
                 response.EnsureSuccessStatusCode();
                 Instance createdInstance = JsonConvert.DeserializeObject<Instance>(responseContent);
                 instanceGuid = Guid.Parse(createdInstance.Id.Split("/")[1]);
+                createdInstance.DataValues.TryGetValue("harIkkeReelleRettighetshavere", out string actualDataValue);
+
                 Assert.Equal("1337", createdInstance.InstanceOwner.PartyId);
+                Assert.Equal("false", actualDataValue, ignoreCase: true);
 
                 string dataUri = createdInstance.Data[0].SelfLinks.Apps;
                 HttpRequestMessage httpRequestMessage2 = new HttpRequestMessage(HttpMethod.Get, dataUri);

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/Instances/ttd/presentationfields-app/1401/447ed22d-67a8-42c7-8add-cc35eba304f2.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/Instances/ttd/presentationfields-app/1401/447ed22d-67a8-42c7-8add-cc35eba304f2.json
@@ -1,0 +1,40 @@
+{
+  "id": "1401/447ed22d-67a8-42c7-8add-cc35eba304f2",
+  "instanceOwner": {
+    "partyId": "1401",
+    "personNumber": "14015678901"
+  },
+  "appId": "ttd/presentationfields-app",
+  "org": "ttd",
+  "process": {
+    "started": "2019-12-11T09:34:35.5471442Z",
+    "startEvent": "StartEvent_1",
+    "currentTask": {
+      "flow": 2,
+      "started": "2019-12-11T09:34:37.6872728Z",
+      "elementId": "Task_1",
+      "name": "Utfylling",
+      "altinnTaskType": "data"
+    }
+  },
+  "status": {
+    "isArchived": false,
+    "isSoftDeleted": false,
+    "isHardDeleted": false,
+    "readStatus": "Read"
+  },
+  "lastChangedBy": "897069650",
+  "lastChanged": "2021-09-23T10:19:43",
+  "presentationTexts": {
+    "Title": "Sophie Salt"
+  },
+  "data": [
+    {
+      "id": "590ebc27-246e-4a0a-aea3-4296cb231d78",
+      "dataType": "default",
+      "contentType": "application/xml",
+      "size": 0,
+      "locked": false
+    }
+  ]
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/externalprefil/config/applicationmetadata.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/externalprefil/config/applicationmetadata.json
@@ -37,6 +37,13 @@
     "enabled": true,
     "excludedDataFields": [ "Skjemainnhold.reelleRettigheter.rettighetId" ]
   },
+  "dataFields": [
+    {
+      "id": "harIkkeReelleRettighetshavere",
+      "path": "Skjemainnhold.reelleRettigheter.harIkkeReelleRettighetshavere",
+      "dataTypeId": "Brønnøysundregistrene_ReelleRettighetshavere_M_2021-04-13_6900_46449_SERES"
+    }
+  ],
   "autoDeleteOnProcessEnd": false,
   "created": "2021-10-19T13:05:38.7523183Z",
   "createdBy": "TheTechArch",


### PR DESCRIPTION
# Setting dataVals and presentationTexts on copy instance

Bug fix for #6695 

## Description

Ensure that presentationTexts and dataValues are set on target instance after copying data

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
