### PR TITLE
Add prefill capability to localtest

### DIFF
--- a/src/development/LocalTest/Clients/CdnAltinnOrgs/AltinnOrgsClient.cs
+++ b/src/development/LocalTest/Clients/CdnAltinnOrgs/AltinnOrgsClient.cs
@@ -21,6 +21,6 @@ public class AltinnOrgsClient
     public async Task<CdnOrgs> GetCdnOrgs()
     {
         var orgsJson = await _client.GetByteArrayAsync("https://altinncdn.no/orgs/altinn-orgs.json");
-        return JsonSerializer.Deserialize<CdnOrgs>(orgsJson, JSON_OPTIONS);
+        return JsonSerializer.Deserialize<CdnOrgs>(orgsJson, JSON_OPTIONS) ?? throw new JsonException("altinn-orgs respones was \"null\"");
     }
 }

--- a/src/development/LocalTest/Clients/CdnAltinnOrgs/AltinnOrgsClient.cs
+++ b/src/development/LocalTest/Clients/CdnAltinnOrgs/AltinnOrgsClient.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace LocalTest.Clients.CdnAltinnOrgs;
+
+/// <summary>
+/// Access data from https://altinncdn.no/orgs/altinn-orgs.json
+/// </summary>
+public class AltinnOrgsClient
+{
+    private static JsonSerializerOptions JSON_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+    private readonly HttpClient _client;
+
+    public AltinnOrgsClient(HttpClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<CdnOrgs> GetCdnOrgs()
+    {
+        var orgsJson = await _client.GetByteArrayAsync("https://altinncdn.no/orgs/altinn-orgs.json");
+        return JsonSerializer.Deserialize<CdnOrgs>(orgsJson, JSON_OPTIONS);
+    }
+}

--- a/src/development/LocalTest/Clients/CdnAltinnOrgs/Models.cs
+++ b/src/development/LocalTest/Clients/CdnAltinnOrgs/Models.cs
@@ -1,0 +1,42 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace LocalTest.Clients.CdnAltinnOrgs;
+
+public class CdnOrgs
+{
+    [JsonPropertyName("orgs")]
+    public Dictionary<string,CdnOrg>? Orgs { get; set; }
+}
+
+public class CdnOrg
+{
+    [JsonPropertyName("name")]
+    public CdnOrgName? Name { get; set; }
+
+    [JsonPropertyName("logo")]
+    public string? Logo { get; set; }
+
+    [JsonPropertyName("orgnr")]
+    public string? Orgnr { get; set; }
+
+    [JsonPropertyName("homepage")]
+    public string? Homepage { get; set; }
+
+    [JsonPropertyName("environments")]
+    public List<string>? Environments { get; set; }
+
+}
+
+public class CdnOrgName
+{
+    [JsonPropertyName("nb")]
+    public string? Nb { get; set; }
+
+    [JsonPropertyName("nn")]
+    public string? Nn { get; set; }
+
+    [JsonPropertyName("en")]
+    public string? En { get; set; }
+}

--- a/src/development/LocalTest/Configuration/Authentication/GeneralSettings.cs
+++ b/src/development/LocalTest/Configuration/Authentication/GeneralSettings.cs
@@ -105,11 +105,11 @@ namespace Altinn.Platform.Authentication.Configuration
         /// <summary>
         /// Gets the jwt cookie validity time from kubernetes environment variables and appsettings if environment variable is not set
         /// </summary>
-        public string GetJwtCookieValidityTime
+        public int GetJwtCookieValidityTime
         {
             get
             {
-                return Environment.GetEnvironmentVariable("GeneralSettings__GetJwtCookieValidityTime") ?? JwtCookieValidityTime;
+                return Convert.ToInt32(Environment.GetEnvironmentVariable("GeneralSettings__GetJwtCookieValidityTime") ?? JwtCookieValidityTime);
             }
         }
 

--- a/src/development/LocalTest/Controllers/Authentication/AuthenticationController.cs
+++ b/src/development/LocalTest/Controllers/Authentication/AuthenticationController.cs
@@ -44,7 +44,7 @@ namespace LocalTest.Controllers.Authentication
             ClaimsPrincipal principal = HttpContext.User;
             _logger.LogInformation("Refreshing token....");
 
-            string token = _authenticationService.GenerateToken(principal, Convert.ToInt32(_generalSettings.JwtCookieValidityTime));
+            string token = _authenticationService.GenerateToken(principal);
             _logger.LogInformation("End of refreshing token");
             return await Task.FromResult(Ok(token));
         }
@@ -69,8 +69,8 @@ namespace LocalTest.Controllers.Authentication
             identity.AddClaims(claims);
             ClaimsPrincipal principal = new ClaimsPrincipal(identity);
 
-            string token = _authenticationService.GenerateToken(principal, Convert.ToInt32(_generalSettings.JwtCookieValidityTime));
-            
+            string token = _authenticationService.GenerateToken(principal);
+
             return await Task.FromResult(Ok(token));
         }
 
@@ -91,8 +91,8 @@ namespace LocalTest.Controllers.Authentication
             identity.AddClaims(claims);
             ClaimsPrincipal principal = new ClaimsPrincipal(identity);
 
-            string token = _authenticationService.GenerateToken(principal, Convert.ToInt32(_generalSettings.JwtCookieValidityTime));
-            
+            string token = _authenticationService.GenerateToken(principal);
+
             return await Task.FromResult(Ok(token));
         }
     }

--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -165,7 +165,7 @@ namespace LocalTest.Controllers
 
                     using var reader = new StreamReader(prefill.OpenReadStream());
                     var content = await reader.ReadToEndAsync();
-                    var newInstance = await _localApp.Instanciate(app.Id, instance, content, xmlDataId);
+                    var newInstance = await _localApp.Instantiate(app.Id, instance, content, xmlDataId);
 
                     return Redirect($"{_generalSettings.GetBaseUrl}/{app.Id}/#/instance/{newInstance.Id}");
                 }

--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -158,6 +158,10 @@ namespace LocalTest.Controllers
                     {
                         instance.InstanceOwner.PersonNumber = owner;
                     }
+                    else
+                    {
+                        throw new Exception($"instance owner must be specified as part of the prefill filename. 9 digigts for OrganisationNumber, 12 for PersonNumber (eg 897069631.xml, not {prefill.FileName})");
+                    }
                     var xmlDataId = app.DataTypes.First(dt => dt.AppLogic is not null).Id;
 
                     var newInstance = await _localApp.Instanciate(app.Id, instance, content, xmlDataId);

--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -78,6 +78,7 @@ namespace LocalTest.Controllers
             model.StaticTestDataPath = _localPlatformSettings.LocalTestingStaticTestDataPath;
             model.LocalAppUrl = _localPlatformSettings.LocalAppUrl;
             var defaultAuthLevel = _localPlatformSettings.LocalAppMode == "http" ? await GetAppAuthLevel(model.TestApps) : 2;
+            model.AppModeIsHttp = _localPlatformSettings.LocalAppMode == "http";
             model.AuthenticationLevels = GetAuthenticationLevels(defaultAuthLevel);
             model.LocalFrontendUrl = HttpContext.Request.Cookies[FRONTEND_URL_COOKIE_NAME];
 

--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -140,9 +140,6 @@ namespace LocalTest.Controllers
                 var prefill = Request.Form.Files.FirstOrDefault();
                 if (prefill != null)
                 {
-                    var owner = prefill.FileName.Split(".")[0];
-                    using var reader = new StreamReader(prefill.OpenReadStream());
-                    var content = await reader.ReadToEndAsync();
                     var instance = new Instance{
                         AppId = app.Id,
                         Org = app.Org,
@@ -150,6 +147,7 @@ namespace LocalTest.Controllers
                         DataValues = new(),
                     };
 
+                    var owner = prefill.FileName.Split(".")[0];
                     if (owner.Length == 9)
                     {
                         instance.InstanceOwner.OrganisationNumber = owner;
@@ -162,8 +160,11 @@ namespace LocalTest.Controllers
                     {
                         throw new Exception($"instance owner must be specified as part of the prefill filename. 9 digigts for OrganisationNumber, 12 for PersonNumber (eg 897069631.xml, not {prefill.FileName})");
                     }
+
                     var xmlDataId = app.DataTypes.First(dt => dt.AppLogic is not null).Id;
 
+                    using var reader = new StreamReader(prefill.OpenReadStream());
+                    var content = await reader.ReadToEndAsync();
                     var newInstance = await _localApp.Instanciate(app.Id, instance, content, xmlDataId);
 
                     return Redirect($"{_generalSettings.GetBaseUrl}/{app.Id}/#/instance/{newInstance.Id}");

--- a/src/development/LocalTest/Models/StartAppModel.cs
+++ b/src/development/LocalTest/Models/StartAppModel.cs
@@ -89,5 +89,10 @@ namespace LocalTest.Models
         /// List of possible authentication levels
         /// </summary>
         public IEnumerable<SelectListItem> AuthenticationLevels { get; set; }
+
+        /// <summary>
+        /// Modify site conditionally on the app mode
+        /// </summary>
+        public bool AppModeIsHttp { get; set; }
     }
 }

--- a/src/development/LocalTest/Services/Authentication/Implementation/AuthenticationService.cs
+++ b/src/development/LocalTest/Services/Authentication/Implementation/AuthenticationService.cs
@@ -1,39 +1,104 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
-
+using System.Threading.Tasks;
+using AuthSettings = Altinn.Platform.Authentication.Configuration.GeneralSettings;
+using Altinn.Platform.Profile.Models;
+using LocalTest.Clients.CdnAltinnOrgs;
 using LocalTest.Services.Authentication.Interface;
-
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using LocalTest.Configuration;
+using AltinnCore.Authentication.Constants;
+using Altinn.Platform.Authorization.Services.Interface;
 
-namespace LocalTest.Services.Authentication.Implementation
+namespace LocalTest.Services.Authentication.Implementation;
+
+public class AuthenticationService : IAuthentication
 {
-    public class AuthenticationService : IAuthentication
+    private readonly AltinnOrgsClient _orgsClient;
+    private readonly AuthSettings _authSettings;
+    private readonly GeneralSettings _generalSettings;
+    private readonly IClaims _claimsService;
+
+    public AuthenticationService(AltinnOrgsClient orgsClient, IOptions<AuthSettings> authSettings, IOptions<GeneralSettings> generalSettings, IClaims claimsService)
     {
-        ///<inheritdoc/>
-        public string GenerateToken(ClaimsPrincipal principal, int cookieValidityTime)
+        _orgsClient = orgsClient;
+        _authSettings = authSettings.Value;
+        _generalSettings = generalSettings.Value;
+        _claimsService = claimsService;
+    }
+    ///<inheritdoc/>
+    public string GenerateToken(ClaimsPrincipal principal)
+    {
+        List<X509Certificate2> certificates = new List<X509Certificate2>
         {
-            List<X509Certificate2> certificates = new List<X509Certificate2>
-            {
-                new X509Certificate2("jwtselfsignedcert.pfx", "qwer1234") // lgtm [cs/hardcoded-credentials]
-            };
+            new X509Certificate2("jwtselfsignedcert.pfx", "qwer1234") // lgtm [cs/hardcoded-credentials]
+        };
 
-            TimeSpan tokenExpiry = new TimeSpan(0, cookieValidityTime, 0);
+        TimeSpan tokenExpiry = new TimeSpan(0, _authSettings.GetJwtCookieValidityTime, 0);
 
-            JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
-            SecurityTokenDescriptor tokenDescriptor = new SecurityTokenDescriptor
-            {
-                Subject = new ClaimsIdentity(principal.Identity),
-                Expires = DateTime.UtcNow.AddSeconds(tokenExpiry.TotalSeconds),
-                SigningCredentials = new X509SigningCredentials(certificates[0])
-            };
+        JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
+        SecurityTokenDescriptor tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(principal.Identity),
+            Expires = DateTime.UtcNow.AddSeconds(tokenExpiry.TotalSeconds),
+            SigningCredentials = new X509SigningCredentials(certificates[0])
+        };
 
-            SecurityToken token = tokenHandler.CreateToken(tokenDescriptor);
-            string serializedToken = tokenHandler.WriteToken(token);
+        SecurityToken token = tokenHandler.CreateToken(tokenDescriptor);
+        string serializedToken = tokenHandler.WriteToken(token);
 
-            return serializedToken;
+        return serializedToken;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GenerateTokenForOrg(string org, string? orgNumber = null)
+    {
+        if (orgNumber is null)
+        {
+            var orgs = await _orgsClient.GetCdnOrgs();
+            orgNumber = (orgs.Orgs?.TryGetValue(org, out var value) == true ? value : null)?.Orgnr;
         }
+
+        List<Claim> claims = new List<Claim>();
+        string issuer = _generalSettings.Hostname;
+        claims.Add(new Claim(AltinnCoreClaimTypes.Org, org.ToLower(), ClaimValueTypes.String, issuer));
+        claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, "2", ClaimValueTypes.Integer32, issuer));
+        claims.Add(new Claim("urn:altinn:scope", "altinn:serviceowner/instances.read", ClaimValueTypes.String, issuer));
+        if (!string.IsNullOrEmpty(orgNumber))
+        {
+            claims.Add(new Claim(AltinnCoreClaimTypes.OrgNumber, orgNumber, ClaimValueTypes.String, issuer));
+        }
+
+        ClaimsIdentity identity = new ClaimsIdentity(_generalSettings.GetClaimsIdentity);
+        identity.AddClaims(claims);
+        ClaimsPrincipal principal = new ClaimsPrincipal(identity);
+
+        // Create a test token with long duration
+        return GenerateToken(principal);
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GenerateTokenForProfile(UserProfile profile, int authenticationLevel)
+    {
+        List<Claim> claims = new List<Claim>();
+        string issuer = _generalSettings.Hostname;
+        claims.Add(new Claim(ClaimTypes.NameIdentifier, profile.UserId.ToString(), ClaimValueTypes.String, issuer));
+        claims.Add(new Claim(AltinnCoreClaimTypes.UserId, profile.UserId.ToString(), ClaimValueTypes.String, issuer));
+        claims.Add(new Claim(AltinnCoreClaimTypes.UserName, profile.UserName, ClaimValueTypes.String, issuer));
+        claims.Add(new Claim(AltinnCoreClaimTypes.PartyID, profile.PartyId.ToString(), ClaimValueTypes.Integer32, issuer));
+        claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, authenticationLevel.ToString(), ClaimValueTypes.Integer32, issuer));
+        claims.AddRange(await _claimsService.GetCustomClaims(profile.UserId, issuer));
+
+        ClaimsIdentity identity = new ClaimsIdentity(_generalSettings.GetClaimsIdentity);
+        identity.AddClaims(claims);
+        ClaimsPrincipal principal = new ClaimsPrincipal(identity);
+
+        return GenerateToken(principal);
     }
 }
+

--- a/src/development/LocalTest/Services/Authentication/Implementation/AuthenticationService.cs
+++ b/src/development/LocalTest/Services/Authentication/Implementation/AuthenticationService.cs
@@ -67,7 +67,8 @@ public class AuthenticationService : IAuthentication
         List<Claim> claims = new List<Claim>();
         string issuer = _generalSettings.Hostname;
         claims.Add(new Claim(AltinnCoreClaimTypes.Org, org.ToLower(), ClaimValueTypes.String, issuer));
-        claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, "2", ClaimValueTypes.Integer32, issuer));
+        // 3 is the default level for altinn tokens form Maskinporten
+        claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, "3", ClaimValueTypes.Integer32, issuer));
         claims.Add(new Claim("urn:altinn:scope", "altinn:serviceowner/instances.read", ClaimValueTypes.String, issuer));
         if (!string.IsNullOrEmpty(orgNumber))
         {

--- a/src/development/LocalTest/Services/Authentication/Interface/IAuthentication.cs
+++ b/src/development/LocalTest/Services/Authentication/Interface/IAuthentication.cs
@@ -1,8 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
+#nullable enable
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Altinn.Platform.Profile.Models;
 
 namespace LocalTest.Services.Authentication.Interface
 {
@@ -12,8 +11,21 @@ namespace LocalTest.Services.Authentication.Interface
         /// Creates a JWT token based on claims principal.
         /// </summary>
         /// <param name="principal">The claims principal.</param>
-        /// <param name="cookieValidityTime">Token validity time in minutes.</param>
-        /// <returns></returns>
-        public string GenerateToken(ClaimsPrincipal principal, int cookieValidityTime);
+        /// <returns>JWT token</returns>
+        public string GenerateToken(ClaimsPrincipal principal);
+
+        /// <summary>
+        /// Generate a JWT token with claims for an application owner org
+        /// </summary>
+        /// <param name="org">Three letter application owner name (eg, TST )</param>
+        /// <param name="orgNumber">Optional Organization number for the application owner. Will be fetched if not provided</param>
+        /// <returns>JWT token</returns>
+        public Task<string> GenerateTokenForOrg(string org, string? orgNumber = null);
+
+        /// <summary>
+        /// Get JWT token for user profile
+        /// </summary>
+        /// <returns>JWT token</returns>
+        public Task<string> GenerateTokenForProfile(UserProfile profile, int authenticationLevel);
     }
 }

--- a/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppFile.cs
+++ b/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppFile.cs
@@ -100,7 +100,7 @@ namespace LocalTest.Services.LocalApp.Implementation
             return null;
         }
 
-        public Task<Instance?> Instanciate(string appId, Instance instance, string xmlPrefill, string xmlDataId)
+        public Task<Instance?> Instantiate(string appId, Instance instance, string xmlPrefill, string xmlDataId)
         {
             throw new NotImplementedException();
         }

--- a/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppFile.cs
+++ b/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppFile.cs
@@ -100,6 +100,11 @@ namespace LocalTest.Services.LocalApp.Implementation
             return null;
         }
 
+        public Task<Instance?> Instanciate(string appId, Instance instance, string xmlPrefill, string xmlDataId)
+        {
+            throw new NotImplementedException();
+        }
+
         private string GetAppPath(string appId)
         {
             return Path.Join(_localPlatformSettings.AppRepositoryBasePath, appId.Split('/').Last());

--- a/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
+++ b/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
@@ -89,7 +89,7 @@ namespace LocalTest.Services.LocalApp.Implementation
             return ret;
         }
 
-        public async Task<Instance?> Instanciate(string appId, Instance instance, string xmlPrefill, string xmlDataId)
+        public async Task<Instance?> Instantiate(string appId, Instance instance, string xmlPrefill, string xmlDataId)
         {
             var requestUri = $"{appId}/instances";
             var serializedInstance = JsonSerializer.Serialize(instance, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault });

--- a/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
+++ b/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
@@ -103,7 +103,6 @@ namespace LocalTest.Services.LocalApp.Implementation
 
             using var message = new HttpRequestMessage(HttpMethod.Post, requestUri);
             message.Content = content;
-            // TODO: Figure out how to get orgnumber for app owner from appId
             message.Headers.Authorization = new ("Bearer", await _authenticationService.GenerateTokenForOrg(appId.Split("/")[0]));
             var response = await _httpClient.SendAsync(message);
             var stringResponse = await response.Content.ReadAsStringAsync();

--- a/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
+++ b/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
@@ -33,6 +33,7 @@ namespace LocalTest.Services.LocalApp.Implementation
             _authenticationService = authenticationService;
             _httpClient = httpClientFactory.CreateClient();
             _httpClient.BaseAddress = new Uri(localPlatformSettings.Value.LocalAppUrl);
+            _httpClient.Timeout = TimeSpan.FromHours(1);
             _cache = cache;
         }
         public async Task<string?> GetXACMLPolicy(string appId)
@@ -106,7 +107,10 @@ namespace LocalTest.Services.LocalApp.Implementation
             message.Headers.Authorization = new ("Bearer", GetOrgToken(appId.Split("/")[0], "840747972"));
             var response = await _httpClient.SendAsync(message);
             var stringResponse = await response.Content.ReadAsStringAsync();
-            response.EnsureSuccessStatusCode();
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException(stringResponse);
+            }
 
             return JsonSerializer.Deserialize<Instance>(stringResponse, new JsonSerializerOptions{PropertyNameCaseInsensitive = true});
         }

--- a/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
+++ b/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
@@ -8,7 +8,6 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Caching.Memory;
-using Newtonsoft.Json;
 
 using Altinn.Platform.Storage.Interface.Models;
 using LocalTest.Services.Authentication.Interface;
@@ -53,7 +52,7 @@ namespace LocalTest.Services.LocalApp.Implementation
                 cacheEntry.SetSlidingExpiration(TimeSpan.FromSeconds(5));
                 return await _httpClient.GetStringAsync($"{appId}/api/v1/applicationmetadata?checkOrgApp=false");
             });
-            return JsonConvert.DeserializeObject<Application>(content);
+            return JsonSerializer.Deserialize<Application>(content, new JsonSerializerOptions{PropertyNameCaseInsensitive = true} );
         }
 
         public async Task<TextResource?> GetTextResource(string org, string app, string language)
@@ -64,7 +63,7 @@ namespace LocalTest.Services.LocalApp.Implementation
                 return await _httpClient.GetStringAsync($"{org}/{app}/api/v1/texts/{language}");
             });
 
-            var textResource = JsonConvert.DeserializeObject<TextResource>(content);
+            var textResource = JsonSerializer.Deserialize<TextResource>(content, new JsonSerializerOptions{PropertyNameCaseInsensitive = true});
             if (textResource != null)
             {
                 textResource.Id = $"{org}-{app}-{language}";

--- a/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
+++ b/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
@@ -100,19 +100,14 @@ namespace LocalTest.Services.LocalApp.Implementation
                 content.Add(new StringContent(xmlPrefill, System.Text.Encoding.UTF8, "application/xml"), xmlDataId);
             }
 
-            var message = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            using var message = new HttpRequestMessage(HttpMethod.Post, requestUri);
             message.Content = content;
             // TODO: Figure out how to get orgnumber for app owner from appId
             message.Headers.Authorization = new ("Bearer", GetOrgToken(appId.Split("/")[0], "840747972"));
             var response = await _httpClient.SendAsync(message);
             var stringResponse = await response.Content.ReadAsStringAsync();
             response.EnsureSuccessStatusCode();
-            if (!response.IsSuccessStatusCode)
-            {
-                // TODO: This is a critical error as we don't know what might have failed and whether an instance actually was created
-                // Figure out a way to ensure that we debug the issue before trying to instantiate more on this app
-                // throw new ApiException($"Instantiation failed POST {response.RequestMessage?.RequestUri} returned {response.StatusCode}\n{stringResponse}");
-            }
+
             return JsonSerializer.Deserialize<Instance>(stringResponse, new JsonSerializerOptions{PropertyNameCaseInsensitive = true});
         }
 

--- a/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
+++ b/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppHttp.cs
@@ -2,12 +2,17 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;
 
 using Altinn.Platform.Storage.Interface.Models;
+using LocalTest.Services.Authentication.Interface;
+using AltinnCore.Authentication.Constants;
 
 using LocalTest.Configuration;
 using LocalTest.Services.LocalApp.Interface;
@@ -19,10 +24,14 @@ namespace LocalTest.Services.LocalApp.Implementation
         public const string XACML_CACHE_KEY = "/api/v1/meta/authorizationpolicy/";
         public const string APPLICATION_METADATA_CACHE_KEY = "/api/v1/applicationmetadata?checkOrgApp=false";
         public const string TEXT_RESOURCE_CACE_KEY = "/api/v1/texts";
+        private readonly GeneralSettings _generalSettings;
+        private readonly IAuthentication _authenticationService;
         private readonly HttpClient _httpClient;
         private readonly IMemoryCache _cache;
-        public LocalAppHttp(IHttpClientFactory httpClientFactory, IOptions<LocalPlatformSettings> localPlatformSettings, IMemoryCache cache)
+        public LocalAppHttp(IOptions<GeneralSettings> generalSettings, IAuthentication authenticationService, IHttpClientFactory httpClientFactory, IOptions<LocalPlatformSettings> localPlatformSettings, IMemoryCache cache)
         {
+            _generalSettings = generalSettings.Value;
+            _authenticationService = authenticationService;
             _httpClient = httpClientFactory.CreateClient();
             _httpClient.BaseAddress = new Uri(localPlatformSettings.Value.LocalAppUrl);
             _cache = cache;
@@ -78,6 +87,55 @@ namespace LocalTest.Services.LocalApp.Implementation
             }
 
             return ret;
+        }
+
+        public async Task<Instance?> Instanciate(string appId, Instance instance, string xmlPrefill, string xmlDataId)
+        {
+            var requestUri = $"{appId}/instances";
+            var serializedInstance = JsonSerializer.Serialize(instance, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault });
+
+            var content = new MultipartFormDataContent();
+            content.Add(new StringContent(serializedInstance, System.Text.Encoding.UTF8, "application/json"), "instance");
+            if (!string.IsNullOrWhiteSpace(xmlPrefill) && xmlDataId is not null)
+            {
+                content.Add(new StringContent(xmlPrefill, System.Text.Encoding.UTF8, "application/xml"), xmlDataId);
+            }
+
+            var message = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            message.Content = content;
+            // TODO: Figure out how to get orgnumber for app owner from appId
+            message.Headers.Authorization = new ("Bearer", GetOrgToken(appId.Split("/")[0], "840747972"));
+            var response = await _httpClient.SendAsync(message);
+            var stringResponse = await response.Content.ReadAsStringAsync();
+            response.EnsureSuccessStatusCode();
+            if (!response.IsSuccessStatusCode)
+            {
+                // TODO: This is a critical error as we don't know what might have failed and whether an instance actually was created
+                // Figure out a way to ensure that we debug the issue before trying to instantiate more on this app
+                // throw new ApiException($"Instantiation failed POST {response.RequestMessage?.RequestUri} returned {response.StatusCode}\n{stringResponse}");
+            }
+            return JsonSerializer.Deserialize<Instance>(stringResponse, new JsonSerializerOptions{PropertyNameCaseInsensitive = true});
+        }
+
+        private string GetOrgToken(string id, string orgNumber)
+        {
+            // Copied from HomeController (should probably be a method of IAuthService)
+            List<Claim> claims = new List<Claim>();
+            string issuer = _generalSettings.Hostname;
+            claims.Add(new Claim(AltinnCoreClaimTypes.Org, id.ToLower(), ClaimValueTypes.String, issuer));
+            claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, "2", ClaimValueTypes.Integer32, issuer));
+            claims.Add(new Claim("urn:altinn:scope", "altinn:serviceowner/instances.read", ClaimValueTypes.String, issuer));
+            if (!string.IsNullOrEmpty(orgNumber))
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.OrgNumber, orgNumber, ClaimValueTypes.String, issuer));
+            }
+
+            ClaimsIdentity identity = new ClaimsIdentity(_generalSettings.GetClaimsIdentity);
+            identity.AddClaims(claims);
+            ClaimsPrincipal principal = new ClaimsPrincipal(identity);
+
+            // Create a test token with long duration
+            return _authenticationService.GenerateToken(principal, 1337);
         }
     }
 }

--- a/src/development/LocalTest/Services/LocalApp/Interface/ILocalApp.cs
+++ b/src/development/LocalTest/Services/LocalApp/Interface/ILocalApp.cs
@@ -15,5 +15,7 @@ namespace LocalTest.Services.LocalApp.Interface
         Task<Dictionary<string, Application>> GetApplications();
 
         Task<TextResource?> GetTextResource(string org, string app, string language);
+
+        Task<Instance?> Instanciate(string appId, Instance instance, string xmlPrefill, string xmlDataId);
     }
 }

--- a/src/development/LocalTest/Services/LocalApp/Interface/ILocalApp.cs
+++ b/src/development/LocalTest/Services/LocalApp/Interface/ILocalApp.cs
@@ -16,6 +16,6 @@ namespace LocalTest.Services.LocalApp.Interface
 
         Task<TextResource?> GetTextResource(string org, string app, string language);
 
-        Task<Instance?> Instanciate(string appId, Instance instance, string xmlPrefill, string xmlDataId);
+        Task<Instance?> Instantiate(string appId, Instance instance, string xmlPrefill, string xmlDataId);
     }
 }

--- a/src/development/LocalTest/Startup.cs
+++ b/src/development/LocalTest/Startup.cs
@@ -21,7 +21,7 @@ using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Repository;
 using AltinnCore.Authentication.Constants;
 using AltinnCore.Authentication.JwtCookie;
-
+using LocalTest.Clients.CdnAltinnOrgs;
 using LocalTest.Configuration;
 using LocalTest.Services.Authentication.Implementation;
 using LocalTest.Services.Authentication.Interface;
@@ -95,6 +95,7 @@ namespace LocalTest
             services.AddSingleton<ITextRepository, TextRepository>();
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddHttpClient<AuthorizationApiClient>();
+            services.AddHttpClient<AltinnOrgsClient>();
             services.AddSingleton<IPDP, PDPAppSI>();
             services.AddSingleton<IAuthentication, AuthenticationService>();
             services.AddTransient<IAuthorizationHandler, AppAccessHandler>();

--- a/src/development/LocalTest/Views/Home/Index.cshtml
+++ b/src/development/LocalTest/Views/Home/Index.cshtml
@@ -65,7 +65,7 @@
 
     <h2>Testing app:  @Model.Org/@Model.App</h2>
 
-    @using (Html.BeginForm("LogInTestUser", "Home", FormMethod.Post, new { Class = "form-signin" }))
+    @using (Html.BeginForm("LogInTestUser", "Home", FormMethod.Post, new { Class = "form-signin", enctype = "multipart/form-data" }))
     {
       @Html.AntiForgeryToken();
       <div class="form-group">
@@ -79,6 +79,10 @@
       <div class="form-group">
         <label for="exampleInputEmail1">Select your authentication level</label>
         @Html.DropDownListFor(model => model.AuthenticationLevel, Model.AuthenticationLevels, new { Class = "form-control" })
+      </div>
+      <div class="form-group">
+        <label for="prefill">Prefill</label>
+        <input class="form-control" type="file" id="prefill" name="prefill" accept=".xml"/>
       </div>
       <button type="submit" class="btn btn-primary">Proceed to app</button>
     }

--- a/src/development/LocalTest/Views/Home/Index.cshtml
+++ b/src/development/LocalTest/Views/Home/Index.cshtml
@@ -32,8 +32,9 @@
         } else {
           <pre>No application running on @Model.LocalAppUrl</pre>
           <p>
-            Please start your an app on this adress.
+            Please start your an app on this adress. Typically run the following command in an app directory.
           </p>
+          <pre>dotnet run</pre>
         }
       } else {
         <pre>
@@ -80,10 +81,13 @@
         <label for="exampleInputEmail1">Select your authentication level</label>
         @Html.DropDownListFor(model => model.AuthenticationLevel, Model.AuthenticationLevels, new { Class = "form-control" })
       </div>
-      <div class="form-group">
-        <label for="prefill">Prefill</label>
-        <input class="form-control" type="file" id="prefill" name="prefill" accept=".xml"/>
-      </div>
+      @if(Model.AppModeIsHttp)
+      {
+        <div class="form-group">
+          <label for="prefill">Prefill xml. The first part of the filename must be "[orgnr]." or "[fnr]." (eg. "897069631.xml" or "897069631.TST-2345.xml")</label>
+          <input class="form-control" type="file" id="prefill" name="prefill" accept=".xml"/>
+        </div>
+      }
       <button type="submit" class="btn btn-primary">Proceed to app</button>
     }
 

--- a/src/development/loadbalancer/nginx.conf
+++ b/src/development/loadbalancer/nginx.conf
@@ -23,6 +23,12 @@ http {
 
     client_max_body_size 50M;
 
+    # Set timeout to 1 hour (helps when debugging)
+    proxy_connect_timeout       3600;
+    proxy_send_timeout          3600;
+    proxy_read_timeout          3600;
+    send_timeout                3600;
+
     sendfile on;
 
 	  upstream localtest {


### PR DESCRIPTION
Some apps need a prefill to be valid, so it would be really nice if there was a simple way to instantiate using prefill to localtest. One might obviously create a separate app that one might run locally to instantiate (as one does in tt02 and prod), but it is rather tedious.

![image](https://user-images.githubusercontent.com/131616/169550800-b099a283-3e8d-461a-b63a-916290bdee88.png)

Current design is that the file need to have the org number (or fødselsnummer) for the party that owns the instance, as the first part of the filename (eg: `[orgnr].xml` or `[orgnr].app.xml`). I'm looking for better ideas on this front. It also only works with `localAppMode=="http"`, because I extended `ILocalApp`, for this. Maybe a new service would be better?. I also had to duplicate some code from `HomeController` in order to get a token. Maybe this should be moved to a service?

I temporary had to hard code the orgnumber of `KRT`, but when https://github.com/Altinn/app-template-dotnet/pull/72 gets released in a nuget package, that might no longer be required.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
