### PR TITLE
test: some links were not updated to the correct location after react-router 6 upgrade

### DIFF
--- a/src/test/cypress/e2e/pageobjects/designer.js
+++ b/src/test/cypress/e2e/pageobjects/designer.js
@@ -1,8 +1,8 @@
 //Selectors in designer
 export const designer = {
   appMenu: {
-    about: "a[href='#/about']",
-    edit: "a[href='#/edit']",
+    about: "a[href='#/']",
+    edit: "a[href='#/ui-editor']",
     texts: "a[href='#/texts']",
     deploy: "a[href='#/deploy']",
   },


### PR DESCRIPTION
## Description
We changed some links when upgrading to React Router 6, to avoid some unnescessary redirects. This broke some tests that were forgotten during the update.

## Related Issue(s)
- #8896

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
