### PR TITLE
Altin2 code list

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
@@ -200,7 +200,7 @@ namespace Altinn.App.Services.Implementation
         {
             _logger.LogInformation($"OnStartProcessTask for {instance.Id}");
 
-            // If this is a revisit to a previous task we need to unlock data 
+            // If this is a revisit to a previous task we need to unlock data
             foreach (DataType dataType in _appMetadata.DataTypes.Where(dt => dt.TaskId == taskId))
             {
                 DataElement dataElement = instance.Data.Find(d => d.DataType == dataType.Id);
@@ -491,7 +491,7 @@ namespace Altinn.App.Services.Implementation
             }
 
             string textResourcesString = JsonConvert.SerializeObject(textResource);
-            Dictionary<string, Dictionary<string, string>> optionsDictionary = await GetOptionsDictionary(formLayoutsFileContent);
+            Dictionary<string, Dictionary<string, string>> optionsDictionary = await GetOptionsDictionary(formLayoutsFileContent, language);
 
             PDFContext pdfContext = new PDFContext
             {
@@ -560,7 +560,7 @@ namespace Altinn.App.Services.Implementation
             return optionsIds;
         }
 
-        private async Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout)
+        private async Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout, string language)
         {
             Dictionary<string, Dictionary<string, string>> dictionary = new Dictionary<string, Dictionary<string, string>>();
             List<string> optionsIdsList = GetOptionIdsFromFormLayout(formLayout);
@@ -569,7 +569,7 @@ namespace Altinn.App.Services.Implementation
             {
                 AppOptions appOptions = new AppOptions();
 
-                appOptions.Options = _resourceService.GetOptions(optionsId);
+                appOptions.Options = await _resourceService.GetOptions(optionsId, language, new Dictionary<string, string>()); //TODO: Add proper variables from layout
 #pragma warning disable CS0618 // Type or member is obsolete
                 appOptions = await GetOptions(optionsId, appOptions);
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppResourcesSI.cs
@@ -174,7 +174,7 @@ namespace Altinn.App.Services.Implementation
             {
                 _logger.LogError("Something went wrong when fetching BPMNProcess. {0}", ex);
             }
-            
+
             return null;
         }
 
@@ -303,6 +303,13 @@ namespace Altinn.App.Services.Implementation
         }
 
         /// <inheritdoc />
+        public async Task<List<AppOption>> GetOptions(string optionId, string language, Dictionary<string, string> keyValuePairs)
+        {
+            var appOptions = await _appOptionsService.GetOptionsAsync(optionId, string.Empty, new Dictionary<string, string>());
+            return appOptions.Options;
+        }
+
+        /// <inheritdoc />
         public string GetLayouts()
         {
           Dictionary<string, object> layouts = new Dictionary<string, object>();
@@ -421,7 +428,7 @@ namespace Altinn.App.Services.Implementation
 
             return filedata;
         }
-       
+
         private byte[] ReadFileContentsFromLegalPath(string legalPath, string filePath)
         {
             var fullFileName = legalPath + filePath;

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAppResources.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IAppResources.cs
@@ -99,7 +99,18 @@ namespace Altinn.App.Services.Interface
         /// </summary>
         /// <param name="optionId">The id of the options list to retrieve</param>
         /// <returns>The list of options</returns>
+        [Obsolete]
         List<AppOption> GetOptions(string optionId);
+
+        /// <summary>
+        /// Get the list of options for a specific options list by its id.
+        /// </summary>
+        /// <param name="optionId">The id of the options list to retrieve</param>
+        /// <param name="language">The name of the language that the option labels might use</param>
+        /// <param name="keyValuePairs">Key/value pairs to control what options to get.
+        /// When called from the options controller this will be the querystring key/value pairs.</param>
+        /// <returns>The list of options</returns>
+        Task<List<AppOption>> GetOptions(string optionId, string language, Dictionary<string, string> keyValuePairs);
 
         /// <summary>
         /// Gets the layouts for the app.

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2CodeListOptionsBuilder.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2CodeListOptionsBuilder.cs
@@ -1,0 +1,47 @@
+#nullable enable
+using System;
+
+using Altinn.App.Common.Models;
+using Altinn.App.PlatformServices.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+
+namespace Altinn.App.PlatformServices.Options.Altinn2Provider
+{
+    /// <summary>
+    /// Builder class used in Altinn2CodeListProviderServiceCollectionExtensions
+    /// <see cref="Altinn.App.PlatformServices.Options.CommonOptionProviderServiceCollectionExtensions.AddAltinn2CodeList(IServiceCollection, Action{Altinn2CodeListOptionsBuilder})" />
+    /// </summary>
+    public class Altinn2CodeListOptionsBuilder
+    {
+        /// <summary>
+        /// Service collection to add altinn2 code list providers to
+        /// </summary>
+        private readonly IServiceCollection _serviceCollection;
+
+        /// <summary>
+        /// Constructor that takes a service
+        /// </summary>
+        public Altinn2CodeListOptionsBuilder(IServiceCollection serviceCollection)
+        {
+            _serviceCollection = serviceCollection;
+        }
+
+        /// <summary>
+        /// Add an IOptionsProvider for the specified codeList in the shared Altinn repo
+        /// </summary>
+        /// <param name="id">
+        ///    The id/name that is used in the <c>optionsId</c> parameter in the SelectionComponents (Checkboxes, RadioButtons, Dropdown ...)
+        ///    If <paramref name="metadataApiId"/> is null, this is also used for altinn2 code list name
+        /// </param>
+        /// <param name="transform">Mapping function to get from the altinn2 model to altinn 3 option</param>
+        /// <param name="filter">Filter function in case you only want a subset of the altinn2 codelist</param>
+        /// <param name="metadataApiId">id for use in altinn2 api (will use <paramref name="id"/>, if this is null)</param>
+        /// <param name="codeListVersion">version of the code list in the altinn2 metadata api</param>
+        public Altinn2CodeListOptionsBuilder Add(string id, Func<MetadataCodeListCodes, AppOption> transform, Func<MetadataCodeListCodes, bool>? filter = null, string? metadataApiId = null, int? codeListVersion = null)
+        {
+            _serviceCollection.AddSingleton<IAppOptionsProvider>(sp => new Altinn2CodeListProvider(id, transform, filter, metadataApiId, codeListVersion));
+            return this;
+        }
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2CodeListOptionsBuilder.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2CodeListOptionsBuilder.cs
@@ -1,10 +1,9 @@
 #nullable enable
 using System;
+using System.Net.Http;
 
 using Altinn.App.Common.Models;
-using Altinn.App.PlatformServices.Options;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http;
 
 namespace Altinn.App.PlatformServices.Options.Altinn2Provider
 {
@@ -40,7 +39,7 @@ namespace Altinn.App.PlatformServices.Options.Altinn2Provider
         /// <param name="codeListVersion">version of the code list in the altinn2 metadata api</param>
         public Altinn2CodeListOptionsBuilder Add(string id, Func<MetadataCodeListCodes, AppOption> transform, Func<MetadataCodeListCodes, bool>? filter = null, string? metadataApiId = null, int? codeListVersion = null)
         {
-            _serviceCollection.AddSingleton<IAppOptionsProvider>(sp => new Altinn2CodeListProvider(id, transform, filter, metadataApiId, codeListVersion));
+            _serviceCollection.AddSingleton<IAppOptionsProvider>(sp => new Altinn2CodeListProvider(sp.GetRequiredService<IHttpClientFactory>(), id, transform, filter, metadataApiId, codeListVersion));
             return this;
         }
     }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2CodeListOptionsBuilder.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2CodeListOptionsBuilder.cs
@@ -1,8 +1,8 @@
 #nullable enable
 using System;
-using System.Net.Http;
 
 using Altinn.App.Common.Models;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Altinn.App.PlatformServices.Options.Altinn2Provider
@@ -39,7 +39,7 @@ namespace Altinn.App.PlatformServices.Options.Altinn2Provider
         /// <param name="codeListVersion">version of the code list in the altinn2 metadata api</param>
         public Altinn2CodeListOptionsBuilder Add(string id, Func<MetadataCodeListCodes, AppOption> transform, Func<MetadataCodeListCodes, bool>? filter = null, string? metadataApiId = null, int? codeListVersion = null)
         {
-            _serviceCollection.AddSingleton<IAppOptionsProvider>(sp => new Altinn2CodeListProvider(sp.GetRequiredService<IHttpClientFactory>(), id, transform, filter, metadataApiId, codeListVersion));
+            _serviceCollection.AddTransient<IAppOptionsProvider>(sp => new Altinn2CodeListProvider(sp.GetRequiredService<IMemoryCache>(), sp.GetRequiredService<Altinn2MetadataApiClient>(), id, transform, filter, metadataApiId, codeListVersion));
             return this;
         }
     }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2CodeListProvider.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2CodeListProvider.cs
@@ -1,0 +1,91 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Altinn.App.Common.Models;
+using Altinn.App.PlatformServices.Options;
+
+namespace Altinn.App.PlatformServices.Options.Altinn2Provider
+{
+    /// <summary>
+    /// Implementation of a IAppOptionsProviders for the old altinn2 apis
+    /// </summary>
+    public class Altinn2CodeListProvider : IAppOptionsProvider
+    {
+        /// <summary>
+        /// Mapping function to get from the altinn2 model to altinn 3 option
+        /// </summary>
+        private readonly Func<MetadataCodeListCodes, AppOption> _transform;
+
+        /// <summary>
+        /// Filter function in case you only want a subset of the altinn2 codelist
+        /// </summary>
+        private readonly Func<MetadataCodeListCodes, bool>? _filter;
+
+        /// <summary>
+        /// id for use in altinn2 api
+        /// </summary>
+        private readonly string _metadataApiId;
+
+        /// <summary>
+        /// version of the code list in the altinn2 metadata api
+        /// </summary>
+        private readonly int? _codeListVersion;
+
+        /// <summary>
+        /// Cache for options as altinn2 options are static
+        /// </summary>
+        private readonly Dictionary<string, AppOptions> _cachedOptions = new();
+
+        /// <inheritdoc />
+        public string Id { get;  private set; }
+
+        /// <summary>
+        /// <see cref="Altinn.App.PlatformServices.Options.Altinn2Provider.Altinn2CodeListOptionsBuilder.Add(string, Func{MetadataCodeListCodes, AppOption}, Func{MetadataCodeListCodes, bool}?, string?, int?)" />
+        /// </summary>
+        public Altinn2CodeListProvider(string id, Func<MetadataCodeListCodes, AppOption> transform, Func<MetadataCodeListCodes, bool>? filter, string? metadataApiId = null, int? codeListVersion = null)
+        {
+            Id = id; // id in layout definitions
+            _metadataApiId = metadataApiId ?? id; // codelist id in api (often the same as id, but if the same codelist is used with different filters, it has to be different)
+            _transform = transform;
+            _filter = filter;
+            _codeListVersion = codeListVersion;
+        }
+
+        /// <inheritdoc/>
+        public async Task<AppOptions> GetAppOptionsAsync(string language, Dictionary<string, string> keyValuePairs)
+        {
+            // TODO: consider making sure this only fetches once even if the server has high load
+            if (!_cachedOptions.ContainsKey(language))
+            {
+                var langCode = language switch
+                {
+                    "nb" => "1044",
+                    "nn" => "2068",
+                    "en" => "1033",
+                    _ => "1044", // default to norwegian bokmål
+                };
+
+                // Don't use httpClientFactory, as this will only run once per language per container reboot
+                using (var client = new HttpClient())
+                {
+                    var version = _codeListVersion == null ? string.Empty : $"/{_codeListVersion.Value}";
+                    var response = await client.GetAsync($"https://www.altinn.no/api/metadata/codelists/{Id}{version}?language={langCode}");
+                    response.EnsureSuccessStatusCode();
+                    var codelist = await response.Content.ReadAsAsync<MetadataCodelistResponse>();
+                    AppOptions options = new()
+                    {
+                        Options = codelist.Codes.Where(_filter ?? (c => true)).Select(_transform).ToList(),
+                        IsCacheable = true
+                    };
+                    _cachedOptions[language] = options;
+                }
+            }
+
+            return _cachedOptions[language];
+        }
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2CodeListProvider.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2CodeListProvider.cs
@@ -65,7 +65,6 @@ namespace Altinn.App.PlatformServices.Options.Altinn2Provider
         /// <inheritdoc/>
         public async Task<AppOptions> GetAppOptionsAsync(string language, Dictionary<string, string> keyValuePairs)
         {
-
             var langCode = language switch
             {
                 "nb" => "1044",
@@ -73,7 +72,7 @@ namespace Altinn.App.PlatformServices.Options.Altinn2Provider
                 "en" => "1033",
                 _ => "1044", // default to norwegian bokmål
             };
-            var codelist = await _cache.GetOrCreateAsync($"{_metadataApiId}{langCode}{_codeListVersion}", async(entry) =>
+            var codelist = await _cache.GetOrCreateAsync($"{_metadataApiId}{langCode}{_codeListVersion}", async (entry) =>
             {
                 entry.Priority = CacheItemPriority.NeverRemove;
                 entry.AbsoluteExpiration = DateTimeOffset.MaxValue;

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2MetadataApiClient.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2MetadataApiClient.cs
@@ -4,16 +4,33 @@ using System.Threading.Tasks;
 
 namespace Altinn.App.PlatformServices.Options.Altinn2Provider
 {
+    /// <summary>
+    /// HttpClientWrapper for the altinn2 metadata/codelists api
+    /// </summary>
     public class Altinn2MetadataApiClient
     {
+        /// <summary>
+        /// HttpClient
+        /// </summary>
         private readonly HttpClient _client;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
         public Altinn2MetadataApiClient(HttpClient client)
         {
             _client = client;
         }
+
+        /// <summary>
+        /// Fetch the code list
+        /// </summary>
+        /// <param name="id">id of the code list</param>
+        /// <param name="langCode">Language code per altinn2 definisions (nb=>1044, ...)</param>
+        /// <param name="version">The version number for the list in the api</param>
         public async Task<MetadataCodelistResponse> GetAltinn2Codelist(string id, string langCode, int? version = null)
         {
-            var response = await _client.GetAsync($"https://www.altinn.no/api/metadata/codelists/{id}/{version?.ToString()??string.Empty}?language={langCode}");
+            var response = await _client.GetAsync($"https://www.altinn.no/api/metadata/codelists/{id}/{version?.ToString() ?? string.Empty}?language={langCode}");
             response.EnsureSuccessStatusCode();
             var codelist = await response.Content.ReadAsAsync<MetadataCodelistResponse>();
             return codelist;

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2MetadataApiClient.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/Altinn2MetadataApiClient.cs
@@ -1,0 +1,22 @@
+#nullable enable
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Altinn.App.PlatformServices.Options.Altinn2Provider
+{
+    public class Altinn2MetadataApiClient
+    {
+        private readonly HttpClient _client;
+        public Altinn2MetadataApiClient(HttpClient client)
+        {
+            _client = client;
+        }
+        public async Task<MetadataCodelistResponse> GetAltinn2Codelist(string id, string langCode, int? version = null)
+        {
+            var response = await _client.GetAsync($"https://www.altinn.no/api/metadata/codelists/{id}/{version?.ToString()??string.Empty}?language={langCode}");
+            response.EnsureSuccessStatusCode();
+            var codelist = await response.Content.ReadAsAsync<MetadataCodelistResponse>();
+            return codelist;
+        }
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/MetadataCodelistResponse.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/Altinn2Provider/MetadataCodelistResponse.cs
@@ -1,0 +1,61 @@
+#nullable disable
+using System.Collections.Generic;
+
+namespace Altinn.App.PlatformServices.Options.Altinn2Provider
+{
+    /// <summary>
+    /// Outer model for the https://www.altinn.no/api/metadata/codelists api
+    /// </summary>
+    public class MetadataCodelistResponse
+    {
+        /// <summary>
+        /// Name of the code list
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Language code of the code list
+        ///  1044 => "no",
+        ///  1044 => "nb",
+        ///  2068 => "nn",
+        ///  1033 => "en",
+        /// </summary>
+        public int Language { get; set; }
+
+        /// <summary>
+        /// Version number from altinn 2 for the code list
+        /// </summary>
+        public int Version { get; set; }
+
+        /// <summary>
+        /// List of the code in the code list
+        /// </summary>
+        public List<MetadataCodeListCodes> Codes { get; set; }
+    }
+
+    /// <summary>
+    /// Altinn 2 code list item
+    /// </summary>
+    public class MetadataCodeListCodes
+    {
+        /// <summary>
+        /// Coode for the entry that is shared between languages
+        /// </summary>
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Value 1 from the altinn2 metadata api
+        /// </summary>
+        public string Value1 { get; set; }
+
+        /// <summary>
+        /// Value 2 from the altinn2 metadata api
+        /// </summary>
+        public string Value2 { get; set; }
+
+        /// <summary>
+        /// Value 3 from the altinn2 metadata api
+        /// </summary>
+        public string Value3 { get; set; }
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/CommonOptionProviderServiceCollectionExtensions.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/CommonOptionProviderServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ namespace Altinn.App.PlatformServices.Options
         /// <summary>
         /// Extention method for IServiceCollection to add the AddAltinn2CodeList() method
         /// <code>
-        /// services.AddCommonAppOptions(builder => {
+        /// services.AddAltinn2CodeList(builder => {
         ///     builder.Add(
         ///         id: "ASF_Land",
         ///         transform: (code) => new (){Value = code.Code, Label=code.Value1},

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/CommonOptionProviderServiceCollectionExtensions.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/CommonOptionProviderServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+
+using Altinn.App.PlatformServices.Options.Altinn2Provider;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Altinn.App.PlatformServices.Options
+{
+    /// <summary>
+    /// class to hold the Extention method for
+    /// IServiceCollection to add the AddAltinn2CodeList() method
+    /// </summary>
+    public static class CommonOptionProviderServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Extention method for IServiceCollection to add the AddAltinn2CodeList() method
+        /// <code>
+        /// services.AddCommonAppOptions(builder => {
+        ///     builder.Add(
+        ///         id: "ASF_Land",
+        ///         transform: (code) => new (){Value = code.Code, Label=code.Value1},
+        ///         // filter: (code) => int.Parse(code.Value3) > 100,
+        ///         codeListVersion: 2758,
+        ///         metadataApiId: "ASF_land"
+        ///     );
+        /// });
+        /// </code>
+        /// </summary>
+        public static IServiceCollection AddAltinn2CodeList(this IServiceCollection serviceCollection, Action<Altinn2CodeListOptionsBuilder> builder)
+        {
+            builder(new Altinn2CodeListOptionsBuilder(serviceCollection));
+            return serviceCollection;
+        }
+    }
+}

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/CommonOptionProviderServiceCollectionExtensions.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/CommonOptionProviderServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace Altinn.App.PlatformServices.Options
         /// services.AddAltinn2CodeList(builder => {
         ///     builder.Add(
         ///         id: "ASF_Land",
-        ///         transform: (code) => new (){Value = code.Code, Label=code.Value1},
+        ///         transform: (code) => new (){ Value = code.Code, Label=code.Value1 },
         ///         // filter: (code) => int.Parse(code.Value3) > 100,
         ///         codeListVersion: 2758,
         ///         metadataApiId: "ASF_land"
@@ -27,6 +27,7 @@ namespace Altinn.App.PlatformServices.Options
         /// </summary>
         public static IServiceCollection AddAltinn2CodeList(this IServiceCollection serviceCollection, Action<Altinn2CodeListOptionsBuilder> builder)
         {
+            serviceCollection.AddHttpClient<Altinn2MetadataApiClient>();
             builder(new Altinn2CodeListOptionsBuilder(serviceCollection));
             return serviceCollection;
         }

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/IAppOptionsProvider.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Options/IAppOptionsProvider.cs
@@ -10,9 +10,8 @@ namespace Altinn.App.PlatformServices.Options
     public interface IAppOptionsProvider
     {
         /// <summary>
-        /// The id/name of the options this provider supports ie. land, fylker, kommuner.
-        /// You can have as many providers as you like, but you should have only one per
-        /// id. 
+        /// The id/name that is used in the <c>optionsId</c> parameter in the SelectionComponents (Checkboxes, RadioButtons, Dropdown ...)
+        /// You can have as many providers as you like, but you should have only one per id.
         /// </summary>
         string Id { get; }
 


### PR DESCRIPTION
When converting altinn2 apps to altinn3 we also need to convert the shared code lists. As there already exist a simple JSON api for the old code lists managed in TUL `https://www.altinn.no/api/metadata/codelists/{Id}{version}?language={langCode}`, I think it makes sense to expose this as a standard functionality to speed up conversion. When the closing of TUL comes closer you can consider creating a new interface for managing the lists (Pull requests to a github repo), or design a full new solution. 

## Description
This enables apps to easily continue using the same code lists from previous schemas by adding the following code to their `Startup.cs`.

```csharp
using Altinn.App.PlatformServices.Options;
.....
            services.AddAltinn2CodeList(builder => {
                builder.Add(
                    id: "ASF_Land",
                    transform: (code) => new (){Value = code.Code, Label=code.Value1},
                    // filter: (code) => int.Parse(code.Value3) > 100,
                    codeListVersion: 2758,
                    metadataApiId: "ASF_land"
                );
            });
```


## Fixes
- The first commit is part of the solution for #7903 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
