### PR TITLE
Fixed default authentication method

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -728,7 +728,7 @@ namespace Altinn.Platform.Authentication.Controllers
 
         private static UserAuthenticationModel GetUserFromToken(JwtSecurityToken jwtSecurityToken, OidcProvider provider)
         {
-            UserAuthenticationModel userAuthenticationModel = new UserAuthenticationModel() { IsAuthenticated = true, ProviderClaims = new Dictionary<string, List<string>>(), Iss = provider.IssuerKey };
+            UserAuthenticationModel userAuthenticationModel = new UserAuthenticationModel() { IsAuthenticated = true, ProviderClaims = new Dictionary<string, List<string>>(), Iss = provider.IssuerKey, AuthenticationMethod = AuthenticationMethod.NotDefined };
             foreach (Claim claim in jwtSecurityToken.Claims)
             {
                 // General OIDC claims
@@ -798,6 +798,11 @@ namespace Altinn.Platform.Authentication.Controllers
                        
                     userAuthenticationModel.ProviderClaims[claim.Type].Add(claim.Value);
                 }
+            }
+
+            if (userAuthenticationModel.AuthenticationMethod.Equals(AuthenticationMethod.NotDefined))
+            {
+                userAuthenticationModel.AuthenticationMethod = (Enum.AuthenticationMethod)System.Enum.Parse(typeof(Enum.AuthenticationMethod), provider.DefaultAuthenticationMethod);
             }
 
             return userAuthenticationModel;

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -728,7 +728,14 @@ namespace Altinn.Platform.Authentication.Controllers
 
         private static UserAuthenticationModel GetUserFromToken(JwtSecurityToken jwtSecurityToken, OidcProvider provider)
         {
-            UserAuthenticationModel userAuthenticationModel = new UserAuthenticationModel() { IsAuthenticated = true, ProviderClaims = new Dictionary<string, List<string>>(), Iss = provider.IssuerKey, AuthenticationMethod = AuthenticationMethod.NotDefined };
+            UserAuthenticationModel userAuthenticationModel = new UserAuthenticationModel()
+            {
+                IsAuthenticated = true,
+                ProviderClaims = new Dictionary<string,
+                List<string>>(), Iss = provider.IssuerKey,
+                AuthenticationMethod = AuthenticationMethod.NotDefined
+            };
+
             foreach (Claim claim in jwtSecurityToken.Claims)
             {
                 // General OIDC claims
@@ -800,9 +807,9 @@ namespace Altinn.Platform.Authentication.Controllers
                 }
             }
 
-            if (userAuthenticationModel.AuthenticationMethod.Equals(AuthenticationMethod.NotDefined))
+            if (userAuthenticationModel.AuthenticationMethod == AuthenticationMethod.NotDefined)
             {
-                userAuthenticationModel.AuthenticationMethod = (Enum.AuthenticationMethod)System.Enum.Parse(typeof(Enum.AuthenticationMethod), provider.DefaultAuthenticationMethod);
+                userAuthenticationModel.AuthenticationMethod = (AuthenticationMethod)System.Enum.Parse(typeof(AuthenticationMethod), provider.DefaultAuthenticationMethod);
             }
 
             return userAuthenticationModel;

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Model/OidcProvider.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Model/OidcProvider.cs
@@ -74,5 +74,10 @@ namespace Altinn.Platform.Authentication.Model
         /// Defines if Altinn Authentication should include the iss in the redirect_uri
         /// </summary>
         public bool IncludeIssInRedirectUri { get; set; }
+
+        /// <summary>
+        /// Defines the default authentication method
+        /// </summary>
+        public string DefaultAuthenticationMethod { get; set; } = "SelfIdentified";
     }
 }


### PR DESCRIPTION
# Fixed default authentication methdo method

Current code set authentications as not defined. This crashes Altinn 2.  This is (maybe) a temporary fix for this. 

We need later to discuss adding new methods for OIDC and then update Altinn 2 code.  

In reality for FEIDE it is self-identified users we are using, but using feide as source

## Description

Added default mechanism

## Fixes
- #8056 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
