### PR TITLE
Feature/6697/correct-spacing-for-header-and-paragraph

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/components/base/__snapshots__/HeaderComponent.test.tsx.snap
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/components/base/__snapshots__/HeaderComponent.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`>>> components/base/HeaderComponent.tsx --- Snapshot +++ should match s
       style={
         Object {
           "marginBottom": "0",
-          "marginTop": "1rem",
+          "marginTop": "0",
         }
       }
     >

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.19.1",
+  "version": "3.18.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.18.1",
+  "version": "3.19.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/HeaderComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/HeaderComponent.tsx
@@ -13,7 +13,7 @@ export interface IHeaderProps {
 }
 
 const marginStyling = {
-  marginTop: '1rem',
+  marginTop: '0',
   marginBottom: '0',
 };
 

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/ParagraphComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/ParagraphComponent.tsx
@@ -14,6 +14,8 @@ export interface IParagraphProps {
 const useStyles = makeStyles({
   spacing: {
     letterSpacing: '0.3px',
+    maxWidth: '684px',
+    marginTop: '-12px',
   },
   // Class to override default stylings for headers created by markdown parsing. Done to align help text icon.
   typography: {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/index.css
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/index.css
@@ -31,6 +31,17 @@ p {
   font-family: 'Altinn-DIN';
 }
 
+h2 {
+  font-size: 22px;
+  font-weight: normal;
+}
+
+@media only screen and (min-width: 576px) {
+  h2 {
+      font-size: 28px;
+  }
+}
+
 option {
   overflow: 'hidden';
   text-overflow: 'ellipsis';


### PR DESCRIPTION
# Correct spacing for header and paragraph

- Improve readability: Set paragraph max-width to 684px to avoid more than [95 characters](https://www.usability.gov/get-involved/blog/2006/08/line-length-and-onscreen-reading.html) per line.
- Set header size (H2) according to Figma-sketches. 28px for desktop, 22px for mobile (font-weight normal). 
- 12px space between paragraphs and between header and paragraph.

## Fixes
- #[6697](https://github.com/Altinn/altinn-studio/issues/6697) 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
