### PR TITLE
bug/7919-empty-pdf-order

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
@@ -160,7 +160,7 @@ public class PDFGenerator {
       renderFormLayout(filteredLayout);
     } else if (formLayouts != null) {
       // contains a map of form layouts. Render each page and separate by a new page
-      if (layoutSettings != null && layoutSettings.getPages() != null && layoutSettings.getPages().getOrder() != null && layoutSettings.getPages().getOrder().size() > 0) {
+      if (layoutSettings != null && layoutSettings.getPages() != null && layoutSettings.getPages().getOrder() != null && !layoutSettings.getPages().getOrder().isEmpty()) {
         // The app developer has specified the order on a page => render pages in accordance
         List<String> order = layoutSettings.getPages().getOrder();
         for (String layoutKey : order) {

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
@@ -160,7 +160,7 @@ public class PDFGenerator {
       renderFormLayout(filteredLayout);
     } else if (formLayouts != null) {
       // contains a map of form layouts. Render each page and separate by a new page
-      if (layoutSettings != null && layoutSettings.getPages() != null && layoutSettings.getPages().getOrder() != null) {
+      if (layoutSettings != null && layoutSettings.getPages() != null && layoutSettings.getPages().getOrder() != null && layoutSettings.getPages().getOrder().size() > 0) {
         // The app developer has specified the order on a page => render pages in accordance
         List<String> order = layoutSettings.getPages().getOrder();
         for (String layoutKey : order) {


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# bug/7919-empty-pdf-order
<!-- Summary of the changes (max 80 characters) -->
#7919 

A change to initialize empty settings in https://github.com/Altinn/altinn-studio/pull/7469 caused empty pdfs to be rendered when no order was set in settings.json. Added a simple check to fall back to alphabetical order also for empty arrays.

## Fixes
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [x] Changelog is updated with a separate linked PR 
  - [x] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [x] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
