### PR TITLE
docs: updated reference to .NET from 5 to 6

### DIFF
--- a/LOCALAPP.md
+++ b/LOCALAPP.md
@@ -8,7 +8,7 @@ These are some of the required steps, tips and tricks when it comes to running a
 
 ### Prerequisites
 
-1. Newest [.NET 5 SDK](https://dotnet.microsoft.com/download/dotnet/5.0)
+1. Newest [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
 2. Newest [Git](https://git-scm.com/downloads)
 3. A code editor - we like [Visual Studio Code](https://code.visualstudio.com/Download)
     - Also install [recommended extensions](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions) (f.ex. [C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
LocalApp is bumped to .NET 6.0 but documentation still points to 5.0

## Related Issue(s)
- #8689

## Verification
- NA
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
