### PR TITLE
Check for common mistake in storage instances/ endpoint

### DIFF
--- a/src/Altinn.Common/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs
+++ b/src/Altinn.Common/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs
@@ -264,7 +264,7 @@ namespace Altinn.Common.PEP.Helpers
         /// <returns>true or false, valid or not</returns>
         public static bool ValidateDecisionResult(XacmlJsonResult result, ClaimsPrincipal user)
         {
-            // Checks that the result is nothing else than "permit"
+            // Checks that the result is nothing else than "Permit"
             if (!result.Decision.Equals(XacmlContextDecision.Permit.ToString()))
             {
                 return false;

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
@@ -149,7 +149,7 @@ namespace Altinn.Platform.Storage.Controllers
                 if (!string.IsNullOrEmpty(appId))
                 {
                     var appParts = appId.Split('/', 2);
-                    if(appParts.Length != 2 || (string.IsNullOrEmpty(org) && appParts[0] != org))
+                    if(appParts.Length != 2 || (!string.IsNullOrEmpty(org) && appParts[0] != org))
                     {
                         return BadRequest("appId must be on the format org/appname.");
                     }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
@@ -143,10 +143,18 @@ namespace Altinn.Platform.Storage.Controllers
 
                 if (string.IsNullOrEmpty(org) && string.IsNullOrEmpty(appId))
                 {
-                    return BadRequest("Org or AppId must be defined.");
+                    return BadRequest("org or appId must be defined.");
                 }
 
-                org = string.IsNullOrEmpty(org) ? appId.Split('/')[0] : org;
+                if (!string.IsNullOrEmpty(appId))
+                {
+                    var appParts = appId.Split('/', 2);
+                    if(appParts.Length != 2 || (string.IsNullOrEmpty(org) && appParts[0] != org))
+                    {
+                        return BadRequest("appId must be on the format org/appname.");
+                    }
+                    org = appParts[0];
+                }
 
                 if (!orgClaim.Equals(org, StringComparison.InvariantCultureIgnoreCase))
                 {

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
@@ -170,7 +170,6 @@ namespace Altinn.Platform.Storage.Controllers
                     return BadRequest("org or appId must be defined.");
                 }
 
-
                 if (!orgClaim.Equals(org, StringComparison.InvariantCultureIgnoreCase))
                 {
                     return Forbid();

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/InstancesController.cs
@@ -134,6 +134,30 @@ namespace Altinn.Platform.Storage.Controllers
             string orgClaim = User.GetOrg();
             int? userId = User.GetUserIdAsInt();
 
+            // If appId is set - verify that appId starts with org/
+            if (!string.IsNullOrEmpty(appId))
+            {
+                if (!appId.Contains('/'))
+                {
+                    return BadRequest("appId must be on the format org/appname.");
+                }
+
+                var appParts = appId.Split('/', 2);
+                if (!string.IsNullOrEmpty(org))
+                {
+                    // Ensure that appId matches org when org is set.
+                    if (appParts[0] != org)
+                    {
+                        return BadRequest($"both appId and org is specified, but they do not match {org} != {appParts[0]}");
+                    }
+                }
+                else
+                {
+                    // set org from appId when org is not set.
+                    org = appParts[0];
+                }
+            }
+
             if (orgClaim != null)
             {
                 if (!_authzHelper.ContainsRequiredScope(_generalSettings.InstanceReadScope, User))
@@ -146,15 +170,6 @@ namespace Altinn.Platform.Storage.Controllers
                     return BadRequest("org or appId must be defined.");
                 }
 
-                if (!string.IsNullOrEmpty(appId))
-                {
-                    var appParts = appId.Split('/', 2);
-                    if(appParts.Length != 2 || (!string.IsNullOrEmpty(org) && appParts[0] != org))
-                    {
-                        return BadRequest("appId must be on the format org/appname.");
-                    }
-                    org = appParts[0];
-                }
 
                 if (!orgClaim.Equals(org, StringComparison.InvariantCultureIgnoreCase))
                 {
@@ -172,7 +187,7 @@ namespace Altinn.Platform.Storage.Controllers
             }
             else
             {
-                return BadRequest();
+                return Forbid("You must either be a org or a user");
             }
 
             if (!string.IsNullOrEmpty(continuationToken))
@@ -181,7 +196,24 @@ namespace Altinn.Platform.Storage.Controllers
                 continuationToken = HttpUtility.UrlDecode(continuationToken);
             }
 
-            Dictionary<string, StringValues> queryParams = QueryHelpers.ParseQuery(Request.QueryString.Value);
+            Dictionary<string, StringValues> queryParams = new Dictionary<string, StringValues>()
+            {
+                { "org", org },
+                { "appId", appId },
+                { "process.currentTask", currentTaskId },
+                { "process.isComplete", processIsComplete?.ToString() },
+                { "process.endEvent", processEndEvent },
+                { "process.ended", processEnded },
+                { "instanceOwner.partyId", instanceOwnerPartyId?.ToString() },
+                { "lastChanged", lastChanged },
+                { "created", created },
+                { "visibleAfter", visibleAfter },
+                { "dueBefore", dueBefore },
+                { "excludeConfirmedBy", excludeConfirmedBy },
+                { "status.isSoftDeleted", isSoftDeleted ? "true" : null },
+                { "status.isHardDeleted", isHardDeleted ? "true" : null },
+                { "status.isArchived", isArchived ? "true" : null },
+            }.Where(el => el.Value != StringValues.Empty).ToDictionary(x => x.Key, x => x.Value);
 
             // filter out hard deleted instances if it isn't appOwner requesting instances
             if (!appOwnerRequestingInstances)

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Altinn.Platform.Storage.UnitTest.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Altinn.Platform.Storage.UnitTest.csproj
@@ -14,11 +14,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Altinn.Platform.Storage.UnitTest.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Altinn.Platform.Storage.UnitTest.csproj
@@ -14,6 +14,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerGETTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerGETTests.cs
@@ -1,0 +1,340 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+using Altinn.Common.PEP.Interfaces;
+using Altinn.Platform.Storage.Clients;
+using Altinn.Platform.Storage.Configuration;
+using Altinn.Platform.Storage.Controllers;
+using Altinn.Platform.Storage.Helpers;
+using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Platform.Storage.Repository;
+using AltinnCore.Authentication.Constants;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using NSubstitute;
+using Xunit;
+
+namespace Altinn.Platform.Storage.UnitTest.TestingControllers;
+
+public class InstancesControllerGETTests
+{
+    private readonly IInstanceRepository _instanceRepository = Substitute.For<IInstanceRepository>();
+    private readonly IInstanceEventRepository _instanceEventRepository = Substitute.For<IInstanceEventRepository>();
+    private readonly IApplicationRepository _applicationRepository = Substitute.For<IApplicationRepository>();
+    private readonly IPartiesWithInstancesClient _partiesWithInstancesClient = Substitute.For<IPartiesWithInstancesClient>();
+    private readonly ILogger<InstancesController> _logger = Substitute.For<ILogger<InstancesController>>();
+    private readonly ILogger<AuthorizationHelper> _authzLogger = Substitute.For<ILogger<AuthorizationHelper>>();
+    private readonly IPDP _pdp = Substitute.For<IPDP>();
+    private readonly IOptions<GeneralSettings> _generalSettings = Substitute.For<IOptions<GeneralSettings>>();
+    private readonly HttpContext _httpContext = Substitute.For<HttpContext>();
+    private readonly RouteData _routeData = Substitute.For<RouteData>();
+    private readonly ModelStateDictionary _modelState = Substitute.For<ModelStateDictionary>();
+    private readonly ControllerContext _controllerContext;
+    private readonly ActionContext _actionContext;
+
+    private readonly InstancesController _controller;
+
+    public InstancesControllerGETTests()
+    {
+        _generalSettings.Value.Returns(new GeneralSettings { Hostname = "testHostName", InstanceReadScope = new List<string> { "altinn:serviceowner/instances.read" } });
+        _actionContext = new ActionContext(_httpContext, _routeData, new ControllerActionDescriptor(), _modelState);
+        _controllerContext = new ControllerContext(_actionContext);
+        _controller = new InstancesController(_instanceRepository, _instanceEventRepository, _applicationRepository, _partiesWithInstancesClient, _logger, _authzLogger, _pdp, _generalSettings);
+        _controller.ControllerContext = _controllerContext;
+    }
+
+    private void SetUserClaims(System.Security.Claims.Claim[] claims)
+    {
+        _controllerContext.HttpContext.User.Returns(new System.Security.Claims.ClaimsPrincipal(new System.Security.Claims.ClaimsIdentity(claims, "AuthenticationTypes.Federation")));
+    }
+
+    // No Auth
+    [Fact]
+    public async Task NoAuth_NoQuery_ForbidResult() =>
+        await RunTestCase(new()
+        {
+            ResultType = typeof(ForbidResult),
+        });
+
+    // Auth Org
+    [Fact]
+    public async Task AuthOrg_AllOrgInstances_ReturnsOk() =>
+        await RunTestCase(new()
+        {
+            AuthOrg = "tdd",
+            Org = "tdd",
+            ResultType = typeof(OkObjectResult),
+            QueryLength = 1,
+        });
+
+    [Fact]
+    public async Task AuthOrg_NoOrgInQuery_ReturnsBadRequest() =>
+        await RunTestCase(new()
+        {
+            AuthOrg = "tdd",
+            ResultType = typeof(BadRequestObjectResult),
+        });
+
+    [Fact]
+    public async Task AuthOrg_WrongAppIdFormat_ReturnsBadRequest() =>
+        await RunTestCase(new()
+        {
+            AuthOrg = "tdd",
+            Org = "tdd",
+            AppId = "krt-krt-1334",
+            ResultType = typeof(BadRequestObjectResult),
+            QueryLength = -1,
+        });
+
+    [Fact]
+    public async Task AuthOrg_OrgMissmatchAppId_ReturnsBadRequest() =>
+        await RunTestCase(new()
+        {
+            AuthOrg = "tdd",
+            Org = "tdd",
+            AppId = "krt/krt-krt1334", // Does not match Org
+            ResultType = typeof(BadRequestObjectResult)
+        });
+
+    [Fact]
+    public async Task AuthOrg_AllAppInstancesWithOrg_ReturnsOk() =>
+        await RunTestCase(new()
+        {
+            AuthOrg = "tdd",
+            Org = "tdd",
+            AppId = "tdd/krt-krt1334",
+            ResultType = typeof(OkObjectResult),
+            QueryLength = 2,
+        });
+
+    [Fact]
+    public async Task AuthOrg_AllAppInstancesWithoutOrg_ReturnsOk() =>
+        await RunTestCase(new()
+        {
+            AuthOrg = "tdd",
+            AppId = "tdd/krt-krt1334",
+            ResultType = typeof(OkObjectResult),
+            QueryLength = 2,
+        });
+
+    [Fact]
+    public async Task AuthUser_NoPartyId_ReturnsBadRequest() =>
+        await RunTestCase(new()
+        {
+            AuthUserId = "3566",
+            ResultType = typeof(BadRequestObjectResult),
+        });
+
+    [Fact]
+    public async Task AuthUser_WithPartyId_ReturnsOk() =>
+        await RunTestCase(new()
+        {
+            AuthUserId = "3566",
+            InstanceOwnerPartyId = 3566,
+            ResultType = typeof(OkObjectResult),
+            QueryLength = 2,
+        });
+
+    [Fact]
+    public async Task AuthUser_Org_ReturnsOk() =>
+        await RunTestCase(new()
+        {
+            AuthUserId = "3566",
+            Org = "tdd",
+            InstanceOwnerPartyId = 3566,
+            ResultType = typeof(OkObjectResult),
+            QueryLength = 3,
+        });
+
+    [Fact]
+    public async Task AuthUser_InvalidAppID_ReturnsBad() =>
+        await RunTestCase(new()
+        {
+            AuthUserId = "3566",
+            AppId = "tdd",
+            InstanceOwnerPartyId = 3566,
+            ResultType = typeof(BadRequestObjectResult),
+        });
+
+    [Fact]
+    public async Task AuthUser_OrgFromAppId_ReturnsOk() =>
+        await RunTestCase(new()
+        {
+            AuthUserId = "3566",
+            AppId = "tdd/test-1234",
+            InstanceOwnerPartyId = 3566,
+            ResultType = typeof(OkObjectResult),
+            QueryLength = 4,
+        });
+
+    [Fact]
+    public async Task AuthUser_OrgFromAppIdMissmatch_ReturnsBadResult() =>
+        await RunTestCase(new()
+        {
+            AuthUserId = "3566",
+            Org = "krt",
+            AppId = "tdd/test-1234",
+            InstanceOwnerPartyId = 3566,
+            ResultType = typeof(BadRequestObjectResult),
+        });
+
+    private async Task RunTestCase(TestCase testCase)
+    {
+        if (testCase.AuthOrg != null)
+        {
+            SetUserClaims(new System.Security.Claims.Claim[]
+            {
+                    new(AltinnCoreClaimTypes.Org, testCase.AuthOrg),
+                    new("urn:altinn:scope", _generalSettings.Value.InstanceReadScope[0])
+            });
+        }
+        else if (testCase.AuthUserId != null)
+        {
+            SetUserClaims(new System.Security.Claims.Claim[]
+            {
+                    new(AltinnCoreClaimTypes.UserId, testCase.AuthUserId),
+            });
+        }
+
+        var instances = new List<Instance>
+            {
+                new()
+                {
+                    Id = $"{testCase.InstanceOwnerPartyId ?? 12345}/{Guid.NewGuid()}",
+                    AppId = "krt/krt-1228a-1",
+                    Org = "krt",
+                    InstanceOwner = new()
+                    {
+                        PartyId = (testCase.InstanceOwnerPartyId ?? 12345).ToString(),
+                    }
+                }
+            };
+        _instanceRepository.GetInstancesFromQuery(default, default, default).ReturnsForAnyArgs((arg) => Task.FromResult(new InstanceQueryResponse() { Instances = instances }));
+        _pdp.GetDecisionForRequest(default).ReturnsForAnyArgs(args =>
+        {
+            return Task.FromResult<XacmlJsonResponse>(new()
+            {
+                Response = new()
+                {
+                        new()
+                        {
+                            Category = new()
+                            {
+                                new()
+                                {
+                                    Attribute = new()
+                                    {
+                                        new()
+                                        {
+                                            // AttributeId = Altinn.Common.PEP.ConstantsAltinnXacmlUrns.InstanceId
+                                            AttributeId = "urn:altinn:instance-id",
+                                            Value = instances.First().Id,
+                                        }
+                                    },
+                                }
+                            },
+                            Decision = "Permit",
+                        }
+                }
+            });
+        });
+
+        var res = await _controller.GetInstances(
+                org: testCase.Org,
+                appId: testCase.AppId,
+                currentTaskId: testCase.CurrentTaskId,
+                processIsComplete: testCase.ProcessIsComplete,
+                processEndEvent: testCase.ProcessEndEvent,
+                processEnded: testCase.ProcessEnded,
+                instanceOwnerPartyId: testCase.InstanceOwnerPartyId,
+                lastChanged: testCase.LastChanged,
+                created: testCase.Created,
+                visibleAfter: testCase.VisibleAfter,
+                dueBefore: testCase.DueBefore,
+                excludeConfirmedBy: testCase.ExcludeConfirmedBy,
+                isSoftDeleted: testCase.IsSoftDeleted,
+                isHardDeleted: testCase.IsHardDeleted,
+                isArchived: testCase.IsArchived,
+                continuationToken: testCase.ContinuationToken,
+                size: testCase.Size);
+        Assert.IsType(testCase.ResultType, res.Result);
+
+        if (res.Result is OkObjectResult result)
+        {
+            Assert.IsType<QueryResponse<Instance>>(result.Value);
+            var objectResponse = result.Value as QueryResponse<Instance>;
+            Assert.Equal(instances, objectResponse?.Instances);
+        }
+
+        var repositoryCalls = _instanceRepository.ReceivedCalls();
+        if(testCase.QueryLength >= 0)
+        {
+            Assert.Single(repositoryCalls);
+            var args = repositoryCalls.First().GetOriginalArguments();
+            Assert.IsType<Dictionary<string, Microsoft.Extensions.Primitives.StringValues>>(args[0]);
+            var query = args[0] as Dictionary<string, Microsoft.Extensions.Primitives.StringValues>;
+            Assert.Equal(testCase.QueryLength, query?.Count);
+        }
+        else
+        {
+            Assert.Empty(repositoryCalls);
+        }
+    }
+
+    public class TestCase
+    {
+        public string? AuthOrg { get; set; }
+
+        public string? AuthUserId { get; set; }
+
+        public string? Org { get; set; }
+
+        public string? AppId { get; set; }
+
+        public string? CurrentTaskId { get; set; }
+
+        public bool? ProcessIsComplete { get; set; }
+
+        public string? ProcessEndEvent { get; set; }
+
+        public string? ProcessEnded { get; set; }
+
+        public int? InstanceOwnerPartyId { get; set; }
+
+        public string? LastChanged { get; set; }
+
+        public string? Created { get; set; }
+
+        public string? VisibleAfter { get; set; }
+
+        public string? DueBefore { get; set; }
+
+        public string? ExcludeConfirmedBy { get; set; }
+
+        public bool IsSoftDeleted { get; set; }
+
+        public bool IsHardDeleted { get; set; }
+
+        public bool IsArchived { get; set; }
+
+        public string? ContinuationToken { get; set; }
+
+        public int? Size { get; set; }
+
+        public Type ResultType { get; set; } = null!;
+
+        public int QueryLength { get; set; } = -1;
+    }
+}

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerTests.cs
@@ -587,7 +587,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetOrgToken("testOrg", scope: "altinn:serviceowner/instances.read");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            string expected = "Org or AppId must be defined.";
+            string expected = "org or appId must be defined.";
 
             // Act
             HttpResponseMessage response = await client.GetAsync(requestUri);

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/InstancesControllerTests.cs
@@ -1099,7 +1099,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
         /// <summary>
         /// Scenario:
-        /// Update an existing presentation field 
+        /// Update an existing presentation field
         /// Result:
         /// Presentation field are succesfully updated, other fields are untouched and the updated instance returned.
         /// </summary>
@@ -1144,7 +1144,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
         /// <summary>
         /// Scenario:
-        /// Delete an existing presentation field 
+        /// Delete an existing presentation field
         /// Result:
         /// Presentation field is succesfully removed, other fields are untouched and the updated instance returned.
         /// </summary>
@@ -1242,7 +1242,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
         [MemberData(nameof(GetPresentationTextsData))]
         public async Task UpdatePresentationFields_PassingNullAsPresentationTexts_Returns400(PresentationTexts presentationTexts)
         {
-            // Arrange            
+            // Arrange
             int instanceOwnerPartyId = 1337;
             string instanceGuid = "20a1353e-91cf-44d6-8ff7-f68993638ffe";
             string requestPutUri = $"{BasePath}/{instanceOwnerPartyId}/{instanceGuid}/presentationtexts";
@@ -1315,7 +1315,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
         /// <summary>
         /// Scenario:
-        /// Update an existing data value 
+        /// Update an existing data value
         /// Result:
         /// Data values are succesfully updated, other values are untouched and the updated instance returned.
         /// </summary>
@@ -1359,7 +1359,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
         /// <summary>
         /// Scenario:
-        /// Delete an existing data value 
+        /// Delete an existing data value
         /// Result:
         /// Data value is succesfully removed, other fields are untouched and the updated instance returned.
         /// </summary>
@@ -1412,7 +1412,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
         [Fact]
         public async Task UpdateDataValues_AddNewDataValueToExistingCollection_ReturnsUpdatedInstance()
         {
-            // Arrange            
+            // Arrange
             var dataValues = new DataValues
             {
                 Values = new Dictionary<string, string>

--- a/src/development/LocalTest/Controllers/Storage/InstancesController.cs
+++ b/src/development/LocalTest/Controllers/Storage/InstancesController.cs
@@ -155,7 +155,7 @@ namespace Altinn.Platform.Storage.Controllers
                 if (!string.IsNullOrEmpty(appId))
                 {
                     var appParts = appId.Split('/', 2);
-                    if(appParts.Length != 2 || (string.IsNullOrEmpty(org) && appParts[0] != org))
+                    if(appParts.Length != 2 || (!string.IsNullOrEmpty(org) && appParts[0] != org))
                     {
                         return BadRequest("appId must be on the format org/appname.");
                     }

--- a/src/development/LocalTest/Controllers/Storage/InstancesController.cs
+++ b/src/development/LocalTest/Controllers/Storage/InstancesController.cs
@@ -149,10 +149,18 @@ namespace Altinn.Platform.Storage.Controllers
 
                 if (string.IsNullOrEmpty(org) && string.IsNullOrEmpty(appId))
                 {
-                    return BadRequest("Org or AppId must be defined.");
+                    return BadRequest("org or appId must be defined.");
                 }
 
-                org = string.IsNullOrEmpty(org) ? appId.Split('/')[0] : org;
+                if (!string.IsNullOrEmpty(appId))
+                {
+                    var appParts = appId.Split('/', 2);
+                    if(appParts.Length != 2 || (string.IsNullOrEmpty(org) && appParts[0] != org))
+                    {
+                        return BadRequest("appId must be on the format org/appname.");
+                    }
+                    org = appParts[0];
+                }
 
                 if (!orgClaim.Equals(org, StringComparison.InvariantCultureIgnoreCase))
                 {

--- a/src/development/LocalTest/Controllers/Storage/InstancesController.cs
+++ b/src/development/LocalTest/Controllers/Storage/InstancesController.cs
@@ -176,7 +176,6 @@ namespace Altinn.Platform.Storage.Controllers
                     return BadRequest("org or appId must be defined.");
                 }
 
-
                 if (!orgClaim.Equals(org, StringComparison.InvariantCultureIgnoreCase))
                 {
                     return Forbid();

--- a/src/development/LocalTest/Controllers/Storage/ProcessController.cs
+++ b/src/development/LocalTest/Controllers/Storage/ProcessController.cs
@@ -151,7 +151,7 @@ namespace Altinn.Platform.Storage.Controllers
         /// </summary>
         /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
         /// <param name="instanceGuid">The id of the instance whos process history to retrieve.</param>
-        /// <returns>Returns a list of the process events.</returns>        
+        /// <returns>Returns a list of the process events.</returns>
         [HttpGet("history")]
         [Authorize(Policy = "InstanceRead")]
         [ProducesResponseType(StatusCodes.Status200OK)]

--- a/src/development/LocalTest/Services/Authorization/Implementation/PolicyInformationRepository.cs
+++ b/src/development/LocalTest/Services/Authorization/Implementation/PolicyInformationRepository.cs
@@ -25,15 +25,14 @@ namespace Altinn.Platform.Authorization.Repositories
         }
 
         /// <inheritdoc/>
-        public Task<Instance> GetInstance(string instanceId, int instanceOwnerId)
+        public Task<Instance> GetInstance(Guid instanceId, int instanceOwnerId)
         {
             if (instanceOwnerId <= 0)
             {
                 throw new ArgumentException("Instance owner id cannot be zero or negative");
             }
 
-            string[] instanceIdParts = instanceId.Split("/");
-            return _instanceRepository.GetOne(int.Parse(instanceIdParts[0]), Guid.Parse(instanceIdParts[1]));
+            return _instanceRepository.GetOne(instanceOwnerId, instanceId);
         }
 
 

--- a/src/development/LocalTest/Services/Authorization/Interface/IPolicyInformationRepository.cs
+++ b/src/development/LocalTest/Services/Authorization/Interface/IPolicyInformationRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 
@@ -14,7 +15,7 @@ namespace Altinn.Platform.Authorization.Repositories.Interface
         /// <param name="instanceId">the instance id</param>
         /// <param name="instanceOwnerId">the instance owner</param>
         /// <returns></returns>
-        Task<Instance> GetInstance(string instanceId, int instanceOwnerId);
+        Task<Instance> GetInstance(Guid instanceId, int instanceOwnerId);
 
         /// <summary>
         /// Gets the information of a given instance


### PR DESCRIPTION
The [`instances/` api in storage ](https://docs.altinn.studio/api/storage/instances/#query-instances) requires `appId` to be on the format `org/appname`. It's easy for api users to get confused when the docs has fields for both `org` and `appId` (as I was), and this small change improves the request validation to ensure that `BadRequest` is returned if the request is bad.


## Related Issue(s)
- https://altinn.slack.com/archives/C02EVE480G2/p1654580020477629

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
