### PR TITLE
Setup dotnet 5 and 6 in workflow

### DIFF
--- a/.github/workflows/dependency-update.yaml
+++ b/.github/workflows/dependency-update.yaml
@@ -15,7 +15,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: |
+          5.0.x
+          6.0.x
 
     - name: update packages
       id: update


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Workflow failing due to .net 6 being set up on the agent. 

## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
~~- [ ] Manual testing done (required)~~
~~- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
~~- [ ] All tests run green~~
