### PR TITLE
updated docker images for studio and altinn apps

### DIFF
--- a/src/Altinn.Apps/AppFrontend/react/receipt/Dockerfile
+++ b/src/Altinn.Apps/AppFrontend/react/receipt/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:16.14.2-alpine3.15 AS generate-receipt-app
+FROM node:16.15.0-alpine3.15 AS generate-receipt-app
 
 WORKDIR /build
 

--- a/src/Altinn.Apps/KubernetesWrapper/Dockerfile
+++ b/src/Altinn.Apps/KubernetesWrapper/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.201-alpine3.15 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0.202-alpine3.15 AS build
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -10,7 +10,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.3-alpine3.15 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.4-alpine3.15 AS final
 WORKDIR /app
 COPY --from=build /app/out .
 ENTRYPOINT ["dotnet", "KubernetesWrapper.dll"]

--- a/src/studio/src/designer/Dockerfile
+++ b/src/studio/src/designer/Dockerfile
@@ -1,5 +1,5 @@
 # studio frontend
-FROM node:16.14.2-alpine3.15 AS generate-studio-frontend
+FROM node:16.15.0-alpine3.15 AS generate-studio-frontend
 
 WORKDIR /build
 
@@ -45,7 +45,7 @@ COPY --from=generate-studio-frontend /build/dist/app-development/app-development
 COPY --from=generate-studio-frontend /build/dist/dashboard/dashboard.js .
 COPY --from=generate-studio-frontend /build/dist/dashboard/dashboard.css .
 
-FROM node:16.14.2-alpine3.15 AS generate-designer-js
+FROM node:16.15.0-alpine3.15 AS generate-designer-js
 WORKDIR /app
 COPY src/designer/backend/package.json .
 COPY src/designer/backend/yarn.lock .

--- a/src/studio/src/designer/frontend/app-development/Dockerfile
+++ b/src/studio/src/designer/frontend/app-development/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:16.14.2-alpine3.15 AS generate-app-development
+FROM node:16.15.0-alpine3.15 AS generate-app-development
 
 WORKDIR /build
 

--- a/src/studio/src/designer/frontend/dashboard/Dockerfile
+++ b/src/studio/src/designer/frontend/dashboard/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:16.14.2-alpine3.15 AS generate-dashboard
+FROM node:16.15.0-alpine3.15 AS generate-dashboard
 
 WORKDIR /build
 

--- a/src/studio/src/designer/frontend/ux-editor/Dockerfile
+++ b/src/studio/src/designer/frontend/ux-editor/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:16.14.2-alpine3.15
+FROM node:16.15.0-alpine3.15
 
 # set working directory
 WORKDIR /usr/src/app

--- a/src/studio/src/repositories/Dockerfile
+++ b/src/studio/src/repositories/Dockerfile
@@ -1,4 +1,4 @@
-FROM gitea/gitea:1.16.5-rootless
+FROM gitea/gitea:1.16.6-rootless
 USER 0:0
 RUN apk --no-cache upgrade expat
 USER 1000:1000


### PR DESCRIPTION
# updated docker images for studio and altinn apps

## Description

patched docker images for studio, altinn apps for week 17 of 2022.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] All tests run green