### PR TITLE
Upgrade LocalTest to .net 6.0.

### DIFF
--- a/.github/workflows/localtest-pr.yml
+++ b/.github/workflows/localtest-pr.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup .NET Core SDK 5.0.x
-        uses: actions/setup-dotnet@v1.7.2
+      - name: Setup .NET Core SDK 6.0.x
+        uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: Install dependencies
         run: dotnet restore
         working-directory: 'src/development/LocalTest/'

--- a/src/development/LocalTest/Dockerfile
+++ b/src/development/LocalTest/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 WORKDIR /LocalTest
 
 COPY ./LocalTest/LocalTest.csproj /LocalTest
@@ -11,7 +11,7 @@ RUN ls /
 RUN dotnet build LocalTest.csproj -c Release -o /app_output
 RUN dotnet publish LocalTest.csproj -c Release -o /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine AS final
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS final
 EXPOSE 5101
 WORKDIR /app
 COPY --from=build /app_output .

--- a/src/development/LocalTest/LocalTest.csproj
+++ b/src/development/LocalTest/LocalTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>56f36ce2-b44b-415e-a8a5-f399a76e35b9</UserSecretsId>
   </PropertyGroup>
 

--- a/src/development/LocalTest/Program.cs
+++ b/src/development/LocalTest/Program.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace LocalTest
 {

--- a/src/development/LocalTest/Services/Storage/Implementation/ApplicationRepository.cs
+++ b/src/development/LocalTest/Services/Storage/Implementation/ApplicationRepository.cs
@@ -1,14 +1,16 @@
-using Altinn.Platform.Storage.Interface.Models;
-using Altinn.Platform.Storage.Repository;
-using LocalTest.Configuration;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+
+using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Platform.Storage.Repository;
+
+using LocalTest.Configuration;
+
+using Microsoft.Extensions.Options;
 
 namespace LocalTest.Services.Storage.Implementation
 {
@@ -65,7 +67,12 @@ namespace LocalTest.Services.Storage.Implementation
         public async Task<Application> Update(Application item)
         {
             Directory.CreateDirectory(GetApplicationsDirectory()+item.Id.Split('/')[0]);
-            await File.WriteAllTextAsync(GetApplicationsDirectory() + item.Id + ".json", JsonSerializer.Serialize(item, new() { WriteIndented = true, DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull }));
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+            await File.WriteAllTextAsync(GetApplicationsDirectory() + item.Id + ".json", JsonSerializer.Serialize(item, options));
             return item;
         }
 
@@ -87,7 +94,7 @@ namespace LocalTest.Services.Storage.Implementation
 
         public string GetApplicationsDirectory()
         {
-            return _localPlatformSettings.LocalTestingStorageBasePath + _localPlatformSettings.DocumentDbFolder + _localPlatformSettings.ApplicationsDataFolder;
+            return Path.Join(_localPlatformSettings.LocalTestingStorageBasePath, _localPlatformSettings.DocumentDbFolder, _localPlatformSettings.ApplicationsDataFolder);
         }
     }
 }

--- a/src/development/LocalTest/appsettings.json
+++ b/src/development/LocalTest/appsettings.json
@@ -36,7 +36,6 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
-
   },
   "AllowedHosts": "*",
   "LocalPlatformSettings": {
@@ -48,8 +47,5 @@
   },
   "PlatformSettings": {
     "ApiAuthorizationEndpoint": "http://localhost:5101/authorization/api/v1/"
-  },
-  "PepSettings": {
-    "DisablePEP": "false"
   }
 }


### PR DESCRIPTION
This is a minimal upgrade of LocalTest to .net 6.0. In practise this only means we've kept the startup file and original program with a main method. This is mostly because of waiting pull requests.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

