### PR TITLE
Test/new frontend tests

### DIFF
--- a/src/test/K6/docker-compose.yml
+++ b/src/test/K6/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - ./grafana-dashboard.yaml/:/etc/grafana/provisioning/dashboards/dashboard.yaml
 
   k6:
-    image: loadimpact/k6:0.35.0
+    image: loadimpact/k6:0.36.0
     networks:
       - k6
     ports:

--- a/src/test/K6/package.json
+++ b/src/test/K6/package.json
@@ -9,7 +9,7 @@
     "prettier:format": "prettier -w src/**/*.js"
   },
   "devDependencies": {
-    "@babel/core": "^7.16.10",
+    "@babel/core": "^7.16.12",
     "@babel/eslint-parser": "^7.16.5",
     "eslint": "^8.7.0",
     "prettier": "^2.5.1"

--- a/src/test/K6/yarn.lock
+++ b/src/test/K6/yarn.lock
@@ -21,16 +21,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.16.10":
-  version: 7.16.10
-  resolution: "@babel/core@npm:7.16.10"
+"@babel/core@npm:^7.16.12":
+  version: 7.16.12
+  resolution: "@babel/core@npm:7.16.12"
   dependencies:
     "@babel/code-frame": ^7.16.7
     "@babel/generator": ^7.16.8
     "@babel/helper-compilation-targets": ^7.16.7
     "@babel/helper-module-transforms": ^7.16.7
     "@babel/helpers": ^7.16.7
-    "@babel/parser": ^7.16.10
+    "@babel/parser": ^7.16.12
     "@babel/template": ^7.16.7
     "@babel/traverse": ^7.16.10
     "@babel/types": ^7.16.8
@@ -40,7 +40,7 @@ __metadata:
     json5: ^2.1.2
     semver: ^6.3.0
     source-map: ^0.5.0
-  checksum: d34c5edf9258e620d0cbea4ed25a2615f5ab86dc7f7c1b96ac19817fb7d57bfae9af72dc244385a724225dbc701cb878d9559158aee9659e2a3c69d03f93f3e1
+  checksum: 29b56f3cb7c329fc038a2efaccf64ac3025835676b3d90f57f2265b6acd477a970114d09021b38d019ac8f20b2bb1596a9e79ce1f820d6b8cf0e4a802891817c
   languageName: node
   linkType: hard
 
@@ -213,6 +213,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: d760606039de8ab8c68e993b7d3ae461754ef51dbf1fbd88d1428bf37d7e13bfb7205105332f0ac0a55d3534c231da527ab7b2db26e7cef6e0f9c8940a3c91a3
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.16.12":
+  version: 7.16.12
+  resolution: "@babel/parser@npm:7.16.12"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: af287f0f3dfa564958a7dddfeb62e08c0de9ce9bd8447fcde0997da26ec477bf19f37161b9d970e2c7e0d1f77e441258907d3347beddd0d42cae85ed46947703
   languageName: node
   linkType: hard
 
@@ -986,7 +995,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "k6-api-tests@workspace:."
   dependencies:
-    "@babel/core": ^7.16.10
+    "@babel/core": ^7.16.12
     "@babel/eslint-parser": ^7.16.5
     eslint: ^8.7.0
     prettier: ^2.5.1

--- a/src/test/cypress/e2e/fixtures/texts.json
+++ b/src/test/cypress/e2e/fixtures/texts.json
@@ -20,5 +20,6 @@
   "continueOrStartNew": "Velg om du vil fortsette på et skjema du har begynt på, eller om du vil starte på ny.",
   "welcome": "Velkommen til Altinn Studio",
   "appExists": "En app med det navnet finnes allerede.",
-  "noDeployAccess": "Du har ikke rettigheter til å starte en deploy til AT21-miljøet. Tilgang kan delegeres av owners"
+  "noDeployAccess": "Du har ikke rettigheter til å starte en deploy til AT21-miljøet. Tilgang kan delegeres av owners",
+  "startingSoon": "Hold deg fast, nå starter vi!"
 }

--- a/src/test/cypress/e2e/integration/app-frontend/components.js
+++ b/src/test/cypress/e2e/integration/app-frontend/components.js
@@ -9,7 +9,9 @@ const appFrontend = new AppFrontend();
 describe('UI Components', () => {
   beforeEach(() => {
     cy.intercept('**/active', []).as('noActiveInstances');
+    cy.intercept('POST', `**/instances?instanceOwnerPartyId*`).as('createInstace');
     cy.startAppInstance(Cypress.env('multiData2Stage'));
+    cy.wait('@createInstace');
   });
 
   it('Image component with help text', () => {
@@ -30,5 +32,21 @@ describe('UI Components', () => {
         cy.get(appFrontend.helpText.alert).should('not.exist');
       });
     cy.get('body').should('have.css', 'background-color', 'rgb(239, 239, 239)');
+  });
+
+  it('is possible to upload and delete attachments', () => {
+    cy.intercept('**/api/layoutsettings/changename').as('getLayoutChangeName');
+    cy.get(appFrontend.sendinButton).then((button) => {
+      cy.get(button).should('be.visible').click();
+      cy.wait('@getLayoutChangeName');
+    });
+    cy.get(appFrontend.changeOfName.uploadDropZone).should('be.visible');
+    cy.get(appFrontend.changeOfName.upload).selectFile('e2e/fixtures/test.pdf', { force: true });
+    cy.get(appFrontend.changeOfName.uploadedTable).should('be.visible');
+    cy.get(appFrontend.changeOfName.uploadingAnimation).should('be.visible');
+    cy.get(appFrontend.changeOfName.uploadSuccess).should('exist');
+    cy.get(appFrontend.changeOfName.deleteAttachment).should('have.length', 1);
+    cy.get(appFrontend.changeOfName.deleteAttachment).click();
+    cy.get(appFrontend.changeOfName.deleteAttachment).should('not.exist');
   });
 });

--- a/src/test/cypress/e2e/integration/app-frontend/components.js
+++ b/src/test/cypress/e2e/integration/app-frontend/components.js
@@ -2,6 +2,7 @@
 /// <reference types="../../support" />
 
 import AppFrontend from '../../pageobjects/app-frontend';
+import * as texts from '../../fixtures/texts.json';
 
 const appFrontend = new AppFrontend();
 
@@ -9,10 +10,13 @@ describe('UI Components', () => {
   beforeEach(() => {
     cy.intercept('**/active', []).as('noActiveInstances');
     cy.startAppInstance(Cypress.env('multiData2Stage'));
-    cy.get(appFrontend.closeButton).should('be.visible');
   });
 
   it('Image component with help text', () => {
+    cy.get('body').should('have.css', 'background-color', 'rgb(239, 239, 239)');
+    cy.get(appFrontend.loadingAnimation).should('be.visible');
+    cy.get(appFrontend.closeButton).should('be.visible');
+    cy.get(appFrontend.header).should('contain.text', texts.startingSoon);
     cy.get(appFrontend.message.logo)
       .should('be.visible')
       .then((image) => {
@@ -25,5 +29,6 @@ describe('UI Components', () => {
         cy.get(appFrontend.helpText.alert).contains('Altinn logo').type('{esc}');
         cy.get(appFrontend.helpText.alert).should('not.exist');
       });
+    cy.get('body').should('have.css', 'background-color', 'rgb(239, 239, 239)');
   });
 });

--- a/src/test/cypress/e2e/integration/app-frontend/components.js
+++ b/src/test/cypress/e2e/integration/app-frontend/components.js
@@ -11,6 +11,7 @@ describe('UI Components', () => {
     cy.intercept('**/active', []).as('noActiveInstances');
     cy.intercept('POST', `**/instances?instanceOwnerPartyId*`).as('createInstace');
     cy.startAppInstance(Cypress.env('multiData2Stage'));
+    cy.get(appFrontend.header).should('contain.text', texts.startingSoon);
     cy.wait('@createInstace');
   });
 
@@ -18,7 +19,7 @@ describe('UI Components', () => {
     cy.get('body').should('have.css', 'background-color', 'rgb(239, 239, 239)');
     cy.get(appFrontend.loadingAnimation).should('be.visible');
     cy.get(appFrontend.closeButton).should('be.visible');
-    cy.get(appFrontend.header).should('contain.text', texts.startingSoon);
+    cy.get(appFrontend.header).should('contain.text', Cypress.env('multiData2Stage'));
     cy.get(appFrontend.message.logo)
       .should('be.visible')
       .then((image) => {

--- a/src/test/cypress/e2e/integration/app-frontend/confirmation.js
+++ b/src/test/cypress/e2e/integration/app-frontend/confirmation.js
@@ -16,5 +16,9 @@ describe('Confirm', () => {
     cy.get(appFrontend.confirmContainer).should('be.visible');
     cy.get(appFrontend.confirmBody).should('contain.text', texts.confirmBody);
     cy.get(appFrontend.confirmSendInButton).should('be.visible');
+    cy.url().then((url) => {
+      var instanceId = url.split('/').slice(-2).join('/');
+      cy.get(appFrontend.confirmBody).contains(instanceId).and('contain.text', Cypress.env('multiData2Stage'));
+    });
   });
 });

--- a/src/test/cypress/e2e/integration/app-frontend/dynamics.js
+++ b/src/test/cypress/e2e/integration/app-frontend/dynamics.js
@@ -32,4 +32,10 @@ describe('Dynamics', () => {
     cy.get(appFrontend.changeOfName.confirmChangeName).should('be.visible').find('input').check();
     cy.get(appFrontend.changeOfName.reasons).should('be.visible');
   });
+
+  /* it('is possible to retrieve options dynamically', () => {
+    cy.get(appFrontend.changeOfName.sources).should('be.visible');
+    cy.get(appFrontend.changeOfName.reference).should('be.visible');
+    cy.get(appFrontend.changeOfName.reference).find('option[value="nordmann"]').should('exist').select();
+  }); */
 });

--- a/src/test/cypress/e2e/integration/app-frontend/message.js
+++ b/src/test/cypress/e2e/integration/app-frontend/message.js
@@ -9,7 +9,7 @@ const appFrontend = new AppFrontend();
 describe('Message', () => {
   let instanceMetadata, instanceId;
   before(() => {
-    cy.intercept('POST', `/ttd/frontend-test/instances?instanceOwnerPartyId*`).as('createdInstance');
+    cy.intercept('POST', `**/instances?instanceOwnerPartyId*`).as('createdInstance');
     cy.intercept('**/active', []).as('noActiveInstances');
     cy.startAppInstance(Cypress.env('multiData2Stage'));
     cy.get(appFrontend.closeButton).should('be.visible');
@@ -39,6 +39,15 @@ describe('Message', () => {
         cy.get(attachments).first().should('contain.text', texts.downloadAttachment);
         cy.get(appFrontend.attachmentIcon).should('be.visible');
       });
+    cy.url().then((url) => {
+      var instantiateUrl =
+        Cypress.env('environment') != 'local'
+          ? 'https://ttd.apps.tt02.altinn.no/ttd/frontend-test/'
+          : 'http://altinn3local.no/ttd/frontend-test';
+      var instanceId = url.split('/').slice(-2).join('/');
+      cy.get(appFrontend.startAgain).contains(instanceId).and('contain.text', Cypress.env('multiData2Stage'));
+      cy.get(appFrontend.startAgain).find('a').should('have.attr', 'href', instantiateUrl);
+    });
     cy.get(appFrontend.sendinButton)
       .should('be.visible')
       .invoke('outerWidth')

--- a/src/test/cypress/e2e/integration/app-frontend/receipt.js
+++ b/src/test/cypress/e2e/integration/app-frontend/receipt.js
@@ -23,5 +23,6 @@ describe('Receipt', () => {
       });
     cy.get(appFrontend.linkToArchive).should('be.visible');
     cy.get(mui.listedAnchor).should('be.visible').and('have.length', 3);
+    cy.get('body').should('have.css', 'background-color', 'rgb(212, 249, 228)');
   });
 });

--- a/src/test/cypress/e2e/integration/app-frontend/redirect.js
+++ b/src/test/cypress/e2e/integration/app-frontend/redirect.js
@@ -14,7 +14,7 @@ describe('Redirect', () => {
   });
 
   it('User missing role to start the app is displayed', () => {
-    cy.intercept('POST', `/ttd/frontend-test/instances?instanceOwnerPartyId*`, {
+    cy.intercept('POST', `**/instances?instanceOwnerPartyId*`, {
       statusCode: 403,
     });
     cy.startAppInstance(Cypress.env('multiData2Stage'));

--- a/src/test/cypress/e2e/integration/app-frontend/stateless.js
+++ b/src/test/cypress/e2e/integration/app-frontend/stateless.js
@@ -12,6 +12,7 @@ describe('Stateless', () => {
   });
 
   it('Prefill from Register and data processing', () => {
+    cy.get('body').should('have.css', 'background-color', 'rgb(239, 239, 239)');
     cy.get(appFrontend.closeButton).should('not.exist');
     cy.get(appFrontend.stateless.name).invoke('val').should('not.be.empty');
     cy.get(appFrontend.stateless.number).should('have.value', '1364');

--- a/src/test/cypress/e2e/integration/app-frontend/tabbing.js
+++ b/src/test/cypress/e2e/integration/app-frontend/tabbing.js
@@ -9,12 +9,12 @@ describe('Tabbing', () => {
   it('Tab through the fiels in change name form', () => {
     cy.navigateToChangeName();
     cy.get(appFrontend.changeOfName.newFirstName).focus().tab();
-    cy.focused().should('have.attr', 'id').and('eq', appFrontend.changeOfName.newLastName.substr(1));
+    cy.focused().should('have.attr', 'id').and('eq', appFrontend.changeOfName.newLastName.substring(1));
     cy.get(appFrontend.changeOfName.newLastName).type('a').blur().tab().tab().tab();
     cy.focused()
       .should('have.value', 'a')
       .should('have.attr', 'id')
-      .and('eq', appFrontend.changeOfName.newFullName.substr(1));
+      .and('eq', appFrontend.changeOfName.newFullName.substring(1));
     cy.tab().tab().tab({
       shift: true,
     });

--- a/src/test/cypress/e2e/integration/app-frontend/validation.js
+++ b/src/test/cypress/e2e/integration/app-frontend/validation.js
@@ -63,7 +63,7 @@ describe('Validation', () => {
 
   it('Validation on uploaded attachment type', () => {
     cy.navigateToChangeName();
-    cy.get(appFrontend.changeOfName.upload).attachFile('test.png');
+    cy.get(appFrontend.changeOfName.upload).selectFile('e2e/fixtures/test.png', { force: true });
     cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.upload.substr(1)))
       .should('exist')
       .should('be.visible')

--- a/src/test/cypress/e2e/integration/app-frontend/validation.js
+++ b/src/test/cypress/e2e/integration/app-frontend/validation.js
@@ -12,7 +12,7 @@ describe('Validation', () => {
   it('Required field validation on blur', () => {
     cy.navigateToChangeName();
     cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').focus().blur();
-    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newFirstName.substr(1)))
+    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newFirstName.substring(1)))
       .should('exist')
       .should('be.visible')
       .should('have.text', texts.requiredField)
@@ -25,7 +25,7 @@ describe('Validation', () => {
     cy.intercept('GET', '**/validate').as('validateData');
     cy.get(appFrontend.changeOfName.newFirstName).should('be.visible').type('test').blur();
     cy.wait('@validateData');
-    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newFirstName.substr(1)))
+    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newFirstName.substring(1)))
       .should('exist')
       .should('be.visible')
       .should('have.text', texts.testIsNotValidValue)
@@ -40,7 +40,7 @@ describe('Validation', () => {
     cy.intercept('GET', '**/validate').as('validateData');
     cy.get(appFrontend.changeOfName.newMiddleName).should('be.visible').type('test').blur();
     cy.wait('@validateData');
-    cy.get(appFrontend.fieldValidationWarning.replace('field', appFrontend.changeOfName.newMiddleName.substr(1)))
+    cy.get(appFrontend.fieldValidationWarning.replace('field', appFrontend.changeOfName.newMiddleName.substring(1)))
       .should('exist')
       .should('be.visible')
       .should('have.text', texts.testIsNotValidValue)
@@ -64,7 +64,7 @@ describe('Validation', () => {
   it('Validation on uploaded attachment type', () => {
     cy.navigateToChangeName();
     cy.get(appFrontend.changeOfName.upload).selectFile('e2e/fixtures/test.png', { force: true });
-    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.upload.substr(1)))
+    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.upload.substring(1)))
       .should('exist')
       .should('be.visible')
       .should('contain.text', texts.attachmentError);
@@ -73,7 +73,7 @@ describe('Validation', () => {
   it('Client side validation from json schema', () => {
     cy.navigateToChangeName();
     cy.get(appFrontend.changeOfName.newLastName).should('be.visible').type('client').blur();
-    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newLastName.substr(1)))
+    cy.get(appFrontend.fieldValidationError.replace('field', appFrontend.changeOfName.newLastName.substring(1)))
       .should('exist')
       .should('be.visible')
       .should('have.text', texts.clientSide);

--- a/src/test/cypress/e2e/pageobjects/app-frontend.js
+++ b/src/test/cypress/e2e/pageobjects/app-frontend.js
@@ -6,6 +6,8 @@ export default class AppFrontend {
     this.startButton = '.btn';
 
     //Common
+    this.loadingAnimation = 'rect[role="presentation"]';
+    this.header = '.a-modal-header';
     this.closeButton = '.a-modal-close-icon';
     this.backButton = '.a-modal-back';
     this.attachmentIcon = '.reg-attachment';

--- a/src/test/cypress/e2e/pageobjects/app-frontend.js
+++ b/src/test/cypress/e2e/pageobjects/app-frontend.js
@@ -34,6 +34,7 @@ export default class AppFrontend {
     this.confirmContainer = '#ConfirmContainer';
     this.confirmBody = '#body-text';
     this.confirmSendInButton = '#confirm-button';
+    this.startAgain = '#startAgain';
 
     //field is a placeholder which has to be replaced with the selector value of the field
     this.fieldValidationError = '[id^="error_field"]';

--- a/src/test/cypress/e2e/pageobjects/app-frontend.js
+++ b/src/test/cypress/e2e/pageobjects/app-frontend.js
@@ -59,6 +59,7 @@ export default class AppFrontend {
       newFullName: '#changeNameTo',
       confirmChangeName: '#confirmChangeName',
       reasons: '#reason',
+      reference: '#reference',
       dateOfEffect: '#dateOfEffect',
       upload: '#fileUpload-changename',
       reasonRelationship: '#reasonRelationship',

--- a/src/test/cypress/e2e/pageobjects/app-frontend.js
+++ b/src/test/cypress/e2e/pageobjects/app-frontend.js
@@ -65,6 +65,11 @@ export default class AppFrontend {
       summaryNameChanges: '#nameChanges',
       mobilenummer: '#mobilnummer',
       sources: '#sources',
+      uploadingAnimation: '#loader-upload',
+      deleteAttachment: 'div[id^="attachment-delete"]',
+      uploadedTable: '#altinn-file-listfileUpload-changename',
+      uploadSuccess: '.ai-check-circle',
+      uploadDropZone: '#altinn-drop-zone-fileUpload-changename',
     };
 
     //group - task 3

--- a/src/test/cypress/e2e/support/app-frontend.js
+++ b/src/test/cypress/e2e/support/app-frontend.js
@@ -11,7 +11,9 @@ const mui = new Common();
  */
 Cypress.Commands.add('navigateToChangeName', () => {
   cy.intercept('**/active', []).as('noActiveInstances');
+  cy.intercept('POST', `**/instances?instanceOwnerPartyId*`).as('createInstace');
   cy.startAppInstance(Cypress.env('multiData2Stage'));
+  cy.wait('@createInstace');
   cy.get(appFrontend.closeButton).should('be.visible');
   cy.intercept('**/api/layoutsettings/changename').as('getLayoutChangeName');
   cy.get(appFrontend.sendinButton).then((button) => {

--- a/src/test/cypress/e2e/support/index.js
+++ b/src/test/cypress/e2e/support/index.js
@@ -4,7 +4,6 @@ import './localtest';
 import './app';
 import './app-frontend';
 import './custom';
-import 'cypress-file-upload';
 import 'cypress-plugin-tab';
 import './start-app-instance';
 import 'cypress-axe';

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -37,7 +37,6 @@
     "axe-core": "^4.3.5",
     "cypress": "^9.3.1",
     "cypress-axe": "^0.14.0",
-    "cypress-file-upload": "^5.0.8",
     "cypress-plugin-tab": "^1.0.5",
     "eslint": "^8.7.0",
     "eslint-plugin-cypress": "^2.12.1",

--- a/src/test/cypress/yarn.lock
+++ b/src/test/cypress/yarn.lock
@@ -574,15 +574,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress-file-upload@npm:^5.0.8":
-  version: 5.0.8
-  resolution: "cypress-file-upload@npm:5.0.8"
-  peerDependencies:
-    cypress: ">3.0.0"
-  checksum: 9c70ca7e0bb137d0ec0b8d38987219ce15b26ac3a40e3ed4e78e6ad4690392eab905586848eec6ad8edd42ee480e68ccc63007b2ebd0a02f4b3eca116ff017e3
-  languageName: node
-  linkType: hard
-
 "cypress-plugin-tab@npm:^1.0.5":
   version: 1.0.5
   resolution: "cypress-plugin-tab@npm:1.0.5"
@@ -599,7 +590,6 @@ __metadata:
     axe-core: ^4.3.5
     cypress: ^9.3.1
     cypress-axe: ^0.14.0
-    cypress-file-upload: ^5.0.8
     cypress-plugin-tab: ^1.0.5
     eslint: ^8.7.0
     eslint-plugin-cypress: ^2.12.1


### PR DESCRIPTION
# New tests and checks for altinn-app-frontend

## Description
- updated k6 test project dependencies
- removed deprecated dependency: `cypress-file-upload` and replaced tests with inbuilt cypress commands in version > 9.3.0
- checks for neutral design - background color
- new test for adding and deleting attachments
- checks for animation, texts in modal header
- checks for texts which are replaced with values from instanceContext and applicationSettings