### PR TITLE
Open up for more media types in Authentication

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -121,7 +121,6 @@ namespace Altinn.Platform.Authentication.Controllers
         /// <param name="dontChooseReportee">Parameter to indicate disabling of reportee selection in Altinn Portal.</param>
         /// <returns>redirect to correct url based on the validation of the form authentication sbl cookie</returns>
         [AllowAnonymous]
-        [Produces("text/plain")]
         [ProducesResponseType(StatusCodes.Status302Found)]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(void), StatusCodes.Status503ServiceUnavailable)]

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -235,7 +235,6 @@ namespace Altinn.Platform.Authentication.Controllers
         /// </summary>
         /// <returns>Ok response with the refreshed token appended.</returns>
         [Authorize]
-        [Produces("text/plain")]
         [HttpGet("refresh")]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
@@ -259,7 +258,6 @@ namespace Altinn.Platform.Authentication.Controllers
         /// </summary>
         /// <returns>The result of the action. Contains the new token if the old token was valid and could be exchanged.</returns>
         [AllowAnonymous]
-        [Produces("text/plain")]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]


### PR DESCRIPTION
# Open up for more media types in Authentication
Allowing clients to ask for more media types than text/plain.


## Description
There might be clients out there asking the endpoint for application/json. Those might be unable to read text/plain.

## Fixes
- Partial revert of PR 7827.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
