### PR TITLE
Stop storing ObligationExpression in delegation policies

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Helpers/PolicyHelper.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Helpers/PolicyHelper.cs
@@ -253,11 +253,6 @@ namespace Altinn.Platform.Authorization.Helpers
                 }
             }
 
-            foreach (XacmlObligationExpression obligation in appPolicy.ObligationExpressions)
-            {
-                delegationPolicy.ObligationExpressions.Add(obligation);
-            }
-
             return delegationPolicy;
         }
 

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/error/postgrewritechangefail/50001337/u20001337/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/error/postgrewritechangefail/50001337/u20001337/delegationpolicy.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
 	<xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 20001337, for resources on the app; error/postgrewritechangefail</xacml:Description>
 	<xacml:Target/>
@@ -35,11 +35,4 @@
 			</xacml:AnyOf>
 		</xacml:Target>
 	</xacml:Rule>
-	<xacml:ObligationExpressions>
-		<xacml:ObligationExpression ObligationId="urn:altinn:obligation:1" FulfillOn="Permit">
-			<xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:1" Category="urn:altinn:minimum-authenticationlevel">
-				<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">4</xacml:AttributeValue>
-			</xacml:AttributeAssignmentExpression>
-		</xacml:ObligationExpression>
-	</xacml:ObligationExpressions>
 </xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org1/app1/50001337/p50001336/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org1/app1/50001337/p50001336/delegationpolicy.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
 	<xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 50001336, for resources on the app; org1/app1</xacml:Description>
 	<xacml:Target/>
@@ -109,16 +109,4 @@
 			</xacml:AnyOf>
 		</xacml:Target>
 	</xacml:Rule>
-	<xacml:ObligationExpressions>
-		<xacml:ObligationExpression ObligationId="urn:altinn:obligation:1" FulfillOn="Permit">
-			<xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:1" Category="urn:altinn:minimum-authenticationlevel">
-				<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">4</xacml:AttributeValue>
-			</xacml:AttributeAssignmentExpression>
-		</xacml:ObligationExpression>
-		<xacml:ObligationExpression ObligationId="urn:altinn:obligation:2" FulfillOn="Permit">
-			<xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:2" Category="urn:altinn:minimum-authenticationlevel-org">
-				<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">3</xacml:AttributeValue>
-			</xacml:AttributeAssignmentExpression>
-		</xacml:ObligationExpression>
-	</xacml:ObligationExpressions>
 </xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org1/app1/50001337/u20001337/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org1/app1/50001337/u20001337/delegationpolicy.xml
@@ -1,1 +1,112 @@
-﻿<?xml version="1.0" encoding="utf-8"?><xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"><xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 20001337, for resources on the app; org1/app1</xacml:Description><xacml:Target /><xacml:Rule RuleId="urn:altinn:ruleid:57b3ee85-f932-42c6-9ab0-941eb6c96eb0" Effect="Permit"><xacml:Description>Delegation of a right/action from 50001337 to 20001337, for a resource on the app; org1/app1, by user; 20001336</xacml:Description><xacml:Target><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org1</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app1</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Read</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf></xacml:Target></xacml:Rule><xacml:Rule RuleId="urn:altinn:ruleid:78e5cced-3bcb-42b6-9089-63c834f89e73" Effect="Permit"><xacml:Description>Delegation of a right/action from 50001337 to 20001337, for a resource on the app; org1/app1, by user; 20001336</xacml:Description><xacml:Target><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org1</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app1</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">task1</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Write</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf></xacml:Target></xacml:Rule><xacml:Rule RuleId="urn:altinn:ruleid:31776194-9921-4383-994d-dfd42a2aa91b" Effect="Permit"><xacml:Description>Delegation of a right/action from 50001337 to 20001337, for a resource on the app; org1/app1, by user; 20001336</xacml:Description><xacml:Target><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org1</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app1</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">event1</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:appresource" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Read</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf></xacml:Target></xacml:Rule><xacml:ObligationExpressions><xacml:ObligationExpression ObligationId="urn:altinn:obligation:1" FulfillOn="Permit"><xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:1" Category="urn:altinn:minimum-authenticationlevel"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">4</xacml:AttributeValue></xacml:AttributeAssignmentExpression></xacml:ObligationExpression><xacml:ObligationExpression ObligationId="urn:altinn:obligation:2" FulfillOn="Permit"><xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:2" Category="urn:altinn:minimum-authenticationlevel-org"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">3</xacml:AttributeValue></xacml:AttributeAssignmentExpression></xacml:ObligationExpression></xacml:ObligationExpressions></xacml:Policy>
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+  <xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 20001337, for resources on the app; org1/app1</xacml:Description>
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:ruleid:57b3ee85-f932-42c6-9ab0-941eb6c96eb0" Effect="Permit">
+    <xacml:Description>Delegation of a right/action from 50001337 to 20001337, for a resource on the app; org1/app1, by user; 20001336</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:ruleid:78e5cced-3bcb-42b6-9089-63c834f89e73" Effect="Permit">
+    <xacml:Description>Delegation of a right/action from 50001337 to 20001337, for a resource on the app; org1/app1, by user; 20001336</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">task1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:ruleid:31776194-9921-4383-994d-dfd42a2aa91b" Effect="Permit">
+    <xacml:Description>Delegation of a right/action from 50001337 to 20001337, for a resource on the app; org1/app1, by user; 20001336</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">event1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:appresource" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+</xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org1/app2/50001337/p50001336/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org1/app2/50001337/p50001336/delegationpolicy.xml
@@ -1,1 +1,38 @@
-﻿<?xml version="1.0" encoding="utf-8"?><xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"><xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 50001336, for resources on the app; org1/app2</xacml:Description><xacml:Target /><xacml:Rule RuleId="urn:altinn:ruleid:8a26290e-76be-4c36-9543-4bd0492a30ba" Effect="Permit"><xacml:Description>Delegation of a right/action from 50001337 to 50001336, for a resource on the app; org1/app2, by user; 20001337</xacml:Description><xacml:Target><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">50001336</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:partyid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org1</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app2</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Write</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf></xacml:Target></xacml:Rule><xacml:ObligationExpressions><xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel1" FulfillOn="Permit"><xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue></xacml:AttributeAssignmentExpression></xacml:ObligationExpression></xacml:ObligationExpressions></xacml:Policy>
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+  <xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 50001336, for resources on the app; org1/app2</xacml:Description>
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:ruleid:8a26290e-76be-4c36-9543-4bd0492a30ba" Effect="Permit">
+    <xacml:Description>Delegation of a right/action from 50001337 to 50001336, for a resource on the app; org1/app2, by user; 20001337</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">50001336</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:partyid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app2</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+</xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org1/app2/50001337/u20001337/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org1/app2/50001337/u20001337/delegationpolicy.xml
@@ -1,1 +1,38 @@
-﻿<?xml version="1.0" encoding="utf-8"?><xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"><xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 20001337, for resources on the app; org1/app2</xacml:Description><xacml:Target /><xacml:Rule RuleId="urn:altinn:ruleid:b5532feb-f0b9-47a0-9036-4ccefcb9b001" Effect="Permit"><xacml:Description>Delegation of a right/action from 50001337 to 20001337, for a resource on the app; org1/app2, by user; 20001336</xacml:Description><xacml:Target><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org1</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app2</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Read</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf></xacml:Target></xacml:Rule><xacml:ObligationExpressions><xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel1" FulfillOn="Permit"><xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue></xacml:AttributeAssignmentExpression></xacml:ObligationExpression></xacml:ObligationExpressions></xacml:Policy>
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+  <xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 20001337, for resources on the app; org1/app2</xacml:Description>
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:ruleid:b5532feb-f0b9-47a0-9036-4ccefcb9b001" Effect="Permit">
+    <xacml:Description>Delegation of a right/action from 50001337 to 20001337, for a resource on the app; org1/app2, by user; 20001336</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app2</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+</xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org1/app3/50001337/u20001337/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org1/app3/50001337/u20001337/delegationpolicy.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
 	<xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 20001336, for resources on the app; org1/app1</xacml:Description>
 	<xacml:Target/>
@@ -68,16 +68,4 @@
 			</xacml:AnyOf>
 		</xacml:Target>
 	</xacml:Rule>
-	<xacml:ObligationExpressions>
-		<xacml:ObligationExpression ObligationId="urn:altinn:obligation:1" FulfillOn="Permit">
-			<xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:1" Category="urn:altinn:minimum-authenticationlevel">
-				<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">4</xacml:AttributeValue>
-			</xacml:AttributeAssignmentExpression>
-		</xacml:ObligationExpression>
-		<xacml:ObligationExpression ObligationId="urn:altinn:obligation:2" FulfillOn="Permit">
-			<xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:2" Category="urn:altinn:minimum-authenticationlevel-org">
-				<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">3</xacml:AttributeValue>
-			</xacml:AttributeAssignmentExpression>
-		</xacml:ObligationExpression>
-	</xacml:ObligationExpressions>
 </xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org1/app4/50001337/u20001337/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org1/app4/50001337/u20001337/delegationpolicy.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
 	<xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 20001336, for resources on the app; org1/app1</xacml:Description>
 	<xacml:Target/>
@@ -68,16 +68,4 @@
 			</xacml:AnyOf>
 		</xacml:Target>
 	</xacml:Rule>
-	<xacml:ObligationExpressions>
-		<xacml:ObligationExpression ObligationId="urn:altinn:obligation:1" FulfillOn="Permit">
-			<xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:1" Category="urn:altinn:minimum-authenticationlevel">
-				<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">4</xacml:AttributeValue>
-			</xacml:AttributeAssignmentExpression>
-		</xacml:ObligationExpression>
-		<xacml:ObligationExpression ObligationId="urn:altinn:obligation:2" FulfillOn="Permit">
-			<xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:2" Category="urn:altinn:minimum-authenticationlevel-org">
-				<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">3</xacml:AttributeValue>
-			</xacml:AttributeAssignmentExpression>
-		</xacml:ObligationExpression>
-	</xacml:ObligationExpressions>
 </xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org2/app1/50001336/u20001337/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org2/app1/50001336/u20001337/delegationpolicy.xml
@@ -1,1 +1,38 @@
-﻿<?xml version="1.0" encoding="utf-8"?><xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"><xacml:Description>Delegation policy containing all delegated rights/actions from 50001336 to 20001337, for resources on the app; org2/app1</xacml:Description><xacml:Target /><xacml:Rule RuleId="urn:altinn:ruleid:b68ef342-6e67-4014-bc51-0667067d3e7b" Effect="Permit"><xacml:Description>Delegation of a right/action from 50001336 to 20001337, for a resource on the app; org2/app1, by user; 20001336</xacml:Description><xacml:Target><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org2</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app1</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Read</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf></xacml:Target></xacml:Rule><xacml:ObligationExpressions><xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel1" FulfillOn="Permit"><xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue></xacml:AttributeAssignmentExpression></xacml:ObligationExpression></xacml:ObligationExpressions></xacml:Policy>
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+  <xacml:Description>Delegation policy containing all delegated rights/actions from 50001336 to 20001337, for resources on the app; org2/app1</xacml:Description>
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:ruleid:b68ef342-6e67-4014-bc51-0667067d3e7b" Effect="Permit">
+    <xacml:Description>Delegation of a right/action from 50001336 to 20001337, for a resource on the app; org2/app1, by user; 20001336</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org2</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+</xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org2/app1/50001337/u20001337/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org2/app1/50001337/u20001337/delegationpolicy.xml
@@ -1,1 +1,38 @@
-﻿<?xml version="1.0" encoding="utf-8"?><xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"><xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 20001337, for resources on the app; org2/app1</xacml:Description><xacml:Target /><xacml:Rule RuleId="urn:altinn:ruleid:f6db3370-b7ea-4e53-b535-142dd0dc1474" Effect="Permit"><xacml:Description>Delegation of a right/action from 50001337 to 20001337, for a resource on the app; org2/app1, by user; 20001336</xacml:Description><xacml:Target><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org2</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app1</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Read</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf></xacml:Target></xacml:Rule><xacml:ObligationExpressions><xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel1" FulfillOn="Permit"><xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue></xacml:AttributeAssignmentExpression></xacml:ObligationExpression></xacml:ObligationExpressions></xacml:Policy>
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+  <xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 20001337, for resources on the app; org2/app1</xacml:Description>
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:ruleid:f6db3370-b7ea-4e53-b535-142dd0dc1474" Effect="Permit">
+    <xacml:Description>Delegation of a right/action from 50001337 to 20001337, for a resource on the app; org2/app1, by user; 20001336</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org2</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+</xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org2/app2/50001336/p50001337/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org2/app2/50001336/p50001337/delegationpolicy.xml
@@ -1,1 +1,38 @@
-﻿<?xml version="1.0" encoding="utf-8"?><xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"><xacml:Description>Delegation policy containing all delegated rights/actions from 50001336 to 50001337, for resources on the app; org2/app2</xacml:Description><xacml:Target /><xacml:Rule RuleId="urn:altinn:ruleid:ea640eba-12d7-483b-b60b-6559108cca5f" Effect="Permit"><xacml:Description>Delegation of a right/action from 50001336 to 50001337, for a resource on the app; org2/app2, by user; 20001336</xacml:Description><xacml:Target><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">50001337</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:partyid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org2</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app2</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Write</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf></xacml:Target></xacml:Rule><xacml:ObligationExpressions><xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel1" FulfillOn="Permit"><xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue></xacml:AttributeAssignmentExpression></xacml:ObligationExpression></xacml:ObligationExpressions></xacml:Policy>
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+  <xacml:Description>Delegation policy containing all delegated rights/actions from 50001336 to 50001337, for resources on the app; org2/app2</xacml:Description>
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:ruleid:ea640eba-12d7-483b-b60b-6559108cca5f" Effect="Permit">
+    <xacml:Description>Delegation of a right/action from 50001336 to 50001337, for a resource on the app; org2/app2, by user; 20001336</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">50001337</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:partyid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org2</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app2</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+</xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org2/app3/50001337/u20001337/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/org2/app3/50001337/u20001337/delegationpolicy.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
 	<xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 20001336, for resources on the app; org1/app1</xacml:Description>
 	<xacml:Target/>
@@ -68,16 +68,4 @@
 			</xacml:AnyOf>
 		</xacml:Target>
 	</xacml:Rule>
-	<xacml:ObligationExpressions>
-		<xacml:ObligationExpression ObligationId="urn:altinn:obligation:1" FulfillOn="Permit">
-			<xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:1" Category="urn:altinn:minimum-authenticationlevel">
-				<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">4</xacml:AttributeValue>
-			</xacml:AttributeAssignmentExpression>
-		</xacml:ObligationExpression>
-		<xacml:ObligationExpression ObligationId="urn:altinn:obligation:2" FulfillOn="Permit">
-			<xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:2" Category="urn:altinn:minimum-authenticationlevel-org">
-				<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">3</xacml:AttributeValue>
-			</xacml:AttributeAssignmentExpression>
-		</xacml:ObligationExpression>
-	</xacml:ObligationExpressions>
 </xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/skd/taxreport/1000/u20001337/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/skd/taxreport/1000/u20001337/delegationpolicy.xml
@@ -1,1 +1,38 @@
-<?xml version="1.0" encoding="utf-8"?><xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"><xacml:Description>Delegation policy containing all delegated rights/actions from 1000 to 20001337, for resources on the app; skd/taxreport</xacml:Description><xacml:Target /><xacml:Rule RuleId="urn:altinn:ruleid:57b3ee85-f932-42c6-9ab0-941eb6c96eb9" Effect="Permit"><xacml:Description>Delegation of a right/action from 1000 to 20001337, for a resource on the app; skd/taxreport, by user; 20001336</xacml:Description><xacml:Target><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">skd</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">taxreport</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf><xacml:AnyOf><xacml:AllOf><xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue><xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" /></xacml:Match></xacml:AllOf></xacml:AnyOf></xacml:Target></xacml:Rule><xacml:ObligationExpressions><xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel1" FulfillOn="Permit"><xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel"><xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue></xacml:AttributeAssignmentExpression></xacml:ObligationExpression></xacml:ObligationExpressions></xacml:Policy>
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+  <xacml:Description>Delegation policy containing all delegated rights/actions from 1000 to 20001337, for resources on the app; skd/taxreport</xacml:Description>
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:ruleid:57b3ee85-f932-42c6-9ab0-941eb6c96eb9" Effect="Permit">
+    <xacml:Description>Delegation of a right/action from 1000 to 20001337, for a resource on the app; skd/taxreport, by user; 20001336</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001337</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">skd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">taxreport</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+</xacml:Policy>


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# Stop storing ObligationExpression in delegation policies

## Description
Azure DevOps Bug 56748: https://dev.azure.com/digdir/Altinn/_workitems/edit/56748
Issue no. 1 as described in #7178

Currently ObligationExpressions for required security level is copied into a new delegation policy at creation.
This is never updated if the app policy changes as any point after the delegation has occurred, and is also not cleared from the delegation policy even if all delegations for the app is deleted.
All of which results in undesired behaviour.

This change:
- Removes code from PolicyHelper, which copies original ObligationExpression from app policy into a new delegation policy.
- Adds code to DecisionController, in order to not rely on ObligationExpression from delegation policies, but in stead always enrich the delegation policy with the current ObligationExpressions from the app policy.

## Fixes
- #7178 (Issue no. 1)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
