### PR TITLE
chore: migrate tests using user-event to updated API in version 14

### DIFF
--- a/src/studio/src/designer/frontend/dashboard/features/createService/CreateService.test.tsx
+++ b/src/studio/src/designer/frontend/dashboard/features/createService/CreateService.test.tsx
@@ -42,13 +42,14 @@ const render = () => {
 
 describe('Dashboard > CreateService', () => {
   it('should show error messages when clicking create and no owner or name is filled in', async () => {
+    const user = userEvent.setup();
     render();
 
     await waitForElementToBeRemoved(() =>
       screen.getByText('dashboard.loading'),
     );
     const createBtn = await screen.findByText('dashboard.create_service_btn');
-    userEvent.click(createBtn);
+    await user.click(createBtn);
 
     const emptyFieldErrors = await screen.findAllByText(
       'dashboard.field_cannot_be_empty',
@@ -76,26 +77,27 @@ describe('Dashboard > CreateService', () => {
   });
 
   it('should show error message that app name is too long when it exceeds max length', async () => {
+    const user = userEvent.setup();
     render();
 
     await waitForElementToBeRemoved(() =>
       screen.getByText('dashboard.loading'),
     );
 
-    userEvent.click(
+    await user.click(
       screen.getByRole((content, element) => {
         return element.hasAttribute('aria-haspopup');
       }),
     );
 
-    userEvent.click(screen.getByRole('option', { name: /user_full_name/i }));
-    userEvent.type(
+    await user.click(screen.getByRole('option', { name: /user_full_name/i }));
+    await user.type(
       screen.getByRole('textbox'),
       'this-app-name-is-longer-than-max',
     );
 
     const createBtn = await screen.findByText('dashboard.create_service_btn');
-    userEvent.click(createBtn);
+    await user.click(createBtn);
 
     const emptyFieldErrors = await screen.findAllByText(
       'dashboard.service_name_is_too_long',
@@ -104,23 +106,24 @@ describe('Dashboard > CreateService', () => {
   });
 
   it('should show error message that app name is invalid when it contains invalid characters', async () => {
+    const user = userEvent.setup();
     render();
 
     await waitForElementToBeRemoved(() =>
       screen.getByText('dashboard.loading'),
     );
 
-    userEvent.click(
+    await user.click(
       screen.getByRole((content, element) => {
         return element.hasAttribute('aria-haspopup');
       }),
     );
 
-    userEvent.click(screen.getByRole('option', { name: /user_full_name/i }));
-    userEvent.type(screen.getByRole('textbox'), 'datamodels');
+    await user.click(screen.getByRole('option', { name: /user_full_name/i }));
+    await user.type(screen.getByRole('textbox'), 'datamodels');
 
     const createBtn = await screen.findByText('dashboard.create_service_btn');
-    userEvent.click(createBtn);
+    await user.click(createBtn);
 
     const emptyFieldErrors = await screen.findAllByText(
       'dashboard.service_name_has_illegal_characters',
@@ -129,6 +132,7 @@ describe('Dashboard > CreateService', () => {
   });
 
   it('should show error message that app already exists when trying to create an app with a name that already exists', async () => {
+    const user = userEvent.setup();
     server.use(
       rest.post(
         'http://localhost/designer/api/v1/repos/user_login',
@@ -144,17 +148,17 @@ describe('Dashboard > CreateService', () => {
       screen.getByText('dashboard.loading'),
     );
 
-    userEvent.click(
+    await user.click(
       screen.getByRole((content, element) => {
         return element.hasAttribute('aria-haspopup');
       }),
     );
 
-    userEvent.click(screen.getByRole('option', { name: /user_full_name/i }));
-    userEvent.type(screen.getByRole('textbox'), 'this-app-name-exists');
+    await user.click(screen.getByRole('option', { name: /user_full_name/i }));
+    await user.type(screen.getByRole('textbox'), 'this-app-name-exists');
 
     const createBtn = await screen.findByText('dashboard.create_service_btn');
-    userEvent.click(createBtn);
+    await user.click(createBtn);
 
     const emptyFieldErrors = await screen.findAllByText(
       'dashboard.app_already_exist',
@@ -163,6 +167,7 @@ describe('Dashboard > CreateService', () => {
   });
 
   it('should show generic error message that app already exists when trying to create an app and something unknown went wrong', async () => {
+    const user = userEvent.setup();
     server.use(
       rest.post(
         'http://localhost/designer/api/v1/repos/user_login',
@@ -178,17 +183,17 @@ describe('Dashboard > CreateService', () => {
       screen.getByText('dashboard.loading'),
     );
 
-    userEvent.click(
+    await user.click(
       screen.getByRole((content, element) => {
         return element.hasAttribute('aria-haspopup');
       }),
     );
 
-    userEvent.click(screen.getByRole('option', { name: /user_full_name/i }));
-    userEvent.type(screen.getByRole('textbox'), 'new-app');
+    await user.click(screen.getByRole('option', { name: /user_full_name/i }));
+    await user.type(screen.getByRole('textbox'), 'new-app');
 
     const createBtn = await screen.findByText('dashboard.create_service_btn');
-    userEvent.click(createBtn);
+    await user.click(createBtn);
 
     const emptyFieldErrors = await screen.findAllByText(
       'dashboard.error_when_creating_app',

--- a/src/studio/src/designer/frontend/dashboard/features/dashboard/index.test.tsx
+++ b/src/studio/src/designer/frontend/dashboard/features/dashboard/index.test.tsx
@@ -69,12 +69,13 @@ describe('Dashboard > index', () => {
   });
 
   it('should show search results list and hide FavoriteReposList and OrgReposList when user types into search input', async () => {
+    const user = userEvent.setup();
     render();
 
     const searchInput = screen.getByRole('textbox', {
       name: /dashboard.search/i,
     });
-    userEvent.type(searchInput, 'search');
+    await user.type(searchInput, 'search');
 
     await waitForElementToBeRemoved(() =>
       screen.getByText('dashboard.favourites'),
@@ -86,12 +87,13 @@ describe('Dashboard > index', () => {
   });
 
   it('should hide search results list and show FavoriteReposList and OrgReposList again when user hits escape while the search input is focused', async () => {
+    const user = userEvent.setup();
     render();
 
     const searchInput = screen.getByRole('textbox', {
       name: /dashboard.search/i,
     });
-    userEvent.type(searchInput, 'search');
+    await user.type(searchInput, 'search');
 
     await waitForElementToBeRemoved(() =>
       screen.getByText('dashboard.favourites'),
@@ -101,7 +103,7 @@ describe('Dashboard > index', () => {
     expect(screen.queryByText('dashboard.my_apps')).not.toBeInTheDocument();
     expect(screen.getByText('dashboard.search_result')).toBeInTheDocument();
 
-    userEvent.keyboard('{esc}');
+    await user.keyboard('{Escape}');
 
     await waitForElementToBeRemoved(() =>
       screen.getByText('dashboard.search_result'),
@@ -115,12 +117,13 @@ describe('Dashboard > index', () => {
   });
 
   it('should hide search results list and show FavoriteReposList and OrgReposList again when user hits clear button on input field', async () => {
+    const user = userEvent.setup();
     render();
 
     const searchInput = screen.getByRole('textbox', {
       name: /dashboard.search/i,
     });
-    userEvent.type(searchInput, 'search');
+    await user.type(searchInput, 'search');
 
     await waitForElementToBeRemoved(() =>
       screen.getByText('dashboard.favourites'),
@@ -130,7 +133,7 @@ describe('Dashboard > index', () => {
     expect(screen.queryByText('dashboard.my_apps')).not.toBeInTheDocument();
     expect(screen.getByText('dashboard.search_result')).toBeInTheDocument();
 
-    userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: /dashboard.clear_search/i }),
     );
 
@@ -145,12 +148,13 @@ describe('Dashboard > index', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should navigate to create new app when clicking new app link', () => {
+  it('should navigate to create new app when clicking new app link', async () => {
+    const user = userEvent.setup();
     render();
 
     expect(window.location.href.includes('new')).toBe(false);
 
-    userEvent.click(
+    await user.click(
       screen.getByRole('link', { name: /dashboard.new_service/i }),
     );
 

--- a/src/studio/src/designer/frontend/dashboard/package.json
+++ b/src/studio/src/designer/frontend/dashboard/package.json
@@ -44,7 +44,7 @@
     "@babel/preset-react": "^7.16.7",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^12.1.4",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.0.0",
     "@types/classnames": "^2.3.1",
     "@types/enzyme": "^3.10.11",
     "@types/jest": "^27.4.1",

--- a/src/studio/src/designer/frontend/packages/schema-editor/package.json
+++ b/src/studio/src/designer/frontend/packages/schema-editor/package.json
@@ -25,7 +25,7 @@
     "@reduxjs/toolkit": "^1.8.0",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^12.1.4",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.0.0",
     "@types/enzyme": "^3.10.11",
     "@types/jest": "^27.4.1",
     "@types/react": "17.0.43",

--- a/src/studio/src/designer/frontend/ux-editor/package.json
+++ b/src/studio/src/designer/frontend/ux-editor/package.json
@@ -43,7 +43,7 @@
     "@babel/preset-react": "^7.16.7",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^12.1.4",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.0.0",
     "@types/classnames": "^2.3.1",
     "@types/deepmerge": "^2.2.0",
     "@types/enzyme": "^3.10.11",

--- a/src/studio/src/designer/frontend/yarn.lock
+++ b/src/studio/src/designer/frontend/yarn.lock
@@ -15,7 +15,7 @@ __metadata:
     "@reduxjs/toolkit": ^1.8.0
     "@testing-library/jest-dom": ^5.16.3
     "@testing-library/react": ^12.1.4
-    "@testing-library/user-event": ^13.5.0
+    "@testing-library/user-event": ^14.0.0
     "@types/enzyme": ^3.10.11
     "@types/jest": ^27.4.1
     "@types/react": 17.0.43
@@ -4617,14 +4617,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/user-event@npm:^13.5.0":
-  version: 13.5.0
-  resolution: "@testing-library/user-event@npm:13.5.0"
-  dependencies:
-    "@babel/runtime": ^7.12.5
+"@testing-library/user-event@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "@testing-library/user-event@npm:14.0.0"
   peerDependencies:
     "@testing-library/dom": ">=7.21.4"
-  checksum: 16319de685fbb7008f1ba667928f458b2d08196918002daca56996de80ef35e6d9de26e9e1ece7d00a004692b95a597cf9142fff0dc53f2f51606a776584f549
+  checksum: 171a40e680616e6a34299f9fb783dcadcd36f255256a53fe06cb71f4149715d8e5b84e65ea1c144af179f2e4b1799af92c79a8fc0c4c0ee2e94a713f2c476efd
   languageName: node
   linkType: hard
 
@@ -9244,7 +9242,7 @@ __metadata:
     "@reduxjs/toolkit": ^1.8.0
     "@testing-library/jest-dom": ^5.16.3
     "@testing-library/react": ^12.1.4
-    "@testing-library/user-event": ^13.5.0
+    "@testing-library/user-event": ^14.0.0
     "@types/classnames": ^2.3.1
     "@types/enzyme": ^3.10.11
     "@types/jest": ^27.4.1
@@ -22405,7 +22403,7 @@ __metadata:
     "@reduxjs/toolkit": ^1.8.0
     "@testing-library/jest-dom": ^5.16.3
     "@testing-library/react": ^12.1.4
-    "@testing-library/user-event": ^13.5.0
+    "@testing-library/user-event": ^14.0.0
     "@types/classnames": ^2.3.1
     "@types/deepmerge": ^2.2.0
     "@types/enzyme": ^3.10.11


### PR DESCRIPTION
## Description
user-event library had some breaking changes in version 14. For us the ones that specifically hit us were;
- all events now return promises, and should be awaited
- name change for key names, f.ex `{esc}` -> `{Escape}`
- the new recommendation is to [use `const user = userEvent.setup()` in tests](https://testing-library.com/docs/user-event/intro#writing-tests-with-userevent), and use the `user` to trigger events, instead of just firing events directly ( `userEvent.click()` -> `const user = userEvent.setup(); user.click();`

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] ~Relevant automated test added (if you find this hard, leave it and we'll help out)~
- [x] All tests run green
