### PR TITLE
7249 deleting a definition does not clean up references

### DIFF
--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaEditor.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaEditor.tsx
@@ -249,6 +249,7 @@ export const SchemaEditor = ({
                   translate={t}
                   onNodeToggle={handlePropertiesNodeExpanded}
                   selectedPointer={selectedPropertyNodeId}
+                  isPropertiesView={true}
                 />
               </TabPanel>
               <TabPanel className={classes.tabPanel} value='definitions'>
@@ -269,6 +270,7 @@ export const SchemaEditor = ({
                   translate={t}
                   onNodeToggle={handleDefinitionsNodeExpanded}
                   selectedPointer={selectedDefinitionNodeId}
+                  isPropertiesView={false}
                 />
               </TabPanel>
             </TabContext>

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
@@ -26,10 +26,10 @@ import {
   combinationIsNullable,
   CombinationKind,
   FieldType,
-  getChildNodesByNode,
+  getChildNodesByPointer,
   getNodeDisplayName,
+  hasNodePointer,
   ObjectKind,
-  pointerExists,
 } from '@altinn/schema-model';
 import { getDomFriendlyID, isValidName } from '../../utils/ui-schema-utils';
 import { Divider } from '../common/Divider';
@@ -51,7 +51,7 @@ export function ItemDataComponent({ language, selectedItem }: IItemDataComponent
   const [title, setItemTitle] = useState<string>('');
   const { fieldType } = selectedItem;
 
-  const childNodes = useSelector((state: ISchemaState) => getChildNodesByNode(state.uiSchema, selectedItem));
+  const childNodes = useSelector((state: ISchemaState) => getChildNodesByPointer(state.uiSchema, selectedItem.pointer));
 
   useEffect(() => {
     setNodeName(getNodeDisplayName(selectedItem));
@@ -101,7 +101,7 @@ export function ItemDataComponent({ language, selectedItem }: IItemDataComponent
 
   const uiSchema = useSelector((state: ISchemaState) => state.uiSchema);
   const handleChangeNodeName = () => {
-    if (pointerExists(uiSchema, nodeName)) {
+    if (hasNodePointer(uiSchema, nodeName)) {
       setNameError(NameError.AlreadyInUse);
       return;
     }

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
@@ -6,7 +6,7 @@ import { addProperty, deleteProperty, setPropertyName } from '../../features/edi
 import { useDispatch, useSelector } from 'react-redux';
 import { getTranslation } from '../../utils/language';
 import type { UiSchemaNode } from '@altinn/schema-model';
-import { getChildNodesByNode, getNodeDisplayName } from '@altinn/schema-model';
+import { getChildNodesByPointer, getNodeDisplayName } from '@altinn/schema-model';
 import classes from './ItemFieldsTab.module.css';
 
 interface ItemFieldsTabProps {
@@ -39,7 +39,7 @@ export const ItemFieldsTab = ({ selectedItem, language }: ItemFieldsTabProps) =>
     event.preventDefault();
     dispatchAddProperty();
   };
-  const childNodes = useSelector((state: ISchemaState) => getChildNodesByNode(state.uiSchema, selectedItem));
+  const childNodes = useSelector((state: ISchemaState) => getChildNodesByPointer(state.uiSchema, selectedItem.pointer));
   return (
     <div className={classes.root}>
       {childNodes.map((childNode) => (

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
@@ -5,7 +5,7 @@ import { changeChildrenOrder, setSelectedId } from '../../features/editor/schema
 import { SchemaItemLabel } from './SchemaItemLabel';
 import { getIconStr } from './tree-view-helpers';
 import type { UiSchemaNode, UiSchemaNodes } from '@altinn/schema-model';
-import { getChildNodesByNode, getNodeByPointer, ObjectKind, splitPointerInBaseAndName } from '@altinn/schema-model';
+import { getChildNodesByPointer, getNodeByPointer, ObjectKind, splitPointerInBaseAndName } from '@altinn/schema-model';
 import type { ISchemaState } from '../../types';
 import classes from './SchemaItem.module.css';
 import classNames from 'classnames';
@@ -35,7 +35,9 @@ export function SchemaItem({ selectedNode, isPropertiesView, editMode, translate
       : undefined,
   );
   const childNodes = useSelector((state: ISchemaState) =>
-    refNode ? getChildNodesByNode(state.uiSchema, refNode) : getChildNodesByNode(state.uiSchema, selectedNode),
+    refNode
+      ? getChildNodesByPointer(state.uiSchema, refNode.pointer)
+      : getChildNodesByPointer(state.uiSchema, selectedNode.pointer),
   );
   const focusedNode = refNode ?? selectedNode;
   const childNodesSorted: UiSchemaNodes = [];

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
@@ -5,7 +5,13 @@ import { changeChildrenOrder, setSelectedId } from '../../features/editor/schema
 import { SchemaItemLabel } from './SchemaItemLabel';
 import { getIconStr } from './tree-view-helpers';
 import type { UiSchemaNode, UiSchemaNodes } from '@altinn/schema-model';
-import { getChildNodesByPointer, getNodeByPointer, ObjectKind, splitPointerInBaseAndName } from '@altinn/schema-model';
+import {
+  getChildNodesByPointer,
+  getNodeByPointer,
+  getReferredNodes,
+  ObjectKind,
+  splitPointerInBaseAndName,
+} from '@altinn/schema-model';
 import type { ISchemaState } from '../../types';
 import classes from './SchemaItem.module.css';
 import classNames from 'classnames';
@@ -15,7 +21,7 @@ import { DragItem } from './dnd-helpers';
 type SchemaItemProps = {
   selectedNode: UiSchemaNode;
   translate: (key: string) => string;
-  isPropertiesView?: boolean;
+  isPropertiesView: boolean;
   editMode: boolean;
   onLabelClick?: (e: any) => void;
   index: number;
@@ -39,6 +45,7 @@ export function SchemaItem({ selectedNode, isPropertiesView, editMode, translate
       ? getChildNodesByPointer(state.uiSchema, refNode.pointer)
       : getChildNodesByPointer(state.uiSchema, selectedNode.pointer),
   );
+  const referredNodes = useSelector((state: ISchemaState) => getReferredNodes(state.uiSchema, selectedNode.pointer));
   const focusedNode = refNode ?? selectedNode;
   const childNodesSorted: UiSchemaNodes = [];
   focusedNode.children.forEach((childPointer) => {
@@ -66,6 +73,7 @@ export function SchemaItem({ selectedNode, isPropertiesView, editMode, translate
             selectedNode={selectedNode}
             refNode={refNode}
             translate={translate}
+            hasReferredNodes={isPropertiesView ? false : referredNodes.length > 0}
           />
         }
         onLabelClick={(e) => onLabelClick(e, selectedNode)}

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.module.css
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.module.css
@@ -63,3 +63,7 @@
 .contextMenuLastItem {
   border-top: 1px #d3d4d5 solid !important;
 }
+
+.greenDot {
+  color: green;
+}

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
@@ -26,13 +26,21 @@ import { Warning } from '@material-ui/icons';
 
 export interface SchemaItemLabelProps {
   editMode: boolean;
+  hasReferredNodes: boolean;
   icon: string;
   refNode?: UiSchemaNode;
   selectedNode: UiSchemaNode;
   translate: (key: string) => string;
 }
 
-export const SchemaItemLabel = ({ editMode, icon, refNode, selectedNode, translate }: SchemaItemLabelProps) => {
+export const SchemaItemLabel = ({
+  editMode,
+  hasReferredNodes,
+  icon,
+  refNode,
+  selectedNode,
+  translate,
+}: SchemaItemLabelProps) => {
   const dispatch = useDispatch();
   const [contextAnchor, setContextAnchor] = useState<any>(null);
 
@@ -89,6 +97,7 @@ export const SchemaItemLabel = ({ editMode, icon, refNode, selectedNode, transla
         </span>{' '}
         <span>{getNodeDisplayName(selectedNode)}</span>
         {selectedNode.isRequired && <span> *</span>}
+        {hasReferredNodes && <span className={classes.greenDot}> ●</span>}
         {refNode && (
           <span
             className={classes.referenceLabel}
@@ -178,9 +187,9 @@ export const SchemaItemLabel = ({ editMode, icon, refNode, selectedNode, transla
             key='delete'
             className={classes.contextMenuLastItem}
             onClick={handleDeleteClick}
-            text={translate('delete')}
+            text={hasReferredNodes ? 'Kan ikke slettes, er i bruk.' : translate('delete')}
             iconClass='fa fa-trash'
-            disabled={!editMode}
+            disabled={!editMode || hasReferredNodes}
           />
         )}
       </AltinnMenu>

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
@@ -89,7 +89,6 @@ export const SchemaItemLabel = ({
 
   const isRef = refNode || pointerIsDefinition(selectedNode.pointer);
   const capabilties = getCapabilities(selectedNode);
-  console.log(selectedNode, capabilties);
   return (
     <div className={classNames(classes.propertiesLabel, { [classes.isArray]: isArray, [classes.isRef]: isRef })}>
       <div className={classes.label} title={selectedNode.pointer}>

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
@@ -89,6 +89,7 @@ export const SchemaItemLabel = ({
 
   const isRef = refNode || pointerIsDefinition(selectedNode.pointer);
   const capabilties = getCapabilities(selectedNode);
+  console.log(selectedNode, capabilties);
   return (
     <div className={classNames(classes.propertiesLabel, { [classes.isArray]: isArray, [classes.isRef]: isRef })}>
       <div className={classes.label} title={selectedNode.pointer}>

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaTreeView.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaTreeView.tsx
@@ -13,6 +13,7 @@ export interface SchemaTreeViewProps {
   items: UiSchemaNode[];
   onNodeToggle: any;
   selectedPointer: string;
+  isPropertiesView: boolean;
   translate: (key: string) => string;
 }
 
@@ -23,6 +24,7 @@ export const SchemaTreeView = ({
   onNodeToggle,
   selectedPointer,
   translate,
+  isPropertiesView,
 }: SchemaTreeViewProps) => {
   return (
     <DndProvider backend={HTML5Backend}>
@@ -39,7 +41,7 @@ export const SchemaTreeView = ({
           <SchemaItem
             index={index}
             editMode={editMode}
-            isPropertiesView={true}
+            isPropertiesView={isPropertiesView}
             selectedNode={item}
             key={item.pointer}
             translate={translate}

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
@@ -33,10 +33,10 @@ import {
   FieldType,
   getChildNodesByPointer,
   getNodeByPointer,
+  hasNodePointer,
   Keywords,
   makePointer,
   ObjectKind,
-  pointerExists,
   UiSchemaNode,
 } from '@altinn/schema-model';
 
@@ -208,7 +208,7 @@ describe('SchemaEditorSlice', () => {
       getNodeByPointer(nextState.uiSchema, '#/$defs/Kontaktperson');
     }).toThrowError();
 
-    expect(pointerExists(nextState.uiSchema, '#/$defs/Kontaktperson')).toBeFalsy();
+    expect(hasNodePointer(nextState.uiSchema, '#/$defs/Kontaktperson')).toBeFalsy();
   });
 
   it('handles addProperty', () => {

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
@@ -33,6 +33,7 @@ import {
   FieldType,
   getChildNodesByPointer,
   getNodeByPointer,
+  getReferredNodes,
   hasNodePointer,
   Keywords,
   makePointer,
@@ -204,13 +205,32 @@ describe('SchemaEditorSlice', () => {
     const payload = {
       path: '#/$defs/Kontaktperson',
     };
-    const nextState = reducer(state, deleteProperty(payload));
+    let nextState = state;
+    getReferredNodes(state.uiSchema, payload.path).forEach((refNode) => {
+      nextState = reducer(
+        nextState,
+        deleteProperty({
+          path: refNode.pointer,
+        }),
+      );
+    });
+    nextState = reducer(nextState, deleteProperty(payload));
     expect(() => {
       getNodeByPointer(nextState.uiSchema, '#/$defs/Kontaktperson');
     }).toThrowError();
 
     expect(hasNodePointer(nextState.uiSchema, '#/$defs/Kontaktperson')).toBeFalsy();
   });
+
+  it('should throw when using deleteProperty (root definition) when there is nodes', () =>
+    expect(() => {
+      reducer(
+        state,
+        deleteProperty({
+          path: '#/$defs/Kontaktperson',
+        }),
+      );
+    }).toThrowError());
 
   it('handles addProperty', () => {
     const payload = {

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
@@ -169,19 +169,20 @@ describe('SchemaEditorSlice', () => {
     });
   });
 
-  it('resets selected id when deleting selected definition', () => {
+  it('throws error when deleting selected definition with referred nodes', () => {
     const mockState = {
       ...state,
       selectedEditorTab: 'definitions',
       selectedDefinitionNodeId: '#/$defs/Kommentar2000Restriksjon',
     } as ISchemaState;
-    const nextState = reducer(
-      mockState,
-      deleteProperty({
-        path: '#/$defs/Kommentar2000Restriksjon',
-      }),
-    );
-    expect(nextState.selectedDefinitionNodeId).toEqual('');
+    expect(() => {
+      reducer(
+        mockState,
+        deleteProperty({
+          path: '#/$defs/Kommentar2000Restriksjon',
+        }),
+      );
+    }).toThrow();
   });
 
   it('resets selected id when deleting selected property', () => {

--- a/src/studio/src/designer/frontend/packages/schema-model/src/index.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/index.ts
@@ -16,7 +16,6 @@ export {
   makePointer,
   pointerIsDefinition,
   combinationIsNullable,
-  pointerExists,
   splitPointerInBaseAndName,
   getNodeDisplayName,
   getUniqueNodePath,
@@ -27,11 +26,11 @@ export { renameNodePointer } from './lib/mutations/rename-node';
 export { convertPropToType } from './lib/mutations/promote-node';
 export { getCapabilities, Capabilites } from './lib/capabilities';
 export {
-  getChildNodesByNode,
   getChildNodesByPointer,
   getNodeByPointer,
   getNodeIndexByPointer,
   getParentNodeByPointer,
   getRootNode,
   getRootNodes,
+  hasNodePointer,
 } from './lib/selectors';

--- a/src/studio/src/designer/frontend/packages/schema-model/src/index.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/index.ts
@@ -30,6 +30,7 @@ export {
   getNodeByPointer,
   getNodeIndexByPointer,
   getParentNodeByPointer,
+  getReferredNodes,
   getRootNode,
   getRootNodes,
   hasNodePointer,

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/build-json-schema.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/build-json-schema.ts
@@ -3,7 +3,7 @@ import { FieldType, JsonSchemaType, Keywords, ObjectKind } from './types';
 import JSONPointer from 'jsonpointer';
 import { findRequiredProps } from './mappers/required';
 import { findJsonFieldType } from './mappers/field-type';
-import { getNodeByPointer } from './selectors';
+import { getRootNode } from './selectors';
 import { sortNodesByChildren } from './mutations/sort-nodes';
 import { ROOT_POINTER } from './constants';
 import { makePointer } from './utils';
@@ -11,7 +11,7 @@ import { ArrRestrictionKeys } from './restrictions';
 
 export const buildJsonSchema = (nodes: UiSchemaNodes): Dict => {
   const out: Dict = {};
-  const rootNode = getNodeByPointer(nodes, ROOT_POINTER);
+  const rootNode = getRootNode(nodes);
   Object.assign(out, rootNode.custom);
   JSONPointer.set(out, '/' + Keywords.Type, !rootNode.implicitType ? rootNode.fieldType : undefined);
   JSONPointer.set(out, '/' + Keywords.Required, findRequiredProps(nodes, rootNode.pointer));

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/capabilities.ts
@@ -1,6 +1,7 @@
 import type { UiSchemaNode } from './types';
 import { FieldType, ObjectKind } from './types';
 import { ROOT_POINTER } from './constants';
+import { pointerIsDefinition } from './utils';
 
 export enum Capabilites {
   CanBeConvertedToArray = 'CAN_BE_CONVERTED_TO_ARRAY', // no restrictions, not combination
@@ -31,7 +32,7 @@ export const getCapabilities = (node: UiSchemaNode): Capabilites[] => {
     output.push(Capabilites.CanBeConvertedToField);
   }
 
-  if (isArray || objectKind === ObjectKind.Field) {
+  if (!pointerIsDefinition(node.pointer)) {
     output.push(Capabilites.CanBeConvertedToReference);
   }
 

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/create-node.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/create-node.test.ts
@@ -31,19 +31,18 @@ test('that we can create nodes', () => {
 
 test('that we can insert nodes into the node array', () => {
   const uiSchemaNodes = buildUiSchema(complexJsonTestSchema);
-  uiSchemaNodes.forEach((uiNode) => {
-    const { objectKind, fieldType } = uiNode;
-    [true, false].forEach((isDefinition) => {
-      if (objectKind === ObjectKind.Combination || fieldType === FieldType.Object) {
+  uiSchemaNodes
+    .filter((uiNode) => uiNode.objectKind === ObjectKind.Combination || uiNode.fieldType === FieldType.Object)
+    .forEach((uiNode) => {
+      [true, false].forEach((isDefinition) => {
         const newNode = createChildNode(uiNode, 'hello', isDefinition);
         newNode.implicitType = false;
         const newUiSchema = insertSchemaNode(uiSchemaNodes, newNode);
         const builtJsonSchema = buildJsonSchema(newUiSchema);
         expect(validateSchema(builtJsonSchema)).toBeTruthy();
         expect(newUiSchema.length).toEqual(uiSchemaNodes.length + 1);
-      }
+      });
     });
-  });
 
   // Should not be mutated
   expect(uiSchemaNodes).toEqual(buildUiSchema(complexJsonTestSchema));

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/create-node.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/create-node.ts
@@ -1,12 +1,14 @@
 import { FieldType, Keywords, ObjectKind, UiSchemaNode, UiSchemaNodes } from '../types';
-import { createNodeBase, pointerExists } from '../utils';
-import { getParentNodeByPointer } from '../selectors';
+import { createNodeBase } from '../utils';
+import { getParentNodeByPointer, hasNodePointer } from '../selectors';
+import { deepCopy } from 'app-shared/pure';
 
 export const insertSchemaNode = (uiSchemaNodes: UiSchemaNodes, newNode: UiSchemaNode): UiSchemaNodes => {
-  if (pointerExists(uiSchemaNodes, newNode.pointer)) {
+  if (hasNodePointer(uiSchemaNodes, newNode.pointer)) {
     throw new Error(`Pointer ${newNode.pointer} exists allready`);
   }
-  const mutatedNodeArray: UiSchemaNodes = JSON.parse(JSON.stringify(uiSchemaNodes));
+
+  const mutatedNodeArray: UiSchemaNodes = deepCopy(uiSchemaNodes);
   const parentNode = getParentNodeByPointer(mutatedNodeArray, newNode.pointer);
   if (!parentNode) {
     throw new Error(`Can't find ParentNode for pointer ${newNode.pointer}`);

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/promote-node.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/promote-node.test.ts
@@ -5,9 +5,9 @@ import { makePointer } from '../utils';
 import { convertPropToType } from './promote-node';
 import { simpleTestJsonSchema } from '../../../test/testUtils';
 
-test('that we can promote a node', () => {
-  const originalNodeMap = buildUiSchema(simpleTestJsonSchema);
-  const promotedNodeMap = convertPropToType(originalNodeMap, makePointer(Keywords.Properties, 'world'));
+test('that we can convertPropToType', () => {
+  const uiSchemaNodes = buildUiSchema(simpleTestJsonSchema);
+  const promotedNodeMap = convertPropToType(uiSchemaNodes, makePointer(Keywords.Properties, 'world'));
   expect(buildJsonSchema(promotedNodeMap)).toEqual({
     [Keywords.Properties]: {
       hello: { [Keywords.Type]: FieldType.String },

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/promote-node.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/promote-node.ts
@@ -46,7 +46,7 @@ export const convertPropToType = (uiSchemaNodes: UiSchemaNodes, pointer: string)
   });
   // Add the promoted node back to the bottom of the stack.
   return insertSchemaNode(
-    updatedUiSchemaNodes,
+    [...updatedUiSchemaNodes],
     Object.assign(deepCopy(uiNode), {
       pointer: promotedNodePointer,
       children,

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/remove-node.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/remove-node.ts
@@ -1,20 +1,26 @@
 // Changes to the uiNodeMap
 import { ObjectKind, UiSchemaNode, UiSchemaNodes } from '../types';
-import { getNodeIndexByPointer, getParentNodeByPointer } from '../selectors';
+import { getParentNodeByPointer, getReferredNodes, hasNodePointer } from '../selectors';
 import { splitPointerInBaseAndName } from '../utils';
 
 export const removeNodeByPointer = (uiNodeMap: UiSchemaNodes, pointer: string, justChildren?: boolean) => {
   let mutatedUiNodeMap: UiSchemaNodes = [...uiNodeMap];
+
   // Remove the child node pointer from the parent
-  const uiSchemaNode = getNodeIndexByPointer(mutatedUiNodeMap, pointer);
-  if (!uiSchemaNode) {
+  if (!hasNodePointer(mutatedUiNodeMap, pointer)) {
     throw new Error(`Can't remove ${pointer}, doesn't exist`);
   }
+
+  // Won't remove containers that have references
+  if (getReferredNodes(mutatedUiNodeMap, pointer).length > 0) {
+    throw new Error(`Won't remove ${pointer}, it has reffered nodes.`);
+  }
+
   const parentNode = getParentNodeByPointer(mutatedUiNodeMap, pointer);
   if (parentNode) {
     parentNode.children = parentNode.children.filter((childPointer) => pointer !== childPointer);
   } else {
-    throw new Error(`Can't find ParentNode for pointer ${pointer}`);
+    throw new Error(`Can't remove ${pointer}, can't find parent node.`);
   }
 
   // Remove itself decendants... just using the pointer

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/remove-node.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/remove-node.ts
@@ -13,7 +13,7 @@ export const removeNodeByPointer = (uiNodeMap: UiSchemaNodes, pointer: string, j
 
   // Won't remove containers that have references
   if (getReferredNodes(mutatedUiNodeMap, pointer).length > 0) {
-    throw new Error(`Won't remove ${pointer}, it has reffered nodes.`);
+    throw new Error(`Won't remove ${pointer}, it has referred nodes.`);
   }
 
   const parentNode = getParentNodeByPointer(mutatedUiNodeMap, pointer);

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/rename-node.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/mutations/rename-node.ts
@@ -1,13 +1,13 @@
 import { CombinationKind, UiSchemaNodes } from '../types';
-import { getNodeByPointer } from '../selectors';
-import { pointerExists, splitPointerInBaseAndName } from '../utils';
+import { getNodeByPointer, hasNodePointer } from '../selectors';
+import { splitPointerInBaseAndName } from '../utils';
 
 export const renameNodePointer = (uiSchemaNodes: UiSchemaNodes, oldPointer: string, newPointer: string) => {
   if (oldPointer === newPointer) {
     throw new Error('Old and new name is equal');
   }
 
-  if (!pointerExists(uiSchemaNodes, oldPointer)) {
+  if (!hasNodePointer(uiSchemaNodes, oldPointer)) {
     const { base, name } = splitPointerInBaseAndName(oldPointer);
     if (Object.values(CombinationKind).includes(name as CombinationKind) && getNodeByPointer(uiSchemaNodes, base)) {
       // Its a valid combo-item... just continue.

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/selectors.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/selectors.test.ts
@@ -1,9 +1,10 @@
 import { buildUiSchema } from './build-ui-schema';
-import { getNodeByPointer, getParentNodeByPointer, getRootNode, getRootNodes } from './selectors';
+import { getNodeByPointer, getParentNodeByPointer, getReferredNodes, getRootNode, getRootNodes } from './selectors';
 import { expect } from '@jest/globals';
 import { getGeneralJsonSchemaForTest, selectorsTestSchema } from '../../test/testUtils';
 import { ROOT_POINTER } from './constants';
 import { makePointer } from './utils';
+import { dataMock } from '../../../schema-editor/src/mockData';
 
 const testSchema = getGeneralJsonSchemaForTest('ElementAnnotation');
 
@@ -48,4 +49,11 @@ test('that getRootNode throws at undefined pointer', () => {
   expect(() => {
     getRootNode([]);
   }).toThrow();
+});
+
+test('that we can get referred nodes', () => {
+  const uiSchemaNodes = buildUiSchema(dataMock);
+  const referedNodes = getReferredNodes(uiSchemaNodes, '#/$defs/RA-0678_M');
+  expect(referedNodes).toHaveLength(1);
+  expect(referedNodes[0].pointer).toBe('#/properties/melding');
 });

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/selectors.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/selectors.ts
@@ -54,9 +54,7 @@ export const getNodeIndexByPointer = (uiSchemaNodes: UiSchemaNodes, pointer: str
 
 export const getChildNodesByPointer = (uiSchemaNodes: UiSchemaNodes, pointer: string): UiSchemaNode[] => {
   const parentNode = getNodeByPointer(uiSchemaNodes, pointer);
-  const childNodes: UiSchemaNodes = [];
-  parentNode.children.forEach((childPointer) => childNodes.push(getNodeByPointer(uiSchemaNodes, childPointer)));
-  return childNodes;
+  return parentNode.children.map((childPointer) => getNodeByPointer(uiSchemaNodes, childPointer));
 };
 
 export const getParentNodeByPointer = (uiSchemaNodes: UiSchemaNodes, pointer: string): UiSchemaNode | undefined => {
@@ -80,13 +78,9 @@ export const getReferredNodes = (uiSchemaNodes: UiSchemaNodes, ref: string) => {
   if (referredNodes.uiSchemaNodes !== uiSchemaNodes || referredNodes.cache.size === 0) {
     referredNodes.uiSchemaNodes = uiSchemaNodes;
     referredNodes.cache = new Map();
-    uiSchemaNodes.forEach((uiSchemaNode) => {
-      if (uiSchemaNode.ref === ref) {
-        const nodes = referredNodes.cache.get(ref) ?? [];
-        nodes.push(uiSchemaNode);
-        referredNodes.cache.set(ref, nodes);
-      }
-    });
+    uiSchemaNodes
+      .filter((node) => node.ref)
+      .forEach((node) => referredNodes.cache.set(node.ref, [...(referredNodes.cache.get(ref) ?? []), node]));
   }
   return referredNodes.cache.get(ref) ?? [];
 };

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/selectors.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/selectors.ts
@@ -79,8 +79,8 @@ export const getReferredNodes = (uiSchemaNodes: UiSchemaNodes, ref: string) => {
     referredNodes.uiSchemaNodes = uiSchemaNodes;
     referredNodes.cache = new Map();
     uiSchemaNodes
-      .filter((node) => node.ref)
-      .forEach((node) => referredNodes.cache.set(node.ref, [...(referredNodes.cache.get(ref) ?? []), node]));
+      .filter((node) => typeof node.ref === 'string')
+      .forEach((node) => referredNodes.cache.set(node.ref ?? '_', [...(referredNodes.cache.get(ref) ?? []), node]));
   }
   return referredNodes.cache.get(ref) ?? [];
 };

--- a/src/studio/src/designer/frontend/packages/schema-model/src/lib/utils.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import type { Dict, UiSchemaNode, UiSchemaNodes } from './types';
 import { CombinationKind, FieldType, Keywords, ObjectKind } from './types';
-import { getNodeIndexByPointer } from './selectors';
+import { hasNodePointer } from './selectors';
 import { ROOT_POINTER } from './constants';
 
 export const createNodeBase = (...args: string[]): UiSchemaNode => ({
@@ -63,9 +63,6 @@ export const splitPointerInBaseAndName = (pointer: string) => {
 
 export const pointerIsDefinition = (pointer: string) => pointer.startsWith(makePointer(Keywords.Definitions));
 
-export const pointerExists = (uiSchemaNodes: UiSchemaNodes, pointer: string): boolean =>
-  getNodeIndexByPointer(uiSchemaNodes, pointer) !== undefined;
-
 export const combinationIsNullable = (childNodes: UiSchemaNode[]): boolean =>
   childNodes.some((child) => child.fieldType === FieldType.Null);
 
@@ -74,7 +71,7 @@ export const getNodeDisplayName = (uiSchemaNode: UiSchemaNode) => uiSchemaNode.p
 export const getUniqueNodePath = (uiNodeMap: UiSchemaNodes, targetPointer: string): string => {
   let newPointer = targetPointer;
   let postfix = 0;
-  while (pointerExists(uiNodeMap, newPointer)) {
+  while (hasNodePointer(uiNodeMap, newPointer)) {
     newPointer = targetPointer + postfix;
     postfix++;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To solve this issue we need to search for referred nodes in the node array. This is inefficient, so this branch introduces also an cached index(internal to the script) for both referred items and node pointers. This actually significantly improves speed in the datamodelling view.

## Related Issue(s)
- #7249

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
