### PR TITLE
Fixing incorrect RevokeLast enum type value

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Migration/v0.05/01-setup-tables.sql
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/Migration/v0.05/01-setup-tables.sql
@@ -1,0 +1,2 @@
+-- Enum: update delegation.delegationChangeType rename revokelast -> revoke_last
+ALTER TYPE delegation.delegationchangetype RENAME VALUE 'revokelast' TO 'revoke_last'

--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Authorization/appsettings.json
@@ -6,7 +6,7 @@
     "MetadataBlobEndpoint": "http://127.0.0.1:10000/devstoreaccount1",
     "DelegationsAccountName": "devstoreaccount1",
     "DelegationsAccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
-    "DelegationsContainer": "delegations",
+    "DelegationsContainer": "delegationpolicies",
     "DelegationsBlobEndpoint": "http://127.0.0.1:10000/devstoreaccount1",
     "BlobLeaseTimeout": 15,
     "DelegationEventQueueEndpoint": "http://127.0.0.1:10000/devstoreaccount1",


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# Fixing incorrect RevokeLast enum type value
<!-- Summary of the changes (max 80 characters) -->

## Description
#8317 
Introduced the new DelegationChangeType enum value used to store the type of delegation action was performed: Grant, Revoke and RevokeLast.

Default parsing of C# Enum value for function calls to postgreSQL db results in:
grant, revoke and revoke_last.

So easiest fix for enums to match is just to rename "revokelast" to "revoke_last".

Also updated default value for DelegationsContainer to: "delegationpolicies"
as this is the naming used in all deployed environments.

## Fixes
- Azure DevOps Bug: [59328](https://dev.azure.com/digdir/Altinn/_workitems/edit/59328)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
