### PR TITLE
9055 datamodell context menu is not correct

### DIFF
--- a/src/studio/src/designer/backend/Languages/ini/en.ini
+++ b/src/studio/src/designer/backend/Languages/ini/en.ini
@@ -411,6 +411,7 @@ array = List
 boolean = Yes/no
 combination = Combination
 combination_inline_object_disclaimer = Currently we only support references as sub schemas when combining schemas (allOf, anyOf and oneOf). Sub schemas that are not references will be displayed in the gray area above, but it will be possible to edit these in the editor yet.
+convert_to_field = Convert to field
 create_model_button = Create new
 create_model_title = Create new model
 create_model_description = Enter the name of the data model

--- a/src/studio/src/designer/backend/Languages/ini/nb.ini
+++ b/src/studio/src/designer/backend/Languages/ini/nb.ini
@@ -415,6 +415,7 @@ array = Liste
 boolean = Ja/nei
 combination = Kombinasjon
 combination_inline_object_disclaimer = I dag støtter vi bare referanser som subskjema når man kombinerer skjema (allOf, anyOf og oneOf). Subskjema som ikke er referanser vil bli vist i det grå feltet over, men det vil ikke være mulig å editere de i editoren her enda.
+convert_to_field = Konverter til felt
 create_model_button = Lag ny
 create_model_title = Lag ny datamodell
 create_model_description = Skriv inn navnet på modellen

--- a/src/studio/src/designer/frontend/packages/schema-editor/README.md
+++ b/src/studio/src/designer/frontend/packages/schema-editor/README.md
@@ -69,29 +69,23 @@ function onChange(id, value) {
 
 `http://localhost:8080/designer/my-org/my-app#/datamodelling`
 
-
-
 ### Context menu logic
 
 For each node type we need to establish which actions that should be
 availiable:
 
-* Field (String, Int, Boolean)
-  * Convert to type ✅
-  * Delete 🗑
-* Reference
-  * Convert to field ❓
-  * Go to reference
-  * Delete 🗑
-* Object
-  * Convert to type ✅
-  * Add Field ✅
-  * Add Combination ✅
-  * Add Reference ✅
-  * Delete 🗑
-* Combination
-  * Add Field ❌
-  * Add Reference
-  * Delete 🗑
-
-
+- Field (String, Int, Boolean)
+  - Convert to type ✅
+  - Delete 🗑
+- Reference
+  - Convert to field ❓
+  - Delete 🗑
+- Object
+  - Convert to type ✅
+  - Add Field ✅
+  - Add Combination ✅
+  - Add Reference ✅
+  - Delete 🗑
+- Combination
+  - Add Reference
+  - Delete 🗑

--- a/src/studio/src/designer/frontend/packages/schema-editor/README.md
+++ b/src/studio/src/designer/frontend/packages/schema-editor/README.md
@@ -93,3 +93,5 @@ availiable:
   * Add Field ❌
   * Add Reference
   * Delete 🗑
+
+

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/SchemaEditorApp.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/SchemaEditorApp.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { Provider } from 'react-redux';
 import './App.css';
 import { IEditorProps, SchemaEditor } from './components/SchemaEditor';
 
 import { store } from './store';
 
-export function SchemaEditorApp({ children, ...other }: React.PropsWithChildren<any> & IEditorProps) {
+export function SchemaEditorApp({ children, ...other }: PropsWithChildren<any> & IEditorProps) {
   return (
     <Provider store={store}>
       <SchemaEditor {...other} Toolbar={children} />

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
@@ -26,17 +26,15 @@ export const ItemFieldsTab = ({ selectedItem, language }: ItemFieldsTabProps) =>
 
   const onDeleteObjectClick = (path: string) => dispatch(deleteProperty({ path }));
 
-  const dispatchAddProperty = () => {
-    const path = selectedItem.pointer;
-    if (path) {
-      dispatch(
-        addProperty({
-          path,
-          keepSelection: true,
-        }),
-      );
-    }
-  };
+  const dispatchAddProperty = () =>
+    dispatch(
+      addProperty({
+        path: selectedItem.pointer,
+        keepSelection: true,
+        props: {},
+      }),
+    );
+
   const onAddPropertyClicked = (event: BaseSyntheticEvent) => {
     event.preventDefault();
     dispatchAddProperty();

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TopToolbarButton.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TopToolbarButton.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { Button, IconButton } from '@material-ui/core';
 import classNames from 'classnames';
 import classes from './TopToolbarButton.module.css';
 
-interface TopToolbarButtonProps extends React.PropsWithChildren<any> {
+interface TopToolbarButtonProps extends PropsWithChildren<any> {
   onClick: (event: any) => void;
   faIcon: string;
   iconSize?: number;

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.module.css
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.module.css
@@ -1,9 +1,3 @@
-.referenceLabel {
-  font-size: 10px;
-  margin-left: 8px;
-  color: gray;
-}
-
 .treeItem {
   margin-left: 8px;
 }

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
@@ -1,24 +1,13 @@
 import React from 'react';
 import TreeItem from '@material-ui/lab/TreeItem';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  addCombinationItem,
-  addProperty,
-  deleteCombinationItem,
-  deleteProperty,
-  navigateToType,
-  promoteProperty,
-  setSelectedId,
-} from '../../features/editor/schemaEditorSlice';
+import { setSelectedId } from '../../features/editor/schemaEditorSlice';
 import { SchemaItemLabel } from './SchemaItemLabel';
 import { getIconStr } from './tree-view-helpers';
 import type { UiSchemaNode } from '@altinn/schema-model';
 import {
-  CombinationKind,
-  FieldType,
   getChildNodesByNode,
   getNodeByPointer,
-  getNodeDisplayName,
   getNodeIndexByPointer,
   Keywords,
   makePointer,
@@ -45,42 +34,11 @@ export function SchemaItem({ selectedNode, isPropertiesView, editMode, translate
   const dispatch = useDispatch();
   const keyPrefix = isPropertiesView ? 'properties' : 'definitions';
 
-  const onItemClick = (e: any, schemaItem: UiSchemaNode) => {
+  const onLabelClick = (e: any, schemaItem: UiSchemaNode) => {
     e.preventDefault();
     dispatch(setSelectedId({ id: schemaItem.pointer }));
   };
 
-  const handlePromoteClick = () => dispatch(promoteProperty({ path: selectedNode.pointer }));
-
-  const handleDeleteClick = () =>
-    selectedNode.objectKind === ObjectKind.Combination
-      ? dispatch(deleteCombinationItem({ path: selectedNode.pointer }))
-      : dispatch(deleteProperty({ path: selectedNode.pointer }));
-
-  const handleAddProperty = (objectKind: ObjectKind) => {
-    const { pointer } = selectedNode;
-    const defaultFieldType: any = {
-      [ObjectKind.Field]: FieldType.String,
-      [ObjectKind.Combination]: CombinationKind.AllOf,
-      [ObjectKind.Array]: FieldType.Array,
-      [ObjectKind.Reference]: undefined,
-    };
-    const propertyProps = {
-      objectKind,
-      fieldType: defaultFieldType[objectKind],
-      ref: objectKind === ObjectKind.Reference ? '' : undefined,
-    };
-
-    selectedNode.objectKind === ObjectKind.Combination
-      ? dispatch(addCombinationItem({ path: pointer, props: propertyProps }))
-      : dispatch(addProperty({ path: pointer, props: propertyProps }));
-  };
-
-  const handleGoToType = () => {
-    if (selectedNode.ref) {
-      dispatch(navigateToType({ id: selectedNode.ref }));
-    }
-  };
   const itemsPointer = makePointer(selectedNode.pointer, Keywords.Items);
 
   const itemsNode = useSelector((state: ISchemaState) => {
@@ -117,44 +75,14 @@ export function SchemaItem({ selectedNode, isPropertiesView, editMode, translate
       label={
         <SchemaItemLabel
           editMode={editMode}
-          isArray={selectedNode.objectKind === ObjectKind.Array || refNode?.objectKind === ObjectKind.Array}
-          isRef={
-            !!((isPropertiesView && selectedNode.pointer.startsWith(makePointer(Keywords.Definitions))) || refNode)
-          }
           icon={getIconStr(refNode ?? itemsNode ?? selectedNode)}
           key={`${selectedNode.pointer}-label`}
-          label={
-            <>
-              <span>{getNodeDisplayName(selectedNode)}</span>
-              {selectedNode.isRequired && <span> *</span>}
-              {refNode && <span className={classes.referenceLabel}>{refNode.pointer}</span>}
-            </>
-          }
+          selectedNode={selectedNode}
+          refNode={refNode}
           translate={translate}
-          limitedItem={selectedNode.objectKind === ObjectKind.Combination}
-          onAddProperty={
-            selectedNode.objectKind === ObjectKind.Field && selectedNode.fieldType === FieldType.Object
-              ? handleAddProperty
-              : undefined
-          }
-          onAddReference={
-            selectedNode.objectKind === ObjectKind.Field || selectedNode.objectKind === ObjectKind.Combination
-              ? handleAddProperty
-              : undefined
-          }
-          onAddCombination={selectedNode.fieldType === FieldType.Object ? handleAddProperty : undefined}
-          onDelete={handleDeleteClick}
-          onGoToType={
-            selectedNode.objectKind === ObjectKind.Combination && isPropertiesView ? handleGoToType : undefined
-          }
-          onPromote={
-            selectedNode.objectKind === ObjectKind.Combination || selectedNode.pointer.startsWith('#/$defs')
-              ? undefined
-              : handlePromoteClick
-          }
         />
       }
-      onLabelClick={(e) => onItemClick(e, selectedNode)}
+      onLabelClick={(e) => onLabelClick(e, selectedNode)}
     >
       {childNodes.map((childNode: UiSchemaNode) => (
         <SchemaItem
@@ -163,7 +91,7 @@ export function SchemaItem({ selectedNode, isPropertiesView, editMode, translate
           selectedNode={childNode}
           key={`${keyPrefix}-${childNode.pointer}`}
           translate={translate}
-          onLabelClick={(e: any) => onItemClick(e, childNode)}
+          onLabelClick={(e: any) => onLabelClick(e, childNode)}
         />
       ))}
     </TreeItem>

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
@@ -34,11 +34,6 @@ export function SchemaItem({ selectedNode, isPropertiesView, editMode, translate
   const dispatch = useDispatch();
   const keyPrefix = isPropertiesView ? 'properties' : 'definitions';
 
-  const onLabelClick = (e: any, schemaItem: UiSchemaNode) => {
-    e.preventDefault();
-    dispatch(setSelectedId({ id: schemaItem.pointer }));
-  };
-
   const itemsPointer = makePointer(selectedNode.pointer, Keywords.Items);
 
   const itemsNode = useSelector((state: ISchemaState) => {
@@ -46,11 +41,7 @@ export function SchemaItem({ selectedNode, isPropertiesView, editMode, translate
     return itemsIndex ? state.uiSchema[itemsIndex] : undefined;
   });
   const refNode = useSelector((state: ISchemaState) => {
-    if (
-      selectedNode.objectKind === ObjectKind.Array &&
-      itemsNode?.ref &&
-      itemsNode.objectKind === ObjectKind.Reference
-    ) {
+    if (selectedNode.objectKind === ObjectKind.Array && itemsNode?.ref) {
       return getNodeByPointer(state.uiSchema, itemsNode.ref);
     } else if (selectedNode.objectKind === ObjectKind.Reference && selectedNode.ref) {
       return getNodeByPointer(state.uiSchema, selectedNode.ref);
@@ -67,6 +58,10 @@ export function SchemaItem({ selectedNode, isPropertiesView, editMode, translate
       return getChildNodesByNode(state.uiSchema, selectedNode);
     }
   });
+  const onLabelClick = (e: any, schemaItem: UiSchemaNode) => {
+    e.preventDefault();
+    dispatch(setSelectedId({ id: schemaItem.pointer }));
+  };
   const isRef = selectedNode.objectKind === ObjectKind.Reference || itemsNode?.objectKind === ObjectKind.Reference;
   return (
     <TreeItem

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
@@ -74,6 +74,7 @@ export function SchemaItem({ selectedNode, isPropertiesView, editMode, translate
           key={`${selectedNode.pointer}-label`}
           selectedNode={selectedNode}
           refNode={refNode}
+          itemsNode={itemsNode}
           translate={translate}
         />
       }

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.module.css
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.module.css
@@ -26,6 +26,10 @@
   padding: 5px 0;
   text-align: center;
 }
+.iconContainer {
+  text-align: center;
+  color: white;
+}
 
 .isArray .iconContainer {
   box-shadow: -3px -3px 0 0 darkgrey;
@@ -35,4 +39,17 @@
 }
 .isRef .label {
   color: darkslateblue;
+}
+
+.referenceLabel {
+  font-size: 10px;
+  margin-left: 12px;
+  color: gray;
+  border-radius: 3px;
+  border: solid 1px darkgrey;
+  padding:3px 6px;
+}
+.referenceLabel:hover {
+  color: white;
+  background-color: darkgrey;
 }

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.module.css
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.module.css
@@ -47,9 +47,18 @@
   color: gray;
   border-radius: 3px;
   border: solid 1px darkgrey;
-  padding:3px 6px;
+  padding: 3px 6px;
 }
 .referenceLabel:hover {
   color: white;
   background-color: darkgrey;
+}
+
+.warning {
+  margin-left: 10px;
+  color: darkred;
+  font-size: 10px;
+}
+.warning svg {
+  margin-right: 10px;
 }

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.module.css
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.module.css
@@ -62,3 +62,7 @@
 .warning svg {
   margin-right: 10px;
 }
+
+.contextMenuLastItem {
+  border-top: 1px #d3d4d5 solid !important;
+}

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
@@ -82,7 +82,6 @@ export const SchemaItemLabel = ({ editMode, icon, refNode, selectedNode, transla
 
   const isRef = refNode || pointerIsDefinition(selectedNode.pointer);
   const capabilties = getCapabilities(selectedNode);
-  console.log(selectedNode, capabilties);
   return (
     <div className={classNames(classes.propertiesLabel, { [classes.isArray]: isArray, [classes.isRef]: isRef })}>
       <div className={classes.label} title={selectedNode.pointer}>
@@ -169,7 +168,7 @@ export const SchemaItemLabel = ({ editMode, icon, refNode, selectedNode, transla
             id='convert-node-to-field-buttonn'
             key='convert-node-to-field'
             onClick={handleConvertToField}
-            text={translate('convert-to-field')}
+            text={translate('convert_to_field')}
             iconClass='fa fa-arrowdown'
             disabled={true}
           />

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
@@ -29,11 +29,19 @@ export interface SchemaItemLabelProps {
   editMode: boolean;
   icon: string;
   refNode?: UiSchemaNode;
+  itemsNode?: UiSchemaNode;
   selectedNode: UiSchemaNode;
   translate: (key: string) => string;
 }
 
-export const SchemaItemLabel = ({ editMode, icon, refNode, selectedNode, translate }: SchemaItemLabelProps) => {
+export const SchemaItemLabel = ({
+  editMode,
+  icon,
+  refNode,
+  itemsNode,
+  selectedNode,
+  translate,
+}: SchemaItemLabelProps) => {
   const dispatch = useDispatch();
   const [contextAnchor, setContextAnchor] = useState<any>(null);
 
@@ -57,7 +65,7 @@ export const SchemaItemLabel = ({ editMode, icon, refNode, selectedNode, transla
   };
 
   const handleAddNode = wrapper((objectKind: ObjectKind) => {
-    const propertyProps = {
+    const props = {
       objectKind,
       fieldType: {
         [ObjectKind.Field]: FieldType.String,
@@ -67,9 +75,10 @@ export const SchemaItemLabel = ({ editMode, icon, refNode, selectedNode, transla
       }[objectKind],
       ref: objectKind === ObjectKind.Reference ? '' : undefined,
     };
+    const path = itemsNode?.pointer ?? selectedNode.pointer;
     selectedNode.objectKind === ObjectKind.Combination
-      ? dispatch(addCombinationItem({ path: selectedNode.pointer, props: propertyProps }))
-      : dispatch(addProperty({ path: selectedNode.pointer, props: propertyProps }));
+      ? dispatch(addCombinationItem({ path, props }))
+      : dispatch(addProperty({ path, props }));
   });
 
   const handleDeleteClick = wrapper(() =>
@@ -81,7 +90,7 @@ export const SchemaItemLabel = ({ editMode, icon, refNode, selectedNode, transla
   const isArray = selectedNode.objectKind === ObjectKind.Array || refNode?.objectKind === ObjectKind.Array;
 
   const isRef = refNode || pointerIsDefinition(selectedNode.pointer);
-  const capabilties = getCapabilities(selectedNode);
+  const capabilties = getCapabilities(itemsNode ?? selectedNode);
   return (
     <div className={classNames(classes.propertiesLabel, { [classes.isArray]: isArray, [classes.isRef]: isRef })}>
       <div className={classes.label} title={selectedNode.pointer}>

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
@@ -12,7 +12,6 @@ import {
   UiSchemaNode,
 } from '@altinn/schema-model';
 import classes from './SchemaItemLabel.module.css';
-import { Divider } from '../common/Divider';
 import classNames from 'classnames';
 import {
   addCombinationItem,
@@ -182,17 +181,17 @@ export const SchemaItemLabel = ({
             disabled={true}
           />
         )}
-        {capabilties.includes(Capabilites.CanBeDeleted) && [
-          <Divider key='delete-divider' inMenu />,
+        {capabilties.includes(Capabilites.CanBeDeleted) && (
           <AltinnMenuItem
             id='delete-node-button'
             key='delete'
+            className={classes.contextMenuLastItem}
             onClick={handleDeleteClick}
             text={translate('delete')}
             iconClass='fa fa-trash'
             disabled={!editMode}
-          />,
-        ]}
+          />
+        )}
       </AltinnMenu>
     </div>
   );

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaTreeView.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaTreeView.tsx
@@ -33,7 +33,7 @@ export const SchemaTreeView = ({
       expanded={expanded}
       onNodeToggle={onNodeToggle}
     >
-      {items?.map((item: UiSchemaNode) => (
+      {items.map((item: UiSchemaNode) => (
         <SchemaItem
           editMode={editMode}
           isPropertiesView={true}

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
@@ -7,6 +7,7 @@ import {
   buildUiSchema,
   castRestrictionType,
   CombinationKind,
+  convertPropToType,
   createNodeBase,
   FieldType,
   getNodeByPointer,
@@ -15,7 +16,6 @@ import {
   Keywords,
   makePointer,
   ObjectKind,
-  promotePropertyToType,
   removeNodeByPointer,
   renameNodePointer,
   replaceLastPointerSegment,
@@ -118,7 +118,7 @@ const schemaEditorSlice = createSlice({
     },
     promoteProperty(state, action: PayloadAction<{ path: string }>) {
       const { path } = action.payload;
-      state.uiSchema = promotePropertyToType(state.uiSchema, path);
+      state.uiSchema = convertPropToType(state.uiSchema, path);
     },
     deleteProperty(state, action: PayloadAction<{ path: string }>) {
       const { path } = action.payload;

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
@@ -13,6 +13,7 @@ import {
   getNodeIndexByPointer,
   getUniqueNodePath,
   Keywords,
+  makePointer,
   ObjectKind,
   promotePropertyToType,
   removeNodeByPointer,
@@ -84,11 +85,11 @@ const schemaEditorSlice = createSlice({
       action: PayloadAction<{
         path: string;
         keepSelection?: boolean;
-        props?: Partial<UiSchemaNode>;
+        props: Partial<UiSchemaNode>;
       }>,
     ) {
       const { path, keepSelection, props } = action.payload;
-      const newNodePointer = getUniqueNodePath(state.uiSchema, [path, Keywords.Properties, 'name'].join('/'));
+      const newNodePointer = getUniqueNodePath(state.uiSchema, makePointer(path, Keywords.Properties, 'name'));
       const addToItem = getNodeByPointer(state.uiSchema, path);
       addToItem.children.push(newNodePointer);
       if (!keepSelection) {
@@ -99,6 +100,7 @@ const schemaEditorSlice = createSlice({
         }
         state.focusNameField = newNodePointer;
       }
+      props.implicitType = false;
       state.uiSchema.push(Object.assign(createNodeBase(newNodePointer), props));
     },
     deleteField(state, action: PayloadAction<{ path: string; key: string }>) {
@@ -270,10 +272,12 @@ const schemaEditorSlice = createSlice({
       const { selectedTab } = action.payload;
       state.selectedEditorTab = selectedTab;
     },
-    navigateToType(state, action: PayloadAction<{ id: string }>) {
+    navigateToType(state, action: PayloadAction<{ id?: string }>) {
       const { id } = action.payload;
-      state.selectedEditorTab = 'definitions';
-      state.selectedDefinitionNodeId = id;
+      if (id) {
+        state.selectedEditorTab = 'definitions';
+        state.selectedDefinitionNodeId = id;
+      }
     },
     toggleArrayField(state, action: PayloadAction<{ pointer: string }>) {
       const { pointer } = action.payload;

--- a/src/studio/src/designer/frontend/packages/schema-model/README.md
+++ b/src/studio/src/designer/frontend/packages/schema-model/README.md
@@ -29,13 +29,6 @@ inspection. Alternatively you could use `anyOf` or `oneOf` to create structures 
 
 I think this is the only way to make a reference nullable.
 
-#### Toggling between field and array
-
-In the current version we doesn't support toggling between a field and an array. This is creating
-some problems as it might delete custom attributes connected to either items. We also need to
-take a choice about how we work with these kind of problems. Do we accept swapping between types
-when restrictions are added or not?
-
 #### Performance issues on large models
 
 Since we changed from a map to an array to hold the internal model performance is actually an issue.
@@ -43,9 +36,19 @@ We need to create some sort of index to improve this. This problem will however 
 with thousands of nodes. Mainly created by converting old SERES models to JSON-schemas without any form for
 simplification.
 
-#### Limit exposed exports from this package
+### Node capabilities
 
-Not a big issue, but at some point we should just expose what is actually used and try to limit this for a cleaner
-surface between these very interconnected models.
+When performing mutations on the model there are some rules that will
+keep logic in the models.
 
-
+```
+CAN_BE_CONVERTED_TO_ARRAY - no restrictions, not combination
+CAN_BE_CONVERTED_TO_FIELD - reference or array with no restrictions
+CAN_BE_CONVERTED_TO_OBJECT - no restrictions
+CAN_BE_CONVERTED_TO_REFERENCE
+CAN_BE_DELETED - not root node
+CAN_HAVE_COMBINATION_ADDED - object or root node
+CAN_HAVE_FIELD_ADDED - object or combination
+CAN_HAVE_OBJECT_ADDED - object or combination
+CAN_HAVE_REFERENCE_ADDED - object or combination
+```

--- a/src/studio/src/designer/frontend/packages/schema-model/README.md
+++ b/src/studio/src/designer/frontend/packages/schema-model/README.md
@@ -39,16 +39,4 @@ simplification.
 ### Node capabilities
 
 When performing mutations on the model there are some rules that will
-keep logic in the models.
-
-```
-CAN_BE_CONVERTED_TO_ARRAY - no restrictions, not combination
-CAN_BE_CONVERTED_TO_FIELD - reference or array with no restrictions
-CAN_BE_CONVERTED_TO_OBJECT - no restrictions
-CAN_BE_CONVERTED_TO_REFERENCE
-CAN_BE_DELETED - not root node
-CAN_HAVE_COMBINATION_ADDED - object or root node
-CAN_HAVE_FIELD_ADDED - object or combination
-CAN_HAVE_OBJECT_ADDED - object or combination
-CAN_HAVE_REFERENCE_ADDED - object or combination
-```
+keep logic in the models, strict.

--- a/src/studio/src/designer/frontend/packages/schema-model/src/index.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/index.ts
@@ -2,16 +2,22 @@ export { buildJsonSchema } from './lib/build-json-schema';
 export { buildUiSchema } from './lib/build-ui-schema';
 export { getRestrictions, StrRestrictionKeys, castRestrictionType } from './lib/restrictions';
 export type { UiSchemaNode, UiSchemaNodes } from './lib/types';
-export { ROOT_POINTER, ObjectKind, Keywords, FieldType, CombinationKind, Capabilites } from './lib/types';
-export { createNodeBase, replaceLastPointerSegment, makePointer, pointerIsDefinition } from './lib/utils';
+export { ROOT_POINTER, ObjectKind, Keywords, FieldType, CombinationKind } from './lib/types';
+export {
+  createNodeBase,
+  replaceLastPointerSegment,
+  makePointer,
+  pointerIsDefinition,
+  combinationIsNullable,
+  pointerExists,
+} from './lib/utils';
 export { createChildNode } from './lib/mutations/create-node';
 export { removeNodeByPointer } from './lib/mutations/remove-node';
 export { renameNodePointer } from './lib/mutations/rename-node';
-export { promotePropertyToType } from './lib/mutations/promote-node';
-export { getCapabilities } from './lib/capabilities';
+export { convertPropToType } from './lib/mutations/promote-node';
+export { getCapabilities, Capabilites } from './lib/capabilities';
 export { toggleArrayAndField, canToggleArrayAndField } from './lib/mutations/toggle-array-field';
 export {
-  combinationIsNullable,
   getChildNodesByNode,
   getChildNodesByPointer,
   getNodeByPointer,
@@ -19,5 +25,4 @@ export {
   getNodeIndexByPointer,
   getRootNodes,
   getUniqueNodePath,
-  pointerExists,
 } from './lib/selectors';

--- a/src/studio/src/designer/frontend/packages/schema-model/src/index.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/index.ts
@@ -2,12 +2,13 @@ export { buildJsonSchema } from './lib/build-json-schema';
 export { buildUiSchema } from './lib/build-ui-schema';
 export { getRestrictions, StrRestrictionKeys, castRestrictionType } from './lib/restrictions';
 export type { UiSchemaNode, UiSchemaNodes } from './lib/types';
-export { ROOT_POINTER, ObjectKind, Keywords, FieldType, CombinationKind } from './lib/types';
-export { createNodeBase, replaceLastPointerSegment, makePointer } from './lib/utils';
+export { ROOT_POINTER, ObjectKind, Keywords, FieldType, CombinationKind, Capabilites } from './lib/types';
+export { createNodeBase, replaceLastPointerSegment, makePointer, pointerIsDefinition } from './lib/utils';
 export { createChildNode } from './lib/mutations/create-node';
 export { removeNodeByPointer } from './lib/mutations/remove-node';
 export { renameNodePointer } from './lib/mutations/rename-node';
 export { promotePropertyToType } from './lib/mutations/promote-node';
+export { getCapabilities } from './lib/capabilities';
 export { toggleArrayAndField, canToggleArrayAndField } from './lib/mutations/toggle-array-field';
 export {
   combinationIsNullable,

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/build-json-schema.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/build-json-schema.ts
@@ -4,7 +4,7 @@ import JSONPointer from 'jsonpointer';
 import { findRequiredProps } from './mappers/required';
 import { findJsonFieldType } from './mappers/field-type';
 import { getNodeByPointer } from './selectors';
-import { sortNodesByChildren } from './utils';
+import { sortNodesByChildren } from './mutations/sort-nodes';
 
 export const buildJsonSchema = (uiSchemaNodes: UiSchemaNodes): JsonSchemaNode => {
   const out: JsonSchemaNode = {};

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.test.ts
@@ -1,6 +1,6 @@
-import { getCapabilities } from './capabilities';
+import { Capabilites, getCapabilities } from './capabilities';
 import { createNodeBase } from './utils';
-import { Capabilites, FieldType, ObjectKind } from './types';
+import { FieldType, ObjectKind } from './types';
 import { expect } from '@jest/globals';
 
 test('that capabilities work as expected', () => {

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.test.ts
@@ -1,0 +1,14 @@
+import { getCapabilities } from './capabilities';
+import { createNodeBase } from './utils';
+import { Capabilites, FieldType, ObjectKind } from './types';
+import { expect } from '@jest/globals';
+
+test('that capabilities work as expected', () => {
+  const test = createNodeBase('asdfas');
+  test.objectKind = ObjectKind.Field;
+  test.fieldType = FieldType.String;
+  const caps = getCapabilities(test);
+  expect(caps.sort()).toStrictEqual(
+    [Capabilites.CanBeConvertedToArray, Capabilites.CanBeConvertedToReference, Capabilites.CanBeDeleted].sort(),
+  );
+});

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.ts
@@ -22,8 +22,12 @@ export const getCapabilities = (node: UiSchemaNode): Capabilites[] => {
     output.push(Capabilites.CanBeConvertedToReference);
   }
 
-  if ((objectKind === ObjectKind.Field && fieldType === FieldType.Object) || objectKind === ObjectKind.Combination) {
+  if (objectKind === ObjectKind.Field && fieldType === FieldType.Object) {
     output.push(Capabilites.CanHaveFieldAdded, Capabilites.CanHaveReferenceAdded);
+  }
+
+  if (objectKind === ObjectKind.Combination) {
+    output.push(Capabilites.CanHaveReferenceAdded);
   }
 
   if (objectKind !== ObjectKind.Reference && fieldType === FieldType.Object) {

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.ts
@@ -1,4 +1,16 @@
-import { Capabilites, FieldType, ObjectKind, ROOT_POINTER, UiSchemaNode } from './types';
+import type { UiSchemaNode } from './types';
+import { FieldType, ObjectKind, ROOT_POINTER } from './types';
+
+export enum Capabilites {
+  CanBeConvertedToArray = 'CAN_BE_CONVERTED_TO_ARRAY', // no restrictions, not combination
+  CanBeConvertedToCombination = 'CAN_BE_CONVERTED_TO_COMBINATION',
+  CanBeConvertedToField = 'CAN_BE_CONVERTED_TO_FIELD', // reference or array with no restrictions
+  CanBeConvertedToReference = 'CAN_BE_CONVERTED_TO_REFERENCE',
+  CanBeDeleted = 'CAN_BE_DELETED', // not root node
+  CanHaveCombinationAdded = 'CAN_HAVE_COMBINATION_ADDED', // object or root node
+  CanHaveFieldAdded = 'CAN_HAVE_FIELD_ADDED', // object or combination
+  CanHaveReferenceAdded = 'CAN_HAVE_REFERENCE_ADDED', // object or combination
+}
 
 export const getCapabilities = (node: UiSchemaNode): Capabilites[] => {
   const { objectKind, fieldType } = node;

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.ts
@@ -2,32 +2,37 @@ import { Capabilites, FieldType, ObjectKind, ROOT_POINTER, UiSchemaNode } from '
 
 export const getCapabilities = (node: UiSchemaNode): Capabilites[] => {
   const { objectKind, fieldType } = node;
-  const capabilities = [];
+  const output = [];
   const isRootNode = node.pointer === ROOT_POINTER;
   const hasRestrictions = Object.keys(node.restrictions).length > 0;
   const hasChildren = node.children.length > 0;
+
   if (objectKind === ObjectKind.Field || objectKind === ObjectKind.Reference) {
-    capabilities.push(Capabilites.CanBeConvertedToArray);
+    output.push(Capabilites.CanBeConvertedToArray);
   }
-
   if (
-    objectKind === ObjectKind.Reference ||
+    (objectKind === ObjectKind.Reference && node.ref) ||
     (objectKind === ObjectKind.Array && !hasRestrictions) ||
-    (fieldType === FieldType.Object && !hasRestrictions && !hasChildren)
+    (objectKind === ObjectKind.Combination && !hasChildren)
   ) {
-    capabilities.push(Capabilites.CanBeConvertedToField);
+    output.push(Capabilites.CanBeConvertedToField);
   }
 
-  if (fieldType === FieldType.Object || ObjectKind.Combination) {
-    capabilities.push(Capabilites.CanHaveFieldAdded, Capabilites.CanHaveReferenceAdded);
+  if (objectKind === ObjectKind.Array || objectKind === ObjectKind.Field) {
+    output.push(Capabilites.CanBeConvertedToReference);
   }
-  if (fieldType === FieldType.Object) {
-    capabilities.push(Capabilites.CanHaveCombinationAdded);
+
+  if ((objectKind === ObjectKind.Field && fieldType === FieldType.Object) || objectKind === ObjectKind.Combination) {
+    output.push(Capabilites.CanHaveFieldAdded, Capabilites.CanHaveReferenceAdded);
+  }
+
+  if (objectKind !== ObjectKind.Reference && fieldType === FieldType.Object) {
+    output.push(Capabilites.CanHaveCombinationAdded);
   }
 
   if (!isRootNode) {
-    capabilities.push(Capabilites.CanBeDeleted);
+    output.push(Capabilites.CanBeDeleted);
   }
 
-  return capabilities;
+  return output;
 };

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.ts
@@ -1,0 +1,33 @@
+import { Capabilites, FieldType, ObjectKind, ROOT_POINTER, UiSchemaNode } from './types';
+
+export const getCapabilities = (node: UiSchemaNode): Capabilites[] => {
+  const { objectKind, fieldType } = node;
+  const capabilities = [];
+  const isRootNode = node.pointer === ROOT_POINTER;
+  const hasRestrictions = Object.keys(node.restrictions).length > 0;
+  const hasChildren = node.children.length > 0;
+  if (objectKind === ObjectKind.Field || objectKind === ObjectKind.Reference) {
+    capabilities.push(Capabilites.CanBeConvertedToArray);
+  }
+
+  if (
+    objectKind === ObjectKind.Reference ||
+    (objectKind === ObjectKind.Array && !hasRestrictions) ||
+    (fieldType === FieldType.Object && !hasRestrictions && !hasChildren)
+  ) {
+    capabilities.push(Capabilites.CanBeConvertedToField);
+  }
+
+  if (fieldType === FieldType.Object || ObjectKind.Combination) {
+    capabilities.push(Capabilites.CanHaveFieldAdded, Capabilites.CanHaveReferenceAdded);
+  }
+  if (fieldType === FieldType.Object) {
+    capabilities.push(Capabilites.CanHaveCombinationAdded);
+  }
+
+  if (!isRootNode) {
+    capabilities.push(Capabilites.CanBeDeleted);
+  }
+
+  return capabilities;
+};

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/create-node.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/create-node.ts
@@ -1,6 +1,5 @@
 import { FieldType, Keywords, ObjectKind, UiSchemaNode, UiSchemaNodes } from '../types';
-import { pointerExists } from '../selectors';
-import { createNodeBase, getParentNodeByPointer } from '../utils';
+import { createNodeBase, getParentNodeByPointer, pointerExists } from '../utils';
 
 export const insertSchemaNode = (uiSchemaNodes: UiSchemaNodes, newNode: UiSchemaNode): UiSchemaNodes => {
   if (pointerExists(uiSchemaNodes, newNode.pointer)) {
@@ -12,7 +11,6 @@ export const insertSchemaNode = (uiSchemaNodes: UiSchemaNodes, newNode: UiSchema
     throw new Error(`Can't find ParentNode for pointer ${newNode.pointer}`);
   }
   parentNode.children.push(newNode.pointer);
-  newNode.implicitType = false;
   mutatedNodeArray.push(newNode);
   return mutatedNodeArray;
 };

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/promote-node.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/promote-node.test.ts
@@ -2,12 +2,12 @@ import { buildUiSchema } from '../build-ui-schema';
 import { buildJsonSchema } from '../build-json-schema';
 import { FieldType, Keywords } from '../types';
 import { makePointer } from '../utils';
-import { promotePropertyToType } from './promote-node';
+import { convertPropToType } from './promote-node';
 import { simpleTestJsonSchema } from '../../../test/testUtils';
 
 test('that we can promote a node', () => {
   const originalNodeMap = buildUiSchema(simpleTestJsonSchema);
-  const promotedNodeMap = promotePropertyToType(originalNodeMap, makePointer(Keywords.Properties, 'world'));
+  const promotedNodeMap = convertPropToType(originalNodeMap, makePointer(Keywords.Properties, 'world'));
   expect(buildJsonSchema(promotedNodeMap)).toEqual({
     [Keywords.Properties]: {
       hello: { [Keywords.Type]: FieldType.String },
@@ -26,6 +26,6 @@ test('that promotePropertyToType throws errors', () => {
       email: { [Keywords.Type]: FieldType.String },
     },
   });
-  expect(() => promotePropertyToType(uiSchemaNodes, '#/$defs/email')).toThrowError();
-  expect(() => promotePropertyToType(uiSchemaNodes, '#/properties/email')).toThrowError();
+  expect(() => convertPropToType(uiSchemaNodes, '#/$defs/email')).toThrowError();
+  expect(() => convertPropToType(uiSchemaNodes, '#/properties/email')).toThrowError();
 });

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/rename-node.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/rename-node.ts
@@ -1,6 +1,6 @@
 import { CombinationKind, UiSchemaNodes } from '../types';
-import { getNodeByPointer, pointerExists } from '../selectors';
-import { splitPointerInBaseAndName } from '../utils';
+import { getNodeByPointer } from '../selectors';
+import { pointerExists, splitPointerInBaseAndName } from '../utils';
 
 export const renameNodePointer = (uiSchemaNodes: UiSchemaNodes, oldPointer: string, newPointer: string) => {
   if (oldPointer === newPointer) {

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/rename-node.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/rename-node.ts
@@ -18,14 +18,19 @@ export const renameNodePointer = (uiSchemaNodes: UiSchemaNodes, oldPointer: stri
   const mutatedNodeArray: UiSchemaNodes = [];
   uiSchemaNodes.forEach((uiNode) => {
     const nodeCopy = Object.assign({}, uiNode);
-    if (uiNode.pointer.startsWith(oldPointer)) {
+    if (pointerIsInBranch(uiNode.pointer, oldPointer)) {
       nodeCopy.pointer = nodeCopy.pointer.replace(oldPointer, newPointer);
     }
-    if (nodeCopy.ref && nodeCopy.ref.startsWith(oldPointer)) {
+    if (nodeCopy.ref === oldPointer) {
       nodeCopy.ref = nodeCopy.ref.replace(oldPointer, newPointer);
     }
-    nodeCopy.children = uiNode.children.map((p) => p.replace(oldPointer, newPointer));
+    nodeCopy.children = uiNode.children.map((childPointer) =>
+      pointerIsInBranch(childPointer, oldPointer) ? childPointer.replace(oldPointer, newPointer) : childPointer,
+    );
     mutatedNodeArray.push(nodeCopy);
   });
   return mutatedNodeArray;
 };
+
+const pointerIsInBranch = (pointer: string, pointer2: string) =>
+  pointer === pointer2 || pointer.startsWith(pointer2 + '/');

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/sort-nodes.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/sort-nodes.test.ts
@@ -1,0 +1,20 @@
+import { createNodeBase } from '../utils';
+import { ROOT_POINTER } from '../types';
+import { expect } from '@jest/globals';
+import { sortNodesByChildren } from './sort-nodes';
+
+test('that we can sortNodes', () => {
+  const rootNode = createNodeBase(ROOT_POINTER);
+  const child1 = createNodeBase('someother path');
+  const child3 = createNodeBase('somepath');
+  rootNode.children.push(child1.pointer);
+  rootNode.children.push(child3.pointer);
+  const child2 = createNodeBase('someother path', 'another one here');
+  child1.children.push(child2.pointer);
+  const testArray = [child1, child2, child3, rootNode];
+  for (let i = 0; i < 5; i++) {
+    testArray.sort(() => Math.random() - 0.5);
+    const sorted = sortNodesByChildren(testArray);
+    expect(sorted).toStrictEqual([rootNode, child1, child2, child3]);
+  }
+});

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/sort-nodes.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/sort-nodes.ts
@@ -1,0 +1,19 @@
+import { ROOT_POINTER, UiSchemaNode, UiSchemaNodes } from '../types';
+
+export const sortNodesByChildren = (uiSchemaNodes: UiSchemaNodes): UiSchemaNodes => {
+  const tempMap = new Map();
+  uiSchemaNodes.forEach((node) => tempMap.set(node.pointer, node));
+  return treeWalker(tempMap, ROOT_POINTER);
+};
+
+const treeWalker = (map: Map<string, UiSchemaNode>, pointer: string): UiSchemaNodes => {
+  const nodes = [];
+  if (map.has(pointer)) {
+    const currentNode = map.get(pointer) as UiSchemaNode;
+    nodes.push(currentNode);
+    currentNode.children.forEach((childPointer) => nodes.push(...treeWalker(map, childPointer)));
+  } else {
+    throw new Error(`Can't find ${pointer} in node-array.`);
+  }
+  return nodes;
+};

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/selectors.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/selectors.test.ts
@@ -1,14 +1,8 @@
 import { FieldType, Keywords } from './types';
 import { buildUiSchema } from './build-ui-schema';
-import {
-  combinationIsNullable,
-  getNodeByPointer,
-  getNodeDisplayName,
-  getRootNodes,
-  getUniqueNodePath,
-} from './selectors';
+import { getNodeByPointer, getNodeDisplayName, getRootNodes, getUniqueNodePath } from './selectors';
 import { expect } from '@jest/globals';
-import { createNodeBase, makePointer } from './utils';
+import { makePointer } from './utils';
 
 const testShema = {
   [Keywords.Definitions]: {
@@ -44,12 +38,4 @@ test('that we can getUniqueNodePath', () => {
   expect(getUniqueNodePath(uiSchemaNodes, makePointer(Keywords.Properties, 'hello'))).toBe(
     makePointer(Keywords.Properties, 'hello0'),
   );
-});
-
-test('that we can check if combination is nullable', () => {
-  const regularChild = createNodeBase('regular child');
-  const nullableChild = createNodeBase('nullable child');
-  nullableChild.fieldType = FieldType.Null;
-  expect(combinationIsNullable([regularChild, regularChild])).toBeFalsy();
-  expect(combinationIsNullable([regularChild, nullableChild])).toBeTruthy();
 });

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/selectors.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/selectors.ts
@@ -1,6 +1,6 @@
 import type { UiSchemaNode, UiSchemaNodes } from './types';
-import { FieldType, Keywords, ROOT_POINTER } from './types';
-import { makePointer } from './utils';
+import { Keywords, ROOT_POINTER } from './types';
+import { makePointer, pointerExists } from './utils';
 
 export const getRootNodes = (uiSchemaMap: UiSchemaNodes, defs: boolean): UiSchemaNode[] => {
   const parentNodeIndex = getNodeIndexByPointer(uiSchemaMap, ROOT_POINTER);
@@ -13,9 +13,6 @@ export const getRootNodes = (uiSchemaMap: UiSchemaNodes, defs: boolean): UiSchem
     return [];
   }
 };
-
-export const pointerExists = (uiSchemaNodes: UiSchemaNodes, pointer: string): boolean =>
-  getNodeIndexByPointer(uiSchemaNodes, pointer) !== undefined;
 
 export const getNodeDisplayName = (uiSchemaNode: UiSchemaNode) => uiSchemaNode.pointer.split('/').pop() ?? '';
 
@@ -61,6 +58,3 @@ export const getChildNodesByPointer = (uiNodeMap: UiSchemaNodes, pointer: string
 
 export const getChildNodesByNode = (uiNodeMap: UiSchemaNodes, parentNode: UiSchemaNode): UiSchemaNode[] =>
   uiNodeMap.filter((node) => parentNode.children.includes(node.pointer));
-
-export const combinationIsNullable = (childNodes: UiSchemaNode[]): boolean =>
-  childNodes.some((child) => child.fieldType === FieldType.Null);

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/types.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/types.ts
@@ -43,13 +43,12 @@ export enum Keywords {
 }
 export enum Capabilites {
   CanBeConvertedToArray = 'CAN_BE_CONVERTED_TO_ARRAY', // no restrictions, not combination
+  CanBeConvertedToCombination = 'CAN_BE_CONVERTED_TO_COMBINATION',
   CanBeConvertedToField = 'CAN_BE_CONVERTED_TO_FIELD', // reference or array with no restrictions
-  CanBeConvertedToObject = 'CAN_BE_CONVERTED_TO_OBJECT', // no restrictions
   CanBeConvertedToReference = 'CAN_BE_CONVERTED_TO_REFERENCE',
   CanBeDeleted = 'CAN_BE_DELETED', // not root node
   CanHaveCombinationAdded = 'CAN_HAVE_COMBINATION_ADDED', // object or root node
   CanHaveFieldAdded = 'CAN_HAVE_FIELD_ADDED', // object or combination
-  CanHaveObjectAdded = 'CAN_HAVE_OBJECT_ADDED', // object or combination
   CanHaveReferenceAdded = 'CAN_HAVE_REFERENCE_ADDED', // object or combination
 }
 

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/types.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/types.ts
@@ -41,16 +41,6 @@ export enum Keywords {
   Title = 'title',
   Type = 'type',
 }
-export enum Capabilites {
-  CanBeConvertedToArray = 'CAN_BE_CONVERTED_TO_ARRAY', // no restrictions, not combination
-  CanBeConvertedToCombination = 'CAN_BE_CONVERTED_TO_COMBINATION',
-  CanBeConvertedToField = 'CAN_BE_CONVERTED_TO_FIELD', // reference or array with no restrictions
-  CanBeConvertedToReference = 'CAN_BE_CONVERTED_TO_REFERENCE',
-  CanBeDeleted = 'CAN_BE_DELETED', // not root node
-  CanHaveCombinationAdded = 'CAN_HAVE_COMBINATION_ADDED', // object or root node
-  CanHaveFieldAdded = 'CAN_HAVE_FIELD_ADDED', // object or combination
-  CanHaveReferenceAdded = 'CAN_HAVE_REFERENCE_ADDED', // object or combination
-}
 
 export const ROOT_POINTER = '#';
 

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/types.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/types.ts
@@ -41,6 +41,17 @@ export enum Keywords {
   Title = 'title',
   Type = 'type',
 }
+export enum Capabilites {
+  CanBeConvertedToArray = 'CAN_BE_CONVERTED_TO_ARRAY', // no restrictions, not combination
+  CanBeConvertedToField = 'CAN_BE_CONVERTED_TO_FIELD', // reference or array with no restrictions
+  CanBeConvertedToObject = 'CAN_BE_CONVERTED_TO_OBJECT', // no restrictions
+  CanBeConvertedToReference = 'CAN_BE_CONVERTED_TO_REFERENCE',
+  CanBeDeleted = 'CAN_BE_DELETED', // not root node
+  CanHaveCombinationAdded = 'CAN_HAVE_COMBINATION_ADDED', // object or root node
+  CanHaveFieldAdded = 'CAN_HAVE_FIELD_ADDED', // object or combination
+  CanHaveObjectAdded = 'CAN_HAVE_OBJECT_ADDED', // object or combination
+  CanHaveReferenceAdded = 'CAN_HAVE_REFERENCE_ADDED', // object or combination
+}
 
 export const ROOT_POINTER = '#';
 

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/utils.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
-import { createNodeBase, getParentNodeByPointer, makePointer, sortNodesByChildren } from './utils';
-import { ROOT_POINTER } from './types';
+import { combinationIsNullable, createNodeBase, getParentNodeByPointer, makePointer } from './utils';
+import { FieldType, ROOT_POINTER } from './types';
 import { getGeneralJsonSchemaForTest } from '../../test/testUtils';
 import { buildUiSchema } from './build-ui-schema';
 import { expect } from '@jest/globals';
@@ -32,18 +32,10 @@ test('that we can makePointer', () => {
   expect(makePointer('#/properties', 'hello')).toBe('#/properties/hello');
 });
 
-test('that we can sortNodes', () => {
-  const rootNode = createNodeBase(ROOT_POINTER);
-  const child1 = createNodeBase('someother path');
-  const child3 = createNodeBase('somepath');
-  rootNode.children.push(child1.pointer);
-  rootNode.children.push(child3.pointer);
-  const child2 = createNodeBase('someother path', 'another one here');
-  child1.children.push(child2.pointer);
-  const testArray = [child1, child2, child3, rootNode];
-  for (let i = 0; i < 5; i++) {
-    testArray.sort(() => Math.random() - 0.5);
-    const sorted = sortNodesByChildren(testArray);
-    expect(sorted).toStrictEqual([rootNode, child1, child2, child3]);
-  }
+test('that we can check if combination is nullable', () => {
+  const regularChild = createNodeBase('regular child');
+  const nullableChild = createNodeBase('nullable child');
+  nullableChild.fieldType = FieldType.Null;
+  expect(combinationIsNullable([regularChild, regularChild])).toBeFalsy();
+  expect(combinationIsNullable([regularChild, nullableChild])).toBeTruthy();
 });

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/utils.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/utils.ts
@@ -41,10 +41,10 @@ export const getObjectKind = (schemaNode: JsonSchemaNode): ObjectKind => {
   }
 };
 
-export const schemaTypeIncludes = (schemaNodeType: string | string[], type: FieldType) =>
+export const schemaTypeIncludes = (schemaNodeType: string | string[], type: FieldType): boolean =>
   schemaNodeType === type || (Array.isArray(schemaNodeType) && schemaNodeType.includes(type));
 
-export const schemaTypeIsNillable = (schemaNodeType: string | string[]) =>
+export const schemaTypeIsNillable = (schemaNodeType: string | string[]): boolean =>
   schemaNodeType !== FieldType.Null && schemaTypeIncludes(schemaNodeType, FieldType.Null);
 
 export const getParentNodeByPointer = (uiSchemaNodes: UiSchemaNodes, pointer: string): UiSchemaNode | undefined => {
@@ -96,20 +96,8 @@ export const pointerReplacer = (node: UiSchemaNode, oldPointer: string, newPoint
   return nodeCopy;
 };
 
-export const sortNodesByChildren = (uiSchemaNodes: UiSchemaNodes): UiSchemaNodes => {
-  const tempMap = new Map();
-  uiSchemaNodes.forEach((node) => tempMap.set(node.pointer, node));
-  return treeWalker(tempMap, ROOT_POINTER);
-};
+export const pointerExists = (uiSchemaNodes: UiSchemaNodes, pointer: string): boolean =>
+  getNodeIndexByPointer(uiSchemaNodes, pointer) !== undefined;
 
-const treeWalker = (map: Map<string, UiSchemaNode>, pointer: string): UiSchemaNodes => {
-  const nodes = [];
-  if (map.has(pointer)) {
-    const currentNode = map.get(pointer) as UiSchemaNode;
-    nodes.push(currentNode);
-    currentNode.children.forEach((childPointer) => nodes.push(...treeWalker(map, childPointer)));
-  } else {
-    throw new Error(`Can't find ${pointer} in node-array.`);
-  }
-  return nodes;
-};
+export const combinationIsNullable = (childNodes: UiSchemaNode[]): boolean =>
+  childNodes.some((child) => child.fieldType === FieldType.Null);

--- a/src/studio/src/designer/frontend/packages/schema-model/test/testUtils.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/test/testUtils.ts
@@ -80,7 +80,7 @@ export const simpleTestJsonSchema = {
     },
     world: {
       [Keywords.Properties]: {
-        hello: {
+        hola: {
           [Keywords.Type]: FieldType.Boolean,
         },
       },

--- a/src/studio/src/designer/frontend/shared/components/molecules/AltinnMenu.tsx
+++ b/src/studio/src/designer/frontend/shared/components/molecules/AltinnMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MenuProps, Menu, makeStyles } from '@material-ui/core';
+import { makeStyles, Menu, MenuProps } from '@material-ui/core';
 
 const useStyles = makeStyles(() => ({
   paper: {
@@ -10,14 +10,13 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-function AltinnMenu(props: MenuProps, ref: React.Ref<unknown>) {
+function AltinnMenu(props: MenuProps) {
   const classes = useStyles();
   return (
     <Menu
       classes={classes}
       elevation={0}
       getContentAnchorEl={null}
-      ref={ref}
       anchorOrigin={{
         vertical: 'bottom',
         horizontal: 'center',
@@ -34,4 +33,4 @@ function AltinnMenu(props: MenuProps, ref: React.Ref<unknown>) {
   );
 }
 
-export default React.forwardRef<unknown, MenuProps>(AltinnMenu);
+export default AltinnMenu;

--- a/src/studio/src/designer/frontend/shared/components/molecules/AltinnMenuItem.tsx
+++ b/src/studio/src/designer/frontend/shared/components/molecules/AltinnMenuItem.tsx
@@ -1,9 +1,9 @@
 import {
-  ListItemText,
-  Typography,
   ListItemIcon,
-  MenuItem,
+  ListItemText,
   makeStyles,
+  MenuItem,
+  Typography,
 } from '@material-ui/core';
 import React from 'react';
 
@@ -13,6 +13,7 @@ export interface IAltinnMenuItemProps {
   onClick: (event: React.SyntheticEvent) => void;
   disabled?: boolean;
   id: string;
+  className?: string;
 }
 
 const useStyles = makeStyles(() => ({
@@ -30,9 +31,10 @@ function AltinnMenuItem(
   ref: React.Ref<HTMLLIElement>,
 ) {
   const classes = useStyles();
-  const { text, iconClass, onClick, disabled, id } = props;
+  const { text, iconClass, onClick, disabled, id, className } = props;
   return (
     <MenuItem
+      className={className}
       onClick={onClick}
       disabled={disabled}
       id={id}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The context menu didn't display the correct menu choices based on which note is selected. To fix this the logic is moved out of the compontent and into the `schema-model`, this makes it fairly more easy to test. Though at this point its not really complex logic there and test coverage should be sufficient.

## Related Issue(s)
- #9055 
- #9043 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
