### PR TITLE
feature/6697/max-width-for-input-and-correct-space-in-addres-component

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.18.2",
+  "version": "3.18.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/AddressComponent.css
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/AddressComponent.css
@@ -4,6 +4,10 @@
   width: 100%;
 }
 
+.address-component .form-control {
+  margin-bottom: 18px;
+}
+
 .address-component input {
   max-width: 100%;
 }

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/index.css
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/index.css
@@ -76,6 +76,7 @@ option {
 
 .a-form-group .form-control {
   border: 2px solid #008FD6;
+  max-width: 684px;
 }
 
 .a-form-group .input-group .input-group-prepend {


### PR DESCRIPTION
# max-width for input and correct space in adress component

- Max width 684px for all input
- 18px space between adress inputs. 

![image](https://user-images.githubusercontent.com/1464915/144028765-a40f42c4-5e8e-450e-a9b7-d8156b5ab585.png)


## Fixes
- #[6697](https://github.com/Altinn/altinn-studio/issues/6697)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)

