### PR TITLE
Use resourceService to get local text resources instead of fetching from storage

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
@@ -482,12 +482,12 @@ namespace Altinn.App.Services.Implementation
             // If layoutset exists pick correct layotFiles
             string formLayoutsFileContent = layoutSet == null ? _resourceService.GetLayouts() : _resourceService.GetLayoutsForSet(layoutSet.Id);
 
-            TextResource textResource = await _textClient.GetText(org, app, language);
+            TextResource textResource = await _resourceService.GetTexts(org, app, language);
 
             if (textResource == null && language != "nb")
             {
                 // fallback to norwegian if texts does not exist
-                textResource = await _textClient.GetText(org, app, "nb");
+                textResource = await _resourceService.GetTexts(org, app, "nb");
             }
 
             string textResourcesString = JsonConvert.SerializeObject(textResource);


### PR DESCRIPTION
This means `IText` is not used anywhere, but because every app inherits
from `AppBase` and calls the base constructor, it can't be removed.

## Fixes
- Is required for pdf generation in #7485 to work
- Also included as part of #7898, but as this is a nuget package update I think you might want to handle it separately.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
