### PR TITLE
Support switching to local js/css from an option in LocalTest

### DIFF
--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -213,7 +213,7 @@ namespace LocalTest.Controllers
                 {
                     new ()
                     {
-                        Text = "Standard CDN",
+                        Text = "Keep as is",
                         Value = "",
                     },
                     new ()

--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -224,7 +224,7 @@ namespace LocalTest.Controllers
                 }
             };
             var cdnVersionsString = await client.GetStringAsync("https://altinncdn.no/toolkits/altinn-app-frontend/index.json");
-            var groupCdnVersions = new SelectListGroup() { Name = "Older versions from cdn" };
+            var groupCdnVersions = new SelectListGroup() { Name = "Specific version from cdn" };
             var versions = JsonSerializer.Deserialize<List<string>>(cdnVersionsString);
             versions.Reverse();
             versions.ForEach(version =>

--- a/src/development/LocalTest/Models/FrontendVersion.cs
+++ b/src/development/LocalTest/Models/FrontendVersion.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+using System.Collections.Generic;
+
+namespace LocalTest.Models
+{
+    public class FrontendVersion
+    {
+        public string Version { get; set; }
+        public List<SelectListItem> Versions { get; set; }
+    }
+}

--- a/src/development/LocalTest/Models/StartAppModel.cs
+++ b/src/development/LocalTest/Models/StartAppModel.cs
@@ -70,6 +70,12 @@ namespace LocalTest.Models
         public string AuthenticationLevel { get; set; }
 
         /// <summary>
+        /// Url for where to load the local frontend from
+        /// (implemented as a cookie that nginx reads and substitutes the content in index.html)
+        /// </summary>
+        public string LocalFrontendUrl { get; set; }
+
+        /// <summary>
         /// List of TestUsers for dropdown
         /// </summary>
         public IEnumerable<SelectListItem> TestUsers { get; set; }

--- a/src/development/LocalTest/Views/Home/FrontendVersion.cshtml
+++ b/src/development/LocalTest/Views/Home/FrontendVersion.cshtml
@@ -1,0 +1,16 @@
+﻿@model FrontendVersion
+
+@{
+    ViewData["Title"] = "Frontend version";
+}
+<h1>@ViewData["Title"]</h1>
+
+@using (Html.BeginForm("FrontendVersion", "Home", FormMethod.Post, new { Class = "form-signin" }))
+{
+  @Html.AntiForgeryToken();
+  <div class="form-group">
+    <label for="exampleInputEmail1">Select your desired frontend version</label>
+    @Html.DropDownListFor(model => model.Version, Model.Versions, new { Class = "form-control" })
+  </div>
+  <button type="submit" class="btn btn-primary">Select</button>
+}

--- a/src/development/LocalTest/Views/Home/Index.cshtml
+++ b/src/development/LocalTest/Views/Home/Index.cshtml
@@ -86,6 +86,19 @@
     <div class="alert alert-light" role="alert">
       To access attachments XML and other data, visit <a href="/LocalPlatformStorage/">/LocalPlatformStorage</a>
     </div>
+
+    @if(string.IsNullOrWhiteSpace(Model.LocalFrontendUrl))
+    {
+      <div class="alert alert-light" role="alert">
+        @Html.ActionLink("Use a different frontend version", "FrontendVersion", "Home")
+      </div>
+    }
+    else
+    {
+      <div class="alert alert-primary" role="alert">
+        You are using frontend js and css from @(Model.LocalFrontendUrl). @Html.ActionLink("Use a different frontend version", "FrontendVersion", "Home")
+      </div>
+    }
   </div>
   }
 }

--- a/src/development/LocalTest/Views/Home/Privacy.cshtml
+++ b/src/development/LocalTest/Views/Home/Privacy.cshtml
@@ -1,6 +1,0 @@
-﻿@{
-    ViewData["Title"] = "Privacy Policy";
-}
-<h1>@ViewData["Title"]</h1>
-
-<p>Use this page to detail your site's privacy policy.</p>

--- a/src/development/docker-compose.yml
+++ b/src/development/docker-compose.yml
@@ -16,7 +16,6 @@ services:
     environment:
       - NGINX_HOST=localhost
       - NGINX_PORT=80
-      - SUB_FILTER=${SUB_FILTER:-}
       - TEST_DOMAIN=${TEST_DOMAIN:-altinn3local.no}
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
     build:

--- a/src/development/loadbalancer/Dockerfile
+++ b/src/development/loadbalancer/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21.6-alpine
+FROM nginx:1.21.6-alpine-perl
 
 # Copy to template in order for Environment variable substitutions to run
 COPY nginx.conf /etc/nginx/templates/nginx.conf.template

--- a/src/development/loadbalancer/nginx.conf
+++ b/src/development/loadbalancer/nginx.conf
@@ -1,8 +1,25 @@
+load_module /etc/nginx/modules/ngx_http_perl_module.so;
+
 worker_processes 1;
 
 events { worker_connections 1024; }
 
 http {
+
+
+    # perl_modules perl/lib;
+    # Support replacing reference to altinn js and css in app with local hosted webpack dev server
+    perl_set $LOCAL_SUB_FILTER 'sub {
+      my $r = shift;
+      my $cookie = $r->header_in("cookie");
+      my $url = $1 if ($cookie =~ /.*frontendVersion=(http.*?);/);
+      if($url)
+      {
+        $uri = $r->unescape($url);
+        return $uri;
+      }
+      return "https://altinncdn.no/toolkits/altinn-app-frontend/3/"
+    }';
 
     client_max_body_size 50M;
 
@@ -43,9 +60,9 @@ http {
 		}
 
 		location / {
-        # Support sub_filter declaration trough environment variable substitution
-        # default empty
-        ${SUB_FILTER}
+        #Support using Local js, when a cookie value is set
+        sub_filter_once off;
+        sub_filter 'https://altinncdn.no/toolkits/altinn-app-frontend/3/' $LOCAL_SUB_FILTER;
         proxy_pass          http://app/;
         error_page 502 /502App.html;
 		}


### PR DESCRIPTION
I have not yet implemented the logic to find urls for all old versions, but now it's easy to do from C# (not nginx), and I've moved the selection to a different page.

Because of cookies beeing url encoded, I had to use the perl mod of nginx. 

Default view in localtest
![image](https://user-images.githubusercontent.com/131616/169507640-d2c365de-efb4-4a7b-bef9-4e5026fc53f2.png)
With localhost selected
![image](https://user-images.githubusercontent.com/131616/169508383-54a29a17-cb17-4067-b97a-caf91f5fad33.png)

Version picker page (could pretty easily be extended to show older versions as well)
![image](https://user-images.githubusercontent.com/131616/169507603-a927c7a9-984b-4566-b915-21ea1b5de749.png)


## Fixes
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
