### PR TITLE
bug/8292-options-same-id-different-mapping

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-app-frontend",
-  "version": "3.33.0",
+  "version": "3.33.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/resources/options/fetch/fetchOptionsSagas.test.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/resources/options/fetch/fetchOptionsSagas.test.ts
@@ -1,10 +1,11 @@
 import { expectSaga, testSaga } from 'redux-saga-test-plan';
 import { select } from 'redux-saga/effects';
 import FormDataActions from 'src/features/form/data/formDataActions';
-import { checkIfOptionsShouldRefetchSaga, fetchSpecificOptionSaga, formDataSelector, instanceIdSelector, optionsSelector, userLanguageSelector, watchCheckIfOptionsShouldRefetchSaga } from 'src/shared/resources/options/fetch/fetchOptionsSagas';
+import { checkIfOptionsShouldRefetchSaga, fetchOptionsSaga, fetchSpecificOptionSaga, formDataSelector, formLayoutSelector, instanceIdSelector, optionsSelector, userLanguageSelector, watchCheckIfOptionsShouldRefetchSaga } from 'src/shared/resources/options/fetch/fetchOptionsSagas';
 import { IOptions, IRuntimeState } from 'src/types';
 import * as networking from 'altinn-shared/utils/networking';
 import { IInstance } from 'altinn-shared/types';
+import { ILayouts, ISelectionComponentProps } from 'src/features/form/layout';
 
 
 describe('shared > resources > options > fetch > fetchOptionsSagas', () => {
@@ -78,6 +79,135 @@ describe('shared > resources > options > fetch > fetchOptionsSagas', () => {
           [select(userLanguageSelector), userLanguage],
           [select(optionsSelector), optionsWithoutField],
         ])
+        .run();
+    });
+  });
+
+  describe('fetchOptionsSaga', () => {
+    it('should spawn fetchSpecificOptionSaga for each unique optionsId', () => {
+      jest.spyOn(networking, 'get').mockResolvedValue([]);
+      const formLayoutWithTwoSharedOptionIds: ILayouts = {
+        formLayout: [
+          {
+            id: 'fylke',
+            type: 'Dropdown',
+            textResourceBindings: {
+              'title': 'fylke'
+            },
+            dataModelBindings: {
+              simpleBinding: 'FlytteFra.Fylke'
+            },
+            optionsId: 'fylke',
+            required: true
+          } as ISelectionComponentProps,
+          {
+            id: 'fylke-2',
+            type: 'Dropdown',
+            textResourceBindings: {
+              title: 'fylke'
+            },
+            dataModelBindings: {
+              simpleBinding: 'FlytteFra.Fylke'
+            },
+            optionsId: 'fylke',
+            required: true
+          } as ISelectionComponentProps,
+          {
+            id: 'kommune',
+            type: 'Dropdown',
+            textResourceBindings: {
+              title: 'kommune'
+            },
+            dataModelBindings: {
+              simpleBinding: 'FlytteFra.Kommune'
+            },
+            optionsId: 'kommune',
+            required: true,
+            mapping: {
+              'FlytteFra.Fylke': 'fylke'
+            }
+          } as ISelectionComponentProps,
+        ]
+      };
+
+      return expectSaga(fetchOptionsSaga)
+        .provide([
+          [select(formLayoutSelector), formLayoutWithTwoSharedOptionIds],
+          [select(instanceIdSelector), 'someId']
+        ])
+        .fork(fetchSpecificOptionSaga, {
+          optionsId: 'fylke',
+          dataMapping: undefined,
+          secure: undefined,
+
+        })
+        .fork(fetchSpecificOptionSaga, {
+          optionsId: 'kommune',
+          dataMapping: {
+            'FlytteFra.Fylke': 'fylke'
+          },
+          secure: undefined,
+        })
+        .run();
+    });
+
+
+    it('should spawn multiple fetchSpecificOptionSaga if components have shared optionsId but different mapping', () => {
+      jest.spyOn(networking, 'get').mockResolvedValue([]);
+      const formLayoutWithSameOptionIdButDifferentMapping: ILayouts = {
+        formLayout: [
+          {
+            id: 'kommune-1',
+            type: 'Dropdown',
+            textResourceBindings: {
+              title: 'kommune'
+            },
+            dataModelBindings: {
+              simpleBinding: 'FlytteFra.Kommune'
+            },
+            optionsId: 'kommune',
+            required: true,
+            mapping: {
+              'FlytteFra.Fylke': 'fylke'
+            }
+          } as ISelectionComponentProps,
+          {
+            id: 'kommune-2',
+            type: 'Dropdown',
+            textResourceBindings: {
+              title: 'kommune'
+            },
+            dataModelBindings: {
+              simpleBinding: 'FlytteTil.Kommune'
+            },
+            optionsId: 'kommune',
+            required: true,
+            mapping: {
+              'FlytteTil.Fylke': 'fylke'
+            }
+          } as ISelectionComponentProps,
+        ]
+      };
+
+      return expectSaga(fetchOptionsSaga)
+        .provide([
+          [select(formLayoutSelector), formLayoutWithSameOptionIdButDifferentMapping],
+          [select(instanceIdSelector), 'someId']
+        ])
+        .fork(fetchSpecificOptionSaga, {
+          optionsId: 'kommune',
+          dataMapping: {
+            'FlytteFra.Fylke': 'fylke'
+          },
+          secure: undefined,
+        })
+        .fork(fetchSpecificOptionSaga, {
+          optionsId: 'kommune',
+          dataMapping: {
+            'FlytteTil.Fylke': 'fylke'
+          },
+          secure: undefined,
+        })
         .run();
     });
   });

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/resources/options/fetch/fetchOptionsSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/resources/options/fetch/fetchOptionsSagas.ts
@@ -26,18 +26,17 @@ export function* fetchOptionsSaga(): SagaIterator {
   const fetchedOptions: string[] = [];
   for (const layoutId of Object.keys(layouts)) {
     for (const element of layouts[layoutId]) {
-      const component = element as ISelectionComponentProps;
-
+      const { optionsId, mapping, secure }  = element as ISelectionComponentProps
       if (
-        component.optionsId &&
-        fetchedOptions.indexOf(component.optionsId) === -1
+        optionsId &&
+        !fetchedOptions.includes(getOptionLookupKey(optionsId, mapping))
       ) {
         yield fork(fetchSpecificOptionSaga, {
-          optionsId: component.optionsId,
-          dataMapping: component.mapping,
-          secure: component.secure,
+          optionsId,
+          dataMapping: mapping,
+          secure,
         });
-        fetchedOptions.push(component.optionsId);
+        fetchedOptions.push(optionsId);
       }
     }
   }

--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/resources/options/fetch/fetchOptionsSagas.ts
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/src/shared/resources/options/fetch/fetchOptionsSagas.ts
@@ -27,16 +27,17 @@ export function* fetchOptionsSaga(): SagaIterator {
   for (const layoutId of Object.keys(layouts)) {
     for (const element of layouts[layoutId]) {
       const { optionsId, mapping, secure }  = element as ISelectionComponentProps
+      const lookupKey = getOptionLookupKey(optionsId, mapping);
       if (
         optionsId &&
-        !fetchedOptions.includes(getOptionLookupKey(optionsId, mapping))
+        !fetchedOptions.includes(lookupKey)
       ) {
         yield fork(fetchSpecificOptionSaga, {
           optionsId,
           dataMapping: mapping,
           secure,
         });
-        fetchedOptions.push(optionsId);
+        fetchedOptions.push(lookupKey);
       }
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# bug/8292-options-same-id-different-mapping
<!-- Summary of the changes (max 80 characters) -->

Fixes check where only one call would be made for each unique id. This is no longer the case as same id's can be used with different mappings and should be fetched. Fixed by now checking against lookup-key and not id. 

App used for testing the case: https://dev.altinn.studio/repos/ttd/option-refetch-v2

## Fixes
- #8292

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [x] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
