### PR TITLE
8915 v2 delete endpoint for languages

### DIFF
--- a/src/studio/src/designer/backend/Controllers/LanguagesController.cs
+++ b/src/studio/src/designer/backend/Controllers/LanguagesController.cs
@@ -9,6 +9,8 @@ using Altinn.Studio.Designer.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NuGet.Protocol;
+using NuGet.Protocol.Plugins;
 
 namespace Altinn.Studio.Designer.Controllers
 {
@@ -16,7 +18,8 @@ namespace Altinn.Studio.Designer.Controllers
     /// Controller containing actions related to languages
     /// </summary>
     [Authorize]
-    [AutoValidateAntiforgeryToken]
+
+    //[AutoValidateAntiforgeryToken]
     [Route("designer/api/v1/{org}/{repo}/languages")]
     public class LanguagesController : ControllerBase
     {
@@ -59,13 +62,24 @@ namespace Altinn.Studio.Designer.Controllers
         [HttpDelete]
         [Produces("application/json")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public ActionResult<bool> DeleteLanguage(string org, string repo, string languageCode)
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [Route("{languageCode}")]
+        public ActionResult<bool> DeleteLanguage(string org, string repo, [FromRoute] string languageCode)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
 
             bool deleted = _languagesService.DeleteLanguage(org, repo , developer, languageCode);
 
-            return Ok(deleted);
+            if (!deleted)
+            {
+                return new NotFoundResult();
+            }
+
+            return new JsonResult(new
+            {
+                Success = deleted,
+                Message = "Language successfully deleted."
+            });
         }
     }
 }

--- a/src/studio/src/designer/backend/Controllers/LanguagesController.cs
+++ b/src/studio/src/designer/backend/Controllers/LanguagesController.cs
@@ -48,5 +48,24 @@ namespace Altinn.Studio.Designer.Controllers
 
             return Ok(languages);
         }
+
+        /// <summary>
+        /// Endpoint for deleting a specific language in the application.
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="repo">Application identifier which is unique within an organisation.</param>
+        /// <param name="languageCode">Language identifier.</param>
+        /// <returns>List of languages as JSON</returns>
+        [HttpDelete]
+        [Produces("application/json")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public ActionResult<bool> DeleteLanguage(string org, string repo, string languageCode)
+        {
+            string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
+
+            bool deleted = _languagesService.DeleteLanguage(org, repo , developer, languageCode);
+
+            return Ok(deleted);
+        }
     }
 }

--- a/src/studio/src/designer/backend/Controllers/LanguagesController.cs
+++ b/src/studio/src/designer/backend/Controllers/LanguagesController.cs
@@ -18,8 +18,7 @@ namespace Altinn.Studio.Designer.Controllers
     /// Controller containing actions related to languages
     /// </summary>
     [Authorize]
-
-    //[AutoValidateAntiforgeryToken]
+    [AutoValidateAntiforgeryToken]
     [Route("designer/api/v1/{org}/{repo}/languages")]
     public class LanguagesController : ControllerBase
     {
@@ -68,7 +67,7 @@ namespace Altinn.Studio.Designer.Controllers
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
 
-            bool deleted = _languagesService.DeleteLanguage(org, repo , developer, languageCode);
+            bool deleted = _languagesService.DeleteLanguage(org, repo, developer, languageCode);
 
             if (!deleted)
             {

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -216,6 +216,33 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         }
 
         /// <summary>
+        /// Deletes the text file for a specific languageCode.
+        /// </summary>
+        /// <param name="org">Organisation identifier</param>
+        /// <param name="repo">Repository identifier</param>
+        /// <param name="languageCode">Language identifier</param>
+        /// <returns>A boolean value that indicates if the file was deleted or not</returns>
+        public bool DeleteLanguage(string org, string repo, string languageCode)
+        {
+            string fileName = $"text.{languageCode}.json";
+
+            var textFileRelativeFilePath = Path.Combine(CONFIG_FOLDER_PATH, LANGUAGE_RESOURCE_FOLDER_NAME, fileName);
+
+            bool deleted = false;
+
+            try
+            {
+                DeleteFileByRelativePath(textFileRelativeFilePath);
+            }
+            catch (Exception e)
+            {
+                return deleted;
+            }
+
+            return deleted;
+        }
+
+        /// <summary>
         /// Save app texts to resource files
         /// </summary>
         /// <param name="allResourceTexts">The texts to be saved</param>

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -228,13 +228,10 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
 
             bool deleted = false;
 
-            try
+            if (File.Exists(fileName))
             {
                 DeleteFileByRelativePath(textFileRelativeFilePath);
-            }
-            catch (Exception e)
-            {
-                return deleted;
+                deleted = true;
             }
 
             return deleted;

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -228,7 +228,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
 
             bool deleted = false;
 
-            if (File.Exists(fileName))
+            if (File.Exists(GetAbsoluteFilePathSanitized(textFileRelativeFilePath)))
             {
                 DeleteFileByRelativePath(textFileRelativeFilePath);
                 deleted = true;

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -218,11 +218,9 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         /// <summary>
         /// Deletes the text file for a specific languageCode.
         /// </summary>
-        /// <param name="org">Organisation identifier</param>
-        /// <param name="repo">Repository identifier</param>
         /// <param name="languageCode">Language identifier</param>
         /// <returns>A boolean value that indicates if the file was deleted or not</returns>
-        public bool DeleteLanguage(string org, string repo, string languageCode)
+        public bool DeleteLanguage(string languageCode)
         {
             string fileName = $"text.{languageCode}.json";
 

--- a/src/studio/src/designer/backend/Services/Implementation/LanguagesService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/LanguagesService.cs
@@ -42,5 +42,15 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
             return languages;
         }
+
+        /// <inheritdoc />
+        public bool DeleteLanguage(string org, string repo, string developer, string languageCode)
+        {
+            var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
+
+            bool deleted = altinnAppGitRepository.DeleteLanguage(languageCode);
+
+            return deleted;
+        }
     }
 }

--- a/src/studio/src/designer/backend/Services/Interfaces/ILanguagesService.cs
+++ b/src/studio/src/designer/backend/Services/Interfaces/ILanguagesService.cs
@@ -18,5 +18,15 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// <param name="developer">Username of developer currently working in the repo.</param>
         /// <returns>The languages</returns>
         public IList<string> GetLanguages(string org, string repo, string developer);
+
+        /// <summary>
+        /// Deletes text file for a specific language.
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="repo">Repository identifier which is unique within an organisation.</param>
+        /// <param name="developer">Username of developer currently working in the repo.</param>
+        /// <param name="languageCode">LanguageCode to identify the specific text file.</param>
+        /// <returns>A boolean value indicating if the language was deleted or not.</returns>
+        public bool DeleteLanguage(string org, string repo, string developer, string languageCode);
     }
 }


### PR DESCRIPTION
## Description
- Add endpoint for deleting a language, by deleting the text file for that specific languageCode
  - if the requested languageCode doesn't have an existing file for it in the app repository, the endpoint returns a `404 Not Found` exception

## Notes ✏️ 
_The method is not `async` due to the fact that the in-built .net method File.Delete() is not async, which is caused by Windows not handling that such operations can be async_

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
