### PR TITLE
fixed bug for repeating group in pdf

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/services/PDFGenerator.java
@@ -279,7 +279,7 @@ public class PDFGenerator {
               String nonIndexedGroupBinding = groupBinding.replace(groupBinding.substring(indexStart, indexEnd + 1), "");
               currentBinding = currentBinding.replace(nonIndexedGroupBinding, groupBinding);
             }
-            String replacedBinding = currentBinding.replace(groupBinding, groupBinding + '[' + groupIndex + ']');
+            String replacedBinding = FormUtils.setGroupIndexForBinding(currentBinding, groupBinding, groupIndex);
             dataBinding.setValue(replacedBinding);
           }
         }

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/utils/FormUtils.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/utils/FormUtils.java
@@ -236,6 +236,19 @@ public class FormUtils {
   }
 
   /**
+   * Useful comments
+   * **/
+  public static String setGroupIndexForBinding(String fullBinding, String groupBinding, int groupIndex)
+  {
+    // Excluding relevant end delimiters is important to not replace an already indexed group property
+    String pattern = String.format("\\b%s\\b(?!\\[)", groupBinding);
+
+    // using replaceAll to get full regex support
+    return fullBinding.replaceAll(pattern, groupBinding + '[' + groupIndex + ']');
+  }
+
+
+  /**
    * Parses the base 64 encoded xml file and creates a Document wrapper
    * @param xmlBaseEncoded the base 64 xml string
    * @return a document wrapper for the xml file

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/utils/FormUtils.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/utils/FormUtils.java
@@ -237,7 +237,7 @@ public class FormUtils {
 
   /**
    * Injects the group index marker [i]
-   * behind the  group binding in the string representing the full binding.
+   * behind the group binding in the string representing the full binding.
    * **/
   public static String setGroupIndexForBinding(String fullBinding, String groupBinding, int groupIndex)
   {

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/utils/FormUtils.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/utils/FormUtils.java
@@ -236,7 +236,8 @@ public class FormUtils {
   }
 
   /**
-   * Useful comments
+   * Injects the group index marker [i]
+   * behind the  group binding in the string representing the full binding.
    * **/
   public static String setGroupIndexForBinding(String fullBinding, String groupBinding, int groupIndex)
   {

--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/test/java/altinn/platform/pdf/utils/FormUtilsTest.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/test/java/altinn/platform/pdf/utils/FormUtilsTest.java
@@ -17,19 +17,19 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class FormUtilsTest extends TestCase {
-  public FormUtilsTest( String testName )
-  {
-    super( testName );
+  public FormUtilsTest(String testName) {
+    super(testName);
   }
 
   private Document formData;
 
-  public static Test suite()
-  {
-    return new TestSuite( altinn.platform.pdf.utils.FormUtilsTest.class );
+  public static Test suite() {
+    return new TestSuite(altinn.platform.pdf.utils.FormUtilsTest.class);
   }
 
   public void test_getFilteredLayout_componentsPartOfGroupsShouldBeFilteredOut() {
@@ -89,8 +89,8 @@ public class FormUtilsTest extends TestCase {
     int nestedCount_2 = FormUtils.getGroupCount("Endringsmelding-grp-9786.OversiktOverEndringene-grp-9788[1].nested-grp-1234", formData);
 
     assertEquals(3, count);
-    assertEquals (3, nestedCount_1);
-    assertEquals (2, nestedCount_2);
+    assertEquals(3, nestedCount_1);
+    assertEquals(2, nestedCount_2);
   }
 
   public void test_getGroupCount_shouldReturnZeroForNonExistentGroup() throws IOException, SAXException, ParserConfigurationException {
@@ -160,6 +160,30 @@ public class FormUtilsTest extends TestCase {
     Document formData = readAndParseFormData();
     String result = FormUtils.getFormDataByKey("Does.Not.Exist", formData);
     assertEquals("", result);
+  }
+
+  public void test_setGroupIndexForBinding() {
+
+    Map<String, String[]> testData = new HashMap<>() {
+      {
+        // (String fullBinding, String groupBinding, int groupIndex) + expectedValued
+        put("TC_1", new String[]{"owner.ownerOrganisationId", "owner", "0", "owner[0].ownerOrganisationId"});
+        put("TC_2", new String[]{"owner", "owner", "0", "owner[0]"});
+        put("TC_3", new String[]{"ownerName", "owner", "0", "ownerName"});
+        put("TC_4", new String[]{"ownerName.ownerOrganisationId", "owner", "0", "ownerName.ownerOrganisationId"});
+        put("TC_5", new String[]{"schema.owner.ownerOrganisationId", "owner", "1", "schema.owner[1].ownerOrganisationId"});
+        put("TC_6", new String[]{"schema.owner", "owner", "1", "schema.owner[1]"});
+        put("TC_7", new String[]{".ownerPet.dog", "owner", "0", ".ownerPet.dog"});
+        put("TC_8", new String[]{"owner[1].faculty.owner", "owner", "0", "owner[1].faculty.owner[0]"});
+      }
+    };
+
+    for (Map.Entry<String, String[]> entry : testData.entrySet()) {
+      String key = entry.getKey();
+      String[] value = entry.getValue();
+      String actual = FormUtils.setGroupIndexForBinding(value[0], value[1], Integer.parseInt(value[2]));
+      assertEquals(value[3], actual);
+    }
   }
 
   private Document readAndParseFormData() throws ParserConfigurationException, IOException, SAXException {


### PR DESCRIPTION
# Fixed missing values for rep group with groupname as substring of child

## Fixes
- https://github.com/Altinn/altinn-pdf/issues/2 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

