### PR TITLE
Disable dynamic concurrency feature for debugging

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/host.json
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/host.json
@@ -11,10 +11,6 @@
       "Altinn.Platform.Authorization.Functions.Services.EventPusherService": "Debug"
     }
   },
-  "concurrency": { /* See https://docs.microsoft.com/en-us/azure/azure-functions/functions-concurrency#dynamic-concurrency-preview */
-    "dynamicConcurrencyEnabled": true,
-    "snapshotPersistenceEnabled": true
-  },
   "extensions": {
     "queues": {
       "maxPollingInterval": "00:00:02",


### PR DESCRIPTION
Disable dynamic concurrency handling in order to debug CPU usage issues. This instead utilized defaults, which is also what Altinn.Platform.Events does.