### PR TITLE
unique build id for every test run

### DIFF
--- a/.github/workflows/cypress-altinn-app-frontend.yml
+++ b/.github/workflows/cypress-altinn-app-frontend.yml
@@ -55,7 +55,7 @@ jobs:
           export CYPRESS_PROJECT_ID=y2jhp6
           export CYPRESS_RECORD_KEY=${{ secrets.CYPRESS_RECORD_KEY }}
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          ./node_modules/.bin/start-server-and-test 'cd $GITHUB_WORKSPACE/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend && yarn start' 8080 'yarn run test:appfrontend:headless --env component=appfrontend,environment=tt02,testUserName=tt02testuser,testUserPwd=${{ secrets.CYPRESS_ALTINN_USERPWD }} --record --parallel --tag "altinn-app-frontend" --group altinn-app-frontend' --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT
+          ./node_modules/.bin/start-server-and-test 'cd $GITHUB_WORKSPACE/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend && yarn start' 8080 'yarn run test:appfrontend:headless --env component=appfrontend,environment=tt02,testUserName=tt02testuser,testUserPwd=${{ secrets.CYPRESS_ALTINN_USERPWD }} --record --parallel --tag "altinn-app-frontend" --group altinn-app-frontend --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT'
         working-directory: src/test/cypress
   
   altinn-app-frontend-test-on-fork-pr:

--- a/.github/workflows/cypress-altinn-app-frontend.yml
+++ b/.github/workflows/cypress-altinn-app-frontend.yml
@@ -55,7 +55,7 @@ jobs:
           export CYPRESS_PROJECT_ID=y2jhp6
           export CYPRESS_RECORD_KEY=${{ secrets.CYPRESS_RECORD_KEY }}
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          ./node_modules/.bin/start-server-and-test 'cd $GITHUB_WORKSPACE/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend && yarn start' 8080 'yarn run test:appfrontend:headless --env component=appfrontend,environment=tt02,testUserName=tt02testuser,testUserPwd=${{ secrets.CYPRESS_ALTINN_USERPWD }} --record --parallel --tag "altinn-app-frontend" --group altinn-app-frontend'
+          ./node_modules/.bin/start-server-and-test 'cd $GITHUB_WORKSPACE/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend && yarn start' 8080 'yarn run test:appfrontend:headless --env component=appfrontend,environment=tt02,testUserName=tt02testuser,testUserPwd=${{ secrets.CYPRESS_ALTINN_USERPWD }} --record --parallel --tag "altinn-app-frontend" --group altinn-app-frontend' --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT
         working-directory: src/test/cypress
   
   altinn-app-frontend-test-on-fork-pr:


### PR DESCRIPTION
# unique build id for every run

## Description

Today, when the github action for cypress tests is re-run, the tests are skipped since the `ci-build-id` is same across all runs in a github run id. So, when one re-runs the failed action, tests are skipped and  it gives a false information that all the tests have run green.

With the changes from this PR, every re-run will be an unique `ci-build-id` and tests results are recorded in cypress dashboard.
