### PR TITLE
Fix port number in nginx redirect from localhost

### DIFF
--- a/src/development/docker-compose.yml
+++ b/src/development/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - NGINX_PORT=80
       - SUB_FILTER=${SUB_FILTER:-}
       - TEST_DOMAIN=${TEST_DOMAIN:-altinn3local.no}
+      - ALTINN3LOCAL_PORT=${ALTINN3LOCAL_PORT:-80}
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
     build:
       context: ./loadbalancer

--- a/src/development/loadbalancer/nginx.conf
+++ b/src/development/loadbalancer/nginx.conf
@@ -20,7 +20,7 @@ http {
       listen 80;
       server_name localhost;
       # server_name localhost altinn3local.no;
-      return 307 $scheme://${TEST_DOMAIN}$request_uri;
+      return 307 $scheme://${TEST_DOMAIN}:${ALTINN3LOCAL_PORT}$request_uri;
     }
 
     upstream receiptcomp {


### PR DESCRIPTION
Just a simple fix on the nginx config to include the port number when redirecting from `localhost` when user might use non-standard port
