### PR TITLE
chore: disable warning overlay for webpack dev server

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/webpack.config.development.js
+++ b/src/Altinn.Apps/AppFrontend/react/altinn-app-frontend/webpack.config.development.js
@@ -32,5 +32,11 @@ module.exports = {
   devServer: {
     historyApiFallback: true,
     allowedHosts: 'all',
+    client: {
+      overlay: {
+        errors: true,
+        warnings: false,
+      },
+    },
   },
 };

--- a/src/Altinn.Apps/AppFrontend/react/receipt/webpack.config.development.js
+++ b/src/Altinn.Apps/AppFrontend/react/receipt/webpack.config.development.js
@@ -32,5 +32,11 @@ module.exports = {
   plugins: [...commonConfig.plugins, new ForkTsCheckerNotifierWebpackPlugin()],
   devServer: {
     historyApiFallback: true,
+    client: {
+      overlay: {
+        errors: true,
+        warnings: false,
+      },
+    },
   },
 };

--- a/src/studio/src/designer/frontend/app-development/webpack.config.development.js
+++ b/src/studio/src/designer/frontend/app-development/webpack.config.development.js
@@ -41,5 +41,11 @@ module.exports = {
     hot: true,
     historyApiFallback: true,
     allowedHosts: 'all',
+    client: {
+      overlay: {
+        errors: true,
+        warnings: false,
+      },
+    },
   },
 };

--- a/src/studio/src/designer/frontend/dashboard/webpack.config.development.js
+++ b/src/studio/src/designer/frontend/dashboard/webpack.config.development.js
@@ -36,5 +36,11 @@ module.exports = {
   plugins: [...commonConfig.plugins, new ForkTsCheckerNotifierWebpackPlugin()],
   devServer: {
     historyApiFallback: true,
+    client: {
+      overlay: {
+        errors: true,
+        warnings: false,
+      },
+    },
   },
 };

--- a/src/studio/src/designer/frontend/packages/schema-editor/webpack.config.development.js
+++ b/src/studio/src/designer/frontend/packages/schema-editor/webpack.config.development.js
@@ -6,5 +6,11 @@ module.exports = {
   devtool: 'inline-source-map',
   devServer: {
     hot: true,
+    client: {
+      overlay: {
+        errors: true,
+        warnings: false,
+      },
+    },
   },
 };

--- a/src/studio/src/designer/frontend/ux-editor/webpack.config.development.js
+++ b/src/studio/src/designer/frontend/ux-editor/webpack.config.development.js
@@ -52,5 +52,11 @@ module.exports = {
   plugins: [...common.plugins, new ForkTsCheckerNotifierWebpackPlugin()],
   devServer: {
     historyApiFallback: true,
+    client: {
+      overlay: {
+        errors: true,
+        warnings: false,
+      },
+    },
   },
 };


### PR DESCRIPTION
## Description
We have some assets over the size limit which will always trigger the warning, and this overlay may interfere with testruns when running tests locally with devserver. I didnt think about this scenario when making the transition to webpack 5.

![image (1)](https://user-images.githubusercontent.com/2082481/161048192-ab66d719-8b72-445f-8d7a-3e2bde8b4861.png)

This change will disable the overlay for warnings, but still appear on errors. If error appear, it would be fine to fail the tests anyway.

## Fixes
- Related to Webpack 5 upgrade #8324 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
