### PR TITLE
Check for pending builds after 5 mins

### DIFF
--- a/src/studio/src/designer/backend/Controllers/DeploymentsController.cs
+++ b/src/studio/src/designer/backend/Controllers/DeploymentsController.cs
@@ -52,7 +52,7 @@ namespace Altinn.Studio.Designer.Controllers
         public async Task<SearchResults<DeploymentEntity>> Get([FromQuery] DocumentQueryModel query)
         {
             SearchResults<DeploymentEntity> deployments = await _deploymentService.GetAsync(query);
-            List<DeploymentEntity> laggingDeployments = deployments.Results.Where(d => d.Build.Status.Equals(BuildStatus.InProgress) && d.Build.Started.Value.AddMinutes(10) < DateTime.UtcNow).ToList();
+            List<DeploymentEntity> laggingDeployments = deployments.Results.Where(d => d.Build.Status.Equals(BuildStatus.InProgress) && d.Build.Started.Value.AddMinutes(5) < DateTime.UtcNow).ToList();
 
             foreach (DeploymentEntity deployment in laggingDeployments)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When Altinn Studio doesn't pick up on a completed build status a new check is initiated 10 minutes after the build was first started. Suggesting we limit this to 5 minutes as the 10 min wait limits the workflow of the app developer. 


## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] All tests run green
