### PR TITLE
Delete duplicate file

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/shared/src/utils/applicationMetadataUtils.ts
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/utils/applicationMetadataUtils.ts
@@ -1,6 +1,0 @@
-import { IApplication, IInstance } from '../types';
-
-export const getCurrentTaskData = (appMetaData: IApplication, instance: IInstance) => {
-  const defaultDatatype = appMetaData.dataTypes.find((element) => element.appLogic !== null);
-  return instance.data.find((element) => element.dataType === defaultDatatype.id);
-};


### PR DESCRIPTION
When cloning altinn studio I got the following mesage.

```
PS C:\Users\xivne\dev> git clone https://github.com/altinn/altinn-studio
Cloning into 'altinn-studio'...
remote: Enumerating objects: 81577, done.
remote: Counting objects: 100% (690/690), done.
remote: Compressing objects: 100% (376/376), done.
remote: Total 81577 (delta 304), reused 606 (delta 250), pack-reused 80887
Receiving objects: 100% (81577/81577), 64.34 MiB | 5.50 MiB/s, done.
Resolving deltas: 100% (58151/58151), done.
Updating files: 100% (7045/7045), done.
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:

  'src/Altinn.Apps/AppFrontend/react/shared/src/utils/applicationMetaDataUtils.ts'
  'src/Altinn.Apps/AppFrontend/react/shared/src/utils/applicationMetadataUtils.ts'
```

This means that in the repo both https://github.com/Altinn/altinn-studio/delete/master/src/Altinn.Apps/AppFrontend/react/shared/src/utils/applicationMetadataUtils.ts and https://github.com/Altinn/altinn-studio/blob/master/src/Altinn.Apps/AppFrontend/react/shared/src/utils/applicationMetaDataUtils.ts exists, and on windows you will only see one of the files on random. This is problematic if someone on windows decides to only update the single file he sees. As `applicationMetaDataUtils` is the version that is used in imports, I think this is the correct file to delete.

# Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green