### PR TITLE
Adding AT05 subscription key support to designer.

### DIFF
--- a/src/studio/src/designer/backend/Configuration/PlatformSettings.cs
+++ b/src/studio/src/designer/backend/Configuration/PlatformSettings.cs
@@ -22,6 +22,11 @@ namespace Altinn.Studio.Designer.Configuration
         public string ApiAuthenticationConvertUri { get; set; }
 
         /// <summary>
+        /// API Management subscription key for platform in AT05.
+        /// </summary>
+        public string SubscriptionKeyAT05 { get; set; }
+
+        /// <summary>
         /// API Management subscription key for platform in AT21.
         /// </summary>
         public string SubscriptionKeyAT21 { get; set; }

--- a/src/studio/src/designer/backend/Helpers/HttpClientHelper.cs
+++ b/src/studio/src/designer/backend/Helpers/HttpClientHelper.cs
@@ -17,7 +17,11 @@ namespace Altinn.Studio.Designer.Helpers
         /// <param name="platformSettings">the platform settings</param>
         public static void AddSubscriptionKeys(HttpClient httpClient, Uri uri, PlatformSettings platformSettings)
         {
-            if (uri.Host.Contains("at21", StringComparison.InvariantCultureIgnoreCase))
+            if (uri.Host.Contains("at05", StringComparison.InvariantCultureIgnoreCase))
+            {
+                httpClient.DefaultRequestHeaders.Add(platformSettings.SubscriptionKeyHeaderName, platformSettings.SubscriptionKeyAT05);
+            }
+            else if (uri.Host.Contains("at21", StringComparison.InvariantCultureIgnoreCase))
             {
                 httpClient.DefaultRequestHeaders.Add(platformSettings.SubscriptionKeyHeaderName, platformSettings.SubscriptionKeyAT21);
             }


### PR DESCRIPTION
# Adding AT05 subscription key support to designer.

The designer needs to be able to use correct subscription key when calling platform in at05.

## Fixes
- #7627

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [x] Changelog is updated with a separate linked PR 
  - [x] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [x] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
