### PR TITLE
Removal of fileupload popover

### DIFF
--- a/src/studio/src/designer/frontend/shared/components/FileSelector.test.tsx
+++ b/src/studio/src/designer/frontend/shared/components/FileSelector.test.tsx
@@ -1,7 +1,5 @@
 import { render as rtlRender, screen } from '@testing-library/react';
-import userEvent, {
-  PointerEventsCheckLevel,
-} from '@testing-library/user-event';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import FileSelector from './FileSelector';
 import type { IFileSelectorProps } from './FileSelector';
@@ -9,21 +7,17 @@ import type { IFileSelectorProps } from './FileSelector';
 const user = userEvent.setup();
 
 describe('FileSelector', () => {
-  it('should not call submitHandler when no files are selected and submit button is clicked', async () => {
-    const userWithNoPointerEventCheck = userEvent.setup({
-      pointerEventsCheck: PointerEventsCheckLevel.Never,
-    });
+  it('should not call submitHandler when no files are selected', async () => {
     const handleSubmit = jest.fn();
     render({ submitHandler: handleSubmit });
 
-    const submitButton = screen.getByRole('button', {
-      name: /upload/i,
-    });
-    await userWithNoPointerEventCheck.click(submitButton);
+    const fileInput = screen.getByTestId('FileSelector-input');
+    await user.upload(fileInput, null);
+
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 
-  it('should call submitHandler when a file is selected and submit button is clicked', async () => {
+  it('should call submitHandler when a file is selected', async () => {
     const file = new File(['hello'], 'hello.png', { type: 'image/png' });
     const handleSubmit = jest.fn();
     render({ submitHandler: handleSubmit });
@@ -31,10 +25,6 @@ describe('FileSelector', () => {
     const fileInput = screen.getByTestId('FileSelector-input');
     await user.upload(fileInput, file);
 
-    const submitButton = screen.getByRole('button', {
-      name: /upload/i,
-    });
-    await user.click(submitButton);
     expect(handleSubmit).toHaveBeenCalledWith(
       expect.any(FormData),
       'hello.png',

--- a/src/studio/src/designer/frontend/shared/components/FileSelector.tsx
+++ b/src/studio/src/designer/frontend/shared/components/FileSelector.tsx
@@ -1,9 +1,8 @@
-import { Description } from '@material-ui/icons';
 import React from 'react';
-import { Button, StyledComponentProps, makeStyles } from '@material-ui/core';
-import classNames from 'classnames';
+import { StyledComponentProps, makeStyles } from '@material-ui/core';
 import { getLanguageFromKey } from '../utils/language';
 import theme from '../theme/altinnStudioTheme';
+import TopToolbarButton from "@altinn/schema-editor/components/TopToolbarButton";
 
 export interface IFileSelectorProps extends StyledComponentProps {
   language: any;
@@ -16,31 +15,8 @@ export interface IFileSelectorProps extends StyledComponentProps {
 
 const useStyles = makeStyles({
   root: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    '&>*': { margin: 4, height: 36 },
-    '& input:focus-visible + label': {
-      outline: '2px solid black',
-    },
-    '& label': {
-      flex: 1,
-      display: 'inline-flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      '& span': {
-        flex: 1,
-        height: 36,
-        padding: 2,
-        paddingTop: 5,
-        boxSizing: 'border-box',
-        border: '1px solid #0062BA',
-        '&.empty': {
-          fontStyle: 'italic',
-          color: 'grey',
-        },
-      },
-    },
     '& button': {
+      height: 36,
       borderBottom: `1px solid ${theme.altinnPalette.primary.blueDark}`,
       color: theme.altinnPalette.primary.white,
       background: theme.altinnPalette.primary.blueDark,
@@ -74,10 +50,9 @@ function FileSelector(props: IFileSelectorProps) {
   } = props;
   const classes = useStyles();
   const fileInput = React.useRef<HTMLInputElement>(null);
-  const [selectedFileName, setSelectedFileName] = React.useState('');
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const handleSubmit = (event?: React.FormEvent<HTMLFormElement>) => {
+    event?.preventDefault();
     const file = fileInput?.current?.files?.item(0);
     if (file) {
       const formData = new FormData();
@@ -88,9 +63,7 @@ function FileSelector(props: IFileSelectorProps) {
 
   const handleInputChange = () => {
     const file = fileInput?.current?.files?.item(0);
-    if (file) {
-      setSelectedFileName(file.name);
-    }
+    if (file) handleSubmit();
   };
 
   return (
@@ -105,19 +78,17 @@ function FileSelector(props: IFileSelectorProps) {
         name={formFileName}
         onChange={handleInputChange}
         disabled={busy}
+        tabIndex={-1}
       />
-      <label
-        htmlFor='file-upload-picker'
-        title={getLanguageFromKey(labelTextResource, language)}
+      <TopToolbarButton
+        data-testid="upload-button"
+        faIcon='fa fa-upload'
+        iconSize={38}
+        hideText={true}
+        onClick={() => fileInput?.current?.click()}
       >
-        <Description fontSize='large' />
-        <span className={classNames({ empty: !selectedFileName })}>
-          {selectedFileName || getLanguageFromKey(labelTextResource, language)}
-        </span>
-      </label>
-      <Button type='submit' disabled={!selectedFileName || busy}>
-        {getLanguageFromKey('shared.submit_upload', language)}
-      </Button>
+        {getLanguageFromKey(labelTextResource, language)}
+      </TopToolbarButton>
     </form>
   );
 }

--- a/src/studio/src/designer/frontend/shared/components/FileSelector.tsx
+++ b/src/studio/src/designer/frontend/shared/components/FileSelector.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StyledComponentProps, makeStyles } from '@material-ui/core';
 import { getLanguageFromKey } from '../utils/language';
 import theme from '../theme/altinnStudioTheme';
-import TopToolbarButton from "@altinn/schema-editor/components/TopToolbarButton";
+import TopToolbarButton from "../../packages/schema-editor/src/components/TopToolbarButton";
 
 export interface IFileSelectorProps extends StyledComponentProps {
   language: any;

--- a/src/studio/src/designer/frontend/shared/features/dataModelling/components/XSDUpload.test.tsx
+++ b/src/studio/src/designer/frontend/shared/features/dataModelling/components/XSDUpload.test.tsx
@@ -11,45 +11,14 @@ jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('XSDUpload', () => {
-  it('should not show file picker by default', () => {
+  it('should show file picker button', () => {
     render();
+
+    const button = screen.getByLabelText("app_data_modelling.upload_xsd");
+    expect(button).toBeInTheDocument();
 
     const fileInput = screen.queryByTestId('FileSelector-input');
-    expect(fileInput).not.toBeInTheDocument();
-  });
-
-  it('should show file picker when clicking upload button', async () => {
-    render();
-
-    await showUploadDialog();
-
-    const fileInput = screen.getByTestId('FileSelector-input');
     expect(fileInput).toBeInTheDocument();
-  });
-
-  it('should show uploading spinner and hide file picker when file upload is in progress', async () => {
-    mockedAxios.post.mockImplementation(() => new Promise(jest.fn()));
-    const file = new File(['hello'], 'hello.xsd', { type: 'text/xml' });
-    render();
-
-    await showUploadDialog();
-
-    expect(
-      screen.queryByText(/app_data_modelling\.uploading_xsd/i),
-    ).not.toBeInTheDocument();
-
-    const fileInput = screen.getByTestId('FileSelector-input');
-    const submitButton = screen.getByRole('button', {
-      name: /shared\.submit_upload/i,
-    });
-
-    await user.upload(fileInput, file);
-    await user.click(submitButton);
-
-    expect(
-      screen.getByText(/app_data_modelling\.uploading_xsd/i),
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId('FileSelector-input')).not.toBeInTheDocument();
   });
 
   it('should show error text when file upload results in error', async () => {
@@ -59,19 +28,15 @@ describe('XSDUpload', () => {
     const file = new File(['hello'], 'hello.xsd', { type: 'text/xml' });
     render();
 
-    await showUploadDialog();
+    await clickUploadButton();
 
     expect(
       screen.queryByText(/form_filler\.file_uploader_validation_error_upload/i),
     ).not.toBeInTheDocument();
 
     const fileInput = screen.getByTestId('FileSelector-input');
-    const submitButton = screen.getByRole('button', {
-      name: /shared\.submit_upload/i,
-    });
 
     await user.upload(fileInput, file);
-    await user.click(submitButton);
 
     expect(
       screen.queryByText(/form_filler\.file_uploader_validation_error_upload/i),
@@ -84,25 +49,18 @@ describe('XSDUpload', () => {
     const handleUpload = jest.fn();
     render({ onXSDUploaded: handleUpload });
 
-    await showUploadDialog();
+    await clickUploadButton();
 
     const fileInput = screen.getByTestId('FileSelector-input');
-    const submitButton = screen.getByRole('button', {
-      name: /shared\.submit_upload/i,
-    });
 
     await user.upload(fileInput, file);
-    await user.click(submitButton);
 
     expect(handleUpload).toHaveBeenCalledWith('hello.xsd');
   });
 });
 
-const showUploadDialog = async () => {
-  const btn = screen.getByRole('button', {
-    name: /app_data_modelling\.upload_xsd/i,
-  });
-
+const clickUploadButton = async () => {
+  const btn = screen.getByLabelText("app_data_modelling.upload_xsd");
   await user.click(btn);
 };
 

--- a/src/studio/src/designer/frontend/shared/features/dataModelling/components/XSDUpload.tsx
+++ b/src/studio/src/designer/frontend/shared/features/dataModelling/components/XSDUpload.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { TopToolbarButton } from '@altinn/schema-editor/index';
-import { PopoverOrigin } from '@material-ui/core/Popover';
-import AltinnPopoverSimple from 'app-shared/components/molecules/AltinnPopoverSimple';
 import { FileSelector, AltinnSpinner } from 'app-shared/components';
 import { getLanguageFromKey } from 'app-shared/utils/language';
 import axios from 'axios';
+import ErrorPopover from "app-shared/components/ErrorPopover";
 
 export interface IXSDUploadProps {
   language: any;
@@ -13,15 +11,11 @@ export interface IXSDUploadProps {
   repo: string;
 }
 
-const anchorOrigin: PopoverOrigin = {
-  vertical: 'bottom',
-  horizontal: 'left',
-};
-
 const XSDUpload = ({ language, onXSDUploaded, org, repo }: IXSDUploadProps) => {
-  const [uploadButtonAnchor, setUploadButtonAnchor] = React.useState(null);
   const [uploading, setUploading] = React.useState(false);
   const [errorText, setErrorText] = React.useState(null);
+
+  const uploadButton = React.useRef(null);
 
   const handleUpload = (formData: FormData, fileName: string) => {
     const XSDUploadUrl = `${window.location.origin}/designer/api/${org}/${repo}/datamodels/upload`;
@@ -35,7 +29,7 @@ const XSDUpload = ({ language, onXSDUploaded, org, repo }: IXSDUploadProps) => {
       .then((response) => {
         if (response) {
           onXSDUploaded(fileName);
-          setUploadButtonAnchor(null);
+          setErrorText(null);
         }
       })
       .catch((error) => {
@@ -51,49 +45,33 @@ const XSDUpload = ({ language, onXSDUploaded, org, repo }: IXSDUploadProps) => {
       .finally(() => setUploading(false));
   };
 
-  const handleUploadCancel = () => {
-    setUploadButtonAnchor(null);
-  };
-
-  const handleUploadClick = (event: any) => {
-    setUploadButtonAnchor(event.currentTarget);
-  };
-
   return (
     <>
-      <TopToolbarButton
-        faIcon='fa fa-upload'
-        iconSize={38}
-        onClick={handleUploadClick}
-        hideText={true}
-      >
-        {getLanguageFromKey('app_data_modelling.upload_xsd', language)}
-      </TopToolbarButton>
-      {uploadButtonAnchor && (
-        <AltinnPopoverSimple
-          anchorEl={uploadButtonAnchor}
-          handleClose={handleUploadCancel}
-          anchorOrigin={anchorOrigin}
-        >
-          {uploading ? (
-            <AltinnSpinner
-              spinnerText={getLanguageFromKey(
-                'app_data_modelling.uploading_xsd',
-                language,
-              )}
-            />
-          ) : (
-            <FileSelector
-              busy={uploading}
-              language={language}
-              submitHandler={handleUpload}
-              accept='.xsd'
-              labelTextResource='app_data_modelling.select_xsd'
-              formFileName='file'
-            />
-          )}
-          {errorText && <p data-test-id='errorText'>{errorText}</p>}
-        </AltinnPopoverSimple>
+      <span ref={uploadButton}>
+        {uploading ? (
+          <AltinnSpinner
+            spinnerText={getLanguageFromKey(
+              'app_data_modelling.uploading_xsd',
+              language,
+            )}
+          />
+        ) : (
+          <FileSelector
+            busy={false}
+            language={language}
+            submitHandler={handleUpload}
+            accept='.xsd'
+            labelTextResource='app_data_modelling.upload_xsd'
+            formFileName='file'
+          />
+        )}
+      </span>
+      {errorText && (
+        <ErrorPopover
+          anchorEl={uploadButton.current}
+          onClose={() => setErrorText(null)}
+          errorMessage={errorText}
+        />
       )}
     </>
   );


### PR DESCRIPTION
## Description
I have removed the fileupload popover in order to avoid UI issues and to simplify the process. With this change, the user gets immediately to the file picker window when clicking the upload button, and the file uploads directly after it has been chosen.

## Related Issue(s)
- #6652 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
  _No test added, but I adjusted the existing ones._
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
  _I'll have a look at this now._
