### PR TITLE
use new app name key for pdf-title

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/AppBase.cs
@@ -516,8 +516,10 @@ namespace Altinn.App.Services.Implementation
             string fileName = null;
             string app = instance.AppId.Split("/")[1];
 
-            TextResourceElement titleText = textResource.Resources.Find(textResourceElement => textResourceElement.Id.Equals("ServiceName"));
-
+            TextResourceElement titleText = 
+                textResource.Resources.Find(textResourceElement => textResourceElement.Id.Equals("appName")) ??
+                textResource.Resources.Find(textResourceElement => textResourceElement.Id.Equals("ServiceName"));
+            
             if (titleText != null && !string.IsNullOrEmpty(titleText.Value))
             {
                 fileName = titleText.Value + ".pdf";


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# use new app name key for pdf-title
<!-- Summary of the changes (max 80 characters) -->
Related to change in #7227 . Use new app-name key for pdf-title, fallback to old. 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
