### PR TITLE
chore: missed config changes during migration to webpack 5

### DIFF
--- a/src/studio/src/designer/frontend/app-development/webpack.config.development.js
+++ b/src/studio/src/designer/frontend/app-development/webpack.config.development.js
@@ -38,10 +38,7 @@ module.exports = {
   plugins: [
     ...commonConfig.plugins,
     new ForkTsCheckerWebpackPlugin(),
-    new ForkTsCheckerNotifierWebpackPlugin({
-      title: 'TypeScript',
-      excludeWarnings: false,
-    }),
+    new ForkTsCheckerNotifierWebpackPlugin(),
   ],
   devServer: {
     hot: true,

--- a/src/studio/src/designer/frontend/dashboard/webpack.config.development.js
+++ b/src/studio/src/designer/frontend/dashboard/webpack.config.development.js
@@ -37,12 +37,7 @@ module.exports = {
   },
   plugins: [
     ...commonConfig.plugins,
-    new ForkTsCheckerWebpackPlugin({
-      eslint: {
-        files:
-          './{actions,config,features,reducers,sagas,sharedResources,store,types,utils}/**/*.{ts,tsx,js,jsx}',
-      },
-    }),
+    new ForkTsCheckerWebpackPlugin(),
     new ForkTsCheckerNotifierWebpackPlugin(),
   ],
   devServer: {

--- a/src/studio/src/designer/frontend/package.json
+++ b/src/studio/src/designer/frontend/package.json
@@ -19,7 +19,6 @@
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.3.0",
-    "ini": "2.0.0",
     "typescript": "^4.6.3"
   },
   "packageManager": "yarn@3.2.0",

--- a/src/studio/src/designer/frontend/ux-editor/webpack.config.development.js
+++ b/src/studio/src/designer/frontend/ux-editor/webpack.config.development.js
@@ -52,12 +52,7 @@ module.exports = {
   },
   plugins: [
     ...common.plugins,
-    new ForkTsCheckerWebpackPlugin({
-      eslint: {
-        files:
-          './{actions,config,features,reducers,sagas,sharedResources,store,types,utils}/**/*.{ts,tsx,js,jsx}',
-      },
-    }),
+    new ForkTsCheckerWebpackPlugin(),
     new ForkTsCheckerNotifierWebpackPlugin(),
   ],
   devServer: {

--- a/src/studio/src/designer/frontend/yarn.lock
+++ b/src/studio/src/designer/frontend/yarn.lock
@@ -6408,7 +6408,6 @@ __metadata:
     eslint-plugin-jsx-a11y: ^6.5.1
     eslint-plugin-react: ^7.29.4
     eslint-plugin-react-hooks: ^4.3.0
-    ini: 2.0.0
     typescript: ^4.6.3
   languageName: unknown
   linkType: soft
@@ -12732,13 +12731,6 @@ __metadata:
   version: 2.0.3
   resolution: "inherits@npm:2.0.3"
   checksum: 78cb8d7d850d20a5e9a7f3620db31483aa00ad5f722ce03a55b110e5a723539b3716a3b463e2b96ce3fe286f33afc7c131fa2f91407528ba80cea98a7545d4c0
-  languageName: node
-  linkType: hard
-
-"ini@npm:2.0.0":
-  version: 2.0.0
-  resolution: "ini@npm:2.0.0"
-  checksum: e7aadc5fb2e4aefc666d74ee2160c073995a4061556b1b5b4241ecb19ad609243b9cceafe91bae49c219519394bbd31512516cb22a3b1ca6e66d869e0447e84e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Not sure how I missed these changes in the first PR (#8316)..

`ForkTsCheckerNotifierWebpackPlugin` changes:
`excludeWarnings` is undefined by default, so we dont need to specify this.
I removed `title` mainly because I didnt see the value of keeping it - less configuration is better :) Lets add it back if we end up missing it.

`ForkTsCheckerWebpackPlugin` changes:
`eslint` is no longer an option. Not even sure if this ever worked as expected, because we have a ton of eslint errors and warnings that have gone unnoticed. I propose we try and clean this up, and when thats done we can add something like [eslint-webpack-plugin](https://github.com/webpack-contrib/eslint-webpack-plugin) to prevent adding more eslint issues.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
