### PR TITLE
Use header sizes h2, h3, h4 in json as in studio

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/HeaderComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/HeaderComponent.tsx
@@ -19,22 +19,19 @@ export function HeaderComponent(props: IHeaderProps) {
   };
 
   const renderHeader = () => {
+    // Allow 'S', 'M' and 'L' for backwards compatibility
     switch (props.size) {
-      case ('S'): {
+      case 'h4':
+      case 'S':
         return <h4 id={props.id} style={marginStyling}>{props.text}</h4>;
-      }
-
-      case ('M'): {
+      case 'h3':
+      case 'M':
         return <h3 id={props.id} style={marginStyling}>{props.text}</h3>;
-      }
-
-      case ('L'): {
+      case 'h2':
+      case 'L':
         return <h2 id={props.id} style={marginStyling}>{props.text}</h2>;
-      }
-
-      default: {
+      default:
         return <h4 id={props.id} style={marginStyling}>{props.text}</h4>;
-      }
     }
   };
 

--- a/src/studio/src/designer/frontend/ux-editor/components/config/HeaderSizeSelect.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/components/config/HeaderSizeSelect.tsx
@@ -12,15 +12,22 @@ export interface HeaderSizeSelectProps {
   handleUpdateHeaderSize: (e: any) => void
 }
 
+const sizeCompat:any = {
+  S: 'h4',
+  M: 'h3',
+  L: 'h2',
+};
+
 const HeaderSizeSelect: React.FunctionComponent<HeaderSizeSelectProps> = (props: HeaderSizeSelectProps) => {
   const {
     renderChangeId, handleTitleChange, handleUpdateHeaderSize,
   } = props;
   const sizes = [
-    { value: 'S', label: props.language.ux_editor.modal_header_type_h4 },
-    { value: 'M', label: props.language.ux_editor.modal_header_type_h3 },
-    { value: 'L', label: props.language.ux_editor.modal_header_type_h2 },
+    { value: 'h4', label: props.language.ux_editor.modal_header_type_h4 },
+    { value: 'h3', label: props.language.ux_editor.modal_header_type_h3 },
+    { value: 'h2', label: props.language.ux_editor.modal_header_type_h2 },
   ];
+  const value = sizeCompat[props.component.size] || props.component.size;
   return (
     <Grid
       container={true}
@@ -38,8 +45,8 @@ const HeaderSizeSelect: React.FunctionComponent<HeaderSizeSelectProps> = (props:
         {renderPropertyLabel(props.language.ux_editor.modal_header_type_helper)}
         <Select
           styles={selectStyles}
-          defaultValue={props.component.size ?
-            sizes.find((size) => size.value === props.component.size) :
+          defaultValue={value ?
+            sizes.find((size) => size.value === value) :
             sizes[0]}
           onChange={handleUpdateHeaderSize}
           options={sizes}


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# Use header sizes h2, h3, h4 in json as in studio


## Description

It is annoying that we use different concepts for the same thing.
I think this should be backwards compatible, but it depends on everyone getting the new frontend before starting to edit headers in altinn.studio. If some apps have version pinned frontend (or if altinn studio gets updated before production frontend), I can modify to let studio keep `S`, `M`, `L` tags 

## Fixes
- #7611 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] Documentation is updated with a separate linked PR in altinn-docs (if applicable)
