### PR TITLE
Remove-max-width-until-focus-is-fixed

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.18.3",
+  "version": "3.18.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/index.css
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/index.css
@@ -87,7 +87,6 @@ option {
 
 .a-form-group .form-control {
   border: 2px solid #008FD6;
-  max-width: 684px;
 }
 
 .a-form-group .input-group .input-group-prepend {


### PR DESCRIPTION
The max-width that was introduced in #[7572](https://github.com/Altinn/altinn-studio/pull/7572) caused error while focusing on the form.

- Remove max-width from forms, until tested correctly with focus state. 