### PR TITLE
set IdleTcpConnectionTimeout for cosmos clients

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/BaseRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/BaseRepository.cs
@@ -6,6 +6,7 @@ namespace Altinn.Platform.Storage.Repository
 
     using Altinn.Platform.Storage.Configuration;
     using Altinn.Platform.Storage.Extensions;
+
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Client;
     using Microsoft.Extensions.Hosting;
@@ -82,6 +83,7 @@ namespace Altinn.Platform.Storage.Repository
             {
                 ConnectionMode = ConnectionMode.Gateway,
                 ConnectionProtocol = Protocol.Https,
+                IdleTcpConnectionTimeout = new TimeSpan(0, 10, 0)
             };
 
             DocumentClient client = new DocumentClient(new Uri(_cosmosSettings.EndpointUri), _cosmosSettings.PrimaryKey, connectionPolicy);


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# Define max idle time for connection for CosmosDB Client

## Description
Setting max idle time for the cosmos DB connection to 10 mins. Should be closed and socket made available to other operations after this time. Hoping this will solve the socket exception we see when creating an instance

## Fixes
- #7402

## Verification
- [x] **Your** code builds clean without any errors or warnings
