### PR TITLE
bug/data-name-layout

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.32.0",
+  "version": "3.32.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/fetch/fetchFormLayoutSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/form/layout/fetch/fetchFormLayoutSagas.ts
@@ -26,7 +26,7 @@ function* fetchLayoutSaga(): SagaIterator {
     const navigationConfig: any = {};
     let autoSave: boolean;
     let firstLayoutKey: string;
-    if (layoutResponse.data) {
+    if (layoutResponse.data?.layout) {
       layouts.FormLayout = layoutResponse.data.layout;
       firstLayoutKey = 'FormLayout';
       autoSave = layoutResponse.data.autoSave;


### PR DESCRIPTION
Found during setup of app development course. Having a layout page called `data` would cause app to get stuck in the loading phase. Because of a bad check in logic to stay backwards compat.