### PR TITLE
support for running test on external pr

### DIFF
--- a/.github/workflows/cypress-altinn-app-frontend.yml
+++ b/.github/workflows/cypress-altinn-app-frontend.yml
@@ -90,5 +90,5 @@ jobs:
       - name: Verify cypress and run tests
         run: |
           yarn run cy:verify
-          ./node_modules/.bin/start-server-and-test 'cd $GITHUB_WORKSPACE/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend && yarn start' 8080 'yarn run test:appfrontend:headless --env component=appfrontend,environment=tt02,testUserName=testuserexternal,testUserPwd=r@h74Rz7XYQJ
+          ./node_modules/.bin/start-server-and-test 'cd $GITHUB_WORKSPACE/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend && yarn start' 8080 'yarn run test:appfrontend:headless --env component=appfrontend,environment=tt02,testUserName=testuserexternal,testUserPwd=r@h74Rz7XYQJ'
         working-directory: src/test/cypress

--- a/.github/workflows/cypress-altinn-app-frontend.yml
+++ b/.github/workflows/cypress-altinn-app-frontend.yml
@@ -16,7 +16,11 @@ on:
 
 jobs:
   altinn-app-frontend-test:
-    if: github.repository_owner == 'Altinn'
+    if: |
+     github.repository_owner == 'Altinn' && 
+     (github.event_name != 'pull_request' && github.event.repository.fork == false) ||
+     (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+    
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -32,8 +36,7 @@ jobs:
           node-version: '16'
 
       - name: Install altinn-app-frontend dependencies
-        run: |
-          yarn --immutable
+        run: yarn --immutable
         working-directory: src/Altinn.Apps/AppFrontend/react
 
       - name: Install cypress and test dependencies
@@ -44,17 +47,48 @@ jobs:
         run: |
           truncate -s 1K test.png
           truncate -s 1K test.pdf
-
         working-directory: src/test/cypress/e2e/fixtures
 
-      - name: Cypress verify
-        run: yarn run cy:verify
-        working-directory: src/test/cypress
-
-      - name: Run tests
+      - name: Verify cypress and run tests
         run: |
+          yarn run cy:verify
           export CYPRESS_PROJECT_ID=y2jhp6
           export CYPRESS_RECORD_KEY=${{ secrets.CYPRESS_RECORD_KEY }}
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           ./node_modules/.bin/start-server-and-test 'cd $GITHUB_WORKSPACE/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend && yarn start' 8080 'yarn run test:appfrontend:headless --env component=appfrontend,environment=tt02,testUserName=tt02testuser,testUserPwd=${{ secrets.CYPRESS_ALTINN_USERPWD }} --record --parallel --tag "altinn-app-frontend" --group altinn-app-frontend'
+        working-directory: src/test/cypress
+  
+  altinn-app-frontend-test-on-fork-pr:
+    if: |
+     github.repository_owner == 'Altinn' &&
+     (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
+    
+    runs-on: ubuntu-latest    
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install altinn-app-frontend dependencies
+        run: yarn --immutable
+        working-directory: src/Altinn.Apps/AppFrontend/react
+
+      - name: Install cypress and test dependencies
+        run: yarn --immutable
+        working-directory: src/test/cypress
+
+      - name: Create test files
+        run: |
+          truncate -s 1K test.png
+          truncate -s 1K test.pdf
+        working-directory: src/test/cypress/e2e/fixtures
+      
+      - name: Verify cypress and run tests
+        run: |
+          yarn run cy:verify
+          ./node_modules/.bin/start-server-and-test 'cd $GITHUB_WORKSPACE/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend && yarn start' 8080 'yarn run test:appfrontend:headless --env component=appfrontend,environment=tt02,testUserName=testuserexternal,testUserPwd=r@h74Rz7XYQJ
         working-directory: src/test/cypress

--- a/src/test/cypress/e2e/config/app/tt02.json
+++ b/src/test/cypress/e2e/config/app/tt02.json
@@ -3,6 +3,8 @@
   "baseUrl": "https://tt02.altinn.no",
   "env": {
     "userFullName": "FAGERLAND MAIKEN",
-    "firstName": "MAIKEN"   
+    "firstName": "MAIKEN",
+    "externalUserFullName": "RISHAUG JULIUS",
+    "externalFistName": "JULIUS"
   }
 }

--- a/src/test/cypress/e2e/integration/app-frontend/prefill.js
+++ b/src/test/cypress/e2e/integration/app-frontend/prefill.js
@@ -7,9 +7,12 @@ const appFrontend = new AppFrontend();
 
 describe('Prefill', () => {
   it('Check Prefill from register and readonly input', () => {
+    var userFullName = Cypress.env('testUserName').includes('external')
+      ? Cypress.env('externalUserFullName')
+      : Cypress.env('userFullName');
     cy.navigateToChangeName();
     cy.get(appFrontend.changeOfName.currentName).then((name) => {
-      cy.get(name).should('be.visible').and('have.value', Cypress.env('userFullName')).and('have.attr', 'readonly');
+      cy.get(name).should('be.visible').and('have.value', userFullName).and('have.attr', 'readonly');
     });
   });
 });

--- a/src/test/cypress/e2e/integration/app-frontend/stateless.js
+++ b/src/test/cypress/e2e/integration/app-frontend/stateless.js
@@ -33,12 +33,15 @@ describe('Stateless', () => {
   });
 
   it('is possible to start app instance from stateless app', () => {
+    var userFirstName = Cypress.env('testUserName').includes('external')
+      ? Cypress.env('externalFistName')
+      : Cypress.env('firstName');
     cy.intercept('POST', '**/instances/create').as('createInstance');
     cy.intercept('**/api/layoutsettings/statefull').as('getLayoutSettings');
     cy.get(appFrontend.instantiationButton).should('be.visible').click();
     cy.wait('@createInstance').its('response.statusCode').should('eq', 201);
     cy.wait('@getLayoutSettings');
-    cy.get(appFrontend.stateless.name).should('have.value', Cypress.env('firstName'));
+    cy.get(appFrontend.stateless.name).should('have.value', userFirstName);
     cy.get(appFrontend.stateless.idnumber).should('have.value', '1364');
     cy.get(appFrontend.sendinButton).should('be.visible');
   });


### PR DESCRIPTION
# support for running test on external pr

## Description
Today, when a PR is created from a fork repo, altinn-app-frontend tests are run and eventually it fails because the secrets are not shared with the PRs from fork repos.

Added a second job which only runs on PRs from fork repos that runs tests sequentially and results are not recorded in cypress dashboard.

## Verification
- [x] All tests run green