### PR TITLE
Bug: display new appName key in message box

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/InstanceHelper.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Helpers/InstanceHelper.cs
@@ -174,7 +174,10 @@ namespace Altinn.Platform.Storage.Helpers
             foreach (MessageBoxInstance instance in instances)
             {
                 string id = $"{instance.Org}-{instance.AppName}-{language}";
-                instance.Title = textResources.FirstOrDefault(t => t.Id.Equals(id))?.Resources.Where(r => r.Id.Equals("ServiceName")).Select(r => r.Value).FirstOrDefault() ?? instance.AppName;
+                string appTitle =
+                    textResources.FirstOrDefault(t => t.Id.Equals(id))?.Resources.Where(r => r.Id.Equals("appName")).Select(r => r.Value).FirstOrDefault() ??
+                    textResources.FirstOrDefault(t => t.Id.Equals(id))?.Resources.Where(r => r.Id.Equals("ServiceName")).Select(r => r.Value).FirstOrDefault();
+                instance.Title = appTitle ?? instance.AppName;
 
                 if (!string.IsNullOrWhiteSpace(instance.PresentationText))
                 {

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/HelperTests/InstanceHelperTest.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/HelperTests/InstanceHelperTest.cs
@@ -139,7 +139,7 @@ namespace Altinn.Platform.Storage.UnitTest
         }
 
         /// <summary>
-        /// Scenario: Getting sbl status for an instance in a confirmation step       
+        /// Scenario: Getting sbl status for an instance in a confirmation step
         /// Expected: The SBL status "Confirmation" is returned
         /// Success: SBL status is as expected
         /// </summary>
@@ -168,7 +168,7 @@ namespace Altinn.Platform.Storage.UnitTest
         }
 
         /// <summary>
-        /// Scenario: Getting sbl status for an instance in a confirmation step       
+        /// Scenario: Getting sbl status for an instance in a confirmation step
         /// Expected: The SBL status "Confirmation" is returned
         /// Success: SBL status is as expected
         /// </summary>
@@ -405,6 +405,81 @@ namespace Altinn.Platform.Storage.UnitTest
 
             // Assert
             Assert.Empty(instances);
+        }
+
+        /// <summary>
+        /// Replaces text keys, appName key is available, should be used as Title
+        /// </summary>
+        [Fact]
+        public void ReplaceTextKeys_AppNameAvailable_AppNameKeyUsedAsTitle()
+        {
+            // Arrange
+            List<MessageBoxInstance> instances = new();
+            instances.Add(new MessageBoxInstance
+            {
+                Org = "ttd",
+                AppName = "test-app"
+            });
+
+            List<TextResource> textResources = new();
+            List<TextResourceElement> textResource = new();
+            textResource.Add(new TextResourceElement
+            {
+                Value = "ValueFromAppNameKey",
+                Id = "appName",
+            });
+            textResource.Add(new TextResourceElement
+            {
+                Value = "ValueFromServiceNameKey",
+                Id = "ServiceName",
+            });
+
+            textResources.Add(new TextResource
+            {
+                Id = "ttd-test-app-nb",
+                Resources = textResource
+            });
+
+            // Act
+            InstanceHelper.ReplaceTextKeys(instances, textResources, "nb");
+
+            // Assert
+            Assert.Equal("ValueFromAppNameKey", instances[0].AppName);
+        }
+
+        /// <summary>
+        /// Replaces text keys, appName key is not available, should default to ServiceName
+        /// </summary>
+        [Fact]
+        public void ReplaceTextKeys_AppNameNotAvailable_ServiceNameKeyUsedAsTitle()
+        {
+            // Arrange
+            List<MessageBoxInstance> instances = new();
+            instances.Add(new MessageBoxInstance
+            {
+                Org = "ttd",
+                AppName = "test-app"
+            });
+
+            List<TextResource> textResources = new();
+            List<TextResourceElement> textResource = new();
+            textResource.Add(new TextResourceElement
+            {
+                Value = "ValueFromServiceNameKey",
+                Id = "ServiceName",
+            });
+
+            textResources.Add(new TextResource
+            {
+                Id = "ttd-test-app-nb",
+                Resources = textResource
+            });
+
+            // Act
+            InstanceHelper.ReplaceTextKeys(instances, textResources, "nb");
+
+            // Assert
+            Assert.Equal("ValueFromServiceNameKey", instances[0].AppName);
         }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/HelperTests/InstanceHelperTest.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/HelperTests/InstanceHelperTest.cs
@@ -412,7 +412,7 @@ namespace Altinn.Platform.Storage.UnitTest
         /// </summary>
         [Fact]
         public void ReplaceTextKeys_AppNameAvailable_AppNameKeyUsedAsTitle()
-        {
+        {   
             // Arrange
             List<MessageBoxInstance> instances = new();
             instances.Add(new MessageBoxInstance
@@ -441,10 +441,10 @@ namespace Altinn.Platform.Storage.UnitTest
             });
 
             // Act
-            InstanceHelper.ReplaceTextKeys(instances, textResources, "nb");
+            instances = InstanceHelper.ReplaceTextKeys(instances, textResources, "nb");
 
             // Assert
-            Assert.Equal("ValueFromAppNameKey", instances[0].AppName);
+            Assert.Equal("ValueFromAppNameKey", instances[0].Title);
         }
 
         /// <summary>
@@ -476,10 +476,10 @@ namespace Altinn.Platform.Storage.UnitTest
             });
 
             // Act
-            InstanceHelper.ReplaceTextKeys(instances, textResources, "nb");
+            instances = InstanceHelper.ReplaceTextKeys(instances, textResources, "nb");
 
             // Assert
-            Assert.Equal("ValueFromServiceNameKey", instances[0].AppName);
+            Assert.Equal("ValueFromServiceNameKey", instances[0].Title);
         }
     }
 }


### PR DESCRIPTION
Related to pr #7863 . We have now introduced the key `appName` which will replace `ServiceName`. Should support this in messagebox.