### PR TITLE
Bug/designer crashes on deploy

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -121,7 +121,6 @@ namespace Altinn.Platform.Authentication.Controllers
         /// <param name="dontChooseReportee">Parameter to indicate disabling of reportee selection in Altinn Portal.</param>
         /// <returns>redirect to correct url based on the validation of the form authentication sbl cookie</returns>
         [AllowAnonymous]
-        [Produces("text/plain")]
         [ProducesResponseType(StatusCodes.Status302Found)]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(void), StatusCodes.Status503ServiceUnavailable)]
@@ -235,7 +234,6 @@ namespace Altinn.Platform.Authentication.Controllers
         /// </summary>
         /// <returns>Ok response with the refreshed token appended.</returns>
         [Authorize]
-        [Produces("text/plain")]
         [HttpGet("refresh")]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
@@ -259,7 +257,6 @@ namespace Altinn.Platform.Authentication.Controllers
         /// </summary>
         /// <returns>The result of the action. Contains the new token if the old token was valid and could be exchanged.</returns>
         [AllowAnonymous]
-        [Produces("text/plain")]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Controllers/PolicyController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Controllers/PolicyController.cs
@@ -166,7 +166,16 @@ namespace Altinn.Platform.Authorization.Controllers
                 }
 
                 response.MinimumAuthenticationLevel = PolicyHelper.GetMinimumAuthenticationLevelFromXacmlPolicy(policy);
-                response.ResourcePolicies = PolicyHelper.GetResourcePoliciesFromXacmlPolicy(policy, language);
+                response.ResourcePolicies = new List<ResourcePolicy>();
+                List<ResourcePolicy> list = PolicyHelper.GetResourcePoliciesFromXacmlPolicy(policy, language);
+                foreach (ResourcePolicy resourcePolicy in list)
+                {
+                    if (resourcePolicy.Resource.First(a => a.Id == XacmlRequestAttribute.OrgAttribute).Value == org
+                        && resourcePolicy.Resource.First(a => a.Id == XacmlRequestAttribute.AppAttribute).Value == app)
+                    {
+                        response.ResourcePolicies.Add(resourcePolicy);
+                    }
+                }
             }
 
             return Ok(resourcePolicyResponses);

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/Json/GetResourcePolicies/SKDUndefinedRequest.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/Json/GetResourcePolicies/SKDUndefinedRequest.json
@@ -1,0 +1,12 @@
+[
+  [
+    {
+      "id": "urn:altinn:org",
+      "value": "SKD"
+    },
+    {
+      "id": "urn:altinn:app",
+      "value": "undefined"
+    }
+  ]
+]

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/Xacml/3.0/AltinnApps/skd/taxreport2/policy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/Xacml/3.0/AltinnApps/skd/taxreport2/policy.xml
@@ -26,7 +26,7 @@
             <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
           </xacml:Match>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">TaxReport</xacml:AttributeValue>
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">TaxReport2</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
           </xacml:Match>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
@@ -40,7 +40,7 @@
             <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
           </xacml:Match>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">TaxReport</xacml:AttributeValue>
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">TaxReport2</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
           </xacml:Match>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
@@ -54,7 +54,7 @@
             <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
           </xacml:Match>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">TaxReport</xacml:AttributeValue>
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">TaxReport2</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
           </xacml:Match>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
@@ -97,7 +97,7 @@
             <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
           </xacml:Match>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">TaxReport</xacml:AttributeValue>
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">TaxReport2</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
           </xacml:Match>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
@@ -145,7 +145,7 @@
             <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
           </xacml:Match>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">TaxReport</xacml:AttributeValue>
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">TaxReport2</xacml:AttributeValue>
             <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
           </xacml:Match>
           <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/Xacml/3.0/AltinnApps/skd/undefined/policy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/Xacml/3.0/AltinnApps/skd/undefined/policy.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy xmlns:xsl="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="urn:altinn:example:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides">
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:1" Effect="Permit">
+    <xacml:Description>Eksempel på samleregel som spesifiserer at både REGNA og DAGL m/sikkerhetsnivå; 2, for ressursen; org1/app1 får tilgang til operasjonene; Read og Write</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regna</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">priv</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:2" Effect="Permit">
+    <xacml:Description>Eksempel på tilleggsregel som spesifiserer at bare DAGL m/sikkerhetsnivå; 2, for ressursen; org1/app1 får tilgang til operasjonen; Sign for Task: task1</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">priv</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">org1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">app1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">task1</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">sign</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:ObligationExpressions>
+    <xacml:ObligationExpression FulfillOn="Permit" ObligationId="urn:altinn:obligation:1">
+      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:1" Category="urn:altinn:minimum-authenticationlevel">
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">4</xacml:AttributeValue>
+      </xacml:AttributeAssignmentExpression>
+    </xacml:ObligationExpression>
+    <xacml:ObligationExpression FulfillOn="Permit" ObligationId="urn:altinn:obligation:2">
+      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:2" Category="urn:altinn:minimum-authenticationlevel-org">
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">3</xacml:AttributeValue>
+      </xacml:AttributeAssignmentExpression>
+    </xacml:ObligationExpression>
+  </xacml:ObligationExpressions>
+</xacml:Policy>

--- a/src/studio/src/designer/backend.Tests/Designer.Tests.csproj
+++ b/src/studio/src/designer/backend.Tests/Designer.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>

--- a/src/studio/src/designer/backend.Tests/TypedHttpClients/AltinnAuthenticationClientTest.cs
+++ b/src/studio/src/designer/backend.Tests/TypedHttpClients/AltinnAuthenticationClientTest.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Altinn.Studio.Designer.Configuration;
+using Altinn.Studio.Designer.TypedHttpClients.AltinnAuthentication;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Moq;
+using Moq.Protected;
+
+using Xunit;
+
+namespace Designer.Tests.TypedHttpClients
+{
+    public class AltinnAuthenticationClientTest
+    {
+        private readonly Mock<IOptionsMonitor<PlatformSettings>> _platformSettingsOptions;
+        private readonly Mock<ILogger<AltinnAuthenticationClient>> _logger;
+        private readonly Mock<HttpMessageHandler> _handlerMock;
+
+        public AltinnAuthenticationClientTest()
+        {
+            _platformSettingsOptions = new();
+            _logger = new();
+            _handlerMock = new(MockBehavior.Strict);
+        }
+
+        [Fact]
+        public async Task TC01()
+        {
+            // Arrange
+            HttpRequestMessage actualRequest = null;
+
+            HttpResponseMessage httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("this is an exchanged token")
+            };
+
+            void SetRequest(HttpRequestMessage request) => actualRequest = request;
+            InitializeMocks(httpResponseMessage, SetRequest);
+            var sut = new AltinnAuthenticationClient(new HttpClient(_handlerMock.Object), _platformSettingsOptions.Object, _logger.Object);
+
+            // Act
+            await sut.ConvertTokenAsync("this is a random token", new Uri("https://platform.at22.altinn.cloud/storage/api/v1/instances"));
+
+            Assert.NotNull(actualRequest);
+            Assert.Equal(HttpMethod.Post, actualRequest.Method);
+            Assert.EndsWith("app", actualRequest.RequestUri.OriginalString);
+        }
+
+        private void InitializeMocks(HttpResponseMessage httpResponseMessage, Action<HttpRequestMessage> callback)
+        {
+            PlatformSettings platformSettings = new PlatformSettings
+            {
+                SubscriptionKeyHeaderName = "HeaderName",
+                ApiAuthenticationConvertUri = "authentication/api/v1/exchange/altinnstudio"
+            };
+
+            _platformSettingsOptions.Setup(s => s.CurrentValue).Returns(platformSettings);
+
+            GeneralSettings generalSettings = new GeneralSettings
+            {
+                HostName = "at22.altinn.cloud"
+            };
+
+            _handlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((request, _) => callback(request))
+                .ReturnsAsync(httpResponseMessage)
+                .Verifiable();
+        }
+    }
+}

--- a/src/studio/src/designer/backend/Exceptions/ApiException.cs
+++ b/src/studio/src/designer/backend/Exceptions/ApiException.cs
@@ -10,7 +10,7 @@
 
 using System;
 
-namespace Altinn.Studio.Designer.RepositoryClient.Client
+namespace Altinn.Studio.Designer.Exceptions
 {
     /// <summary>
     /// API Exception

--- a/src/studio/src/designer/backend/RepositoryClient/Api/IUserApi.cs
+++ b/src/studio/src/designer/backend/RepositoryClient/Api/IUserApi.cs
@@ -13,8 +13,11 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+
+using Altinn.Studio.Designer.Exceptions;
 using Altinn.Studio.Designer.RepositoryClient.Client;
 using Altinn.Studio.Designer.RepositoryClient.Model;
+
 using RestSharp;
 
 namespace Altinn.Studio.Designer.RepositoryClient.Api
@@ -1334,8 +1337,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Repository</returns>
         public Model.Repository CreateCurrentUserRepo(CreateRepoOption body = null)
         {
-             ApiResponse<Altinn.Studio.Designer.RepositoryClient.Model.Repository> localVarResponse = CreateCurrentUserRepoWithHttpInfo(body);
-             return localVarResponse.Data;
+            ApiResponse<Altinn.Studio.Designer.RepositoryClient.Model.Repository> localVarResponse = CreateCurrentUserRepoWithHttpInfo(body);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1443,8 +1446,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of Repository</returns>
         public async System.Threading.Tasks.Task<Altinn.Studio.Designer.RepositoryClient.Model.Repository> CreateCurrentUserRepoAsync(CreateRepoOption body = null)
         {
-             ApiResponse<Altinn.Studio.Designer.RepositoryClient.Model.Repository> localVarResponse = await CreateCurrentUserRepoAsyncWithHttpInfo(body);
-             return localVarResponse.Data;
+            ApiResponse<Altinn.Studio.Designer.RepositoryClient.Model.Repository> localVarResponse = await CreateCurrentUserRepoAsyncWithHttpInfo(body);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1552,8 +1555,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;Email&gt;</returns>
         public List<Email> UserAddEmail(CreateEmailOption body = null)
         {
-             ApiResponse<List<Email>> localVarResponse = UserAddEmailWithHttpInfo(body);
-             return localVarResponse.Data;
+            ApiResponse<List<Email>> localVarResponse = UserAddEmailWithHttpInfo(body);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1662,8 +1665,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;Email&gt;</returns>
         public async System.Threading.Tasks.Task<List<Email>> UserAddEmailAsync(CreateEmailOption body = null)
         {
-             ApiResponse<List<Email>> localVarResponse = await UserAddEmailAsyncWithHttpInfo(body);
-             return localVarResponse.Data;
+            ApiResponse<List<Email>> localVarResponse = await UserAddEmailAsyncWithHttpInfo(body);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1772,7 +1775,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <param name="followee">username of followed user</param>
         public void UserCheckFollowing(string follower, string followee)
         {
-             UserCheckFollowingWithHttpInfo(follower, followee);
+            UserCheckFollowingWithHttpInfo(follower, followee);
         }
 
         /// <summary>
@@ -1897,7 +1900,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of void</returns>
         public async System.Threading.Tasks.Task UserCheckFollowingAsync(string follower, string followee)
         {
-             await UserCheckFollowingAsyncWithHttpInfo(follower, followee);
+            await UserCheckFollowingAsyncWithHttpInfo(follower, followee);
         }
 
         /// <summary>
@@ -2020,7 +2023,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <param name="name"> (optional)</param>
         public void UserCreateToken(string name = null)
         {
-             UserCreateTokenWithHttpInfo(name);
+            UserCreateTokenWithHttpInfo(name);
         }
 
         /// <summary>
@@ -2124,7 +2127,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of void</returns>
         public async System.Threading.Tasks.Task UserCreateTokenAsync(string name = null)
         {
-             await UserCreateTokenAsyncWithHttpInfo(name);
+            await UserCreateTokenAsyncWithHttpInfo(name);
         }
 
         /// <summary>
@@ -2227,7 +2230,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <param name="followee">username of followed user</param>
         public void UserCurrentCheckFollowing(string followee)
         {
-             UserCurrentCheckFollowingWithHttpInfo(followee);
+            UserCurrentCheckFollowingWithHttpInfo(followee);
         }
 
         /// <summary>
@@ -2339,7 +2342,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of void</returns>
         public async System.Threading.Tasks.Task UserCurrentCheckFollowingAsync(string followee)
         {
-             await UserCurrentCheckFollowingAsyncWithHttpInfo(followee);
+            await UserCurrentCheckFollowingAsyncWithHttpInfo(followee);
         }
 
         /// <summary>
@@ -2451,7 +2454,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <param name="repo">name of the repo</param>
         public void UserCurrentCheckStarring(string owner, string repo)
         {
-             UserCurrentCheckStarringWithHttpInfo(owner, repo);
+            UserCurrentCheckStarringWithHttpInfo(owner, repo);
         }
 
         /// <summary>
@@ -2576,7 +2579,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of void</returns>
         public async System.Threading.Tasks.Task UserCurrentCheckStarringAsync(string owner, string repo)
         {
-             await UserCurrentCheckStarringAsyncWithHttpInfo(owner, repo);
+            await UserCurrentCheckStarringAsyncWithHttpInfo(owner, repo);
         }
 
         /// <summary>
@@ -2699,7 +2702,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <param name="username">username of user to unfollow</param>
         public void UserCurrentDeleteFollow(string username)
         {
-             UserCurrentDeleteFollowWithHttpInfo(username);
+            UserCurrentDeleteFollowWithHttpInfo(username);
         }
 
         /// <summary>
@@ -2811,7 +2814,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of void</returns>
         public async System.Threading.Tasks.Task UserCurrentDeleteFollowAsync(string username)
         {
-             await UserCurrentDeleteFollowAsyncWithHttpInfo(username);
+            await UserCurrentDeleteFollowAsyncWithHttpInfo(username);
         }
 
         /// <summary>
@@ -2922,7 +2925,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <param name="id">id of key to delete</param>
         public void UserCurrentDeleteGPGKey(int? id)
         {
-             UserCurrentDeleteGPGKeyWithHttpInfo(id);
+            UserCurrentDeleteGPGKeyWithHttpInfo(id);
         }
 
         /// <summary>
@@ -3033,7 +3036,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of void</returns>
         public async System.Threading.Tasks.Task UserCurrentDeleteGPGKeyAsync(int? id)
         {
-             await UserCurrentDeleteGPGKeyAsyncWithHttpInfo(id);
+            await UserCurrentDeleteGPGKeyAsyncWithHttpInfo(id);
         }
 
         /// <summary>
@@ -3143,7 +3146,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <param name="id">id of key to delete</param>
         public void UserCurrentDeleteKey(int? id)
         {
-             UserCurrentDeleteKeyWithHttpInfo(id);
+            UserCurrentDeleteKeyWithHttpInfo(id);
         }
 
         /// <summary>
@@ -3254,7 +3257,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of void</returns>
         public async System.Threading.Tasks.Task UserCurrentDeleteKeyAsync(int? id)
         {
-             await UserCurrentDeleteKeyAsyncWithHttpInfo(id);
+            await UserCurrentDeleteKeyAsyncWithHttpInfo(id);
         }
 
         /// <summary>
@@ -3365,7 +3368,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <param name="repo">name of the repo to unstar</param>
         public void UserCurrentDeleteStar(string owner, string repo)
         {
-             UserCurrentDeleteStarWithHttpInfo(owner, repo);
+            UserCurrentDeleteStarWithHttpInfo(owner, repo);
         }
 
         /// <summary>
@@ -3490,7 +3493,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of void</returns>
         public async System.Threading.Tasks.Task UserCurrentDeleteStarAsync(string owner, string repo)
         {
-             await UserCurrentDeleteStarAsyncWithHttpInfo(owner, repo);
+            await UserCurrentDeleteStarAsyncWithHttpInfo(owner, repo);
         }
 
         /// <summary>
@@ -3614,8 +3617,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>GPGKey</returns>
         public GPGKey UserCurrentGetGPGKey(int? id)
         {
-             ApiResponse<GPGKey> localVarResponse = UserCurrentGetGPGKeyWithHttpInfo(id);
-             return localVarResponse.Data;
+            ApiResponse<GPGKey> localVarResponse = UserCurrentGetGPGKeyWithHttpInfo(id);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -3726,8 +3729,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of GPGKey</returns>
         public async System.Threading.Tasks.Task<GPGKey> UserCurrentGetGPGKeyAsync(int? id)
         {
-             ApiResponse<GPGKey> localVarResponse = await UserCurrentGetGPGKeyAsyncWithHttpInfo(id);
-             return localVarResponse.Data;
+            ApiResponse<GPGKey> localVarResponse = await UserCurrentGetGPGKeyAsyncWithHttpInfo(id);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -3838,8 +3841,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>PublicKey</returns>
         public PublicKey UserCurrentGetKey(int? id)
         {
-             ApiResponse<PublicKey> localVarResponse = UserCurrentGetKeyWithHttpInfo(id);
-             return localVarResponse.Data;
+            ApiResponse<PublicKey> localVarResponse = UserCurrentGetKeyWithHttpInfo(id);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -3950,8 +3953,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of PublicKey</returns>
         public async System.Threading.Tasks.Task<PublicKey> UserCurrentGetKeyAsync(int? id)
         {
-             ApiResponse<PublicKey> localVarResponse = await UserCurrentGetKeyAsyncWithHttpInfo(id);
-             return localVarResponse.Data;
+            ApiResponse<PublicKey> localVarResponse = await UserCurrentGetKeyAsyncWithHttpInfo(id);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -4061,8 +4064,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;User&gt;</returns>
         public List<User> UserCurrentListFollowers()
         {
-             ApiResponse<List<User>> localVarResponse = UserCurrentListFollowersWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<User>> localVarResponse = UserCurrentListFollowersWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -4160,8 +4163,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;User&gt;</returns>
         public async System.Threading.Tasks.Task<List<User>> UserCurrentListFollowersAsync()
         {
-             ApiResponse<List<User>> localVarResponse = await UserCurrentListFollowersAsyncWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<User>> localVarResponse = await UserCurrentListFollowersAsyncWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -4259,8 +4262,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;User&gt;</returns>
         public List<User> UserCurrentListFollowing()
         {
-             ApiResponse<List<User>> localVarResponse = UserCurrentListFollowingWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<User>> localVarResponse = UserCurrentListFollowingWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -4358,8 +4361,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;User&gt;</returns>
         public async System.Threading.Tasks.Task<List<User>> UserCurrentListFollowingAsync()
         {
-             ApiResponse<List<User>> localVarResponse = await UserCurrentListFollowingAsyncWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<User>> localVarResponse = await UserCurrentListFollowingAsyncWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -4457,8 +4460,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;GPGKey&gt;</returns>
         public List<GPGKey> UserCurrentListGPGKeys()
         {
-             ApiResponse<List<GPGKey>> localVarResponse = UserCurrentListGPGKeysWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<GPGKey>> localVarResponse = UserCurrentListGPGKeysWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -4556,8 +4559,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;GPGKey&gt;</returns>
         public async System.Threading.Tasks.Task<List<GPGKey>> UserCurrentListGPGKeysAsync()
         {
-             ApiResponse<List<GPGKey>> localVarResponse = await UserCurrentListGPGKeysAsyncWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<GPGKey>> localVarResponse = await UserCurrentListGPGKeysAsyncWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -4655,8 +4658,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;PublicKey&gt;</returns>
         public List<PublicKey> UserCurrentListKeys()
         {
-             ApiResponse<List<PublicKey>> localVarResponse = UserCurrentListKeysWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<PublicKey>> localVarResponse = UserCurrentListKeysWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -4754,8 +4757,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;PublicKey&gt;</returns>
         public async System.Threading.Tasks.Task<List<PublicKey>> UserCurrentListKeysAsync()
         {
-             ApiResponse<List<PublicKey>> localVarResponse = await UserCurrentListKeysAsyncWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<PublicKey>> localVarResponse = await UserCurrentListKeysAsyncWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -4853,8 +4856,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;Repository&gt;</returns>
         public List<Altinn.Studio.Designer.RepositoryClient.Model.Repository> UserCurrentListRepos()
         {
-             ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = UserCurrentListReposWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = UserCurrentListReposWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -4952,8 +4955,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;Repository&gt;</returns>
         public async System.Threading.Tasks.Task<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> UserCurrentListReposAsync()
         {
-             ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = await UserCurrentListReposAsyncWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = await UserCurrentListReposAsyncWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -5051,8 +5054,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;Repository&gt;</returns>
         public List<Altinn.Studio.Designer.RepositoryClient.Model.Repository> UserCurrentListStarred()
         {
-             ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = UserCurrentListStarredWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = UserCurrentListStarredWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -5150,8 +5153,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;Repository&gt;</returns>
         public async System.Threading.Tasks.Task<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> UserCurrentListStarredAsync()
         {
-             ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = await UserCurrentListStarredAsyncWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = await UserCurrentListStarredAsyncWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -5249,8 +5252,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;Repository&gt;</returns>
         public List<Altinn.Studio.Designer.RepositoryClient.Model.Repository> UserCurrentListSubscriptions()
         {
-             ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = UserCurrentListSubscriptionsWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = UserCurrentListSubscriptionsWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -5348,8 +5351,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;Repository&gt;</returns>
         public async System.Threading.Tasks.Task<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> UserCurrentListSubscriptionsAsync()
         {
-             ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = await UserCurrentListSubscriptionsAsyncWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = await UserCurrentListSubscriptionsAsyncWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -5448,8 +5451,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>GPGKey</returns>
         public GPGKey UserCurrentPostGPGKey(CreateGPGKeyOption form = null)
         {
-             ApiResponse<GPGKey> localVarResponse = UserCurrentPostGPGKeyWithHttpInfo(form);
-             return localVarResponse.Data;
+            ApiResponse<GPGKey> localVarResponse = UserCurrentPostGPGKeyWithHttpInfo(form);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -5557,8 +5560,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of GPGKey</returns>
         public async System.Threading.Tasks.Task<GPGKey> UserCurrentPostGPGKeyAsync(CreateGPGKeyOption form = null)
         {
-             ApiResponse<GPGKey> localVarResponse = await UserCurrentPostGPGKeyAsyncWithHttpInfo(form);
-             return localVarResponse.Data;
+            ApiResponse<GPGKey> localVarResponse = await UserCurrentPostGPGKeyAsyncWithHttpInfo(form);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -5666,8 +5669,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>PublicKey</returns>
         public PublicKey UserCurrentPostKey(CreateKeyOption body = null)
         {
-             ApiResponse<PublicKey> localVarResponse = UserCurrentPostKeyWithHttpInfo(body);
-             return localVarResponse.Data;
+            ApiResponse<PublicKey> localVarResponse = UserCurrentPostKeyWithHttpInfo(body);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -5775,8 +5778,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of PublicKey</returns>
         public async System.Threading.Tasks.Task<PublicKey> UserCurrentPostKeyAsync(CreateKeyOption body = null)
         {
-             ApiResponse<PublicKey> localVarResponse = await UserCurrentPostKeyAsyncWithHttpInfo(body);
-             return localVarResponse.Data;
+            ApiResponse<PublicKey> localVarResponse = await UserCurrentPostKeyAsyncWithHttpInfo(body);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -5883,7 +5886,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <param name="username">username of user to follow</param>
         public void UserCurrentPutFollow(string username)
         {
-             UserCurrentPutFollowWithHttpInfo(username);
+            UserCurrentPutFollowWithHttpInfo(username);
         }
 
         /// <summary>
@@ -5995,7 +5998,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of void</returns>
         public async System.Threading.Tasks.Task UserCurrentPutFollowAsync(string username)
         {
-             await UserCurrentPutFollowAsyncWithHttpInfo(username);
+            await UserCurrentPutFollowAsyncWithHttpInfo(username);
         }
 
         /// <summary>
@@ -6107,7 +6110,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <param name="repo">name of the repo to star</param>
         public void UserCurrentPutStar(string owner, string repo)
         {
-             UserCurrentPutStarWithHttpInfo(owner, repo);
+            UserCurrentPutStarWithHttpInfo(owner, repo);
         }
 
         /// <summary>
@@ -6232,7 +6235,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of void</returns>
         public async System.Threading.Tasks.Task UserCurrentPutStarAsync(string owner, string repo)
         {
-             await UserCurrentPutStarAsyncWithHttpInfo(owner, repo);
+            await UserCurrentPutStarAsyncWithHttpInfo(owner, repo);
         }
 
         /// <summary>
@@ -6355,8 +6358,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;TrackedTime&gt;</returns>
         public List<TrackedTime> UserCurrentTrackedTimes()
         {
-             ApiResponse<List<TrackedTime>> localVarResponse = UserCurrentTrackedTimesWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<TrackedTime>> localVarResponse = UserCurrentTrackedTimesWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -6454,8 +6457,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;TrackedTime&gt;</returns>
         public async System.Threading.Tasks.Task<List<TrackedTime>> UserCurrentTrackedTimesAsync()
         {
-             ApiResponse<List<TrackedTime>> localVarResponse = await UserCurrentTrackedTimesAsyncWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<TrackedTime>> localVarResponse = await UserCurrentTrackedTimesAsyncWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -6553,7 +6556,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <param name="body"> (optional)</param>
         public void UserDeleteEmail(DeleteEmailOption body = null)
         {
-             UserDeleteEmailWithHttpInfo(body);
+            UserDeleteEmailWithHttpInfo(body);
         }
 
         /// <summary>
@@ -6662,7 +6665,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of void</returns>
         public async System.Threading.Tasks.Task UserDeleteEmailAsync(DeleteEmailOption body = null)
         {
-             await UserDeleteEmailAsyncWithHttpInfo(body);
+            await UserDeleteEmailAsyncWithHttpInfo(body);
         }
 
         /// <summary>
@@ -6771,8 +6774,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>User</returns>
         public User UserGet(string username)
         {
-             ApiResponse<User> localVarResponse = UserGetWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<User> localVarResponse = UserGetWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -6883,8 +6886,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of User</returns>
         public async System.Threading.Tasks.Task<User> UserGetAsync(string username)
         {
-             ApiResponse<User> localVarResponse = await UserGetAsyncWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<User> localVarResponse = await UserGetAsyncWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -6994,8 +6997,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>User</returns>
         public User UserGetCurrent()
         {
-             ApiResponse<User> localVarResponse = UserGetCurrentWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<User> localVarResponse = UserGetCurrentWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -7093,8 +7096,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of User</returns>
         public async System.Threading.Tasks.Task<User> UserGetCurrentAsync()
         {
-             ApiResponse<User> localVarResponse = await UserGetCurrentAsyncWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<User> localVarResponse = await UserGetCurrentAsyncWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -7191,7 +7194,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// IO.Swagger.Client.ApiException thrown when fails to make API call
         public void UserGetTokens()
         {
-             UserGetTokensWithHttpInfo();
+            UserGetTokensWithHttpInfo();
         }
 
         /// <summary>
@@ -7289,7 +7292,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of void</returns>
         public async System.Threading.Tasks.Task UserGetTokensAsync()
         {
-             await UserGetTokensAsyncWithHttpInfo();
+            await UserGetTokensAsyncWithHttpInfo();
         }
 
         /// <summary>
@@ -7387,8 +7390,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;Email&gt;</returns>
         public List<Email> UserListEmails()
         {
-             ApiResponse<List<Email>> localVarResponse = UserListEmailsWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<Email>> localVarResponse = UserListEmailsWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -7486,8 +7489,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;Email&gt;</returns>
         public async System.Threading.Tasks.Task<List<Email>> UserListEmailsAsync()
         {
-             ApiResponse<List<Email>> localVarResponse = await UserListEmailsAsyncWithHttpInfo();
-             return localVarResponse.Data;
+            ApiResponse<List<Email>> localVarResponse = await UserListEmailsAsyncWithHttpInfo();
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -7586,8 +7589,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;User&gt;</returns>
         public List<User> UserListFollowers(string username)
         {
-             ApiResponse<List<User>> localVarResponse = UserListFollowersWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<User>> localVarResponse = UserListFollowersWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -7698,8 +7701,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;User&gt;</returns>
         public async System.Threading.Tasks.Task<List<User>> UserListFollowersAsync(string username)
         {
-             ApiResponse<List<User>> localVarResponse = await UserListFollowersAsyncWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<User>> localVarResponse = await UserListFollowersAsyncWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -7810,8 +7813,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;User&gt;</returns>
         public List<User> UserListFollowing(string username)
         {
-             ApiResponse<List<User>> localVarResponse = UserListFollowingWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<User>> localVarResponse = UserListFollowingWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -7922,8 +7925,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;User&gt;</returns>
         public async System.Threading.Tasks.Task<List<User>> UserListFollowingAsync(string username)
         {
-             ApiResponse<List<User>> localVarResponse = await UserListFollowingAsyncWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<User>> localVarResponse = await UserListFollowingAsyncWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -8034,8 +8037,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;GPGKey&gt;</returns>
         public List<GPGKey> UserListGPGKeys(string username)
         {
-             ApiResponse<List<GPGKey>> localVarResponse = UserListGPGKeysWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<GPGKey>> localVarResponse = UserListGPGKeysWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -8146,8 +8149,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;GPGKey&gt;</returns>
         public async System.Threading.Tasks.Task<List<GPGKey>> UserListGPGKeysAsync(string username)
         {
-             ApiResponse<List<GPGKey>> localVarResponse = await UserListGPGKeysAsyncWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<GPGKey>> localVarResponse = await UserListGPGKeysAsyncWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -8258,8 +8261,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;PublicKey&gt;</returns>
         public List<PublicKey> UserListKeys(string username)
         {
-             ApiResponse<List<PublicKey>> localVarResponse = UserListKeysWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<PublicKey>> localVarResponse = UserListKeysWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -8370,8 +8373,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;PublicKey&gt;</returns>
         public async System.Threading.Tasks.Task<List<PublicKey>> UserListKeysAsync(string username)
         {
-             ApiResponse<List<PublicKey>> localVarResponse = await UserListKeysAsyncWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<PublicKey>> localVarResponse = await UserListKeysAsyncWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -8482,8 +8485,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;Repository&gt;</returns>
         public List<Altinn.Studio.Designer.RepositoryClient.Model.Repository> UserListRepos(string username)
         {
-             ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = UserListReposWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = UserListReposWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -8594,8 +8597,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;Repository&gt;</returns>
         public async System.Threading.Tasks.Task<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> UserListReposAsync(string username)
         {
-             ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = await UserListReposAsyncWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = await UserListReposAsyncWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -8706,8 +8709,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;Repository&gt;</returns>
         public List<Altinn.Studio.Designer.RepositoryClient.Model.Repository> UserListStarred(string username)
         {
-             ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = UserListStarredWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = UserListStarredWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -8818,8 +8821,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;Repository&gt;</returns>
         public async System.Threading.Tasks.Task<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> UserListStarredAsync(string username)
         {
-             ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = await UserListStarredAsyncWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = await UserListStarredAsyncWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -8930,8 +8933,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;Repository&gt;</returns>
         public List<Altinn.Studio.Designer.RepositoryClient.Model.Repository> UserListSubscriptions(string username)
         {
-             ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = UserListSubscriptionsWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = UserListSubscriptionsWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -9042,8 +9045,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;Repository&gt;</returns>
         public async System.Threading.Tasks.Task<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> UserListSubscriptionsAsync(string username)
         {
-             ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = await UserListSubscriptionsAsyncWithHttpInfo(username);
-             return localVarResponse.Data;
+            ApiResponse<List<Altinn.Studio.Designer.RepositoryClient.Model.Repository>> localVarResponse = await UserListSubscriptionsAsyncWithHttpInfo(username);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -9155,8 +9158,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;User&gt;</returns>
         public List<User> UserSearch(string q = null, int? limit = null)
         {
-             ApiResponse<List<User>> localVarResponse = UserSearchWithHttpInfo(q, limit);
-             return localVarResponse.Data;
+            ApiResponse<List<User>> localVarResponse = UserSearchWithHttpInfo(q, limit);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -9268,8 +9271,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;User&gt;</returns>
         public async System.Threading.Tasks.Task<List<User>> UserSearchAsync(string q = null, int? limit = null)
         {
-             ApiResponse<List<User>> localVarResponse = await UserSearchAsyncWithHttpInfo(q, limit);
-             return localVarResponse.Data;
+            ApiResponse<List<User>> localVarResponse = await UserSearchAsyncWithHttpInfo(q, limit);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -9382,8 +9385,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>List&lt;TrackedTime&gt;</returns>
         public List<TrackedTime> UserTrackedTimes(string owner, string repo, string user)
         {
-             ApiResponse<List<TrackedTime>> localVarResponse = UserTrackedTimesWithHttpInfo(owner, repo, user);
-             return localVarResponse.Data;
+            ApiResponse<List<TrackedTime>> localVarResponse = UserTrackedTimesWithHttpInfo(owner, repo, user);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -9520,8 +9523,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.Api
         /// <returns>Task of List&lt;TrackedTime&gt;</returns>
         public async System.Threading.Tasks.Task<List<TrackedTime>> UserTrackedTimesAsync(string owner, string repo, string user)
         {
-             ApiResponse<List<TrackedTime>> localVarResponse = await UserTrackedTimesAsyncWithHttpInfo(owner, repo, user);
-             return localVarResponse.Data;
+            ApiResponse<List<TrackedTime>> localVarResponse = await UserTrackedTimesAsyncWithHttpInfo(owner, repo, user);
+            return localVarResponse.Data;
         }
 
         /// <summary>

--- a/src/studio/src/designer/backend/RepositoryClient/Client/ApiClient.cs
+++ b/src/studio/src/designer/backend/RepositoryClient/Client/ApiClient.cs
@@ -1,4 +1,4 @@
-/*
+*
  * Gitea API.
  *
  * This documentation describes the Gitea API.
@@ -11,14 +11,15 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Web;
+
+using Altinn.Studio.Designer.Exceptions;
+
 using Newtonsoft.Json;
+
 using RestSharp;
 
 namespace Altinn.Studio.Designer.RepositoryClient.Client
@@ -142,7 +143,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Client
             // add file parameter, if any
             foreach (var param in fileParams)
             {
-               // request.AddFile(param.Value.Name, param.Value.Writer, param.Value.FileName, param.Value.ContentType);
+                // request.AddFile(param.Value.Name, param.Value.Writer, param.Value.FileName, param.Value.ContentType);
             }
 
             // http body (model or byte[]) parameter
@@ -360,7 +361,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Client
             // return a datetime object
             if (type.Name.StartsWith("System.Nullable`1[[System.DateTime"))
             {
-                return DateTime.Parse(response.Content,  null, System.Globalization.DateTimeStyles.RoundtripKind);
+                return DateTime.Parse(response.Content, null, System.Globalization.DateTimeStyles.RoundtripKind);
             }
 
             // return primitive type

--- a/src/studio/src/designer/backend/RepositoryClient/Client/ApiClient.cs
+++ b/src/studio/src/designer/backend/RepositoryClient/Client/ApiClient.cs
@@ -1,4 +1,4 @@
-*
+/*
  * Gitea API.
  *
  * This documentation describes the Gitea API.

--- a/src/studio/src/designer/backend/RepositoryClient/Client/Configuration.cs
+++ b/src/studio/src/designer/backend/RepositoryClient/Client/Configuration.cs
@@ -12,9 +12,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
+
+using Altinn.Studio.Designer.Exceptions;
 
 namespace Altinn.Studio.Designer.RepositoryClient.Client
 {
@@ -213,7 +212,7 @@ namespace Altinn.Studio.Designer.RepositoryClient.Client
             int timeout = 100000,
             string userAgent = "Swagger-Codegen/1.0.0/csharp")
 
-            // ReSharper restore UnusedParameter.Local
+        // ReSharper restore UnusedParameter.Local
         {
         }
 

--- a/src/studio/src/designer/backend/TypedHttpClients/AltinnAuthentication/AltinnAuthenticationClient.cs
+++ b/src/studio/src/designer/backend/TypedHttpClients/AltinnAuthentication/AltinnAuthenticationClient.cs
@@ -2,7 +2,10 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+
 using Altinn.Studio.Designer.Configuration;
+using Altinn.Studio.Designer.Exceptions;
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -61,9 +64,16 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnAuthentication
             };
 
             HttpResponseMessage response = await _httpClient.SendAsync(message);
-
             _logger.LogInformation($"//AltinnAuthenticationClient // ConvertTokenAsync // Response: {response}");
-            return await response.Content.ReadAsAsync<string>();
+
+            if (response.IsSuccessStatusCode)
+            {
+                return await response.Content.ReadAsStringAsync();
+            }
+
+            _logger.LogInformation($"//AltinnAuthenticationClient // ConvertTokenAsync // Token exchange failed with status code {response.StatusCode}");
+
+            throw new ApiException((int)response.StatusCode, await response.Content.ReadAsStringAsync());
         }
     }
 }


### PR DESCRIPTION
# Read exchange token response as string regardless of content type
<!-- Summary of the changes (max 80 characters) -->


## Description
Designer started crashing on deploy after #7827 was merged. Most likely a result of `[Produces("text/plain")]` being introduced changing the content-type of the response. Handling of the response in designer was highly dependent on the content-type. Changed it to read response as string regardless of conent-type. This is the same behavior as the clients in app template.

## Fixes
- Bug introduces with #7827.
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green