### PR TITLE
Change from altinn3local.no to local.altinn.cloud for localtest

### DIFF
--- a/LOCALAPP.md
+++ b/LOCALAPP.md
@@ -13,10 +13,6 @@ These are some of the required steps, tips and tricks when it comes to running a
 3. A code editor - we like [Visual Studio Code](https://code.visualstudio.com/Download)
     - Also install [recommended extensions](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions) (f.ex. [C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp))
 4. [Docker Desktop](https://www.docker.com/products/docker-desktop) (Linux users can also use native Docker)
-5. Update hosts file (`C:/Windows/System32/drivers/etc/hosts`) by adding the following values. On MacOS add the same values to `/private/etc/hosts` using cmd `sudo nano /private/etc/hosts`. On Linux, edit `/etc/hosts`.
-   ```txt
-   127.0.0.1 altinn3local.no
-   ```
 
 ### Setup
 
@@ -45,7 +41,7 @@ These are some of the required steps, tips and tricks when it comes to running a
    dotnet run
    ```
 
-The app and local platform services are now running locally. The app can be accessed on <http://altinn3local.no>.
+The app and local platform services are now running locally. The app can be accessed on <http://local.altinn.cloud>.
 
 Log in with a test user, using your app name and org name. This will redirect you to the app.
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ docker-compose down
 
    - If you need to debug (or run locally) the app front-end, see details in [app-frontend-react repository](https://github.com/Altinn/app-frontend-react#developing-app-frontend)
 
-The app and local platform services are now running locally.
-If you have configured your hosts as [described in the prerequisites](/src/studio/README.md#prerequisites), the app can be accessed on altinn3local.no.
+The app and local platform services are now running locally, and the app can be accessed on local.altinn.cloud.
 
 Log in with a test user, using your app name and org name. This will redirect you to the app.
 

--- a/src/development/LocalTest/Properties/launchSettings.json
+++ b/src/development/LocalTest/Properties/launchSettings.json
@@ -1,9 +1,9 @@
 {
   "iisSettings": {
-    "windowsAuthentication": false, 
-    "anonymousAuthentication": true, 
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:5101",
+      "applicationUrl": "http://local.altinn.cloud",
       "sslPort": 0
     }
   },
@@ -11,8 +11,8 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "http://altinn3local.no/",
-      "applicationUrl": "http://localhost:5101",
+      "launchUrl": "http://local.altinn.cloud/",
+      "applicationUrl": "http://local.altinn.cloud",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -20,8 +20,8 @@
     "LocalTest": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://altinn3local.no/",
-      "applicationUrl": "http://localhost:5101",
+      "launchUrl": "http://local.altinn.cloud/",
+      "applicationUrl": "http://local.altinn.cloud",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ASPNETCORE_URLS": "http://localhost:5101/"

--- a/src/development/LocalTest/appsettings.json
+++ b/src/development/LocalTest/appsettings.json
@@ -39,11 +39,11 @@
   },
   "AllowedHosts": "*",
   "LocalPlatformSettings": {
-    "LocalAppMode": "http",
+    "LocalAppMode": "file",
     "LocalAppUrl": "http://localhost:5005",
     "LocalTestingStorageBasePath": "c:/AltinnPlatformLocal/",
     "AppRepositoryBasePath": "<Path to your repos folder where you have cloned the Altinn Studio application repositories>",
-    "LocalTestingStaticTestDataPath": "c:/Users/xivne/dev/altinn-studio//src/development/TestData/"
+    "LocalTestingStaticTestDataPath": "<Path to altinn-studio repo>/src/development/TestData/"
   },
   "PlatformSettings": {
     "ApiAuthorizationEndpoint": "http://localhost:5101/authorization/api/v1/"

--- a/src/development/LocalTest/appsettings.json
+++ b/src/development/LocalTest/appsettings.json
@@ -5,9 +5,9 @@
     "PersonCacheLifetimeSeconds": 3600
   },
   "GeneralSettings": {
-    "HostName": "altinn3local.no",
+    "HostName": "local.altinn.cloud",
     "SBLCookieName": ".ASPXAUTH",
-    "BaseUrl": "http://altinn3local.no",
+    "BaseUrl": "http://local.altinn.cloud",
     "PlatformEndpoint": "http://localhost:5040/",
     "ClaimsIdentity": "UserLogin",
     "JwtCookieValidityTime": "960",
@@ -39,11 +39,11 @@
   },
   "AllowedHosts": "*",
   "LocalPlatformSettings": {
-    "LocalAppMode": "file",
+    "LocalAppMode": "http",
     "LocalAppUrl": "http://localhost:5005",
     "LocalTestingStorageBasePath": "c:/AltinnPlatformLocal/",
     "AppRepositoryBasePath": "<Path to your repos folder where you have cloned the Altinn Studio application repositories>",
-    "LocalTestingStaticTestDataPath": "<Path to altinn-studio repo>/src/development/TestData/"
+    "LocalTestingStaticTestDataPath": "c:/Users/xivne/dev/altinn-studio//src/development/TestData/"
   },
   "PlatformSettings": {
     "ApiAuthorizationEndpoint": "http://localhost:5101/authorization/api/v1/"

--- a/src/development/docker-compose.yml
+++ b/src/development/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       - NGINX_HOST=localhost
       - NGINX_PORT=80
-      - TEST_DOMAIN=${TEST_DOMAIN:-altinn3local.no}
+      - TEST_DOMAIN=${TEST_DOMAIN:-local.altinn.cloud}
       - ALTINN3LOCAL_PORT=${ALTINN3LOCAL_PORT:-80}
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
     build:
@@ -51,8 +51,8 @@ services:
     environment:
       - DOTNET_ENVIRONMENT=Docker
       - ASPNETCORE_URLS=http://*:5101/
-      - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-altinn3local.no}:${ALTINN3LOCAL_PORT:-80}
-      - GeneralSettings__HostName=${TEST_DOMAIN:-altinn3local.no}
+      - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-80}
+      - GeneralSettings__HostName=${TEST_DOMAIN:-local.altinn.cloud}
     volumes:
       - ${ALTINN3LOCALSTORAGE_PATH:-AltinnPlatformLocal}:/AltinnPlatformLocal
     extra_hosts:

--- a/src/development/loadbalancer/nginx.conf
+++ b/src/development/loadbalancer/nginx.conf
@@ -32,11 +32,10 @@ http {
     upstream app {
         server host.docker.internal:5005;
     }
-    # Redirect localhost (future altinn3local.no) to the configured test domain
+    # Redirect localhost and the old altinn3local.no to the configured test domain
     server {
       listen 80;
-      server_name localhost;
-      # server_name localhost altinn3local.no;
+      server_name localhost altinn3local.no;
       return 307 $scheme://${TEST_DOMAIN}:${ALTINN3LOCAL_PORT}$request_uri;
     }
 

--- a/src/studio/AppTemplates/AspNet/App/appsettings.json
+++ b/src/studio/AppTemplates/AspNet/App/appsettings.json
@@ -9,10 +9,10 @@
   "AppSettings": {
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
     "RuntimeCookieName": "AltinnStudioRuntime",
-    "RegisterEventsWithEventsComponent": false 
+    "RegisterEventsWithEventsComponent": false
   },
   "GeneralSettings": {
-    "HostName": "altinn3local.no",
+    "HostName": "local.altinn.cloud",
     "SoftValidationPrefix": "*WARNING*",
     "FixedValidationPrefix": "*FIXED*",
     "AltinnPartyCookieName": "AltinnPartyId"

--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -24,7 +24,6 @@ These instructions will get you a copy of Altinn Studio up and running on your l
    ```txt
    localhost altinn3.no
    127.0.0.1 altinn3.no
-   127.0.0.1 altinn3local.no
    ```
    _On MacOS add the same values to values `/private/etc/hosts` with `sudo nano /private/etc/hosts` in treminal._
 7. If you are running Docker Desktop in Hyper-V mode you need to make sure your C drive is shared with Docker, Docker Settings -> Shared Drives

--- a/src/studio/src/designer/backend.Tests/_TestData/Remote/ttd/apps-test/App/appsettings.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Remote/ttd/apps-test/App/appsettings.json
@@ -8,7 +8,7 @@
   },
   "AppSettings": {
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
-    "Hostname": "altinn3local.no",
+    "Hostname": "local.altinn.cloud",
     "RuntimeCookieName": "AltinnStudioRuntime",
     "RegisterEventsWithEventsComponent": true
   },

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/apps-test-2021/App/appsettings.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/apps-test-2021/App/appsettings.json
@@ -8,7 +8,7 @@
   },
   "AppSettings": {
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
-    "Hostname": "altinn3local.no",
+    "Hostname": "local.altinn.cloud",
     "RuntimeCookieName": "AltinnStudioRuntime",
     "RegisterEventsWithEventsComponent": true
   },

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/apps-test/App/appsettings.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/apps-test/App/appsettings.json
@@ -8,7 +8,7 @@
   },
   "AppSettings": {
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
-    "Hostname": "altinn3local.no",
+    "Hostname": "local.altinn.cloud",
     "RuntimeCookieName": "AltinnStudioRuntime",
     "RegisterEventsWithEventsComponent": true
   },

--- a/src/test/Postman/collections/App.postman_collection.json
+++ b/src/test/Postman/collections/App.postman_collection.json
@@ -3004,7 +3004,7 @@
 							"query": [
 								{
 									"key": "url",
-									"value": "https://altinn3local.no",
+									"value": "https://local.altinn.cloud",
 									"disabled": true
 								},
 								{

--- a/src/test/Postman/collections/Local-Test.postman_collection.json
+++ b/src/test/Postman/collections/Local-Test.postman_collection.json
@@ -2,7 +2,7 @@
 	"info": {
 		"_postman_id": "ec4fc3e8-b3fb-4ee3-b1bb-76bed9ce9f85",
 		"name": "Local-Test",
-		"description": "### **Collection variables**\n\n*   envUrl - the environment running your app (example: altinn3local.no)\n*   altinnToken - filled in automatically after sending request \"Get Test Org Token\"\n*   appOwner - name of organisation/user that created the app (example :ttd)\n*   appName - name of the app you are testing (example: apps-test)\n*   userId - id of the test user you are testing the app with (example: 1337)\n    *   find local testusers in /altinn-studio/src/development/TestData/Profile/User\n*   instanceOwnerId - id of the party the instance is created for (example: 501337)\n    *   find your local testusers partyId in /altinn-studio/src/development/TestData/Register/Party\n*   SSN - ssn of the user (example: 01039012345)\n    *   used to send \"Post Multipart ...\" requests\n    *   find your local testusers SSN in /altinn-studio/src/development/TestData/Register/Party\n*   instanceId - id of an existing instance, used to send \"Get Instance\" request\n    *   updated automatically after successfully sending request \"Post Multipart\"\n*   dataId - reference to the data in a given instance\n    *   updated automatically after successfully sending request \"Post Multipart\"\n*   attachmentDataId - id of the field in your app containing multipart attachment (example: d84913c1-2b32-4ab0-a605-409be875bae6)\n    *   found in your apps metadata. /App/config/appmetadata.json under datatypes.\n    *   used to send \"Post Multipart ...\" requests\n*   organizationNumber - a organization number of a chosen test organisation\n    *   used to send \"Post Multipart from Org\"\n\n### **Possible problems**\n\n**400 - Bad request (no message)**  \nIf you have the cookie called \"AltinnStudioRuntime\" the api will assume you are making a request from a browser and you will get 400 due to the ValidateAntiforgeryTokenIfAuthCookieAuthorizationFilter.\n\nTo mitigate this filter you can simply delete the cookie called \"AltinnStudioRuntime\". (When in a request you can click \"Cookies\" in the top right part of your postman window below the Send button.)",
+		"description": "### **Collection variables**\n\n*   envUrl - the environment running your app (example: local.altinn.cloud)\n*   altinnToken - filled in automatically after sending request \"Get Test Org Token\"\n*   appOwner - name of organisation/user that created the app (example :ttd)\n*   appName - name of the app you are testing (example: apps-test)\n*   userId - id of the test user you are testing the app with (example: 1337)\n    *   find local testusers in /altinn-studio/src/development/TestData/Profile/User\n*   instanceOwnerId - id of the party the instance is created for (example: 501337)\n    *   find your local testusers partyId in /altinn-studio/src/development/TestData/Register/Party\n*   SSN - ssn of the user (example: 01039012345)\n    *   used to send \"Post Multipart ...\" requests\n    *   find your local testusers SSN in /altinn-studio/src/development/TestData/Register/Party\n*   instanceId - id of an existing instance, used to send \"Get Instance\" request\n    *   updated automatically after successfully sending request \"Post Multipart\"\n*   dataId - reference to the data in a given instance\n    *   updated automatically after successfully sending request \"Post Multipart\"\n*   attachmentDataId - id of the field in your app containing multipart attachment (example: d84913c1-2b32-4ab0-a605-409be875bae6)\n    *   found in your apps metadata. /App/config/appmetadata.json under datatypes.\n    *   used to send \"Post Multipart ...\" requests\n*   organizationNumber - a organization number of a chosen test organisation\n    *   used to send \"Post Multipart from Org\"\n\n### **Possible problems**\n\n**400 - Bad request (no message)**  \nIf you have the cookie called \"AltinnStudioRuntime\" the api will assume you are making a request from a browser and you will get 400 due to the ValidateAntiforgeryTokenIfAuthCookieAuthorizationFilter.\n\nTo mitigate this filter you can simply delete the cookie called \"AltinnStudioRuntime\". (When in a request you can click \"Cookies\" in the top right part of your postman window below the Send button.)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -166,7 +166,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://altinn3local.no/{{appOwner}}/{{appName}}/api/v1/profile/user",
+							"raw": "http://local.altinn.cloud/{{appOwner}}/{{appName}}/api/v1/profile/user",
 							"protocol": "http",
 							"host": [
 								"altinn3local",
@@ -232,7 +232,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://altinn3local.no/{{appOwner}}/{{appName}}/api/v1/applicationmetadata",
+							"raw": "http://local.altinn.cloud/{{appOwner}}/{{appName}}/api/v1/applicationmetadata",
 							"protocol": "http",
 							"host": [
 								"altinn3local",
@@ -291,7 +291,7 @@
 				"method": "POST",
 				"header": [],
 				"url": {
-					"raw": "http://altinn3local.no/{{appOwner}}/{{appName}}/instances?instanceOwnerPartyId={{instanceOwnerId}}",
+					"raw": "http://local.altinn.cloud/{{appOwner}}/{{appName}}/instances?instanceOwnerPartyId={{instanceOwnerId}}",
 					"protocol": "http",
 					"host": [
 						"altinn3local",
@@ -329,7 +329,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://altinn3local.no/{{appOwner}}/{{appName}}/instances/{{instanceOwnerId}}/{{instanceId}}/data/{{dataId}}",
+					"raw": "http://local.altinn.cloud/{{appOwner}}/{{appName}}/instances/{{instanceOwnerId}}/{{instanceId}}/data/{{dataId}}",
 					"protocol": "http",
 					"host": [
 						"altinn3local",
@@ -364,7 +364,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://altinn3local.no/{{appOwner}}/{{appName}}/instances/{{instanceOwnerId}}/{{instanceId}}",
+					"raw": "http://local.altinn.cloud/{{appOwner}}/{{appName}}/instances/{{instanceOwnerId}}/{{instanceId}}",
 					"protocol": "http",
 					"host": [
 						"altinn3local",
@@ -431,7 +431,7 @@
 					"raw": "--abcdefg\r\nContent-Type: application/json; charset=utf-8\r\nContent-Disposition: form-data; name=\"instance\"\r\n\r\n{\r\n    \"instanceOwner\": {\r\n    \t\"partyId\": \"{{instanceOwnerId}}\"\r\n    }\r\n}\r\n\r\n--abcdefg\r\nContent-Type: application/xml\r\nContent-Disposition: form-data; name=\"default\"\r\n\r\n<?xml version=\"1.0\"?>\r\n<Skjema xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" skjemanummer=\"1472\" spesifikasjonsnummer=\"9812\" blankettnummer=\"AFP-01\" tittel=\"Arbeidsgiverskjema AFP\" gruppeid=\"8818\">\r\n  <OpplysningerOmArbeidstakeren-grp-8819 gruppeid=\"8819\">\r\n    <Skjemainstans-grp-8854 gruppeid=\"8854\">\r\n      <Journalnummer-datadef-33316 orid=\"33316\">9827</Journalnummer-datadef-33316>\r\n    </Skjemainstans-grp-8854>\r\n  </OpplysningerOmArbeidstakeren-grp-8819>\r\n</Skjema>\r\n\r\n--abcdefg--"
 				},
 				"url": {
-					"raw": "http://altinn3local.no/{{appOwner}}/{{appName}}/instances",
+					"raw": "http://local.altinn.cloud/{{appOwner}}/{{appName}}/instances",
 					"protocol": "http",
 					"host": [
 						"altinn3local",
@@ -496,7 +496,7 @@
 					"raw": "--abcdefg\r\nContent-Type: application/json; charset=utf-8\r\nContent-Disposition: form-data; name=\"instance\"\r\n\r\n{\r\n    \"instanceOwner\": {\r\n        \"personNumber\": \"{{SSN}}\"\r\n    }\r\n}\r\n\r\n--abcdefg\r\nContent-Type: application/xml\r\nContent-Disposition: form-data; name=\"default\"\r\n\r\n<?xml version=\"1.0\"?>\r\n<Skjema xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" skjemanummer=\"1472\" spesifikasjonsnummer=\"9812\" blankettnummer=\"AFP-01\" tittel=\"Arbeidsgiverskjema AFP\" gruppeid=\"8818\">\r\n  <OpplysningerOmArbeidstakeren-grp-8819 gruppeid=\"8819\">\r\n    <Skjemainstans-grp-8854 gruppeid=\"8854\">\r\n      <Journalnummer-datadef-33316 orid=\"33316\">9827</Journalnummer-datadef-33316>\r\n    </Skjemainstans-grp-8854>\r\n  </OpplysningerOmArbeidstakeren-grp-8819>\r\n</Skjema>\r\n\r\n--abcdefg\r\nContent-Type: application/octet-stream\r\nContent-Disposition: attachment; filename=test.xml; name=\"{{attachmentDataId}}\"\r\n\r\n<?xml version=\"1.0\"?>\r\n<Skjema xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" skjemanummer=\"1472\" spesifikasjonsnummer=\"9812\" blankettnummer=\"AFP-01\" tittel=\"Arbeidsgiverskjema AFP\" gruppeid=\"8818\">\r\n  <OpplysningerOmArbeidstakeren-grp-8819 gruppeid=\"8819\">\r\n    <Skjemainstans-grp-8854 gruppeid=\"8854\">\r\n      <Journalnummer-datadef-33316 orid=\"33316\">9827</Journalnummer-datadef-33316>\r\n    </Skjemainstans-grp-8854>\r\n  </OpplysningerOmArbeidstakeren-grp-8819>\r\n</Skjema>\r\n\r\n--abcdefg--\r\n"
 				},
 				"url": {
-					"raw": "http://altinn3local.no/{{appOwner}}/{{appName}}/instances",
+					"raw": "http://local.altinn.cloud/{{appOwner}}/{{appName}}/instances",
 					"protocol": "http",
 					"host": [
 						"altinn3local",
@@ -553,7 +553,7 @@
 					"raw": "--abcdefg\r\nContent-Type: application/json; charset=utf-8\r\nContent-Disposition: form-data; name=\"instance\"\r\n\r\n{\r\n    \"instanceOwner\": {\r\n    \t\"organisationNumber\" : \"{{organizationNumber}}\"\r\n    }\r\n}\r\n\r\n--abcdefg\r\nContent-Type: application/xml\r\nContent-Disposition: form-data; name=\"default\"\r\n\r\n<?xml version=\"1.0\"?>\r\n<Skjema xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" skjemanummer=\"1472\" spesifikasjonsnummer=\"9812\" blankettnummer=\"AFP-01\" tittel=\"Arbeidsgiverskjema AFP\" gruppeid=\"8818\">\r\n  <OpplysningerOmArbeidstakeren-grp-8819 gruppeid=\"8819\">\r\n    <Skjemainstans-grp-8854 gruppeid=\"8854\">\r\n      <Journalnummer-datadef-33316 orid=\"33316\">9827</Journalnummer-datadef-33316>\r\n    </Skjemainstans-grp-8854>\r\n  </OpplysningerOmArbeidstakeren-grp-8819>\r\n</Skjema>\r\n\r\n--abcdefg--"
 				},
 				"url": {
-					"raw": "http://altinn3local.no/{{appOwner}}/{{appName}}/instances",
+					"raw": "http://local.altinn.cloud/{{appOwner}}/{{appName}}/instances",
 					"protocol": "http",
 					"host": [
 						"altinn3local",
@@ -666,7 +666,7 @@
 	"variable": [
 		{
 			"key": "envUrl",
-			"value": "altinn3local.no",
+			"value": "local.altinn.cloud",
 			"type": "default"
 		},
 		{


### PR DESCRIPTION
Note: I'm adding a redirect for nginx (loadbalancer) so that altinn3local.no will be obsolete and impossible to use. This is a great way to move people over, but would requre some testing

I'm not sure what I should do with the postman collections, but I just did a global find/replace. It might just work in test environments, but I don't know how to verify.


## Related Issue(s)
- https://github.com/Altinn/altinn-studio/issues/6864
- Previous attemt in https://github.com/Altinn/altinn-studio/pull/7092
- Reopening this in light of https://github.com/Altinn/altinn-studio/issues/8916

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

Another question is if we still need the `.env` file config for configuring the domain name trough docker compose. Maybe it's not required anymore, and it's better to just fully remove traces?
