### PR TITLE
LocalTest: Increasing JWT cookie validity time

### DIFF
--- a/src/development/LocalTest/appsettings.json
+++ b/src/development/LocalTest/appsettings.json
@@ -10,7 +10,7 @@
     "BaseUrl": "http://altinn3local.no",
     "PlatformEndpoint": "http://localhost:5040/",
     "ClaimsIdentity": "UserLogin",
-    "JwtCookieValidityTime": "30",
+    "JwtCookieValidityTime": "960",
     "AltinnPartyCookieName": "AltinnPartyId"
   },
   "CertificateSettings": {
@@ -25,7 +25,7 @@
     "SBLRedirectEndpoint": "https://at22.altinn.cloud/ui/authentication/",
     "PlatformEndpoint": "http://localhost:5101/",
     "ClaimsIdentity": "UserLogin",
-    "JwtCookieValidityTime": "30",
+    "JwtCookieValidityTime": "960",
     "AltinnPartyCookieName": "AltinnPartyId",
     "MaskinportenWellKnownConfigEndpoint": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server",
     "OrganisationRepositoryLocation": "https://altinncdn.no/orgs/altinn-orgs.json"


### PR DESCRIPTION
## Description
Increasing the JWT cookie validity time to 16 hours in LocalTest. When developing changes in the `app-frontend-react` project, being forcibly logged out every 30 minutes is annoying (especially when you spend some time reproducing a bug and have to start over filling out a form to reproduce the bug again after a while).

16 hours was chosen since it's more than the 8 hours in a workday (allows for some overtime in the same session), while also being less than 24 hours (avoids the timeout hitting you every day ~24 hours after the last one). This should lead to you having to log in to a new session every working day when working on something long-term.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- ~~[ ] All tests run green~~

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
