### PR TITLE
Studio tests with cypress

### DIFF
--- a/src/test/cypress/cypress.json
+++ b/src/test/cypress/cypress.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://on.cypress.io/cypress.schema.json",
   "env": {
-    "appOwner": "ttd",
     "multiData2Stage": "frontend-test",
     "stateless": "stateless-app"
   },

--- a/src/test/cypress/e2e/config/studio/dev.json
+++ b/src/test/cypress/e2e/config/studio/dev.json
@@ -6,10 +6,10 @@
     "noDeployUser": "automatedtest@email.com",
     "useCaseUser": "bruksmonsterDev",
     "deployApp": "ttd/autodeploy-v3",
-    "compilerErrorApp": "ttd/compile-error-app",
     "designerApp": "AutoTest/auto-designer-app",
     "withoutDataModelApp": "AutoTest/appwithout-dm",
-    "rulesApp": "AutoTest/rulesservice"
+    "rulesApp": "AutoTest/rulesservice",
+    "appOwner": "Testdepartementet"
   },
   "defaultCommandTimeout": 20000,
   "requestTimeout": 20000,

--- a/src/test/cypress/e2e/config/studio/dev.json
+++ b/src/test/cypress/e2e/config/studio/dev.json
@@ -12,5 +12,6 @@
     "rulesApp": "AutoTest/rulesservice"
   },
   "defaultCommandTimeout": 20000,
-  "requestTimeout": 20000
+  "requestTimeout": 20000,
+  "chromeWebSecurity": false
 }

--- a/src/test/cypress/e2e/config/studio/local.json
+++ b/src/test/cypress/e2e/config/studio/local.json
@@ -2,9 +2,10 @@
   "$schema": "https://on.cypress.io/cypress.schema.json",
   "baseUrl": "http://altinn3.no",
   "env": {
-    "userName": "testuser",
-    "userPwd": "Studio@123",
-    "testEmail": "test1@test.com"   
+    "autoTestUser": "testuser",
+    "autoTestUserPwd": "Studio@123",
+    "noDeployUser": "automatedtest@email.com",
+    "testEmail": "test1@test.com"
   },
   "defaultCommandTimeout": 20000,
   "requestTimeout": 20000

--- a/src/test/cypress/e2e/config/studio/local.json
+++ b/src/test/cypress/e2e/config/studio/local.json
@@ -5,7 +5,12 @@
     "autoTestUser": "testuser",
     "autoTestUserPwd": "Studio@123",
     "noDeployUser": "automatedtest@email.com",
-    "testEmail": "test1@test.com"
+    "testEmail": "test1@test.com",
+    "deployApp": "ttd/deploy",
+    "designerApp": "ttd/designer",
+    "withoutDataModelApp": "ttd/appwithout-dm",
+    "rulesApp": "ttd/rulesservice",
+    "appOwner": "ttd"
   },
   "defaultCommandTimeout": 20000,
   "requestTimeout": 20000

--- a/src/test/cypress/e2e/config/studio/prod.json
+++ b/src/test/cypress/e2e/config/studio/prod.json
@@ -6,10 +6,10 @@
     "noDeployUser": "noDeployUser",
     "useCaseUser": "bruksmonster",
     "deployApp": "ttd/auto-deploy-app-v2",
-    "compilerErrorApp": "ttd/compile-error-app",
     "designerApp": "AutoTest/auto-designer-app",
     "withoutDataModelApp": "AutoTest/appwithout-dm",
-    "rulesApp": "AutoTest/rules-service"
+    "rulesApp": "AutoTest/rules-service",
+    "appOwner": "Testdepartementet"
   },
   "defaultCommandTimeout": 20000,
   "requestTimeout": 20000

--- a/src/test/cypress/e2e/config/studio/staging.json
+++ b/src/test/cypress/e2e/config/studio/staging.json
@@ -5,10 +5,10 @@
     "autoTestUser": "AutoTest",
     "noDeployUser": "automatedtest@email.com",    
     "deployApp": "ttd/autodeploy-v3",
-    "compilerErrorApp": "ttd/compile-error-app",
     "designerApp": "AutoTest/auto-designer-app",
     "withoutDataModelApp": "AutoTest/appwithout-dm",
-    "rulesApp": "AutoTest/rulesservice"
+    "rulesApp": "AutoTest/rulesservice",
+    "appOwner": "Testdepartementet"
   },
   "defaultCommandTimeout": 20000,
   "requestTimeout": 20000

--- a/src/test/cypress/e2e/integration/studio/dashboard.js
+++ b/src/test/cypress/e2e/integration/studio/dashboard.js
@@ -19,13 +19,16 @@ context('Dashboard', () => {
     cy.get(dashboard.appOwners).click();
     cy.contains(dashboard.appOwnersList, Cypress.env('appOwner')).click();
     cy.get(dashboard.appName).type('dashboard');
-    cy.get(dashboard.closeButton).click();
+    cy.get(dashboard.closeButton).click({ force: true });
   });
 
   it('Login and dashboard lists app', () => {
-    if(Cypress.env('environment') == 'local')
-      cy.intercept('GET', '**/designerapi/Repository/UserRepos', repos(10));
+    if (Cypress.env('environment') == 'local') cy.intercept('GET', '**/designerapi/Repository/UserRepos', repos(10));
     cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.get('h2').parent('div').siblings(common.gridContainer).children(common.gridItem).should('have.length.greaterThan', 1);
+    cy.get('h2')
+      .parent('div')
+      .siblings(common.gridContainer)
+      .children(common.gridItem)
+      .should('have.length.greaterThan', 1);
   });
 });

--- a/src/test/cypress/e2e/integration/studio/dashboard.js
+++ b/src/test/cypress/e2e/integration/studio/dashboard.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+/// <reference types="../../support" />
 
 import * as dashboard from '../../pageobjects/dashboard';
 import Common from '../../pageobjects/common';
@@ -12,7 +13,7 @@ context('Dashboard', () => {
   });
 
   it('Create an app and exit creation', () => {
-    cy.studiologin(Cypress.env('userName'), Cypress.env('userPwd'));
+    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
     cy.get(dashboard.newApp).should('be.visible');
     cy.get(dashboard.newApp).click();
     cy.get(dashboard.appOwners).click();
@@ -22,8 +23,9 @@ context('Dashboard', () => {
   });
 
   it('Login and dashboard lists app', () => {
-    cy.intercept('GET', '**/designerapi/Repository/UserRepos', repos(10));
-    cy.studiologin(Cypress.env('userName'), Cypress.env('userPwd'));
-    cy.get('h2').parent('div').siblings(common.gridContainer).children(common.gridItem).should('have.length', 10);
+    if(Cypress.env('environment') == 'local')
+      cy.intercept('GET', '**/designerapi/Repository/UserRepos', repos(10));
+    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.get('h2').parent('div').siblings(common.gridContainer).children(common.gridItem).should('have.length.greaterThan', 1);
   });
 });

--- a/src/test/cypress/e2e/integration/studio/deploy.js
+++ b/src/test/cypress/e2e/integration/studio/deploy.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+/// <reference types="../../support" />
 
 import * as designer from '../../pageobjects/designer';
 import Common from '../../pageobjects/common';
@@ -11,22 +12,26 @@ const common = new Common();
 
 context('Deploy', () => {
   before(() => {
-    cy.visit('/');
-    cy.studiologin(Cypress.env('userName'), Cypress.env('userPwd'));
-    cy.createapp(Cypress.env('appOwner'), 'deploy');
-    cy.get(header.profileButton).click();
-    cy.contains(header.menuItem, 'Logout').click();
+    if (Cypress.env('environment') == 'local') {
+      cy.visit('/');
+      cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+      cy.createapp(Cypress.env('appOwner'), 'deploy');
+      cy.get(header.profileButton).click();
+      cy.contains(header.menuItem, 'Logout').click();
+    }
   });
   beforeEach(() => {
     cy.visit('/');
-    cy.studiologin(Cypress.env('userName'), Cypress.env('userPwd'));
-    cy.get(dashboard.searchApp).type('deploy');
+    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.get(dashboard.searchApp).type(Cypress.env('deployApp').split('/')[1]);
     cy.contains(common.gridItem, 'deploy').click();
     cy.get(designer.appMenu['deploy']).click();
   });
 
   it('Inprogress build', () => {
-    cy.intercept('GET', '**/designer/api/v1/ttd/deploy/releases**', builds('inprogress')).as('buildstatus');
+    cy.intercept('GET', `**/designer/api/v1/${Cypress.env('deployApp')}/releases**`, builds('inprogress')).as(
+      'buildstatus',
+    );
     cy.wait('@buildstatus').its('response.statusCode').should('eq', 200);
     cy.contains(common.gridItem, designer.olderBuilds)
       .next(common.gridContainer)
@@ -36,7 +41,9 @@ context('Deploy', () => {
   });
 
   it('Failed build', () => {
-    cy.intercept('GET', '**/designer/api/v1/ttd/deploy/releases**', builds('failed')).as('buildstatus');
+    cy.intercept('GET', `**/designer/api/v1/${Cypress.env('deployApp')}/releases**`, builds('failed')).as(
+      'buildstatus',
+    );
     cy.wait('@buildstatus').its('response.statusCode').should('eq', 200);
     cy.contains(common.gridItem, designer.olderBuilds)
       .next(common.gridContainer)
@@ -46,7 +53,9 @@ context('Deploy', () => {
   });
 
   it('Successful build', () => {
-    cy.intercept('GET', '**/designer/api/v1/ttd/deploy/releases**', builds('succeeded')).as('buildstatus');
+    cy.intercept('GET', `**/designer/api/v1/${Cypress.env('deployApp')}/releases**`, builds('succeeded')).as(
+      'buildstatus',
+    );
     cy.wait('@buildstatus').its('response.statusCode').should('eq', 200);
     cy.contains(common.gridItem, designer.olderBuilds)
       .next(common.gridContainer)
@@ -59,6 +68,6 @@ context('Deploy', () => {
     cy.intercept('GET', '**/designer/api/v1/*/*/Deployments**', deploys()).as('deploys');
     cy.wait('@deploys').its('response.statusCode').should('eq', 200);
     cy.contains('div', 'AT22').should('be.visible');
-    cy.get(designer.at22Deploys).find('tbody > tr').should('contain.text', 'testuser');
+    cy.get(designer.deployHistory.at22).find('tbody > tr').should('contain.text', 'testuser');
   });
 });

--- a/src/test/cypress/e2e/integration/studio/designer.js
+++ b/src/test/cypress/e2e/integration/studio/designer.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+/// <reference types="../../support" />
 
 import * as designer from '../../pageobjects/designer';
 import * as dashboard from '../../pageobjects/dashboard';
@@ -9,26 +10,28 @@ const common = new Common();
 
 context('Designer', () => {
   before(() => {
-    cy.visit('/');
-    cy.studiologin(Cypress.env('userName'), Cypress.env('userPwd'));
-    cy.createapp(Cypress.env('appOwner'), 'designer');
-    cy.get(header.profileButton).click();
-    cy.contains(header.menuItem, 'Logout').click();
+    if (Cypress.env('environment') == 'local') {
+      cy.visit('/');
+      cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+      cy.createapp(Cypress.env('appOwner'), 'designer');
+      cy.get(header.profileButton).click();
+      cy.contains(header.menuItem, 'Logout').click();
+    }
   });
   beforeEach(() => {
     cy.visit('/');
-    cy.studiologin(Cypress.env('userName'), Cypress.env('userPwd'));
-    cy.get(dashboard.searchApp).type('designer');
+    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.get(dashboard.searchApp).type(Cypress.env('designerApp').split('/')[1]);
     cy.contains(common.gridItem, 'designer').click();
   });
 
   it('About App', () => {
-    cy.contains(designer.appHeader, 'Om appen').should('be.visible');
+    cy.contains(designer.aboutApp.appHeader, 'Om appen').should('be.visible');
     cy.contains(common.button, 'Endre').click();
-    cy.get(designer.appName).clear().type('New app name');
-    cy.get(designer.appDescription).clear().type('App description');
-    cy.get(designer.appName).invoke('val').should('contain', 'New app name');
-    cy.get(designer.appDescription).invoke('val').should('contain', 'App description');
+    cy.get(designer.aboutApp.appName).clear().type('New app name');
+    cy.get(designer.aboutApp.appDescription).clear().type('App description');
+    cy.get(designer.aboutApp.appName).invoke('val').should('contain', 'New app name');
+    cy.get(designer.aboutApp.appDescription).invoke('val').should('contain', 'App description');
   });
 
   it('UI Editor', () => {
@@ -36,7 +39,7 @@ context('Designer', () => {
     cy.get(common.leftDrawer).trigger('mouseover', { force: true });
     cy.get(designer.appEditorMenu['datamodel']).should('be.visible');
     cy.get(common.leftDrawer).trigger('mouseout');
-    cy.get(designer.shortAnswer).parents(designer.draggable).trigger('dragstart');
+    cy.get(designer.formComponents.shortAnswer).parents(designer.draggable).trigger('dragstart');
     cy.get(designer.dragToArea).parents(designer.draggable).trigger('drop');
     cy.deletecomponents();
   });

--- a/src/test/cypress/e2e/integration/studio/login.js
+++ b/src/test/cypress/e2e/integration/studio/login.js
@@ -1,6 +1,8 @@
 /// <reference types="cypress" />
+/// <reference types="../../support" />
 
 import * as loginPage from '../../pageobjects/loginandreg';
+import * as dashboard from '../../pageobjects/dashboard';
 
 context('Login', () => {
   beforeEach(() => {
@@ -8,11 +10,12 @@ context('Login', () => {
   });
 
   it('Login with valid user credentials', () => {
-    cy.studiologin(Cypress.env('userName'), Cypress.env('userPwd'));
+    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.get(dashboard.searchApp).should('be.visible');
   });
 
   it('Login with invalid user credentials', () => {
-    cy.studiologin(Cypress.env('userName'), 'test123');
+    cy.studiologin(Cypress.env('autoTestUser'), 'test123');
     cy.get(loginPage.errorMessage).should('be.visible');
   });
 });

--- a/src/test/cypress/e2e/integration/usecase/usecase.js
+++ b/src/test/cypress/e2e/integration/usecase/usecase.js
@@ -1,0 +1,59 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
+/// <reference types="cypress" />
+/// <reference types="../../support" />
+
+import * as designer from '../../pageobjects/designer';
+
+context(
+  'Bruksmønster',
+  {
+    retries: {
+      runMode: 2,
+    },
+  },
+  () => {
+    before(() => {
+      cy.visit('/');
+      cy.studiologin(Cypress.env('useCaseUser'), Cypress.env('useCaseUserPwd'));
+    });
+    beforeEach(() => {
+      cy.intercept('**/RepoStatus*').as('repoStatus');
+      Cypress.Cookies.preserveOnce('AltinnStudioDesigner', 'i_like_gitea', 'XSRF-TOKEN', 'AS-XSRF-TOKEN');
+      cy.visit(`designer/${Cypress.env('deployApp')}#/about`);
+      cy.wait('@repoStatus');
+      cy.get(designer.layOutContainer).should('be.visible');
+    });
+
+    it('Navigation', () => {
+      cy.get(designer.aboutApp.repoName)
+        .find('input')
+        .invoke('val')
+        .should('contain', Cypress.env('deployApp').split('/')[1]);
+      cy.get(designer.appMenu.edit).should('be.visible').click();
+      cy.get(designer.formComponents.shortAnswer).parentsUntil(designer.draggable).should('be.visible');
+      cy.get(designer.appMenu.texts).should('be.visible').click();
+      cy.getIframeBody().find('#tabs').should('be.visible');
+      cy.getIframeBody().find('#saveTextsBtn').should('be.visible');
+    });
+
+    it('Gitea connection - Pull changes', () => {      
+      cy.deleteLocalChanges(Cypress.env('deployApp'));
+      cy.wait(5000);
+      cy.intercept(/.*designerapi\/Repository\/Pull.*/).as('pullChanges');
+      cy.get(designer.syncApp.pull).should('be.visible').click();
+      cy.wait('@pullChanges');
+      cy.get('h3').contains('Appen din er oppdatert til siste versjon').should('be.visible');
+    });
+
+    it('App builds and deploys', () => {
+      cy.intercept('**/Deployments*').as('deploys');
+      cy.get(designer.appMenu.deploy).should('be.visible').click();
+      cy.wait('@deploys').its('response.statusCode').should('eq', 200);
+      var checkDeployOf = Cypress.env('environment') == 'prod' ? 'prod' : 'at22';
+      cy.get(designer.deployHistory[checkDeployOf]).then((table) => {
+        cy.get(table).isVisible();
+        cy.get(table).find('tbody > tr').should('have.length.gte', 1);
+      });
+    });
+  },
+);

--- a/src/test/cypress/e2e/pageobjects/designer.js
+++ b/src/test/cypress/e2e/pageobjects/designer.js
@@ -12,13 +12,34 @@ export const inprogressSpinner = "[role='progressbar']";
 export const failedCheck = "i[class*='ai-circle-exclamation']";
 export const successCheck = "i[class*='ai-check-circle']";
 
-export const at22Deploys = '#deploy-history-table-at22';
+export const deployHistory ={
+  at22: '#deploy-history-table-at22',
+  prod: '#deploy-history-table-production',
+};
 
 //About app
-export const appHeader = '#altinn-column-layout-header';
-export const appName = '#administrationInputServicename_textField';
-export const appDescription = '#administrationInputDescription_textField';
-export const deleteChanges = '#reset-repo-button';
+export const aboutApp = {
+  appName: '#administrationInputServicename_textField',
+  appDescription: '#administrationInputDescription_textField',
+  appHeader: '#altinn-column-layout-header',
+  repoName: '#administrationInputReponame',
+};
+
+export const syncApp = {
+  pull: '#fetch_changes_btn',
+  push: '#changes_to_share_btn',
+  noChanges: '#no_changes_to_share_btn',
+  pushButton: '#share_changes_modal_button',
+};
+
+export const deleteChanges = {
+  reset: '#reset-repo-button',
+  name: '#delete-repo-name',
+  confirm: '#confirm-reset-repo-button',
+};
+
+export const sideMenu = '#altinn-column-layout-side-menu';
+export const layOutContainer= '#altinn-column-layout-container';
 
 export const appEditorMenu = {
   datamodel: "a[href='#/datamodel']",
@@ -29,13 +50,15 @@ export const appEditorMenu = {
 //UI components
 export const dragToArea = '.col-12';
 export const draggable = "div[draggable='true']";
-export const shortAnswer = "i[class^='fa fa-short-answer']";
-export const longtAnswer = "i[class^='fa fa-long-answer']";
-export const checkBox = "i[class^='fa fa-checkbox']";
-export const radioDutton = "i[class^='fa fa-radio-button']";
-export const dropDown = "i[class^='fa fa-drop-down']";
-export const attachment = "i[class^='fa fa-attachment']";
-export const date = "i[class^='fa fa-date']";
-export const formButton = "i[class^='fa fa-button']";
+export const formComponents = {
+  shortAnswer: "i[class^='fa fa-short-answer']",
+  longAnswer: "i[class^='fa fa-long-answer']",
+  checkBox: "i[class^='fa fa-checkbox']",
+  radioDutton: "i[class^='fa fa-radio-button']",
+  dropDown: "i[class^='fa fa-drop-down']",
+  attachment: "i[class^='fa fa-attachment']",
+  date: "i[class^='fa fa-date']",
+  formButton: "i[class^='fa fa-button']",
+};
 
 export const deleteComponent = '.fa-circletrash';

--- a/src/test/cypress/e2e/support/custom.js
+++ b/src/test/cypress/e2e/support/custom.js
@@ -1,0 +1,10 @@
+Cypress.Commands.add(
+  'isVisible',
+  {
+    prevSubject: true,
+  },
+  (subject) => {
+    const isVisible = (elem) => !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length);
+    expect(isVisible(subject[0])).to.be.true;
+  },
+);

--- a/src/test/cypress/e2e/support/index.d.ts
+++ b/src/test/cypress/e2e/support/index.d.ts
@@ -111,5 +111,22 @@ declare namespace Cypress {
      * @example cy.testWcag()
      */
       testWcag(): Chainable<Element>;
+
+      /**
+     * Reset local repo of an app
+     * @example cy.deleteLocalChanges('test/test-app')
+     */
+       deleteLocalChanges(appId: String): Chainable<Element>;
+
+       /**
+     * Get body of ifram from the DOM
+     * @example cy.getIframeBody()
+     */
+        getIframeBody(): Chainable<Element>;
+
+      /**
+       * check visibility of an element whose parent is found hidden by cypress 
+       */
+        isVisible(): Chainable<Element>;
   }
 }

--- a/src/test/cypress/e2e/support/index.js
+++ b/src/test/cypress/e2e/support/index.js
@@ -3,6 +3,7 @@ import './studio';
 import './localtest';
 import './app';
 import './app-frontend';
+import './custom';
 import 'cypress-file-upload';
 import 'cypress-plugin-tab';
 import './start-app-instance';

--- a/src/test/cypress/e2e/support/studio.js
+++ b/src/test/cypress/e2e/support/studio.js
@@ -39,7 +39,7 @@ Cypress.Commands.add('deletecomponents', () => {
         cy.get($component).each(($el) => {
           cy.wrap($el).click();
         });
-        cy.get(designer.deleteComponent).parents('button').click();
+        cy.get(designer.deleteComponent).parents('button').click({ multiple: true, force: true});
       }
     });
 });

--- a/src/test/cypress/e2e/support/studio.js
+++ b/src/test/cypress/e2e/support/studio.js
@@ -9,7 +9,7 @@ import * as designer from '../pageobjects/designer';
 Cypress.Commands.add('studiologin', (userName, userPwd) => {
   cy.get(loginPage.loginButton).click();
   cy.get(loginPage.userName).type(userName);
-  cy.get(loginPage.userPwd).type(userPwd);
+  cy.get(loginPage.userPwd).type(userPwd, { log: false });
   cy.get(loginPage.submit).click();
 });
 
@@ -42,4 +42,37 @@ Cypress.Commands.add('deletecomponents', () => {
         cy.get(designer.deleteComponent).parents('button').click();
       }
     });
+});
+
+/**
+ * Delete local changes of an app for a logged in user
+ */
+Cypress.Commands.add('deleteLocalChanges', (appId) => {
+  cy.getCookie('AltinnStudioDesigner').should('exist');
+  cy.intercept('**/RepoStatus*').as('repoStatus');
+  cy.visit(`designer/${Cypress.env('deployApp')}#/about`);
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(5000);
+  cy.wait('@repoStatus');
+  cy.get(designer.aboutApp.repoName).should('be.visible');
+  cy.get(designer.sideMenu)
+    .find(designer.deleteChanges.reset)
+    .should(($button) => {
+      expect(Cypress.dom.isDetached($button), 'button should not be detached').to.eq(false);
+    })
+    .should('be.visible')
+    .click();
+  cy.get(designer.deleteChanges.name)
+    .should('be.visible')
+    .type(`${appId.split('/')[1]}`)
+    .blur();
+  cy.get(designer.deleteChanges.confirm).should('be.visible').click();
+  cy.get(designer.deleteChanges.name).should('not.exist');
+});
+
+/**
+ * Get body of an iframe document
+ */
+Cypress.Commands.add('getIframeBody', () => {
+  return cy.get('iframe').its('0.contentDocument.body').should('not.be.empty').then(cy.wrap);
 });

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -15,6 +15,8 @@
     "eslint:fix": "eslint \"e2e/**\" --fix",
     "cy:open": "cypress open --env component=%npm_config_component%,environment=%npm_config_env%",
     "cy:verify": "cypress verify",
+    "cy:version": "cypress -v",
+    "cy:run": "cypress run",
     "before:all": "cypress run -b chrome -s 'e2e/integration/setup/before.js'",
     "after:all": "cypress run -b chrome -s 'e2e/integration/setup/after.js'",
     "test:studio": "cypress run --env component=studio,environment=%npm_config_env% -b chrome -s 'e2e/integration/studio/*.js'",

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -16,6 +16,7 @@
     "cy:open": "cypress open --env component=%npm_config_component%,environment=%npm_config_env%",
     "cy:verify": "cypress verify",
     "cy:version": "cypress -v",
+    "cy:cachelist": "cypress cache list",
     "cy:run": "cypress run",
     "before:all": "cypress run -b chrome -s 'e2e/integration/setup/before.js'",
     "after:all": "cypress run -b chrome -s 'e2e/integration/setup/after.js'",

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -33,16 +33,16 @@
   },
   "devDependencies": {
     "axe-core": "^4.3.5",
-    "cypress": "^9.0.0",
+    "cypress": "^9.1.0",
     "cypress-axe": "^0.13.0",
     "cypress-file-upload": "^5.0.8",
     "cypress-plugin-tab": "^1.0.5",
-    "eslint": "^8.2.0",
+    "eslint": "^8.3.0",
     "eslint-plugin-cypress": "^2.12.1",
     "faker": "^5.5.3",
     "fs-extra": "^10.0.0",
     "path": "^0.12.7",
-    "prettier": "^2.4.1",
+    "prettier": "^2.5.0",
     "start-server-and-test": "^1.14.0"
   },
   "packageManager": "yarn@3.1.0"

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -25,6 +25,8 @@ steps:
   condition: succeededOrFailed()
 
 - bash: |
+   apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+
    yarn --immutable
 
    yarn run cy:version   

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -29,9 +29,9 @@ steps:
   condition: succeededOrFailed()
 
 - bash: |
+   yarn run cy:cachelist
+   
    yarn --immutable
-
-   npx cypress cache list
 
    yarn run cy:version
 

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -25,7 +25,7 @@ steps:
   condition: succeededOrFailed()
 
 - bash: |
-   apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+   sudo apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
    yarn --immutable
 

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -11,13 +11,13 @@ variables:
   cyCacheDir: "/home/AzDevOps/.cache/Cypress"
   cypressTestDir: "$(Build.SourcesDirectory)/src/test/cypress"
 
-#schedules:
-#- cron: "10,25,40,55 * * * *"
-#  displayName: Bruksmønster
-#  branches:
-#    include:
-#    - master
-#  always: true
+schedules:
+- cron: "10,25,40,55 * * * *"
+  displayName: Bruksmønster
+  branches:
+    include:
+    - master
+  always: true
 
 steps:
 - task: DeleteFiles@1
@@ -28,17 +28,8 @@ steps:
       *.xml
   condition: succeededOrFailed()
 
-#- task: Cache@2
-#  inputs:
-#    key: '$(cypressTestDir)/yarn.lock'
-#    path: $(cyCacheDir)
-#    cacheHitVar: CYPRESS_CACHE_RESTORED
-#  displayName: "Cache Cypress binary"
-
 - bash: |
    yarn --immutable
-
-   npx cypress cache path
 
    npx cypress cache list
 

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -8,7 +8,7 @@ trigger: none
 pr: none
 
 variables:  
-  cyCacheDir: "/home/AzDevOps/.cache/Cypress"
+  cyCacheDir: "~/.cache/Cypress"
   cypressTestDir: "$(Build.SourcesDirectory)/src/test/cypress"
 
 #schedules:
@@ -30,7 +30,7 @@ steps:
 
 - task: Cache@2
   inputs:
-    key: '$(cyCacheDir)/yarn.lock'
+    key: '$(cypressTestDir)/yarn.lock'
     path: $(cyCacheDir)
     cacheHitVar: CYPRESS_CACHE_RESTORED
   displayName: "Cache Cypress binary"

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -28,12 +28,12 @@ steps:
       *.xml
   condition: succeededOrFailed()
 
-- task: Cache@2
-  inputs:
-    key: '$(cypressTestDir)/yarn.lock'
-    path: $(cyCacheDir)
-    cacheHitVar: CYPRESS_CACHE_RESTORED
-  displayName: "Cache Cypress binary"
+#- task: Cache@2
+#  inputs:
+#    key: '$(cypressTestDir)/yarn.lock'
+#    path: $(cyCacheDir)
+#    cacheHitVar: CYPRESS_CACHE_RESTORED
+#  displayName: "Cache Cypress binary"
 
 - bash: |
    yarn --immutable
@@ -43,6 +43,8 @@ steps:
    npx cypress cache list
 
    yarn run cy:version
+
+   yarn run cy:verify
 
   workingDirectory: '$(cypressTestDir)'
   displayName: 'Studio Tests'

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -8,7 +8,7 @@ trigger: none
 pr: none
 
 variables:  
-  cyCacheDir: "~/.cache/Cypress"
+  cyCacheDir: "/home/AzDevOps/.cache/Cypress"
   cypressTestDir: "$(Build.SourcesDirectory)/src/test/cypress"
 
 #schedules:
@@ -28,23 +28,23 @@ steps:
       *.xml
   condition: succeededOrFailed()
 
-#- task: Cache@2
-#  inputs:
-#    key: '$(cyCacheDir)/yarn.lock'
-#    path: $(cyCacheDir)
-#    cacheHitVar: CYPRESS_CACHE_RESTORED
-#  displayName: "Cache Cypress binary"
+- task: Cache@2
+  inputs:
+    key: '$(cyCacheDir)/yarn.lock'
+    path: $(cyCacheDir)
+    cacheHitVar: CYPRESS_CACHE_RESTORED
+  displayName: "Cache Cypress binary"
 
 - bash: |
-   yarn --frozen-lockfile
+   yarn --immutable
 
    npx cypress cache path
 
    npx cypress cache list
 
-   yarn run cy:version   
+   yarn run cy:version
 
-   yarn cache dir   
+   yarn run cy:verify
 
   workingDirectory: '$(cypressTestDir)'
   displayName: 'Studio Tests'

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -7,6 +7,10 @@ trigger: none
 
 pr: none
 
+variables:  
+  cyCacheDir: "/home/vsts/.cache/Cypress"
+  cypressTestDir: "$(Build.SourcesDirectory)/src/test/cypress"
+
 #schedules:
 #- cron: "10,25,40,55 * * * *"
 #  displayName: Bruksmønster
@@ -19,28 +23,33 @@ steps:
 - task: DeleteFiles@1
   displayName: 'Delete test results'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)/src/test/cypress/reports'
+    SourceFolder: '$(cypressTestDir)/reports'
     Contents: |
       *.xml
   condition: succeededOrFailed()
 
-- bash: |
-   sudo apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+- task: Cache@2
+  inputs:
+    key: '$(cyCacheDir)/yarn.lock'
+    path: $(cyCacheDir)
+    cacheHitVar: CYPRESS_CACHE_RESTORED
+  displayName: "Cache Cypress binary"
 
-   yarn --immutable
+- bash: |
+   yarn --frozen-lockfile
 
    yarn run cy:version   
 
-   yarn run cy:run -s 'e2e/integration/usecase/usecase.js' -e environment=$(environment),useCaseUserPwd=$(userPassword),component=studio
+   yarn cache dir   
 
-  workingDirectory: '$(Build.SourcesDirectory)/src/test/cypress'
+  workingDirectory: '$(cypressTestDir)'
   displayName: 'Studio Tests'
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results'
   inputs:
     testResultsFiles: '*.xml'
-    searchFolder: '$(Build.SourcesDirectory)/src/test/cypress/reports'
+    searchFolder: '$(cypressTestDir)/reports'
     mergeTestResults: true
     failTaskOnFailedTests: true
     testRunTitle: '$(environment)_studio_use_cases'

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -1,0 +1,45 @@
+pool:
+  name: altinn-vmss-testagent
+
+name: $(environment)_Studio_Usecases_$(Date:ddMMyyyy)_$(Date:HHmm)
+
+trigger: none
+
+pr: none
+
+#schedules:
+#- cron: "10,25,40,55 * * * *"
+#  displayName: Bruksmønster
+#  branches:
+#    include:
+#    - master
+#  always: true
+
+steps:
+- task: DeleteFiles@1
+  displayName: 'Delete test results'
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)/src/test/cypress/reports'
+    Contents: |
+      *.xml
+  condition: succeededOrFailed()
+
+- bash: |
+   yarn --immutable
+
+   yarn run cy:version   
+
+   yarn run cy:run -s 'e2e/integration/usecase/usecase.js' -e environment=$(environment),useCaseUserPwd=$(userPassword),component=studio
+
+  workingDirectory: '$(Build.SourcesDirectory)/src/test/cypress'
+  displayName: 'Studio Tests'
+
+- task: PublishTestResults@2
+  displayName: 'Publish Test Results'
+  inputs:
+    testResultsFiles: '*.xml'
+    searchFolder: '$(Build.SourcesDirectory)/src/test/cypress/reports'
+    mergeTestResults: true
+    failTaskOnFailedTests: true
+    testRunTitle: '$(environment)_studio_use_cases'
+  condition: succeededOrFailed()

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -46,6 +46,8 @@ steps:
 
    yarn run cy:verify
 
+   yarn run cy:run -s 'e2e/integration/usecase/usecase.js' -e environment=$(environment),useCaseUserPwd=$(userPassword),component=studio
+
   workingDirectory: '$(cypressTestDir)'
   displayName: 'Studio Tests'
 

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -28,15 +28,19 @@ steps:
       *.xml
   condition: succeededOrFailed()
 
-- task: Cache@2
-  inputs:
-    key: '$(cyCacheDir)/yarn.lock'
-    path: $(cyCacheDir)
-    cacheHitVar: CYPRESS_CACHE_RESTORED
-  displayName: "Cache Cypress binary"
+#- task: Cache@2
+#  inputs:
+#    key: '$(cyCacheDir)/yarn.lock'
+#    path: $(cyCacheDir)
+#    cacheHitVar: CYPRESS_CACHE_RESTORED
+#  displayName: "Cache Cypress binary"
 
 - bash: |
    yarn --frozen-lockfile
+
+   npx cypress cache path
+
+   npx cypress cache list
 
    yarn run cy:version   
 

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -8,7 +8,7 @@ trigger: none
 pr: none
 
 variables:  
-  cyCacheDir: "/home/vsts/.cache/Cypress"
+  cyCacheDir: "~/.cache/Cypress"
   cypressTestDir: "$(Build.SourcesDirectory)/src/test/cypress"
 
 #schedules:

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -44,8 +44,6 @@ steps:
 
    yarn run cy:version
 
-   yarn run cy:verify
-
   workingDirectory: '$(cypressTestDir)'
   displayName: 'Studio Tests'
 

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -8,7 +8,7 @@ trigger: none
 pr: none
 
 variables:  
-  cyCacheDir: "~/.cache/Cypress"
+  cyCacheDir: "/home/AzDevOps/.cache/Cypress"
   cypressTestDir: "$(Build.SourcesDirectory)/src/test/cypress"
 
 #schedules:

--- a/src/test/cypress/use-cases.yaml
+++ b/src/test/cypress/use-cases.yaml
@@ -29,9 +29,9 @@ steps:
   condition: succeededOrFailed()
 
 - bash: |
-   yarn run cy:cachelist
-   
    yarn --immutable
+
+   yarn run cy:cachelist
 
    yarn run cy:version
 

--- a/src/test/cypress/yarn.lock
+++ b/src/test/cypress/yarn.lock
@@ -346,7 +346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bluebird@npm:3.7.2, bluebird@npm:^3.7.2":
+"bluebird@npm:3.7.2":
   version: 3.7.2
   resolution: "bluebird@npm:3.7.2"
   checksum: 869417503c722e7dc54ca46715f70e15f4d9c602a423a02c825570862d12935be59ed9c7ba34a9b31f186c017c23cac6b54e35446f8353059c101da73eac22ef
@@ -573,23 +573,23 @@ __metadata:
   resolution: "cypress-studio@workspace:."
   dependencies:
     axe-core: ^4.3.5
-    cypress: ^9.0.0
+    cypress: ^9.1.0
     cypress-axe: ^0.13.0
     cypress-file-upload: ^5.0.8
     cypress-plugin-tab: ^1.0.5
-    eslint: ^8.2.0
+    eslint: ^8.3.0
     eslint-plugin-cypress: ^2.12.1
     faker: ^5.5.3
     fs-extra: ^10.0.0
     path: ^0.12.7
-    prettier: ^2.4.1
+    prettier: ^2.5.0
     start-server-and-test: ^1.14.0
   languageName: unknown
   linkType: soft
 
-"cypress@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "cypress@npm:9.0.0"
+"cypress@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "cypress@npm:9.1.0"
   dependencies:
     "@cypress/request": ^2.88.7
     "@cypress/xvfb": ^1.2.4
@@ -598,7 +598,7 @@ __metadata:
     "@types/sizzle": ^2.3.2
     arch: ^2.2.0
     blob-util: ^2.0.2
-    bluebird: ^3.7.2
+    bluebird: 3.7.2
     cachedir: ^2.3.0
     chalk: ^4.1.0
     check-more-types: ^2.24.0
@@ -634,7 +634,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: ae481f26f6a51370bad6571b7edd525559c0b4e36fb9c33ac26c822610bd2f0b419614f12c1d87aff59c46afb3c2f06f7e167f924023da65fe2a3987927255c8
+  checksum: 37f2cd704d9e67c4b525e2e8a723f82b0e0eb573cd276fa6460d86ce665cf2a53fd490a4a0ca79394694ba0d91306a03194479089b57457fdc6b9cb9e9747b54
   languageName: node
   linkType: hard
 
@@ -800,7 +800,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.2.0":
+"eslint@npm:^8.3.0":
   version: 8.3.0
   resolution: "eslint@npm:8.3.0"
   dependencies:
@@ -1813,12 +1813,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.4.1":
-  version: 2.4.1
-  resolution: "prettier@npm:2.4.1"
+"prettier@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "prettier@npm:2.5.0"
   bin:
     prettier: bin-prettier.js
-  checksum: cc6830588b401b0d742862fe9c46bc9118204fb307c3abe0e49e95b35ed23629573807ffdf9cdd65289c252a0bb51fc0171437f6626ee36378dea80f0ee80b91
+  checksum: aad1b35b73e7c14596d389d90977a83dad0db689ba5802a0ef319c357b7867f55b885db197972aa6a56c30f53088c9f8e0d7f7930ae074c275a4e9cbe091d21d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Studio tests with cypress
First version of moving the studio tests from testcafe to cypress.

## Description
With testcafe, the pipeline has timeout sporadically and triggered many false alarms. this PR is a first step to move away from testcafe.

-  added config for all studio env
-  moved a part of regression tests 
-  added bruksmønster cases for cypress tests
- new yaml for bruksmønster
- updated deps in cypress

## Fixes
a part of #6944 

## Verification
- [x] All tests run green