### PR TITLE
enable retry on api requests

### DIFF
--- a/src/test/K6/src/api/app/data.js
+++ b/src/test/K6/src/api/app/data.js
@@ -1,12 +1,13 @@
 import http from 'k6/http';
 import * as config from '../../config.js';
 import * as header from '../../buildrequestheaders.js';
+import { httpGet } from '../../wrapper.js';
 
 //Api call to App Api:Data to get a data by id of an app instance and returns response
 export function getDataById(altinnStudioRuntimeCookie, partyId, instaceId, dataId, appOwner, appName) {
   var endpoint = config.appApiBaseUrl(appOwner, appName) + config.buildAppApiUrls(partyId, instaceId, dataId, 'dataid');
   var params = header.buildHearderWithRuntime(altinnStudioRuntimeCookie, 'app');
-  return http.get(endpoint, params);
+  return httpGet(endpoint, params);
 }
 
 //Function to return the first data id from an instance JSON object

--- a/src/test/K6/src/api/app/instances.js
+++ b/src/test/K6/src/api/app/instances.js
@@ -1,6 +1,7 @@
 import http from 'k6/http';
 import * as config from '../../config.js';
 import * as header from '../../buildrequestheaders.js';
+import { httpPost } from '../../wrapper.js';
 
 //Api call to App Api:Instances to create an app instance and returns response
 export function postInstance(altinnStudioRuntimeCookie, partyId, appOwner, appName) {
@@ -92,7 +93,7 @@ export function postInstanceWithMultipartData(altinnStudioRuntimeCookie, partyId
     `Content-Disposition: form-data; name=\"default\"\r\n\r\n${formDataXml}\r\n\r\n` +
     `--abcdefg--`;
 
-  return http.post(endpoint, requestBody, params);
+  return httpPost(endpoint, requestBody, params);
 }
 
 /**

--- a/src/test/K6/src/api/platform/storage/messageboxinstances.js
+++ b/src/test/K6/src/api/platform/storage/messageboxinstances.js
@@ -2,6 +2,7 @@ import http from 'k6/http';
 import * as config from '../../../config.js';
 import * as header from '../../../buildrequestheaders.js';
 import * as support from '../../../support.js';
+import { httpGet } from '../../../wrapper.js';
 
 //Api call to Storage:SBL instances to get an instance by id and return response
 export function getSblInstanceById(altinnStudioRuntimeCookie, partyId, instanceId) {
@@ -62,5 +63,5 @@ export function filterInstancesByAppName(appNames, responseJson) {
 export function searchSblInstances(altinnStudioRuntimeCookie, filters) {
   var endpoint = config.platformStorage['messageBoxInstances'] + '/search' + support.buildQueryParametersForEndpoint(filters);
   var params = header.buildHearderWithRuntimeforSbl(altinnStudioRuntimeCookie, 'platform');
-  return http.get(endpoint, params);
+  return httpGet(endpoint, params);
 }

--- a/src/test/K6/src/wrapper.js
+++ b/src/test/K6/src/wrapper.js
@@ -4,25 +4,29 @@ import { sleep } from 'k6';
 //wrapper functions around k6 http methods enabling retrying requests when response code is 0, 408 and > 500
 
 export function httpPost(url, body, params) {
-  var res;
+  var res,
+    retriedCount = 0;
   for (var retries = 3; retries > 0; retries--) {
     res = http.post(url, body, params);
     if (res.status != 0 && res.status != 408 && res.status < 500) {
       return res;
     }
     sleep(10);
+    console.log(`Retry number: ${++retriedCount}`);
   }
   return res;
 }
 
 export function httpGet(url, params) {
-  var res;
+  var res,
+    retriedCount = 0;
   for (var retries = 3; retries > 0; retries--) {
     res = http.get(url, params);
     if (res.status != 0 && res.status != 408 && res.status < 500) {
       return res;
     }
     sleep(10);
+    console.log(`Retry number: ${++retriedCount}`);
   }
   return res;
 }

--- a/src/test/K6/src/wrapper.js
+++ b/src/test/K6/src/wrapper.js
@@ -6,7 +6,7 @@ export function httpPost(url, body, params) {
   var res;
   for (var retries = 3; retries > 0; retries--) {
     res = http.post(url, body, params);
-    if (res.status != 0 && res.status != 201 && res.status < 500) {
+    if (res.status != 0 && res.status != 408 && res.status < 500) {
       return res;
     }
   }

--- a/src/test/K6/src/wrapper.js
+++ b/src/test/K6/src/wrapper.js
@@ -1,4 +1,5 @@
 import http from 'k6/http';
+import { sleep } from 'k6';
 
 //wrapper functions around k6 http methods enabling retrying requests when response code is 0, 408 and > 500
 
@@ -9,6 +10,7 @@ export function httpPost(url, body, params) {
     if (res.status != 0 && res.status != 408 && res.status < 500) {
       return res;
     }
+    sleep(10);
   }
   return res;
 }
@@ -20,6 +22,7 @@ export function httpGet(url, params) {
     if (res.status != 0 && res.status != 408 && res.status < 500) {
       return res;
     }
+    sleep(10);
   }
   return res;
 }

--- a/src/test/K6/src/wrapper.js
+++ b/src/test/K6/src/wrapper.js
@@ -1,0 +1,25 @@
+import http from 'k6/http';
+
+//wrapper functions around k6 http methods enabling retrying requests when response code is 0, 408 and > 500
+
+export function httpPost(url, body, params) {
+  var res;
+  for (var retries = 3; retries > 0; retries--) {
+    res = http.post(url, body, params);
+    if (res.status != 0 && res.status != 201 && res.status < 500) {
+      return res;
+    }
+  }
+  return res;
+}
+
+export function httpGet(url, params) {
+  var res;
+  for (var retries = 3; retries > 0; retries--) {
+    res = http.get(url, params);
+    if (res.status != 0 && res.status != 408 && res.status < 500) {
+      return res;
+    }
+  }
+  return res;
+}


### PR DESCRIPTION
# Enable retry on API requests

## Description
Some of the API requests in bruksmønster timeout and triggers false alarms. #7402

Added a wrapper function that retries requests which returns response codes: 0, 408 or >500, for a maximum of 3 times before returning the response to the test.

Function waits 10 seconds before retrying the failed request. Retry count is printed to the console.

Used these wrapper functions only on the tests that have timed out in the last 30 days.