### PR TITLE
bug/7773-stateless-to-stateful

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/form/layout/layoutSlice.test.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__tests__/features/form/layout/layoutSlice.test.ts
@@ -1,0 +1,55 @@
+import reducer, {
+  initialState, FormLayoutActions, ILayoutState
+ } from 'src/features/form/layout/formLayoutSlice';
+
+describe('features > form > layout > layoutSlice.ts', () => {
+  describe('fetchLayoutFulfilled', () => {
+    const layouts = {};
+    const navigationConfig = {};
+
+    it('should set layout state accordingly', () => {
+      const nextState = reducer(initialState, FormLayoutActions.fetchLayoutFulfilled({ 
+        layouts,
+        navigationConfig
+      }));
+
+      expect(nextState.layouts).toEqual(layouts);
+      expect(nextState.uiConfig.layoutOrder).toEqual(Object.keys(layouts));
+      expect(nextState.uiConfig.navigationConfig).toEqual(navigationConfig);
+    });
+
+    it('should reset repeatingGroups if set', () => {
+      const stateWithRepGroups: ILayoutState = {
+        ...initialState,
+        uiConfig: {
+          ...initialState.uiConfig,
+          repeatingGroups: {
+            someId: {
+              count: 2
+            },
+          },
+        },
+      };
+      const nextState = reducer(stateWithRepGroups, FormLayoutActions.fetchLayoutFulfilled({
+        layouts,
+        navigationConfig,
+      }));
+      
+      expect(nextState.uiConfig.repeatingGroups).toEqual({});
+    });
+
+    it('should reset error if set', () => {
+      const stateWithError: ILayoutState = {
+        ...initialState,
+        error: new Error('mock'),
+      };
+      const nextState = reducer(stateWithError, FormLayoutActions.fetchLayoutFulfilled({
+        layouts,
+        navigationConfig,
+      }));
+
+      expect(nextState.error).toEqual(null);
+    });
+
+  })
+});

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.22.5",
+  "version": "3.22.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/formLayoutSlice.ts
@@ -11,7 +11,7 @@ export interface ILayoutState {
   layoutsets: ILayoutSets;
 }
 
-const initialState: ILayoutState = {
+export const initialState: ILayoutState = {
   layouts: null,
   error: null,
   uiConfig: {
@@ -39,6 +39,7 @@ const formLayoutSlice = createSlice({
       state.uiConfig.navigationConfig = navigationConfig;
       state.uiConfig.layoutOrder = Object.keys(layouts);
       state.error = null;
+      state.uiConfig.repeatingGroups = {};
     },
     fetchLayoutRejected: (state, action: PayloadAction<LayoutTypes.IFormLayoutActionRejected>) => {
       const { error } = action.payload;

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/update/updateFormLayoutSagas.ts
@@ -348,7 +348,6 @@ export function* initRepeatingGroupsSaga(): SagaIterator {
   });
   if (groupsToRemoveValidations.length > 0) {
     let validations = state.formValidations.validations;
-    // eslint-disable-next-line no-restricted-syntax
     for (const group of groupsToRemoveValidations) {
       for (let i = 0; i <= currentGroups[group].count; i++) {
         validations = removeGroupValidationsByIndex(group, i, state.formLayout.uiConfig.currentView, layouts, currentGroups, validations, false);


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# bug/7773-stateless-to-stateful
<!-- Summary of the changes (max 80 characters) -->

Fixed bug where repeating group state would be persisted after the app has gone from stateless to stateful which caused app-frontend to crash. PR #7746 caused this bug to come to light.

## Fixes
- #7773 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [x] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
