### PR TITLE
Introducing DelegationChangeType and pushing to DelegationChangeEventQueue

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Altinn.Platform.Authorization.sln
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Altinn.Platform.Authorization.sln
@@ -15,7 +15,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Altinn.Authorization.ABAC.U
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Altinn.Platform.Authorization.Functions", "Functions\Altinn.Platform.Authorization.Functions.csproj", "{E3B2051B-26AE-4E5D-9B50-F7601CCCCAA8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Platform.Authorization.Functions.UnitTest", "Functions\Tests\Altinn.Platform.Authorization.Functions.UnitTest.csproj", "{A0D319A5-0C9D-42D7-B896-643A5CBAC9D5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Altinn.Platform.Authorization.Functions.UnitTest", "Functions\Tests\Altinn.Platform.Authorization.Functions.UnitTest.csproj", "{A0D319A5-0C9D-42D7-B896-643A5CBAC9D5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Altinn.Platform.Authorization.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Altinn.Platform.Authorization.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Altinn.Common.PEP" Version="1.0.39" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.1.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.11.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.9.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Altinn.Authorization.ABAC" Version="0.0.5" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.8.2" />

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Configuration/AzureStorageConfiguration.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Configuration/AzureStorageConfiguration.cs
@@ -49,5 +49,20 @@ namespace Altinn.Platform.Authorization.Configuration
         /// The blob lease timeout value in seconds
         /// </summary>
         public int BlobLeaseTimeout { get; set; }
+
+        /// <summary>
+        /// The endpoint url for the storage account for delegation event queue
+        /// </summary>
+        public string DelegationEventQueueEndpoint { get; set; }
+
+        /// <summary>
+        /// The storage account name for delegation event queue
+        /// </summary>
+        public string DelegationEventQueueAccountName { get; set; }
+
+        /// <summary>
+        /// The account key for the storage account for delegation event queue
+        /// </summary>
+        public string DelegationEventQueueAccountKey { get; set; }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Controllers/DecisionController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Controllers/DecisionController.cs
@@ -316,7 +316,7 @@ namespace Altinn.Platform.Authorization.Controllers
                 Status = new XacmlContextStatus(XacmlContextStatusCode.Success)
             });
 
-            foreach (DelegationChange delegation in delegations.Where(d => !d.IsDeleted))
+            foreach (DelegationChange delegation in delegations.Where(d => d.DelegationChangeType != DelegationChangeType.RevokeLast))
             {
                 XacmlPolicy delegationPolicy = await _prp.GetPolicyVersionAsync(delegation.BlobStoragePolicyPath, delegation.BlobStorageVersionId);
                 foreach (XacmlObligationExpression obligationExpression in appPolicy.ObligationExpressions)

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Migration/v0.04/01-setup-tables.sql
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Migration/v0.04/01-setup-tables.sql
@@ -22,6 +22,9 @@ CREATE TABLE IF NOT EXISTS delegation.delegationChanges
 )
 TABLESPACE pg_default;
 
+-- Set start value of delegationChangeId to 100K to allow some room for manual debugging without collision
+ALTER SEQUENCE delegation.delegationchanges_delegationchangeid_seq RESTART WITH 100000 INCREMENT BY 1;
+
 -- Index: idx_altinnappid
 CREATE INDEX IF NOT EXISTS idx_altinnappid
   ON delegation.delegationChanges USING btree

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Migration/v0.04/01-setup-tables.sql
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Migration/v0.04/01-setup-tables.sql
@@ -1,0 +1,47 @@
+-- Enum: delegation.delegationChangeType
+DO $$ BEGIN
+    CREATE TYPE delegation.delegationChangeType AS ENUM ('Grant', 'Revoke', 'RevokeLast');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+-- Table: drop/create delegation.delegationChanges table both to drop old content and change from isDeleted to delegationChangeType
+DROP TABLE IF EXISTS delegation.delegationChanges CASCADE;
+CREATE TABLE IF NOT EXISTS delegation.delegationChanges
+(
+  delegationChangeId bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  delegationChangeType delegation.delegationChangeType NOT NULL,
+  altinnAppId character varying COLLATE pg_catalog."default" NOT NULL,
+  offeredByPartyId integer NOT NULL,
+  coveredByPartyId integer,
+  coveredByUserId integer,
+  performedByUserId integer NOT NULL,
+  blobStoragePolicyPath character varying COLLATE pg_catalog."default" NOT NULL,
+  blobStorageVersionId character varying COLLATE pg_catalog."default",
+  created timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP
+)
+TABLESPACE pg_default;
+
+-- Index: idx_altinnappid
+CREATE INDEX IF NOT EXISTS idx_altinnappid
+  ON delegation.delegationChanges USING btree
+  (altinnappid COLLATE pg_catalog."default" ASC NULLS LAST)
+  TABLESPACE pg_default;
+
+-- Index: idx_offeredby
+CREATE INDEX IF NOT EXISTS idx_offeredby
+    ON delegation.delegationChanges USING btree
+    (offeredbypartyid ASC NULLS LAST)
+    TABLESPACE pg_default;
+
+-- Index: idx_coveredbyuser
+CREATE INDEX IF NOT EXISTS idx_coveredbyuser
+    ON delegation.delegationChanges USING btree
+    (coveredbyuserid ASC NULLS LAST)
+    TABLESPACE pg_default;
+
+-- Index: idx_coveredbyparty
+CREATE INDEX IF NOT EXISTS idx_coveredbyparty
+    ON delegation.delegationChanges USING btree
+    (coveredbypartyid ASC NULLS LAST)
+    TABLESPACE pg_default;

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Migration/v0.04/01-setup-tables.sql
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Migration/v0.04/01-setup-tables.sql
@@ -1,6 +1,6 @@
 -- Enum: delegation.delegationChangeType
 DO $$ BEGIN
-    CREATE TYPE delegation.delegationChangeType AS ENUM ('Grant', 'Revoke', 'RevokeLast');
+    CREATE TYPE delegation.delegationChangeType AS ENUM ('grant', 'revoke', 'revokelast');
 EXCEPTION
     WHEN duplicate_object THEN null;
 END $$;

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Migration/v0.04/02-setup-procedures.sql
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Migration/v0.04/02-setup-procedures.sql
@@ -1,0 +1,217 @@
+-- Function: new insert function delegation.insert_delegationchange to replace old stored proc delegation.insert_change
+DROP ROUTINE IF EXISTS delegation.insert_change(
+  _altinnAppId character varying,
+  _offeredByPartyId integer,
+  _coveredByUserId integer,
+  _coveredByPartyId integer,
+  _performedByUserId integer,
+  _blobStoragePolicyPath character varying,
+  _blobStorageVersionId character varying,
+  _isDeleted bool,
+  inout _delegationChangeId bigint);
+
+CREATE OR REPLACE FUNCTION delegation.insert_delegationchange(
+  _delegationChangeType delegation.delegationChangeType,
+  _altinnappid character varying,
+  _offeredbypartyid integer,
+  _coveredbyuserid integer,
+  _coveredbypartyid integer,
+  _performedbyuserid integer,
+  _blobstoragepolicypath character varying,
+  _blobstorageversionid character varying
+)
+RETURNS SETOF delegation.delegationchanges 
+LANGUAGE 'sql'
+VOLATILE
+ROWS 1
+AS $BODY$
+  INSERT INTO delegation.delegationChanges(
+    delegationChangeType,
+    altinnAppId, 
+    offeredByPartyId,
+    coveredByUserId,
+    coveredByPartyId,
+    performedByUserId,
+    blobStoragePolicyPath,
+    blobStorageVersionId
+  )
+  VALUES (
+    _delegationChangeType,
+    _altinnAppId,
+    _offeredByPartyId,
+    _coveredByUserId,
+    _coveredByPartyId,
+    _performedByUserId,
+    _blobStoragePolicyPath,
+    _blobStorageVersionId
+  ) RETURNING *;
+$BODY$;
+
+
+-- Function: update get_current_change from including isDeleted to return delegationChangeType
+CREATE OR REPLACE FUNCTION delegation.get_current_change(
+  _altinnAppId character varying,
+  _offeredByPartyId integer,
+  _coveredByUserId integer,
+  _coveredByPartyId integer
+)
+RETURNS SETOF delegation.delegationChanges
+LANGUAGE 'sql'
+STABLE PARALLEL SAFE
+ROWS 1
+AS $BODY$
+  SELECT
+    delegationChangeId,
+    delegationChangeType,
+    altinnAppId, 
+    offeredByPartyId,
+    coveredByUserId,
+    coveredByPartyId,
+    performedByUserId,
+    blobStoragePolicyPath,
+    blobStorageVersionId,
+    created
+  FROM delegation.delegationChanges
+  WHERE
+    altinnAppId = _altinnAppId
+    AND offeredByPartyId = _offeredByPartyId
+    AND (_coveredByUserId IS NULL OR coveredByUserId = _coveredByUserId)
+    AND (_coveredByPartyId IS NULL OR coveredByPartyId = _coveredByPartyId)
+  ORDER BY delegationChangeId DESC LIMIT 1
+$BODY$;
+
+
+-- Function: get_all_changes from including isDeleted to return delegationChangeType
+CREATE OR REPLACE FUNCTION delegation.get_all_changes(
+  _altinnAppId character varying,
+  _offeredByPartyId integer,
+  _coveredByUserId integer,
+  _coveredByPartyId integer
+)
+RETURNS SETOF delegation.delegationChanges
+LANGUAGE 'sql'
+STABLE PARALLEL SAFE
+AS $BODY$
+  SELECT
+    delegationChangeId,
+    delegationChangeType,
+    altinnAppId, 
+    offeredByPartyId,
+    coveredByUserId,
+    coveredByPartyId,
+    performedByUserId,
+    blobStoragePolicyPath,
+    blobStorageVersionId,
+    created
+  FROM delegation.delegationChanges
+  WHERE
+    altinnAppId = _altinnAppId
+    AND offeredByPartyId = _offeredByPartyId
+    AND (_coveredByUserId IS NULL OR coveredByUserId = _coveredByUserId)
+    AND (_coveredByPartyId IS NULL OR coveredByPartyId = _coveredByPartyId)
+$BODY$;
+
+
+-- Function: delegation.get_all_current_changes from including isDeleted to return delegationChangeType
+CREATE OR REPLACE FUNCTION delegation.get_all_current_changes_offeredbypartyid_only(
+  _altinnappids character varying[],
+  _offeredbypartyids integer[]
+)
+RETURNS SETOF delegation.delegationchanges 
+LANGUAGE 'sql'
+STABLE PARALLEL SAFE 
+AS $BODY$
+  SELECT
+    delegationchangeid,
+    delegationChangeType,
+    altinnappid,
+    offeredbypartyid,
+    coveredbypartyid,
+    coveredbyuserid,
+    performedbyuserid,
+    blobstoragepolicypath,
+    blobstorageversionid,
+    created
+  FROM delegation.delegationchanges
+	INNER JOIN
+	(
+		SELECT MAX(delegationChangeId) AS maxChange
+	 	FROM delegation.delegationchanges
+		WHERE
+		  (_altinnappids IS NULL OR altinnAppId = ANY (_altinnAppIds))
+		  AND (offeredByPartyId = ANY (_offeredByPartyIds))
+		GROUP BY altinnAppId, offeredByPartyId, coveredByPartyId, coveredByUserId
+	) AS selectMaxChange
+	ON delegationChangeId = selectMaxChange.maxChange
+$BODY$;
+
+
+-- Function: delegation.get_all_current_changes_coveredbypartyids from including isDeleted to return delegationChangeType
+CREATE OR REPLACE FUNCTION delegation.get_all_current_changes_coveredbypartyids(
+  _altinnappids character varying[],
+  _offeredbypartyids integer[],
+  _coveredbypartyids integer[]
+)
+RETURNS SETOF delegation.delegationchanges 
+LANGUAGE 'sql'
+STABLE PARALLEL SAFE
+AS $BODY$
+  SELECT
+    delegationchangeid,
+    delegationChangeType,
+    altinnappid,
+    offeredbypartyid,
+    coveredbypartyid,
+    coveredbyuserid,
+    performedbyuserid,
+    blobstoragepolicypath,
+    blobstorageversionid,
+    created
+  FROM delegation.delegationchanges
+    INNER JOIN
+    (
+	  SELECT MAX(delegationChangeId) AS maxChange
+	  FROM delegation.delegationchanges
+	  WHERE
+	    (_altinnappids IS NULL OR altinnAppId = ANY (_altinnAppIds))
+	    AND (offeredByPartyId = ANY (_offeredByPartyIds))
+	    AND coveredByPartyId = ANY (_coveredByPartyIds)
+      GROUP BY altinnAppId, offeredByPartyId, coveredByPartyId
+    ) AS selectMaxChange
+    ON delegationChangeId = selectMaxChange.maxChange
+$BODY$;
+
+-- Function: delegation.get_all_current_changes_coveredbyuserids from including isDeleted to return delegationChangeType
+CREATE OR REPLACE FUNCTION delegation.get_all_current_changes_coveredbyuserids(
+  _altinnappids character varying[],
+  _offeredbypartyids integer[],
+  _coveredbyuserids integer[]
+)
+RETURNS SETOF delegation.delegationchanges 
+LANGUAGE 'sql'
+STABLE PARALLEL SAFE 
+AS $BODY$
+  SELECT
+    delegationchangeid,
+    delegationChangeType,
+    altinnappid,
+    offeredbypartyid,
+    coveredbypartyid,
+    coveredbyuserid,
+    performedbyuserid,
+    blobstoragepolicypath,
+    blobstorageversionid,
+    created
+  FROM delegation.delegationchanges
+    INNER JOIN
+    (
+	  SELECT MAX(delegationChangeId) AS maxChange
+	  FROM delegation.delegationchanges
+	  WHERE
+        (_altinnappids IS NULL OR altinnAppId = ANY (_altinnAppIds))
+        AND (offeredByPartyId = ANY (_offeredByPartyIds))
+        AND coveredByUserId = ANY (_coveredByUserIds)
+	  GROUP BY altinnAppId, offeredByPartyId, coveredByUserId
+    ) AS selectMaxChange
+    ON delegationChangeId = selectMaxChange.maxChange
+$BODY$;

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Migration/v0.04/03-setup-grants.sql
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Migration/v0.04/03-setup-grants.sql
@@ -1,0 +1,3 @@
+-- Grants for platform_authorization must be executed again for new sequence (Enum) and since delegationChanges table has been drop/created
+GRANT SELECT,INSERT,UPDATE,REFERENCES,DELETE,TRUNCATE,TRIGGER ON ALL TABLES IN SCHEMA delegation TO platform_authorization;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA delegation TO platform_authorization;

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChangeEvent/DelegationChangeEvent.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChangeEvent/DelegationChangeEvent.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Platform.Authorization.Models.DelegationChangeEvent
+{
+    /// <summary>
+    /// Internal model for a delegation change event used between Altinn.Platform.Authorization and this function app
+    /// </summary>
+    public class DelegationChangeEvent
+    {
+        /// <summary>
+        /// Gets or sets the type of the event.
+        /// </summary>
+        /// <value>
+        /// The type of the event.
+        /// </value>
+        [JsonPropertyName("e")]
+        public DelegationChangeEventType EventType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the delegation change.
+        /// </summary>
+        /// <value>
+        /// The delegation change.
+        /// </value>
+        [JsonPropertyName("d")]
+        public SimpleDelegationChange DelegationChange { get; set; }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChangeEvent/DelegationChangeEventList.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChangeEvent/DelegationChangeEventList.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Altinn.Platform.Authorization.Models.DelegationChangeEvent
+{
+    /// <summary>
+    /// The internal wrapper model for expressing a list of delegation change events sent from Altinn.Platform.Authorization
+    /// </summary>
+    public class DelegationChangeEventList
+    {
+        /// <summary>
+        /// Gets or sets the delegation change events.
+        /// </summary>
+        /// <value>
+        /// The delegation change events.
+        /// </value>
+        [JsonPropertyName("l")]
+        public List<DelegationChangeEvent> DelegationChangeEvents { get; set; }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChangeEvent/DelegationChangeEventType.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChangeEvent/DelegationChangeEventType.cs
@@ -1,0 +1,29 @@
+namespace Altinn.Platform.Authorization.Models.DelegationChangeEvent
+{
+    /// <summary>
+    /// The type of delegation change event
+    /// </summary>
+    public enum DelegationChangeEventType
+    {
+        /// <summary>
+        /// Undefined default value
+        /// </summary>
+        // ReSharper disable UnusedMember.Global
+        Undefined = 0,
+
+        /// <summary>
+        /// Grant event
+        /// </summary>
+        Grant = 1,
+
+        /// <summary>
+        /// Revoke event
+        /// </summary>
+        Revoke = 2,
+
+        /// <summary>
+        /// Revoke last right event
+        /// </summary>
+        RevokeLast = 3
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChangeEvent/SimpleDelegationChange.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChangeEvent/SimpleDelegationChange.cs
@@ -9,10 +9,10 @@ namespace Altinn.Platform.Authorization.Models.DelegationChangeEvent
     public class SimpleDelegationChange
     {
         /// <summary>
-        /// Gets or sets the policy change id
+        /// Gets or sets the delegation change id
         /// </summary>
-        [JsonPropertyName("p")]
-        public int PolicyChangeId { get; set; }
+        [JsonPropertyName("i")]
+        public int DelegationChangeId { get; set; }
 
         /// <summary>
         /// Gets or sets the altinnappid. E.g. skd/skattemelding

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChangeEvent/SimpleDelegationChange.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChangeEvent/SimpleDelegationChange.cs
@@ -1,71 +1,55 @@
 using System;
 using System.Text.Json.Serialization;
 
-namespace Altinn.Platform.Authorization.Models
+namespace Altinn.Platform.Authorization.Models.DelegationChangeEvent
 {
     /// <summary>
-    /// This model describes a delegation change as stored in the Authorization postgre DelegationChanges table.
+    /// This model describes a delegation change as stored in the PostgreSQL-database Authorization in the table DelegatedPolicy.
     /// </summary>
-    public class DelegationChange
+    public class SimpleDelegationChange
     {
         /// <summary>
-        /// Gets or sets the delegation change id
+        /// Gets or sets the policy change id
         /// </summary>
-        [JsonPropertyName("delegationchangeid")]
-        public int DelegationChangeId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the delegation change type
-        /// </summary>
-        [JsonPropertyName("delegationchangetype")]
-        public DelegationChangeType DelegationChangeType { get; set; }
+        [JsonPropertyName("p")]
+        public int PolicyChangeId { get; set; }
 
         /// <summary>
         /// Gets or sets the altinnappid. E.g. skd/skattemelding
         /// </summary>
-        [JsonPropertyName("altinnappid")]
+        [JsonPropertyName("a")]
         public string AltinnAppId { get; set; }
 
         /// <summary>
         /// Gets or sets the offeredbypartyid, refering to the party id of the user or organization offering the delegation.
         /// </summary>
-        [JsonPropertyName("offeredbypartyid")]
+        [JsonPropertyName("o")]
         public int OfferedByPartyId { get; set; }
 
         /// <summary>
         /// Gets or sets the coveredbypartyid, refering to the party id of the organization having received the delegation. Otherwise Null if the recipient is a user.
         /// </summary>
-        [JsonPropertyName("coveredbypartyid")]
+        [JsonPropertyName("cp")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public int? CoveredByPartyId { get; set; }
 
         /// <summary>
         /// Gets or sets the coveredbyuserid, refering to the user id of the user having received the delegation. Otherwise Null if the recipient is an organization.
         /// </summary>
-        [JsonPropertyName("coveredbyuserid")]
+        [JsonPropertyName("cu")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public int? CoveredByUserId { get; set; }
 
         /// <summary>
         /// Gets or sets the user id of the user that performed the delegation change (either added or removed rules to the policy, or deleted it entirely).
         /// </summary>
-        [JsonPropertyName("performedbyuserid")]
+        [JsonPropertyName("u")]
         public int PerformedByUserId { get; set; }
-
-        /// <summary>
-        /// Gets or sets blobstoragepolicypath.
-        /// </summary>
-        [JsonPropertyName("blobstoragepolicypath")]
-        public string BlobStoragePolicyPath { get; set; }
-
-        /// <summary>
-        /// Gets or sets the blobstorage versionid
-        /// </summary>
-        [JsonPropertyName("blobstorageversionid")]
-        public string BlobStorageVersionId { get; set; }
 
         /// <summary>
         /// Gets or sets the created date and timestamp for the delegation change
         /// </summary>
-        [JsonPropertyName("created")]
+        [JsonPropertyName("t")]
         public DateTime Created { get; set; }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChangeType.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Models/DelegationChangeType.cs
@@ -1,0 +1,29 @@
+namespace Altinn.Platform.Authorization.Models
+{
+    /// <summary>
+    /// The type of delegation change
+    /// </summary>
+    public enum DelegationChangeType
+    {
+        /// <summary>
+        /// Undefined default value
+        /// </summary>
+        // ReSharper disable UnusedMember.Global
+        Undefined = 0,
+
+        /// <summary>
+        /// Grant event
+        /// </summary>
+        Grant = 1,
+
+        /// <summary>
+        /// Revoke event
+        /// </summary>
+        Revoke = 2,
+
+        /// <summary>
+        /// Revoke last right event
+        /// </summary>
+        RevokeLast = 3
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Repositories/DelegationMetadataRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Repositories/DelegationMetadataRepository.cs
@@ -40,6 +40,7 @@ namespace Altinn.Platform.Authorization.Repositories
             _connectionString = string.Format(
                 postgresSettings.Value.ConnectionString,
                 postgresSettings.Value.AuthorizationDbPwd);
+            NpgsqlConnection.GlobalTypeMapper.MapEnum<DelegationChangeType>("delegation.delegationchangetype");
         }
 
         /// <inheritdoc/>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Repositories/DelegationMetadataRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Repositories/DelegationMetadataRepository.cs
@@ -48,7 +48,7 @@ namespace Altinn.Platform.Authorization.Repositories
         {
             try
             {
-                using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
+                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
                 await conn.OpenAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand(insertDelegationChangeFunc, conn);
@@ -81,7 +81,7 @@ namespace Altinn.Platform.Authorization.Repositories
         {
             try
             {
-                using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
+                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
                 await conn.OpenAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand(getCurrentDelegationChangeSql, conn);
@@ -110,7 +110,7 @@ namespace Altinn.Platform.Authorization.Repositories
         {
             try
             {
-                using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
+                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
                 await conn.OpenAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand(getAllDelegationChangesSql, conn);
@@ -195,7 +195,7 @@ namespace Altinn.Platform.Authorization.Repositories
         {
             try
             {
-                using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
+                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
                 await conn.OpenAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand(getAllCurrentDelegationChangesPartyIdsSql, conn);
@@ -224,7 +224,7 @@ namespace Altinn.Platform.Authorization.Repositories
         {
             try
             {
-                using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
+                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
                 await conn.OpenAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand(getAllCurrentDelegationChangesUserIdsSql, conn);
@@ -253,7 +253,7 @@ namespace Altinn.Platform.Authorization.Repositories
         {
             try
             {
-                using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
+                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
                 await conn.OpenAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand(getAllCurrentDelegationChangesOfferedByPartyIdOnlysSql, conn);

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Repositories/DelegationMetadataRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Repositories/DelegationMetadataRepository.cs
@@ -20,7 +20,7 @@ namespace Altinn.Platform.Authorization.Repositories
     {
         private readonly string _connectionString;
         private readonly ILogger _logger;
-        private readonly string insertDelegationChangeSql = "call delegation.insert_change(@_altinnAppId, @_offeredByPartyId, @_coveredByUserId, @_coveredByPartyId, @_performedByUserId, @_blobStoragePolicyPath, @_blobStorageVersionId, @_isDeleted, @_delegationChangeId)";
+        private readonly string insertDelegationChangeFunc = "select * from delegation.insert_delegationchange(@_delegationChangeType, @_altinnAppId, @_offeredByPartyId, @_coveredByUserId, @_coveredByPartyId, @_performedByUserId, @_blobStoragePolicyPath, @_blobStorageVersionId)";
         private readonly string getCurrentDelegationChangeSql = "select * from delegation.get_current_change(@_altinnAppId, @_offeredByPartyId, @_coveredByUserId, @_coveredByPartyId)";
         private readonly string getAllDelegationChangesSql = "select * from delegation.get_all_changes(@_altinnAppId, @_offeredByPartyId, @_coveredByUserId, @_coveredByPartyId)";
         private readonly string getAllCurrentDelegationChangesPartyIdsSql = "select * from delegation.get_all_current_changes_coveredbypartyids(@_altinnAppIds, @_offeredByPartyIds, @_coveredByPartyIds)";
@@ -43,28 +43,30 @@ namespace Altinn.Platform.Authorization.Repositories
         }
 
         /// <inheritdoc/>
-        public async Task<bool> InsertDelegation(string altinnAppId, int offeredByPartyId, int? coveredByPartyId, int? coveredByUserId, int delegatedByUserId, string blobStoragePolicyPath, string blobStorageVersionId, bool isDeleted = false)
+        public async Task<DelegationChange> InsertDelegation(DelegationChange delegationChange)
         {
             try
             {
                 using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
                 await conn.OpenAsync();
 
-                NpgsqlCommand pgcom = new NpgsqlCommand(insertDelegationChangeSql, conn);
-                pgcom.Parameters.AddWithValue("_altinnAppId", altinnAppId);
-                pgcom.Parameters.AddWithValue("_offeredByPartyId", offeredByPartyId);
-                pgcom.Parameters.AddWithValue("_coveredByUserId", coveredByUserId.HasValue ? coveredByUserId.Value : DBNull.Value);
-                pgcom.Parameters.AddWithValue("_coveredByPartyId", coveredByPartyId.HasValue ? coveredByPartyId.Value : DBNull.Value);
-                pgcom.Parameters.AddWithValue("_performedByUserId", delegatedByUserId);
-                pgcom.Parameters.AddWithValue("_blobStoragePolicyPath", blobStoragePolicyPath);
-                pgcom.Parameters.AddWithValue("_blobStorageVersionId", blobStorageVersionId);
-                pgcom.Parameters.AddWithValue("_isDeleted", isDeleted);
+                NpgsqlCommand pgcom = new NpgsqlCommand(insertDelegationChangeFunc, conn);
+                pgcom.Parameters.AddWithValue("_delegationChangeType", delegationChange.DelegationChangeType);
+                pgcom.Parameters.AddWithValue("_altinnAppId", delegationChange.AltinnAppId);
+                pgcom.Parameters.AddWithValue("_offeredByPartyId", delegationChange.OfferedByPartyId);
+                pgcom.Parameters.AddWithValue("_coveredByUserId", delegationChange.CoveredByUserId.HasValue ? delegationChange.CoveredByUserId.Value : DBNull.Value);
+                pgcom.Parameters.AddWithValue("_coveredByPartyId", delegationChange.CoveredByPartyId.HasValue ? delegationChange.CoveredByPartyId.Value : DBNull.Value);
+                pgcom.Parameters.AddWithValue("_performedByUserId", delegationChange.PerformedByUserId);
+                pgcom.Parameters.AddWithValue("_blobStoragePolicyPath", delegationChange.BlobStoragePolicyPath);
+                pgcom.Parameters.AddWithValue("_blobStorageVersionId", delegationChange.BlobStorageVersionId);
 
-                pgcom.Parameters.AddWithValue("_delegationChangeId", 0); // Must be included since it's specified in stored proc, but so far unable to get inserted value back.
+                using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
+                if (reader.Read())
+                {
+                    return GetDelegationChange(reader);
+                }
 
-                await pgcom.ExecuteNonQueryAsync();
-
-                return true;
+                return null;
             }
             catch (Exception e)
             {
@@ -173,18 +175,19 @@ namespace Altinn.Platform.Authorization.Repositories
 
         private static DelegationChange GetDelegationChange(NpgsqlDataReader reader)
         {
-            DelegationChange delegationChange = new DelegationChange();
-            delegationChange.PolicyChangeId = reader.GetValue<int>("delegationchangeid");
-            delegationChange.AltinnAppId = reader.GetValue<string>("altinnappid");
-            delegationChange.OfferedByPartyId = reader.GetValue<int>("offeredbypartyid");
-            delegationChange.CoveredByPartyId = reader.GetValue<int>("coveredbypartyid");
-            delegationChange.CoveredByUserId = reader.GetValue<int>("coveredbyuserid");
-            delegationChange.PerformedByUserId = reader.GetValue<int>("performedbyuserid");
-            delegationChange.BlobStoragePolicyPath = reader.GetValue<string>("blobstoragepolicypath");
-            delegationChange.BlobStorageVersionId = reader.GetValue<string>("blobstorageversionid");
-            delegationChange.IsDeleted = reader.GetValue<bool>("isdeleted");
-            delegationChange.Created = reader.GetValue<DateTime>("created");
-            return delegationChange;
+            return new DelegationChange
+            {
+                DelegationChangeId = reader.GetValue<int>("delegationchangeid"),
+                DelegationChangeType = reader.GetValue<DelegationChangeType>("delegationchangetype"),
+                AltinnAppId = reader.GetValue<string>("altinnappid"),
+                OfferedByPartyId = reader.GetValue<int>("offeredbypartyid"),
+                CoveredByPartyId = reader.GetValue<int>("coveredbypartyid"),
+                CoveredByUserId = reader.GetValue<int>("coveredbyuserid"),
+                PerformedByUserId = reader.GetValue<int>("performedbyuserid"),
+                BlobStoragePolicyPath = reader.GetValue<string>("blobstoragepolicypath"),
+                BlobStorageVersionId = reader.GetValue<string>("blobstorageversionid"),
+                Created = reader.GetValue<DateTime>("created")
+            };
         }
 
         private async Task<List<DelegationChange>> GetAllCurrentDelegationChangesCoveredByPartyIds(List<string> altinnAppIds = null, List<int> offeredByPartyIds = null, List<int> coveredByPartyIds = null)

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Repositories/Interface/IDelegationMetadataRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Repositories/Interface/IDelegationMetadataRepository.cs
@@ -11,18 +11,11 @@ namespace Altinn.Platform.Authorization.Repositories.Interface
     public interface IDelegationMetadataRepository
     {
         /// <summary>
-        /// Writes the delegation metadata to the delegation database
+        /// Writes the delegation change metadata to the delegation database
         /// </summary>
-        /// <param name="altinnAppId">The AltinnApp identifier iin the format org/appname</param>
-        /// <param name="offeredByPartyId">The party id of the entity offering the delegated the policy</param>
-        /// <param name="coveredByPartyId">The party id of the entity having received the delegated policy, if the entity is an organization</param>
-        /// <param name="coveredByUserId">The user id of the entity having received the delegated policy, if the entity is a user</param>
-        /// <param name="delegatedByUserId">The user id of the entity performing the delegation of the policy</param>
-        /// <param name="blobStoragePolicyPath">The path to the blobstorage location of the policy file</param>
-        /// <param name="blobStorageVersionId">The current blobstorage version</param>
-        /// <param name="isDeleted">Whether the delegation change is a (soft) deletion of the delegation policy</param>
-        /// <returns>A bool value representing the whether the result of the asynchronous operation was successful</returns>
-        Task<bool> InsertDelegation(string altinnAppId, int offeredByPartyId, int? coveredByPartyId, int? coveredByUserId, int delegatedByUserId, string blobStoragePolicyPath, string blobStorageVersionId, bool isDeleted = false);
+        /// <param name="delegationChange">The DelegationChange model describing the delegation, to insert in the database</param>
+        /// <returns>The complete DelegationChange record stored in the database</returns>
+        Task<DelegationChange> InsertDelegation(DelegationChange delegationChange);
 
         /// <summary>
         /// Gets the latest delegation change matching the filter values

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/DelegationChangeEventQueue.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/DelegationChangeEventQueue.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Altinn.Platform.Authorization.Configuration;
+using Altinn.Platform.Authorization.Models;
+using Altinn.Platform.Authorization.Models.DelegationChangeEvent;
+using Altinn.Platform.Authorization.Services.Interface;
+using Azure.Storage;
+using Azure.Storage.Queues;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Altinn.Platform.Authorization.Services.Implementation
+{
+    /// <inheritdoc />
+    public class DelegationChangeEventQueue : IDelegationChangeEventQueue
+    {
+        private readonly ILogger _logger;
+        private readonly AzureStorageConfiguration _storageConfig;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelegationChangeEventQueue"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="storageConfig">Azure storage queue config</param>
+        public DelegationChangeEventQueue(ILogger<DelegationChangeEventQueue> logger, IOptions<AzureStorageConfiguration> storageConfig)
+        {
+            _logger = logger;
+            _storageConfig = storageConfig.Value;
+        }
+
+        /// <summary>
+        /// Converts the delegation change to a delegation change event and pushes it to the event queue.
+        /// Throws exception if something fails
+        /// </summary>
+        /// <param name="delegationChange">The delegation change stored in postgresql</param>
+        public Task Push(DelegationChange delegationChange)
+        {
+            DelegationChangeEventList dceList = new DelegationChangeEventList
+            {
+                DelegationChangeEvents = new List<DelegationChangeEvent>
+                {
+                    new DelegationChangeEvent
+                    {
+                        EventType = (DelegationChangeEventType)delegationChange.DelegationChangeType,
+                        DelegationChange = new SimpleDelegationChange
+                        {
+                            PolicyChangeId = delegationChange.DelegationChangeId,
+                            AltinnAppId = delegationChange.AltinnAppId,
+                            OfferedByPartyId = delegationChange.OfferedByPartyId,
+                            CoveredByPartyId = delegationChange.CoveredByPartyId,
+                            CoveredByUserId = delegationChange.CoveredByUserId,
+                            PerformedByUserId = delegationChange.PerformedByUserId,
+                            Created = delegationChange.Created
+                        }
+                    }
+                }
+            };
+
+            StorageSharedKeyCredential queueCredentials = new StorageSharedKeyCredential(_storageConfig.DelegationEventQueueAccountName, _storageConfig.DelegationEventQueueAccountKey);
+            QueueClient queueClient = new QueueClient(new Uri($"{_storageConfig.DelegationEventQueueEndpoint}/delegationevents"), queueCredentials, new QueueClientOptions { MessageEncoding = QueueMessageEncoding.Base64 });
+            queueClient.SendMessage(JsonSerializer.Serialize(dceList));
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/EventMapperService.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/EventMapperService.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using Altinn.Platform.Authorization.Models;
+using Altinn.Platform.Authorization.Models.DelegationChangeEvent;
+using Altinn.Platform.Authorization.Services.Interface;
+
+namespace Altinn.Platform.Authorization.Services.Implementation
+{
+    /// <inheritdoc />
+    public class EventMapperService : IEventMapperService
+    {
+        /// <inheritdoc/>
+        public DelegationChangeEventList MapToDelegationChangeEventList(List<DelegationChange> delegationChanges)
+        {
+            return new DelegationChangeEventList
+            {
+                DelegationChangeEvents = delegationChanges.Select(delegationChange => new DelegationChangeEvent
+                {
+                    EventType = (DelegationChangeEventType)delegationChange.DelegationChangeType,
+                    DelegationChange = new SimpleDelegationChange
+                    {
+                        DelegationChangeId = delegationChange.DelegationChangeId,
+                        AltinnAppId = delegationChange.AltinnAppId,
+                        OfferedByPartyId = delegationChange.OfferedByPartyId,
+                        CoveredByPartyId = delegationChange.CoveredByPartyId,
+                        CoveredByUserId = delegationChange.CoveredByUserId,
+                        PerformedByUserId = delegationChange.PerformedByUserId,
+                        Created = delegationChange.Created
+                    }
+                }).ToList()
+            };
+        }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/PolicyAdministrationPoint.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/PolicyAdministrationPoint.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Platform.Authorization.Helpers;
 using Altinn.Platform.Authorization.Models;
-using Altinn.Platform.Authorization.Models.DelegationChangeEvent;
 using Altinn.Platform.Authorization.Repositories.Interface;
 using Altinn.Platform.Authorization.Services.Interface;
 using Azure;
@@ -26,7 +25,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         private readonly IPolicyRetrievalPoint _prp;
         private readonly IPolicyRepository _policyRepository;
         private readonly IDelegationMetadataRepository _delegationRepository;
-        private readonly IDelegationChangeEventQueue eventQueue;
+        private readonly IDelegationChangeEventQueue _eventQueue;
         private readonly int delegationChangeEventQueueErrorId = 911;
 
         /// <summary>
@@ -42,7 +41,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             _prp = policyRetrievalPoint;
             _policyRepository = policyRepository;
             _delegationRepository = delegationRepository;
-            this.eventQueue = eventQueue;
+            _eventQueue = eventQueue;
             _logger = logger;
         }
 
@@ -226,7 +225,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
 
                     try
                     {
-                        await eventQueue.Push(change);
+                        await _eventQueue.Push(change);
                     }
                     catch (Exception ex)
                     {
@@ -328,7 +327,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
 
                     try
                     {
-                        await eventQueue.Push(change);
+                        await _eventQueue.Push(change);
                     }
                     catch (Exception ex)
                     {
@@ -433,7 +432,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
 
                 try
                 {
-                    await eventQueue.Push(change);
+                    await _eventQueue.Push(change);
                 }
                 catch (Exception ex)
                 {

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/PolicyAdministrationPoint.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/PolicyAdministrationPoint.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Platform.Authorization.Helpers;
 using Altinn.Platform.Authorization.Models;
+using Altinn.Platform.Authorization.Models.DelegationChangeEvent;
 using Altinn.Platform.Authorization.Repositories.Interface;
 using Altinn.Platform.Authorization.Services.Interface;
 using Azure;
@@ -25,6 +26,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         private readonly IPolicyRetrievalPoint _prp;
         private readonly IPolicyRepository _policyRepository;
         private readonly IDelegationMetadataRepository _delegationRepository;
+        private readonly IDelegationChangeEventQueue eventQueue;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolicyAdministrationPoint"/> class.
@@ -32,12 +34,14 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         /// <param name="policyRetrievalPoint">The policy retrieval point</param>
         /// <param name="policyRepository">The policy repository (blob storage)</param>
         /// <param name="delegationRepository">The delegation change repository (postgresql)</param>
+        /// <param name="eventQueue">The delegation change event queue service to post events for any delegation change</param>
         /// <param name="logger">Logger instance</param>
-        public PolicyAdministrationPoint(IPolicyRetrievalPoint policyRetrievalPoint, IPolicyRepository policyRepository, IDelegationMetadataRepository delegationRepository, ILogger<IPolicyAdministrationPoint> logger)
+        public PolicyAdministrationPoint(IPolicyRetrievalPoint policyRetrievalPoint, IPolicyRepository policyRepository, IDelegationMetadataRepository delegationRepository, IDelegationChangeEventQueue eventQueue, ILogger<IPolicyAdministrationPoint> logger)
         {
             _prp = policyRetrievalPoint;
             _policyRepository = policyRepository;
             _delegationRepository = delegationRepository;
+            this.eventQueue = eventQueue;
             _logger = logger;
         }
 
@@ -72,7 +76,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "An exception occured while processing authorization rules for delegation on delegation policy path: {delegationPolicypath}", delegationPolicypath);
-                }                
+                }
 
                 foreach (Rule rule in delegationDict[delegationPolicypath])
                 {
@@ -163,7 +167,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     // Check for a current delegation change from postgresql
                     DelegationChange currentChange = await _delegationRepository.GetCurrentDelegationChange($"{org}/{app}", offeredByPartyId, coveredByPartyId, coveredByUserId);
                     XacmlPolicy existingDelegationPolicy = null;
-                    if (currentChange != null && !currentChange.IsDeleted)
+                    if (currentChange != null && currentChange.DelegationChangeType != DelegationChangeType.RevokeLast)
                     {
                         existingDelegationPolicy = await _prp.GetPolicyVersionAsync(policyPath, currentChange.BlobStorageVersionId);
                     }
@@ -197,8 +201,20 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     }
 
                     // Write delegation change to postgresql
-                    bool postgreSuccess = await _delegationRepository.InsertDelegation($"{org}/{app}", offeredByPartyId, coveredByPartyId, coveredByUserId, delegatedByUserId, policyPath, blobResponse.Value.VersionId);
-                    if (!postgreSuccess)
+                    DelegationChange change = new DelegationChange
+                    {
+                        DelegationChangeType = DelegationChangeType.Grant,
+                        AltinnAppId = $"{org}/{app}",
+                        OfferedByPartyId = offeredByPartyId,
+                        CoveredByPartyId = coveredByPartyId,
+                        CoveredByUserId = coveredByUserId,
+                        PerformedByUserId = delegatedByUserId,
+                        BlobStoragePolicyPath = policyPath,
+                        BlobStorageVersionId = blobResponse.Value.VersionId
+                    };
+
+                    change = await _delegationRepository.InsertDelegation(change);
+                    if (change == null || change.DelegationChangeId <= 0)
                     {
                         // Comment:
                         // This means that the current version of the root blob is no longer in sync with changes in authorization postgresql delegation.delegatedpolicy table.
@@ -207,7 +223,20 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                         return false;
                     }
 
+                    try
+                    {
+                        await eventQueue.Push(change);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogCritical(new EventId(911, "DelegationChangeEventQueue.Push.Error"), ex, "AddRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {change}", change);
+                    }
+                    
                     return true;
+                }
+                catch (Exception ex)
+                {
+                    throw; // todo cleanup temp debug
                 }
                 finally
                 {
@@ -237,7 +266,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 DelegationChange currentChange = await _delegationRepository.GetCurrentDelegationChange($"{org}/{app}", deleteRequest.PolicyMatch.OfferedByPartyId, coveredByPartyId, coveredByUserId);
 
                 XacmlPolicy existingDelegationPolicy = null;
-                if (currentChange.IsDeleted)
+                if (currentChange.DelegationChangeType == DelegationChangeType.RevokeLast)
                 {
                     _logger.LogWarning("The policy is already deleted for App: {org}/{app} CoveredBy: {coveredBy} OfferedBy: {offeredBy}", org, app, coveredBy, offeredBy);
                     return null;
@@ -278,14 +307,35 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     }
 
                     // Write delegation change to postgresql
-                    bool postgreSuccess = await _delegationRepository.InsertDelegation($"{org}/{app}", deleteRequest.PolicyMatch.OfferedByPartyId, coveredByPartyId, coveredByUserId, deleteRequest.DeletedByUserId, policyPath, response.Value.VersionId, isAllRulesDeleted);
-                    if (!postgreSuccess)
+                    DelegationChange change = new DelegationChange
+                    {
+                        DelegationChangeType = isAllRulesDeleted ? DelegationChangeType.RevokeLast : DelegationChangeType.Revoke,
+                        AltinnAppId = $"{org}/{app}",
+                        OfferedByPartyId = deleteRequest.PolicyMatch.OfferedByPartyId,
+                        CoveredByPartyId = coveredByPartyId,
+                        CoveredByUserId = coveredByUserId,
+                        PerformedByUserId = deleteRequest.DeletedByUserId,
+                        BlobStoragePolicyPath = policyPath,
+                        BlobStorageVersionId = response.Value.VersionId
+                    };
+
+                    change = await _delegationRepository.InsertDelegation(change);
+                    if (change == null || change.DelegationChangeId <= 0)
                     {
                         // Comment:
                         // This means that the current version of the root blob is no longer in sync with changes in authorization postgresql delegation.delegatedpolicy table.
                         // The root blob is in effect orphaned/ignored as the delegation policies are always to be read by version, and will be overritten by the next delegation change.
                         _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {policyPath}. is authorization postgresql database alive and well?", policyPath);
                         return null;
+                    }
+
+                    try
+                    {
+                        await eventQueue.Push(change);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogCritical(new EventId(911, "DelegationChangeEventQueue.Push.Error"), ex, "DeleteRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChangeEventType: eventType, DelegationChange: {change}", change);
                     }
                 }
             }
@@ -335,7 +385,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             {
                 DelegationChange currentChange = await _delegationRepository.GetCurrentDelegationChange($"{org}/{app}", policyToDelete.PolicyMatch.OfferedByPartyId, coveredByPartyId, coveredByUserId);
 
-                if (currentChange.IsDeleted)
+                if (currentChange.DelegationChangeType == DelegationChangeType.RevokeLast)
                 {
                     _logger.LogWarning("The policy is already deleted for App: {org}/{app} CoveredBy: {coveredBy} OfferedBy: {policyToDelete.PolicyMatch.OfferedByPartyId}", org, app, coveredBy, policyToDelete.PolicyMatch.OfferedByPartyId);
                     return null;
@@ -362,14 +412,35 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     return null;
                 }
 
-                bool postgreSuccess = await _delegationRepository.InsertDelegation($"{org}/{app}", policyToDelete.PolicyMatch.OfferedByPartyId, coveredByPartyId, coveredByUserId, policyToDelete.DeletedByUserId, policyPath, response.Value.VersionId, true);
-                if (!postgreSuccess)
+                DelegationChange change = new DelegationChange
+                {
+                    DelegationChangeType = DelegationChangeType.RevokeLast,
+                    AltinnAppId = $"{org}/{app}",
+                    OfferedByPartyId = policyToDelete.PolicyMatch.OfferedByPartyId,
+                    CoveredByPartyId = coveredByPartyId,
+                    CoveredByUserId = coveredByUserId,
+                    PerformedByUserId = policyToDelete.DeletedByUserId,
+                    BlobStoragePolicyPath = policyPath,
+                    BlobStorageVersionId = response.Value.VersionId
+                };
+
+                change = await _delegationRepository.InsertDelegation(change);
+                if (change == null || change.DelegationChangeId <= 0)
                 {
                     // Comment:
                     // This means that the current version of the root blob is no longer in sync with changes in authorization postgresql delegation.delegatedpolicy table.
                     // The root blob is in effect orphaned/ignored as the delegation policies are always to be read by version, and will be overritten by the next delegation change.
                     _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {policyPath}. is authorization postgresql database alive and well?", policyPath);
                     return null;
+                }
+
+                try
+                {
+                    await eventQueue.Push(change);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogCritical(new EventId(911, "DelegationChangeEventQueue.Push.Error"), ex, "DeletePolicy could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChangeEventType: {DelegationChangeEventType.RevokeLast}, DelegationChange: {change}", DelegationChangeEventType.RevokeLast, change);
                 }
 
                 return currentPolicyRules;

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/PolicyAdministrationPoint.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/PolicyAdministrationPoint.cs
@@ -27,6 +27,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         private readonly IPolicyRepository _policyRepository;
         private readonly IDelegationMetadataRepository _delegationRepository;
         private readonly IDelegationChangeEventQueue eventQueue;
+        private readonly int delegationChangeEventQueueErrorId = 911;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolicyAdministrationPoint"/> class.
@@ -229,14 +230,10 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogCritical(new EventId(911, "DelegationChangeEventQueue.Push.Error"), ex, "AddRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {change}", change);
+                        _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "AddRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {change}", change);
                     }
                     
                     return true;
-                }
-                catch (Exception ex)
-                {
-                    throw; // todo cleanup temp debug
                 }
                 finally
                 {
@@ -335,7 +332,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogCritical(new EventId(911, "DelegationChangeEventQueue.Push.Error"), ex, "DeleteRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChangeEventType: eventType, DelegationChange: {change}", change);
+                        _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "DeleteRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {change}", change);
                     }
                 }
             }
@@ -440,7 +437,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogCritical(new EventId(911, "DelegationChangeEventQueue.Push.Error"), ex, "DeletePolicy could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChangeEventType: {DelegationChangeEventType.RevokeLast}, DelegationChange: {change}", DelegationChangeEventType.RevokeLast, change);
+                    _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "DeletePolicy could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {change}", change);
                 }
 
                 return currentPolicyRules;

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/PolicyInformationPoint.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Implementation/PolicyInformationPoint.cs
@@ -38,7 +38,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             List<DelegationChange> delegationChanges = await _delegationRepository.GetAllCurrentDelegationChanges(offeredByPartyIds, appIds, coveredByPartyIds, coveredByUserIds);
             foreach (DelegationChange delegationChange in delegationChanges)
             {
-                if (!delegationChange.IsDeleted)
+                if (delegationChange.DelegationChangeType != DelegationChangeType.RevokeLast)
                 {
                     XacmlPolicy policy = await _prp.GetPolicyVersionAsync(delegationChange.BlobStoragePolicyPath, delegationChange.BlobStorageVersionId);
                     rules.AddRange(GetRulesFromPolicyAndDelegationChange(policy.Rules, delegationChange));

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Interface/IDelegationChangeEventQueue.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Interface/IDelegationChangeEventQueue.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Altinn.Platform.Authorization.Models;
+using Azure.Storage.Queues.Models;
 
 namespace Altinn.Platform.Authorization.Services.Interface
 {
@@ -13,6 +14,6 @@ namespace Altinn.Platform.Authorization.Services.Interface
         /// Throws exception if something fails
         /// </summary>
         /// <param name="delegationChange">The delegation change stored in postgresql</param>
-        Task Push(DelegationChange delegationChange);
+        Task<SendReceipt> Push(DelegationChange delegationChange);
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Interface/IDelegationChangeEventQueue.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Interface/IDelegationChangeEventQueue.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using Altinn.Platform.Authorization.Models;
+
+namespace Altinn.Platform.Authorization.Services.Interface
+{
+    /// <summary>
+    /// The service used to map internal delegation change to delegation change events and push them to the event queue.
+    /// </summary>
+    public interface IDelegationChangeEventQueue
+    {
+        /// <summary>
+        /// Converts the delegation change to a delegation change event and pushes it to the event queue.
+        /// Throws exception if something fails
+        /// </summary>
+        /// <param name="delegationChange">The delegation change stored in postgresql</param>
+        Task Push(DelegationChange delegationChange);
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Interface/IEventMapperService.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Interface/IEventMapperService.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Altinn.Platform.Authorization.Models;
+using Altinn.Platform.Authorization.Models.DelegationChangeEvent;
+
+namespace Altinn.Platform.Authorization.Services.Interface
+{
+    /// <summary>
+    /// Service mapping internal delegation changes to delegation change events
+    /// </summary>
+    public interface IEventMapperService
+    {
+        /// <summary>
+        /// Maps to DelegationChangeEventList used for pushing delegation events to the event queue
+        /// </summary>
+        /// <param name="delegationChanges">List of delegation changes from postgreSQL</param>
+        /// <returns>DelegationChangeEventList</returns>
+        public DelegationChangeEventList MapToDelegationChangeEventList(List<DelegationChange> delegationChanges);
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Interface/IPolicyAdministrationPoint.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Services/Interface/IPolicyAdministrationPoint.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Platform.Authorization.Models;
 
 namespace Altinn.Platform.Authorization.Services.Interface

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Startup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Startup.cs
@@ -88,11 +88,12 @@ namespace Altinn.Platform.Authorization
             services.AddSingleton<IContextHandler, ContextHandler>();
             services.AddSingleton<IDelegationContextHandler, DelegationContextHandler>();
             services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPoint>();
-            services.AddSingleton<Services.Interface.IPolicyInformationPoint, PolicyInformationPoint>();
+            services.AddSingleton<IPolicyInformationPoint, PolicyInformationPoint>();
             services.AddSingleton<IPolicyAdministrationPoint, PolicyAdministrationPoint>();
             services.AddSingleton<IPolicyRepository, PolicyRepository>();
             services.AddSingleton<IInstanceMetadataRepository, InstanceMetadataRepository>();
             services.AddSingleton<IDelegationMetadataRepository, DelegationMetadataRepository>();
+            services.AddSingleton<IDelegationChangeEventQueue, DelegationChangeEventQueue>();
             services.Configure<GeneralSettings>(Configuration.GetSection("GeneralSettings"));
             services.Configure<AzureStorageConfiguration>(Configuration.GetSection("AzureStorageConfiguration"));
             services.Configure<AzureCosmosSettings>(Configuration.GetSection("AzureCosmosSettings"));

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Startup.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Startup.cs
@@ -94,6 +94,7 @@ namespace Altinn.Platform.Authorization
             services.AddSingleton<IInstanceMetadataRepository, InstanceMetadataRepository>();
             services.AddSingleton<IDelegationMetadataRepository, DelegationMetadataRepository>();
             services.AddSingleton<IDelegationChangeEventQueue, DelegationChangeEventQueue>();
+            services.AddSingleton<IEventMapperService, EventMapperService>();
             services.Configure<GeneralSettings>(Configuration.GetSection("GeneralSettings"));
             services.Configure<AzureStorageConfiguration>(Configuration.GetSection("AzureStorageConfiguration"));
             services.Configure<AzureCosmosSettings>(Configuration.GetSection("AzureCosmosSettings"));

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/appsettings.json
@@ -8,7 +8,10 @@
     "DelegationsAccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
     "DelegationsContainer": "delegations",
     "DelegationsBlobEndpoint": "http://127.0.0.1:10000/devstoreaccount1",
-    "BlobLeaseTimeout": 15
+    "BlobLeaseTimeout": 15,
+    "DelegationEventQueueEndpoint": "http://127.0.0.1:10000/devstoreaccount1",
+    "DelegationEventQueueAccountName": "devstoreaccount1",
+    "DelegationEventQueueAccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
   },
   "AzureCosmosSettings": {
     "EndpointUri": "https://localhost:8081",
@@ -26,7 +29,7 @@
     "AuthorizationDbPwd": "Password"
   },
   "GeneralSettings": {
-    "OpenIdWellKnownEndpoint": "http://localhost:5040/authentication/api/v1/openid/",
+    "OpenIdWellKnownEndpoint": "https://platform.at22.altinn.cloud/authentication/api/v1/openid/",
     "BridgeApiEndpoint": "https://at22.altinn.cloud/sblbridge/authorization/api/",
     "RuntimeCookieName": "AltinnStudioRuntime",
     "SBLBaseAdress": "https://at22.altinn.cloud/",

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Clients/BridgeClient.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Clients/BridgeClient.cs
@@ -18,7 +18,7 @@ namespace Altinn.Platform.Authorization.Functions.Clients;
 public class BridgeClient : IBridgeClient
 {
     private readonly IAccessTokenProvider _accessTokenProvider;
-    private const string DelegationEventEndpoint = "delegationevent";
+    private const string DelegationEventEndpoint = "platformDelegationEvents";
 
     /// <summary>
     /// Gets an instance of httpclient from httpclientfactory

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Models/DelegationChange.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Models/DelegationChange.cs
@@ -9,10 +9,10 @@ namespace Altinn.Platform.Authorization.Functions.Models;
 public class DelegationChange
 {
     /// <summary>
-    /// Gets or sets the policy change id
+    /// Gets or sets the delegation change id
     /// </summary>
-    [JsonPropertyName("p")]
-    public int PolicyChangeId { get; set; }
+    [JsonPropertyName("i")]
+    public int DelegationChangeId { get; set; }
 
     /// <summary>
     /// Gets or sets the altinnappid. E.g. skd/skattemelding

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Services/EventMapperService.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Services/EventMapperService.cs
@@ -14,7 +14,7 @@ public class EventMapperService : IEventMapperService
         return delegationChangeEventList.DelegationChangeEvents.Select(delegationChangeEvent => new PlatformDelegationEvent()
             {
                 EventType = delegationChangeEvent.EventType,
-                PolicyChangeId = delegationChangeEvent.DelegationChange.PolicyChangeId,
+                PolicyChangeId = delegationChangeEvent.DelegationChange.DelegationChangeId,
                 Created = delegationChangeEvent.DelegationChange.Created,
                 AltinnAppId = delegationChangeEvent.DelegationChange.AltinnAppId,
                 OfferedByPartyId = delegationChangeEvent.DelegationChange.OfferedByPartyId,

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Services/EventPusherService.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Services/EventPusherService.cs
@@ -100,6 +100,6 @@ public class EventPusherService : IEventPusherService
         return string.Join(
             ',',
             delegationChangeEventList.DelegationChangeEvents.Select(delegationChangeEvent =>
-                delegationChangeEvent.DelegationChange.PolicyChangeId));
+                delegationChangeEvent.DelegationChange.DelegationChangeId));
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Tests/EventMapperServiceTest.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Tests/EventMapperServiceTest.cs
@@ -24,7 +24,7 @@ public class EventMapperServiceTest
                     EventType = DelegationChangeEventType.Grant,
                     DelegationChange = new DelegationChange
                     {
-                        PolicyChangeId = 1,
+                        DelegationChangeId = 1,
                         AltinnAppId = "ttd/testapp",
                         OfferedByPartyId = 123,
                         CoveredByPartyId = 234,
@@ -72,7 +72,7 @@ public class EventMapperServiceTest
                     EventType = DelegationChangeEventType.Grant,
                     DelegationChange = new DelegationChange
                     {
-                        PolicyChangeId = 1,
+                        DelegationChangeId = 1,
                         AltinnAppId = "ttd/testapp",
                         OfferedByPartyId = 123,
                         CoveredByUserId = 234,

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Tests/EventPusherServiceTest.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Tests/EventPusherServiceTest.cs
@@ -100,7 +100,7 @@ public class EventPusherServiceTest
                     EventType = DelegationChangeEventType.Grant,
                     DelegationChange = new DelegationChange
                     {
-                        PolicyChangeId = 1,
+                        DelegationChangeId = 1,
                         AltinnAppId = "ttd/testapp",
                         OfferedByPartyId = 123,
                         CoveredByPartyId = 234,
@@ -113,7 +113,7 @@ public class EventPusherServiceTest
                     EventType = DelegationChangeEventType.Revoke,
                     DelegationChange = new DelegationChange
                     {
-                        PolicyChangeId = 2,
+                        DelegationChangeId = 2,
                         AltinnAppId = "ttd/testapp",
                         OfferedByPartyId = 123,
                         CoveredByPartyId = 234,
@@ -126,7 +126,7 @@ public class EventPusherServiceTest
                     EventType = DelegationChangeEventType.Grant,
                     DelegationChange = new DelegationChange
                     {
-                        PolicyChangeId = 3,
+                        DelegationChangeId = 3,
                         AltinnAppId = "ttd/testapp",
                         OfferedByPartyId = 123,
                         CoveredByUserId = 345,
@@ -139,7 +139,7 @@ public class EventPusherServiceTest
                     EventType = DelegationChangeEventType.RevokeLast,
                     DelegationChange = new DelegationChange
                     {
-                        PolicyChangeId = 4,
+                        DelegationChangeId = 4,
                         AltinnAppId = "ttd/testapp",
                         OfferedByPartyId = 123,
                         CoveredByUserId = 345,

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/local.settings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/local.settings.json
@@ -4,8 +4,8 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsSecretStorageType": "files",
     "QueueStorage__queueServiceUri": "https://storageaccountrgdel8df8.queue.core.windows.net",
-    "Platform:BridgeApiEndpoint": "http://devenv.altinn.no/sblbridge/authorization/api/",
-    "Platform:AccessTokenIssuer": "https://platform.at21.altinn.cloud/authentication/api/v1/openid/",
+    "Platform:BridgeApiEndpoint": "https://at22.altinn.cloud/sblbridge/authorization/api/",
+    "Platform:AccessTokenIssuer": "https://platform.at22.altinn.cloud/authentication/api/v1/openid/",
     "KeyVault:KeyVaultURI": "https://kv-delegationevents-test.vault.azure.net/"
   }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Altinn.Platform.Authorization.IntegrationTests.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Altinn.Platform.Authorization.IntegrationTests.csproj
@@ -59,11 +59,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Data\blobs\input\error\delegationeventfail\policy.xml" />
     <None Remove="Data\blobs\input\skd\taxreport\1000\u20001337\delegationpolicy.xml" />
+    <None Remove="Data\Json\AddRules\DelegationEventError.json" />
     <None Remove="Data\Json\GetResourcePolicies\Org2App1Request.json" />
     <None Remove="Data\Json\GetResourcePolicies\Org2App2Request.json" />
     <None Remove="Data\Xacml\3.0\AltinnApps\AltinnApps0001DelegationRequest.xml" />
     <None Remove="Data\Xacml\3.0\AltinnApps\AltinnApps0001DelegationResponse.xml" />
+    <None Remove="Data\Xacml\3.0\AltinnApps\error\delegationeventfail\policy.xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Altinn.Platform.Authorization.IntegrationTests.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Altinn.Platform.Authorization.IntegrationTests.csproj
@@ -59,6 +59,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Data\blobs\input\error\delegationeventfail\50001337\u20001336\delegationpolicy.xml" />
     <None Remove="Data\blobs\input\error\delegationeventfail\policy.xml" />
     <None Remove="Data\blobs\input\skd\taxreport\1000\u20001337\delegationpolicy.xml" />
     <None Remove="Data\Json\AddRules\DelegationEventError.json" />

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/Json/AddRules/DelegationEventError.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/Json/AddRules/DelegationEventError.json
@@ -1,0 +1,26 @@
+[
+  {
+    "delegatedByUserId": 20001337,
+    "offeredByPartyId": 50001337,
+    "coveredBy": [
+      {
+        "id": "urn:altinn:userid",
+        "value": "20001336"
+      }
+    ],
+    "resource": [
+      {
+        "id": "urn:altinn:org",
+        "value": "error"
+      },
+      {
+        "id": "urn:altinn:app",
+        "value": "delegationeventfail"
+      }
+    ],
+    "action": {
+      "id": "urn:oasis:names:tc:xacml:1.0:action:action-id",
+      "value": "read"
+    }
+  }
+]

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/TestDataHelper.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/TestDataHelper.cs
@@ -65,22 +65,22 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Data
             return requestToDelete;
         }
 
-        public static DelegationChange GetDelegationChange(string appid, int offeredByPartyId, int performedByUserId, bool isDeleted = true, int? coveredByPartyId = null, int? coveredByUserId = null)
+        public static DelegationChange GetDelegationChange(string altinnAppId, int offeredByPartyId, int? coveredByUserId = null, int? coveredByPartyId = null, int performedByUserId = 20001336, DelegationChangeType changeType = DelegationChangeType.Grant, int changeId = 1337)
         {
             string coveredBy = coveredByPartyId != null ? $"p{coveredByPartyId}" : $"u{coveredByUserId}";
-            DelegationChange result = new DelegationChange
+            return new DelegationChange
             {
-                AltinnAppId = appid,
+                DelegationChangeId = changeId,
+                DelegationChangeType = changeType,
+                AltinnAppId = altinnAppId,
                 OfferedByPartyId = offeredByPartyId,
                 CoveredByPartyId = coveredByPartyId,
                 CoveredByUserId = coveredByUserId,
                 PerformedByUserId = performedByUserId,
-                BlobStoragePolicyPath = $"{appid}/{offeredByPartyId}/{coveredBy}/delegationpolicy.xml",
+                BlobStoragePolicyPath = $"{altinnAppId}/{offeredByPartyId}/{coveredBy}/delegationpolicy.xml",
                 BlobStorageVersionId = "CorrectLeaseId",
-                IsDeleted = isDeleted,
                 Created = DateTime.Now
             };
-            return result;
         }
 
         public static ResourceAction GetResourceActionModel(string action, IEnumerable<string> roles)
@@ -126,24 +126,6 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Data
 
             policy.Title = title;
             return policy;
-        }
-
-        public static DelegationChange GetDelegationChange(string altinnAppId, int offeredByPartyId = 0, int? coveredByUserId = null, int? coveredByPartyId = null, bool isDeleted = false)
-        {
-            string coveredBy = coveredByPartyId != null ? $"p{coveredByPartyId}" : $"u{coveredByUserId}";
-            return new DelegationChange
-            {
-                AltinnAppId = altinnAppId,
-                BlobStorageVersionId = "CorrectLeaseId",
-                BlobStoragePolicyPath = $"{altinnAppId}/{offeredByPartyId}/{coveredBy}/delegationpolicy.xml",
-                CoveredByPartyId = coveredByPartyId,
-                CoveredByUserId = coveredByUserId,
-                Created = DateTime.Now,
-                IsDeleted = isDeleted,
-                OfferedByPartyId = offeredByPartyId,
-                PerformedByUserId = 20001336,
-                PolicyChangeId = new Random().Next()
-            };
         }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/Xacml/3.0/AltinnApps/error/delegationeventfail/policy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/Xacml/3.0/AltinnApps/error/delegationeventfail/policy.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy xmlns:xsl="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="urn:altinn:example:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides">
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:1" Effect="Permit">
+    <xacml:Description>Eksempel på samleregel som spesifiserer at både PRIV og DAGL m/sikkerhetsnivå; 2, for ressursen; error/delegationeventfail får tilgang til operasjonene; Read og Write</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">priv</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">error</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">delegationeventfail</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:ObligationExpressions>
+    <xacml:ObligationExpression FulfillOn="Permit" ObligationId="urn:altinn:obligation:1">
+      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:1" Category="urn:altinn:minimum-authenticationlevel">
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue>
+      </xacml:AttributeAssignmentExpression>
+    </xacml:ObligationExpression>
+  </xacml:ObligationExpressions>
+</xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/error/delegationeventfail/50001337/u20001336/delegationpolicy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/error/delegationeventfail/50001337/u20001336/delegationpolicy.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+	<xacml:Description>Delegation policy containing all delegated rights/actions from 50001337 to 20001336, for resources on the app; error/delegationeventfail</xacml:Description>
+	<xacml:Target/>
+	<xacml:Rule RuleId="c73079c1-ed67-4958-91e3-a388ee355097" Effect="Permit">
+		<xacml:Target>
+			<xacml:AnyOf>
+				<xacml:AllOf>
+					<xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+						<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001336</xacml:AttributeValue>
+						<xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+					</xacml:Match>
+				</xacml:AllOf>
+			</xacml:AnyOf>
+			<xacml:AnyOf>
+				<xacml:AllOf>
+					<xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+						<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">error</xacml:AttributeValue>
+						<xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+					</xacml:Match>
+					<xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+						<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">delegationeventfail</xacml:AttributeValue>
+						<xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+					</xacml:Match>
+				</xacml:AllOf>
+			</xacml:AnyOf>
+			<xacml:AnyOf>
+				<xacml:AllOf>
+					<xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+						<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Read</xacml:AttributeValue>
+						<xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+					</xacml:Match>
+				</xacml:AllOf>
+			</xacml:AnyOf>
+		</xacml:Target>
+	</xacml:Rule>
+	<xacml:Rule RuleId="79df518c-88be-479e-a594-bf05be199caa" Effect="Permit">
+		<xacml:Target>
+			<xacml:AnyOf>
+				<xacml:AllOf>
+					<xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+						<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">20001336</xacml:AttributeValue>
+						<xacml:AttributeDesignator AttributeId="urn:altinn:userid" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+					</xacml:Match>
+				</xacml:AllOf>
+			</xacml:AnyOf>
+			<xacml:AnyOf>
+				<xacml:AllOf>
+					<xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+						<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">error</xacml:AttributeValue>
+						<xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+					</xacml:Match>
+					<xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+						<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">delegationeventfail</xacml:AttributeValue>
+						<xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+					</xacml:Match>
+				</xacml:AllOf>
+			</xacml:AnyOf>
+			<xacml:AnyOf>
+				<xacml:AllOf>
+					<xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+						<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Write</xacml:AttributeValue>
+						<xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+					</xacml:Match>
+				</xacml:AllOf>
+			</xacml:AnyOf>
+		</xacml:Target>
+	</xacml:Rule>
+</xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/error/delegationeventfail/policy.xml
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Data/blobs/input/error/delegationeventfail/policy.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xacml:Policy xmlns:xsl="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="urn:altinn:example:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides">
+  <xacml:Target/>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:1" Effect="Permit">
+    <xacml:Description>Eksempel på samleregel som spesifiserer at både PRIV og DAGL m/sikkerhetsnivå; 2, for ressursen; error/delegationeventfail får tilgang til operasjonene; Read og Write</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">dagl</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">priv</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">error</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">delegationeventfail</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:ObligationExpressions>
+    <xacml:ObligationExpression FulfillOn="Permit" ObligationId="urn:altinn:obligation:1">
+      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation-assignment:1" Category="urn:altinn:minimum-authenticationlevel">
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue>
+      </xacml:AttributeAssignmentExpression>
+    </xacml:ObligationExpression>
+  </xacml:ObligationExpressions>
+</xacml:Policy>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/EventMapperServiceTest.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/EventMapperServiceTest.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using Altinn.Platform.Authorization.IntegrationTests.Util;
+using Altinn.Platform.Authorization.Models;
+using Altinn.Platform.Authorization.Models.DelegationChangeEvent;
+using Altinn.Platform.Authorization.Services.Implementation;
+using Xunit;
+
+namespace Altinn.Platform.Authorization.IntegrationTests
+{
+    public class EventMapperServiceTest
+    {
+        [Fact]
+        public void MapToDelegationChangeEventList()
+        {
+            // Arrange
+            EventMapperService mapper = new EventMapperService();
+
+            DateTime now = DateTime.Now;
+            DelegationChangeEventList expected = new DelegationChangeEventList
+            {
+                DelegationChangeEvents = new List<DelegationChangeEvent>
+                {
+                    new DelegationChangeEvent
+                    {
+                        EventType = DelegationChangeEventType.Grant,
+                        DelegationChange = new SimpleDelegationChange
+                        {
+                            DelegationChangeId = 1,
+                            AltinnAppId = "ttd/testapp",
+                            OfferedByPartyId = 123,
+                            CoveredByPartyId = 234,
+                            PerformedByUserId = 567,
+                            Created = now
+                        }
+                    }
+                }
+            };
+
+            List<DelegationChange> input = new List<DelegationChange>()
+            {
+                new DelegationChange()
+                {
+                    DelegationChangeId = 1,
+                    DelegationChangeType = DelegationChangeType.Grant,
+                    AltinnAppId = "ttd/testapp",
+                    OfferedByPartyId = 123,
+                    CoveredByPartyId = 234,
+                    PerformedByUserId = 567,
+                    BlobStoragePolicyPath = "ttd/testapp/123/p234/delegationpolicy.xml",
+                    BlobStorageVersionId = now.ToString(),
+                    Created = now
+                }
+            };
+
+            // Act
+            DelegationChangeEventList actual = mapper.MapToDelegationChangeEventList(input);
+
+            // Assert
+            AssertionUtil.AssertEqual(expected, actual);
+        }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Fixtures/PolicyRetrievalPointFixture.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Fixtures/PolicyRetrievalPointFixture.cs
@@ -43,6 +43,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Fixtures
                     services.AddScoped<IDelegationMetadataRepository, DelegationMetadataRepositoryMock>();
                     services.AddScoped<IRoles, RolesMock>();
                     services.AddScoped<IPolicyRepository, PolicyRepositoryMock>();
+                    services.AddScoped<IDelegationChangeEventQueue, DelegationChangeEventQueueMock>();
                     services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 })
                 .ConfigureAppConfiguration((hostingContext, config) =>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/MockServices/DelegationChangeEventQueueMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/MockServices/DelegationChangeEventQueueMock.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Threading.Tasks;
 using Altinn.Platform.Authorization.Models;
-using Altinn.Platform.Authorization.Models.DelegationChangeEvent;
 using Altinn.Platform.Authorization.Services.Interface;
+using Azure.Storage.Queues.Models;
 
 namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
 {
@@ -13,14 +13,14 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
         /// Mocks pushing delegation changes to the event queue
         /// </summary>
         /// <param name="delegationChange">The delegation change stored in postgresql</param>
-        public Task Push(DelegationChange delegationChange)
+        public Task<SendReceipt> Push(DelegationChange delegationChange)
         {
             if (string.IsNullOrEmpty(delegationChange.AltinnAppId) || delegationChange.AltinnAppId == "error/delegationeventfail")
             {
                 throw new Exception("DelegationChangeEventQueue || Push || Error");
             }
 
-            return Task.CompletedTask;
+            return Task.FromResult((SendReceipt)null);
         }
     }
 }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/MockServices/DelegationChangeEventQueueMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/MockServices/DelegationChangeEventQueueMock.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using Altinn.Platform.Authorization.Models;
+using Altinn.Platform.Authorization.Models.DelegationChangeEvent;
+using Altinn.Platform.Authorization.Services.Interface;
+
+namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
+{
+    /// <inheritdoc />
+    public class DelegationChangeEventQueueMock : IDelegationChangeEventQueue
+    {
+        /// <summary>
+        /// Mocks pushing delegation changes to the event queue
+        /// </summary>
+        /// <param name="delegationChange">The delegation change stored in postgresql</param>
+        public Task Push(DelegationChange delegationChange)
+        {
+            if (string.IsNullOrEmpty(delegationChange.AltinnAppId) || delegationChange.AltinnAppId == "error/delegationeventfail")
+            {
+                throw new Exception("DelegationChangeEventQueue || Push || Error");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/MockServices/DelegationMetadataRepositoryMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/MockServices/DelegationMetadataRepositoryMock.cs
@@ -17,11 +17,11 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             MetadataChanges = new Dictionary<string, List<DelegationChange>>();
         }
 
-        public Task<bool> InsertDelegation(string altinnAppId, int offeredByPartyId, int? coveredByPartyId, int? coveredByUserId, int delegatedByUserId, string blobStoragePolicyPath, string blobStorageVersionId, bool isDeleted)
+        public Task<DelegationChange> InsertDelegation(DelegationChange delegationChange)
         {
             List<DelegationChange> current;
-            string coveredBy = coveredByPartyId != null ? $"p{coveredByPartyId}" : $"u{coveredByUserId}";
-            string key = $"{altinnAppId}/{offeredByPartyId}/{coveredBy}";
+            string coveredBy = delegationChange.CoveredByPartyId != null ? $"p{delegationChange.CoveredByPartyId}" : $"u{delegationChange.CoveredByUserId}";
+            string key = $"{delegationChange.AltinnAppId}/{delegationChange.OfferedByPartyId}/{coveredBy}";
 
             if (MetadataChanges.ContainsKey(key))
             {
@@ -35,25 +35,27 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
 
             DelegationChange currentDelegationChange = new DelegationChange
             {
-                AltinnAppId = altinnAppId,
-                OfferedByPartyId = offeredByPartyId,
-                CoveredByPartyId = coveredByPartyId,
-                CoveredByUserId = coveredByUserId,
-                PerformedByUserId = delegatedByUserId,
-                BlobStoragePolicyPath = blobStoragePolicyPath,
-                BlobStorageVersionId = blobStorageVersionId,
-                IsDeleted = isDeleted,
+                DelegationChangeId = 1337,
+                DelegationChangeType = delegationChange.DelegationChangeType,
+                AltinnAppId = delegationChange.AltinnAppId,
+                OfferedByPartyId = delegationChange.OfferedByPartyId,
+                CoveredByPartyId = delegationChange.CoveredByPartyId,
+                CoveredByUserId = delegationChange.CoveredByUserId,
+                PerformedByUserId = delegationChange.PerformedByUserId,
+                BlobStoragePolicyPath = delegationChange.BlobStoragePolicyPath,
+                BlobStorageVersionId = delegationChange.BlobStorageVersionId,
                 Created = DateTime.Now
             };
     
             current.Add(currentDelegationChange);
 
-            if (string.IsNullOrEmpty(altinnAppId) || altinnAppId == "error/postgrewritechangefail")
+            if (string.IsNullOrEmpty(delegationChange.AltinnAppId) || delegationChange.AltinnAppId == "error/postgrewritechangefail")
             {
-                return Task.FromResult(false);
+                currentDelegationChange.DelegationChangeId = 0;
+                return Task.FromResult(currentDelegationChange);
             }
 
-            return Task.FromResult(true);
+            return Task.FromResult(currentDelegationChange);
         }
 
         public Task<DelegationChange> GetCurrentDelegationChange(string altinnAppId, int offeredByPartyId, int? coveredByPartyId, int? coveredByUserId)
@@ -70,7 +72,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
                     result = TestDataHelper.GetDelegationChange(altinnAppId, offeredByPartyId, coveredByUserId, coveredByPartyId);
                     break;
                 case "org1/app5":
-                    result = TestDataHelper.GetDelegationChange(altinnAppId, offeredByPartyId, coveredByUserId, coveredByPartyId, isDeleted: true);
+                    result = TestDataHelper.GetDelegationChange(altinnAppId, offeredByPartyId, coveredByUserId, coveredByPartyId, changeType: DelegationChangeType.RevokeLast);
                     break;
                 case "error/postgregetcurrentfail":
                     throw new Exception("Some exception happened");
@@ -104,7 +106,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             if (altinnAppIds.Any(appId => appId == "org1/app1") && offeredByPartyIds.Contains(50001337) && (coveredByUserIds != null && coveredByUserIds.Contains(20001338)))
             {
                 DelegationChange delegation = TestDataHelper.GetDelegationChange("org1/app1", 50001337, coveredByUserId: 20001338);
-                delegation.IsDeleted = true;
+                delegation.DelegationChangeType = DelegationChangeType.RevokeLast;
                 result.Add(delegation);
             }
 
@@ -115,37 +117,37 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
 
             if (altinnAppIds.Contains("SKD/TaxReport") && offeredByPartyIds.Contains(50001337) && (coveredByUserIds != null && coveredByUserIds.Contains(20001336)))
             {
-                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001337, isDeleted: false, coveredByUserId: 20001336, performedByUserId: 20001337));
+                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001337, coveredByUserId: 20001336, performedByUserId: 20001337, changeType: DelegationChangeType.Grant));
             }
 
             if (altinnAppIds.Contains("SKD/TaxReport") && offeredByPartyIds.Contains(50001337) && (coveredByUserIds != null && coveredByUserIds.Contains(20001335)))
             {
-                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001337, isDeleted: false, coveredByPartyId: 50001335, performedByUserId: 20001337));
+                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001337, coveredByPartyId: 50001335, performedByUserId: 20001337, changeType: DelegationChangeType.Grant));
             }
 
             if (altinnAppIds.Contains("SKD/TaxReport") && offeredByPartyIds.Contains(50001337) && (coveredByPartyIds != null && coveredByPartyIds.Contains(50001336)))
             {
-                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001337, isDeleted: false, coveredByPartyId: 50001338, performedByUserId: 20001337));
+                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001337, coveredByPartyId: 50001338, performedByUserId: 20001337, changeType: DelegationChangeType.Grant));
             }
 
             if (altinnAppIds.Contains("SKD/TaxReport") && offeredByPartyIds.Contains(50001338) && (coveredByPartyIds != null && coveredByPartyIds.Contains(50001339)))
             {
-                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001338, isDeleted: false, coveredByPartyId: 50001339, performedByUserId: 20001338));
+                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001338, coveredByPartyId: 50001339, performedByUserId: 20001338, changeType: DelegationChangeType.Grant));
             }
 
             if (altinnAppIds.Contains("SKD/TaxReport") && offeredByPartyIds.Contains(50001338) && (coveredByPartyIds != null && coveredByPartyIds.Contains(50001340)))
             {
-                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001338, isDeleted: false, coveredByPartyId: 50001340, performedByUserId: 20001338));
+                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001338, coveredByPartyId: 50001340, performedByUserId: 20001338, changeType: DelegationChangeType.Grant));
             }
 
             if (altinnAppIds.Contains("SKD/TaxReport") && offeredByPartyIds.Contains(50001338) && (coveredByPartyIds != null && coveredByPartyIds.Contains(50001336)))
             {
-                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001338, isDeleted: false, coveredByPartyId: 50001336, performedByUserId: 20001339));
+                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001338, coveredByPartyId: 50001336, performedByUserId: 20001339, changeType: DelegationChangeType.Grant));
             }
 
             if (altinnAppIds.Contains("SKD/TaxReport") && offeredByPartyIds.Contains(50001339) && (coveredByPartyIds != null && coveredByUserIds.Contains(20001336)))
             {
-                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001335, isDeleted: false, coveredByPartyId: 50001337, performedByUserId: 20001339));
+                result.Add(TestDataHelper.GetDelegationChange("SKD/TaxReport", 50001335, coveredByPartyId: 50001337, performedByUserId: 20001339, changeType: DelegationChangeType.Grant));
             }
 
             return Task.FromResult(result);

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/MockServices/DelegationMetadataRepositoryMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/MockServices/DelegationMetadataRepositoryMock.cs
@@ -76,6 +76,9 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
                     break;
                 case "error/postgregetcurrentfail":
                     throw new Exception("Some exception happened");
+                case "error/delegationeventfail":
+                    result = TestDataHelper.GetDelegationChange(altinnAppId, offeredByPartyId, coveredByUserId, coveredByPartyId, changeType: DelegationChangeType.Grant);
+                    break;
                 default:
                     result = null;
                     break;

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/PolicyAdministrationPointTest.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/PolicyAdministrationPointTest.cs
@@ -32,6 +32,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
     {
         private readonly IPolicyAdministrationPoint _pap;
         private readonly IPolicyRepository _prp;
+        private readonly IDelegationChangeEventQueue _eventQueue;
         private readonly Mock<ILogger<IPolicyAdministrationPoint>> _logger;
         private DelegationMetadataRepositoryMock _delegationMetadataRepositoryMock;
 
@@ -46,10 +47,12 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _logger = new Mock<ILogger<IPolicyAdministrationPoint>>();
             _delegationMetadataRepositoryMock = new DelegationMetadataRepositoryMock();
             _prp = new PolicyRepositoryMock();
+            _eventQueue = new DelegationChangeEventQueueMock();
             _pap = new PolicyAdministrationPoint(
                 new PolicyRetrievalPoint(_prp, memoryCache, Options.Create(new GeneralSettings { PolicyCacheTimeout = 1 })),
                 _prp,
                 _delegationMetadataRepositoryMock,
+                _eventQueue,
                 _logger.Object);
         }
 
@@ -141,9 +144,9 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, isDeleted: false, coveredByUserId: coveredBy) } },
-                { "org1/app4/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app4", offeredByPartyId, performedByUserId, isDeleted: false, coveredByUserId: coveredBy) } }
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.Revoke) } },
+                { "org1/app4/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app4", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.Revoke) } }
             };
 
             // Act
@@ -192,8 +195,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, isDeleted: false, coveredByUserId: coveredBy) } },
-                { "org1/app4/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app4", offeredByPartyId, performedByUserId, isDeleted: false, coveredByUserId: coveredBy) } }
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.Revoke) } },
+                { "org1/app4/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app4", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.Revoke) } }
             };
 
             // Act
@@ -248,7 +251,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app1/50001337/p50001336", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app1", offeredByPartyId, performedByUserId, isDeleted: false, coveredByPartyId: coveredBy) } },
+                { "org1/app1/50001337/p50001336", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app1", offeredByPartyId, performedByUserId: performedByUserId, coveredByPartyId: coveredBy, changeType: DelegationChangeType.Revoke) } },
             };
 
             // Act
@@ -298,8 +301,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, isDeleted: false, coveredByUserId: coveredBy) } },
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.Revoke) } },
             };
 
             // Act
@@ -349,8 +352,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, isDeleted: false, coveredByUserId: coveredBy) } },
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.Revoke) } },
             };
 
             // Act
@@ -408,8 +411,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, isDeleted: false, coveredByUserId: coveredBy) } },
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.Revoke) } },
             };
 
             // Act
@@ -467,8 +470,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, isDeleted: false, coveredByUserId: coveredBy) } },
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.Revoke) } },
             };
 
             // Act
@@ -526,9 +529,9 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, isDeleted: false, coveredByUserId: coveredBy) } },
-                { "error/postgrewritechangefail/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("error/postgrewritechangefail", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.Revoke) } },
+                { "error/postgrewritechangefail/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("error/postgrewritechangefail", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
             };
 
             // Act
@@ -585,8 +588,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, isDeleted: false, coveredByUserId: coveredBy) } },
-                { "org1/app4/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app4", offeredByPartyId, performedByUserId, isDeleted: false, coveredByUserId: coveredBy) } }
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.Revoke) } },
+                { "org1/app4/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app4", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.Revoke) } }
             };
 
             // Act
@@ -639,9 +642,9 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org1/app4/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app4", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } }
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org1/app4/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app4", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } }
             };
 
             // Act
@@ -692,8 +695,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
             };
 
             // Act
@@ -752,8 +755,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
             };
 
             // Act
@@ -804,8 +807,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
             };
 
             // Act
@@ -856,9 +859,9 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "error/postgrewritechangefail/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("error/postgrewritechangefail", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } }
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "error/postgrewritechangefail/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("error/postgrewritechangefail", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } }
             };
 
             // Act
@@ -917,8 +920,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
             };
 
             // Act
@@ -977,8 +980,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             Dictionary<string, List<DelegationChange>> expectedDbUpdates = new Dictionary<string, List<DelegationChange>>
             {
-                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } },
-                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId, coveredByUserId: coveredBy) } }
+                { "org1/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org1/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } },
+                { "org2/app3/50001337/u20001337", new List<DelegationChange> { TestDataHelper.GetDelegationChange("org2/app3", offeredByPartyId, performedByUserId: performedByUserId, coveredByUserId: coveredBy, changeType: DelegationChangeType.RevokeLast) } }
             };
 
             // Act
@@ -1339,6 +1342,53 @@ namespace Altinn.Platform.Authorization.IntegrationTests
                     LogLevel.Error,
                     It.IsAny<EventId>(),
                     It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == "Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: error/postgrewritechangefail/50001337/u20001337/delegationpolicy.xml" && @type.Name == "FormattedLogValues"),
+                    It.IsAny<Exception>(),
+                    (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                Times.Once);
+        }
+
+        /// <summary>
+        /// Scenario:
+        /// Tests the TryWriteDelegationPolicyRules function, but pushing the delegation event to the queue fails.
+        /// Input:
+        /// List with a rule for delegation of the app error/delegationeventfail between for a single offeredby/coveredby combination resulting in a single delegation policy.
+        /// Expected Result:
+        /// Internal exception cause pushing delegation event to fail, after delegation has been stored.
+        /// Success Criteria:
+        /// TryWriteDelegationPolicyRules returns rules as created, but a Critical Error has been logged
+        /// </summary>
+        [Fact]
+        public async Task TryWriteDelegationPolicyRules_DelegationEventQueue_Push_Exception()
+        {
+            // Arrange
+            int delegatedByUserId = 20001337;
+            int offeredByPartyId = 50001337;
+            string coveredBy = "20001336";
+            string coveredByType = AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute;
+
+            List<Rule> unsortedRules = new List<Rule>
+            {
+                TestDataHelper.GetRuleModel(delegatedByUserId, offeredByPartyId, coveredBy, coveredByType, "read", "error", "delegationeventfail"),
+            };
+
+            List<Rule> expected = new List<Rule>
+            {
+                TestDataHelper.GetRuleModel(delegatedByUserId, offeredByPartyId, coveredBy, coveredByType, "read", "error", "delegationeventfail", createdSuccessfully: true),
+            };
+
+            // Act
+            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules);
+
+            // Assert
+            Assert.Equal(expected.Count, actual.Count);
+            Assert.True(actual.All(r => r.CreatedSuccessfully));
+            Assert.True(actual.All(r => !string.IsNullOrEmpty(r.RuleId)));
+            AssertionUtil.AssertEqual(expected, actual);
+            _logger.Verify(
+                x => x.Log(
+                    LogLevel.Critical,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((@object, @type) => @object.ToString().StartsWith("AddRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange:") && @type.Name == "FormattedLogValues"),
                     It.IsAny<Exception>(),
                     (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
                 Times.Once);

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Util/AssertionUtil.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Util/AssertionUtil.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using Altinn.Platform.Authorization.Models;
+using Altinn.Platform.Authorization.Models.DelegationChangeEvent;
 using Xunit;
 
 namespace Altinn.Platform.Authorization.IntegrationTests.Util
@@ -122,6 +123,50 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Util
                                                                         && a.DelegationChangeType == expectedEntity.DelegationChangeType);
                 Assert.NotNull(actualentity);
             }
+        }
+
+        public static void AssertEqual(DelegationChangeEventList expected, DelegationChangeEventList actual)
+        {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+                return;
+            }
+
+            Assert.Equal(expected.DelegationChangeEvents.Count, actual.DelegationChangeEvents.Count);
+            for (int i = 0; i < expected.DelegationChangeEvents.Count; i++)
+            {
+                AssertEqual(expected.DelegationChangeEvents[i], actual.DelegationChangeEvents[i]);
+            }
+        }
+
+        public static void AssertEqual(DelegationChangeEvent expected, DelegationChangeEvent actual)
+        {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+                return;
+            }
+
+            Assert.Equal(expected.EventType, actual.EventType);
+            AssertEqual(expected.DelegationChange, actual.DelegationChange);
+        }
+
+        public static void AssertEqual(SimpleDelegationChange expected, SimpleDelegationChange actual)
+        {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+                return;
+            }
+
+            Assert.Equal(expected.DelegationChangeId, actual.DelegationChangeId);
+            Assert.Equal(expected.AltinnAppId, actual.AltinnAppId);
+            Assert.Equal(expected.OfferedByPartyId, actual.OfferedByPartyId);
+            Assert.Equal(expected.CoveredByPartyId, actual.CoveredByPartyId);
+            Assert.Equal(expected.CoveredByUserId, actual.CoveredByUserId);
+            Assert.Equal(expected.PerformedByUserId, actual.PerformedByUserId);
+            Assert.Equal(expected.Created, actual.Created);
         }
 
         /// <summary>

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Util/AssertionUtil.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/Util/AssertionUtil.cs
@@ -119,7 +119,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Util
                                                                         && a.CoveredByPartyId == expectedEntity.CoveredByPartyId
                                                                         && a.CoveredByUserId == expectedEntity.CoveredByUserId
                                                                         && a.OfferedByPartyId == expectedEntity.OfferedByPartyId
-                                                                        && a.IsDeleted == expectedEntity.IsDeleted);
+                                                                        && a.DelegationChangeType == expectedEntity.DelegationChangeType);
                 Assert.NotNull(actualentity);
             }
         }

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/IntegrationTests/appsettings.json
@@ -8,7 +8,10 @@
     "DelegationsAccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
     "DelegationsContainer": "metadata",
     "DelegationsBlobEndpoint": "http://127.0.0.1:10000/devstoreaccount1",
-    "BlobLeaseTimeout": 15
+    "BlobLeaseTimeout": 15,
+    "DelegationEventQueueEndpoint": "http://127.0.0.1:10000/devstoreaccount1",
+    "DelegationEventQueueAccountName": "devstoreaccount1",
+    "DelegationEventQueueAccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
   },
   "AzureCosmosSettings": {
     "EndpointUri": "https://localhost:8081",


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# Introducing DelegationChangeType and pushing to DelegationChangeEventQueue

## Description

DelegationChange table in postgreSQL updated from having IsDeleted column to a ChangeType (Grant, Revoke, RevokeLast), in order to be able to generate a complete DelegationChangeEvent, which can be retried on the DelegationChangeEventQueue for syncing with SBL Authorization (2.0) through the SBL Bridge API.

The changes to the postgreSQL database is done as a complete drop and recreate of both the table and functions.
This can/will cause errors from the production-pod during deploy, but all exceptions are  handled by code, and should not cause runtime issues only logging-"noice" during deploy.

## Fixes
- Azure DevOps US: [57862](https://dev.azure.com/digdir/Altinn/_workitems/edit/57862)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
