### PR TITLE
Add person lookup endpoint to local test

### DIFF
--- a/src/development/LocalTest/Controllers/Register/PersonsController.cs
+++ b/src/development/LocalTest/Controllers/Register/PersonsController.cs
@@ -1,0 +1,91 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+using Altinn.Platform.Register.Core;
+using Altinn.Platform.Register.Models;
+using AltinnCore.Authentication.Constants;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.Platform.Register.Controllers
+{
+    /// <summary>
+    /// The <see cref="PersonsController"/> provides the API endpoints related to persons.
+    /// </summary>
+    [Authorize]
+    [Route("register/api/v1/persons")]
+    public class PersonsController : ControllerBase
+    {
+        private readonly IPersonLookup _personLookup;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PersonsController"/> class.
+        /// </summary>
+        /// <param name="personLookup">An implementation of the <see cref="IPersonLookup"/> service.</param>
+        public PersonsController(IPersonLookup personLookup)
+        {
+            _personLookup = personLookup;
+        }
+
+        /// <summary>
+        /// Gets the party for the given national identity number.
+        /// </summary>
+        /// <remarks>
+        /// This method can be used to retrieve the party and person object for an identified person with
+        /// a national identity number. The service will track the number of invalid input combinations and
+        /// block further requests if the number of failed lookups have exceeded a configurable number. The
+        /// user will be prevented from performing new searches for a configurable number of seconds.
+        /// </remarks>
+        /// <returns>The party of the identified person.</returns>
+        [HttpGet]
+        [ProducesResponseType(400)]
+        [ProducesResponseType(403)]
+        [ProducesResponseType(404)]
+        [ProducesResponseType(200)]
+        [Produces("application/json")]
+        public async Task<ActionResult<Person>> GetPerson(PersonLookupIdentifiers personLookup)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            int? userId = GetUserId(HttpContext);
+
+            if (userId is null)
+            {
+                return Forbid();
+            }
+
+            Person? person;
+            try
+            {
+                person = await _personLookup.GetPerson(
+                    personLookup.NationalIdentityNumber, personLookup.LastName, userId.Value);
+            }
+            catch (TooManyFailedLookupsException)
+            {
+                return StatusCode(StatusCodes.Status429TooManyRequests);
+            }
+
+            if (person is null)
+            {
+                return NotFound();
+            }
+
+            return person;
+        }
+
+        private static int? GetUserId(HttpContext context)
+        {
+            Claim? userIdClaim = context.User.Claims.FirstOrDefault(c => c.Type.Equals(AltinnCoreClaimTypes.UserId));
+
+            return userIdClaim is not null ? Convert.ToInt32(userIdClaim.Value) : null;
+        }
+    }
+}

--- a/src/development/LocalTest/Models/PersonLookupIdentifiers.cs
+++ b/src/development/LocalTest/Models/PersonLookupIdentifiers.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.Platform.Register.Models
+{
+    /// <summary>
+    /// Represents the input parameters for the Person lookup endpoint.
+    /// </summary>
+    public class PersonLookupIdentifiers
+    {
+        /// <summary>
+        /// The unique national identity number of the person.
+        /// </summary>
+        [FromHeader(Name = "X-Ai-NationalIdentityNumber")]
+        [Required]
+        public string NationalIdentityNumber { get; set; }
+
+        /// <summary>
+        /// The last name of the person. This must match.
+        /// </summary>
+        [FromHeader(Name = "X-Ai-LastName")]
+        [Required]
+        public string LastName { get; set; }
+    }
+}

--- a/src/development/LocalTest/Services/Register/Implementation/PartiesWrapper.cs
+++ b/src/development/LocalTest/Services/Register/Implementation/PartiesWrapper.cs
@@ -1,59 +1,73 @@
 using System.IO;
 using System.Threading.Tasks;
+
 using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
+
 using LocalTest.Configuration;
 using LocalTest.Services.Register.Interface;
+
 using Microsoft.Extensions.Options;
+
 using Newtonsoft.Json;
 
 namespace LocalTest.Services.Register.Implementation
 {
-    /// <summary>
-    /// The parties wrapper
-    /// </summary>
     public class PartiesWrapper : IParties
     {
         private readonly LocalPlatformSettings _localPlatformSettings;
         private readonly IPersons _personService;
         private readonly IOrganizations _organizationService;
 
-
-        public PartiesWrapper(IOptions<LocalPlatformSettings> localPlatformSettings,
-            IPersons personsService, IOrganizations organizationService)
+        public PartiesWrapper(
+            IOptions<LocalPlatformSettings> localPlatformSettings,
+            IPersons personsService,
+            IOrganizations organizationService)
         {
             _localPlatformSettings = localPlatformSettings.Value;
-            this._organizationService = organizationService;
-            this._personService = personsService;
+            _organizationService = organizationService;
+            _personService = personsService;
         }
 
         /// <inheritdoc />
         public async Task<Party> GetParty(int partyId)
         {
             Party party = null;
-            string path = this._localPlatformSettings.LocalTestingStaticTestDataPath + "Register/Party/" + partyId + ".json";
+            string path = _localPlatformSettings.LocalTestingStaticTestDataPath + "Register/Party/" + partyId + ".json";
             if (File.Exists(path))
             {
                 string content = File.ReadAllText(path);
                 party = (Party)JsonConvert.DeserializeObject(content, typeof(Party));
             }
 
+            await AddPersonOrOrganization(party);
 
-            if (party.PartyTypeName.Equals(PartyType.Person))
-            {
-                party.Person = await _personService.GetPerson(party.SSN);
-            }
-            else if (party.PartyTypeName.Equals(PartyType.Organisation))
-            {
-                party.Organization = await _organizationService.GetOrganization(party.OrgNumber);
-            }
             return party;
         }
 
         /// <inheritdoc />
         public async Task<Party> LookupPartyBySSNOrOrgNo(string lookupValue)
         {
-            string path = this._localPlatformSettings.LocalTestingStaticTestDataPath + "Register/Party";
+            Party party = FindParty(lookupValue);
+
+            await AddPersonOrOrganization(party);
+
+            return party;
+        }
+
+        /// <inheritdoc />
+        public async Task<int> LookupPartyIdBySSNOrOrgNo(string lookupValue)
+        {
+            await Task.CompletedTask;
+
+            Party party = FindParty(lookupValue);
+
+            return party?.PartyId ?? -1;
+        }
+
+        private Party FindParty(string lookupValue)
+        {
+            string path = _localPlatformSettings.LocalTestingStaticTestDataPath + "Register/Party";
             string[] allPathsToParties = Directory.GetFiles(path);
 
             foreach (string partyPath in allPathsToParties)
@@ -62,36 +76,32 @@ namespace LocalTest.Services.Register.Implementation
 
                 string targetOrgNbr = $"\"orgNumber\": \"{lookupValue}\"";
                 string targetSsn = $"\"ssn\": \"{lookupValue}\"";
+
                 if (content.Contains(targetOrgNbr) || content.Contains(targetSsn))
                 {
-                    Party party = (Party)JsonConvert.DeserializeObject(content, typeof(Party));
-                    return await Task.FromResult(party);
+                    return (Party)JsonConvert.DeserializeObject(content, typeof(Party));
                 }
             }
 
             return null;
         }
 
-        /// <inheritdoc />
-        public async Task<int> LookupPartyIdBySSNOrOrgNo(string lookupValue)
+        private async Task AddPersonOrOrganization(Party party)
         {
-            string path = this._localPlatformSettings.LocalTestingStaticTestDataPath + "Register/Party";
-            string[] allPathsToOrgs = Directory.GetFiles(path);
-
-            foreach (string orgPath in allPathsToOrgs)
+            if (party is null)
             {
-                string content = File.ReadAllText(orgPath);
-
-                string targetOrgNbr = "\"orgNumber\": \"" + lookupValue + "\"";
-                string targetSSN = "\"ssn\": " + lookupValue;
-                if (content.Contains(targetOrgNbr) || content.Contains(targetSSN))
-                {
-                    Party party = (Party)JsonConvert.DeserializeObject(content, typeof(Party));
-                    return await Task.FromResult(party.PartyId);
-                }
+                return;
             }
 
-            return -1;
+            switch (party.PartyTypeName)
+            {
+                case PartyType.Person:
+                    party.Person = await _personService.GetPerson(party.SSN);
+                    break;
+                case PartyType.Organisation:
+                    party.Organization = await _organizationService.GetOrganization(party.OrgNumber);
+                    break;
+            }
         }
     }
 }

--- a/src/development/LocalTest/Services/Register/Implementation/PersonLookupService.cs
+++ b/src/development/LocalTest/Services/Register/Implementation/PersonLookupService.cs
@@ -1,0 +1,79 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+
+using Altinn.Platform.Register.Models;
+using LocalTest.Services.Register.Interface;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Altinn.Platform.Register.Core
+{
+    /// <summary>
+    /// Represents the business logic related to checking if a national identity number is in use.
+    /// </summary>
+    public class PersonLookupService : IPersonLookup
+    {
+        private const string PersonLookupFailedAttempts = "Person-Lookup-Failed-Attempts";
+
+        private readonly IParties _partiesService;
+        private readonly PersonLookupSettings _personLookupSettings;
+        private readonly IMemoryCache _memoryCache;
+        private readonly ILogger<PersonLookupService> _logger;
+
+        /// <summary>
+        /// Initialize a new instance of the <see cref="PersonLookupService"/> class.
+        /// </summary>
+        public PersonLookupService(
+            IParties partiesService,
+            IOptions<PersonLookupSettings> personLookupSettings,
+            IMemoryCache memoryCache,
+            ILogger<PersonLookupService> logger)
+        {
+            _partiesService = partiesService;
+            _personLookupSettings = personLookupSettings.Value;
+            _memoryCache = memoryCache;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Operation for checking if a given national identity number is connected to a person.
+        /// </summary>
+        /// <param name="nationalIdentityNumber">The national identity number to check.</param>
+        /// <param name="lastName">The last name of the person. Must match the last name of the person.</param>
+        /// <param name="activeUser">The unique id of the user performing the check.</param>
+        /// <returns>The identified <see cref="Task{Party}"/> if last name was correct.</returns>
+        public async Task<Person?> GetPerson(string nationalIdentityNumber, string lastName, int activeUser)
+        {
+            string uniqueCacheKey = PersonLookupFailedAttempts + activeUser;
+
+            _ = _memoryCache.TryGetValue(uniqueCacheKey, out int failedAttempts);
+            if (failedAttempts >= _personLookupSettings.MaximumFailedAttempts)
+            {
+                _logger.LogInformation(
+                    "User {userId} has performed too many failed person lookup attempts.", activeUser);
+
+                throw new TooManyFailedLookupsException();
+            }
+
+            Party? party = await _partiesService.LookupPartyBySSNOrOrgNo(nationalIdentityNumber);
+
+            string nameFromParty = party?.Person?.LastName ?? string.Empty;
+
+            if (nameFromParty.Length > 0 && nameFromParty.IsSimilarTo(lastName))
+            {
+                return party!.Person;
+            }
+
+            failedAttempts += 1;
+            MemoryCacheEntryOptions memoryCacheOptions = new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(_personLookupSettings.FailedAttemptsCacheLifetimeSeconds)
+            };
+            _memoryCache.Set(uniqueCacheKey, failedAttempts, memoryCacheOptions);
+            return null;
+        }
+    }
+}

--- a/src/development/LocalTest/Services/Register/Implementation/PersonLookupSettings.cs
+++ b/src/development/LocalTest/Services/Register/Implementation/PersonLookupSettings.cs
@@ -1,0 +1,23 @@
+namespace Altinn.Platform.Register.Core
+{
+    /// <summary>
+    /// Represents settings related to the person lookup endpoint.
+    /// </summary>
+    public class PersonLookupSettings
+    {
+        /// <summary>
+        /// The maximum number of times a user can fail to enter correct match.
+        /// </summary>
+        public int MaximumFailedAttempts { get; set; } = 1;
+
+        /// <summary>
+        /// The number of seconds the failed attempts counter will be kept in the cache.
+        /// </summary>
+        public int FailedAttemptsCacheLifetimeSeconds { get; set; } = 3600;
+
+        /// <summary>
+        /// The number of seconds a successfully retrieved person object should be cached.
+        /// </summary>
+        public int PersonCacheLifetimeSeconds { get; set; } = 3600;
+    }
+}

--- a/src/development/LocalTest/Services/Register/Implementation/StringExtensions.cs
+++ b/src/development/LocalTest/Services/Register/Implementation/StringExtensions.cs
@@ -1,0 +1,84 @@
+#nullable enable
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace Altinn.Platform.Register.Core
+{
+    /// <summary>
+    /// Represents a collection of extension methods for string
+    /// </summary>
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Compare to strings doing a loose compare ignoring case and diacritics
+        /// </summary>
+        /// <param name="text1">First text</param>
+        /// <param name="text2">Second text</param>
+        /// <returns>true if the texts are similar.</returns>
+        public static bool IsSimilarTo(this string text1, string text2)
+        {
+            const int CompareLength = 4;
+
+            text1 ??= string.Empty;
+            text2 ??= string.Empty;
+
+            text1 = text1.Trim().Length > CompareLength ? text1.Remove(CompareLength).Trim() : text1.Trim();
+            text2 = text2.Trim().Length > CompareLength ? text2.Remove(CompareLength).Trim() : text2.Trim();
+
+            text1 = text1.RemoveDiacritics();
+            text2 = text2.RemoveDiacritics();
+
+            return text1.Equals(text2, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        /// <summary>
+        /// Remove diacritics from a string while normalizing it.
+        /// </summary>
+        /// <param name="text">The text to normalize.</param>
+        /// <returns>The normalized text.</returns>
+        public static string RemoveDiacritics(this string text)
+        {
+            string normalizedText;
+
+            // Å is not a special character in Norwegian hence handling this character differently
+            if (text.ToUpper().Contains('Å'))
+            {
+                StringBuilder firstPassBuilder = new StringBuilder();
+                foreach (char ch in text)
+                {
+                    if (ch == 'Å' || ch == 'å')
+                    {
+                        // NormalizationForm C doesn't convert Å to A
+                        firstPassBuilder.Append(ch.ToString().Normalize(NormalizationForm.FormC));
+                    }
+                    else
+                    {
+                        firstPassBuilder.Append(ch.ToString().Normalize(NormalizationForm.FormD));
+                    }
+                }
+
+                normalizedText = firstPassBuilder.ToString();
+            }
+            else
+            {
+                normalizedText = text.Normalize(NormalizationForm.FormD);
+            }
+
+            StringBuilder secondPassBuilder = new StringBuilder();
+            foreach (char ch in normalizedText)
+            {
+                // Unicode information of the characters, e.g. Uppercase, Lowercase, NonSpacingMark, etc.
+                UnicodeCategory unicode = CharUnicodeInfo.GetUnicodeCategory(ch);
+
+                if (unicode != UnicodeCategory.NonSpacingMark)
+                {
+                    // StringBuilder is appended with the characters that are not diacritics
+                    secondPassBuilder.Append(ch);
+                }
+            }
+
+            return secondPassBuilder.ToString().Normalize(NormalizationForm.FormC);
+        }
+    }
+}

--- a/src/development/LocalTest/Services/Register/Implementation/TooManyFailedLookupsException.cs
+++ b/src/development/LocalTest/Services/Register/Implementation/TooManyFailedLookupsException.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Altinn.Platform.Register.Core
+{
+    /// <summary>
+    /// Represents a situation where a user has performed too many failed lookup requests.
+    /// </summary>
+    [Serializable]
+    public class TooManyFailedLookupsException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TooManyFailedLookupsException"/> class.
+        /// </summary>
+        public TooManyFailedLookupsException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TooManyFailedLookupsException"/> class.
+        /// </summary>
+        /// <param name="message">The message that descibes the error.</param>
+        public TooManyFailedLookupsException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initialize a new instance of the <see cref="TooManyFailedLookupsException"/> class using the
+        /// given <see cref="SerializationInfo"/>.
+        /// </summary>
+        protected TooManyFailedLookupsException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/development/LocalTest/Services/Register/Interface/IPersonLookup.cs
+++ b/src/development/LocalTest/Services/Register/Interface/IPersonLookup.cs
@@ -1,0 +1,22 @@
+#nullable enable
+using System.Threading.Tasks;
+
+using Altinn.Platform.Register.Models;
+
+namespace Altinn.Platform.Register.Core
+{
+    /// <summary>
+    /// Describes the methods required by a person check service.
+    /// </summary>
+    public interface IPersonLookup
+    {
+        /// <summary>
+        /// Describes the signature of a lookup method.
+        /// </summary>
+        /// <param name="nationalIdentityNumber">The national identity number to check.</param>
+        /// <param name="lastName">The last name of the person. Must match the last name of the person.</param>
+        /// <param name="activeUser">The unique id of the user performing the check.</param>
+        /// <returns>The identified person if found.</returns>
+        Task<Person?> GetPerson(string nationalIdentityNumber, string lastName, int activeUser);
+    }
+}

--- a/src/development/LocalTest/Startup.cs
+++ b/src/development/LocalTest/Startup.cs
@@ -1,51 +1,52 @@
 using System;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.Json.Serialization;
 
-using AltinnCore.Authentication.JwtCookie;
-using AltinnCore.Authentication.Constants;
 using Altinn.Authorization.ABAC.Interface;
 using Altinn.Common.PEP.Authorization;
-using Altinn.Common.PEP.Interfaces;
-using Altinn.Common.PEP.Implementation;
 using Altinn.Common.PEP.Clients;
-using Altinn.Platform.Authorization.Services.Implementation;
-using Altinn.Platform.Authorization.Services.Interface;
+using Altinn.Common.PEP.Implementation;
+using Altinn.Common.PEP.Interfaces;
+using Altinn.Platform.Authorization.ModelBinding;
 using Altinn.Platform.Authorization.Repositories;
 using Altinn.Platform.Authorization.Repositories.Interface;
-using Altinn.Platform.Authorization.ModelBinding;
+using Altinn.Platform.Authorization.Services.Implementation;
+using Altinn.Platform.Authorization.Services.Interface;
 using Altinn.Platform.Events.Repository;
+using Altinn.Platform.Register.Core;
 using Altinn.Platform.Storage.Clients;
-using Altinn.Platform.Storage.Repository;
 using Altinn.Platform.Storage.Helpers;
+using Altinn.Platform.Storage.Repository;
+using AltinnCore.Authentication.Constants;
+using AltinnCore.Authentication.JwtCookie;
 
 using LocalTest.Configuration;
-using LocalTest.Services.Authentication.Interface;
 using LocalTest.Services.Authentication.Implementation;
+using LocalTest.Services.Authentication.Interface;
 using LocalTest.Services.Authorization.Implementation;
+using LocalTest.Services.Authorization.Interface;
 using LocalTest.Services.Events.Implementation;
 using LocalTest.Services.LocalApp.Implementation;
 using LocalTest.Services.LocalApp.Interface;
-using LocalTest.Services.Profile.Interface;
+using LocalTest.Services.Localtest.Implementation;
+using LocalTest.Services.Localtest.Interface;
 using LocalTest.Services.Profile.Implementation;
-using LocalTest.Services.Register.Interface;
+using LocalTest.Services.Profile.Interface;
 using LocalTest.Services.Register.Implementation;
+using LocalTest.Services.Register.Interface;
 using LocalTest.Services.Storage.Implementation;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.IdentityModel.Logging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
-using LocalTest.Services.Localtest.Interface;
-using LocalTest.Services.Localtest.Implementation;
-using System.Text.Json.Serialization;
-using LocalTest.Services.Authorization.Interface;
 
 namespace LocalTest
 {
@@ -76,6 +77,7 @@ namespace LocalTest
             services.Configure<Altinn.Platform.Authentication.Configuration.GeneralSettings>(Configuration.GetSection("AuthnGeneralSettings"));
             services.Configure<CertificateSettings>(Configuration);
             services.Configure<CertificateSettings>(Configuration.GetSection("CertificateSettings"));
+            services.Configure<PersonLookupSettings>(Configuration.GetSection("PersonLookupSettings"));
             services.AddSingleton<ILocalTestAppSelection, LocalTestAppSelectionSI>();
             services.AddSingleton<IUserProfiles, UserProfilesWrapper>();
             services.AddSingleton<IOrganizations, OrganizationsWrapper>();
@@ -94,6 +96,7 @@ namespace LocalTest
             services.AddSingleton<IAuthentication, AuthenticationService>();
             services.AddTransient<IAuthorizationHandler, AppAccessHandler>();
             services.AddTransient<IAuthorizationHandler, ScopeAccessHandler>();
+            services.AddTransient<IPersonLookup, PersonLookupService>();
 
             services.AddSingleton<IContextHandler, ContextHandler>();
             services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPoint>();

--- a/src/development/LocalTest/appsettings.json
+++ b/src/development/LocalTest/appsettings.json
@@ -1,4 +1,9 @@
 {
+  "PersonLookupSettings": {
+    "MaximumFailedAttempts": 2,
+    "FailedAttemptsCacheLifetimeSeconds": 3600,
+    "PersonCacheLifetimeSeconds": 3600
+  },
   "GeneralSettings": {
     "HostName": "altinn3local.no",
     "SBLCookieName": ".ASPXAUTH",


### PR DESCRIPTION
# Add person lookup endpoint to local test

## Description
We recently gave Register a new endpoint that can be used to verify a person national identity number. This PR copies this endpoint into LocalTest.

## Fixes
- #5623

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
