### PR TITLE
Allow users to add fields by pressing the enter key

### DIFF
--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/EnumField.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/EnumField.tsx
@@ -13,6 +13,7 @@ export interface IEnumFieldProps {
   fullWidth?: boolean;
   onChange: (value: string, oldValue?: string) => void;
   onDelete?: (path: string, key: string) => void;
+  onEnterKeyPress?: () => void;
 }
 
 const useStyles = makeStyles({
@@ -51,6 +52,9 @@ export const EnumField = (props: IEnumFieldProps) => {
     setVal(e.target.value);
   };
 
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) =>
+    e?.key === 'Enter' && props.onEnterKeyPress && props.onEnterKeyPress();
+
   const baseId = getDomFriendlyID(props.path);
   return (
     <>
@@ -66,6 +70,8 @@ export const EnumField = (props: IEnumFieldProps) => {
           InputProps={{
             disableUnderline: true,
           }}
+          onKeyDown={onKeyDown}
+          autoFocus
         />
       </Grid>
       <Grid item xs={1} />

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/PropertyItem.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/PropertyItem.tsx
@@ -53,6 +53,7 @@ export interface IPropertyItemProps {
   onChangeRequired?: (path: string, required: boolean) => void;
   onDeleteField?: (path: string, key: string) => void;
   readOnly?: boolean;
+  onEnterKeyPress?: () => void;
 }
 
 export function PropertyItem(props: IPropertyItemProps) {
@@ -86,11 +87,15 @@ export function PropertyItem(props: IPropertyItemProps) {
       }),
     );
   };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) =>
+    e?.key === 'Enter' && props.onEnterKeyPress && props.onEnterKeyPress();
+
   const baseId = getDomFriendlyID(props.fullPath);
   return (
     <>
       <Grid item xs={4}>
-      <FormControl>
+        <FormControl>
           <Input
             id={`${baseId}-key-${getUniqueNumber()}`}
             value={value}
@@ -101,6 +106,7 @@ export function PropertyItem(props: IPropertyItemProps) {
             onChange={onChangeValue}
             onBlur={onBlur}
             className={classes.field}
+            onKeyDown={onKeyDown}
           />
         </FormControl>
       </Grid>

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector.test.tsx
@@ -94,3 +94,46 @@ test('dispatches correctly when changing restriction value', async () => {
     expect([100, 666]).toContain(action.payload.value);
   });
 });
+
+test('Adds new object field when pressing the enter key', async () => {
+  const { store, user } = renderSchemaInspector({
+    uiSchema: [
+      {
+        type: "object",
+        path: "#/properties/test",
+        displayName: "test",
+        properties: [
+          {
+            path: "#/properties/test/properties/abc",
+            displayName: "abc"
+          }
+        ]
+      }
+    ],
+    selectedPropertyNodeId: '#/properties/test',
+    selectedDefinitionNodeId: ''
+  });
+  await user.click(screen.queryAllByRole('tab')[2]);
+  await user.click(screen.getByDisplayValue('abc'));
+  await user.keyboard('{Enter}');
+  expect(store.getActions().map(a => a.type)).toContain('schemaEditor/addProperty');
+});
+
+test('Adds new valid value field when pressing the enter key', async () => {
+  const { store, user } = renderSchemaInspector({
+    uiSchema: [
+      {
+        type: "string",
+        path: "#/properties/test",
+        displayName: "test",
+        enum: ["valid value"]
+      }
+    ],
+    selectedPropertyNodeId: '#/properties/test',
+    selectedDefinitionNodeId: ''
+  });
+  await user.click(screen.queryAllByRole('tab')[1]);
+  await user.click(screen.getByDisplayValue('valid value'));
+  await user.keyboard('{Enter}');
+  expect(store.getActions().map(a => a.type)).toContain('schemaEditor/addEnum');
+});

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector.tsx
@@ -218,8 +218,7 @@ const SchemaInspector = (props: ISchemaInspectorProps) => {
     }
   };
 
-  const onAddPropertyClicked = (event: React.BaseSyntheticEvent) => {
-    event.preventDefault();
+  const dispatchAddProperty = () => {
     const path = itemToDisplay?.path;
     if (path) {
       dispatch(
@@ -229,6 +228,11 @@ const SchemaInspector = (props: ISchemaInspectorProps) => {
         }),
       );
     }
+  };
+
+  const onAddPropertyClicked = (event: React.BaseSyntheticEvent) => {
+    event.preventDefault();
+    dispatchAddProperty();
   };
 
   const onAddRestrictionClick = (event?: React.BaseSyntheticEvent) => {
@@ -244,8 +248,7 @@ const SchemaInspector = (props: ISchemaInspectorProps) => {
     }
   };
 
-  const onAddEnumButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
+  const dispatchAddEnum = () => {
     if (itemToDisplay) {
       dispatch(
         addEnum({
@@ -254,6 +257,11 @@ const SchemaInspector = (props: ISchemaInspectorProps) => {
         }),
       );
     }
+  };
+
+  const onAddEnumButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    dispatchAddEnum();
   };
   const handleRequiredChanged = (e: any, checked: boolean) => {
     if (selectedItem) {
@@ -282,6 +290,7 @@ const SchemaInspector = (props: ISchemaInspectorProps) => {
           fullPath={p.path}
           onChangeValue={onChangePropertyName}
           onDeleteField={onDeleteObjectClick}
+          onEnterKeyPress={dispatchAddProperty}
         />
       );
     });
@@ -319,6 +328,7 @@ const SchemaInspector = (props: ISchemaInspectorProps) => {
         value={value}
         onChange={onChangeEnumValue}
         onDelete={onDeleteEnumClick}
+        onEnterKeyPress={dispatchAddEnum}
       />
     ));
 


### PR DESCRIPTION
## Description
I have added a new property `onEnterKeyPress`, which accepts a function that will be called by pressing Enter, to the components `EnumField` and `PropertyItem`. This property is then used with a function that adds a new instance of the respective component by dispatching a Redux action.

## Related Issue(s)
- #7244 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
