### PR TITLE
9108 clicking on a type in tree view should openfocus that specific type

### DIFF
--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
@@ -90,7 +90,7 @@ export function ItemDataComponent({ language, selectedItem }: IItemDataComponent
   const onGoToDefButtonClick = () => {
     const ref = selectedItem.ref;
     if (ref !== undefined) {
-      dispatch(navigateToType({ id: ref }));
+      dispatch(navigateToType({ pointer: ref }));
     }
   };
 

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
@@ -52,9 +52,14 @@ export function SchemaItem({ selectedNode, isPropertiesView, editMode, translate
     const node = childNodes.find((node) => node.pointer === childPointer);
     node && childNodesSorted.push(node);
   });
+  const selectedPointer = useSelector((state: ISchemaState) =>
+    state.selectedEditorTab === 'definitions' ? state.selectedDefinitionNodeId : state.selectedPropertyNodeId,
+  );
   const onLabelClick = (e: any, schemaItem: UiSchemaNode) => {
     e.preventDefault();
-    dispatch(setSelectedId({ id: schemaItem.pointer }));
+    if (selectedPointer !== schemaItem.pointer) {
+      dispatch(setSelectedId({ pointer: schemaItem.pointer }));
+    }
   };
   const isRef = selectedNode.objectKind === ObjectKind.Reference;
   const { base } = splitPointerInBaseAndName(selectedNode.pointer);

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TreeView/SchemaItemLabel.tsx
@@ -6,7 +6,8 @@ import {
   CombinationKind,
   FieldType,
   getCapabilities,
-  getNodeDisplayName, Keywords,
+  getNodeDisplayName,
+  Keywords,
   ObjectKind,
   pointerIsDefinition,
   UiSchemaNode,
@@ -53,7 +54,7 @@ export const SchemaItemLabel = ({
     };
   };
 
-  const handleGoToType = () => dispatch(navigateToType({ id: selectedNode.ref }));
+  const handleGoToType = wrapper(() => dispatch(navigateToType({ pointer: selectedNode.ref })));
   const handleConvertToReference = wrapper(() => dispatch(promoteProperty({ path: selectedNode.pointer })));
   const handleConvertToField = wrapper(() => dispatch(promoteProperty({ path: selectedNode.pointer })));
   const handleCloseContextMenu = wrapper(() => undefined);

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
@@ -85,7 +85,6 @@ describe('SchemaEditorSlice', () => {
         name: 'navn_endret',
       }),
     );
-    let item = getNodeByPointer(nextState.uiSchema, '#/$defs/Kontaktperson/properties/navn_endret');
     expect(nextState.uiSchema).not.toHaveProperty('#/$defs/Kontaktperson/properties/navn');
 
     // test that child paths are also updated
@@ -96,7 +95,7 @@ describe('SchemaEditorSlice', () => {
         name: 'batman',
       }),
     );
-    item = getNodeByPointer(nextState.uiSchema, '#/$defs/batman');
+    const item = getNodeByPointer(nextState.uiSchema, '#/$defs/batman');
     expect(item.children).toContain('#/$defs/batman/properties/navn_endret');
   });
 
@@ -127,26 +126,26 @@ describe('SchemaEditorSlice', () => {
   });
 
   it('handles setSelectedId', () => {
-    const payload = {
-      id: '#/$defs/Kommentar2000Restriksjon',
-    };
-    const nextState = reducer({ ...state, selectedEditorTab: 'definitions' }, setSelectedId(payload));
+    const nextState = reducer(
+      { ...state, selectedEditorTab: 'definitions' },
+      setSelectedId({ pointer: '#/$defs/Kommentar2000Restriksjon' }),
+    );
     expect(nextState.selectedDefinitionNodeId).toEqual('#/$defs/Kommentar2000Restriksjon');
   });
 
   it('handles setSelectedId by properties tab', () => {
-    const payload = {
-      id: '#/properties/someField',
-    };
-    const nextState = reducer({ ...state, selectedEditorTab: 'properties' }, setSelectedId(payload));
+    const nextState = reducer(
+      { ...state, selectedEditorTab: 'properties' },
+      setSelectedId({ pointer: '#/properties/someField' }),
+    );
     expect(nextState.selectedPropertyNodeId).toEqual('#/properties/someField');
   });
 
   it('handles navigateToType', () => {
-    const payload = {
-      id: '#/$defs/someField',
-    };
-    const nextState = reducer({ ...state, selectedEditorTab: 'properties' }, navigateToType(payload));
+    const nextState = reducer(
+      { ...state, selectedEditorTab: 'properties' },
+      navigateToType({ pointer: '#/$defs/someField' }),
+    );
     expect(nextState.selectedEditorTab).toEqual('definitions');
     expect(nextState.selectedDefinitionNodeId).toEqual('#/$defs/someField');
   });

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
@@ -217,16 +217,15 @@ const schemaEditorSlice = createSlice({
       const { name } = action.payload;
       state.name = name;
     },
-    setSaveSchemaUrl(state, action: PayloadAction<{ saveUrl: string}>) {
+    setSaveSchemaUrl(state, action: PayloadAction<{ saveUrl: string }>) {
       const { saveUrl } = action.payload;
       state.saveSchemaUrl = saveUrl;
     },
-    setSelectedId(state, action: PayloadAction<{ id: string; focusName?: string }>) {
-      const { id, focusName } = action.payload;
+    setSelectedId(state, action: PayloadAction<{ pointer: string; focusName?: string }>) {
+      const { pointer, focusName } = action.payload;
       state.focusNameField = focusName;
-      state.selectedEditorTab === 'definitions'
-        ? (state.selectedDefinitionNodeId = id)
-        : (state.selectedPropertyNodeId = id);
+      const key = state.selectedEditorTab === 'definitions' ? 'selectedDefinitionNodeId' : 'selectedPropertyNodeId';
+      state[key] !== pointer ? (state[key] = pointer) : undefined;
     },
     setUiSchema(state, action: PayloadAction<{ name: string }>) {
       const { name } = action.payload;
@@ -248,11 +247,13 @@ const schemaEditorSlice = createSlice({
       const { selectedTab } = action.payload;
       state.selectedEditorTab = selectedTab;
     },
-    navigateToType(state, action: PayloadAction<{ id?: string }>) {
-      const { id } = action.payload;
-      if (id) {
-        state.selectedEditorTab = 'definitions';
-        state.selectedDefinitionNodeId = id;
+    navigateToType(state, action: PayloadAction<{ pointer?: string }>) {
+      const { pointer } = action.payload;
+      if (pointer) {
+        Object.assign(state, {
+          selectedEditorTab: 'definitions',
+          selectedDefinitionNodeId: pointer,
+        });
       }
     },
     toggleArrayField(state, action: PayloadAction<{ pointer: string }>) {

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
@@ -225,7 +225,9 @@ const schemaEditorSlice = createSlice({
       const { pointer, focusName } = action.payload;
       state.focusNameField = focusName;
       const key = state.selectedEditorTab === 'definitions' ? 'selectedDefinitionNodeId' : 'selectedPropertyNodeId';
-      state[key] !== pointer ? (state[key] = pointer) : undefined;
+      Object.assign(state, {
+        [key]: pointer,
+      });
     },
     setUiSchema(state, action: PayloadAction<{ name: string }>) {
       const { name } = action.payload;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was a bug in the way this click was handled. Fix was fairly easy. This PR also fixes some naming convetions. Mainly `path` to `pointer` and `id` to `pointer`. We also now makes a click not dispatch a navigate payload when an node/item is already selected.

## Related Issue(s)
- #9108

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
