### PR TITLE
Adding caching for SBL-Bridge API calls for GetMainUnits and GetKeyRolePartyIds

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Configuration/GeneralSettings.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Configuration/GeneralSettings.cs
@@ -37,6 +37,16 @@ namespace Altinn.Platform.Authorization.Configuration
         public int RoleCacheTimeout { get; set; }
 
         /// <summary>
+        /// Gets or sets the cache timeout for lookup of mainunits
+        /// </summary>
+        public int MainUnitCacheTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cache timeout for lookup of keyrole partyIds
+        /// </summary>
+        public int KeyrolePartyIdsCacheTimeout { get; set; }
+
+        /// <summary>
         /// Gets or sets the cache timeout
         /// </summary>
         public int PolicyCacheTimeout { get; set;  }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Controllers/DecisionController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Controllers/DecisionController.cs
@@ -277,7 +277,7 @@ namespace Altinn.Platform.Authorization.Controllers
             }
 
             // 2. Direct user delegations from mainunit
-            List<MainUnit> mainunits = await _partiesWrapper.GetMainUnits(new MainUnitQuery { PartyIds = new List<int> { reporteePartyId } });
+            List<MainUnit> mainunits = await _delegationContextHandler.GetMainUnits(new MainUnitQuery { PartyIds = new List<int> { reporteePartyId } });
             List<int> mainunitPartyIds = mainunits.Where(m => m.PartyId.HasValue).Select(m => m.PartyId.Value).ToList();
 
             if (mainunitPartyIds.Any())
@@ -297,14 +297,14 @@ namespace Altinn.Platform.Authorization.Controllers
             }
 
             // 3. Direct party delegations to keyrole units
-            List<int> keyroleParties = await _partiesWrapper.GetKeyRoleParties(subjectUserId);
-            if (keyroleParties.Any())
+            List<int> keyrolePartyIds = await _delegationContextHandler.GetKeyRolePartyIds(subjectUserId);
+            if (keyrolePartyIds.Any())
             {
-                delegations = await _delegationRepository.GetAllCurrentDelegationChanges(appIds, offeredByPartyIds, coveredByPartyIds: keyroleParties);
+                delegations = await _delegationRepository.GetAllCurrentDelegationChanges(appIds, offeredByPartyIds, coveredByPartyIds: keyrolePartyIds);
 
                 if (delegations.Any())
                 {
-                    _delegationContextHandler.Enrich(decisionRequest, keyroleParties);
+                    _delegationContextHandler.Enrich(decisionRequest, keyrolePartyIds);
                     delegationContextResponse = await AuthorizeBasedOnDelegations(decisionRequest, delegations, appPolicy);
                 }
             }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChange.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChange.cs
@@ -18,7 +18,7 @@ namespace Altinn.Platform.Authorization.Models
         /// <summary>
         /// Gets or sets the altinnappid. E.g. skd/skattemelding
         /// </summary>
-        [JsonPropertyName("altinnappis")]
+        [JsonPropertyName("altinnappid")]
         public string AltinnAppId { get; set; }
 
         /// <summary>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/ContextHandler.cs
@@ -30,6 +30,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
     {
         private readonly IInstanceMetadataRepository _policyInformationRepository;
         private readonly IRoles _rolesWrapper;
+        private readonly IParties _partiesWrapper;
         private readonly IMemoryCache _memoryCache;
         private readonly GeneralSettings _generalSettings;
 
@@ -38,13 +39,15 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         /// </summary>
         /// <param name="policyInformationRepository">the policy information repository handler</param>
         /// <param name="rolesWrapper">the roles handler</param>
+        /// <param name="partiesWrapper">the party information handler</param>
         /// <param name="memoryCache">The cache handler </param>
         /// <param name="settings">The app settings</param>
         public ContextHandler(
-            IInstanceMetadataRepository policyInformationRepository, IRoles rolesWrapper, IMemoryCache memoryCache, IOptions<GeneralSettings> settings)
+            IInstanceMetadataRepository policyInformationRepository, IRoles rolesWrapper, IParties partiesWrapper, IMemoryCache memoryCache, IOptions<GeneralSettings> settings)
         {
             _policyInformationRepository = policyInformationRepository;
             _rolesWrapper = rolesWrapper;
+            _partiesWrapper = partiesWrapper;
             _memoryCache = memoryCache;
             _generalSettings = settings.Value;
         }
@@ -295,6 +298,54 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             }
 
             return roles;
+        }
+
+        /// <summary>
+        /// Gets the list of mainunits for a subunit
+        /// </summary>
+        /// <param name="mainUnitQuery">Query model for the list of subunit partyIds to check and retrieve mainunits for</param>
+        /// <returns>List of mainunits</returns>
+        protected async Task<List<MainUnit>> GetMainUnits(MainUnitQuery mainUnitQuery)
+        {
+            string cacheKey = $"GetMainUnitsFor:{string.Join(",", mainUnitQuery.PartyIds)}";
+
+            if (!_memoryCache.TryGetValue(cacheKey, out List<MainUnit> mainUnits))
+            {
+                // Key not in cache, so get data.
+                mainUnits = await _partiesWrapper.GetMainUnits(mainUnitQuery);
+
+                var cacheEntryOptions = new MemoryCacheEntryOptions()
+               .SetPriority(CacheItemPriority.High)
+               .SetAbsoluteExpiration(new TimeSpan(0, _generalSettings.MainUnitCacheTimeout, 0));
+
+                _memoryCache.Set(cacheKey, mainUnits, cacheEntryOptions);
+            }
+
+            return mainUnits;
+        }
+
+        /// <summary>
+        /// Gets the list of keyrole unit partyIds for a user
+        /// </summary>
+        /// <param name="subjectUserId">The userid to retrieve keyrole unit for</param>
+        /// <returns>List of partyIds for units where user has keyrole</returns>
+        protected async Task<List<int>> GetKeyRolePartyIds(int subjectUserId)
+        {
+            string cacheKey = $"GetKeyRolePartyIdsFor:{subjectUserId}";
+
+            if (!_memoryCache.TryGetValue(cacheKey, out List<int> keyrolePartyIds))
+            {
+                // Key not in cache, so get data.
+                keyrolePartyIds = await _partiesWrapper.GetKeyRoleParties(subjectUserId);
+
+                var cacheEntryOptions = new MemoryCacheEntryOptions()
+               .SetPriority(CacheItemPriority.High)
+               .SetAbsoluteExpiration(new TimeSpan(0, _generalSettings.MainUnitCacheTimeout, 0));
+
+                _memoryCache.Set(cacheKey, keyrolePartyIds, cacheEntryOptions);
+            }
+
+            return keyrolePartyIds;
         }
 
         private string GetCacheKey(int userId, int partyId)

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/DelegationContextHandler.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/DelegationContextHandler.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Altinn.Authorization.ABAC.Constants;
 using Altinn.Authorization.ABAC.Interface;
 using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Platform.Authorization.Configuration;
@@ -10,8 +9,6 @@ using Altinn.Platform.Authorization.Constants;
 using Altinn.Platform.Authorization.Models;
 using Altinn.Platform.Authorization.Repositories.Interface;
 using Altinn.Platform.Authorization.Services.Interface;
-using Altinn.Platform.Storage.Interface.Models;
-using Authorization.Platform.Authorization.Models;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 
@@ -28,10 +25,11 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         /// </summary>
         /// <param name="policyInformationRepository">the policy information repository handler</param>
         /// <param name="rolesWrapper">the roles handler</param>
+        /// <param name="partiesWrapper">the party information handler</param>
         /// <param name="memoryCache">The cache handler </param>
         /// <param name="settings">The app settings</param>
-        public DelegationContextHandler(IInstanceMetadataRepository policyInformationRepository, IRoles rolesWrapper, IMemoryCache memoryCache, IOptions<GeneralSettings> settings)
-            : base(policyInformationRepository, rolesWrapper, memoryCache, settings)
+        public DelegationContextHandler(IInstanceMetadataRepository policyInformationRepository, IRoles rolesWrapper, IParties partiesWrapper, IMemoryCache memoryCache, IOptions<GeneralSettings> settings)
+            : base(policyInformationRepository, rolesWrapper, partiesWrapper, memoryCache, settings)
         {
         }
 
@@ -72,6 +70,26 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         {
             XacmlContextAttributes resourceContextAttributes = request.GetResourceAttributes();
             return GetResourceAttributeValues(resourceContextAttributes);
+        }
+
+        /// <summary>
+        /// Gets the list of mainunits for a subunit
+        /// </summary>
+        /// <param name="mainUnitQuery">Query model for the list of subunit partyIds to check and retrieve mainunits for</param>
+        /// <returns>List of mainunits</returns>
+        public async new Task<List<MainUnit>> GetMainUnits(MainUnitQuery mainUnitQuery)
+        {
+            return await GetMainUnits(mainUnitQuery);
+        }
+
+        /// <summary>
+        /// Gets the list of keyrole unit partyIds for a user
+        /// </summary>
+        /// <param name="subjectUserId">The userid to retrieve keyrole unit for</param>
+        /// <returns>List of partyIds for units where user has keyrole</returns>
+        public async new Task<List<int>> GetKeyRolePartyIds(int subjectUserId)
+        {
+            return await GetKeyRolePartyIds(subjectUserId);
         }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Interface/IDelegationContextHandler.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Interface/IDelegationContextHandler.cs
@@ -30,5 +30,19 @@ namespace Altinn.Authorization.ABAC.Interface
         /// <param name="request">The Xacml Context Request</param>
         /// <returns>XacmlResourceAttributes model</returns>
         public XacmlResourceAttributes GetResourceAttributes(XacmlContextRequest request);
+
+        /// <summary>
+        /// Gets the list of mainunits for a subunit
+        /// </summary>
+        /// <param name="mainUnitQuery">Query model for the list of subunit partyIds to check and retrieve mainunits for</param>
+        /// <returns>List of mainunits</returns>
+        public Task<List<MainUnit>> GetMainUnits(MainUnitQuery mainUnitQuery);
+
+        /// <summary>
+        /// Gets the list of keyrole unit partyIds for a user
+        /// </summary>
+        /// <param name="subjectUserId">The userid to retrieve keyrole unit for</param>
+        /// <returns>List of partyIds for units where user has keyrole</returns>
+        public Task<List<int>> GetKeyRolePartyIds(int subjectUserId);
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/appsettings.json
@@ -31,6 +31,8 @@
     "RuntimeCookieName": "AltinnStudioRuntime",
     "SBLBaseAdress": "https://at22.altinn.cloud/",
     "RoleCacheTimeout": 5,
+    "MainUnitCacheTimeout": 5,
+    "KeyrolePartyIdsCacheTimeout": 5,
     "PolicyCacheTimeout": 10
   }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/ContextHandlerTest.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/ContextHandlerTest.cs
@@ -25,6 +25,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _contextHandler = new ContextHandler(
                 new InstanceMetadataRepositoryMock(),
                 new RolesMock(),
+                new PartiesMock(),
                 new MemoryCache(new MemoryCacheOptions()),
                 Options.Create(new GeneralSettings { RoleCacheTimeout = 5 }));
         }


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# Adding caching for SBL-Bridge API calls for GetMainUnits and GetKeyRolePartyIds

## Description

Using the same caching approach as used for GetRoles to add caching for SBL-Bridge API calls for GetMainUnits and GetKeyRolePartyIds.

These calles are used by DecisionController when attempting authorization based on delegations. Without caching these two calls would be made for each decision attempt for an instance where the user is not authorized through having a role which gives access.

## Fixes
- #7987

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
