### PR TITLE
pushed stable apptemplate nugets

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.26.0-alpha</Version>
+    <Version>4.26.0</Version>
     <AssemblyVersion>4.26.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.26.0-alpha</Version>
+    <Version>4.26.0</Version>
     <AssemblyVersion>4.26.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.26.0-alpha</Version>
+    <Version>4.26.0</Version>
     <AssemblyVersion>4.26.0.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>

--- a/src/Altinn.Apps/AppTemplates/AspNet/App/App.csproj
+++ b/src/Altinn.Apps/AppTemplates/AspNet/App/App.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="4.25.0">
+    <PackageReference Include="Altinn.App.Api" Version="4.26.0">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Common" Version="4.25.0" />
-    <PackageReference Include="Altinn.App.PlatformServices" Version="4.25.0" />
+    <PackageReference Include="Altinn.App.Common" Version="4.26.0" />
+    <PackageReference Include="Altinn.App.PlatformServices" Version="4.26.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>

--- a/src/studio/AppTemplates/AspNet/App/App.csproj
+++ b/src/studio/AppTemplates/AspNet/App/App.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="4.25.0">
+    <PackageReference Include="Altinn.App.Api" Version="4.26.0">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Common" Version="4.25.0" />
-    <PackageReference Include="Altinn.App.PlatformServices" Version="4.25.0" />
+    <PackageReference Include="Altinn.App.Common" Version="4.26.0" />
+    <PackageReference Include="Altinn.App.PlatformServices" Version="4.26.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>


### PR DESCRIPTION
# stable nuget 4.26.0

## Description

Package contains
- Use new `appName` text resource as PDF title.
- Use local texts for pdf generation instead of text resources from Platform Storage.
