### PR TITLE
feat: use version 4.27.0 of app template

### DIFF
--- a/src/studio/AppTemplates/AspNet/App/App.csproj
+++ b/src/studio/AppTemplates/AspNet/App/App.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="4.26.0">
+    <PackageReference Include="Altinn.App.Api" Version="4.27.0">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Common" Version="4.26.0" />
-    <PackageReference Include="Altinn.App.PlatformServices" Version="4.26.0" />
+    <PackageReference Include="Altinn.App.Common" Version="4.27.0" />
+    <PackageReference Include="Altinn.App.PlatformServices" Version="4.27.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>


### PR DESCRIPTION
# Use 4.27.0 version of app nuget 
This uses the 4.27.0 version of the app template introducing secure options endpoint.

## Fixes
- #7893 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
