### PR TITLE
Changed the nginx config so that our local test projects will work

### DIFF
--- a/src/development/loadbalancer/nginx.conf
+++ b/src/development/loadbalancer/nginx.conf
@@ -5,83 +5,91 @@ worker_processes 1;
 events { worker_connections 1024; }
 
 http {
-
-
-    # perl_modules perl/lib;
-    # Support replacing reference to altinn js and css in app with local hosted webpack dev server
-    perl_set $LOCAL_SUB_FILTER 'sub {
-      my $r = shift;
-      my $cookie = $r->header_in("cookie");
-      my $url = $1 if ($cookie =~ /.*frontendVersion=(http.*?);/);
-      if($url)
-      {
-        $uri = $r->unescape($url);
-        return $uri;
-      }
-      return "https://altinncdn.no/toolkits/altinn-app-frontend/3/"
-    }';
-
-    client_max_body_size 50M;
-
-    sendfile on;
-
-	  upstream localtest {
-        server host.docker.internal:5101;
+  # perl_modules perl/lib;
+  # Support replacing reference to altinn js and css in app with local hosted webpack dev server
+  perl_set $LOCAL_SUB_FILTER 'sub {
+    my $r = shift;
+    my $cookie = $r->header_in("cookie");
+    my $url = $1 if ($cookie =~ /.*frontendVersion=(http.*?);/);
+    if($url)
+    {
+      $uri = $r->unescape($url);
+      return $uri;
     }
+    return null
+  }';
 
-    upstream app {
-        server host.docker.internal:5005;
-    }
-    # Redirect localhost and the old altinn3local.no to the configured test domain
-    server {
-      listen 80;
-      server_name localhost altinn3local.no;
-      return 307 $scheme://${TEST_DOMAIN}:${ALTINN3LOCAL_PORT}$request_uri;
-    }
+  client_max_body_size 50M;
 
-    upstream receiptcomp {
-        server host.docker.internal:5060;
-    }
+  sendfile on;
 
-    server {
-		    listen 80 default_server;
-        server_name ${TEST_DOMAIN};
+  upstream localtest {
+      server host.docker.internal:5101;
+  }
 
-        proxy_redirect      off;
-        proxy_set_header    Host $host;
-        proxy_set_header    X-Real-IP $remote_addr;
-        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+  upstream app {
+      server host.docker.internal:5005;
+  }
+  # Redirect localhost and the old altinn3local.no to the configured test domain
+  server {
+    listen 80;
+    server_name localhost altinn3local.no;
+    return 307 $scheme://${TEST_DOMAIN}:${ALTINN3LOCAL_PORT}$request_uri;
+  }
+
+  upstream receiptcomp {
+      server host.docker.internal:5060;
+  }
+
+  server {
+    listen 80 default_server;
+    server_name ${TEST_DOMAIN};
+
+    proxy_redirect      off;
+    proxy_set_header    Host $host;
+    proxy_set_header    X-Real-IP $remote_addr;
+    proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
 
     error_page 502 /502LocalTest.html;
 
-		location = / {
-        proxy_pass          http://localtest/Home/;
-		}
+    location = / {
+      proxy_pass          http://localtest/Home/;
+    }
 
-		location / {
-        #Support using Local js, when a cookie value is set
-        sub_filter_once off;
-        sub_filter 'https://altinncdn.no/toolkits/altinn-app-frontend/3/' $LOCAL_SUB_FILTER;
-        proxy_pass          http://app/;
-        error_page 502 /502App.html;
-		}
 
-		location /Home/ {
-			  proxy_pass		      http://localtest/Home/;
-		}
+    location / {
+      set $CDN_VER_FILES 'https://altinncdn.no/toolkits/altinn-app-frontend/3/';
+      set $CDN_TO $CDN_VER_FILES;
+      set $LOCAL_VER_FILES 'http://localhost:8080/';
+      set $LOCAL_TO $LOCAL_VER_FILES;
+      if ($LOCAL_SUB_FILTER != null) {
+        set $CDN_TO $LOCAL_SUB_FILTER;
+        set $LOCAL_TO $LOCAL_SUB_FILTER;
+      }
+      #Support using Local js, when a cookie value is set
+      sub_filter_once off;
+      sub_filter $CDN_VER_FILES $CDN_TO;
+      sub_filter $LOCAL_VER_FILES $LOCAL_TO;
+      proxy_pass          http://app/;
+      error_page 502 /502App.html;
+    }
+
+    location /Home/ {
+      proxy_pass		      http://localtest/Home/;
+    }
 
     location /receipt/ {
-			  proxy_pass		      http://receiptcomp/receipt/;
-			  error_page 502 /502Receipt.html;
-		}
+      proxy_pass		      http://receiptcomp/receipt/;
+      error_page 502 /502Receipt.html;
+    }
 
     location /storage/ {
-			  proxy_pass		      http://localtest/storage/;
-		}
+      proxy_pass		      http://localtest/storage/;
+    }
 
     location /localtestresources/ {
-			  proxy_pass		      http://localtest/localtestresources/;
-		}
+      proxy_pass		      http://localtest/localtestresources/;
+    }
     location /LocalPlatformStorage/ {
       proxy_pass           http://localtest/LocalPlatformStorage/;
     }
@@ -94,6 +102,5 @@ http {
     location /502Receipt.html {
       root /www;
     }
-
-	}
+  }
 }


### PR DESCRIPTION
## Description
Changed the nginx config so that our local test projects will work with different versions without editing their respective index.cshtml files.
This is a quicker fix than to replace all the refs to http://localhost:8080 in our test-projects...
Doing so will also require us to update Cypress tests accordingly.

## Related Issue(s)
 - #9032 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
