### PR TITLE
Use http:// instead of https:// in selfLinks when testing locally

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Helpers/SelfLinkHelper.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Helpers/SelfLinkHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Http;
 
@@ -9,6 +10,19 @@ namespace Altinn.App.Common.Helpers
     /// </summary>
     public static class SelfLinkHelper
     {
+        private static string[] testDomains = { "altinn3local.no", "local.altinn.cloud" };
+
+        private static string GetSafeScheme(HttpRequest request)
+        {
+            if (testDomains.Contains(request.Host.Host))
+            {
+                return request.Scheme;
+            }
+
+            // return https for all non-whitelisted domains
+            return "https";
+        }
+
         /// <summary>
         /// Sets the application specific self links.
         /// </summary>
@@ -16,7 +30,7 @@ namespace Altinn.App.Common.Helpers
         /// <param name="request">the http request to extract host and path name</param>
         public static void SetInstanceAppSelfLinks(Instance instance, HttpRequest request)
         {
-            string host = $"https://{request.Host.ToUriComponent()}";
+            string host = $"{GetSafeScheme(request)}://{request.Host.ToUriComponent()}";
             string url = request.Path;
 
             string selfLink = $"{host}{url}";
@@ -56,7 +70,7 @@ namespace Altinn.App.Common.Helpers
         /// <param name="request">the http request to extract host and path name</param>
         public static void SetDataAppSelfLinks(int instanceOwnerPartyId, Guid instanceGuid, DataElement dataElement, HttpRequest request)
         {
-            string host = $"https://{request.Host.ToUriComponent()}";
+            string host = $"{GetSafeScheme(request)}://{request.Host.ToUriComponent()}";
             string url = request.Path;
 
             string selfLink = $"{host}{url}";


### PR DESCRIPTION
To ensure that this does not affect production setups where internal traffic
runs over http, I added a domain whitelist.

This is important for Receipt page where `https` in urls caused links to attachemnts and PDF to fail.

![image](https://user-images.githubusercontent.com/131616/151243498-351961ea-dc24-4c36-b2fb-3e6ed5d1db48.png)


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
