### PR TITLE
Add some annotations in Authentication for better swagger specifications

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -261,7 +261,7 @@ namespace Altinn.Platform.Authentication.Controllers
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(typeof(void), StatusCodes.Status424FailedDependency)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status429TooManyRequests)]
         [HttpGet("exchange/{tokenProvider}")]
         public async Task<ActionResult> ExchangeExternalSystemToken(string tokenProvider, [FromQuery] bool test)
         {

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -237,6 +237,8 @@ namespace Altinn.Platform.Authentication.Controllers
         [Authorize]
         [Produces("text/plain")]
         [HttpGet("refresh")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
         public async Task<ActionResult> RefreshJwtCookie()
         {
             _logger.LogInformation("Starting to refresh token...");

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -121,6 +121,10 @@ namespace Altinn.Platform.Authentication.Controllers
         /// <param name="dontChooseReportee">Parameter to indicate disabling of reportee selection in Altinn Portal.</param>
         /// <returns>redirect to correct url based on the validation of the form authentication sbl cookie</returns>
         [AllowAnonymous]
+        [Produces("text/plain")]
+        [ProducesResponseType(StatusCodes.Status302Found)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status503ServiceUnavailable)]
         [HttpGet("authentication")]
         public async Task<ActionResult> AuthenticateUser([FromQuery] string goTo, [FromQuery] bool dontChooseReportee)
         {
@@ -231,6 +235,7 @@ namespace Altinn.Platform.Authentication.Controllers
         /// </summary>
         /// <returns>Ok response with the refreshed token appended.</returns>
         [Authorize]
+        [Produces("text/plain")]
         [HttpGet("refresh")]
         public async Task<ActionResult> RefreshJwtCookie()
         {
@@ -252,6 +257,11 @@ namespace Altinn.Platform.Authentication.Controllers
         /// </summary>
         /// <returns>The result of the action. Contains the new token if the old token was valid and could be exchanged.</returns>
         [AllowAnonymous]
+        [Produces("text/plain")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status424FailedDependency)]
         [HttpGet("exchange/{tokenProvider}")]
         public async Task<ActionResult> ExchangeExternalSystemToken(string tokenProvider, [FromQuery] bool test)
         {

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/OpenIdController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/OpenIdController.cs
@@ -44,7 +44,8 @@ namespace Altinn.Platform.Authentication.Controllers
         /// </summary>
         /// <returns>The configuration object for Open ID Connect.</returns>
         [HttpGet("openid-configuration")]
-        public async Task<IActionResult> GetOpenIdConfigurationAsync()
+        [Produces("application/json")]
+        public DiscoveryDocument GetOpenIdConfigurationAsync()
         {
             string baseUrl = _generalSettings.AltinnOidcIssuerUrl;
 
@@ -72,15 +73,16 @@ namespace Altinn.Platform.Authentication.Controllers
                 IdTokenSigningAlgValuesSupported = new[] { "RS256" }
             };
 
-            return await Task.FromResult(Ok(discoveryDocument));
+            return discoveryDocument;
         }
 
         /// <summary>
         /// Returns the JSON Web Key Set to use when validating a token.
         /// </summary>
         /// <returns>The Altinn JSON Web Key Set.</returns>
+        [Produces("application/json")]
         [HttpGet("openid-configuration/jwks")]
-        public async Task<IActionResult> GetJsonWebKeySetAsync()
+        public async Task<JwksDocument> GetJsonWebKeySetAsync()
         {
             JwksDocument jwksDocument = new JwksDocument
             {
@@ -108,7 +110,7 @@ namespace Altinn.Platform.Authentication.Controllers
                 jwksDocument.Keys.Add(jwkDocument);
             }
 
-            return Ok(jwksDocument);
+            return jwksDocument;
         }
 
         private List<string> ExportChain(X509Certificate2 cert)


### PR DESCRIPTION
Not sure this is correct, but I was having some issues with generating C# clients for platform.authentication using NSwag where the `ExchangeToken` endpoint was declared to have a `void` return type. Adding some annotations seems to fix it. I went trough and tried to all controllers in Platform.Authentication.

Note:
The generated swagger file from `http://localhost:5040/authentication/swagger/v1/swagger.json` does not match the swagger file published in docs. It seems to be deliberate.
