### PR TITLE
Removed auto-generation of datatype in ApplicationsController

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/ApplicationsController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/ApplicationsController.cs
@@ -140,24 +140,11 @@ namespace Altinn.Platform.Storage.Controllers
             application.Created = creationTime;
             application.LastChangedBy = GetUserId();
             application.LastChanged = creationTime;
+            application.DataTypes ??= new();
+
             if (application.ValidFrom == null)
             {
                 application.ValidFrom = creationTime;
-            }
-
-            if (application.DataTypes == null || application.DataTypes.Count == 0)
-            {
-                application.DataTypes = new List<DataType>();
-
-                DataType form = new DataType()
-                {
-                    Id = "default",
-                    AllowedContentTypes = new List<string>(),
-                };
-                form.AllowedContentTypes.Add("text/xml");
-                form.AllowedContentTypes.Add("application/xml");
-
-                application.DataTypes.Add(form);
             }
 
             Application result = await repository.Create(application);

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/ApplicationsController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/ApplicationsController.cs
@@ -65,7 +65,7 @@ namespace Altinn.Platform.Storage.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<ApplicationList>> GetMany(string org)
         {
-            if (string.IsNullOrEmpty(org) || org.Contains("-") || org.Contains(" "))
+            if (string.IsNullOrEmpty(org) || org.Contains('-') || org.Contains(' '))
             {
                 return BadRequest($"Application owner id '{org}' is not valid");
             }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/ApplicationsController.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/Storage/Controllers/ApplicationsController.cs
@@ -65,7 +65,7 @@ namespace Altinn.Platform.Storage.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<ApplicationList>> GetMany(string org)
         {
-            if (string.IsNullOrEmpty(org) || org.Contains('-') || org.Contains(' '))
+            if (string.IsNullOrEmpty(org) || org.Contains("-") || org.Contains(" "))
             {
                 return BadRequest($"Application owner id '{org}' is not valid");
             }

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/TextRepositoryMock.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/Mocks/Repository/TextRepositoryMock.cs
@@ -47,7 +47,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
                 string org = appId.Split("/")[0];
                 string app = appId.Split("/")[1];
 
-                TextResource resource = Get(org, app, language).Result;
+                TextResource resource = await Get(org, app, language);
                 if (resource != null)
                 {
                     result.Add(resource);

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/ApplicationsControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/ApplicationsControllerTests.cs
@@ -101,7 +101,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             // Assert
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
-            string content = response.Content.ReadAsStringAsync().Result;
+            string content = await response.Content.ReadAsStringAsync();
             Application application = JsonConvert.DeserializeObject(content, typeof(Application)) as Application;
 
             Assert.NotNull(application);
@@ -140,7 +140,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-            string content = response.Content.ReadAsStringAsync().Result;
+            string content = await response.Content.ReadAsStringAsync();
             Assert.True(string.IsNullOrEmpty(content));
         }
 
@@ -175,7 +175,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-            string content = response.Content.ReadAsStringAsync().Result;
+            string content = await response.Content.ReadAsStringAsync();
             Assert.True(string.IsNullOrEmpty(content));
         }
 
@@ -209,7 +209,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-            string content = response.Content.ReadAsStringAsync().Result;
+            string content = await response.Content.ReadAsStringAsync();
 
             Assert.Contains("not valid", content);
         }
@@ -244,7 +244,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-            string content = response.Content.ReadAsStringAsync().Result;
+            string content = await response.Content.ReadAsStringAsync();
             Assert.True(string.IsNullOrEmpty(content));
         }
 
@@ -278,7 +278,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-            string content = response.Content.ReadAsStringAsync().Result;
+            string content = await response.Content.ReadAsStringAsync();
             Assert.True(string.IsNullOrEmpty(content));
         }
 
@@ -315,7 +315,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            string content = response.Content.ReadAsStringAsync().Result;
+            string content = await response.Content.ReadAsStringAsync();
             Application application = JsonConvert.DeserializeObject(content, typeof(Application)) as Application;
 
             Assert.NotNull(application);
@@ -354,7 +354,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            string content = response.Content.ReadAsStringAsync().Result;
+            string content = await response.Content.ReadAsStringAsync();
             Application application = JsonConvert.DeserializeObject(content, typeof(Application)) as Application;
 
             Assert.NotNull(application);
@@ -394,7 +394,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-            string content = response.Content.ReadAsStringAsync().Result;
+            string content = await response.Content.ReadAsStringAsync();
             Assert.True(string.IsNullOrEmpty(content));
         }
 
@@ -429,7 +429,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-            string content = response.Content.ReadAsStringAsync().Result;
+            string content = await response.Content.ReadAsStringAsync();
             Assert.True(string.IsNullOrEmpty(content));
         }
 

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/ApplicationsControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/ApplicationsControllerTests.cs
@@ -106,8 +106,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             Assert.NotNull(application);
             Assert.NotNull(application.DataTypes);
-            Assert.Single(application.DataTypes);
-            Assert.Equal("default", application.DataTypes[0].Id);
+            Assert.Empty(application.DataTypes);
         }
 
         /// <summary>

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/ApplicationsControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/ApplicationsControllerTests.cs
@@ -75,7 +75,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
         /// Expected result:
         ///   Returns HttpStatus Created and the Application instance.
         /// Success criteria:
-        ///   The response has correct status and the returned application instance has been populated with a data type.
+        ///   The response has correct status and the returned application instance has been populated with an empty list of data type.
         /// </summary>
         [Fact]
         public async void Post_GivenValidApplication_ReturnsStatusCreatedAndCorrectData()

--- a/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/TextsControllerTests.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Storage/UnitTest/TestingControllers/TextsControllerTests.cs
@@ -66,7 +66,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 JsonContent.Create(GetValidTextResource(), new MediaTypeHeaderValue("application/json")));
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            string content = response.Content.ReadAsStringAsync().Result;
+            string content = await response.Content.ReadAsStringAsync();
             Assert.False(string.IsNullOrEmpty(content));
         }
 

--- a/src/development/LocalTest/Controllers/Storage/ApplicationsController.cs
+++ b/src/development/LocalTest/Controllers/Storage/ApplicationsController.cs
@@ -11,7 +11,6 @@ using Altinn.Platform.Storage.Repository;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.Documents;
 using Microsoft.Extensions.Logging;
 
 using DataType = Altinn.Platform.Storage.Interface.Models.DataType;
@@ -66,29 +65,16 @@ namespace Altinn.Platform.Storage.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<ApplicationList>> GetMany(string org)
         {
-            if (string.IsNullOrEmpty(org) || org.Contains("-") || org.Contains(" "))
+            if (string.IsNullOrEmpty(org) || org.Contains('-') || org.Contains(' '))
             {
                 return BadRequest($"Application owner id '{org}' is not valid");
             }
 
-            try
-            {
-                List<Application> applications = await repository.FindByOrg(org);
+            List<Application> applications = await repository.FindByOrg(org);
 
-                ApplicationList applicationList = new ApplicationList { Applications = applications };
+            ApplicationList applicationList = new ApplicationList { Applications = applications };
 
-                return Ok(applicationList);
-            }
-            catch (DocumentClientException dce)
-            {
-                logger.LogError($"Unable to access document database {dce}");
-                return StatusCode(500, $"Unable to access document database {dce}");
-            }
-            catch (Exception e)
-            {
-                logger.LogError($"Unable to perform query request {e}");
-                return StatusCode(500, $"Unable to perform query request {e}");
-            }
+            return Ok(applicationList);
         }
 
         /// <summary>
@@ -107,27 +93,14 @@ namespace Altinn.Platform.Storage.Controllers
         {
             string appId = $"{org}/{app}";
 
-            try
-            {
-                Application result = await repository.FindOne(appId, org);
+            Application result = await repository.FindOne(appId, org);
 
-                return Ok(result);
-            }
-            catch (DocumentClientException dce)
+            if (result == null)
             {
-                if (dce.StatusCode == HttpStatusCode.NotFound)
-                {
-                    return NotFound($"Could not find an application with appId={appId}");
-                }
+                return NotFound($"Could not find an application with appId={appId}");
+            }
 
-                logger.LogError($"Unable to access document database: {dce}");
-                return StatusCode(500, $"Unable to access document database: {dce}");
-            }
-            catch (Exception e)
-            {
-                logger.LogError($"Unable to perform request: {e.Message}");
-                return StatusCode(500, $"Unable to perform request: {e.Message}");
-            }
+            return Ok(result);
         }
 
         /// <summary>
@@ -144,7 +117,6 @@ namespace Altinn.Platform.Storage.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<Application>> Post(string appId, [FromBody] Application application)
         {
-            // TODO Validate only Designer can call this.
             if (!IsValidAppId(appId))
             {
                 return BadRequest("AppId is not valid.");
@@ -152,24 +124,11 @@ namespace Altinn.Platform.Storage.Controllers
 
             string org = appId.Split("/")[0];
 
-            try
-            {
-                await repository.FindOne(appId, org);
+            var existingApp = await repository.FindOne(appId, org);
 
+            if (existingApp != null)
+            {
                 return BadRequest("Application already exists in repository! Try update application instead. ");
-            }
-            catch (DocumentClientException e)
-            {
-                // repository throws exception if not found
-                if (e.StatusCode != HttpStatusCode.NotFound)
-                {
-                    return StatusCode(500, $"Unable to access application collection: {e}");
-                }
-            }
-            catch (Exception e)
-            {
-                logger.LogError($"Unable to perform request: {e}");
-                return StatusCode(500, $"Unable to perform request: {e}");
             }
 
             DateTime creationTime = DateTime.UtcNow;
@@ -181,39 +140,18 @@ namespace Altinn.Platform.Storage.Controllers
             application.Created = creationTime;
             application.LastChangedBy = GetUserId();
             application.LastChanged = creationTime;
+            application.DataTypes ??= new();
+
             if (application.ValidFrom == null)
             {
                 application.ValidFrom = creationTime;
             }
 
-            if (application.DataTypes == null || application.DataTypes.Count == 0)
-            {
-                application.DataTypes = new List<DataType>();
+            Application result = await repository.Create(application);
 
-                DataType form = new DataType()
-                {
-                    Id = "default",
-                    AllowedContentTypes = new List<string>(),
-                };
-                form.AllowedContentTypes.Add("text/xml");
-                form.AllowedContentTypes.Add("application/xml");
+            logger.LogInformation($"Application {appId} sucessfully stored", result);
 
-                application.DataTypes.Add(form);
-            }
-
-            try
-            {
-                Application result = await repository.Create(application);
-
-                logger.LogInformation($"Application {appId} sucessfully stored", result);
-
-                return Created(appId, result);
-            }
-            catch (Exception e)
-            {
-                logger.LogError($"Unable to store application data in database. {e}");
-                return StatusCode(500, $"Unable to store application data in database. {e}");
-            }
+            return Created(appId, result);
         }
 
         /// <summary>
@@ -250,18 +188,12 @@ namespace Altinn.Platform.Storage.Controllers
             }
 
             Application existingApplication;
-            try
-            {
-                existingApplication = await repository.FindOne(appId, org);
-            }
-            catch (DocumentClientException dce)
-            {
-                if (dce.StatusCode == HttpStatusCode.NotFound)
-                {
-                    return NotFound($"Cannot find application {appId}");
-                }
 
-                return StatusCode(500, $"Unable to find application with appId={appId} to update: {dce.Message}");
+            existingApplication = await repository.FindOne(appId, org);
+
+            if (existingApplication == null)
+            {
+                return NotFound($"Cannot find application {appId}");
             }
 
             existingApplication.LastChangedBy = GetUserId();
@@ -275,28 +207,15 @@ namespace Altinn.Platform.Storage.Controllers
             existingApplication.DataTypes = application.DataTypes;
             existingApplication.PartyTypesAllowed = application.PartyTypesAllowed ?? new PartyTypesAllowed();
             existingApplication.AutoDeleteOnProcessEnd = application.AutoDeleteOnProcessEnd;
+            existingApplication.PresentationFields = application.PresentationFields;
+            existingApplication.OnEntry = application.OnEntry;
+            existingApplication.DataFields = application.DataFields;
+            existingApplication.MessageBoxConfig = application.MessageBoxConfig;
+            existingApplication.CopyInstanceSettings = application.CopyInstanceSettings;
 
-            try
-            {
-                Application result = await repository.Update(existingApplication);
+            Application result = await repository.Update(existingApplication);
 
-                return Ok(result);
-            }
-            catch (DocumentClientException dce)
-            {
-                if (dce.Error.Code.Equals("NotFound"))
-                {
-                    return NotFound($"Did not find application with id={appId} to update");
-                }
-
-                logger.LogError($"Document database error: {dce}");
-                return StatusCode(500, $"Document database error: {dce}");
-            }
-            catch (Exception exception)
-            {
-                logger.LogError($"Unable to perform request: {exception}");
-                return StatusCode(500, $"Unable to perform request: {exception}");
-            }
+            return Ok(result);
         }
 
         /// <summary>
@@ -317,43 +236,30 @@ namespace Altinn.Platform.Storage.Controllers
             string appId = $"{org}/{app}";
             string appOwnerId = org;
 
-            try
+            Application application = await repository.FindOne(appId, appOwnerId);
+
+            if (application == null)
             {
-                Application application = await repository.FindOne(appId, appOwnerId);
-
-                if (hard.HasValue && hard == true)
-                {
-                    await repository.Delete(appId, appOwnerId);
-
-                    return Ok(application);
-                }
-                else
-                {
-                    DateTime timestamp = DateTime.UtcNow;
-
-                    application.LastChangedBy = GetUserId();
-                    application.LastChanged = timestamp;
-                    application.ValidTo = timestamp;
-
-                    Application softDeleteApplication = await repository.Update(application);
-
-                    return Ok(softDeleteApplication);
-                }
+                return NotFound($"Didn't find the object that should be deleted with appId={appId}");
             }
-            catch (DocumentClientException dce)
-            {
-                if (dce.StatusCode == HttpStatusCode.NotFound)
-                {
-                    return NotFound($"Didn't find the object that should be deleted with appId={appId}");
-                }
 
-                logger.LogError($"Unable to reach document database {dce}");
-                return StatusCode(500, $"Unable to reach document database {dce}");
-            }
-            catch (Exception e)
+            if (hard.HasValue && hard == true)
             {
-                logger.LogError($"Unable to perform request: {e}");
-                return StatusCode(500, $"Unable to perform request: {e}");
+                await repository.Delete(appId, appOwnerId);
+
+                return Ok(application);
+            }
+            else
+            {
+                DateTime timestamp = DateTime.UtcNow;
+
+                application.LastChangedBy = GetUserId();
+                application.LastChanged = timestamp;
+                application.ValidTo = timestamp;
+
+                Application softDeleteApplication = await repository.Update(application);
+
+                return Ok(softDeleteApplication);
             }
         }
 


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Storage had been autogenerating a default data type if no datatypes were defined for an application. 
This has been removed, as storage is only responsible for persisting the application as it is received.

## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
