### PR TITLE
Add options with correct formatting and encoding to jsonSerializer

### DIFF
--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.Json;
-using System.Text.Unicode;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Schema;

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Text.Json;
+using System.Text.Unicode;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Schema;
@@ -192,10 +194,10 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         public async Task SaveTextsV2(string languageCode, Dictionary<string, string> jsonTexts)
         {
             string fileName = $"{languageCode}.texts.json";
-
             var textsFileRelativeFilePath = GetPathToJsonTextsFile(fileName);
 
-            string texts = System.Text.Json.JsonSerializer.Serialize(jsonTexts);
+            var jsonOptions = new JsonSerializerOptions() { WriteIndented = true, Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+            string texts = System.Text.Json.JsonSerializer.Serialize(jsonTexts, jsonOptions);
 
             await WriteTextByRelativePathAsync(textsFileRelativeFilePath, texts);
         }


### PR DESCRIPTION
## Description
Options is added to jsonserializer method when saving texts in V2 format. The options include;
- `WriteIndented = true,` which represents the json in correct pretty format instead of a oneliner
- `Encoder = ...JavaScriptEncoder.UnsafeRelaxedJsonEscaping` which provides correct encoding of æ,ø,å

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
