### PR TITLE
call correlating method in decorated service

### DIFF
--- a/src/studio/src/designer/backend/Services/Implementation/SourceControlLoggingDecorator.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/SourceControlLoggingDecorator.cs
@@ -99,11 +99,11 @@ namespace Altinn.Studio.Designer.Services.Implementation
         {
             try
             {
-                return _decoratedService.CloneRemoteRepository(org, repository);
+                return _decoratedService.CloneRemoteRepository(org, repository, destinationPath, branchName);
             }
             catch (Exception ex)
             {
-                LogError(ex, "CloneRemoteRepository", org, repository);
+                LogError(ex, "CloneRemoteRepository", org, repository, destinationPath, branchName);
                 throw;
             }
         }
@@ -423,10 +423,15 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
         private void LogError(Exception ex, string method, string org, string repository)
         {
+            LogError(ex, method, org, repository, repository, string.Empty);
+        }
+
+        private void LogError(Exception ex, string method, string org, string repository, string destinationPath, string branch)
+        {
             var user = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
             var debugInfo = GetDebugInfo();
 
-            _logger.LogError(ex, "Failed executing method {0} for user {1} in org {2} / repository {3}. Debug info: {4}", method, user, org, repository, debugInfo);
+            _logger.LogError(ex, "Failed executing method {0} for user {1} in org {2} / repository {3}. Destination: {5}. Branch: {5}. Debug info: {6}", method, user, org, repository, destinationPath, branch, debugInfo);
         }
 
         private object GetDebugInfo()


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# Copy app fails in studio
LogDecarator service called wrong method overload resulting in clone without destinationDirectory specified 


## Description

Whe LogDecarator called CloneRemoteRepository(org, repository) and not CloneRemoteRepository(org, repository, destinationPath, branchName) clone destination will be equal to reponame. This lead to an already exists exception.

If we want tests to reduce the chance of this happening again I would require som help in test design.

## Fixes
- #8081 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
