### PR TITLE
Add check for existing index before creating.

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Events/Events/Migration/v0.08/01-setup-index.sql
+++ b/src/Altinn.Platform/Altinn.Platform.Events/Events/Migration/v0.08/01-setup-index.sql
@@ -2,6 +2,6 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 CREATE INDEX IF NOT EXISTS idx_gin_events_source ON events.events USING gin (source gin_trgm_ops);
 
-CREATE INDEX idx_events_time ON events.events USING btree ("time" ASC NULLS LAST);
+CREATE INDEX IF NOT EXISTS idx_events_time ON events.events USING btree ("time" ASC NULLS LAST);
 
-CREATE INDEX idx_events_subject ON events.events USING btree (subject ASC NULLS LAST);
+CREATE INDEX IF NOT EXISTS idx_events_subject ON events.events USING btree (subject ASC NULLS LAST);


### PR DESCRIPTION
## Description
This PR is only cosmetics, consistency in SQL scripts. The script versioning being used with Yuniql will ensure the script isn't run again. The statements in this PR has already been run in all environments. 

The SQL statement creating an index should check for an existing index and execute only if the index is new.
