### PR TITLE
8930 unable to drag and drop an element between two groups in altinn …

### DIFF
--- a/src/studio/src/designer/frontend/ux-editor/containers/DesignView.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DesignView.tsx
@@ -9,12 +9,7 @@ import {
   removeArrayElement,
   swapArrayElements,
 } from './helpers/array-functions';
-import {
-  ContainerPos,
-  EditorDndEvents,
-  EditorDndItem,
-  ItemType,
-} from './helpers/dnd-types';
+import { EditorDndEvents, EditorDndItem, ItemType } from './helpers/dnd-types';
 
 export interface IDesignerPreviewState {
   layoutOrder: IFormLayoutOrder;
@@ -113,7 +108,7 @@ export const DesignView = (initialState: IDesignerPreviewState) => {
   const moveItem = (
     movedItem: EditorDndItem,
     targetItem: EditorDndItem,
-    containerPos?: ContainerPos,
+    toIndex?: number,
   ): void => {
     if (!movedItem.id) {
       return;
@@ -136,12 +131,11 @@ export const DesignView = (initialState: IDesignerPreviewState) => {
 
     if (movedItem.containerId === targetItem.containerId) {
       swapItemsInsideTheSameContainer(movedItem, targetItem.id);
-    } else if (targetItem.type === ItemType.Container && containerPos) {
-      moveItemBetweenContainers(
-        movedItem,
-        targetItem.id,
-        containerPos === ContainerPos.Top ? 0 : 99,
-      );
+    } else if (
+      targetItem.type === ItemType.Container &&
+      toIndex !== undefined
+    ) {
+      moveItemBetweenContainers(movedItem, targetItem.id, toIndex);
     } else if (
       targetItem.type === ItemType.Item &&
       movedItem.id !== targetItem.containerId

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableComponent.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableComponent.tsx
@@ -25,7 +25,7 @@ const dropTargetSpec = (
     handleDrop(
       droppedItem,
       monitor,
-      events,
+      events.onDropItem,
       targetItem.containerId,
       targetItem.index,
     );

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableComponent.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableComponent.tsx
@@ -5,7 +5,11 @@ import {
   useDrag,
   useDrop,
 } from 'react-dnd';
-import { dragSourceSpec, hoverIndexHelper } from './helpers/dnd-helpers';
+import {
+  dragSourceSpec,
+  handleDrop,
+  hoverIndexHelper,
+} from './helpers/dnd-helpers';
 import { EditorDndEvents, EditorDndItem, ItemType } from './helpers/dnd-types';
 
 const dropTargetSpec = (
@@ -18,21 +22,13 @@ const dropTargetSpec = (
     return monitor.isOver({ shallow: true });
   },
   drop(droppedItem: EditorDndItem, monitor: DropTargetMonitor) {
-    if (!droppedItem) {
-      return;
-    }
-    if (!monitor.isOver({ shallow: true })) {
-      return;
-    }
-    if (monitor.getItemType() === ItemType.ToolbarItem) {
-      if (!droppedItem.onDrop) {
-        console.warn("Draggable Item doesn't have an onDrop-event");
-        return;
-      }
-      droppedItem.onDrop(targetItem.containerId, targetItem.index);
-    } else {
-      events.onDropItem();
-    }
+    handleDrop(
+      droppedItem,
+      monitor,
+      events,
+      targetItem.containerId,
+      targetItem.index,
+    );
   },
   hover(draggedItem: EditorDndItem, monitor: DropTargetMonitor) {
     if (!draggedItem) {

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableComponent.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableComponent.tsx
@@ -38,7 +38,12 @@ const dropTargetSpec = (
       return;
     }
     if (
-      !hoverIndexHelper(draggedItem, targetItem, ref, monitor.getClientOffset())
+      !hoverIndexHelper(
+        draggedItem,
+        targetItem,
+        ref.current?.getBoundingClientRect(),
+        monitor.getClientOffset(),
+      )
     ) {
       return;
     }

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableComponent.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableComponent.tsx
@@ -12,7 +12,7 @@ import {
 } from './helpers/dnd-helpers';
 import { EditorDndEvents, EditorDndItem, ItemType } from './helpers/dnd-types';
 
-const dropTargetSpec = (
+export const dropTargetSpec = (
   targetItem: EditorDndItem,
   events: EditorDndEvents,
   ref: RefObject<HTMLDivElement>,

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableComponent.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableComponent.tsx
@@ -9,6 +9,7 @@ import {
   dragSourceSpec,
   handleDrop,
   hoverIndexHelper,
+  hoverShouldBeIgnored,
 } from './helpers/dnd-helpers';
 import { EditorDndEvents, EditorDndItem, ItemType } from './helpers/dnd-types';
 
@@ -31,10 +32,7 @@ export const dropTargetSpec = (
     );
   },
   hover(draggedItem: EditorDndItem, monitor: DropTargetMonitor) {
-    if (!draggedItem) {
-      return;
-    }
-    if (!monitor.isOver({ shallow: true })) {
+    if (hoverShouldBeIgnored(monitor, draggedItem)) {
       return;
     }
     if (

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.test.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.test.tsx
@@ -1,0 +1,60 @@
+import React, { createRef } from 'react';
+import {
+  createMockedDndEvents,
+  createMockMonitor,
+} from './helpers/dnd-helpers.test';
+import { render, screen } from '@testing-library/react';
+import { DndProvider, DropTargetMonitor } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { randomUUID } from 'crypto';
+import {
+  DroppableDraggableContainer,
+  dropTargetSpec as createDropTargetSpec,
+} from './DroppableDraggableContainer';
+import { ItemType } from './helpers/dnd-types';
+
+test('that DroppableDraggableContainer gets rendered', () => {
+  const events = createMockedDndEvents();
+  render(
+    <DndProvider backend={HTML5Backend}>
+      <DroppableDraggableContainer
+        index={2}
+        dndEvents={events}
+        canDrag
+        id={randomUUID()}
+        isBaseContainer={false}
+      />
+    </DndProvider>,
+  );
+  expect(screen.getByTestId('droppable-draggable-container')).toBeDefined();
+});
+
+test("that DroppableDraggableContainer's droptarget spec is working", () => {
+  const events = createMockedDndEvents();
+  const monitor = createMockMonitor(true, ItemType.Item) as DropTargetMonitor;
+
+  const dropTargetSpec = createDropTargetSpec(
+    {
+      id: randomUUID(),
+      containerId: randomUUID(),
+      type: ItemType.Container,
+    },
+    events,
+    createRef(),
+  );
+  expect(dropTargetSpec.accept).toStrictEqual(Object.values(ItemType));
+
+  dropTargetSpec.hover(
+    {
+      id: randomUUID(),
+      index: 0,
+      type: ItemType.Item,
+      containerId: randomUUID(),
+    },
+    monitor,
+  );
+  expect(events.moveItem).not.toBeCalled();
+  expect(dropTargetSpec.collect(monitor)).toStrictEqual({
+    isOver: true,
+  });
+});

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.test.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.test.tsx
@@ -13,35 +13,34 @@ import {
 } from './DroppableDraggableContainer';
 import { ItemType } from './helpers/dnd-types';
 
-test('that DroppableDraggableContainer gets rendered', () => {
-  const events = createMockedDndEvents();
-  render(
-    <DndProvider backend={HTML5Backend}>
-      <DroppableDraggableContainer
-        index={2}
-        dndEvents={events}
-        canDrag
-        id={randomUUID()}
-        isBaseContainer={false}
-      />
-    </DndProvider>,
-  );
-  expect(screen.getByTestId('droppable-draggable-container')).toBeDefined();
-});
+test.each([[true], [false]])(
+  'that DroppableDraggableContainer gets rendered isBaseContainer %p',
+  (isBaseContainer: boolean) => {
+    const events = createMockedDndEvents();
+    render(
+      <DndProvider backend={HTML5Backend}>
+        <DroppableDraggableContainer
+          index={2}
+          dndEvents={events}
+          canDrag
+          id={randomUUID()}
+          isBaseContainer={isBaseContainer}
+        />
+      </DndProvider>,
+    );
+    expect(screen.getByTestId('droppable-draggable-container')).toBeDefined();
+  },
+);
 
 test("that DroppableDraggableContainer's droptarget spec is working", () => {
   const events = createMockedDndEvents();
   const monitor = createMockMonitor(true, ItemType.Item) as DropTargetMonitor;
-
-  const dropTargetSpec = createDropTargetSpec(
-    {
-      id: randomUUID(),
-      containerId: randomUUID(),
-      type: ItemType.Container,
-    },
-    events,
-    createRef(),
-  );
+  const targetItem = {
+    id: randomUUID(),
+    containerId: randomUUID(),
+    type: ItemType.Container,
+  };
+  const dropTargetSpec = createDropTargetSpec(targetItem, events, createRef());
   expect(dropTargetSpec.accept).toStrictEqual(Object.values(ItemType));
 
   dropTargetSpec.hover(
@@ -54,6 +53,11 @@ test("that DroppableDraggableContainer's droptarget spec is working", () => {
     monitor,
   );
   expect(events.moveItem).not.toBeCalled();
+
+  // Should not be able to hover yourself
+  dropTargetSpec.hover(targetItem, monitor);
+  expect(events.moveItem).not.toBeCalled();
+
   expect(dropTargetSpec.collect(monitor)).toStrictEqual({
     isOver: true,
   });

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
@@ -13,6 +13,7 @@ import {
   EditorDndItem,
   ItemType,
 } from './helpers/dnd-types';
+import { DummyDropTarget } from './DummyDropTarget';
 
 const dropTargetSpec = (
   targetItem: EditorDndItem,
@@ -81,7 +82,8 @@ const dropTargetSpec = (
         ? events.moveItemToBottom(draggedItem)
         : events.moveItemToTop(draggedItem);
     } else if (containerPos) {
-      events.moveItem(draggedItem, targetItem, containerPos);
+      const toIndex = containerPos === ContainerPos.Top ? 0 : 99;
+      events.moveItem(draggedItem, targetItem, toIndex);
     }
   },
 });
@@ -125,20 +127,30 @@ export const DroppableDraggableContainer = memo(
       backgroundColor,
       paddingLeft: '1.2rem',
       paddingRight: '1.2rem',
-      paddingTop: isBaseContainer ? '1.2rem' : '',
       border: parentContainerId ? '' : '1px solid #ccc',
-      marginBottom: isBaseContainer ? '' : '12px',
       opacity,
     };
     drag(drop(ref));
     return (
-      <div
-        style={style}
-        ref={ref}
-        data-testid={'droppable-draggable-container'}
-      >
-        {children}
-      </div>
+      <>
+        <DummyDropTarget
+          index={isBaseContainer ? 0 : index}
+          containerId={isBaseContainer ? id : parentContainerId}
+          events={dndEvents}
+        />
+        <div
+          style={style}
+          ref={ref}
+          data-testid={'droppable-draggable-container'}
+        >
+          {children}
+        </div>
+        <DummyDropTarget
+          index={isBaseContainer ? 99 : index + 1}
+          containerId={isBaseContainer ? id : parentContainerId}
+          events={dndEvents}
+        />
+      </>
     );
   },
 );

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
@@ -19,7 +19,7 @@ import {
 } from './helpers/dnd-types';
 import { DummyDropTarget } from './DummyDropTarget';
 
-const dropTargetSpec = (
+export const dropTargetSpec = (
   targetItem: EditorDndItem,
   events: EditorDndEvents,
   ref: RefObject<HTMLDivElement>,
@@ -37,7 +37,7 @@ const dropTargetSpec = (
       events.onDropItem,
       targetItem.id,
       getContainerPosition(
-        ref.current.getBoundingClientRect(),
+        ref.current?.getBoundingClientRect(),
         monitor.getClientOffset(),
       ) === ContainerPos.Top
         ? 0

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
@@ -114,7 +114,7 @@ export const DroppableDraggableContainer = memo(
       backgroundColor,
       paddingLeft: '1.2rem',
       paddingRight: '1.2rem',
-      border: parentContainerId ? '' : '1px solid #ccc',
+      border: isBaseContainer ? '' : '1px solid #ccc',
       opacity,
     };
     drag(drop(ref));

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
@@ -10,6 +10,7 @@ import {
   dragSourceSpec,
   getContainerPosition,
   handleDrop,
+  hoverShouldBeIgnored,
 } from './helpers/dnd-helpers';
 import {
   ContainerPos,
@@ -45,13 +46,7 @@ export const dropTargetSpec = (
     );
   },
   hover(draggedItem: EditorDndItem, monitor: DropTargetMonitor) {
-    if (!draggedItem) {
-      return;
-    }
-    if (!monitor.isOver({ shallow: true })) {
-      return;
-    }
-    if (!draggedItem.containerId && draggedItem.type !== ItemType.ToolbarItem) {
+    if (hoverShouldBeIgnored(monitor, draggedItem)) {
       return;
     }
     if (draggedItem.id === targetItem.id) {

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
@@ -6,7 +6,11 @@ import {
   useDrop,
 } from 'react-dnd';
 import altinnTheme from 'app-shared/theme/altinnStudioTheme';
-import { dragSourceSpec, getContainerPosition } from './helpers/dnd-helpers';
+import {
+  dragSourceSpec,
+  getContainerPosition,
+  handleDrop,
+} from './helpers/dnd-helpers';
 import {
   ContainerPos,
   EditorDndEvents,
@@ -27,30 +31,18 @@ const dropTargetSpec = (
     };
   },
   drop(droppedItem: EditorDndItem, monitor: DropTargetMonitor) {
-    if (!droppedItem) {
-      return;
-    }
-    if (!monitor.isOver({ shallow: true })) {
-      return;
-    }
-    if (monitor.getItemType() === ItemType.ToolbarItem) {
-      if (!droppedItem.onDrop) {
-        console.warn("Draggable Item doesn't have an onDrop-event");
-        return;
-      }
-      if (
-        getContainerPosition(
-          ref.current.getBoundingClientRect(),
-          monitor.getClientOffset(),
-        ) === ContainerPos.Top
-      ) {
-        droppedItem.onDrop(targetItem.id, 0);
-      } else {
-        droppedItem.onDrop(targetItem.id, 99);
-      }
-    } else {
-      events.onDropItem();
-    }
+    handleDrop(
+      droppedItem,
+      monitor,
+      events,
+      targetItem.id,
+      getContainerPosition(
+        ref.current.getBoundingClientRect(),
+        monitor.getClientOffset(),
+      ) === ContainerPos.Top
+        ? 0
+        : 99,
+    );
   },
   hover(draggedItem: EditorDndItem, monitor: DropTargetMonitor) {
     if (!draggedItem) {

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
@@ -34,7 +34,7 @@ const dropTargetSpec = (
     handleDrop(
       droppedItem,
       monitor,
-      events,
+      events.onDropItem,
       targetItem.id,
       getContainerPosition(
         ref.current.getBoundingClientRect(),

--- a/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DroppableDraggableContainer.tsx
@@ -114,7 +114,7 @@ export const DroppableDraggableContainer = memo(
       backgroundColor,
       paddingLeft: '1.2rem',
       paddingRight: '1.2rem',
-      border: isBaseContainer ? '' : '1px solid #ccc',
+      border: isBaseContainer ? '1px solid #ccc' : '',
       opacity,
     };
     drag(drop(ref));

--- a/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.test.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.test.tsx
@@ -1,22 +1,45 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { DummyDropTarget } from './DummyDropTarget';
+import {
+  dropTargetSpec as dummyDropTargetSpec,
+  DummyDropTarget,
+} from './DummyDropTarget';
 import { randomUUID } from 'crypto';
-import { EditorDndEvents } from './helpers/dnd-types';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import { DndProvider } from 'react-dnd';
+import { DndProvider, DropTargetMonitor } from 'react-dnd';
+import {
+  createMockedDndEvents,
+  createMockMonitor,
+} from './helpers/dnd-helpers.test';
+import { ItemType } from './helpers/dnd-types';
 
 test('that DummyDropTarget gets rendered', () => {
-  const events: EditorDndEvents = {
-    moveItem: jest.fn(),
-    moveItemToBottom: jest.fn(),
-    moveItemToTop: jest.fn(),
-    onDropItem: jest.fn(),
-  };
+  const events = createMockedDndEvents();
   render(
     <DndProvider backend={HTML5Backend}>
       <DummyDropTarget index={2} containerId={randomUUID()} events={events} />
     </DndProvider>,
   );
   expect(screen.getByTestId('dummy-drop-target')).toBeDefined();
+});
+
+test("that DummyDropTarget's droptarget spec is working", () => {
+  const events = createMockedDndEvents();
+  const monitor = createMockMonitor(true, ItemType.Item) as DropTargetMonitor;
+  const dropTargetSpec = dummyDropTargetSpec(randomUUID(), 2, events);
+  expect(dropTargetSpec.accept).toStrictEqual(Object.values(ItemType));
+
+  dropTargetSpec.hover(
+    {
+      id: randomUUID(),
+      index: 0,
+      type: ItemType.Item,
+      containerId: randomUUID(),
+    },
+    monitor,
+  );
+  expect(events.moveItem).toBeCalled();
+  expect(dropTargetSpec.collect(monitor)).toStrictEqual({
+    isOver: true,
+  });
 });

--- a/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.test.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DummyDropTarget } from './DummyDropTarget';
+import { randomUUID } from 'crypto';
+import { EditorDndEvents } from './helpers/dnd-types';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { DndProvider } from 'react-dnd';
+
+test('that DummyDropTarget gets rendered', () => {
+  const events: EditorDndEvents = {
+    moveItem: jest.fn(),
+    moveItemToBottom: jest.fn(),
+    moveItemToTop: jest.fn(),
+    onDropItem: jest.fn(),
+  };
+  render(
+    <DndProvider backend={HTML5Backend}>
+      <DummyDropTarget index={2} containerId={randomUUID()} events={events} />
+    </DndProvider>,
+  );
+  expect(screen.getByTestId('dummy-drop-target')).toBeDefined();
+});

--- a/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.tsx
@@ -1,7 +1,7 @@
 import { DropTargetHookSpec, DropTargetMonitor, useDrop } from 'react-dnd';
 import React from 'react';
 import { EditorDndEvents, EditorDndItem, ItemType } from './helpers/dnd-types';
-import { handleDrop } from './helpers/dnd-helpers';
+import { handleDrop, hoverShouldBeIgnored } from './helpers/dnd-helpers';
 
 export const dropTargetSpec = (
   containerId: string,
@@ -18,13 +18,7 @@ export const dropTargetSpec = (
     handleDrop(droppedItem, monitor, events.onDropItem, containerId, index);
   },
   hover(draggedItem: EditorDndItem, monitor: DropTargetMonitor) {
-    if (!draggedItem) {
-      return;
-    }
-    if (!monitor.isOver({ shallow: true })) {
-      return;
-    }
-    if (!draggedItem.containerId && draggedItem.type !== ItemType.ToolbarItem) {
+    if (hoverShouldBeIgnored(monitor, draggedItem)) {
       return;
     }
     const targetItem: EditorDndItem = {

--- a/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { EditorDndEvents, EditorDndItem, ItemType } from './helpers/dnd-types';
 import { handleDrop } from './helpers/dnd-helpers';
 
-const dropTargetSpec = (
+export const dropTargetSpec = (
   containerId: string,
   index: number,
   events: EditorDndEvents,
@@ -27,7 +27,6 @@ const dropTargetSpec = (
     if (!draggedItem.containerId && draggedItem.type !== ItemType.ToolbarItem) {
       return;
     }
-
     const targetItem: EditorDndItem = {
       id: containerId,
       type: ItemType.Container,

--- a/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.tsx
@@ -15,7 +15,7 @@ const dropTargetSpec = (
     };
   },
   drop(droppedItem: EditorDndItem, monitor: DropTargetMonitor) {
-    handleDrop(droppedItem, monitor, events, containerId, index);
+    handleDrop(droppedItem, monitor, events.onDropItem, containerId, index);
   },
   hover(draggedItem: EditorDndItem, monitor: DropTargetMonitor) {
     if (!draggedItem) {
@@ -48,5 +48,11 @@ export const DummyDropTarget = ({
   events,
 }: DummyDropTargetProps) => {
   const [, drop] = useDrop(dropTargetSpec(containerId, index, events));
-  return <div ref={drop} style={{ height: 12 }}></div>;
+  return (
+    <div
+      ref={drop}
+      style={{ height: 12 }}
+      data-testid={'dummy-drop-target'}
+    ></div>
+  );
 };

--- a/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.tsx
@@ -1,6 +1,7 @@
 import { DropTargetHookSpec, DropTargetMonitor, useDrop } from 'react-dnd';
 import React from 'react';
 import { EditorDndEvents, EditorDndItem, ItemType } from './helpers/dnd-types';
+import { handleDrop } from './helpers/dnd-helpers';
 
 const dropTargetSpec = (
   containerId: string,
@@ -14,21 +15,7 @@ const dropTargetSpec = (
     };
   },
   drop(droppedItem: EditorDndItem, monitor: DropTargetMonitor) {
-    if (!droppedItem) {
-      return;
-    }
-    if (!monitor.isOver({ shallow: true })) {
-      return;
-    }
-    if (monitor.getItemType() === ItemType.ToolbarItem) {
-      if (!droppedItem.onDrop) {
-        console.warn("Draggable Item doesn't have an onDrop-event");
-        return;
-      }
-      droppedItem.onDrop(containerId, index);
-    } else {
-      events.onDropItem();
-    }
+    handleDrop(droppedItem, monitor, events, containerId, index);
   },
   hover(draggedItem: EditorDndItem, monitor: DropTargetMonitor) {
     if (!draggedItem) {

--- a/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/DummyDropTarget.tsx
@@ -1,0 +1,65 @@
+import { DropTargetHookSpec, DropTargetMonitor, useDrop } from 'react-dnd';
+import React from 'react';
+import { EditorDndEvents, EditorDndItem, ItemType } from './helpers/dnd-types';
+
+const dropTargetSpec = (
+  containerId: string,
+  index: number,
+  events: EditorDndEvents,
+): DropTargetHookSpec<any, any, any> => ({
+  accept: Object.values(ItemType),
+  collect(monitor: DropTargetMonitor) {
+    return {
+      isOver: monitor.isOver(),
+    };
+  },
+  drop(droppedItem: EditorDndItem, monitor: DropTargetMonitor) {
+    if (!droppedItem) {
+      return;
+    }
+    if (!monitor.isOver({ shallow: true })) {
+      return;
+    }
+    if (monitor.getItemType() === ItemType.ToolbarItem) {
+      if (!droppedItem.onDrop) {
+        console.warn("Draggable Item doesn't have an onDrop-event");
+        return;
+      }
+      droppedItem.onDrop(containerId, index);
+    } else {
+      events.onDropItem();
+    }
+  },
+  hover(draggedItem: EditorDndItem, monitor: DropTargetMonitor) {
+    if (!draggedItem) {
+      return;
+    }
+    if (!monitor.isOver({ shallow: true })) {
+      return;
+    }
+    if (!draggedItem.containerId && draggedItem.type !== ItemType.ToolbarItem) {
+      return;
+    }
+
+    const targetItem: EditorDndItem = {
+      id: containerId,
+      type: ItemType.Container,
+      index: null,
+    };
+    events.moveItem(draggedItem, targetItem, index);
+  },
+});
+
+interface DummyDropTargetProps {
+  index: number;
+  containerId: string;
+  events: EditorDndEvents;
+}
+export const DummyDropTarget = ({
+  index,
+  containerId,
+  events,
+}: DummyDropTargetProps) => {
+  const [, drop] = useDrop(dropTargetSpec(containerId, index, events));
+  return <div ref={drop} style={{ height: 12 }}></div>;
+};

--- a/src/studio/src/designer/frontend/ux-editor/containers/EditContainer.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/containers/EditContainer.tsx
@@ -41,7 +41,6 @@ const useStyles = makeStyles({
     border: `0.15rem dotted ${altinnTheme.altinnPalette.primary.grey}`,
     color: `${altinnTheme.altinnPalette.primary.blueDarker}!important`,
     padding: '0.45rem 1.05rem 1.05rem 1.05rem',
-    marginBottom: '1.2rem',
     '&:hover': {
       backgroundColor: '#fff',
       boxShadow: '0rem 0rem 0.4rem rgba(0, 0, 0, 0.25)',

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.test.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.test.ts
@@ -145,6 +145,9 @@ test('that hoverIndexHelper can be initiated', () => {
     hoverIndexHelper(draggedItem, hoveredItem, undefined, clientOffset),
   ).toBeFalsy();
   expect(
+    hoverIndexHelper(draggedItem, hoveredItem, boundingBox, undefined),
+  ).toBeFalsy();
+  expect(
     hoverIndexHelper(draggedItem, draggedItem, boundingBox, clientOffset),
   ).toBeFalsy();
 });

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.test.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.test.ts
@@ -2,6 +2,7 @@ import {
   getContainerPosition,
   handleDrop,
   hoverIndexHelper,
+  hoverShouldBeIgnored,
 } from './dnd-helpers';
 import { DropTargetMonitor, XYCoord } from 'react-dnd';
 import {
@@ -41,7 +42,7 @@ test('getContainerPosition returns correct positions', () => {
 export const createMockMonitor = (
   isOver: boolean,
   itemType: ItemType,
-): Partial<DropTargetMonitor> => {
+): DropTargetMonitor => {
   const monitor: Partial<DropTargetMonitor> = {
     isOver(): boolean {
       return isOver;
@@ -53,7 +54,7 @@ export const createMockMonitor = (
       return { x: 100, y: 200 };
     },
   };
-  return monitor;
+  return monitor as DropTargetMonitor;
 };
 export const createMockedDndEvents = (): EditorDndEvents => ({
   moveItem: jest.fn(),
@@ -145,3 +146,16 @@ test('that hoverIndexHelper can be initiated', () => {
   );
   expect(result).toBeFalsy();
 });
+const id = randomUUID();
+test.each([
+  [true, undefined, true],
+  [false, undefined, true],
+  [true, { id, type: ItemType.Item }, true],
+  [true, { id, containerId: randomUUID(), type: ItemType.Item }, false],
+])(
+  'if hoverShouldBeIgnored when isOver is %p and item is %p',
+  (isOver: boolean, item: EditorDndItem, result: boolean) => {
+    const monitor = createMockMonitor(isOver, item?.type);
+    expect(hoverShouldBeIgnored(monitor, item)).toBe(result);
+  },
+);

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.test.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.test.ts
@@ -138,14 +138,17 @@ test('that hoverIndexHelper can be initiated', () => {
     index: 1,
   };
   const clientOffset: XYCoord = { x: 500, y: 290 };
-  const result = hoverIndexHelper(
-    draggedItem,
-    hoveredItem,
-    boundingBox,
-    clientOffset,
-  );
-  expect(result).toBeFalsy();
+  expect(
+    hoverIndexHelper(draggedItem, hoveredItem, boundingBox, clientOffset),
+  ).toBeFalsy();
+  expect(
+    hoverIndexHelper(draggedItem, hoveredItem, undefined, clientOffset),
+  ).toBeFalsy();
+  expect(
+    hoverIndexHelper(draggedItem, draggedItem, boundingBox, clientOffset),
+  ).toBeFalsy();
 });
+
 const id = randomUUID();
 test.each([
   [true, undefined, true],

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.test.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.test.ts
@@ -1,6 +1,7 @@
-import { getContainerPosition } from './dnd-helpers';
-import { XYCoord } from 'react-dnd';
-import { ContainerPos } from './dnd-types';
+import { getContainerPosition, handleDrop } from './dnd-helpers';
+import { DropTargetMonitor, XYCoord } from 'react-dnd';
+import { ContainerPos, EditorDndItem, ItemType } from './dnd-types';
+import { randomUUID } from 'crypto';
 
 test('getContainerPosition returns correct positions', () => {
   const boundingBox: DOMRect = {
@@ -26,4 +27,53 @@ test('getContainerPosition returns correct positions', () => {
     const result = getContainerPosition(boundingBox, xyCord);
     expect(result).toBe(expected);
   });
+});
+
+const createDummyData = (
+  itemType: ItemType,
+): [EditorDndItem, Partial<DropTargetMonitor>, () => void, () => void] => {
+  const onDrop = jest.fn();
+
+  const droppedItem: EditorDndItem = {
+    id: randomUUID(),
+    type: itemType,
+    onDrop,
+  };
+  const monitor: Partial<DropTargetMonitor> = {
+    isOver(): boolean {
+      return true;
+    },
+    getItemType(): string | null {
+      return droppedItem.type;
+    },
+  };
+  const onDropItem = jest.fn();
+
+  return [droppedItem, monitor, onDrop, onDropItem];
+};
+
+test('should handle that ' + ItemType.Item + ' gets dropped', () => {
+  const [droppedItem, monitor, onDrop, onDropItem] = createDummyData(
+    ItemType.Item,
+  );
+  handleDrop(droppedItem, monitor, onDropItem, randomUUID(), 3);
+  expect(onDrop).not.toBeCalled();
+  expect(onDropItem).toBeCalled();
+});
+test('should handle that ' + ItemType.Container + ' gets dropped', () => {
+  const [droppedItem, monitor, onDrop, onDropItem] = createDummyData(
+    ItemType.Container,
+  );
+  handleDrop(droppedItem, monitor, onDropItem, randomUUID(), 3);
+  expect(onDrop).not.toBeCalled();
+  expect(onDropItem).toBeCalled();
+});
+
+test('should handle that ' + ItemType.ToolbarItem + ' gets dropped', () => {
+  const [droppedItem, monitor, onDrop, onDropItem] = createDummyData(
+    ItemType.ToolbarItem,
+  );
+  handleDrop(droppedItem, monitor, onDropItem, randomUUID(), 3);
+  expect(onDrop).toBeCalled();
+  expect(onDropItem).not.toBeCalled();
 });

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.test.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.test.ts
@@ -4,7 +4,12 @@ import {
   hoverIndexHelper,
 } from './dnd-helpers';
 import { DropTargetMonitor, XYCoord } from 'react-dnd';
-import { ContainerPos, EditorDndItem, ItemType } from './dnd-types';
+import {
+  ContainerPos,
+  EditorDndEvents,
+  EditorDndItem,
+  ItemType,
+} from './dnd-types';
 import { randomUUID } from 'crypto';
 
 const boundingBox: DOMRect = {
@@ -33,7 +38,29 @@ test('getContainerPosition returns correct positions', () => {
     expect(result).toBe(expected);
   });
 });
-
+export const createMockMonitor = (
+  isOver: boolean,
+  itemType: ItemType,
+): Partial<DropTargetMonitor> => {
+  const monitor: Partial<DropTargetMonitor> = {
+    isOver(): boolean {
+      return isOver;
+    },
+    getItemType(): string | null {
+      return itemType;
+    },
+    getClientOffset(): XYCoord | null {
+      return { x: 100, y: 200 };
+    },
+  };
+  return monitor;
+};
+export const createMockedDndEvents = (): EditorDndEvents => ({
+  moveItem: jest.fn(),
+  moveItemToBottom: jest.fn(),
+  moveItemToTop: jest.fn(),
+  onDropItem: jest.fn(),
+});
 const createDummyData = (
   itemType: ItemType,
   isOver: boolean,
@@ -45,14 +72,8 @@ const createDummyData = (
     type: itemType,
     onDrop,
   };
-  const monitor: Partial<DropTargetMonitor> = {
-    isOver(): boolean {
-      return isOver;
-    },
-    getItemType(): string | null {
-      return droppedItem.type;
-    },
-  };
+  const monitor = createMockMonitor(isOver, droppedItem.type);
+
   const onDropItem = jest.fn();
 
   return [droppedItem, monitor, onDrop, onDropItem];

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
@@ -88,6 +88,9 @@ export const getContainerPosition = (
   boundingClientRect: DOMRect,
   clientOffset: XYCoord,
 ): ContainerPos | undefined => {
+  if (!clientOffset) {
+    return undefined;
+  }
   // need to support smaller boxes so that they don't jump around.
   const boundaryHeight = Math.min(50, boundingClientRect.height / 4);
   const toptop = boundingClientRect.top;

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
@@ -124,3 +124,19 @@ export const handleDrop = (
     onDropItem();
   }
 };
+
+export const hoverShouldBeIgnored = (
+  monitor: DropTargetMonitor,
+  draggedItem?: EditorDndItem,
+) => {
+  if (!draggedItem) {
+    return true;
+  }
+  if (!monitor.isOver({ shallow: true })) {
+    return true;
+  }
+  if (!draggedItem.containerId && draggedItem.type !== ItemType.ToolbarItem) {
+    return true;
+  }
+  return false;
+};

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
@@ -4,25 +4,21 @@ import {
   DropTargetMonitor,
   XYCoord,
 } from 'react-dnd';
-import { RefObject } from 'react';
 import { ContainerPos, EditorDndItem, ItemType } from './dnd-types';
 
 // @see https://react-dnd.github.io/react-dnd/examples/sortable/simple
 export const hoverIndexHelper = (
   draggedItem: EditorDndItem,
   hoveredItem: EditorDndItem,
-  ref: RefObject<HTMLDivElement>,
+  hoverBoundingRect: DOMRect,
   clientOffset: XYCoord,
 ): boolean => {
   const dragIndex = draggedItem.index;
   const hoverIndex = hoveredItem.index;
 
-  if (!ref.current || dragIndex === hoverIndex) {
+  if (!hoverBoundingRect || dragIndex === hoverIndex) {
     return false;
   }
-
-  // Determine rectangle on screen
-  const hoverBoundingRect = ref.current?.getBoundingClientRect();
 
   // Get vertical middle
   const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
@@ -10,13 +10,16 @@ import { ContainerPos, EditorDndItem, ItemType } from './dnd-types';
 export const hoverIndexHelper = (
   draggedItem: EditorDndItem,
   hoveredItem: EditorDndItem,
-  hoverBoundingRect: DOMRect,
-  clientOffset: XYCoord,
+  hoverBoundingRect?: DOMRect,
+  clientOffset?: XYCoord,
 ): boolean => {
   const dragIndex = draggedItem.index;
   const hoverIndex = hoveredItem.index;
 
   if (!hoverBoundingRect || dragIndex === hoverIndex) {
+    return false;
+  }
+  if (!clientOffset) {
     return false;
   }
 

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
@@ -82,6 +82,9 @@ export const getContainerPosition = (
   if (!clientOffset) {
     return undefined;
   }
+  if (!boundingClientRect) {
+    return undefined;
+  }
   // need to support smaller boxes so that they don't jump around.
   const boundaryHeight = Math.min(50, boundingClientRect.height / 4);
   const toptop = boundingClientRect.top;

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
@@ -1,6 +1,16 @@
-import { DragSourceHookSpec, DragSourceMonitor, XYCoord } from 'react-dnd';
+import {
+  DragSourceHookSpec,
+  DragSourceMonitor,
+  DropTargetMonitor,
+  XYCoord,
+} from 'react-dnd';
 import { RefObject } from 'react';
-import { ContainerPos, EditorDndItem } from './dnd-types';
+import {
+  ContainerPos,
+  EditorDndEvents,
+  EditorDndItem,
+  ItemType,
+} from './dnd-types';
 
 // @see https://react-dnd.github.io/react-dnd/examples/sortable/simple
 export const hoverIndexHelper = (
@@ -92,4 +102,28 @@ export const getContainerPosition = (
     return ContainerPos.Bottom;
   }
   return undefined;
+};
+
+export const handleDrop = (
+  droppedItem: EditorDndItem,
+  monitor: DropTargetMonitor,
+  events: EditorDndEvents,
+  containerId: string,
+  index: number,
+) => {
+  if (!droppedItem) {
+    return;
+  }
+  if (!monitor.isOver({ shallow: true })) {
+    return;
+  }
+  if (monitor.getItemType() === ItemType.ToolbarItem) {
+    if (!droppedItem.onDrop) {
+      console.warn("Draggable Item doesn't have an onDrop-event");
+      return;
+    }
+    droppedItem.onDrop(containerId, index);
+  } else {
+    events.onDropItem();
+  }
 };

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-helpers.ts
@@ -5,12 +5,7 @@ import {
   XYCoord,
 } from 'react-dnd';
 import { RefObject } from 'react';
-import {
-  ContainerPos,
-  EditorDndEvents,
-  EditorDndItem,
-  ItemType,
-} from './dnd-types';
+import { ContainerPos, EditorDndItem, ItemType } from './dnd-types';
 
 // @see https://react-dnd.github.io/react-dnd/examples/sortable/simple
 export const hoverIndexHelper = (
@@ -109,8 +104,8 @@ export const getContainerPosition = (
 
 export const handleDrop = (
   droppedItem: EditorDndItem,
-  monitor: DropTargetMonitor,
-  events: EditorDndEvents,
+  monitor: Partial<DropTargetMonitor>,
+  onDropItem: () => void,
   containerId: string,
   index: number,
 ) => {
@@ -127,6 +122,6 @@ export const handleDrop = (
     }
     droppedItem.onDrop(containerId, index);
   } else {
-    events.onDropItem();
+    onDropItem();
   }
 };

--- a/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-types.ts
+++ b/src/studio/src/designer/frontend/ux-editor/containers/helpers/dnd-types.ts
@@ -24,7 +24,7 @@ export interface EditorDndEvents {
   moveItem: (
     movedItem: EditorDndItem,
     targetItem: EditorDndItem,
-    containerPos?: ContainerPos,
+    toIndex?: number,
   ) => void;
   moveItemToBottom: (item: EditorDndItem) => void;
   moveItemToTop: (item: EditorDndItem) => void;


### PR DESCRIPTION
…studio

<!--- Provide a general summary of your changes in the Title above -->

## Description
Introdused a drop area at the bottom and top of an container that allows for dropping items between groups. This dummy area also solves a few other problems that this DND-view have. In the future we could benefit from using this approach in other parts of the dnd-view too. Its easier to debug when drop areas are distict elements and not based on pointer-location at the current element.

SonarCloud was not very forgetting about test-coverage. Several new test was introduced that is not realated to this change, but was neccesary to come through this step. Some code was refactored to remove duplication too. So this PR is a little bit larger than strictly needed.

## Related Issue(s)
- #{8930}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
