### PR TITLE
condition that skip cypress test on pr from forks

### DIFF
--- a/.github/workflows/cypress-altinn-app-frontend.yml
+++ b/.github/workflows/cypress-altinn-app-frontend.yml
@@ -16,7 +16,9 @@ on:
 
 jobs:
   altinn-app-frontend-test:
-    if: github.repository_owner == 'Altinn'
+    if: |
+     (github.event_name != 'pull_request' && github.event.repository.fork == false) ||
+     (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
# condition that skip cypress test on pr from forks

## Description
Today, when a PR is created from a fork repo, altinn-app-frontend tests are run and eventually it fails because the secrets are not shared with the PRs from fork repos.

This change will skip the test when a PR is created from fork repo.