### PR TITLE
Ensure that cookies set on the app, gets rewritten to use local.altinn.cloud

### DIFF
--- a/src/development/loadbalancer/nginx.conf
+++ b/src/development/loadbalancer/nginx.conf
@@ -64,6 +64,7 @@ http {
         sub_filter 'https://altinncdn.no/toolkits/altinn-app-frontend/3/' $LOCAL_SUB_FILTER;
         proxy_pass          http://app/;
         error_page 502 /502App.html;
+        proxy_cookie_domain altinn3local.no local.altinn.cloud;
 		}
 
 		location /Home/ {


### PR DESCRIPTION
Simple change to let nginx rewrite the domain name, so that things works as before the domain change. I can't update/fix the domain name, as this config is in `appsettings.json` of all the apps in altinn3.

I get really confused trying to understand how the `AltinnPartyId` cookie works. It seems to be pretty random and never really exactly what I want.

## Related Issue(s)
- #8957 