### PR TITLE
Downgraded .net 6 dep for ABAC

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Authorization/UnitTest/Altinn.Authorization.ABAC.UnitTest.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Authorization/UnitTest/Altinn.Authorization.ABAC.UnitTest.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.17" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Build failing for test project as it runs .net 5 but has .net 6 dependencies

## Related Issue(s)
- N/A
- 
## Verification
- [x] **Your** code builds clean without any errors or warnings

