### PR TITLE
chore: post window message to update versionControlHeader when resetting repo

### DIFF
--- a/src/studio/src/designer/frontend/app-development/sharedResources/repoStatus/reset/resetLocalRepoSagas.ts
+++ b/src/studio/src/designer/frontend/app-development/sharedResources/repoStatus/reset/resetLocalRepoSagas.ts
@@ -5,6 +5,7 @@ import { get } from 'app-shared/utils/networking';
 import { IRepoStatusAction, RepoStatusActions } from '../repoStatusSlice';
 import { fetchRepoStatus } from '../../../features/handleMergeConflict/handleMergeConflictSlice';
 import { repoStatusUrl } from '../../../utils/urlHelper';
+import postMessages from 'app-shared/utils/postMessages';
 
 // GET MASTER REPO
 export function* resetLocalRepoSaga({ payload: {
@@ -20,7 +21,7 @@ export function* resetLocalRepoSaga({ payload: {
       org,
       repo,
     }));
-
+    window.postMessage(postMessages.filesAreSaved, window.location.href);
     yield put(RepoStatusActions.resetLocalRepoFulfilled({ result }));
   } catch (error) {
     yield put(RepoStatusActions.resetLocalRepoRejected({ error }));


### PR DESCRIPTION
After merge of https://github.com/Altinn/altinn-studio/pull/7909 we fixed an issue where app-development app would rerender needlessly. This seems to have uncovered an underlying bug when using the "Reset repo" functionality where the "Push" button would still be bold indicating that the user had changes to push even when local changes was reset to match remote.

This was caused by VersionControlHeader would completely rerender when this functionality was used before, thus resetting the internal state of the VersionControlHeader. Since we now no longer do this, we actually have to tell VerisonControlHeader to update its state. This will lead to two dupliate calls to check for status, but I see no other easy fix for this right now. 

There are a lot of confusing stuff going on here, this was a quick fix for a specific issue that caused trouble for our use case tests, but we should do something about the VerisonControlHeader. There was an attempt at this when working with https://github.com/Altinn/altinn-studio/issues/7093 , but this is harder than anticipated because we mix internal and global state and a lot going on.

Long story short: not an ideal fix, but doing this right is going to be hard... 