### PR TITLE
A lookup component for entering eg. orgnr

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/GenericComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/GenericComponent.tsx
@@ -130,11 +130,9 @@ export function GenericComponent(props: IGenericComponentProps) {
     );
   }, [componentValidations]);
 
-  if (hidden) {
-    return null;
-  }
 
-  const handleDataUpdate = (value: any, key = 'simpleBinding') => {
+
+  const handleDataUpdate = React.useCallback((value: any, key = 'simpleBinding') => {
     if (!props.dataModelBindings || !props.dataModelBindings[key]) {
       return;
     }
@@ -177,8 +175,12 @@ export function GenericComponent(props: IGenericComponentProps) {
       props.dataModelBindings[key],
       value,
     );
-  };
+  }, [currentView, dispatch, props.dataModelBindings, formData, props.id, props.readOnly, props.triggers]);
 
+  if (hidden) {
+    return null;
+  }
+  
   const handleFocusUpdate = (componentId: string, step?: number) => {
     dispatch(
       FormLayoutActions.updateFocus({

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/advanced/InputLookupComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/advanced/InputLookupComponent.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { IInputProps, InputComponent } from '../base/InputComponent';
+
+interface LookupSource{
+  url: string,
+  regex: RegExp,
+}
+
+// Utility function to get correct type on lookupSources
+function _typeLookupSource<T extends {[name:string]: LookupSource}>(s:T): T{
+  return s;
+}
+
+const lookupSources = _typeLookupSource({
+  "orgnr": {
+    url: "https://data.brreg.no/enhetsregisteret/api/enheter/{value}",
+    regex: /[0-9]{9}/,
+  },
+  "postnummer":{
+    url: "https://api.bring.com/shippingguide/api/postalCode.json",
+    regex: /[0-9]{4}/,
+  }
+});
+
+interface IInputLookupProps extends IInputProps {
+  lookupSrc: keyof typeof lookupSources
+}
+
+
+export function InputLookupComponent(props: IInputLookupProps){
+  const {
+    lookupSrc,
+    formData,
+    handleDataChange,
+    ...inputProps
+  } = props;
+
+  const simpleBinding = formData.simpleBinding;
+  const simpleBindingRef = React.useRef(null);
+  simpleBindingRef.current = simpleBinding;
+  const lookupResultRef = React.useRef(null);
+  lookupResultRef.current = formData.lookupResult;
+  const prevLookup = React.useRef(null);
+
+  React.useEffect(()=>{
+    const src = lookupSources[lookupSrc];
+    if(src.regex.test(simpleBinding) && prevLookup.current !== simpleBinding){
+      prevLookup.current = simpleBinding;
+      const ac = new AbortController();
+      let done = false;
+      fetch(src.url.replace("{value}", simpleBinding), { signal: ac.signal})
+      .then(resp=>resp.json())
+      .then(result=>{
+        done = true;
+        // Only update lookupResult if value has not changed
+        if(simpleBinding === simpleBindingRef.current && lookupResultRef.current !== result.navn){
+          handleDataChange(result.navn, "lookupResult" )
+        }
+      })
+      .catch(e=>{
+        if(e.name !== "AbortError" && simpleBinding === simpleBindingRef.current){
+          // value has not changed, and this is a real server error
+          // inform the user by setting the lookup result to 
+          done = true;
+          handleDataChange( "error", "lookupResult")
+        }
+      })
+      // cleanup when effect dependencies change (or component is unmounted)
+      return ()=>{
+        // Ensure that pending calls are aborted
+        if(!done) ac.abort();
+      }
+    }
+    else
+    if( !src.regex.test(simpleBinding) && lookupResultRef.current && lookupResultRef.current !== "error"){
+      handleDataChange("", "lookupResult");
+    }
+  },[lookupSrc, simpleBinding, handleDataChange])
+
+  return <InputComponent {...inputProps} formData={simpleBinding} handleDataChange={handleDataChange} />
+}

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/InputComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/InputComponent.tsx
@@ -10,7 +10,7 @@ export interface IInputBaseProps {
   readOnly: boolean;
   required: boolean;
   formatting?: IInputFormatting;
-  handleDataChange: (value: any) => void;
+  handleDataChange: (value: string, key?:string) => void;
 }
 
 export interface IInputFormatting {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/index.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/index.ts
@@ -15,6 +15,7 @@ import { TextAreaComponent } from './base/TextAreaComponent';
 import { ImageComponent } from './base/ImageComponent';
 import { NavigationButtons as NavigationButtonsComponent } from './presentation/NavigationButtons';
 import { InstantiationButtonComponent } from './base/InstantiationButtonComponent';
+import { InputLookupComponent } from './advanced/InputLookupComponent';
 
 export interface IComponent {
   name: string;
@@ -39,6 +40,7 @@ export enum ComponentTypes {
   Button,
   Group,
   AddressComponent,
+  InputLookupComponent,
   NavigationButtons,
   InstantiationButton,
   AttachmentList,
@@ -156,6 +158,14 @@ export const advancedComponents: IComponent[] = [
       readOnly: false,
     },
   },
+  {
+    name: 'InputLookupComponent',
+    Tag: InputLookupComponent,
+    Type: ComponentTypes.InputLookupComponent,
+    customProperties: {
+      readonly: false,
+    }
+  }
 ];
 
 const components: IComponent[] = textComponents.concat(schemaComponents, advancedComponents);

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/index.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/index.ts
@@ -35,6 +35,7 @@ export type GroupTypes = 'Group' | 'group';
 
 export type ComponentTypes =
   | 'AddressComponent'
+  | 'InputLookupComponent'
   | 'AttachmentList'
   | 'Button'
   | 'Checkboxes'
@@ -52,6 +53,7 @@ export type ComponentTypes =
   | 'TextArea';
 
 export interface IDataModelBindings {
+  simpleBinding?: string;
   [id: string]: string;
 }
 

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/types/index.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/types/index.ts
@@ -62,6 +62,7 @@ export interface IDataModelBinding {
 }
 
 export interface IDataModelBindings {
+  simpleBinding?: string;
   [id: string]: string;
 }
 

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/formComponentUtils.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/formComponentUtils.ts
@@ -65,7 +65,7 @@ export const getFormDataForComponent = (
     return '';
   }
 
-  if (dataModelBindings.simpleBinding) {
+  if (Object.keys(dataModelBindings).length == 1 && dataModelBindings.simpleBinding) {
     const formDataVal = formData[dataModelBindings.simpleBinding];
     return formDataVal;
   }

--- a/src/studio/src/designer/frontend/ux-editor/components/config/EditModalContent.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/components/config/EditModalContent.tsx
@@ -172,6 +172,12 @@ export class EditModalContentComponent extends React.Component<IEditModalContent
     this.props.handleComponentUpdate(updatedComponent);
   }
 
+  public handleUpdateLookupSrc = (event: any) => {
+    const updatedComponent: IInputLookupComponent = this.props.component as IInputLookupComponent;
+    updatedComponent.lookupSrc = event.value;
+    this.props.handleComponentUpdate(updatedComponent);
+  }
+
   public handleDescriptionChange = (selectedText: any): void => {
     const updatedComponent = this.props.component;
     updatedComponent.textResourceBindings.description
@@ -584,6 +590,69 @@ export class EditModalContentComponent extends React.Component<IEditModalContent
                 this.props.language,
                 this.state.component.textResourceBindings?.title,
                 getLanguageFromKey('ux_editor.modal_properties_button_type_submit', this.props.language))}
+            </Grid>
+          </>
+        );
+      }
+
+      case ComponentTypes.InputLookupComponent: {
+        return (
+          <>
+            {this.renderChangeId()}
+            <EditBoilerplate
+              component={this.props.component}
+              textResources={this.props.textResources}
+              handleDataModelChange={this.handleDataModelChange}
+              handleTitleChange={this.handleTitleChange}
+              handleDescriptionChange={this.handleDescriptionChange}
+              language={this.props.language}
+            />
+            <Grid
+              item={true} xs={12}
+              style={styles.gridItem}
+            >
+              <AltinnCheckBox
+                checked={this.state.component.readOnly}
+                onChangeFunction={this.handleReadOnlyChange}
+              />
+              {this.props.language.ux_editor.modal_configure_read_only}
+            </Grid>
+            <Grid
+              item={true} xs={12}
+            >
+              <AltinnCheckBox
+                checked={this.state.component.required}
+                onChangeFunction={this.handleRequiredChange}
+              />
+              {this.props.language.ux_editor.modal_configure_required}
+            </Grid>
+            <Grid
+              item={true} xs={12}
+            >
+              <AltinnRadioGroup onChange={this.handleUpdateLookupSrc}
+                value={this.props.component.lookupSrc}
+                description="TODO: velg data kilde">
+                <AltinnRadio
+                  value="orgnr"
+                  label={"TODO: organisasjonsnummer"}
+                />
+                <AltinnRadio
+                  value="postnr"
+                  label={"TODO: postnummer"}
+                />
+              </AltinnRadioGroup>
+            </Grid>
+            <Grid
+              item={true} xs={12}
+            >
+              {renderSelectDataModelBinding(
+                this.props.component.dataModelBindings,
+                this.handleDataModelChange,
+                this.props.language,
+                "TODO: lookupResultBinding-textResouce",
+                "lookupResult",
+                "lookupResult",
+              )}
             </Grid>
           </>
         );

--- a/src/studio/src/designer/frontend/ux-editor/components/index.ts
+++ b/src/studio/src/designer/frontend/ux-editor/components/index.ts
@@ -1,5 +1,5 @@
-export interface IComponentIcon {
-  [key: string]: string;
+export type IComponentIcon = {
+  [key in keyof typeof ComponentTypes ]: string;
 }
 
 export interface IComponent {
@@ -23,6 +23,7 @@ export enum ComponentTypes {
   FileUpload = 'FileUpload',
   Button = 'Button',
   AddressComponent = 'AddressComponent',
+  InputLookupComponent = 'InputLookupComponent',
   Group = 'Group',
   NavigationButtons = 'NavigationButtons',
   AttachmentList = 'AttachmentList',
@@ -41,6 +42,7 @@ export const componentIcons: IComponentIcon = {
   FileUpload: 'fa fa-attachment',
   Button: 'fa fa-button',
   AddressComponent: 'fa fa-address',
+  InputLookupComponent: 'fa fa-glasses',
   Group: 'fa fa-group',
   NavigationButtons: 'fa fa-button',
   AttachmentList: 'fa fa-attachment',
@@ -142,6 +144,10 @@ export const advancedComponents: IComponent[] = [
       simplified: true,
       readOnly: false,
     },
+  },
+  {
+    name: ComponentTypes.InputLookupComponent,
+    Icon: componentIcons.InputLookupComponent,
   },
   {
     name: ComponentTypes.AttachmentList,

--- a/src/studio/src/designer/frontend/ux-editor/types/global.ts
+++ b/src/studio/src/designer/frontend/ux-editor/types/global.ts
@@ -128,6 +128,7 @@ declare global {
   }
 
   export interface IDataModelBindings {
+    simpleBinding?: string;
     [id: string]: string;
   }
 
@@ -147,6 +148,10 @@ declare global {
 
   export interface IFormAddressComponent extends IFormComponent {
     simplified: boolean;
+  }
+
+  export interface IInputLookupComponent extends IFormComponent {
+    lookupSrc: string;
   }
 
   export interface IFormGroupComponent extends IFormComponent {


### PR DESCRIPTION
When people need to input numbers (like orgnumbers, postal codes, ssn?), it is good to be able to show the name that the number actually referencees.

## Fixes
- https://github.com/Altinn/altinn-studio/issues/7605

## Sample schema
The first field is the new component `InputLookupComponent` with `dataModelBindings.lookupResult` set to the same model variable as the next readonly `Input` field. This lets a user input an orgnr and if correct, they will see the name of the org in the next field.
```json
{
  "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
  "data": {
    "layout": [
      {
        "id": "e1752559-aed4-42ce-9457-59f355544030",
        "type": "InputLookupComponent",
        "textResourceBindings": {
          "title": "ServiceName",
          "description": "ServiceName"
        },
        "dataModelBindings": {
          "simpleBinding": "OppgaveKRT-1006.rapporteringsenhet.organisasjonsnummer.value",
          "lookupResult": "OppgaveKRT-1006.rapporteringsenhet.navn.value"
        },
        "lookupSrc": "orgnr",
        "formatting":{
          "number":{
            "format": "### ### ###"
          }
        },
        "required": true
      },
      {
        "id": "a1cbe420-6ad0-4609-ad22-04644ab123d1",
        "type": "Input",
        "textResourceBindings": {
          "title": "ServiceName",
          "description": "ServiceName"
        },
        "dataModelBindings": {
          "simpleBinding": "OppgaveKRT-1006.rapporteringsenhet.navn.value"
        },
        "required": true,
        "readOnly": true
      }
    ]
  }
}
```


## Further work suggestions

1. Make `"lookupSrc": "postnummer"` actually work (requires some changes to `interface LookupSource`)
2. Support more APIs
3. Support configuration of api from app.
4. Support server side validation that end user did not play with browser devtools to deliver inconsistent schema.
5. Be more flexible about what field in the response to write to the data binding (not just `result.name`)
6. Support writing data to multiple dataModelBindings
7. Fix studio edit so you can actually set `lookupSrc`
8. Fix PDF to treat this as a normal Input (as it currently behaves)

(too bad the important one is last on my list 👎 )

## Alternaltive solutions
1. Display the lookup value in the design of `InputLookupComponent`
2. [please add more]

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
