### PR TITLE
chore: ignore unsupported components from pdf-generation

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
@@ -272,7 +272,8 @@ public class PDFGenerator {
   private void renderLayoutElement(FormLayoutElement element) throws IOException {
     String componentType = element.getType();
     String componentId = element.getId();
-    if (componentsIgnoredFromGeneration.contains(element.getType())) {
+    if (componentsIgnoredFromGeneration.contains(element.getType())
+      || !LayoutUtils.includeComponentInPdf(componentId, layoutSettings)) {
       return;
     }
     // Render title

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
@@ -69,6 +69,13 @@ public class PDFGenerator {
   private int mcid = 1;
   private PDStructureElement currentPart;
   private PDStructureElement currentSection;
+  private List<String> componentsIgnoredFromGeneration = Arrays.asList(
+    "Button",
+    "Image",
+    "NavigationBar",
+    "NavigationButtons",
+    "Summary"
+  );
 
 
   /**
@@ -265,10 +272,7 @@ public class PDFGenerator {
   private void renderLayoutElement(FormLayoutElement element) throws IOException {
     String componentType = element.getType();
     String componentId = element.getId();
-    if (componentType.equals("Button")
-      || componentType.equalsIgnoreCase("NavigationButtons")
-      || componentType.equalsIgnoreCase("NavigationBar")
-      || !LayoutUtils.includeComponentInPdf(componentId, layoutSettings)) {
+    if (componentsIgnoredFromGeneration.contains(element.getType())) {
       return;
     }
     // Render title

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
@@ -272,7 +272,7 @@ public class PDFGenerator {
   private void renderLayoutElement(FormLayoutElement element) throws IOException {
     String componentType = element.getType();
     String componentId = element.getId();
-    if (componentsIgnoredFromGeneration.contains(element.getType())
+    if (componentsIgnoredFromGeneration.contains(componentType)
       || !LayoutUtils.includeComponentInPdf(componentId, layoutSettings)) {
       return;
     }


### PR DESCRIPTION
Instead of manually making sure you remember to add `Image` and `Summary` components to the ignore list this is now handled in PDF-generator.