### PR TITLE
7241 node stays closed when adding a child in data model editor

### DIFF
--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaEditor.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaEditor.test.tsx
@@ -141,7 +141,7 @@ test('should show context menu and trigger correct dispatch when adding field on
   const actions = store.getActions();
   const lastAction = actions.at(-1);
   expect(lastAction.type).toBe('schemaEditor/addProperty');
-  expect(lastAction.payload.path).toBe('#/properties/mockItem');
+  expect(lastAction.payload.pointer).toBe('#/properties/mockItem');
   expect(lastAction.payload.props.objectKind).toBe(ObjectKind.Field);
   expect(lastAction.payload.props.fieldType).toBe(FieldType.String);
 });

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaEditor.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaEditor.test.tsx
@@ -160,7 +160,7 @@ test('should show context menu and trigger correct dispatch when adding referenc
   const actions = store.getActions();
   const lastAction = actions.at(-1);
   expect(lastAction.type).toBe('schemaEditor/addProperty');
-  expect(lastAction.payload.path).toBe('#/properties/mockItem');
+  expect(lastAction.payload.pointer).toBe('#/properties/mockItem');
   expect(lastAction.payload.props.objectKind).toBe(ObjectKind.Reference);
   expect(lastAction.payload.props.ref).toBe('');
 });
@@ -290,7 +290,7 @@ test('should show context menu and trigger correct dispatch when adding a combin
   const lastAction = actions.at(-1);
   expect(lastAction.type).toBe('schemaEditor/addProperty');
   expect(lastAction.payload).toEqual({
-    path: '#/properties/mockItem',
+    pointer: '#/properties/mockItem',
     props: {
       objectKind: ObjectKind.Combination,
       fieldType: CombinationKind.AllOf,

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaEditor.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaEditor.test.tsx
@@ -320,3 +320,12 @@ test('should only be possible to add a reference to a combination type', async (
   expect(menuItemIds).toContain('add-reference-to-node-button');
   expect(menuItemIds).not.toContain('add-combination-to-node-button');
 });
+
+test('should trigger correct dispatch when changing tab', async () => {
+  const { store, user } = renderEditor();
+  const tab = screen.getByRole('tab', { name: 'types' });
+  await user.click(tab);
+  const lastAction = store.getActions().at(-1);
+  expect(lastAction.type).toBe('schemaEditor/setSelectedTab');
+  expect(lastAction.payload).toStrictEqual({ selectedTab: 'definitions' });
+});

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaEditor.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaEditor.tsx
@@ -106,7 +106,7 @@ export const SchemaEditor = ({
     if (selectedPropertyParent && !expandedPropNodes.includes(selectedPropertyParent.pointer)) {
       setExpandedPropNodes((prevState) => [...prevState, selectedPropertyParent.pointer]);
     }
-  }, [selectedPropertyParent]);
+  }, [selectedPropertyParent, expandedPropNodes]);
 
   const selectedDefinitionNodeId = useSelector((state: ISchemaState) => state.selectedDefinitionNodeId);
   const selectedDefinitionParent = useSelector((state: ISchemaState) =>
@@ -116,7 +116,7 @@ export const SchemaEditor = ({
     if (selectedDefinitionParent && !expandedDefNodes.includes(selectedDefinitionParent.pointer)) {
       setExpandedDefNodes((prevState) => [...prevState, selectedDefinitionParent.pointer]);
     }
-  }, [selectedPropertyParent]);
+  }, [selectedPropertyParent, expandedDefNodes]);
 
   const handlePropertiesNodeExpanded = (_x: ChangeEvent<unknown>, nodeIds: string[]) => setExpandedPropNodes(nodeIds);
 

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaEditor.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaEditor.tsx
@@ -24,6 +24,7 @@ import {
   FieldType,
   getChildNodesByPointer,
   getNodeByPointer,
+  getParentNodeByPointer,
   Keywords,
   makePointer,
   ObjectKind,
@@ -92,12 +93,30 @@ export const SchemaEditor = ({
     }
   }, [dispatch, schema, name]);
 
-  const selectedPropertyNode = useSelector((state: ISchemaState) => state.selectedPropertyNodeId);
-  const selectedDefinitionNode = useSelector((state: ISchemaState) => state.selectedDefinitionNodeId);
-  const selectedTab = useSelector((state: ISchemaState) => state.selectedEditorTab);
-
   const [expandedPropNodes, setExpandedPropNodes] = useState<string[]>([]);
   const [expandedDefNodes, setExpandedDefNodes] = useState<string[]>([]);
+
+  const selectedEditorTab = useSelector((state: ISchemaState) => state.selectedEditorTab);
+
+  const selectedPropertyNodeId = useSelector((state: ISchemaState) => state.selectedPropertyNodeId);
+  const selectedPropertyParent = useSelector((state: ISchemaState) =>
+    getParentNodeByPointer(state.uiSchema, state.selectedPropertyNodeId),
+  );
+  useEffect(() => {
+    if (selectedPropertyParent && !expandedPropNodes.includes(selectedPropertyParent.pointer)) {
+      setExpandedPropNodes((prevState) => [...prevState, selectedPropertyParent.pointer]);
+    }
+  }, [selectedPropertyParent]);
+
+  const selectedDefinitionNodeId = useSelector((state: ISchemaState) => state.selectedDefinitionNodeId);
+  const selectedDefinitionParent = useSelector((state: ISchemaState) =>
+    getParentNodeByPointer(state.uiSchema, state.selectedDefinitionNodeId),
+  );
+  useEffect(() => {
+    if (selectedDefinitionParent && !expandedDefNodes.includes(selectedDefinitionParent.pointer)) {
+      setExpandedDefNodes((prevState) => [...prevState, selectedDefinitionParent.pointer]);
+    }
+  }, [selectedPropertyParent]);
 
   const handlePropertiesNodeExpanded = (_x: ChangeEvent<unknown>, nodeIds: string[]) => setExpandedPropNodes(nodeIds);
 
@@ -171,7 +190,7 @@ export const SchemaEditor = ({
         {LandingPagePanel}
         {name && schema ? (
           <div data-testid='schema-editor' id='schema-editor' className={classes.editor}>
-            <TabContext value={selectedTab}>
+            <TabContext value={selectedEditorTab}>
               <AppBar position='static' color='default' className={classes.appBar}>
                 <TabList onChange={handleTabChanged} aria-label='model-tabs'>
                   <SchemaTab label={t('model')} value='properties' />
@@ -229,7 +248,7 @@ export const SchemaEditor = ({
                   items={properties}
                   translate={t}
                   onNodeToggle={handlePropertiesNodeExpanded}
-                  selectedPointer={selectedPropertyNode}
+                  selectedPointer={selectedPropertyNodeId}
                 />
               </TabPanel>
               <TabPanel className={classes.tabPanel} value='definitions'>
@@ -249,7 +268,7 @@ export const SchemaEditor = ({
                   items={definitions}
                   translate={t}
                   onNodeToggle={handleDefinitionsNodeExpanded}
-                  selectedPointer={selectedDefinitionNode}
+                  selectedPointer={selectedDefinitionNodeId}
                 />
               </TabPanel>
             </TabContext>

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
@@ -74,7 +74,7 @@ export function ItemDataComponent({ language, selectedItem }: IItemDataComponent
 
   const onChangeNullable = (event: any) => {
     if (event.target.checked) {
-      dispatch(addCombinationItem({ path: selectedItem.pointer, props: { fieldType: FieldType.Null } }));
+      dispatch(addCombinationItem({ pointer: selectedItem.pointer, props: { fieldType: FieldType.Null } }));
     } else {
       childNodes.forEach((childNode: UiSchemaNode) => {
         if (childNode.fieldType === FieldType.Null) {

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
@@ -29,7 +29,7 @@ export const ItemFieldsTab = ({ selectedItem, language }: ItemFieldsTabProps) =>
   const dispatchAddProperty = () =>
     dispatch(
       addProperty({
-        path: selectedItem.pointer,
+        pointer: selectedItem.pointer,
         keepSelection: true,
         props: {},
       }),

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
@@ -7,7 +7,6 @@ import { getIconStr } from './tree-view-helpers';
 import type { UiSchemaNode, UiSchemaNodes } from '@altinn/schema-model';
 import { getChildNodesByNode, getNodeByPointer, ObjectKind, splitPointerInBaseAndName } from '@altinn/schema-model';
 import type { ISchemaState } from '../../types';
-import { getDomFriendlyID } from '../../utils/ui-schema-utils';
 import classes from './SchemaItem.module.css';
 import classNames from 'classnames';
 import { DndItem } from './DnDWrapper';
@@ -55,7 +54,7 @@ export function SchemaItem({ selectedNode, isPropertiesView, editMode, translate
   return (
     <DndItem index={index} itemId={selectedNode.pointer} containerId={base} onMove={onMove}>
       <TreeItem
-        nodeId={getDomFriendlyID(selectedNode.pointer)}
+        nodeId={selectedNode.pointer}
         classes={{ root: classNames(classes.treeItem, isRef && classes.isRef) }}
         label={
           <SchemaItemLabel

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
@@ -65,10 +65,10 @@ export const SchemaItemLabel = ({ editMode, icon, refNode, selectedNode, transla
       }[objectKind],
       ref: objectKind === ObjectKind.Reference ? '' : undefined,
     };
-    const path = selectedNode.pointer;
+    const { pointer } = selectedNode;
     selectedNode.objectKind === ObjectKind.Combination
-      ? dispatch(addCombinationItem({ path, props }))
-      : dispatch(addProperty({ path, props }));
+      ? dispatch(addCombinationItem({ pointer, props }))
+      : dispatch(addProperty({ pointer, props }));
   });
 
   const handleDeleteClick = wrapper(() =>

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaTreeView.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaTreeView.tsx
@@ -3,7 +3,6 @@ import { TreeView } from '@material-ui/lab';
 import { ArrowDropDown, ArrowRight } from '@material-ui/icons';
 import { SchemaItem } from './SchemaItem';
 import { UiSchemaNode } from '@altinn/schema-model';
-import { getDomFriendlyID } from '../../utils/ui-schema-utils';
 import classes from './SchemaTreeView.module.css';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -30,7 +29,7 @@ export const SchemaTreeView = ({
       <TreeView
         className={classes.treeView}
         multiSelect={false}
-        selected={getDomFriendlyID(selectedPointer)}
+        selected={selectedPointer}
         defaultCollapseIcon={<ArrowDropDown />}
         defaultExpandIcon={<ArrowRight />}
         expanded={expanded}

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
@@ -448,7 +448,7 @@ describe('SchemaEditorSlice', () => {
     let nextState = reducer(
       state,
       addCombinationItem({
-        path: '#/$defs/anyOfTestSeveralItems',
+        pointer: '#/$defs/anyOfTestSeveralItems',
         props: { fieldType: FieldType.String },
       }),
     );
@@ -464,7 +464,7 @@ describe('SchemaEditorSlice', () => {
     nextState = reducer(
       state,
       addCombinationItem({
-        path: '#/$defs/allOfTest',
+        pointer: '#/$defs/allOfTest',
         props: { fieldType: FieldType.String },
       }),
     );
@@ -479,7 +479,7 @@ describe('SchemaEditorSlice', () => {
     nextState = reducer(
       state,
       addCombinationItem({
-        path: '#/$defs/oneOfTestNullable',
+        pointer: '#/$defs/oneOfTestNullable',
         props: { fieldType: FieldType.String },
       }),
     );

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
@@ -71,6 +71,7 @@ describe('SchemaEditorSlice', () => {
       setPropertyName({
         path: '#/$defs/Kontaktperson/properties/navn',
         name: '',
+        navigate: true,
       }),
     );
     expect(nextState).toBe(state);

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
@@ -207,7 +207,7 @@ describe('SchemaEditorSlice', () => {
 
   it('handles addProperty', () => {
     const payload = {
-      path: '#/$defs/Kontaktperson',
+      pointer: '#/$defs/Kontaktperson',
       props: {
         fieldType: FieldType.Object,
       } as Partial<UiSchemaNode>,

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
@@ -65,7 +65,16 @@ describe('SchemaEditorSlice', () => {
     }
     expect(field).toBe(666);
   });
-
+  it('handles that setPropertyName comes with empty string', () => {
+    const nextState = reducer(
+      state,
+      setPropertyName({
+        path: '#/$defs/Kontaktperson/properties/navn',
+        name: '',
+      }),
+    );
+    expect(nextState).toBe(state);
+  });
   it('handles setPropertyName', () => {
     let nextState = reducer(
       state,
@@ -74,11 +83,7 @@ describe('SchemaEditorSlice', () => {
         name: 'navn_endret',
       }),
     );
-
     let item = getNodeByPointer(nextState.uiSchema, '#/$defs/Kontaktperson/properties/navn_endret');
-    if (!item) {
-      fail('item not found');
-    }
     expect(nextState.uiSchema).not.toHaveProperty('#/$defs/Kontaktperson/properties/navn');
 
     // test that child paths are also updated
@@ -250,19 +255,19 @@ describe('SchemaEditorSlice', () => {
     // add
     let nextState = reducer(state, addEnum(payload));
     let item = getNodeByPointer(nextState.uiSchema, '#/$defs/StatistiskeEnhetstyper');
-    expect(item && item.enum).toContainEqual('test');
+    expect(item.enum).toContainEqual('test');
     // rename
     payload.oldValue = 'test';
     payload.value = 'test2';
     nextState = reducer(nextState, addEnum(payload));
     item = getNodeByPointer(nextState.uiSchema, '#/$defs/StatistiskeEnhetstyper');
 
-    expect(item && item.enum).not.toContainEqual('test');
-    expect(item && item.enum).toContainEqual('test2');
+    expect(item.enum).not.toContainEqual('test');
+    expect(item.enum).toContainEqual('test2');
     // delete
     nextState = reducer(nextState, deleteEnum(payload));
     item = getNodeByPointer(nextState.uiSchema, '#/$defs/StatistiskeEnhetstyper');
-    expect(item && item.enum).not.toContainEqual('test2');
+    expect(item.enum).not.toContainEqual('test2');
   });
 
   it('handles updateJsonSchema', () => {

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
@@ -42,9 +42,7 @@ const schemaEditorSlice = createSlice({
     addEnum(state, action: PayloadAction<{ path: string; value: string; oldValue?: string }>) {
       const { path, value, oldValue } = action.payload;
       const addToItem = getNodeByPointer(state.uiSchema, path);
-      if (!addToItem.enum) {
-        addToItem.enum = [];
-      }
+      addToItem.enum = addToItem.enum ?? [];
       if (!oldValue) {
         addToItem.enum.push(value);
       }
@@ -76,9 +74,6 @@ const schemaEditorSlice = createSlice({
       }
       state.focusNameField = newPointer;
     },
-    clearNameFocus(state) {
-      state.focusNameField = undefined;
-    },
     addProperty(
       state,
       action: PayloadAction<{
@@ -102,11 +97,6 @@ const schemaEditorSlice = createSlice({
       }
       props.implicitType = false;
       state.uiSchema.push(Object.assign(createNodeBase(newNodePointer), props));
-    },
-    deleteField(state, action: PayloadAction<{ path: string; key: string }>) {
-      const { path, key } = action.payload;
-      const removeFromItem = getNodeByPointer(state.uiSchema, path);
-      delete removeFromItem.restrictions[key];
     },
     deleteEnum(state, action: PayloadAction<{ path: string; value: string }>) {
       const { path, value } = action.payload;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As described in the title. This PR actually also fikses an error in adding items to arrays. And is starting to refactor towards using a more concise lanuage, mainly replacing `path` with `pointer`. (Pointer is more correct as it is connected to the jsonpointer spec.

## Related Issue(s)
- #7241 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
