### PR TITLE
set partition key if one party

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
@@ -159,11 +159,14 @@ namespace Altinn.Platform.Storage.Repository
 
                 if (queryParameter.Equals("instanceOwner.partyId"))
                 {
-                    queryBuilder = queryBuilder.Where(i => queryValues.Contains(i.InstanceOwner.PartyId));
-
                     if (queryValues.Count == 1)
                     {
                         options.PartitionKey = new PartitionKey(queryValues.First());
+                        queryBuilder = queryBuilder.Where(i => queryValues == i.InstanceOwner.PartyId);
+                    }
+                    else
+                    {
+                        queryBuilder = queryBuilder.Where(i => queryValues.Contains(i.InstanceOwner.PartyId));
                     }
 
                     continue;

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Repository/InstanceRepository.cs
@@ -99,7 +99,7 @@ namespace Altinn.Platform.Storage.Repository
 
                 try
                 {
-                    queryBuilder = BuildQueryFromParameters(queryParams, queryBuilder);
+                    queryBuilder = BuildQueryFromParameters(queryParams, queryBuilder, options);
                 }
                 catch (Exception e)
                 {
@@ -144,7 +144,7 @@ namespace Altinn.Platform.Storage.Repository
             return queryResponse;
         }
 
-        private static IQueryable<Instance> BuildQueryFromParameters(Dictionary<string, StringValues> queryParams, IQueryable<Instance> queryBuilder)
+        private static IQueryable<Instance> BuildQueryFromParameters(Dictionary<string, StringValues> queryParams, IQueryable<Instance> queryBuilder, QueryRequestOptions options)
         {
             foreach (KeyValuePair<string, StringValues> param in queryParams)
             {
@@ -160,6 +160,12 @@ namespace Altinn.Platform.Storage.Repository
                 if (queryParameter.Equals("instanceOwner.partyId"))
                 {
                     queryBuilder = queryBuilder.Where(i => queryValues.Contains(i.InstanceOwner.PartyId));
+
+                    if (queryValues.Count == 1)
+                    {
+                        options.PartitionKey = new PartitionKey(queryValues.First());
+                    }
+
                     continue;
                 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If querying for instances we never set the partitionkey, however in most cases it only a query for a single partyId. 

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
