### PR TITLE
Fix: Correct padding for modal header (mobile)

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.32.3",
+  "version": "3.32.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/index.css
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/styles/index.css
@@ -197,15 +197,16 @@ select.disabled {
   background-color: #fff;
   color: #000;
   border-bottom: 1px solid #eee;
+  padding-left: 24px;
 }
 
-@media only screen and (min-width: 753px) {
+@media only screen and (min-width: 768px) {
   .a-iconText.a-iconText-background {
     padding-left: 84px;
   }
 }
 
-@media only screen and (min-width: 977px) {
+@media only screen and (min-width: 992px) {
   .a-iconText.a-iconText-background {
     padding-left: 96px;
   }


### PR DESCRIPTION
# Fix: correct padding for modal header (mobile)

Bug: 
![image](https://user-images.githubusercontent.com/1464915/156176113-f178aa25-61ab-4171-b012-29aa4327a385.png)

Fix: 
<img width="414" alt="image" src="https://user-images.githubusercontent.com/1464915/156176260-9231e2a7-b089-4256-a99f-f3f564cf9328.png">
