### PR TITLE
382 better handling of markdown in translation files

### DIFF
--- a/src/studio/src/designer/backend.Tests/Controllers/TextsControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/TextsControllerTests.cs
@@ -207,6 +207,31 @@ namespace Designer.Tests.Controllers
             }
         }
 
+        [Fact]
+        public async Task Delete_Markdown_200Ok()
+        {
+            var targetRepository = Guid.NewGuid().ToString();
+            await TestDataHelper.CopyRepositoryForTest("ttd", "markdown-files", "testUser", targetRepository);
+            HttpClient client = GetTestClient();
+            string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/texts/nb";
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, dataPathWithData);
+            await AuthenticationUtil.AddAuthenticateAndAuthAndXsrFCookieToRequest(client, httpRequestMessage);
+
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonDocument responseDocument = JsonDocument.Parse(responseBody);
+
+            try
+            {
+                Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+                Assert.Equal("Texts file, nb.texts.json, was successfully deleted.", responseDocument.RootElement.ToString());
+            }
+            finally
+            {
+                TestDataHelper.DeleteAppRepository("ttd", targetRepository, "testUser");
+            }
+        }
+
         private HttpClient GetTestClient()
         {
             string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(DatamodelsControllerTests).Assembly.Location).LocalPath);

--- a/src/studio/src/designer/backend.Tests/Controllers/TextsControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/TextsControllerTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -9,23 +8,18 @@ using System.Threading.Tasks;
 
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Controllers;
-using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
 
 using Designer.Tests.Mocks;
 using Designer.Tests.Utils;
 
-using LibGit2Sharp;
-
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
-using Xunit.Sdk;
 
 using IRepository = Altinn.Studio.Designer.Services.Interfaces.IRepository;
 

--- a/src/studio/src/designer/backend.Tests/Controllers/TextsControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/TextsControllerTests.cs
@@ -56,6 +56,28 @@ namespace Designer.Tests.Controllers
         }
 
         [Fact]
+        public async Task Get_Markdown_200Ok()
+        {
+            var targetRepository = Guid.NewGuid().ToString();
+            await TestDataHelper.CopyRepositoryForTest("ttd", "markdown-files", "testUser", targetRepository);
+            HttpClient client = GetTestClient();
+            string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/texts/nb";
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, dataPathWithData);
+            await AuthenticationUtil.AddAuthenticateAndAuthAndXsrFCookieToRequest(client, httpRequestMessage);
+
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            try
+            {
+                Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+            }
+            finally
+            {
+                TestDataHelper.DeleteAppRepository("ttd", targetRepository, "testUser");
+            }
+        }
+
+        [Fact]
         public async Task Get_NonExistingFile_404NotFound()
         {
             HttpClient client = GetTestClient();
@@ -97,6 +119,29 @@ namespace Designer.Tests.Controllers
             string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/texts/nb";
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, dataPathWithData);
             httpRequestMessage.Content = JsonContent.Create(new { new_key_1 = "new_value_1", new_key_2 = "new_value_2" });
+            await AuthenticationUtil.AddAuthenticateAndAuthAndXsrFCookieToRequest(client, httpRequestMessage);
+
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            try
+            {
+                Assert.Equal(StatusCodes.Status204NoContent, (int)response.StatusCode);
+            }
+            finally
+            {
+                TestDataHelper.DeleteAppRepository("ttd", targetRepository, "testUser");
+            }
+        }
+
+        [Fact]
+        public async Task Put_Markdown_204NoContent()
+        {
+            var targetRepository = Guid.NewGuid().ToString();
+            await TestDataHelper.CopyRepositoryForTest("ttd", "markdown-files", "testUser", targetRepository);
+            HttpClient client = GetTestClient();
+            string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/texts/nb";
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, dataPathWithData);
+            httpRequestMessage.Content = JsonContent.Create(new { markdown_key = "## This is a markdown text \n\n Here is a list \n - Item1 \n - Item2 \n - Item3 \n\n # HERE IS SOME IMPORTANT CODE \n `print(Hello world)`" });
             await AuthenticationUtil.AddAuthenticateAndAuthAndXsrFCookieToRequest(client, httpRequestMessage);
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/markdown-files/App/config/texts/md/markdown-text.uk.texts.md
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/markdown-files/App/config/texts/md/markdown-text.uk.texts.md
@@ -1,0 +1,7 @@
+# HEADING
+Some text.
+
+_foo_
+```
+ bar
+```

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/markdown-files/App/config/texts/md/more-markdown.nb.texts.md
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/markdown-files/App/config/texts/md/more-markdown.nb.texts.md
@@ -1,0 +1,2 @@
+# Some more Markdown 
+ **FOO** _BAR_

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/markdown-files/App/config/texts/md/text-with-markdown.nb.texts.md
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/markdown-files/App/config/texts/md/text-with-markdown.nb.texts.md
@@ -1,0 +1,9 @@
+## This is a markdown text 
+
+ Here is a list 
+ - Item1 
+ - Item2 
+ - Item3 
+
+ # HERE IS SOME IMPORTANT CODE 
+ `print(Hello world)`

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/markdown-files/App/config/texts/nb.texts.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/markdown-files/App/config/texts/nb.texts.json
@@ -1,0 +1,5 @@
+{
+  "text-with-markdown": "${{text-with-markdown.nb.texts.md}}",
+  "Some-normal-text": "Just me saying hello world",
+  "more-markdown": "${{more-markdown.nb.texts.md}}"
+}

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/markdown-files/App/config/texts/uk.texts.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/markdown-files/App/config/texts/uk.texts.json
@@ -1,0 +1,5 @@
+{
+  "markdown-text": "# HEADING \n Some text. \n\n _foo_ \n``` \n bar \n```",
+  "no-markdown-text": "No markdown here.",
+  "inline-markdown": "**bar**"
+}

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/new-texts-format/App/config/texts/md/should-not-be-included-in-languages.uk.texts.md
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/new-texts-format/App/config/texts/md/should-not-be-included-in-languages.uk.texts.md
@@ -1,0 +1,7 @@
+# HEADING
+Some text.
+
+_foo_
+```
+ bar
+```

--- a/src/studio/src/designer/backend/Controllers/LanguagesController.cs
+++ b/src/studio/src/designer/backend/Controllers/LanguagesController.cs
@@ -1,7 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text.Json;
 
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Services.Interfaces;

--- a/src/studio/src/designer/backend/Controllers/TextsController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextsController.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -11,7 +9,6 @@ using Altinn.Studio.Designer.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Altinn.Studio.Designer.Controllers
 {

--- a/src/studio/src/designer/backend/Controllers/TextsController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextsController.cs
@@ -109,7 +109,6 @@ namespace Altinn.Studio.Designer.Controllers
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="repo">Application identifier which is unique within an organisation.</param>
         /// <param name="languageCode">Language identifier.</param>
-        /// <returns>List of languages as JSON</returns>
         [HttpDelete]
         [Produces("application/json")]
         [ProducesResponseType(StatusCodes.Status200OK)]

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -32,7 +33,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         private const string MARKDOWN_TEXTS_FOLDER_NAME = "md/";
 
         private const string APP_METADATA_FILENAME = "applicationmetadata.json";
-        private const string TEXT_FILES_PATTERN = "*.texts.*";
+        private const string MARKDOWN_TEXT_FILES_PATTERN = ".texts.*";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AltinnGitRepository"/> class.
@@ -298,16 +299,34 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         }
 
         /// <summary>
+        /// Get the markdown text specific for a key identified in the filename.
+        /// </summary>
+        /// <param name="markdownFileName">Filename for file with markdown text for a key</param>
+        /// <returns>Markdown text as a string</returns>
+        public async Task<string> GetMarkdownText(string markdownFileName)
+        {
+            var textsFileRelativeFilePath = Path.Combine(CONFIG_FOLDER_PATH, LANGUAGE_RESOURCE_FOLDER_NAME, MARKDOWN_TEXTS_FOLDER_NAME, markdownFileName);
+
+            string text = await ReadTextByRelativePathAsync(textsFileRelativeFilePath);
+
+            return text;
+        }
+
+        /// <summary>
         /// Deletes the texts file for a specific languageCode.
         /// </summary>
         /// <param name="languageCode">Language identifier</param>
         public void DeleteTexts(string languageCode)
         {
-            // string fileName = $"{languageCode}.texts.json";
-            foreach (string fileNamePath in FindFiles(new string[] { TEXT_FILES_PATTERN }))
+            string textsFileName = $"{languageCode}.texts.json";
+            var textsFileRelativeFilePath = Path.Combine(CONFIG_FOLDER_PATH, LANGUAGE_RESOURCE_FOLDER_NAME, textsFileName);
+            DeleteFileByRelativePath(textsFileRelativeFilePath);
+
+            var fileNames = FindFiles(new string[] { $"*.{languageCode}{MARKDOWN_TEXT_FILES_PATTERN}" });
+            foreach (string fileNamePath in fileNames)
             {
                 string fileName = Path.GetFileName(fileNamePath);
-                var textsFileRelativeFilePath = fileName.Contains(".md") ? Path.Combine(CONFIG_FOLDER_PATH, LANGUAGE_RESOURCE_FOLDER_NAME, MARKDOWN_TEXTS_FOLDER_NAME, fileName) : Path.Combine(CONFIG_FOLDER_PATH, LANGUAGE_RESOURCE_FOLDER_NAME, fileName);
+                textsFileRelativeFilePath = Path.Combine(CONFIG_FOLDER_PATH, LANGUAGE_RESOURCE_FOLDER_NAME, MARKDOWN_TEXTS_FOLDER_NAME, fileName);
                 DeleteFileByRelativePath(textsFileRelativeFilePath);
             }
         }

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -1,17 +1,11 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Schema;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.ModelMetadatalModels;
-
-using Microsoft.AspNetCore.Mvc;
 
 using Newtonsoft.Json;
 using Formatting = Newtonsoft.Json.Formatting;
@@ -322,7 +316,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
             var textsFileRelativeFilePath = Path.Combine(CONFIG_FOLDER_PATH, LANGUAGE_RESOURCE_FOLDER_NAME, textsFileName);
             DeleteFileByRelativePath(textsFileRelativeFilePath);
 
-            var fileNames = FindFiles(new string[] { $"*.{languageCode}{MARKDOWN_TEXT_FILES_PATTERN}" });
+            var fileNames = FindFiles(new[] { $"*.{languageCode}{MARKDOWN_TEXT_FILES_PATTERN}" });
             foreach (string fileNamePath in fileNames)
             {
                 string fileName = Path.GetFileName(fileNamePath);

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -297,7 +297,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         /// </summary>
         /// <param name="markdownFileName">Filename for file with markdown text for a key</param>
         /// <returns>Markdown text as a string</returns>
-        public async Task<string> GetMarkdownText(string markdownFileName)
+        public async Task<string> GetTextMarkdown(string markdownFileName)
         {
             var textsFileRelativeFilePath = Path.Combine(CONFIG_FOLDER_PATH, LANGUAGE_RESOURCE_FOLDER_NAME, MARKDOWN_TEXTS_FOLDER_NAME, markdownFileName);
 

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnGitRepository.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -85,7 +84,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         /// </summary>
         public IList<AltinnCoreFile> GetSchemaFiles()
         {
-            var schemaFiles = FindFiles(new string[] { SCHEMA_FILES_PATTERN_JSON });
+            var schemaFiles = FindFiles(new[] { SCHEMA_FILES_PATTERN_JSON });
 
             var altinnCoreSchemaFiles = MapFilesToAltinnCoreFiles(schemaFiles);
 

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnGitRepository.cs
@@ -23,7 +23,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
     {
         private const string SCHEMA_FILES_PATTERN_JSON = "*.schema.json";
         private const string STUDIO_SETTINGS_FILEPATH = ".altinnstudio/settings.json";
-        private const string TEXT_FILES_PATTERN_JSON = "*.texts.*";
+        private const string TEXT_FILES_PATTERN_JSON = "*.texts.json";
 
         private AltinnStudioSettings _altinnStudioSettings;
 

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnGitRepository.cs
@@ -24,7 +24,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
     {
         private const string SCHEMA_FILES_PATTERN_JSON = "*.schema.json";
         private const string STUDIO_SETTINGS_FILEPATH = ".altinnstudio/settings.json";
-        private const string TEXT_FILES_PATTERN_JSON = "*.texts.json";
+        private const string TEXT_FILES_PATTERN_JSON = "*.texts.*";
 
         private AltinnStudioSettings _altinnStudioSettings;
 

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -33,7 +33,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             foreach (string markdownFileName in markdownFileNames)
             {
                 string key = markdownFileName.Split('.')[0];
-                string text = await altinnAppGitRepository.GetMarkdownText(markdownFileName);
+                string text = await altinnAppGitRepository.GetTextMarkdown(markdownFileName);
                 jsonTexts[key] = text;
             }
 

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -1,14 +1,8 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Text.Json;
 using System.Threading.Tasks;
 
 using Altinn.Studio.Designer.Services.Interfaces;
-
-using Microsoft.AspNetCore.Mvc;
 
 namespace Altinn.Studio.Designer.Services.Implementation
 {
@@ -69,6 +63,11 @@ namespace Altinn.Studio.Designer.Services.Implementation
             altinnAppGitRepository.DeleteTexts(languageCode);
         }
 
+        /// <summary>
+        /// Helper method for extracting the markdown filenames from values in a texts objects.
+        /// </summary>
+        /// <param name="texts">Json object consisting of texts with key:value pairs id:text</param>
+        /// <returns>List of markdown filenames</returns>
         private static List<string> ExtractMarkdownFileNames(Dictionary<string, string> texts)
         {
             List<string> markdownFileNames = new List<string>();
@@ -81,8 +80,17 @@ namespace Altinn.Studio.Designer.Services.Implementation
             return markdownFileNames;
         }
 
-        // REMARKS: Autosave in FE results in old md files that never will be overwritten when client change ID.
-        // returns Tuple(Dictionary<string, string>, Dictionary<string, string>) of keys and texts that should be stored as markdown
+        /// <summary>
+        /// Replacing inline markdown from text-values in texts object
+        /// with a reference to a .md file and stores content in that file.
+        /// </summary>
+        /// <param name="languageCode">Language identifier</param>
+        /// <param name="texts">Texts object with inline markdown</param>
+        /// <returns>Tuple of dictionary with keys and texts that
+        /// should be stored as markdown and the original texts objects
+        /// where inline markdown is replaced with the filename.</returns>
+        /// <remarks>Autosave in FE results in old md files that never
+        /// will be overwritten when client change ID.</remarks>
         private static (Dictionary<string, string> TtextsWithMd, Dictionary<string, string> Ttexts) ExtractMarkdown(string languageCode, Dictionary<string, string> texts)
         {
             Dictionary<string, string> textsWithMd = new Dictionary<string, string>();

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -84,7 +84,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
         // REMARKS: Autosave in FE results in old md files that never will be overwritten when client change ID.
         // returns Tuple(Dictionary<string, string>, Dictionary<string, string>) of keys and texts that should be stored as markdown
-        private static (Dictionary<string, string> textsWithMd, Dictionary<string, string> texts) ExtractMarkdown(string languageCode, Dictionary<string, string> texts)
+        private static (Dictionary<string, string> TtextsWithMd, Dictionary<string, string> Ttexts) ExtractMarkdown(string languageCode, Dictionary<string, string> texts)
         {
             Dictionary<string, string> textsWithMd = new Dictionary<string, string>();
             foreach (KeyValuePair<string, string> text in texts)

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -70,13 +72,10 @@ namespace Altinn.Studio.Designer.Services.Implementation
         private static List<string> ExtractMarkdownFileNames(Dictionary<string, string> texts)
         {
             List<string> markdownFileNames = new List<string>();
-            foreach (KeyValuePair<string, string> text in texts)
+            foreach (KeyValuePair<string, string> text in texts.Where(text => text.Value.StartsWith("${{") && text.Value.EndsWith(".md}}")))
             {
-                if (text.Value.StartsWith("${{") && text.Value.EndsWith(".md}}"))
-                {
-                    string fileName = text.Value.Substring(3, text.Value.Length - 5);
-                    markdownFileNames.Add(fileName);
-                }
+                string fileName = text.Value.Substring(3, text.Value.Length - 5);
+                markdownFileNames.Add(fileName);
             }
 
             return markdownFileNames;
@@ -87,14 +86,11 @@ namespace Altinn.Studio.Designer.Services.Implementation
         private static (Dictionary<string, string> TtextsWithMd, Dictionary<string, string> Ttexts) ExtractMarkdown(string languageCode, Dictionary<string, string> texts)
         {
             Dictionary<string, string> textsWithMd = new Dictionary<string, string>();
-            foreach (KeyValuePair<string, string> text in texts)
+            foreach (KeyValuePair<string, string> text in texts.Where(text => text.Value.Contains('\n')))
             {
-                if (text.Value.Contains('\n'))
-                {
-                    textsWithMd[text.Key] = text.Value;
-                    string fileName = $"{text.Key}.{languageCode}.texts.md";
-                    texts[text.Key] = "${{" + fileName + "}}";
-                }
+                textsWithMd[text.Key] = text.Value;
+                string fileName = $"{text.Key}.{languageCode}.texts.md";
+                texts[text.Key] = "${{" + fileName + "}}";
             }
 
             return (textsWithMd, texts);

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -39,6 +41,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
         {
             var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
 
+            // Dictionary<string, string> jsonTextsWithoutMd = ExtractMarkdown(languageCode, jsonTexts)
             await altinnAppGitRepository.SaveTextsV2(languageCode, jsonTexts);
         }
 
@@ -48,6 +51,23 @@ namespace Altinn.Studio.Designer.Services.Implementation
             var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
 
             altinnAppGitRepository.DeleteTexts(languageCode);
+        }
+
+        // returns Tuple(Dictionary<string, string>, Dictionary<string, string>) of keys and texts that should be stored as markdown
+        private Tuple<Dictionary<string, string>, Dictionary<string, string>> ExtractMarkdown(string languageCode, Dictionary<string, string> texts)
+        {
+            Dictionary<string, string> textsWithMd = new Dictionary<string, string>();
+            foreach (KeyValuePair<string, string> text in texts)
+            {
+                if (text.Value.Contains('\n'))
+                {
+                    string fileName = $"{text.Key}.{languageCode}.md";
+                    text.Value = "${{}}";
+
+                }
+            }
+
+            return Tuple.Create(texts, texts);
         }
     }
 }

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -71,13 +71,23 @@ namespace Altinn.Studio.Designer.Services.Implementation
         private static List<string> ExtractMarkdownFileNames(Dictionary<string, string> texts)
         {
             List<string> markdownFileNames = new List<string>();
-            foreach (KeyValuePair<string, string> text in texts.Where(text => text.Value.StartsWith("${{") && text.Value.EndsWith(".md}}")))
+            foreach (KeyValuePair<string, string> text in texts.Where(text => IsFileReference(text.Value)))
             {
                 string fileName = text.Value.Substring(3, text.Value.Length - 5);
                 markdownFileNames.Add(fileName);
             }
 
             return markdownFileNames;
+        }
+
+        /// <summary>
+        /// Checks if value text from texts file is a reference to a filename.
+        /// </summary>
+        /// <param name="textValue">A value in the key:value pair from a texts file</param>
+        /// <returns>boolean value indicating if value is a filename reference or not</returns>
+        private static bool IsFileReference(string textValue)
+        {
+            return textValue.StartsWith("${{") && textValue.EndsWith(".md}}");
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
- Replace markdown content in text field with filename of markdown file if `\n` is discovered in the text in PUT endpoint. Markdown file is also created with name: `{id}.{languageCode}.texts.md`
- Add logic for deleting all `.md` files for a language in DELETE endpoint
- Replace filename with actual markdown content  in GET endpoint where a reference to a md file is the only value in the text field

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
