### PR TITLE
add h2 as default for header in studio

### DIFF
--- a/src/studio/src/designer/frontend/ux-editor/components/index.ts
+++ b/src/studio/src/designer/frontend/ux-editor/components/index.ts
@@ -50,6 +50,9 @@ export const textComponents: IComponent[] = [
   {
     name: ComponentTypes.Header,
     Icon: componentIcons.Header,
+    customProperties: {
+      size: "L",
+    },
   },
   {
     name: ComponentTypes.Paragraph,


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# add h2 as default for header in studio
<!-- Summary of the changes (max 80 characters) -->

Setst H2 (L)  as default in studio when adding header

## Description

<!-- Longer desription -->

## Fixes
- partially fixes #7488 

