### PR TITLE
Change to use base64 encoding in URL for return URL

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/appUrlHelper.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/utils/appUrlHelper.ts
@@ -79,7 +79,7 @@ export function getCompleteProcessUrl() {
 }
 
 export function getRedirectUrl(returnUrl: string) {
-  return `${appPath}/api/v1/redirect?url=${encodeURIComponent(returnUrl)}`;
+  return `${appPath}/api/v1/redirect?url=${returnUrl}`;
 }
 
 export function getUpgradeAuthLevelUrl(reqAuthLevel: string) {

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/RedirectController.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.Api/Controllers/RedirectController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Text;
 
 using Altinn.App.Api.Filters;
 using Altinn.App.Services.Configuration;
@@ -40,9 +41,11 @@ namespace Altinn.App.Api.Controllers
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public ActionResult<string> ValidateUrl([BindRequired, FromQuery, Url] string url)
+        public ActionResult<string> ValidateUrl([BindRequired, FromQuery] string url)
         {
-            Uri uri = new Uri(url);
+            var byteArrayUri = Convert.FromBase64String(url);
+            var convertedUri = Encoding.UTF8.GetString(byteArrayUri);
+            Uri uri = new Uri(convertedUri);
 
             if (!IsValidRedirectUri(uri.Host))
             {
@@ -51,7 +54,7 @@ namespace Altinn.App.Api.Controllers
                 return ValidationProblem();
             }
 
-            return Ok(url);
+            return Ok(convertedUri);
         }
 
         private bool IsValidRedirectUri(string urlHost)


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# Custom return URL from apps doesn't work when containing a hash and a timeout triggers reauthentication
Custom return URL from apps doesn't work when containing a hash and a timeout triggers reauthentication

## Description

If you use a custom return url that includes a hash when you invoke an app and the app "times out" for reauthentication in Altinn II, then the app will fail when it's finally reactivated after authentication.

## Fixes
- #7963

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
