### PR TITLE
Added caching to http calls to fetch policy.xml in LocalTest

### DIFF
--- a/src/development/LocalTest/LocalTest.csproj
+++ b/src/development/LocalTest/LocalTest.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="JWTCookieAuthentication" Version="2.4.2" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.16.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
+++ b/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;
 
 using Altinn.Platform.Storage.Interface.Models;
@@ -15,19 +16,31 @@ namespace LocalTest.Services.LocalApp.Implementation
 {
     public class LocalAppHttp : ILocalApp
     {
+        public static string XACML_CACHE_KEY = "/api/v1/meta/authorizationpolicy/";
+        public static string APPLICATION_METADATA_CACHE_KEY = "/api/v1/applicationmetadata?checkOrgApp=false";
         private readonly HttpClient _httpClient;
-        public LocalAppHttp(IHttpClientFactory httpClientFactory, IOptions<LocalPlatformSettings> localPlatformSettings)
+        private readonly IMemoryCache _cache;
+        public LocalAppHttp(IHttpClientFactory httpClientFactory, IOptions<LocalPlatformSettings> localPlatformSettings, IMemoryCache cache)
         {
             _httpClient = httpClientFactory.CreateClient();
             _httpClient.BaseAddress = new Uri(localPlatformSettings.Value.LocalAppUrl);
+            _cache = cache;
         }
         public async Task<string?> GetXACMLPolicy(string appId)
         {
-            return await _httpClient.GetStringAsync($"{appId}/api/v1/meta/authorizationpolicy");
+            return await _cache.GetOrCreateAsync(XACML_CACHE_KEY + appId, async cacheEntry => {
+                // Cache with very short duration to not slow down page load, where this file can be accessed many many times
+                cacheEntry.SetSlidingExpiration(TimeSpan.FromSeconds(5));
+                return await _httpClient.GetStringAsync($"{appId}/api/v1/meta/authorizationpolicy");
+            });
         }
         public async Task<Application?> GetApplicationMetadata(string appId)
         {
-            var content = await _httpClient.GetStringAsync($"{appId}/api/v1/applicationmetadata?checkOrgApp=false");
+            var content = await _cache.GetOrCreateAsync(APPLICATION_METADATA_CACHE_KEY + appId, async cacheEntry => {
+                // Cache with very short duration to not slow down page load, where this file can be accessed many many times
+                cacheEntry.SetSlidingExpiration(TimeSpan.FromSeconds(5));
+                return await _httpClient.GetStringAsync($"{appId}/api/v1/applicationmetadata?checkOrgApp=false");
+            });
             return JsonConvert.DeserializeObject<Application>(content);
         }
         

--- a/src/development/LocalTest/Startup.cs
+++ b/src/development/LocalTest/Startup.cs
@@ -100,6 +100,7 @@ namespace LocalTest
             services.AddSingleton<IPolicyInformationRepository, PolicyInformationRepository>();
             services.AddSingleton<IRoles, RolesWrapper>();
             services.AddSingleton<IPartiesWithInstancesClient, PartiesWithInstancesClient>();
+            services.AddMemoryCache();
 
             X509Certificate2 cert = new X509Certificate2("JWTValidationCert.cer");
             SecurityKey key = new X509SecurityKey(cert);


### PR DESCRIPTION
In https://github.com/Altinn/altinn-studio/issues/7494#issuecomment-996572153 it was mentioned that running LocalTest in `http` mode was very slow. The XACML policy is fetched multiple times during a normal page load, so I try to add some caching with short expriation to see if that fixes the issue. 

## Description
I'm not getting nearly as bad slowdown as @jeevananthank but this seems like a good change that speed things up somewhat.

We might consider setting a longer caching window here, but there is always the risk that users change their policy.xml and need to restart LocalTest or wait in order for the changes to be applied.

## Fixes
- https://github.com/Altinn/altinn-studio/issues/7494

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] ~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~
- [ ] ~Changelog is updated with a separate linked PR~
  - [ ] ~[altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)~
  - [ ] ~[nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)~
