### PR TITLE
move usecase script to yaml

### DIFF
--- a/src/test/Testcafe/use-cases.yaml
+++ b/src/test/Testcafe/use-cases.yaml
@@ -31,7 +31,7 @@ steps:
 
    export useCaseUserPwd=$(userPassword)
 
-   yarn run usecase
+   testcafe 'chrome:headless' ./usecase/usecase.js --assertion-timeout 15000 --selector-timeout 15000 -u -e -q successThreshold=1 --reporter junit > testresult.xml
 
   workingDirectory: '$(Build.SourcesDirectory)/src/test/Testcafe'
   displayName: 'Studio Tests'


### PR DESCRIPTION
testcafe is installed globally in the test agents.

`yarn run usecase` did not manage to use the package installed globally rather tried to access `node_modules` in `src/test/Testcafe`

so, moving usecase script for studio from package.json to yaml as a quick fix.
