### PR TITLE
bug: show spinner during complete for confirm + show pdf

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__mocks__/instanceDataStateMock.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/__mocks__/instanceDataStateMock.ts
@@ -27,6 +27,27 @@ export function getInstanceDataStateMock(customStates?: Partial<IInstanceDataSta
           lastChanged: new Date('2021-06-04T13:30:48.4307222Z'),
           lastChangedBy: '12345',
         },
+        {
+          id: '917e7e06-2665-4307-8c05-b0accd8964c6',
+          instanceGuid: 'b174e1f8-135c-4419-bd1c-fd171a0af1fe',
+          dataType: 'ref-data-as-pdf',
+          filename: 'mockApp.pdf',
+          contentType: 'application/pdf',
+          blobStoragePath: 'mockOrg/mockApp/b174e1f8-135c-4419-bd1c-fd171a0af1fe/data/917e7e06-2665-4307-8c05-b0accd8964c6',
+          selfLinks: {
+            apps: 'https://altinn3local.no/mockOrg/mockApp/instances/501337/b174e1f8-135c-4419-bd1c-fd171a0af1fe/data/917e7e06-2665-4307-8c05-b0accd8964c6',
+            platform: 'https://platform.altinn3local.no/storage/api/v1/instances/501337/b174e1f8-135c-4419-bd1c-fd171a0af1fe/data/917e7e06-2665-4307-8c05-b0accd8964c6'
+          },
+          size: 3537,
+          locked: false,
+          refs: [],
+          isRead: true,
+          tags: [],
+          created: new Date('2022-02-22T14:07:07.490511Z'),
+          createdBy: '12345',
+          lastChanged: new Date('2022-02-22T14:07:07.490511Z'),
+          lastChangedBy: '12345'
+        }
       ],
       id: '91cefc5e-c47b-40ff-a8a4-05971205f783',
       instanceState: null,

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.31.3",
+  "version": "3.31.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.test.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.test.tsx
@@ -42,6 +42,24 @@ describe('features > confirm > Confirm', () => {
     expect(contentLoader).not.toBeInTheDocument();
   });
 
+  it('should present pdf as part of previously submitted data', () => {
+    renderWithProviders(
+      <MemoryRouter>
+        <Confirm />
+      </MemoryRouter>,
+      {
+        preloadedState: getInitialStateMock({
+          attachments: { attachments: {} },
+        }),
+      },
+    );
+    const pdf = screen.getByText('mockApp.pdf');
+    expect(pdf).toBeInTheDocument();
+
+    const contentLoader = screen.queryByText('Loading...');
+    expect(contentLoader).not.toBeInTheDocument();
+  });
+
   it('should show loading when clicking submit', () => {
     renderWithProviders(
       <MemoryRouter>

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
@@ -12,7 +12,7 @@ import {
 import { IParty } from 'altinn-shared/types';
 import { getLanguageFromKey } from 'altinn-shared/utils/language';
 import { mapInstanceAttachments } from 'altinn-shared/utils';
-import { getAttachmentGroupings } from 'altinn-shared/utils/attachmentsUtils';
+import { getAttachmentGroupings, getInstancePdf } from 'altinn-shared/utils/attachmentsUtils';
 import ProcessDispatcher from '../../../shared/resources/process/processDispatcher';
 import { IAltinnWindow } from '../../../types';
 import { get } from '../../../utils/networking';
@@ -168,6 +168,7 @@ const Confirm = () => {
               null,
               true,
             )}
+            pdf={getInstancePdf(instance.data)}
           />
           <SubmitButton />
         </>
@@ -185,17 +186,10 @@ const SubmitButton = () => {
     (state) => state.textResources.resources,
   );
   const language = useAppSelector((state) => state.language.language);
-  const validations = useAppSelector(
-    (state) => state.formValidations.validations,
-  );
 
   const [isSubmitting, setIsSubmitting] = React.useState<boolean>(false);
 
   const { instanceId } = window as Window as IAltinnWindow;
-
-  React.useEffect(() => {
-    setIsSubmitting(false);
-  }, [validations]);
 
   const handleConfirmClick = () => {
     setIsSubmitting(true);
@@ -209,6 +203,8 @@ const SubmitButton = () => {
         dispatch(updateValidations({ validations: mappedValidations }));
         if (data.length === 0) {
           ProcessDispatcher.completeProcess();
+        } else {
+          setIsSubmitting(false);
         }
       })
       .catch(() => {


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# bug: show spinner during complete for confirm + show pdf

Show spinner for the whole duration of complete call + show pdf files in confirm view.

## Fixes
- #7824 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
