### PR TITLE
Add yarn commands for running jest in watch mode

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -8,6 +8,8 @@
     "build": "cross-env NODE_ENV=production webpack --config webpack.config.production.js --progress",
     "build-develop": "cross-env NODE_ENV=development webpack --config webpack.config.development --progress --watch",
     "test": "jest",
+    "test:watch": "jest --watch",
+    "test:watchall": "jest --watchAll",
     "compile-ts": "tsc",
     "clean": "rimraf dist compiled",
     "webpack-watch": "cross-env NODE_ENV=development webpack --mode=development --config webpack.config.development.js --watch --progress",


### PR DESCRIPTION
Rerunning tests manually is slow. This exposes the jest flags `--watch`
and `--watchAll` so that you can run them with yarn directly.



## Verification
- [ ] ~**Your** code builds clean without any errors or warnings~
- [ ] ~Manual testing done (required)~
- [ ] ~Relevant automated test added (if you find this hard, leave it and we'll help out)~
- [ ] ~All tests run green~
