### PR TITLE
fix: reset selected context to self, if user does not have access to …

### DIFF
--- a/src/studio/src/designer/frontend/dashboard/app/App.tsx
+++ b/src/studio/src/designer/frontend/dashboard/app/App.tsx
@@ -18,8 +18,10 @@ import { fetchLanguage } from '../resources/fetchLanguage/languageSlice';
 import Header, {
   IHeaderContext,
   HeaderContext,
+  SelectedContextType,
 } from 'app-shared/navigation/main-header/Header';
 
+import { userHasAccessToSelectedContext } from 'common/utils';
 import { generateClassName, themeV4, themeV5 } from 'common/utils/muiUtils';
 import { useAppSelector, useAppDispatch } from 'common/hooks';
 import { CenterContainer } from 'common/components/CenterContainer';
@@ -44,7 +46,7 @@ export const App = () => {
   const selectedContext = useAppSelector(
     (state) => state.dashboard.selectedContext,
   );
-  const { data, isLoading: isLoadingOrganizations } =
+  const { data: orgs = [], isLoading: isLoadingOrganizations } =
     useGetOrganizationsQuery();
 
   const setSelectedContext = (newSelectedContext: SelectedContext) => {
@@ -55,8 +57,15 @@ export const App = () => {
     );
   };
 
+  if (
+    !isLoadingOrganizations &&
+    !userHasAccessToSelectedContext({ selectedContext, orgs })
+  ) {
+    setSelectedContext(SelectedContextType.Self);
+  }
+
   const headerContextValue: IHeaderContext = {
-    selectableOrgs: data,
+    selectableOrgs: orgs,
     selectedContext,
     setSelectedContext,
     user,

--- a/src/studio/src/designer/frontend/dashboard/common/utils/index.tsx
+++ b/src/studio/src/designer/frontend/dashboard/common/utils/index.tsx
@@ -1,5 +1,30 @@
+import { SelectedContextType } from 'app-shared/navigation/main-header/Header';
+import { SelectedContext } from '../../resources/fetchDashboardResources/dashboardSlice';
+import { Organizations } from 'services/organizationApi';
+
 export const appNameRegex = /^(?!datamodels$)[a-z][a-z0-9-]{1,28}[a-z0-9]$/;
 
 export const validateRepoName = (repoName: string) => {
   return appNameRegex.test(repoName);
+};
+
+export const userHasAccessToSelectedContext = ({
+  selectedContext,
+  orgs,
+}: {
+  selectedContext: SelectedContext;
+  orgs: Organizations;
+}) => {
+  if (
+    selectedContext == SelectedContextType.Self ||
+    selectedContext == SelectedContextType.All
+  ) {
+    return true;
+  }
+
+  const selectedContextIsInOrgsList = Boolean(
+    orgs.find((org) => org.id === selectedContext),
+  );
+
+  return selectedContextIsInOrgsList;
 };

--- a/src/studio/src/designer/frontend/dashboard/common/utils/index.tsx
+++ b/src/studio/src/designer/frontend/dashboard/common/utils/index.tsx
@@ -22,9 +22,5 @@ export const userHasAccessToSelectedContext = ({
     return true;
   }
 
-  const selectedContextIsInOrgsList = Boolean(
-    orgs.find((org) => org.id === selectedContext),
-  );
-
-  return selectedContextIsInOrgsList;
+  return Boolean(orgs.find((org) => org.id === selectedContext));
 };

--- a/src/studio/src/designer/frontend/dashboard/test/__tests__/common/utils/index.test.ts
+++ b/src/studio/src/designer/frontend/dashboard/test/__tests__/common/utils/index.test.ts
@@ -1,4 +1,5 @@
-import { validateRepoName } from 'common/utils';
+import { SelectedContextType } from 'app-shared/navigation/main-header/Header';
+import { validateRepoName, userHasAccessToSelectedContext } from 'common/utils';
 
 describe('validateRepoName', () => {
   it('should return true when repo name does not contain invalid characters', () => {
@@ -35,5 +36,63 @@ describe('validateRepoName', () => {
 
   it('should return false when length is more than 30 characters', () => {
     expect(validateRepoName('a234567890123456789012345678901')).toBe(false);
+  });
+});
+
+describe('userHasAccessToSelectedContext', () => {
+  it('should return true when context is self', () => {
+    const result = userHasAccessToSelectedContext({
+      selectedContext: SelectedContextType.Self,
+      orgs: [],
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true when context is all', () => {
+    const result = userHasAccessToSelectedContext({
+      selectedContext: SelectedContextType.All,
+      orgs: [],
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true when context id is present in orgs list', () => {
+    const result = userHasAccessToSelectedContext({
+      selectedContext: 1,
+      orgs: [
+        {
+          avatar_url: 'avatar_url',
+          description: '',
+          full_name: 'full_name',
+          id: 1,
+          location: '',
+          username: 'username',
+          website: '',
+        },
+      ],
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when context id is not present in orgs list', () => {
+    const result = userHasAccessToSelectedContext({
+      selectedContext: 2,
+      orgs: [
+        {
+          avatar_url: 'avatar_url',
+          description: '',
+          full_name: 'full_name',
+          id: 1,
+          location: '',
+          username: 'username',
+          website: '',
+        },
+      ],
+    });
+
+    expect(result).toBe(false);
   });
 });


### PR DESCRIPTION
…stored selected context

## Description
In https://github.com/Altinn/altinn-studio/pull/7788 we introduced a way for selected context to be remembered between sessions. This uses localStorage, and is persisted in the browser. When user A first logged in, and selected context 1, it caused a problem when user B later logged in in the same browser, since user B did not have access to context 1.

To fix this, we do a check if the logged in user has access to the selected context. If they do not, the selected context is reset to default (Self).


## Fixes
- #7665 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
