### PR TITLE
feat/8243-confirm-page-texts

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.32.10",
+  "version": "3.33.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.test.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.test.tsx
@@ -9,6 +9,7 @@ import { renderWithProviders } from '../../../../testUtils';
 import Confirm, {
   returnConfirmSummaryObject,
 } from 'src/features/confirm/containers/Confirm';
+import { IParty } from 'altinn-shared/types';
 
 describe('features > confirm > Confirm', () => {
   it('should show spinner when loading required data', () => {
@@ -90,10 +91,10 @@ describe('features > confirm > Confirm', () => {
       const result = returnConfirmSummaryObject({
         languageData: {},
         instanceOwnerParty: {
-          partyId: 50001,
+          partyId: '50001',
           name: 'Ola Privatperson',
           ssn: '01017512345',
-        },
+        } as IParty,
       });
 
       expect(result).toEqual({
@@ -105,11 +106,11 @@ describe('features > confirm > Confirm', () => {
       const result = returnConfirmSummaryObject({
         languageData: {},
         instanceOwnerParty: {
-          partyId: 50001,
+          partyId: '50001',
           name: 'Ola Privatperson',
           ssn: '01017512345',
-          orgNumber: '987654321',
-        },
+          orgNumber: 987654321,
+        } as IParty,
       });
 
       expect(result).toEqual({
@@ -121,10 +122,10 @@ describe('features > confirm > Confirm', () => {
       const result = returnConfirmSummaryObject({
         languageData: {},
         instanceOwnerParty: {
-          partyId: 50001,
+          partyId: '50001',
           name: 'Ola Bedrift',
-          orgNumber: '987654321',
-        },
+          orgNumber: 987654321,
+        } as IParty,
       });
 
       expect(result).toEqual({
@@ -136,9 +137,9 @@ describe('features > confirm > Confirm', () => {
       const result = returnConfirmSummaryObject({
         languageData: {},
         instanceOwnerParty: {
-          partyId: 50001,
+          partyId: '50001',
           name: 'Ola Bedrift',
-        },
+        } as IParty,
       });
 
       expect(result).toEqual({
@@ -153,6 +154,22 @@ describe('features > confirm > Confirm', () => {
 
       expect(result).toEqual({
         'confirm.sender': '',
+      });
+    });
+
+    it('should return custom value for confirm.sender if key is supplied in text resources', () => {
+      const result = returnConfirmSummaryObject({
+        languageData: {},
+        textResources: [{ id: 'confirm.sender', value: 'Some custom value'}],
+        instanceOwnerParty: {
+          partyId: '50001',
+          name: 'Ola Privatperson',
+          ssn: '01017512345',
+        } as IParty,
+      });
+
+      expect(result).toEqual({
+        'Some custom value': '01017512345-Ola Privatperson',
       });
     });
   });

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.test.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.test.tsx
@@ -9,7 +9,7 @@ import { renderWithProviders } from '../../../../testUtils';
 import Confirm, {
   returnConfirmSummaryObject,
 } from 'src/features/confirm/containers/Confirm';
-import { IParty } from 'altinn-shared/types';
+import type { IParty } from 'altinn-shared/types';
 
 describe('features > confirm > Confirm', () => {
   it('should show spinner when loading required data', () => {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
@@ -9,7 +9,7 @@ import {
   AltinnButton,
   AltinnLoader,
 } from 'altinn-shared/components';
-import { IParty } from 'altinn-shared/types';
+import { ILanguage, IParty, ITextResource } from 'altinn-shared/types';
 import { getLanguageFromKey } from 'altinn-shared/utils/language';
 import { mapInstanceAttachments } from 'altinn-shared/utils';
 import { getAttachmentGroupings, getInstancePdf } from 'altinn-shared/utils/attachmentsUtils';
@@ -46,8 +46,9 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export interface ISummaryData {
-  languageData?: any;
-  instanceOwnerParty?: any;
+  languageData?: ILanguage;
+  instanceOwnerParty?: IParty;
+  textResources?: ITextResource[];
 }
 
 const loaderStyles = {
@@ -59,6 +60,7 @@ const loaderStyles = {
 export const returnConfirmSummaryObject = ({
   languageData,
   instanceOwnerParty,
+  textResources
 }: ISummaryData) => {
   let sender = '';
   if (instanceOwnerParty?.ssn) {
@@ -68,7 +70,13 @@ export const returnConfirmSummaryObject = ({
   }
 
   return {
-    [getLanguageFromKey('confirm.sender', languageData)]: sender,
+    [getTextFromAppOrDefault(
+      'confirm.sender',
+      textResources,
+      languageData,
+      null,
+      true,
+    )]: sender,
   };
 };
 
@@ -106,6 +114,7 @@ const Confirm = () => {
       return returnConfirmSummaryObject({
         languageData: language,
         instanceOwnerParty,
+        textResources,
       });
     }
 

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/features/confirm/containers/Confirm.tsx
@@ -9,7 +9,7 @@ import {
   AltinnButton,
   AltinnLoader,
 } from 'altinn-shared/components';
-import { ILanguage, IParty, ITextResource } from 'altinn-shared/types';
+import type { ILanguage, IParty, ITextResource } from 'altinn-shared/types';
 import { getLanguageFromKey } from 'altinn-shared/utils/language';
 import { mapInstanceAttachments } from 'altinn-shared/utils';
 import { getAttachmentGroupings, getInstancePdf } from 'altinn-shared/utils/attachmentsUtils';

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/language/texts/en.ts
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/language/texts/en.ts
@@ -20,7 +20,7 @@ export function en() {
       body: 'You are ready to submit {0}. Before you submit, we recomment that you look over and verify your responses. You cannot change your responses after submitting.',
       button_text: 'Submit',
       deadline: 'Deadline',
-      sender: 'Person',
+      sender: 'Party',
       title: 'Check your responses before submitting',
     },
     date_picker: {

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/language/texts/nb.ts
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/language/texts/nb.ts
@@ -20,7 +20,7 @@ export function nb() {
       body: 'Du er nå  klar for å sende inn {0}. Før du sender inn vil vi anbefale å se over svarene dine. Du kan ikke endre svarene etter at du har sendt inn.',
       button_text: 'Send inn',
       deadline: 'Frist innsending',
-      sender: 'Person',
+      sender: 'Aktør',
       title: 'Se over svarene dine før du sender inn',
     },
     date_picker: {

--- a/src/Altinn.Apps/AppFrontend/react/shared/src/language/texts/nn.ts
+++ b/src/Altinn.Apps/AppFrontend/react/shared/src/language/texts/nn.ts
@@ -18,7 +18,7 @@ export function nn() {
       body: 'Du er no  klar for å sende inn {0}. Før du sender inn vil vi anbefale å sjå over svara dine. Du kan ikkje endre svara etter at du har sendt inn.',
       button_text: 'Send inn',
       deadline: 'Frist innsending',
-      sender: 'Person',
+      sender: 'Aktør',
       title: 'Sjå over svara dine før du sender inn',
     },
     date_picker: {


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# feat/8243-confirm-page-texts
<!-- Summary of the changes (max 80 characters) -->
- feat: changed text for `sender` in confirm view to work for both person and orgs
- feat: possible to override `confirm.sender` with custom text

## Fixes
- #8243

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) - https://github.com/Altinn/altinn-studio-docs/pull/458
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
