### PR TITLE
Auth level localtest

### DIFF
--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -71,6 +71,7 @@ namespace LocalTest.Controllers
             model.AppPath = _localPlatformSettings.AppRepositoryBasePath;
             model.StaticTestDataPath = _localPlatformSettings.LocalTestingStaticTestDataPath;
             model.LocalAppUrl = _localPlatformSettings.LocalAppUrl;
+            model.AuthenticationLevels = GetAuthenticationLevels();
 
             if (!model.TestApps?.Any() ?? true)
             {
@@ -112,7 +113,7 @@ namespace LocalTest.Controllers
             claims.Add(new Claim(AltinnCoreClaimTypes.UserId, profile.UserId.ToString(), ClaimValueTypes.String, issuer));
             claims.Add(new Claim(AltinnCoreClaimTypes.UserName, profile.UserName, ClaimValueTypes.String, issuer));
             claims.Add(new Claim(AltinnCoreClaimTypes.PartyID, profile.PartyId.ToString(), ClaimValueTypes.Integer32, issuer));
-            claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, "2", ClaimValueTypes.Integer32, issuer));
+            claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, startAppModel.AuthenticationLevel, ClaimValueTypes.Integer32, issuer));
 
             ClaimsIdentity identity = new ClaimsIdentity(_generalSettings.GetClaimsIdentity);
             identity.AddClaims(claims);
@@ -224,6 +225,39 @@ namespace LocalTest.Controllers
             }
 
             return userItems;
+        }
+
+        private List<SelectListItem> GetAuthenticationLevels()
+        {
+            return new()
+            {
+                new()
+                {
+                    Value = "0",
+                    Text = "Nivå 0",
+                },
+                new()
+                {
+                    Value = "1",
+                    Text = "Nivå 1",
+                },
+                new()
+                {
+                    Value = "2",
+                    Text = "Nivå 2",
+                    Selected = true,
+                },
+                new()
+                {
+                    Value = "3",
+                    Text = "Nivå 3",
+                },
+                new()
+                {
+                    Value = "4",
+                    Text = "Nivå 4",
+                },
+            };
         }
 
         private async Task<IEnumerable<SelectListItem>> GetAppsList()

--- a/src/development/LocalTest/Models/StartAppModel.cs
+++ b/src/development/LocalTest/Models/StartAppModel.cs
@@ -65,6 +65,11 @@ namespace LocalTest.Models
         public string AppPathSelection { get; set; }
 
         /// <summary>
+        /// Authentication level for the test user
+        /// </summary>
+        public string AuthenticationLevel { get; set; }
+
+        /// <summary>
         /// List of TestUsers for dropdown
         /// </summary>
         public IEnumerable<SelectListItem> TestUsers { get; set; }
@@ -73,5 +78,10 @@ namespace LocalTest.Models
         /// List of selectable Apps for dropdown
         /// </summary>
         public IEnumerable<SelectListItem> TestApps { get; set; }
+
+        /// <summary>
+        /// List of possible authentication levels
+        /// </summary>
+        public IEnumerable<SelectListItem> AuthenticationLevels { get; set; }
     }
 }

--- a/src/development/LocalTest/Views/Home/Index.cshtml
+++ b/src/development/LocalTest/Views/Home/Index.cshtml
@@ -3,7 +3,7 @@
   ViewData["Title"] = "Altinn Studio Local Testing";
 }
 
-@{ 
+@{
   if (Model.HttpException != null)
   {
     <div class="alert alert-dark" role="alert">
@@ -75,6 +75,10 @@
       <div class="form-group">
         <label for="exampleInputEmail1">Select app to test found in @Model.AppPath</label>
         @Html.DropDownListFor(model => model.AppPathSelection, Model.TestApps, new { Class = "form-control" })
+      </div>
+      <div class="form-group">
+        <label for="exampleInputEmail1">Select your authentication level</label>
+        @Html.DropDownListFor(model => model.AuthenticationLevel, Model.AuthenticationLevels, new { Class = "form-control" })
       </div>
       <button type="submit" class="btn btn-primary">Sign in</button>
     }


### PR DESCRIPTION
I'm, trying to rewrite [LOCALAPP.md](https://github.com/Altinn/altinn-studio/blob/master/LOCALAPP.md) for the changes in https://github.com/Altinn/altinn-studio/pull/7898. I wanted it to be as short as possible, and when I read about changing authentication level, I remembered #7025 and that there was a small change required to delete that section.

I did also go one step further and try to read from `policy.xml` to get the authentication level of the app when `LocalAppMode == "http"`

## Fixes
- https://github.com/Altinn/altinn-studio/issues/7025

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [x] Changelog is updated with a separate linked PR 
  - [x] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [x] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
