### PR TITLE
Expose prefill method to user

### DIFF
--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/PrefillSI.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Implementation/PrefillSI.cs
@@ -53,12 +53,18 @@ namespace Altinn.App.Services.Implementation
         }
 
         /// <inheritdoc/>
+        public void PrefillDataModel(object dataModel, Dictionary<string, string> externalPrefill, bool continueOnError = false)
+        {
+            LoopThroughDictionaryAndAssignValuesToDataModel(SwapKeyValuesForPrefil(externalPrefill), null, dataModel, continueOnError);
+        }
+
+        /// <inheritdoc/>
         public async Task PrefillDataModel(string partyId, string dataModelName, object dataModel, Dictionary<string, string> externalPrefill)
         {
             // Prefill from external input. Only available during instansiation
             if (externalPrefill != null && externalPrefill.Count > 0)
             {
-                LoopThroughDictionaryAndAssignValuesToDataModel(SwapKeyValuesForPrefil(externalPrefill), null, dataModel, true);
+                PrefillDataModel(dataModel, externalPrefill, true);
             }
 
             string jsonConfig = _appResourcesService.GetPrefillJson(dataModelName);

--- a/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IPrefill.cs
+++ b/src/Altinn.Apps/AppTemplates/AspNet/Altinn.App.PlatformServices/Interface/IPrefill.cs
@@ -16,5 +16,13 @@ namespace Altinn.App.Services.Interface
         /// <param name="dataModel">The data model object</param>
         /// <param name="externalPrefill">External given prefill</param>
         Task PrefillDataModel(string partyId, string dataModelName, object dataModel, Dictionary<string, string> externalPrefill = null);
+
+        /// <summary>
+        /// Prefills the data model based on key/values in the dictionary.
+        /// </summary>
+        /// <param name="dataModel">The data model object</param>
+        /// <param name="externalPrefill">External given prefill</param>
+        /// <param name="continueOnError">Ignore errors when true, throw on errors when false</param>
+        void PrefillDataModel(object dataModel, Dictionary<string, string> externalPrefill, bool continueOnError = false);
     }
 }


### PR DESCRIPTION
# Expose prefill method to user

Writing prefill code is tedious and error-prone (as the tree might have
been partially constructed). Exposing the inner functionality of
PrefillSI, we can use the same key/value pairs as is used in the prefill
json.

E.g.
```csharp
   public async Task DataCreation(Instance instance, object data, Dictionary<string, string> prefill) {
       prefillService.PrefillDataModel(data, new Dictionary<string, string> {
           { "a.value", "a" },
           { "b.value", "b" },
           // ..
       });
       await Task.CompletedTask;
   }
```

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
