### PR TITLE
Bug/fix keyvault settings after dotnet6 upgrade

### DIFF
--- a/src/studio/src/designer/backend/Designer.csproj
+++ b/src/studio/src/designer/backend/Designer.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Altinn.Common.AccessToken" Version="1.1.1" />
     <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.0.5" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.8.2" />
     <PackageReference Include="CompilerAttributes" Version="1.1.2" />

--- a/src/studio/src/designer/backend/Designer.csproj
+++ b/src/studio/src/designer/backend/Designer.csproj
@@ -48,8 +48,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
     <PackageReference Include="Scrutor" Version="4.1.0" />
-    <PackageReference Include="Yuniql.AspNetCore" Version="1.1.55" />
-    <PackageReference Include="Yuniql.PostgreSql" Version="1.1.55" />
+    <PackageReference Include="Yuniql.AspNetCore" Version="1.2.25" />
+    <PackageReference Include="Yuniql.PostgreSql" Version="1.2.25" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
   </ItemGroup>

--- a/src/studio/src/designer/backend/Designer.csproj
+++ b/src/studio/src/designer/backend/Designer.csproj
@@ -47,8 +47,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
     <PackageReference Include="Scrutor" Version="4.1.0" />
-    <PackageReference Include="Yuniql.AspNetCore" Version="1.2.25" />
-    <PackageReference Include="Yuniql.PostgreSql" Version="1.2.25" />
+    <PackageReference Include="Yuniql.AspNetCore" Version="1.1.55" />
+    <PackageReference Include="Yuniql.PostgreSql" Version="1.1.55" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
   </ItemGroup>

--- a/src/studio/src/designer/backend/Program.cs
+++ b/src/studio/src/designer/backend/Program.cs
@@ -68,7 +68,7 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
     logger.LogInformation($"// Program.cs // SetConfigurationProviders // Attempting to configure providers.");
     string basePath = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
     config.SetBasePath(basePath);
-    config.AddJsonFile("altinn-appsettings/altinn-appsettings-secret.json", optional: true, reloadOnChange: true);
+    config.AddJsonFile(basePath + "app/altinn-appsettings/altinn-appsettings-secret.json", optional: true, reloadOnChange: true);
     string envName = hostingEnvironment.EnvironmentName;
 
     if (basePath == "/")

--- a/src/studio/src/designer/backend/Program.cs
+++ b/src/studio/src/designer/backend/Program.cs
@@ -65,6 +65,7 @@ void ConfigureSetupLogging()
 
 async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnvironment hostingEnvironment)
 {
+    logger.LogInformation($"// Program.cs // SetConfigurationProviders // Attempting to configure providers.");
     string basePath = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
     config.SetBasePath(basePath);
     config.AddJsonFile("altinn-appsettings/altinn-appsettings-secret.json", optional: true, reloadOnChange: true);
@@ -119,6 +120,7 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
             config.AddUserSecrets(assembly, true);
         }
     }
+    logger.LogInformation($"// Program.cs // SetConfigurationProviders // Configured providers.");
 }
 
 void ConfigureLogging(ILoggingBuilder builder)

--- a/src/studio/src/designer/backend/Program.cs
+++ b/src/studio/src/designer/backend/Program.cs
@@ -2,12 +2,12 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using Altinn.Common.AccessToken.Configuration;
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Health;
 using Altinn.Studio.Designer.Infrastructure;
 using Altinn.Studio.Designer.Infrastructure.Authorization;
 using Altinn.Studio.Designer.TypedHttpClients;
-using AltinnCore.Authentication.Constants;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.EventCounterCollector;
 using Microsoft.AspNetCore.Builder;
@@ -67,7 +67,6 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
 {
     logger.LogInformation($"// Program.cs // SetConfigurationProviders // Attempting to configure providers.");
     string basePath = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
-    logger.LogInformation($"// Program.cs // SetConfigurationProviders // Base path: {basePath}");
     config.SetBasePath(basePath);
     config.AddJsonFile(basePath + "app/altinn-appsettings/altinn-appsettings-secret.json", optional: true, reloadOnChange: true);
     string envName = hostingEnvironment.EnvironmentName;
@@ -84,7 +83,7 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
     config.AddEnvironmentVariables();
     config.AddCommandLine(args);
 
-    Altinn.Common.AccessToken.Configuration.KeyVaultSettings keyVaultSettings = new Altinn.Common.AccessToken.Configuration.KeyVaultSettings();
+    KeyVaultSettings keyVaultSettings = new KeyVaultSettings();
     config.GetSection("kvSetting").Bind(keyVaultSettings);
 
     if (!string.IsNullOrEmpty(keyVaultSettings.ClientId) &&

--- a/src/studio/src/designer/backend/Program.cs
+++ b/src/studio/src/designer/backend/Program.cs
@@ -91,6 +91,7 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
         !string.IsNullOrEmpty(keyVaultSettings.ClientSecret) &&
         !string.IsNullOrEmpty(keyVaultSettings.SecretUri))
     {
+        logger.LogInformation("Setting up Key Vault");
         AzureServiceTokenProvider azureServiceTokenProvider = new AzureServiceTokenProvider($"RunAs=App;AppId={keyVaultSettings.ClientId};TenantId={keyVaultSettings.TenantId};AppKey={keyVaultSettings.ClientSecret}");
         KeyVaultClient keyVaultClient = new KeyVaultClient(
             new KeyVaultClient.AuthenticationCallback(

--- a/src/studio/src/designer/backend/Program.cs
+++ b/src/studio/src/designer/backend/Program.cs
@@ -67,6 +67,7 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
 {
     logger.LogInformation($"// Program.cs // SetConfigurationProviders // Attempting to configure providers.");
     string basePath = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
+    logger.LogInformation($"// Program.cs // SetConfigurationProviders // Base path: {basePath}");
     config.SetBasePath(basePath);
     config.AddJsonFile(basePath + "app/altinn-appsettings/altinn-appsettings-secret.json", optional: true, reloadOnChange: true);
     string envName = hostingEnvironment.EnvironmentName;
@@ -83,7 +84,7 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
     config.AddEnvironmentVariables();
     config.AddCommandLine(args);
 
-    KeyVaultSettings keyVaultSettings = new KeyVaultSettings();
+    Altinn.Common.AccessToken.Configuration.KeyVaultSettings keyVaultSettings = new Altinn.Common.AccessToken.Configuration.KeyVaultSettings();
     config.GetSection("kvSettings").Bind(keyVaultSettings);
 
     if (!string.IsNullOrEmpty(keyVaultSettings.ClientId) &&
@@ -91,7 +92,7 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
         !string.IsNullOrEmpty(keyVaultSettings.ClientSecret) &&
         !string.IsNullOrEmpty(keyVaultSettings.SecretUri))
     {
-        logger.LogInformation("Setting up Key Vault");
+        logger.LogInformation($"// Program.cs // SetConfigurationProviders // Attempting to configure KeyVault.");
         AzureServiceTokenProvider azureServiceTokenProvider = new AzureServiceTokenProvider($"RunAs=App;AppId={keyVaultSettings.ClientId};TenantId={keyVaultSettings.TenantId};AppKey={keyVaultSettings.ClientSecret}");
         KeyVaultClient keyVaultClient = new KeyVaultClient(
             new KeyVaultClient.AuthenticationCallback(
@@ -121,6 +122,7 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
             config.AddUserSecrets(assembly, true);
         }
     }
+    
     logger.LogInformation($"// Program.cs // SetConfigurationProviders // Configured providers.");
 }
 

--- a/src/studio/src/designer/backend/Program.cs
+++ b/src/studio/src/designer/backend/Program.cs
@@ -85,7 +85,7 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
     config.AddCommandLine(args);
 
     Altinn.Common.AccessToken.Configuration.KeyVaultSettings keyVaultSettings = new Altinn.Common.AccessToken.Configuration.KeyVaultSettings();
-    config.GetSection("kvSettings").Bind(keyVaultSettings);
+    config.GetSection("kvSetting").Bind(keyVaultSettings);
 
     if (!string.IsNullOrEmpty(keyVaultSettings.ClientId) &&
         !string.IsNullOrEmpty(keyVaultSettings.TenantId) &&
@@ -122,7 +122,7 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
             config.AddUserSecrets(assembly, true);
         }
     }
-    
+
     logger.LogInformation($"// Program.cs // SetConfigurationProviders // Configured providers.");
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# Bug/fix keyvault settings after dotnet6 upgrade
Fixed one small typo to make designer run in aks after dotnet6 upgrade


## Description
Branch name does no longer reflect the change, but PR does
Using same nuget (Altinn.Common.AccessToken) for keyvault settings as platform components.
Added som logging to ease later debugging


## Fixes
- #8305 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
