### PR TITLE
Fix for DelegationEvent function sometimes using invalid tokens

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Services/AccessTokenProvider.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/Functions/Services/AccessTokenProvider.cs
@@ -58,9 +58,9 @@ public class AccessTokenProvider : IAccessTokenProvider
                     _platformSettings.AccessTokenIssuer,
                     "platform.authorization",
                     new X509Certificate2(Convert.FromBase64String(certBase64), (string)null, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable));
-            }
 
-            _cacheTokenUntil = DateTime.UtcNow.AddSeconds(_accessTokenSettings.TokenLifetimeInSeconds - 2); // Add some slack to avoid tokens expiring in transit
+                _cacheTokenUntil = DateTime.UtcNow.AddSeconds(_accessTokenSettings.TokenLifetimeInSeconds - 2); // Add some slack to avoid tokens expiring in transit
+            }
 
             return _accessToken;
         }


### PR DESCRIPTION
<!-- Thank you for contributing to Altinn:) We know this isn't the fun part, but please make sure you follow our [contributing guidelines](../../CONTRIBUTING.md) and put the same effort into the pull request as you did into the code and it should soon find it's way to master. -->

# Fix for DelegationEvent function sometimes using invalid tokens

## Description
Bug was found from logs in AT22 where the function from time to time fails with the error:
 Bridge returned non-success. resultCode=Unauthorized reasonPhrase=IDX10223: Lifetime validation failed. The token is expired. ValidTo: '4/21/2022 1:01:04 PM', Current time: '4/21/2022 1:04:58 PM'. resultBody= numEventsSent=1 changeIds=xxx

Causing some delegation events to not be synced to SBL Authorization.
The bug is assumed to be in AccessTokenProvider.GetAccessToken() where the private variable _cacheTokenUntil, which is used for gating whether a new token should be retrieved, is pushed forward with every call to GetAccessToken().

Fix is just setting the variable once inside the scope of the if, when a new token is retrieved.

## Fixes
- Azure DevOps Bug: https://dev.azure.com/digdir/Altinn/_workitems/edit/59528

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
