### PR TITLE
Chore/make designer test run on linux

### DIFF
--- a/.github/workflows/designer-dotnet-test.yaml
+++ b/.github/workflows/designer-dotnet-test.yaml
@@ -1,11 +1,11 @@
 name: Build and Test on windows, linux and macos
 on:
   push:
-    branches: [ main, chore/make-test-run-on-linux ]
+    branches: [ master ]
     paths:
       - 'src/studio/src/designer/**'
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
     types: [opened, synchronize, reopened]
     paths:
       - 'src/studio/src/designer/**'

--- a/.github/workflows/designer-dotnet-test.yaml
+++ b/.github/workflows/designer-dotnet-test.yaml
@@ -1,0 +1,36 @@
+name: Build and Test on windows, linux and macos
+on:
+  push:
+    branches: [ main, chore/make-test-run-on-linux ]
+    paths:
+      - 'src/studio/src/designer/**'
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/studio/src/designer/**'
+  workflow_dispatch:
+jobs:
+  analyze:
+    strategy:
+      matrix:
+        os: [macos-latest,windows-latest,ubuntu-latest] # TODO: Fix test to run on ubuntu-latest also
+    name: Run dotnet build and test
+    runs-on: ${{ matrix.os}}
+    env: 
+      DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE: false
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            6.0.x
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Build
+        run: |
+           dotnet build src/studio/src/designer/Designer.sln -v m
+      - name: Test
+        run: |
+           dotnet build src/studio/src/designer/Designer.sln -v m

--- a/src/studio/src/designer/Dockerfile
+++ b/src/studio/src/designer/Dockerfile
@@ -97,3 +97,4 @@ COPY src/designer/backend/Languages/ini ./Languages
 COPY src/designer/backend/Migration ./Migration
 
 ENTRYPOINT ["dotnet", "Altinn.Studio.Designer.dll"]
+

--- a/src/studio/src/designer/Dockerfile
+++ b/src/studio/src/designer/Dockerfile
@@ -97,4 +97,3 @@ COPY src/designer/backend/Languages/ini ./Languages
 COPY src/designer/backend/Migration ./Migration
 
 ENTRYPOINT ["dotnet", "Altinn.Studio.Designer.dll"]
-

--- a/src/studio/src/designer/backend.Tests/Controllers/DatamodelsControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/DatamodelsControllerTests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Configuration;
@@ -35,7 +36,10 @@ namespace Designer.Tests.Controllers
         public DatamodelsControllerTests(WebApplicationFactory<DatamodelsController> factory)
         {
             _factory = factory;
-            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
+            }
         }
 
         [Fact]

--- a/src/studio/src/designer/backend.Tests/Controllers/DatamodelsControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/DatamodelsControllerTests.cs
@@ -36,10 +36,7 @@ namespace Designer.Tests.Controllers
         public DatamodelsControllerTests(WebApplicationFactory<DatamodelsController> factory)
         {
             _factory = factory;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
-            }
+            TestSetupUtils.SetupDirtyHackIfLinux();
         }
 
         [Fact]

--- a/src/studio/src/designer/backend.Tests/Controllers/DatamodelsControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/DatamodelsControllerTests.cs
@@ -35,6 +35,7 @@ namespace Designer.Tests.Controllers
         public DatamodelsControllerTests(WebApplicationFactory<DatamodelsController> factory)
         {
             _factory = factory;
+            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
         }
 
         [Fact]
@@ -111,7 +112,7 @@ namespace Designer.Tests.Controllers
                 File.Delete(unitTestFolder + "/Repositories/testuser/ttd/ttd-datamodels/App/models/32578.schema.json");
             }
 
-            File.Copy(unitTestFolder + "/Model/Xsd/schema_2978_1_forms_3478_32578.xsd", unitTestFolder + "/Repositories/testuser/ttd/ttd-datamodels/App/models/32578.xsd", true);
+            File.Copy(unitTestFolder + "/Model/Xsd/schema_2978_1_forms_3478_32578.xsd", unitTestFolder + "/Repositories/testUser/ttd/ttd-datamodels/App/models/32578.xsd", true);
 
             HttpClient client = GetTestClient();
 
@@ -156,7 +157,7 @@ namespace Designer.Tests.Controllers
                 File.Delete(unitTestFolder + "/Repositories/testuser/ttd/ttd-datamodels/App/models/41111.schema.json");
             }
 
-            File.Copy(unitTestFolder + "/Model/Xsd/schema_4581_100_forms_5245_41111.xsd", unitTestFolder + "/Repositories/testuser/ttd/ttd-datamodels/App/models/41111.xsd", true);
+            File.Copy(unitTestFolder + "/Model/Xsd/schema_4581_100_forms_5245_41111.xsd", unitTestFolder + "/Repositories/testUser/ttd/ttd-datamodels/App/models/41111.xsd", true);
 
             HttpClient client = GetTestClient();
 
@@ -201,7 +202,7 @@ namespace Designer.Tests.Controllers
                 File.Delete(unitTestFolder + "/Repositories/testuser/ttd/ttd-datamodels/App/models/0678.schema.json");
             }
 
-            File.Copy(unitTestFolder + "/Model/Xsd/RA-0678_M.xsd", unitTestFolder + "/Repositories/testuser/ttd/ttd-datamodels/App/models/0678.xsd", true);
+            File.Copy(unitTestFolder + "/Model/Xsd/RA-0678_M.xsd", unitTestFolder + "/Repositories/testUser/ttd/ttd-datamodels/App/models/0678.xsd", true);
 
             HttpClient client = GetTestClient();
 
@@ -297,7 +298,7 @@ namespace Designer.Tests.Controllers
             var client = GetTestClient();
             var url = $"{_versionPrefix}/ttd/hvem-er-hvem/Datamodels/";
 
-            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);            
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             await AuthenticationUtil.AddAuthenticateAndAuthAndXsrFCookieToRequest(client, httpRequestMessage);
 
@@ -315,16 +316,15 @@ namespace Designer.Tests.Controllers
             var client = GetTestClient();
             var url = $"{_versionPrefix}/ttd/hvem-er-hvem/Datamodels/";
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
-            
+
             var response = await client.SendAsync(httpRequestMessage);
-            
+
             Assert.Equal(HttpStatusCode.Found, response.StatusCode);
             Assert.Contains("/login/", response.Headers.Location.AbsoluteUri.ToLower());
         }
 
         [Theory]
         [InlineData("App/models/HvemErHvem_SERES.schema.json")]
-        [InlineData("App/models/hvemerhvem_seres.schema.json")]
         [InlineData("App%2Fmodels%2FHvemErHvem_SERES.schema.json")]
         public async Task GetDatamodel_ValidPath_ShouldReturnContent(string modelPath)
         {
@@ -423,7 +423,7 @@ namespace Designer.Tests.Controllers
         public async Task PostDatamodel_FromFormPost_ShouldReturnCreatedFromTemplate(string relativeDirectory, bool altinn2Compatible, string sourceRepository)
         {
             // Arrange
-            var org = "ttd";            
+            var org = "ttd";
             var developer = "testUser";
             var targetRepository = Guid.NewGuid().ToString();
 
@@ -650,6 +650,6 @@ namespace Designer.Tests.Controllers
                 });
             }).CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
             return client;
-        }       
+        }
     }
 }

--- a/src/studio/src/designer/backend.Tests/Controllers/ReleasesControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/ReleasesControllerTests.cs
@@ -40,10 +40,7 @@ namespace Designer.Tests.Controllers
             _factory = factory;
             _options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
             _options.Converters.Add(new JsonStringEnumConverter());
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
-            }
+            TestSetupUtils.SetupDirtyHackIfLinux();
         }
 
         [Fact]

--- a/src/studio/src/designer/backend.Tests/Controllers/ReleasesControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/ReleasesControllerTests.cs
@@ -39,6 +39,7 @@ namespace Designer.Tests.Controllers
             _factory = factory;
             _options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
             _options.Converters.Add(new JsonStringEnumConverter());
+            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
         }
 
         [Fact]
@@ -78,7 +79,6 @@ namespace Designer.Tests.Controllers
         public async Task GetReleases_SingleLaggingRelease_PipelineServiceCalled()
         {
             // Arrange
-            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
             string uri = $"{_versionPrefix}/udi/kjaerestebesok/releases?sortDirection=Descending";
             List<ReleaseEntity> completedReleases = GetReleasesList("singleLaggingRelease.json");
 

--- a/src/studio/src/designer/backend.Tests/Controllers/ReleasesControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/ReleasesControllerTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -39,7 +40,10 @@ namespace Designer.Tests.Controllers
             _factory = factory;
             _options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
             _options.Converters.Add(new JsonStringEnumConverter());
-            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
+            }
         }
 
         [Fact]

--- a/src/studio/src/designer/backend.Tests/Controllers/ReleasesControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/ReleasesControllerTests.cs
@@ -78,6 +78,7 @@ namespace Designer.Tests.Controllers
         public async Task GetReleases_SingleLaggingRelease_PipelineServiceCalled()
         {
             // Arrange
+            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
             string uri = $"{_versionPrefix}/udi/kjaerestebesok/releases?sortDirection=Descending";
             List<ReleaseEntity> completedReleases = GetReleasesList("singleLaggingRelease.json");
 

--- a/src/studio/src/designer/backend.Tests/Controllers/RepositoryControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/RepositoryControllerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 using Altinn.Studio.Designer;
@@ -34,7 +35,10 @@ namespace Designer.Tests.Controllers
         public RepositoryControllerTests(WebApplicationFactory<RepositoryController> factory)
         {
             _factory = factory;
-            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
+            }
         }
 
         [Fact]

--- a/src/studio/src/designer/backend.Tests/Controllers/RepositoryControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/RepositoryControllerTests.cs
@@ -34,6 +34,7 @@ namespace Designer.Tests.Controllers
         public RepositoryControllerTests(WebApplicationFactory<RepositoryController> factory)
         {
             _factory = factory;
+            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
         }
 
         [Fact]

--- a/src/studio/src/designer/backend.Tests/Controllers/RepositoryControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/RepositoryControllerTests.cs
@@ -35,10 +35,7 @@ namespace Designer.Tests.Controllers
         public RepositoryControllerTests(WebApplicationFactory<RepositoryController> factory)
         {
             _factory = factory;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
-            }
+            TestSetupUtils.SetupDirtyHackIfLinux();
         }
 
         [Fact]

--- a/src/studio/src/designer/backend.Tests/Controllers/RepositorySettingsControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/RepositorySettingsControllerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer;
@@ -28,7 +29,10 @@ namespace Designer.Tests.Controllers
         public RepositorySettingsControllerTests(WebApplicationFactory<RepositorySettingsController> factory)
         {
             _factory = factory;
-            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
+            }
         }
 
         [Fact]

--- a/src/studio/src/designer/backend.Tests/Controllers/RepositorySettingsControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/RepositorySettingsControllerTests.cs
@@ -33,6 +33,7 @@ namespace Designer.Tests.Controllers
         [Fact]
         public async Task Get_RepositorySettings_ShouldReturnOk()
         {
+            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
             var org = "ttd";
             var sourceRepository = "xyz-datamodels";
             var developer = "testUser";

--- a/src/studio/src/designer/backend.Tests/Controllers/RepositorySettingsControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/RepositorySettingsControllerTests.cs
@@ -29,10 +29,7 @@ namespace Designer.Tests.Controllers
         public RepositorySettingsControllerTests(WebApplicationFactory<RepositorySettingsController> factory)
         {
             _factory = factory;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
-            }
+            TestSetupUtils.SetupDirtyHackIfLinux();
         }
 
         [Fact]

--- a/src/studio/src/designer/backend.Tests/Controllers/RepositorySettingsControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/RepositorySettingsControllerTests.cs
@@ -28,12 +28,12 @@ namespace Designer.Tests.Controllers
         public RepositorySettingsControllerTests(WebApplicationFactory<RepositorySettingsController> factory)
         {
             _factory = factory;
+            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
         }
 
         [Fact]
         public async Task Get_RepositorySettings_ShouldReturnOk()
         {
-            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
             var org = "ttd";
             var sourceRepository = "xyz-datamodels";
             var developer = "testUser";

--- a/src/studio/src/designer/backend.Tests/Controllers/SessionControllerTest.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/SessionControllerTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Controllers;
@@ -36,14 +37,16 @@ namespace Designer.Tests.Controllers
         {
             _factory = factory;
             _generalSettings = Options.Create(new GeneralSettings { SessionTimeoutCookieName = "timeoutCookie" });
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
+            }
         }
 
         [Fact]
         public async Task GetRemainingSessionTime_Ok()
         {
             // Arrange
-            var keysDirectory = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys");
-            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", keysDirectory);
             string uri = $"{_versionPrefix}/remaining";
 
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, uri);

--- a/src/studio/src/designer/backend.Tests/Controllers/SessionControllerTest.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/SessionControllerTest.cs
@@ -1,8 +1,8 @@
+using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Altinn.Studio.Designer;
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Controllers;
 using Altinn.Studio.Designer.Services.Interfaces;
@@ -42,6 +42,8 @@ namespace Designer.Tests.Controllers
         public async Task GetRemainingSessionTime_Ok()
         {
             // Arrange
+            var keysDirectory = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys");
+            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", keysDirectory);
             string uri = $"{_versionPrefix}/remaining";
 
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
@@ -55,7 +57,7 @@ namespace Designer.Tests.Controllers
             string responseString = await response.Content.ReadAsStringAsync();
             int remainingTime = int.Parse(responseString);
 
-            // Assert          
+            // Assert
             Assert.True(remainingTime == 194);
         }
 
@@ -85,7 +87,7 @@ namespace Designer.Tests.Controllers
             // Act
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
-            // Assert          
+            // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 

--- a/src/studio/src/designer/backend.Tests/Controllers/SessionControllerTest.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/SessionControllerTest.cs
@@ -37,10 +37,7 @@ namespace Designer.Tests.Controllers
         {
             _factory = factory;
             _generalSettings = Options.Create(new GeneralSettings { SessionTimeoutCookieName = "timeoutCookie" });
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
-            }
+            TestSetupUtils.SetupDirtyHackIfLinux();
         }
 
         [Fact]

--- a/src/studio/src/designer/backend.Tests/Factories/ModelFactory/CustomXsd2JsonSchemaTests.cs
+++ b/src/studio/src/designer/backend.Tests/Factories/ModelFactory/CustomXsd2JsonSchemaTests.cs
@@ -9,8 +9,8 @@ namespace Designer.Tests.Factories.ModelFactory
     public class CustomXsd2JsonSchemaTests
     {
         [Theory]
-        [InlineData(@"Model/xsd/statsbygg_custom_unmodified.xsd")]
-        [InlineData(@"Model/xsd/statsbygg_custom_modified.xsd")]
+        [InlineData(@"Model/Xsd/statsbygg_custom_unmodified.xsd")]
+        [InlineData(@"Model/Xsd/statsbygg_custom_modified.xsd")]
         public void AsJsonSchema_ConvertXsdToJsonSchema_CorrectNumberOfPropertiesAndDefinitions(string xsdPath)
         {
             // Arrange
@@ -18,7 +18,7 @@ namespace Designer.Tests.Factories.ModelFactory
             XsdToJsonSchema target = new XsdToJsonSchema(xsdReader);
 
             // Act
-            JsonSchema actual = target.AsJsonSchema();            
+            JsonSchema actual = target.AsJsonSchema();
 
             // Assert
             Assert.NotNull(actual);

--- a/src/studio/src/designer/backend.Tests/Factories/ModelFactory/JsonSchemaToMetamodelConverterTests.cs
+++ b/src/studio/src/designer/backend.Tests/Factories/ModelFactory/JsonSchemaToMetamodelConverterTests.cs
@@ -32,7 +32,7 @@ namespace Designer.Tests.Factories.ModelFactory
         }
 
         [Theory]
-        [InlineData("Model/Xsd/HvemErHvem.xsd", "Model/Metadata/HvemErhvem.metadata.json")]
+        [InlineData("Model/Xsd/HvemErHvem.xsd", "Model/Metadata/HvemErHvem.metadata.json")]
         [InlineData("Model/Xsd/SeresBasicSchema.xsd", "Model/Metadata/SeresBasicSchema.metadata.json")]
         [InlineData("Model/Xsd/schema_5259_1_forms_9999_50000.xsd", "Model/Metadata/schema_5259_1_forms_9999_50000.metadata.json")]
         [InlineData("Model/Xsd/schema_5064_1_forms_5793_42882.xsd", "Model/Metadata/schema_5064_1_forms_5793_42882.metadata.json")]
@@ -64,7 +64,7 @@ namespace Designer.Tests.Factories.ModelFactory
             var expectedMetamodelJson = TestDataHelper.LoadTestDataFromFileAsString(expectedMetamodelPath);
             var expectedMetamodel = JsonSerializer.Deserialize<ModelMetadata>(expectedMetamodelJson, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true, Converters = { new JsonStringEnumConverter() } });
             MetadataAssertions.IsEquivalentTo(expectedMetamodel, actualMetamodel);
-            
+
             actualMetamodel.Elements.Values.Where(e => e.ParentElement == null).ToList().Count.Should().Be(1);
 
             // Compile the generated class to verify it compiles without errors

--- a/src/studio/src/designer/backend.Tests/Factories/ModelFactory/XsdToJsonSchemaTests.cs
+++ b/src/studio/src/designer/backend.Tests/Factories/ModelFactory/XsdToJsonSchemaTests.cs
@@ -54,7 +54,7 @@ namespace Designer.Tests.Factories.ModelFactory
         public void ConvertXsdToJsonSchema_CorrectNumberOfPropertiesAndDefinitions()
         {
                 // Arrange
-                using XmlReader xsdReader = XmlReader.Create(LoadTestData("Model/xsd/Skjema-1603-12392.xsd"));
+                using XmlReader xsdReader = XmlReader.Create(LoadTestData("Model/Xsd/Skjema-1603-12392.xsd"));
                 XsdToJsonSchema target = new XsdToJsonSchema(xsdReader);
 
                 // Act
@@ -65,7 +65,7 @@ namespace Designer.Tests.Factories.ModelFactory
                 Assert.Equal(12, actual.Properties().Count);
                 Assert.Equal(19, actual.Definitions().Count);
         }
-        
+
         private Stream LoadTestData(string resourceName)
         {
             string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(XsdToJsonSchemaTests).Assembly.Location).LocalPath);

--- a/src/studio/src/designer/backend.Tests/Infrastructure/GitRepository/AltinnGitRepositoryTests.cs
+++ b/src/studio/src/designer/backend.Tests/Infrastructure/GitRepository/AltinnGitRepositoryTests.cs
@@ -41,8 +41,8 @@ namespace Designer.Tests.Infrastructure.GitRepository
         {
             string repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
             string repositoryDirectory = TestDataHelper.GetTestDataRepositoryDirectory("ttd", "hvem-er-hvem", "testUser");
-            
-            Assert.Throws<ArgumentException>(() => new AltinnGitRepository(org, repository, developer, repositoriesRootDirectory, repositoryDirectory));            
+
+            Assert.Throws<ArgumentException>(() => new AltinnGitRepository(org, repository, developer, repositoriesRootDirectory, repositoryDirectory));
         }
 
         [Theory]
@@ -50,7 +50,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
         public void Constructor_ValidParameters_ShouldInstantiate(string org, string repository, string developer)
         {
             string repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
-            string repositoryDirectory = TestDataHelper.GetTestDataRepositoryDirectory(org, repository, developer);            
+            string repositoryDirectory = TestDataHelper.GetTestDataRepositoryDirectory(org, repository, developer);
 
             var altinnGitRepository = new AltinnGitRepository(org, repository, developer, repositoriesRootDirectory, repositoryDirectory);
 
@@ -77,17 +77,17 @@ namespace Designer.Tests.Infrastructure.GitRepository
         {
             var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
             var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(repositoriesRootDirectory);
-            
+
             var altinnGitRepository = altinnGitRepositoryFactory.GetAltinnGitRepository(org, repository, developer);
             var files = altinnGitRepository.GetSchemaFiles();
 
             Assert.Equal(expectedSchemaFiles, files.Count);
         }
 
-        [Fact]        
+        [Fact]
         public void GetSchemaFiles_FilesExist_ShouldReturnFilesWithCorrectProperties()
-        {            
-            var altinnGitRepository = GetTestRepository("ttd", "hvem-er-hvem", "testuser");
+        {
+            var altinnGitRepository = GetTestRepository("ttd", "hvem-er-hvem", "testUser");
             var file = altinnGitRepository.GetSchemaFiles().First(f => f.FileName == "HvemErHvem_ExternalTypes.schema.json");
 
             Assert.Equal(".json", file.FileType);
@@ -96,7 +96,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
         [Fact]
         public async Task RepositoryType_SettingsExists_ShouldUseThat()
-        {            
+        {
             var altinnGitRepository = GetTestRepository("ttd", "ttd-datamodels", "testUser");
 
             Assert.Equal(AltinnRepositoryType.Datamodels, await altinnGitRepository.GetRepositoryType());

--- a/src/studio/src/designer/backend.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
+++ b/src/studio/src/designer/backend.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
@@ -35,11 +35,11 @@ namespace Designer.Tests.Infrastructure.GitRepository
         }
 
         [Theory]
-        [InlineData(@"app/models/Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES.metadata.json")]
-        [InlineData(@"app/models/HvemErHvem.json")]
-        [InlineData(@"app/models/HvemErHvem_FlatNoTypes.schema.json")]
-        [InlineData(@"app/models/HvemErHvem_SERES.schema.json")]
-        [InlineData(@"/app/models/HvemErHvem_SERES.schema.json")]
+        [InlineData(@"App/models/Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES.metadata.json")]
+        [InlineData(@"App/models/HvemErHvem.json")]
+        [InlineData(@"App/models/HvemErHvem_FlatNoTypes.schema.json")]
+        [InlineData(@"App/models/HvemErHvem_SERES.schema.json")]
+        [InlineData(@"/App/models/HvemErHvem_SERES.schema.json")]
         public async Task WriteTextByRelativePathAsync_ReadWriteRoundtrip_ShouldReadBackEqual(string expectedFilePath)
         {
             var org = "ttd";

--- a/src/studio/src/designer/backend.Tests/Utils/TestSetupUtils.cs
+++ b/src/studio/src/designer/backend.Tests/Utils/TestSetupUtils.cs
@@ -1,0 +1,16 @@
+using System;
+using System.IO;
+
+namespace Designer.Tests.Utils;
+
+public class TestSetupUtils
+{
+    // Dirty hack to make test run on Linux. We need to set the environment variable ALTINN_KEY_DIRECTORY
+    public static void SetupDirtyHackIfLinux()
+    {
+        if (System.Environment.OSVersion.Platform == PlatformID.Unix)
+        {
+            Environment.SetEnvironmentVariable("ALTINN_KEYS_DIRECTORY", Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "ASP.NET", "DataProtection-Keys"));
+        }
+    }
+}

--- a/src/studio/src/designer/backend/Infrastructure/DataProtectionConfiguration.cs
+++ b/src/studio/src/designer/backend/Infrastructure/DataProtectionConfiguration.cs
@@ -33,12 +33,12 @@ namespace Altinn.Studio.Designer.Infrastructure
                 logger.LogWarning("Missing settings for key vault. Will not encrypt data protection keys.");
                 return;
             }
-            
+
             dataProtectionBuilder.ProtectKeysWithAzureKeyVault($"{keyVaultSettings.SecretUri}/keys/data-protection", keyVaultSettings.ClientId, keyVaultSettings.ClientSecret);
         }
 
         /// <summary>
-        /// Return a directory based on the running operating system. It is possible to override the directory based on the KEYS_DIRECTORY environment variable. 
+        /// Return a directory based on the running operating system. It is possible to override the directory based on the ALTINN_KEYS_DIRECTORY environment variable.
         /// </summary>
         /// <returns></returns>
         private static string GetKeysDirectory()


### PR DESCRIPTION
## Description

Make test run on linux. Now we support running xUnit test on windows, macos and linux.

Added github action workflow that runs all dotnet test on all oses on push/pr against master

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [x] Changelog is updated with a separate linked PR
  - [x] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
