### PR TITLE
The suggested code in FormatPdf gives null pointer exception

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
@@ -395,6 +395,14 @@ namespace Altinn.App.Services.Implementation
                 layoutSettings = JsonConvert.DeserializeObject<LayoutSettings>(layoutSettingsFileContent);
             }
 
+            // Ensure layoutsettings are initialized in FormatPdf
+            layoutSettings ??= new();
+            layoutSettings.Pages ??= new();
+            layoutSettings.Pages.Order ??= new();
+            layoutSettings.Pages.ExcludeFromPdf ??= new();
+            layoutSettings.Components ??= new();
+            layoutSettings.Components.ExcludeFromPdf ??= new();
+
             object data = await _dataClient.GetFormData(instanceGuid, dataElementModelType, org, app, instanceOwnerId, new Guid(dataElement.Id));
 
             layoutSettings = await FormatPdf(layoutSettings, data);

--- a/src/Altinn.Apps/AppTemplates/AspNet/App/logic/App.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App/logic/App.cs
@@ -195,7 +195,7 @@ namespace Altinn.App.AppLogic
         /// <summary>
         /// Hook to run logic to hide pages or components when generatring PDF
         /// </summary>
-        /// <param name="layoutSettings">The layoutsettings. Can be null and need to be created in method</param>
+        /// <param name="layoutSettings">The layoutsettings.</param>
         /// <param name="data">The data that there is generated PDF from</param>
         /// <returns>Layoutsetting with possible hidden fields or pages</returns>
         public override async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data)

--- a/src/studio/AppTemplates/AspNet/App/logic/App.cs
+++ b/src/studio/AppTemplates/AspNet/App/logic/App.cs
@@ -195,7 +195,7 @@ namespace Altinn.App.AppLogic
         /// <summary>
         /// Hook to run logic to hide pages or components when generatring PDF
         /// </summary>
-        /// <param name="layoutSettings">The layoutsettings. Can be null and need to be created in method</param>
+        /// <param name="layoutSettings">The layoutsettings</param>
         /// <param name="data">The data that there is generated PDF from</param>
         /// <returns>Layoutsetting with possible hidden fields or pages</returns>
         public override async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data)


### PR DESCRIPTION
This change initialises everything regardless of whether fields are
initialised in Settings.json

```
/// <summary>
/// Method to format PDF dynamic
/// </summary>
/// <example>
///     if (data.GetType() == typeof(Skjema)
///     {
///     // need to create object if not there
///     layoutSettings.Components.ExcludeFromPdf.Add("a23234234");
///     }
/// </example>
/// <param name="layoutSettings">the layoutsettings</param>
```


This might be fixed by initializing everything in the constructor for Layoutsettings as well.

## Fixes
- No issue yet

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
~~- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [x] All tests run green
- [x] Documentation is updated with a separate linked PR in altinn-docs (if applicable)
