### PR TITLE
chore: removed deprecated cypress option

### DIFF
--- a/src/test/cypress/cypress.config.js
+++ b/src/test/cypress/cypress.config.js
@@ -23,7 +23,6 @@ module.exports = defineConfig({
   },
   video: false,
   fixturesFolder: 'e2e/fixtures',
-  pluginsFile: 'e2e/plugins/index.js',
   downloadsFolder: 'downloads',
   screenshotOnRunFailure: true,
   screenshotsFolder: 'screenshots',


### PR DESCRIPTION
fixes failing cypress tests