### PR TITLE
Add eslint-disable-next-line react-hooks/exhaustive-deps

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/App.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/App.tsx
@@ -62,6 +62,7 @@ export const App = () => {
     return function cleanup() {
       removeEventListeners();
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appOidcProvider]);
 
   if (hasApiErrors) {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/GenericComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/GenericComponent.tsx
@@ -123,6 +123,7 @@ export function GenericComponent(props: IGenericComponentProps) {
 
   React.useEffect(() => {
     setIsSimple(isSimpleComponent(props.dataModelBindings, props.type));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   React.useEffect(() => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/advanced/AddressComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/advanced/AddressComponent.tsx
@@ -104,6 +104,7 @@ export function AddressComponent(props: IAddressComponentProps) {
     return function cleanup() {
       source.cancel('ComponentWillUnmount');
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.formData.zipCode]);
 
   const onBlurField: (key: AddressKeys, value: any) => void = (key: AddressKeys, value: any) => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/CheckboxesContainerComponent.tsx
@@ -95,10 +95,12 @@ export const CheckboxContainerComponent = (props: ICheckboxContainerProps) => {
 
   React.useEffect(() => {
     returnState();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options]);
 
   React.useEffect(() => {
     returnState();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.formData]);
 
   const returnState = () => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/DatepickerComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/DatepickerComponent.tsx
@@ -155,10 +155,12 @@ function DatepickerComponent(props: IDatePickerProps) {
     const dateValue = props.formData ? moment(props.formData) : null;
     setDate(dateValue);
     setValidationMessages(getValidationMessages());
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.formData]);
 
   React.useEffect(() => {
     setValidationMessages(getValidationMessages());
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.componentValidations]);
 
   const handleDataChangeWrapper = (dateValue: moment.Moment) => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/DropdownComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/DropdownComponent.tsx
@@ -42,6 +42,7 @@ function DropdownComponent(props: IDropdownProps) {
 
   React.useEffect(() => {
     returnState();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options]);
 
   const returnState = () => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/RadioButtonsContainerComponent.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/base/RadioButtonsContainerComponent.tsx
@@ -83,10 +83,12 @@ export const RadioButtonContainerComponent = (
 
   React.useEffect(() => {
     returnSelected();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options]);
 
   React.useEffect(() => {
     returnSelected();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.formData]);
 
   const returnSelected = () => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/presentation/NavigationButtons.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/components/presentation/NavigationButtons.tsx
@@ -47,6 +47,7 @@ export function NavigationButtons(props: INavigationButtons) {
     const currentViewIndex = orderedLayoutKeys?.indexOf(currentView);
     setDisableBack(!!returnToView || (!previous && currentViewIndex === 0));
     setDisableNext(!returnToView && !next && currentViewIndex === orderedLayoutKeys.length - 1);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentView, orderedLayoutKeys]);
 
   const onClickPrevious = () => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
@@ -115,6 +115,7 @@ const Confirm = (props: IConfirmProps) => {
       routeParams.partyId,
       routeParams.instanceGuid,
     );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   React.useEffect(() => {
@@ -129,6 +130,7 @@ const Confirm = (props: IConfirmProps) => {
       });
       setInstanceMetaObject(obj);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [parties, instance, lastChangedDateTime, applicationMetadata]);
 
   React.useEffect(() => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/entrypoint/Entrypoint.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/entrypoint/Entrypoint.tsx
@@ -59,17 +59,20 @@ export default function Entrypoint() {
     if (action === 'select-instance' && partyValidation?.valid) {
       fetchExistingInstances();
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [action, partyValidation]);
 
   React.useEffect(() => {
     if (selectedParty) {
       validatatePartySelection();
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedParty]);
 
   React.useEffect(() => {
     // If user comes back to entrypoint from an active instance we need to clear validation messages
     dispatch(updateValidations({ validations: {} }));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   React.useEffect(() => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/index.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/instantiate/containers/index.tsx
@@ -60,6 +60,7 @@ function InstantiateContainer() {
     ) {
       createNewInstance();
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [instantiating]);
 
   if (instantiation.error !== null && checkIfAxiosError(instantiation.error)) {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/receipt/containers/receiptContainer.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/receipt/containers/receiptContainer.tsx
@@ -99,6 +99,7 @@ const ReceiptContainer = (props: IReceiptContainerProps) => {
       routeParams.partyId,
       routeParams.instanceGuid,
     );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   React.useEffect(() => {
@@ -124,6 +125,7 @@ const ReceiptContainer = (props: IReceiptContainerProps) => {
       );
       setInstanceMetaObject(obj);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allOrgs, parties, instance, lastChangedDateTime]);
 
   React.useEffect(() => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/containers/ProcessWrapper.tsx
@@ -76,6 +76,7 @@ const ProcessWrapper = (props) => {
       return appName;
     };
     setAppHeader(getHeaderText());
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serviceName, applicationMetadata]);
 
   React.useEffect(() => {
@@ -103,12 +104,14 @@ const ProcessWrapper = (props) => {
       default:
         break;
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [process, applicationMetadata, instanceData]);
 
   React.useEffect(() => {
     if (!instantiating && !instanceId) {
       InstanceDataActions.getInstanceData(partyId, instanceGuid);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [instantiating, instanceId]);
 
   if (hasApiErrors) {


### PR DESCRIPTION
Make altinn-app-frontend compile without warnings. Actually fixing all issues is hard (because dependencies might not be referentially stable), but flooding the build logs with warnings risks concealing new issues.

After https://github.com/Altinn/altinn-studio/pull/7722 was closed, I think this is the best temporary change we should do. (@haakemon?)

Related to https://github.com/Altinn/altinn-studio/issues/7464

## Verification
- [x] **ALL** code builds clean without any errors or warnings


