### PR TITLE
chore: fix incorrect yarn version used in docker builds

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/receipt/Dockerfile
+++ b/src/Altinn.Apps/AppFrontend/react/receipt/Dockerfile
@@ -1,15 +1,20 @@
 # base image
 FROM node:16.13.1-alpine3.14 AS generate-receipt-app
 
+WORKDIR /build
+
 # Context is ./src, see docker-compose.yaml in src\Altinn.Platform\Altinn.Platform.Receipt\docker-compose.yml
 COPY Altinn.Apps/AppFrontend/react/package.json .
 COPY Altinn.Apps/AppFrontend/react/yarn.lock .
+COPY Altinn.Apps/AppFrontend/react/.yarn/ ./.yarn/
+COPY Altinn.Apps/AppFrontend/react/.yarnrc.yml .
 
 # Copy shared and receipt
-COPY Altinn.Apps/AppFrontend/react/shared/ /shared/
-COPY Altinn.Apps/AppFrontend/react/receipt/ /receipt/
+COPY Altinn.Apps/AppFrontend/react/shared/ ./shared/
+COPY Altinn.Apps/AppFrontend/react/receipt/ ./receipt/
 
 # Install
+RUN corepack enable
 RUN yarn --immutable
 
 # Build runtime

--- a/src/Altinn.Apps/AppFrontend/react/receipt/Dockerfile
+++ b/src/Altinn.Apps/AppFrontend/react/receipt/Dockerfile
@@ -9,7 +9,8 @@ COPY Altinn.Apps/AppFrontend/react/yarn.lock .
 COPY Altinn.Apps/AppFrontend/react/.yarn/ ./.yarn/
 COPY Altinn.Apps/AppFrontend/react/.yarnrc.yml .
 
-# Copy shared and receipt
+# Copy shared, receipt, and app-frontend. App-frontend is needed because they all share the same yarn.lock file. Without this copy, the lockfile will be modified, and install will fail
+COPY Altinn.Apps/AppFrontend/react/altinn-app-frontend/ ./altinn-app-frontend/
 COPY Altinn.Apps/AppFrontend/react/shared/ ./shared/
 COPY Altinn.Apps/AppFrontend/react/receipt/ ./receipt/
 

--- a/src/Altinn.Platform/Altinn.Platform.Receipt/Receipt/Dockerfile
+++ b/src/Altinn.Platform/Altinn.Platform.Receipt/Receipt/Dockerfile
@@ -15,8 +15,8 @@ FROM mcr.microsoft.com/dotnet/aspnet:5.0.12-alpine3.14 AS final
 EXPOSE 5060
 WORKDIR /app
 COPY --from=build /app_output .
-COPY --from=generate-receipt-react-app /receipt/dist/receipt.js ./wwwroot/receipt/js/react/receipt.js
-COPY --from=generate-receipt-react-app /receipt/dist/receipt.css ./wwwroot/receipt/css/receipt.css
+COPY --from=generate-receipt-react-app /build/receipt/dist/receipt.js ./wwwroot/receipt/js/react/receipt.js
+COPY --from=generate-receipt-react-app /build/receipt/dist/receipt.css ./wwwroot/receipt/css/receipt.css
 
 # setup the user and group
 # the user will have no password, using shell /bin/false and using the group dotnet

--- a/src/studio/src/designer/Dockerfile
+++ b/src/studio/src/designer/Dockerfile
@@ -1,20 +1,24 @@
 # studio frontend
 FROM node:16.13.1-alpine3.14 AS generate-studio-frontend
 
+WORKDIR /build
+
 COPY ./src/designer/frontend/package.json .
 COPY ./src/designer/frontend/yarn.lock .
+COPY ./src/designer/frontend/.yarn/ ./.yarn/
+COPY ./src/designer/frontend/.yarnrc.yml .
 
 # Copy and install dependencies
-COPY ./src/designer/frontend/shared/package.json /shared/
-COPY ./src/designer/frontend/app-development/package.json /app-development/
-COPY ./src/designer/frontend/ux-editor/package.json /ux-editor/
+COPY ./src/designer/frontend/shared/package.json ./shared/
+COPY ./src/designer/frontend/app-development/package.json ./app-development/
+COPY ./src/designer/frontend/ux-editor/package.json ./ux-editor/
 COPY ./src/designer/frontend/dashboard/package.json ./dashboard/
-COPY ./src/designer/frontend/packages/schema-editor/package.json /packages/schema-editor/
+COPY ./src/designer/frontend/packages/schema-editor/package.json ./packages/schema-editor/
 
+RUN corepack enable
 RUN yarn --immutable
 
 # Copy shared, app-development, ux-editor and dashboard
-WORKDIR /
 COPY ./src/designer/frontend/shared/ ./shared/
 COPY ./src/designer/frontend/app-development/ ./app-development/
 COPY ./src/designer/frontend/ux-editor ./ux-editor/
@@ -30,26 +34,32 @@ RUN yarn workspace dashboard run build
 # Create altinn-studio-frontend base image
 FROM alpine as altinn-studio-frontend
 WORKDIR /dist/
-COPY --from=generate-studio-frontend /dist/app-development/app-development.js .
-COPY --from=generate-studio-frontend /dist/app-development/1.app-development.js .
-COPY --from=generate-studio-frontend /dist/app-development/2.app-development.js .
-COPY --from=generate-studio-frontend /dist/app-development/3.app-development.js .
-COPY --from=generate-studio-frontend /dist/app-development/4.app-development.js .
-COPY --from=generate-studio-frontend /dist/app-development/editor.worker.js .
-COPY --from=generate-studio-frontend /dist/app-development/ts.worker.js .
-COPY --from=generate-studio-frontend /dist/app-development/app-development.css .
-COPY --from=generate-studio-frontend /dist/dashboard/dashboard.js .
-COPY --from=generate-studio-frontend /dist/dashboard/dashboard.css .
+COPY --from=generate-studio-frontend /build/dist/app-development/app-development.js .
+COPY --from=generate-studio-frontend /build/dist/app-development/1.app-development.js .
+COPY --from=generate-studio-frontend /build/dist/app-development/2.app-development.js .
+COPY --from=generate-studio-frontend /build/dist/app-development/3.app-development.js .
+COPY --from=generate-studio-frontend /build/dist/app-development/4.app-development.js .
+COPY --from=generate-studio-frontend /build/dist/app-development/editor.worker.js .
+COPY --from=generate-studio-frontend /build/dist/app-development/ts.worker.js .
+COPY --from=generate-studio-frontend /build/dist/app-development/app-development.css .
+COPY --from=generate-studio-frontend /build/dist/dashboard/dashboard.js .
+COPY --from=generate-studio-frontend /build/dist/dashboard/dashboard.css .
 
 FROM node:16.13.1-alpine3.14 AS generate-designer-js
 WORKDIR /app
 COPY src/designer/backend/package.json .
 COPY src/designer/backend/yarn.lock .
-COPY src/designer/backend .
+COPY src/designer/backend/.yarn ./.yarn
+COPY src/designer/backend/.yarnrc.yml .
+
+RUN corepack enable
 RUN yarn --immutable
+
+COPY src/designer/backend .
 RUN yarn run gulp build
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0.403-alpine3.14 AS build
+WORKDIR /build
 COPY src/designer/Designer.sln ./
 COPY src/designer/backend ./designer/
 COPY src/designer/DataModeling ./DataModeling/

--- a/src/studio/src/designer/frontend/app-development/Dockerfile
+++ b/src/studio/src/designer/frontend/app-development/Dockerfile
@@ -1,34 +1,37 @@
 # base image
 FROM node:16.13.1-alpine3.14 AS generate-app-development
 
+WORKDIR /build
+
 COPY ./src/designer/frontend/package.json .
 COPY ./src/designer/frontend/yarn.lock .
+COPY ./src/designer/frontend/.yarn/ ./.yarn/
+COPY ./src/designer/frontend/.yarnrc.yml .
 
 # Copy and install dependencies
-COPY ./src/designer/frontend/shared/package.json /shared/
-COPY ./src/designer/frontend/app-development/package.json /app-development/
-COPY ./src/designer/frontend/ux-editor/package.json /ux-editor/
+COPY ./src/designer/frontend/shared/package.json ./shared/
+COPY ./src/designer/frontend/app-development/package.json ./app-development/
+COPY ./src/designer/frontend/ux-editor/package.json ./ux-editor/
 
+RUN corepack enable
 RUN yarn --immutable
 
 # Copy and build shared + app-development + ux-editor
-WORKDIR /
 COPY ./src/designer/frontend/shared/ ./shared/
 COPY ./src/designer/frontend/app-development/ ./app-development/
 COPY ./src/designer/frontend/ux-editor ./ux-editor/
-WORKDIR /
 RUN yarn workspace app-development run build
 
 # Create Service-Development base image
 FROM alpine
 WORKDIR /dist/
-COPY --from=generate-app-development /dist/app-development/app-development.js .
-COPY --from=generate-app-development /dist/app-development/0.app-development.js .
-COPY --from=generate-app-development /dist/app-development/1.app-development.js .
-COPY --from=generate-app-development /dist/app-development/2.app-development.js .
-COPY --from=generate-app-development /dist/app-development/3.app-development.js .
-COPY --from=generate-app-development /dist/app-development/js/react/editor.worker.js .
-COPY --from=generate-app-development /dist/app-development/js/react/typescript.worker.js .
-COPY --from=generate-app-development /dist/app-development/app-development.css .
+COPY --from=generate-app-development /build/dist/app-development/app-development.js .
+COPY --from=generate-app-development /build/dist/app-development/0.app-development.js .
+COPY --from=generate-app-development /build/dist/app-development/1.app-development.js .
+COPY --from=generate-app-development /build/dist/app-development/2.app-development.js .
+COPY --from=generate-app-development /build/dist/app-development/3.app-development.js .
+COPY --from=generate-app-development /build/dist/app-development/js/react/editor.worker.js .
+COPY --from=generate-app-development /build/dist/app-development/js/react/typescript.worker.js .
+COPY --from=generate-app-development /build/dist/app-development/app-development.css .
 
 CMD ["echo", "done"]

--- a/src/studio/src/designer/frontend/dashboard/Dockerfile
+++ b/src/studio/src/designer/frontend/dashboard/Dockerfile
@@ -1,17 +1,21 @@
 # base image
 FROM node:16.13.1-alpine3.14 AS generate-dashboard
 
+WORKDIR /build
+
 COPY ./src/designer/frontend/package.json .
 COPY ./src/designer/frontend/yarn.lock .
+COPY ./src/designer/frontend/.yarn/ ./.yarn/
+COPY ./src/designer/frontend/.yarnrc.yml .
 
 # Copy and install dependencies
 COPY ./src/designer/frontend/shared/package.json ./shared/
 COPY ./src/designer/frontend/dashboard/package.json ./dashboard/
 
+RUN corepack enable
 RUN yarn --immutable
 
 # Copy and build Shared + Dashboard
-WORKDIR /
 COPY ./src/designer/frontend/shared/ ./shared/
 COPY ./src/designer/frontend/dashboard/ ./dashboard/
 RUN yarn workspace dashboard run build
@@ -19,7 +23,7 @@ RUN yarn workspace dashboard run build
 # Create Dashboard base image
 FROM alpine
 WORKDIR /dist
-COPY --from=generate-dashboard ./dist/dashboard/dashboard.js .
-COPY --from=generate-dashboard ./dist/dashboard/dashboard.css .
+COPY --from=generate-dashboard /build/dist/dashboard/dashboard.js .
+COPY --from=generate-dashboard /build/dist/dashboard/dashboard.css .
 
 CMD ["echo", "done"]

--- a/src/studio/src/designer/frontend/ux-editor/Dockerfile
+++ b/src/studio/src/designer/frontend/ux-editor/Dockerfile
@@ -2,12 +2,16 @@
 FROM node:16.13.1-alpine3.14
 
 # set working directory
-RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
 
 # install and cache app dependencies
-COPY package.json /usr/src/app/package.json
-COPY yarn.lock /usr/src/app/yarn.lock
+COPY package.json .
+COPY yarn.lock .
+COPY .yarn/ ./.yarn/
+COPY .yarnrc.yml .
+
+
+RUN corepack enable
 RUN yarn --immutable
 
 # start app


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# Fix incorrect yarn version used in docker builds
When running builds in Docker, yarn version 1.x was used, because corepack was not enabled.


## Description
The fix is to copy some files needed for yarn, and enable corepack before running yarn commands.
Some docker builds was also using the root as the workdir, which caused other issues with yarn 3.x, and the commands could not be executed correctly. The fix here was to use specific workdirs, instead of using root.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
