### PR TITLE
bug: filter illegal chars in file name on pdf

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/utils/InstanceUtils.java
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/src/main/java/altinn/platform/pdf/utils/InstanceUtils.java
@@ -26,7 +26,7 @@ public class InstanceUtils {
 
     for (Data data: instance.getData()) {
       if (id.equals(data.getDataType())) {
-        list.add(data.getFilename());
+        list.add(TextUtils.removeIllegalChars(data.getFilename()));
       }
     }
     return list;
@@ -46,7 +46,7 @@ public class InstanceUtils {
 
     for (Data data: instance.getData()) {
       if (id.equals(data.getDataType())) {
-        map.put(data.getFilename(), data.getTags());
+        map.put(TextUtils.removeIllegalChars(data.getFilename()), data.getTags());
       }
     }
     return map;


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

Reverting changes introduced in https://github.com/Altinn/altinn-studio/pull/8556/files#diff-e9fa0350ad73d2e3c298ca18eaaefa7507fa6c38ddd6dc947f4694530f08f174L29.
## Related Issue(s)
Fixed as this caused issues for [DAT](https://altinn.slack.com/archives/C02FK32FBR6/p1662988766672379).

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
