### PR TITLE
Bug/get rules returns 500 when offeredby is 0

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Controllers/DelegationsController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Controllers/DelegationsController.cs
@@ -126,6 +126,12 @@ namespace Altinn.Platform.Authorization.Controllers
                 offeredByPartyIds.Add(ruleQuery.OfferedByPartyId);
             }
 
+            if (offeredByPartyIds.Count == 0)
+            {
+                _logger.LogInformation($"Unable to get the rules: Missing offeredbyPartyId value.");
+                return StatusCode(400, $"Unable to get the rules: Missing offeredbyPartyId value.");
+            }
+
             if (offeredByPartyIds.Count == 0 && coveredByPartyIds.Count == 0 && coveredByUserIds.Count == 0)
             {
                 _logger.LogInformation($"Unable to get the rules: Missing offeredby and coveredby values.");

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/Json/GetRules/GetRules_MissingOfferedByInRequestRequest.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/Json/GetRules/GetRules_MissingOfferedByInRequestRequest.json
@@ -1,0 +1,25 @@
+{
+  "parentPartyId": 0,
+  "keyRolePartyIds": [
+    0
+  ],
+  "offeredByPartyId": 0,
+  "resources": [
+    [
+        {
+          "id": "urn:altinn:org",
+          "value": "SKD"
+        },
+	{
+	"id": "urn:altinn:app",
+	"value": "TaxReport"
+	}
+    ]
+  ],
+  "coveredBy": [
+    {
+      "id": "urn:altinn:userid",
+      "value": "20001336"
+    }
+  ]
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/DelegationsControllerTest.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/DelegationsControllerTest.cs
@@ -994,6 +994,26 @@ namespace Altinn.Platform.Authorization.IntegrationTests
         }
 
         /// <summary>
+        /// Test case: GetRules with missing values in the request
+        /// Expected: GetRules returns a BadRequest response
+        /// </summary>
+        [Fact]
+        public async Task GetRules_MissingOfferedByInRequest()
+        {
+            // Arrange
+            Stream dataStream = File.OpenRead("Data/Json/GetRules/GetRules_MissingOfferedByInRequestRequest.json");
+            StreamContent content = new StreamContent(dataStream);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            // Act
+            HttpResponseMessage response = await _client.PostAsync($"authorization/api/v1/delegations/getrules", content);
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        /// <summary>
         /// Test case: GetRules for a coveredby that does not have any rules
         /// Expected: GetRules returns an empty list
         /// </summary>


### PR DESCRIPTION
# DelegationsController.GetRules returns 500 error when offeredByPartyId is "0"
GetRules should return 400 bad request when offeredbyPartyId is 0

## Description
If the offeredByPartyId value is 0 in a GetRules request, it would throw an ArgumentNullException or ArgumentOutOfRangeException. A check was added in GetRules that logs the error and returns a 400 bad request if offeredByPartyId is 0.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
