### PR TITLE
use k6 execution iterationInTest

### DIFF
--- a/src/test/K6/src/setup.js
+++ b/src/test/K6/src/setup.js
@@ -4,7 +4,6 @@ import * as config from './config.js';
 import * as headers from './buildrequestheaders.js';
 import { getParties } from './api/platform/authorization/authorization.js';
 import { addErrorCount, stopIterationOnFail } from './errorcounter.js';
-import * as support from './support.js';
 import { convertMaskinPortenToken } from './api/platform/authentication.js';
 import { generateToken } from './api/altinn-testtools/token-generator.js';
 
@@ -96,25 +95,6 @@ export function clearCookies() {
   jar.set('https://' + config.baseUrl, '.ASPXAUTH', 'test', { expires: 'Mon, 02 Jan 2010 15:04:05 MST' });
 }
 
-//Generate array with type of attachment for all the iterations
-//based on the distribution across small, medium and large attachment
-export function buildAttachmentTypeArray(distribution, totalIterations) {
-  distribution = distribution.split(';');
-  var small = distribution[0] != null ? buildArray(totalIterations * (distribution[0] / 100), 's') : [];
-  var medium = distribution[1] != null ? buildArray(totalIterations * (distribution[1] / 100), 'm') : [];
-  var large = distribution[2] != null ? buildArray(totalIterations * (distribution[2] / 100), 'l') : [];
-  var attachmentTypes = small.concat(medium, large);
-  return support.shuffle(attachmentTypes);
-}
-
-//Function to build an array with the specified value and count
-function buildArray(count, value) {
-  var array = [];
-  for (var i = 0; i < count; i++) {
-    array.push(value);
-  }
-  return array;
-}
 /**
  * generate an altinn token for TTD based on the environment
  * use exchange token if prod, and altinnTestTools for test environments

--- a/src/test/K6/src/support.js
+++ b/src/test/K6/src/support.js
@@ -40,3 +40,23 @@ export function isGuid(stringToTest) {
   var regexGuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   return regexGuid.test(stringToTest);
 }
+
+//Generate array with type of attachment for all the iterations
+//based on the distribution across small, medium and large attachment
+export function buildAttachmentTypeArray(distribution, totalIterations) {
+  distribution = distribution.split(';');
+  var small = distribution[0] != null ? buildArray(totalIterations * (distribution[0] / 100), 's') : [];
+  var medium = distribution[1] != null ? buildArray(totalIterations * (distribution[1] / 100), 'm') : [];
+  var large = distribution[2] != null ? buildArray(totalIterations * (distribution[2] / 100), 'l') : [];
+  var attachmentTypes = small.concat(medium, large);
+  return shuffle(attachmentTypes);
+}
+
+//Function to build an array with the specified value and count
+function buildArray(count, value) {
+  var array = [];
+  for (var i = 0; i < count; i++) {
+    array.push(value);
+  }
+  return array;
+}

--- a/src/test/K6/src/tests/app/performance/rf0002withattachment.js
+++ b/src/test/K6/src/tests/app/performance/rf0002withattachment.js
@@ -25,6 +25,7 @@ import * as platformInstances from '../../../api/platform/storage/instances.js';
 import * as apps from '../../../api/platform/storage/applications.js';
 import { deleteSblInstance } from '../../../api/platform/storage/messageboxinstances.js';
 import * as setUpData from '../../../setup.js';
+import * as support from '../../../support.js';
 
 const appOwner = __ENV.org;
 const level2App = __ENV.level2app;
@@ -54,7 +55,7 @@ export function setup() {
   var data = {};
   var totalIterations = options.iterations ? options.iterations : 1;
   attachmentDistribution = attachmentDistribution ? attachmentDistribution : '';
-  let attachmentTypes = setUpData.buildAttachmentTypeArray(attachmentDistribution, totalIterations);
+  let attachmentTypes = support.buildAttachmentTypeArray(attachmentDistribution, totalIterations);
   data.attachmentTypes = attachmentTypes;
   return data;
 }

--- a/src/test/K6/src/tests/app/performance/rf0002withattachment.js
+++ b/src/test/K6/src/tests/app/performance/rf0002withattachment.js
@@ -8,14 +8,15 @@
 		"partyid": ""
     }
   ]
-  Create and archive instances of RF-0002 with attachments, where the distribution of attachments is based on 
+  Create and archive instances of RF-0002 with attachments, where the distribution of attachments is based on
   parameter attachmentdistribution among small, medium and large attachment.
-  example: k6 run -i 20 -u 10 /src/tests/app/rf0002withattachment.js 
+  example: k6 run -i 20 -u 10 /src/tests/app/rf0002withattachment.js
   -e env=test -e org=ttd -e level2app=rf-0002 -e appsaccesskey=*** -e attachmentdistribution="60;30;10"
 */
 
 import { check } from 'k6';
 import { SharedArray } from 'k6/data';
+import { scenario } from 'k6/execution';
 import { addErrorCount, stopIterationOnFail } from '../../../errorcounter.js';
 import * as appInstances from '../../../api/app/instances.js';
 import * as appData from '../../../api/app/data.js';
@@ -52,8 +53,6 @@ export const options = {
 export function setup() {
   var data = {};
   var totalIterations = options.iterations ? options.iterations : 1;
-  var maxVus = options.vus ? options.vus : 1;
-  data.maxIter = Math.floor(totalIterations / maxVus); //maximum iteration per vu
   attachmentDistribution = attachmentDistribution ? attachmentDistribution : '';
   let attachmentTypes = setUpData.buildAttachmentTypeArray(attachmentDistribution, totalIterations);
   data.attachmentTypes = attachmentTypes;
@@ -63,12 +62,11 @@ export function setup() {
 //Tests for App API: RF-0002
 export default function (data) {
   var userNumber = (__VU - 1) % usersCount;
-  var maxIter = data.maxIter;
   var attachmentTypes = data.attachmentTypes[0] ? data.attachmentTypes : ['s'];
   var instanceId, dataId, res, success;
 
   //Find a unique number for the type of attachment to upload
-  var uniqueNum = __VU * maxIter - maxIter + __ITER;
+  var uniqueNum = scenario.iterationInTest;
   uniqueNum = uniqueNum > attachmentTypes.length ? Math.floor(uniqueNum % attachmentTypes.length) : uniqueNum;
 
   //Find a username and password from the users file

--- a/src/test/K6/src/tests/app/performance/uploadanddownload.js
+++ b/src/test/K6/src/tests/app/performance/uploadanddownload.js
@@ -1,9 +1,9 @@
 /*
   This test script can only be run with virtual users and iterations count and not based on duration.
-  Create and archive instances of RF-0002 with attachments, where the distribution of attachments is based on 
+  Create and archive instances of RF-0002 with attachments, where the distribution of attachments is based on
   parameter attachmentdistribution among small, medium and large attachment.
 
-  example: k6 run -i 20 -u 10 --logformat raw --console-output=./src/data/instances.csv 
+  example: k6 run -i 20 -u 10 --logformat raw --console-output=./src/data/instances.csv
   /src/tests/app/rf0002withattachment.js -e env=test -e org=ttd -e level2app=rf-0002 -e appsaccesskey=*** -e attachmentdistribution="60;30;10"
 
    Test data: a json file named as ex: users_prod.json with user data in below format in the K6/src/data folder and deployed RF-0002 app
@@ -19,6 +19,7 @@
 
 import { check } from 'k6';
 import { SharedArray } from 'k6/data';
+import { scenario } from 'k6/execution';
 import { addErrorCount, stopIterationOnFail } from '../../../errorcounter.js';
 import * as appInstances from '../../../api/app/instances.js';
 import * as appData from '../../../api/app/data.js';
@@ -56,8 +57,6 @@ export const options = {
 export function setup() {
   var data = {};
   var totalIterations = options.iterations ? options.iterations : 1;
-  var maxVus = options.vus ? options.vus : 1;
-  data.maxIter = Math.floor(totalIterations / maxVus); //maximum iteration per vu
   attachmentDistribution = attachmentDistribution ? attachmentDistribution : '';
   let attachmentTypes = setUpData.buildAttachmentTypeArray(attachmentDistribution, totalIterations);
   data.attachmentTypes = attachmentTypes;
@@ -67,12 +66,11 @@ export function setup() {
 //Tests for App API: RF-0002
 export default function (data) {
   var userNumber = (__VU - 1) % usersCount;
-  var maxIter = data.maxIter;
   var attachmentTypes = data.attachmentTypes[0] ? data.attachmentTypes : ['s'];
   var instanceId, dataId, res, success;
 
   //Find a unique number for the type of attachment to upload
-  var uniqueNum = __VU * maxIter - maxIter + __ITER;
+  var uniqueNum = scenario.iterationInTest;
   uniqueNum = uniqueNum > attachmentTypes.length ? Math.floor(uniqueNum % attachmentTypes.length) : uniqueNum;
 
   //Find a username and password from the users file

--- a/src/test/K6/src/tests/app/performance/uploadanddownload.js
+++ b/src/test/K6/src/tests/app/performance/uploadanddownload.js
@@ -29,6 +29,7 @@ import * as apps from '../../../api/platform/storage/applications.js';
 import * as storageData from '../../../api/platform/storage/data.js';
 import { deleteSblInstance } from '../../../api/platform/storage/messageboxinstances.js';
 import * as setUpData from '../../../setup.js';
+import * as support from '../../../support.js';
 
 const instanceFormDataXml = open('../../../data/' + level2App + '.xml');
 const appOwner = __ENV.org;
@@ -58,7 +59,7 @@ export function setup() {
   var data = {};
   var totalIterations = options.iterations ? options.iterations : 1;
   attachmentDistribution = attachmentDistribution ? attachmentDistribution : '';
-  let attachmentTypes = setUpData.buildAttachmentTypeArray(attachmentDistribution, totalIterations);
+  let attachmentTypes = support.buildAttachmentTypeArray(attachmentDistribution, totalIterations);
   data.attachmentTypes = attachmentTypes;
   return data;
 }

--- a/src/test/K6/src/tests/platform/appowner/completeconfirmation.js
+++ b/src/test/K6/src/tests/platform/appowner/completeconfirmation.js
@@ -1,19 +1,20 @@
-/* Pre-reqisite for test for prod: 
+/* Pre-reqisite for test for prod:
     1. MaskinPorteTokenGenerator https://github.com/Altinn/MaskinportenTokenGenerator built
     2. Installed appOwner certificate
     3. Send maskinporten token as environment variable: -e maskinporten=token
 
-    Environment variables for test environments: 
+    Environment variables for test environments:
     -e tokengenuser=*** -e tokengenuserpwd=*** -e scopes=altinn:serviceowner/instances.read
 
     This test script sets complete confirmation as app owner on all the instances from a csv file.
     The iteration is shared between the virtual users and each VU runs exactly same number of iternations (maxIter).
 
-    example: k6 run /src/tests/platform/storage/appowner/completeconfirmation.js 
+    example: k6 run /src/tests/platform/storage/appowner/completeconfirmation.js
     -e env=test -e appsaccesskey=*** -e maskinporten=token -e vus=**(number of virtual users)
 */
 
 import { check } from 'k6';
+import { scenario } from 'k6/execution';
 import { stopIterationOnFail } from '../../../errorcounter.js';
 import * as storageInstances from '../../../api/platform/storage/instances.js';
 import * as setUpData from '../../../setup.js';
@@ -52,7 +53,7 @@ export default function (data) {
   const instances = data.instances;
   var res, success, partyId, instanceId;
 
-  var uniqueNum = __VU * maxIter - maxIter + __ITER;
+  var uniqueNum = scenario.iterationInTest;
   uniqueNum = uniqueNum > instances.length ? Math.floor(uniqueNum % instances.length) : uniqueNum;
 
   //Get instance ids and separate party id and instance id

--- a/src/test/K6/src/tests/platform/appowner/downloadinstances.js
+++ b/src/test/K6/src/tests/platform/appowner/downloadinstances.js
@@ -1,18 +1,19 @@
-/* Pre-reqisite for test: 
+/* Pre-reqisite for test:
     1. MaskinPorteTokenGenerator https://github.com/Altinn/MaskinportenTokenGenerator built
     2. Installed appOwner certificate
     3. Send maskinporten token as environment variable: -e maskinporten=token
 
-    Environment variables for test environments: 
+    Environment variables for test environments:
     -e tokengenuser=*** -e tokengenuserpwd=*** -e scopes=altinn:serviceowner/instances.read
 
     This test script can only be run with virtual users and iterations count and not based on duration.
-    
-    example: k6 run -i 20 -u 10 /src/tests/platform/storage/appowner/downloadinstances.js -e env=test -e org=ttd 
+
+    example: k6 run -i 20 -u 10 /src/tests/platform/storage/appowner/downloadinstances.js -e env=test -e org=ttd
     -e level2app=rf-0002 -e appsaccesskey=*** -e maskinporten=token
 */
 
 import { check } from 'k6';
+import { scenario } from 'k6/execution';
 import { addErrorCount, stopIterationOnFail } from '../../../errorcounter.js';
 import * as storageInstances from '../../../api/platform/storage/instances.js';
 import * as storageData from '../../../api/platform/storage/data.js';
@@ -34,9 +35,7 @@ export const options = {
 export function setup() {
   var altinnStudioRuntimeToken = setUpData.getAltinnTokenForTTD();
   var data = {};
-  var maxVus = options.vus ? options.vus : 1;
   var totalIterations = options.iterations ? options.iterations : 1;
-  data.maxIter = Math.floor(totalIterations / maxVus); //maximum iteration per vu
   data.runtimeToken = altinnStudioRuntimeToken;
   var archivedAppInstances = storageInstances.findAllArchivedInstances(altinnStudioRuntimeToken, appOwner, level2App, totalIterations, createdDateTime);
   archivedAppInstances = support.shuffle(archivedAppInstances);
@@ -48,8 +47,7 @@ export function setup() {
 export default function (data) {
   const runtimeToken = data['runtimeToken'];
   const instances = data.instances;
-  var maxIter = data.maxIter;
-  var uniqueNum = __VU * maxIter - maxIter + __ITER;
+  var uniqueNum = scenario.iterationInTest;
   uniqueNum = uniqueNum > instances.length ? Math.floor(uniqueNum % instances.length) : uniqueNum;
   var res, success;
 


### PR DESCRIPTION
# use k6 execution iterationInTest

## Description

Until now, there was a math logic used in performance scripts to find unique number. 

From k6 version `0.34.0` it is possible to get unique number with [k6/execution](https://k6.io/docs/javascript-api/k6-execution/#scenario) module  `scenario.iterationInTest`.

This PR, removes the math logic and updates with the new properties.