### PR TITLE
Add lastChangedDate to PDF header

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.PDF/Dockerfile
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/Dockerfile
@@ -1,10 +1,12 @@
 FROM maven:3.8.4-openjdk-17 AS build
-WORKDIR build
-COPY . .
+WORKDIR /build
+COPY pom.xml .
+RUN mvn -B dependency:go-offline
+COPY src src
 RUN mvn -Pprod package
 
 FROM mcr.microsoft.com/openjdk/jdk:17-ubuntu AS final
-WORKDIR app
+WORKDIR /app
 COPY --from=build /build/target .
 # setup the user and group
 # the user will have no password, using shell /bin/false and using the group dotnet

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/models/Instance.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/models/Instance.java
@@ -3,6 +3,11 @@ package altinn.platform.pdf.models;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 
 @Schema(description = "The instance metadata json file.")
@@ -14,8 +19,8 @@ public class Instance {
   private String appId;
   @NotNull
   private String org;
-  private String createdDateTime;
-  private String lastChangedDateTime;
+  private String created;
+  private String lastChanged;
   private Title title;
 
   public Title getTitle() {
@@ -66,19 +71,27 @@ public class Instance {
     this.org = org;
   }
 
-  public String getCreatedDateTime() {
-    return createdDateTime;
+  public String getCreated() {
+    return created;
   }
 
-  public void setCreatedDateTime(String createdDateTime) {
-    this.createdDateTime = createdDateTime;
+  public void setCreated(String createdDateTime) {
+    this.created = createdDateTime;
   }
 
-  public String getLastChangedDateTime() {
-    return lastChangedDateTime;
+  public String getLastChanged() {
+    return lastChanged;
+  }
+  public ZonedDateTime getLastChangedZonedDateTime() {
+    try{
+      return ZonedDateTime.parse(lastChanged, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }catch (DateTimeParseException e){
+      System.out.println(e);
+      return null;
+    }
   }
 
-  public void setLastChangedDateTime(String lastChangedDateTime) {
-    this.lastChangedDateTime = lastChangedDateTime;
+  public void setLastChanged(String lastChangedDateTime) {
+    this.lastChanged = lastChangedDateTime;
   }
 }

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/models/Instance.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/models/Instance.java
@@ -82,14 +82,6 @@ public class Instance {
   public String getLastChanged() {
     return lastChanged;
   }
-  public ZonedDateTime getLastChangedZonedDateTime() {
-    try{
-      return ZonedDateTime.parse(lastChanged, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-    }catch (DateTimeParseException e){
-      System.out.println(e);
-      return null;
-    }
-  }
 
   public void setLastChanged(String lastChangedDateTime) {
     this.lastChanged = lastChangedDateTime;

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/models/Instance.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/models/Instance.java
@@ -4,10 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.validation.constraints.NotNull;
 
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 
 @Schema(description = "The instance metadata json file.")

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
@@ -26,6 +26,9 @@ import org.w3c.dom.Document;
 import java.awt.*;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.List;
 import java.util.Map;
@@ -351,6 +354,10 @@ public class PDFGenerator {
     }
     List<String> lines = TextUtils.splitTextToLines(submittedBy, font, fontSize, width);
     lines.add(getLanguageString("reference_number") + " " + TextUtils.getInstanceGuid(instance.getId()).split("-")[4]);
+    ZonedDateTime lastChanged = instance.getLastChangedZonedDateTime();
+    if(lastChanged != null){
+      lines.add(getLanguageString("date_sent") + " " + lastChanged.withZoneSameInstant(ZoneId.of("Europe/Oslo")).format(DateTimeFormatter.ofPattern("dd.MM.yyyy / HH:mm")));
+    }
     for (String line : lines) {
       currentContent.showText(line);
       currentContent.newLineAtOffset(0, -leading);

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
@@ -354,10 +354,7 @@ public class PDFGenerator {
     }
     List<String> lines = TextUtils.splitTextToLines(submittedBy, font, fontSize, width);
     lines.add(getLanguageString("reference_number") + " " + TextUtils.getInstanceGuid(instance.getId()).split("-")[4]);
-    ZonedDateTime lastChanged = instance.getLastChangedZonedDateTime();
-    if(lastChanged != null){
-      lines.add(getLanguageString("date_sent") + " " + lastChanged.withZoneSameInstant(ZoneId.of("Europe/Oslo")).format(DateTimeFormatter.ofPattern("dd.MM.yyyy / HH:mm")));
-    }
+    lines.add(getLanguageString("date_geneated") + " " + ZonedDateTime.now().withZoneSameInstant(ZoneId.of("Europe/Oslo")).format(DateTimeFormatter.ofPattern("dd.MM.yyyy / HH:mm")));
     for (String line : lines) {
       currentContent.showText(line);
       currentContent.newLineAtOffset(0, -leading);

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/language/en.json
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/language/en.json
@@ -2,6 +2,7 @@
   "delivered_by": "Delivered by",
   "on_behalf_of": "on behalf of",
   "reference_number": "Reference number:",
+  "date_sent": "Date sent:",
   "address": "Address",
   "care_of": "C/O or other additional address",
   "house_number": "House number",

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/language/en.json
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/language/en.json
@@ -2,7 +2,7 @@
   "delivered_by": "Delivered by",
   "on_behalf_of": "on behalf of",
   "reference_number": "Reference number:",
-  "date_sent": "Date sent:",
+  "date_generated": "PDF generated:",
   "address": "Address",
   "care_of": "C/O or other additional address",
   "house_number": "House number",

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/language/nb.json
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/language/nb.json
@@ -2,6 +2,7 @@
   "delivered_by": "Levert av",
   "on_behalf_of": "på vegne av",
   "reference_number": "Referansenummer:",
+  "date_sent": "Dato sendt:",
   "address": "Gateadresse",
   "care_of": "C/O eller annen tilleggsadresse",
   "house_number": "Bolignummer",

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/language/nb.json
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/language/nb.json
@@ -2,7 +2,7 @@
   "delivered_by": "Levert av",
   "on_behalf_of": "på vegne av",
   "reference_number": "Referansenummer:",
-  "date_sent": "Dato sendt:",
+  "date_generated": "PDF generert:",
   "address": "Gateadresse",
   "care_of": "C/O eller annen tilleggsadresse",
   "house_number": "Bolignummer",

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/language/nn.json
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/language/nn.json
@@ -2,6 +2,7 @@
   "delivered_by": "Levert av",
   "on_behalf_of": "på vegne av",
   "reference_number": "Referansenummer:",
+  "date_sent": "Dato sendt:",
   "address": "Gateadresse",
   "care_of": "C/O eller annan tilleggsadresse",
   "house_number": "Bustadnummer",

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/language/nn.json
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/resources/language/nn.json
@@ -2,7 +2,7 @@
   "delivered_by": "Levert av",
   "on_behalf_of": "på vegne av",
   "reference_number": "Referansenummer:",
-  "date_sent": "Dato sendt:",
+  "date_generated": "PDF generert:",
   "address": "Gateadresse",
   "care_of": "C/O eller annan tilleggsadresse",
   "house_number": "Bustadnummer",


### PR DESCRIPTION
At Finanstilsynet we got a comment that the date (and time) a schema was submitted was not included in the PDF.

This pull request adds another line at the top of the PDF with the relevant time. I think "Europe/Oslo" is correct timezone, but please advise if you think I should be able to find it in some configuration.
![image](https://user-images.githubusercontent.com/131616/151176071-d7a02105-b4a2-4817-99cc-a88ecde14e44.png)



## Description
I also had to fix some schema errors in the PDF interface (names of properties did not match)
and got frustrated enough to use layers to speed up docker image rebuilds. I think that is OK to just tag on here.

## Fixes
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
