### PR TITLE
Feature/8338 includeidclaim

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Altinn.Platform.Authentication.Tests/Controllers/AuthenticationControllerTests.cs
@@ -842,6 +842,7 @@ namespace Altinn.Platform.Authentication.Tests.Controllers
             Assert.NotNull(claimPrincipal);
             Assert.NotNull(claimPrincipal.Claims.FirstOrDefault(r => r.Type.Equals("urn:altinn:userid")));
             Assert.Equal("234235", claimPrincipal.Claims.FirstOrDefault(r => r.Type.Equals("urn:altinn:userid")).Value);
+            Assert.Equal("2346t44663423s", claimPrincipal.Claims.FirstOrDefault(r => r.Type.Equals("sub")).Value);
         }
 
         /// <summary>

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Altinn.Platform.Authentication.Tests/JwtTokenMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Altinn.Platform.Authentication.Tests/JwtTokenMock.cs
@@ -139,6 +139,7 @@ namespace Altinn.Platform.Authentication.Tests
             };
 
             JwtSecurityTokenHandler validator = new JwtSecurityTokenHandler();
+            validator.MapInboundClaims = false;
             return validator.ValidateToken(token, validationParameters, out _);
         }
 

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Altinn.Platform.Authentication.Tests/appsettings.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Altinn.Platform.Authentication.Tests/appsettings.json
@@ -46,7 +46,7 @@
       "ExternalIdentityClaim": "sub",
       "UserNamePrefix": "UIDP_",
       "IncludeIssInRedirectUri": true,
-      "ProviderClaims": [ "locale", "urn:feide:role" ]
+      "ProviderClaims": [ "locale", "urn:feide:role", "sub" ]
     }
 
   }

--- a/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authentication/Authentication/Controllers/AuthenticationController.cs
@@ -793,7 +793,6 @@ namespace Altinn.Platform.Authentication.Controllers
                 if (!string.IsNullOrEmpty(provider.ExternalIdentityClaim) && claim.Type.Equals(provider.ExternalIdentityClaim))
                 {
                     userAuthenticationModel.ExternalIdentity = claim.Value;
-                    continue;
                 }
 
                 // General claims handling


### PR DESCRIPTION
# Support keeping identy claim in altinn token


## Description
Made it possible to have the identity claim also transferred to new token. 

Had to turn of automapping of claim in mock since sub is a taken word


## Fixes
- #8338 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
