### PR TITLE
removing hostname from appsettings, only using generalsettings

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.20.0-alpha.1</Version>
+    <Version>4.20.0</Version>
     <AssemblyVersion>4.20.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.20.0-alpha</Version>
+    <Version>4.20.0-alpha.1</Version>
     <AssemblyVersion>4.20.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/RedirectController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/RedirectController.cs
@@ -19,15 +19,15 @@ namespace Altinn.App.Api.Controllers
     [ApiController]
     public class RedirectController : ControllerBase
     {
-        private readonly AppSettings _appSettings;
+        private readonly GeneralSettings _settings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RedirectController"/> class.
         /// </summary>
-        /// <param name="appSettings">The app settings.</param>
-        public RedirectController(IOptions<AppSettings> appSettings)
+        /// <param name="settings">The general settings.</param>
+        public RedirectController(IOptions<GeneralSettings> settings)
         {
-            _appSettings = appSettings.Value;
+            _settings = settings.Value;
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace Altinn.App.Api.Controllers
         {
             Uri uri = new Uri(url);
 
-            if (_appSettings.Hostname != uri.Host)
+            if (_settings.HostName != uri.Host)
             {
                 string errorMessage = $"Invalid domain from query parameter {nameof(url)}.";
                 ModelState.AddModelError(nameof(url), errorMessage);

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/RedirectController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/RedirectController.cs
@@ -40,7 +40,7 @@ namespace Altinn.App.Api.Controllers
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public ActionResult ValidateUrl([BindRequired, FromQuery, Url] string url)
+        public ActionResult<string> ValidateUrl([BindRequired, FromQuery, Url] string url)
         {
             Uri uri = new Uri(url);
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/RedirectController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/RedirectController.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
 using Altinn.App.Api.Filters;
 using Altinn.App.Services.Configuration;
 using Microsoft.AspNetCore.Authorization;
@@ -41,7 +44,7 @@ namespace Altinn.App.Api.Controllers
         {
             Uri uri = new Uri(url);
 
-            if (_settings.HostName != uri.Host)
+            if (!IsValidRedirectUri(uri.Host))
             {
                 string errorMessage = $"Invalid domain from query parameter {nameof(url)}.";
                 ModelState.AddModelError(nameof(url), errorMessage);
@@ -49,6 +52,17 @@ namespace Altinn.App.Api.Controllers
             }
 
             return Ok(url);
+        }
+
+        private bool IsValidRedirectUri(string urlHost)
+        {
+            string validHost = _settings.HostName;
+            int segments = _settings.HostName.Split('.').Length;
+
+            List<string> goToList = Enumerable.Reverse(new List<string>(urlHost.Split('.'))).Take(segments).Reverse().ToList();
+            string redirectHost = string.Join(".", goToList);
+
+            return validHost.Equals(redirectHost);
         }
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.20.0-alpha</Version>
+    <Version>4.20.0-alpha.1</Version>
     <AssemblyVersion>4.20.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.20.0-alpha.1</Version>
+    <Version>4.20.0</Version>
     <AssemblyVersion>4.20.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.20.0-alpha.1</Version>
+    <Version>4.20.0</Version>
     <AssemblyVersion>4.20.0.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.20.0-alpha</Version>
+    <Version>4.20.0-alpha.1</Version>
     <AssemblyVersion>4.20.0.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Configuration/AppSettings.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Configuration/AppSettings.cs
@@ -142,11 +142,6 @@ namespace Altinn.App.Services.Configuration
         public string AppOidcProvider { get; set; }
 
         /// <summary>
-        /// Hostname
-        /// </summary>
-        public string Hostname { get; set; }
-
-        /// <summary>
         /// Name of the cookie for runtime
         /// </summary>
         public string RuntimeCookieName { get; set; }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/RedirectApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/RedirectApiTest.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+using Altinn.App.IntegrationTests;
+using Altinn.Platform.Storage.Interface.Models;
+
+using App.IntegrationTests.Utils;
+
+using Newtonsoft.Json;
+
+using Xunit;
+
+namespace App.IntegrationTestsRef.ApiTests
+{
+    public class RedirectApiTest : IClassFixture<CustomWebApplicationFactory<Altinn.App.Startup>>
+    {
+        private readonly CustomWebApplicationFactory<Altinn.App.Startup> _factory;
+
+        public RedirectApiTest(CustomWebApplicationFactory<Altinn.App.Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Theory]
+        [InlineData("https://altinn3local.no/ttd/en-annen-app", HttpStatusCode.BadRequest)]
+        [InlineData("https://vg.no", HttpStatusCode.BadRequest)]
+        [InlineData("https://tt02.hacker.altinn.no", HttpStatusCode.BadRequest)]
+        [InlineData("https://tt02.altinnn.no/we/will/hack/you", HttpStatusCode.BadRequest)]
+        [InlineData("https://ttd.apps.tt02.altinn.no/ttd/en-annen-app", HttpStatusCode.OK)]
+        [InlineData("https://nav.apps.tt02.altinn.no/nav/aap", HttpStatusCode.OK)]
+        [InlineData("https://tt02.altinn.no/ui/messagebox", HttpStatusCode.OK)]
+        public async Task ValidateUrl(string url, HttpStatusCode expectedStatusCode)
+        {
+            string token = PrincipalUtil.GetToken(1337);
+
+            HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, $"/tdd/endring-av-navn/api/v1/redirect?url={url}");
+
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            Assert.Equal(expectedStatusCode, response.StatusCode);
+        }
+
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/RedirectApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/RedirectApiTest.cs
@@ -35,9 +35,9 @@ namespace App.IntegrationTestsRef.ApiTests
         {
             string token = PrincipalUtil.GetToken(1337);
 
-            HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
+            HttpClient client = SetupUtil.GetTestClient(_factory, "ttd", "dayplanner");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, $"/tdd/endring-av-navn/api/v1/redirect?url={url}");
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, $"/ttd/dayplanner/api/v1/redirect?url={url}");
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/RedirectApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/RedirectApiTest.cs
@@ -43,6 +43,5 @@ namespace App.IntegrationTestsRef.ApiTests
 
             Assert.Equal(expectedStatusCode, response.StatusCode);
         }
-
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/endring-av-navn/appsettings.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/endring-av-navn/appsettings.json
@@ -10,7 +10,7 @@
     "DisableCsrfCheck":  false
   },
   "GeneralSettings": {
-    "HostName": "tt02.altinn.no",
+    "HostName": "localhost",
     "TemplateLocation": "../Templates",
     "RuntimeMode": "AltinnStudio",
     "LanguageFilesLocation": "../Common/Languages/ini/",

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/endring-av-navn/appsettings.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/tdd/endring-av-navn/appsettings.json
@@ -10,7 +10,7 @@
     "DisableCsrfCheck":  false
   },
   "GeneralSettings": {
-    "HostName": "localhost",
+    "HostName": "tt02.altinn.no",
     "TemplateLocation": "../Templates",
     "RuntimeMode": "AltinnStudio",
     "LanguageFilesLocation": "../Common/Languages/ini/",

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/dayplanner/appsettings.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/dayplanner/appsettings.json
@@ -13,7 +13,7 @@
     "RegisterEventsWithEventsComponent": false
   },
   "GeneralSettings": {
-    "HostName": "altinn3local.no",
+    "HostName": "tt02.altinn.no",
     "SoftValidationPrefix": "*WARNING*",
     "AltinnPartyCookieName": "AltinnPartyId"
   },

--- a/src/Altinn.Apps/AppTemplates/AspNet/App/App.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App/App.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="4.19.0">
+    <PackageReference Include="Altinn.App.Api" Version="4.20.0">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Common" Version="4.19.0" />
-    <PackageReference Include="Altinn.App.PlatformServices" Version="4.19.0" />
+    <PackageReference Include="Altinn.App.Common" Version="4.20.0" />
+    <PackageReference Include="Altinn.App.PlatformServices" Version="4.20.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>

--- a/src/Altinn.Apps/AppTemplates/AspNet/App/appsettings.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App/appsettings.json
@@ -8,7 +8,6 @@
   },
   "AppSettings": {
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
-    "Hostname": "altinn3local.no",
     "RuntimeCookieName": "AltinnStudioRuntime",
     "RegisterEventsWithEventsComponent": false 
   },

--- a/src/studio/AppTemplates/AspNet/App/App.csproj
+++ b/src/studio/AppTemplates/AspNet/App/App.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="4.19.0">
+    <PackageReference Include="Altinn.App.Api" Version="4.20.0">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Common" Version="4.19.0" />
-    <PackageReference Include="Altinn.App.PlatformServices" Version="4.19.0" />
+    <PackageReference Include="Altinn.App.Common" Version="4.20.0" />
+    <PackageReference Include="Altinn.App.PlatformServices" Version="4.20.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>

--- a/src/studio/AppTemplates/AspNet/App/appsettings.json
+++ b/src/studio/AppTemplates/AspNet/App/appsettings.json
@@ -8,9 +8,8 @@
   },
   "AppSettings": {
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
-    "Hostname": "altinn3local.no",
     "RuntimeCookieName": "AltinnStudioRuntime",
-    "RegisterEventsWithEventsComponent": false
+    "RegisterEventsWithEventsComponent": false 
   },
   "GeneralSettings": {
     "HostName": "altinn3local.no",


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# Bug fixes for redirect controller #7183

## Description
AppSettings exposes a hostname prop, this has been removed as it is a duplicate of generalsettings, and it is never set in the app cluster.

Validation of host adjustet to allow for all subdomains of the host

Added unit tests


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [ ] Documentation is updated with a separate linked PR in altinn-docs (if applicable)
