### PR TITLE
Make LocalTest maintain a copy of applicationmetadata

### DIFF
--- a/src/development/LocalTest/Configuration/LocalPlatformSettings.cs
+++ b/src/development/LocalTest/Configuration/LocalPlatformSettings.cs
@@ -36,6 +36,8 @@ namespace LocalTest.Configuration
 
         public string InstanceCollectionFolder { get; set; } = "instances/";
 
+        public string ApplicationsDataFolder { get; set; } = "applications/";
+
         public string DataCollectionFolder { get; set; } = "data/";
 
         public string EventsCollectionFolder { get; set; } = "events/";

--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Options;
 using AltinnCore.Authentication.Constants;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Platform.Storage.Repository;
 
 using LocalTest.Configuration;
 using LocalTest.Models;
@@ -35,6 +36,7 @@ namespace LocalTest.Controllers
         private readonly LocalPlatformSettings _localPlatformSettings;
         private readonly IUserProfiles _userProfileService;
         private readonly IAuthentication _authenticationService;
+        private readonly IApplicationRepository _applicationRepository;
         private readonly ILocalApp _localApp;
 
         public HomeController(
@@ -42,12 +44,14 @@ namespace LocalTest.Controllers
             IOptions<LocalPlatformSettings> localPlatformSettings,
             IUserProfiles userProfileService,
             IAuthentication authenticationService,
+            IApplicationRepository applicationRepository,
             ILocalApp localApp)
         {
             _generalSettings = generalSettings.Value;
             _localPlatformSettings = localPlatformSettings.Value;
             _userProfileService = userProfileService;
             _authenticationService = authenticationService;
+            _applicationRepository = applicationRepository;
             _localApp = localApp;
         }
 
@@ -121,6 +125,9 @@ namespace LocalTest.Controllers
             CreateJwtCookieAndAppendToResponse(token);
 
             Application app = await _localApp.GetApplicationMetadata(startAppModel.AppPathSelection);
+
+            // Ensure that the documentstorage in LocalTestingStorageBasePath is updated with the most recent app data
+            await _applicationRepository.Update(app);
 
             return Redirect($"{_generalSettings.GetBaseUrl}/{app.Id}/");
         }


### PR DESCRIPTION
LocalTest previously assumed all local apps were availible locally, so that the `/storage/api/v1/applications` endpoints could work. When running LocalTest in docker, we need to keep a copy of prevously seen apps in documentdb/applications so that we can access data about apps not currently running. This is required when an API app is fetching instances, and need to know the `Id` of the `dataType` with `appLogic` specified.

If this PR would be considered, I think the same change should be done in order to cache the policy.xml file and replace the implementation in https://github.com/Altinn/altinn-studio/pull/8229 with a caching version.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [x] Changelog is updated with a separate linked PR 
  - [x] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [x] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
