### PR TITLE
Replaced SimpleAppSettings with FrontEndSettings

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.22.0-alpha.1</Version>
-    <AssemblyVersion>4.22.0.0</AssemblyVersion>
+    <Version>4.22.1-alpha.1</Version>
+    <AssemblyVersion>4.22.1.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>
     <Description>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/ApplicationSettingsController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/ApplicationSettingsController.cs
@@ -1,5 +1,8 @@
+using System.Text.Json;
+
 using Altinn.App.Api.Models;
 using Altinn.App.Services.Configuration;
+
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -11,14 +14,21 @@ namespace Altinn.App.Api.Controllers
     [ApiController]
     public class ApplicationSettingsController : ControllerBase
     {
+        private JsonSerializerOptions _serializerOptions = new JsonSerializerOptions
+        {
+            DictionaryKeyPolicy = JsonNamingPolicy.CamelCase
+        };
+
         private readonly AppSettings _appSettings;
+        private readonly FrontEndSettings _frontEndSettings;
 
         /// <summary>
         /// Controller that exposes a subset of app setings
         /// </summary>
-        public ApplicationSettingsController(IOptions<AppSettings> appSettings)
+        public ApplicationSettingsController(IOptions<AppSettings> appSettings, IOptions<FrontEndSettings> frontEndSettings)
         {
             _appSettings = appSettings.Value;
+            _frontEndSettings = frontEndSettings.Value;
         }
 
         /// <summary>
@@ -27,14 +37,15 @@ namespace Altinn.App.Api.Controllers
         [HttpGet("{org}/{app}/api/v1/applicationsettings")]
         public IActionResult GetAction(string org, string app)
         {
-            return Ok(GetSettings());
-        }
+            FrontEndSettings frontEndSettings = _frontEndSettings;
 
-        private SimpleAppSettings GetSettings()
-        {
-            SimpleAppSettings settings = new SimpleAppSettings();
-            settings.AppOidcProvider = _appSettings.AppOidcProvider;
-            return settings;
+            // Adding key from _appSettings to be backwards compatible.
+            if (!frontEndSettings.ContainsKey(nameof(_appSettings.AppOidcProvider)) && !string.IsNullOrEmpty(_appSettings.AppOidcProvider))
+            {
+                frontEndSettings.Add(nameof(_appSettings.AppOidcProvider), _appSettings.AppOidcProvider);
+            }
+
+            return new JsonResult(frontEndSettings, _serializerOptions);
         }
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.22.0-alpha.1</Version>
-    <AssemblyVersion>4.22.0.0</AssemblyVersion>
+    <Version>4.22.1-alpha.1</Version>
+    <AssemblyVersion>4.22.1.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>
     <Description>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.22.0-alpha.1</Version>
-    <AssemblyVersion>4.22.0.0</AssemblyVersion>
+    <Version>4.22.1-alpha.1</Version>
+    <AssemblyVersion>4.22.1.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>
     <Description>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Configuration/FrontEndSettings.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Configuration/FrontEndSettings.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Altinn.App.Services.Configuration
+{
+    /// <summary>
+    /// Represents settings used by the front end react application. These settings are separate because they are
+    /// exposed to the end user. They should never contain secrets.
+    /// </summary>
+    public class FrontEndSettings : Dictionary<string, string>
+    {
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Extensions/ServiceCollectionExtensions.cs
@@ -78,6 +78,7 @@ namespace Altinn.App.PlatformServices.Extensions
             services.Configure<Altinn.Common.PEP.Configuration.PlatformSettings>(configuration.GetSection("PlatformSettings"));
             services.Configure<AccessTokenSettings>(configuration.GetSection("AccessTokenSettings"));
             services.Configure<Altinn.Common.EFormidlingClient.Configuration.EFormidlingClientSettings>(configuration.GetSection("EFormidlingClientSettings"));
+            services.Configure<FrontEndSettings>(configuration.GetSection(nameof(FrontEndSettings)));
 
             if (!env.IsDevelopment())
             {

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/ApplicationSettingsApiTest.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/ApiTests/ApplicationSettingsApiTest.cs
@@ -2,10 +2,12 @@ using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Altinn.App.Api.Models;
-using Altinn.App.IntegrationTests;
 
+using Altinn.App.IntegrationTests;
+using Altinn.App.Services.Configuration;
 using App.IntegrationTests.Utils;
+using App.IntegrationTestsRef.Models;
+
 using Xunit;
 
 namespace App.IntegrationTestsRef.ApiTests
@@ -29,9 +31,7 @@ namespace App.IntegrationTestsRef.ApiTests
             HttpClient client = SetupUtil.GetTestClient(_factory, "ttd", "model-validation");
 
             string requestUri = "/ttd/model-validation/api/v1/applicationsettings";
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri)
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
@@ -40,7 +40,7 @@ namespace App.IntegrationTestsRef.ApiTests
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             };
-            SimpleAppSettings appsettings = System.Text.Json.JsonSerializer.Deserialize<SimpleAppSettings>(responseContent, options);
+            SimpleAppSettings appsettings = JsonSerializer.Deserialize<SimpleAppSettings>(responseContent, options);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("idporten", appsettings.AppOidcProvider);
@@ -56,9 +56,7 @@ namespace App.IntegrationTestsRef.ApiTests
             HttpClient client = SetupUtil.GetTestClient(_factory, "ttd", "externalprefil");
 
             string requestUri = "/ttd/model-validation/api/v1/applicationsettings";
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri)
-            {
-            };
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
@@ -67,10 +65,62 @@ namespace App.IntegrationTestsRef.ApiTests
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             };
-            SimpleAppSettings appsettings = System.Text.Json.JsonSerializer.Deserialize<SimpleAppSettings>(responseContent, options);
+            SimpleAppSettings appsettings = JsonSerializer.Deserialize<SimpleAppSettings>(responseContent, options);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Null(appsettings.AppOidcProvider);
+        }
+
+        /// <summary>
+        /// Scenario: Get application settings for app with a configured AppOidcProvider
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task GetApplicationSettings_WithHomeBasePath()
+        {
+            HttpClient client = SetupUtil.GetTestClient(_factory, "ttd", "model-validation");
+
+            string requestUri = "/ttd/model-validation/api/v1/applicationsettings";
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            string responseContent = await response.Content.ReadAsStringAsync();
+            var options = new JsonSerializerOptions
+            {
+                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+            };
+
+            FrontEndSettings appsettings = JsonSerializer.Deserialize<FrontEndSettings>(responseContent, options);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("idporten", appsettings["appOidcProvider"]);
+            Assert.Equal("https://www.testdirektoratet.no", appsettings["homeBasePath"]);
+        }
+
+        /// <summary>
+        /// Scenario: Get application settings for app with a configured AppOidcProvider
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task GetApplicationSettings_WithNoFrontEndSettings()
+        {
+            HttpClient client = SetupUtil.GetTestClient(_factory, "ttd", "externalprefil");
+
+            string requestUri = "/ttd/model-validation/api/v1/applicationsettings";
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            string responseContent = await response.Content.ReadAsStringAsync();
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+            FrontEndSettings appsettings = JsonSerializer.Deserialize<FrontEndSettings>(responseContent, options);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Empty(appsettings);
         }
     }
 }

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/model-validation/appsettings.json
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Data/apps/ttd/model-validation/appsettings.json
@@ -9,6 +9,9 @@
   "AppSettings": {
     "AppOidcProvider": "idporten"
   },
+  "FrontEndSettings": {
+    "HomeBasePath": "https://www.testdirektoratet.no"
+  },
   "GeneralSettings": {
     "HostName": "altinn3.no",
     "TemplateLocation": "../Templates",

--- a/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Models/SimpleAppSettings.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App.IntegrationTests/Models/SimpleAppSettings.cs
@@ -1,8 +1,12 @@
-namespace Altinn.App.Api.Models
+namespace App.IntegrationTestsRef.Models
 {
     /// <summary>
     /// Simplified app settings exposing application settings needed for frontend or end user system
     /// </summary>
+    /// <remarks>
+    /// This class was originally a part of the app template, but was moved here when it was replaced with FrontEndSettings.
+    /// We kept it here in the test project to proove backwards compatibility.
+    /// </remarks>
     public class SimpleAppSettings
     {
         /// <summary>


### PR DESCRIPTION
# Replaced SimpleAppSettings with FrontEndSettings
Added a more dynamic dictionary based settings for the applicationsettings endpoint to the app backend api. This replaces the property based SimpleAppSettings class.

## Fixes
The change is related to issue #7520.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
