### PR TITLE
Assume LastName in person lookup is base64 encoded.

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Register/Altinn.Platform.Register.Tests/IntegrationTests/PersonsControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Register/Altinn.Platform.Register.Tests/IntegrationTests/PersonsControllerTests.cs
@@ -55,7 +55,7 @@ namespace Altinn.Platform.Register.Tests.IntegrationTests
             HttpRequestMessage testRequest = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/persons/");
             testRequest.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
             testRequest.Headers.Add("X-Ai-NationalIdentityNumber", "personnumber");
-            testRequest.Headers.Add("X-Ai-LastName", "lastname");
+            testRequest.Headers.Add("X-Ai-LastName", ConvertToBase64("lastname"));
 
             // Act
             HttpResponseMessage response = await client.SendAsync(testRequest);
@@ -110,7 +110,7 @@ namespace Altinn.Platform.Register.Tests.IntegrationTests
             HttpRequestMessage testRequest = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/persons/");
             testRequest.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
             testRequest.Headers.Add("X-Ai-NationalIdentityNumber", "personnumber");
-            testRequest.Headers.Add("X-Ai-LastName", "lastname");
+            testRequest.Headers.Add("X-Ai-LastName", ConvertToBase64("lastname"));
 
             // Act
             HttpResponseMessage response = await client.SendAsync(testRequest);
@@ -147,7 +147,7 @@ namespace Altinn.Platform.Register.Tests.IntegrationTests
             HttpRequestMessage testRequest = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/persons/");
             testRequest.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
             testRequest.Headers.Add("X-Ai-NationalIdentityNumber", "personnumber");
-            testRequest.Headers.Add("X-Ai-LastName", "lastname");
+            testRequest.Headers.Add("X-Ai-LastName", ConvertToBase64("lastname"));
 
             // Act
             HttpResponseMessage response = await client.SendAsync(testRequest);
@@ -178,7 +178,26 @@ namespace Altinn.Platform.Register.Tests.IntegrationTests
             HttpRequestMessage testRequest = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/persons/");
             testRequest.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
             testRequest.Headers.Add("X-Ai-NationalIdentityNumber", "personnumber");
-            testRequest.Headers.Add("X-Ai-LastName", "lastname");
+            testRequest.Headers.Add("X-Ai-LastName", ConvertToBase64("lastname"));
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(testRequest);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetPerson_AuthenticationLevelTooLow_ReturnsForbidden()
+        {
+            // Arrange
+            string token = PrincipalUtil.GetToken(1, 1);
+
+            HttpClient client = _webApplicationFactorySetup.GetTestServerClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            HttpRequestMessage testRequest = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/persons/");
+            testRequest.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
 
             // Act
             HttpResponseMessage response = await client.SendAsync(testRequest);
@@ -192,6 +211,12 @@ namespace Altinn.Platform.Register.Tests.IntegrationTests
             string content = JsonSerializer.Serialize(obj);
             StringContent stringContent = new StringContent(content, Encoding.UTF8, "application/json");
             return await Task.FromResult(new HttpResponseMessage { Content = stringContent });
+        }
+
+        private string ConvertToBase64(string text)
+        {
+            var bytes = Encoding.UTF8.GetBytes(text);
+            return Convert.ToBase64String(bytes);
         }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Register/Altinn.Platform.Register.Tests/UnitTests/PersonLookupIdentifiersTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Register/Altinn.Platform.Register.Tests/UnitTests/PersonLookupIdentifiersTests.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+using System;
+using System.Text;
+
+using Altinn.Platform.Register.Models;
+
+using Xunit;
+
+namespace Altinn.Platform.Register.Tests.UnitTests
+{
+    public class PersonLookupIdentifiersTests
+    {
+        [Fact]
+        public void LastNameTest_ReadNotEncoded_ReturnsLiteral()
+        {
+            // Arrange
+            var target = new PersonLookupIdentifiers
+            {
+                LastName = "hopla"
+            };
+
+            // Act
+            var actual = target.LastName;
+
+            // Asserts
+            Assert.Equal("hopla", actual);
+        }
+
+        [Fact]
+        public void LastNameTest_ReadEncoded_ReturnsDecoded()
+        {
+            // Arrange
+            var bytes = Encoding.UTF8.GetBytes("Hørtfør");
+            var base64 = Convert.ToBase64String(bytes);
+            var target = new PersonLookupIdentifiers
+            {
+                LastName = base64
+            };
+
+            // Act
+            var actual = target.LastName;
+
+            // Asserts
+            Assert.Equal("Hørtfør", actual);
+        }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Register/Register/Controllers/PersonsController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Register/Register/Controllers/PersonsController.cs
@@ -18,6 +18,7 @@ namespace Altinn.Platform.Register.Controllers
     /// The <see cref="PersonsController"/> provides the API endpoints related to persons.
     /// </summary>
     [Authorize(Policy = "PlatformAccess")]
+    [Authorize(Policy = "AuthorizationLevel2")]
     [Route("register/api/v1/persons")]
     public class PersonsController : ControllerBase
     {
@@ -36,10 +37,10 @@ namespace Altinn.Platform.Register.Controllers
         /// Gets the <see cref="Person"/> with the given national identity number.
         /// </summary>
         /// <remarks>
-        /// This method can be used to retrieve the party and person object for an identified person with
-        /// a national identity number. The service will track the number of invalid input combinations and
-        /// block further requests if the number of failed lookups have exceeded a configurable number. The
-        /// user will be prevented from performing new searches for a configurable number of seconds.
+        /// This endpoint can be used to retrieve the person object for an identified person. The service
+        /// will track the number of failed lookup attempts and block further requests if the number of failed
+        /// lookups have exceeded a configurable number. The user will be prevented from performing new searches
+        /// for a configurable number of seconds.
         /// </remarks>
         /// <returns>The party of the identified person.</returns>
         [HttpGet]

--- a/src/Altinn.Platform/Altinn.Platform.Register/Register/Models/PersonLookupIdentifiers.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Register/Register/Models/PersonLookupIdentifiers.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
 
 using Microsoft.AspNetCore.Mvc;
 
@@ -9,6 +11,8 @@ namespace Altinn.Platform.Register.Models
     /// </summary>
     public class PersonLookupIdentifiers
     {
+        private string _lastName;
+
         /// <summary>
         /// The unique national identity number of the person.
         /// </summary>
@@ -17,10 +21,29 @@ namespace Altinn.Platform.Register.Models
         public string NationalIdentityNumber { get; set; }
 
         /// <summary>
-        /// The last name of the person. This must match.
+        /// The last name of the person. This must match the last name of the identified person.
+        /// The value is assumed to be base64 encoded from an UTF-8 string.
         /// </summary>
         [FromHeader(Name = "X-Ai-LastName")]
         [Required]
-        public string LastName { get; set; }
+        public string LastName
+        {
+            get
+            {
+                if (_lastName is null)
+                {
+                    return null;
+                }
+
+                Span<byte> buffer = stackalloc byte[_lastName.Length];
+                bool success = Convert.TryFromBase64String(_lastName, buffer, out int bytesParsed);
+                return success ? Encoding.UTF8.GetString(buffer[..bytesParsed]) : _lastName;
+            }
+
+            set
+            {
+                _lastName = value;
+            }
+        }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Register/Register/Program.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Register/Register/Program.cs
@@ -217,6 +217,8 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddAuthorization(options =>
     {
         options.AddPolicy("PlatformAccess", policy => policy.Requirements.Add(new AccessTokenRequirement()));
+        options.AddPolicy("AuthorizationLevel2", policy =>
+            policy.RequireClaim(AltinnCore.Authentication.Constants.AltinnCoreClaimTypes.AuthenticationLevel, "2", "3", "4"));
     });
 
     services.AddHttpClient<IOrganizations, OrganizationsWrapper>();


### PR DESCRIPTION
# Assume LastName in person lookup is base64 encoded.

## Description
Adding base64 decoding of the last name parameter for the person lookup endpoint. This should make it possible to send a name with characters not in the ASCII table.

## Fixes
- #8162

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
