### PR TITLE
Make focus and select behave correctly when adding fields

### DIFF
--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.test.tsx
@@ -1,0 +1,142 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { renderWithRedux } from '../../../test/renderWithRedux';
+import { ItemFieldsTab, ItemFieldsTabProps } from './ItemFieldsTab';
+import {
+  createChildNode,
+  createNodeBase,
+  FieldType,
+  Keywords,
+  ObjectKind,
+  UiSchemaNode,
+  UiSchemaNodes
+} from '@altinn/schema-model';
+
+// Test data:
+const selectedItem: UiSchemaNode = {
+  ...createNodeBase(Keywords.Properties, 'test'),
+  objectKind: ObjectKind.Field,
+  fieldType: FieldType.Object,
+};
+const fieldNames = ['Donald', 'Dolly'];
+const childNodes = fieldNames.map((childNodeName) => ({
+  ...createChildNode(selectedItem, childNodeName, false),
+  fieldType: FieldType.String
+}));
+const numberOfFields = fieldNames.length;
+selectedItem.children = childNodes.map(({ pointer }) => pointer);
+const uiSchema: UiSchemaNodes = [selectedItem, ...childNodes];
+const textRequired = 'Required';
+const textDelete = 'Delete';
+const textAdd = 'Legg til felt';
+const language = {
+  schema_editor: {
+    add_property: textAdd,
+    delete_field: textDelete,
+    required: textRequired,
+  }
+};
+const defaultProps: ItemFieldsTabProps = {
+  language,
+  selectedItem
+};
+const defaultState = { uiSchema };
+
+const renderItemFieldsTab = (props?: Partial<ItemFieldsTabProps>, state?: any) => renderWithRedux(
+  <ItemFieldsTab { ...defaultProps } { ...props } />,
+  { ...defaultState, ...state }
+);
+
+test('Inputs and delete buttons appear for all fields', () => {
+  renderItemFieldsTab();
+  const textboxes = screen.getAllByRole('textbox');
+  expect(textboxes).toHaveLength(numberOfFields);
+  textboxes.forEach((textbox, i) => expect(textbox).toHaveValue(fieldNames[i]));
+  expect(screen.getAllByRole('checkbox')).toHaveLength(numberOfFields);
+  expect(screen.queryAllByLabelText(textDelete)).toHaveLength(numberOfFields);
+});
+
+test('"Add property" button appears', () => {
+  renderItemFieldsTab();
+  expect(screen.getByText(textAdd)).toBeDefined();
+});
+
+test('setPropertyName action is called with correct payload when a name is changed', async () => {
+  const { user, store } = renderItemFieldsTab();
+  const suffix = 'Duck';
+  for (const fieldName of fieldNames) {
+    await user.type(screen.getByDisplayValue(fieldName), suffix);
+    await user.tab();
+  }
+  const setPropertyNameActions = store.getActions().filter(action => action.type === 'schemaEditor/setPropertyName');
+  expect(setPropertyNameActions).toHaveLength(numberOfFields);
+  setPropertyNameActions.forEach((action, i) => {
+    expect(action.payload.name).toEqual(fieldNames[i] + suffix);
+    expect(action.payload.path).toEqual(childNodes[i].pointer);
+  });
+});
+
+test('addProperty action is called with correct payload when the "Add property" button is clicked', async () => {
+  const { user, store } = renderItemFieldsTab();
+  await user.click(screen.getByText(textAdd));
+  const addPropertyActions = store.getActions().filter(action => action.type === 'schemaEditor/addProperty');
+  expect(addPropertyActions).toHaveLength(1);
+  expect(addPropertyActions[0].payload.pointer).toEqual(selectedItem.pointer);
+});
+
+test(
+  'addProperty action is calledd with correct payload when a field is focused and the Enter key is clicked',
+  async () => {
+    const { user, store } = renderItemFieldsTab();
+    await user.click(screen.getAllByRole('textbox')[0]);
+    await user.keyboard('{Enter}');
+    const addPropertyActions = store.getActions().filter(action => action.type === 'schemaEditor/addProperty');
+    expect(addPropertyActions).toHaveLength(1);
+    expect(addPropertyActions[0].payload.pointer).toEqual(selectedItem.pointer);
+  }
+);
+
+test('deleteProperty action is called with correct payload when delete button is clicked', async () => {
+  const { user, store } = renderItemFieldsTab();
+  for (const i in fieldNames) {
+    await user.click(screen.queryAllByLabelText(textDelete)[i]);
+  }
+  const setPropertyNameActions = store.getActions().filter(action => action.type === 'schemaEditor/deleteProperty');
+  expect(setPropertyNameActions).toHaveLength(numberOfFields);
+  setPropertyNameActions.forEach((action, i) => expect(action.payload.path).toEqual(childNodes[i].pointer));
+});
+
+test('Newly added field gets focus and its text becomes selected', async () => {
+  const { user, rerenderWithRedux } = renderItemFieldsTab();
+  const newChildNodeName = 'Skrue';
+  const newChildNode = {
+    ...createChildNode(selectedItem, newChildNodeName, false),
+    fieldType: FieldType.String,
+  };
+  const newSelectedItem = { ...selectedItem, children: [...selectedItem.children, newChildNode.pointer] };
+  const newUiSchema = [...uiSchema, newChildNode];
+  rerenderWithRedux(
+    <ItemFieldsTab {...defaultProps} selectedItem={newSelectedItem} />,
+    { uiSchema: newUiSchema },
+  );
+  expect(screen.getByDisplayValue(newChildNodeName)).toHaveFocus();
+  await user.keyboard('a'); // Should replace the current value since the text should be selected
+  expect(screen.getByDisplayValue('a')).toBeDefined();
+  expect(screen.queryByDisplayValue(newChildNodeName)).toBeFalsy();
+});
+
+test('Inputs are enabled by default', () => {
+  renderItemFieldsTab();
+  screen.queryAllByRole("textbox").forEach((input) => expect(input).toBeEnabled());
+  screen.queryAllByRole("checkbox").forEach((input) => expect(input).toBeEnabled());
+});
+
+test('Inputs are disabled if the selected item is a reference', () => {
+  const referencedNode = createNodeBase(Keywords.Definitions, 'testtype');
+  renderItemFieldsTab(
+    { selectedItem: { ...selectedItem, objectKind: ObjectKind.Reference, ref: referencedNode.pointer } },
+    { uiSchema: [...uiSchema, referencedNode]},
+  );
+  screen.queryAllByRole("textbox").forEach((input) => expect(input).toBeDisabled());
+  screen.queryAllByRole("checkbox").forEach((input) => expect(input).toBeDisabled());
+});

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.test.tsx
@@ -114,7 +114,7 @@ test('Newly added field gets focus and its text becomes selected', async () => {
     fieldType: FieldType.String,
   };
   const newSelectedItem = { ...selectedItem, children: [...selectedItem.children, newChildNode.pointer] };
-  const newUiSchema = [...uiSchema, newChildNode];
+  const newUiSchema = [newSelectedItem, ...childNodes, newChildNode];
   rerenderWithRedux(
     <ItemFieldsTab {...defaultProps} selectedItem={newSelectedItem} />,
     { uiSchema: newUiSchema },

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
@@ -1,4 +1,4 @@
-import React, { BaseSyntheticEvent } from 'react';
+import React, { BaseSyntheticEvent, useEffect } from 'react';
 import { AddPropertyButton } from './AddPropertyButton';
 import type { ILanguage, ISchemaState } from '../../types';
 import { PropertyItem } from './PropertyItem';
@@ -8,14 +8,31 @@ import { getTranslation } from '../../utils/language';
 import type { UiSchemaNode } from '@altinn/schema-model';
 import { getChildNodesByNode, getNodeDisplayName } from '@altinn/schema-model';
 import classes from './ItemFieldsTab.module.css';
+import { getDomFriendlyID } from '../../utils/ui-schema-utils';
+import { usePrevious } from '../../hooks/usePrevious';
 
-interface ItemFieldsTabProps {
+export interface ItemFieldsTabProps {
   selectedItem: UiSchemaNode;
   language: ILanguage;
 }
 export const ItemFieldsTab = ({ selectedItem, language }: ItemFieldsTabProps) => {
   const readonly = selectedItem.ref !== undefined;
   const dispatch = useDispatch();
+
+  const childNodes = useSelector((state: ISchemaState) => getChildNodesByNode(state.uiSchema, selectedItem));
+
+  const numberOfChildNodes = childNodes.length;
+  const prevNumberOfChildNodes = usePrevious<number>(numberOfChildNodes) ?? 0;
+
+  useEffect(() => {
+    if (numberOfChildNodes > prevNumberOfChildNodes) {
+      const newNodeId = propertyInputIdFromNode(childNodes[childNodes.length - 1]);
+      const newNodeInput = document.getElementById(newNodeId) as HTMLInputElement;
+      newNodeInput?.focus();
+      newNodeInput?.select();
+    }
+  }, [numberOfChildNodes])
+
   const onChangePropertyName = (path: string, value: string) =>
     dispatch(
       setPropertyName({
@@ -39,20 +56,21 @@ export const ItemFieldsTab = ({ selectedItem, language }: ItemFieldsTabProps) =>
     event.preventDefault();
     dispatchAddProperty();
   };
-  const childNodes = useSelector((state: ISchemaState) => getChildNodesByNode(state.uiSchema, selectedItem));
+
   return (
     <div className={classes.root}>
       {childNodes.map((childNode) => (
         <PropertyItem
-          language={language}
-          key={childNode.pointer}
-          required={childNode.isRequired}
-          readOnly={readonly}
-          value={getNodeDisplayName(childNode)}
           fullPath={childNode.pointer}
+          inputId={propertyInputIdFromNode(childNode)}
+          key={childNode.pointer}
+          language={language}
           onChangeValue={onChangePropertyName}
           onDeleteField={onDeleteObjectClick}
           onEnterKeyPress={dispatchAddProperty}
+          readOnly={readonly}
+          required={childNode.isRequired}
+          value={getNodeDisplayName(childNode)}
         />
       ))}
       {!readonly && (
@@ -66,3 +84,5 @@ export const ItemFieldsTab = ({ selectedItem, language }: ItemFieldsTabProps) =>
     </div>
   );
 };
+
+const propertyInputIdFromNode = (node: UiSchemaNode) => getDomFriendlyID(node.pointer, 'input');

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
@@ -25,13 +25,14 @@ export const ItemFieldsTab = ({ selectedItem, language }: ItemFieldsTabProps) =>
   const prevNumberOfChildNodes = usePrevious<number>(numberOfChildNodes) ?? 0;
 
   useEffect(() => {
+    // If the number of fields has increased, a new field has been added and should get focus
     if (numberOfChildNodes > prevNumberOfChildNodes) {
       const newNodeId = propertyInputIdFromNode(childNodes[childNodes.length - 1]);
       const newNodeInput = document.getElementById(newNodeId) as HTMLInputElement;
       newNodeInput?.focus();
       newNodeInput?.select();
     }
-  }, [numberOfChildNodes])
+  }, [numberOfChildNodes, prevNumberOfChildNodes, childNodes])
 
   const onChangePropertyName = (path: string, value: string) =>
     dispatch(

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/PropertyItem.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/PropertyItem.test.tsx
@@ -6,19 +6,28 @@ import { renderWithRedux } from '../../../test/renderWithRedux';
 // Test data:
 const textRequired = 'Required';
 const textDelete = 'Delete';
+const fullPath = 'test';
+const inputId = 'some-random-id';
+const value = '';
 const mockLanguage = {
   schema_editor: {
+    delete_field: textDelete,
     required: textRequired,
-    delete_field: textDelete
   }
+};
+const defaultProps: IPropertyItemProps = {
+  fullPath,
+  inputId,
+  language: mockLanguage,
+  onChangeValue: jest.fn(),
+  onDeleteField: jest.fn(),
+  onEnterKeyPress: jest.fn(),
+  value,
 };
 
 const renderPropertyItem = (props?: Partial<IPropertyItemProps>) => renderWithRedux(
   <PropertyItem
-    fullPath='test'
-    language={mockLanguage}
-    onChangeValue={jest.fn}
-    value=''
+    {...defaultProps}
     {...props}
   />
 );
@@ -54,7 +63,7 @@ test('onChangeValue is called on blur when text changes', async () => {
   const {user} = renderPropertyItem({onChangeValue});
   await user.type(screen.getByRole('textbox'), 'test');
   await user.tab();
-  expect(onChangeValue).toHaveBeenCalled();
+  expect(onChangeValue).toHaveBeenCalledTimes(1);
 });
 
 test('onChangeValue is not called when there is no change', async () => {
@@ -83,6 +92,11 @@ test('onEnterKeyPress is not called when another key but Enter is pressed in the
   expect(onEnterKeyPress).not.toHaveBeenCalled();
 });
 
+test('Name input field has given id', async () => {
+  const { container } = renderPropertyItem().renderResult;
+  expect(container.querySelector(`#${inputId}`)).toBeDefined();
+});
+
 test('"Required" checkbox appears', () => {
   renderPropertyItem();
   expect(screen.getByRole('checkbox')).toBeDefined();
@@ -108,13 +122,23 @@ test('"Required" label appears on screen', () => {
   expect(screen.getByText(textRequired)).toBeDefined();
 });
 
-test('Delete button does not appear by default', () => {
+test('"Required" checkbox is enabled by default', () => {
   renderPropertyItem();
-  expect(screen.queryAllByRole('button')).toHaveLength(0);
+  expect(screen.getByRole('checkbox')).toBeEnabled();
 });
 
-test('Delete button appears if onDeleteField is defined', () => {
-  renderPropertyItem({onDeleteField: jest.fn});
+test('"Required" checkbox is disabled if the "readOnly" prop is true', () => {
+  renderPropertyItem({ readOnly: true });
+  expect(screen.getByRole('textbox')).toBeDisabled();
+});
+
+test('"Required" checkbox is enabled if the "readOnly" prop is false', () => {
+  renderPropertyItem({ readOnly: false });
+  expect(screen.getByRole('checkbox')).toBeEnabled();
+});
+
+test('Delete button appears', () => {
+  renderPropertyItem();
   expect(screen.getByRole('button')).toBeDefined();
 });
 
@@ -122,10 +146,10 @@ test('onDeleteField is called when the delete button is clicked', async () => {
   const onDeleteField = jest.fn();
   const {user} = renderPropertyItem({onDeleteField});
   await user.click(screen.getByRole('button'));
-  expect(onDeleteField).toHaveBeenCalled();
+  expect(onDeleteField).toHaveBeenCalledTimes(1);
 });
 
 test('Delete button is labelled with the delete text', async () => {
-  renderPropertyItem({onDeleteField: jest.fn});
+  renderPropertyItem();
   expect(screen.getByRole('button')).toHaveAccessibleName(textDelete);
 });

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/PropertyItem.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/PropertyItem.tsx
@@ -20,54 +20,64 @@ export interface IPropertyItemProps {
   value: string;
 }
 
-export function PropertyItem(props: IPropertyItemProps) {
-  const [value, setValue] = useState<string>(props.value || '');
+export function PropertyItem({
+  fullPath,
+  inputId,
+  language,
+  onChangeValue,
+  onDeleteField,
+  onEnterKeyPress,
+  readOnly,
+  required,
+  value,
+}: IPropertyItemProps) {
+  const [inputValue, setInputValue] = useState<string>(value || '');
   const dispatch = useDispatch();
 
-  useEffect(() => setValue(props.value), [props.value]);
-  const onChangeValue: ChangeEventHandler<HTMLInputElement> = (e) => setValue(e.target.value);
+  useEffect(() => setInputValue(value), [value]);
+  const changeValueHandler: ChangeEventHandler<HTMLInputElement> = (e) => setInputValue(e.target.value);
 
   const onBlur: FocusEventHandler<HTMLInputElement> = (e) => {
-    if (value !== props.value) {
-      props.onChangeValue(props.fullPath, e.target.value);
+    if (inputValue !== value) {
+      onChangeValue(fullPath, e.target.value);
     }
   };
 
-  const onClickDelete = () => props.onDeleteField?.(props.fullPath, props.value);
+  const deleteHandler = () => onDeleteField?.(fullPath, value);
 
-  const onChangeRequired: ChangeEventHandler<HTMLInputElement> = (e) =>
+  const changeRequiredHandler: ChangeEventHandler<HTMLInputElement> = (e) =>
     dispatch(
       setRequired({
-        path: props.fullPath,
+        path: fullPath,
         required: e.target.checked,
       }),
     );
 
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) =>
-    e?.key === 'Enter' && props.onEnterKeyPress && props.onEnterKeyPress();
+    e?.key === 'Enter' && onEnterKeyPress && onEnterKeyPress();
 
   return (
     <div className={classes.root}>
       <span className={classes.nameInputCell}>
         <TextField
-          id={props.inputId}
-          value={value}
-          disabled={props.readOnly}
-          onChange={onChangeValue}
+          id={inputId}
+          value={inputValue}
+          disabled={readOnly}
+          onChange={changeValueHandler}
           onBlur={onBlur}
           onKeyDown={onKeyDown}
         />
       </span>
       <Checkbox
-        checked={props.required ?? false}
-        disabled={props.readOnly}
-        onChange={onChangeRequired}
+        checked={required ?? false}
+        disabled={readOnly}
+        onChange={changeRequiredHandler}
         name='checkedArray'
-        label={getTranslation('required', props.language)}
+        label={getTranslation('required', language)}
       />
       <IconButton
-        aria-label={getTranslation('delete_field', props.language)}
-        onClick={onClickDelete}
+        aria-label={getTranslation('delete_field', language)}
+        onClick={deleteHandler}
         className={classes.delete}
       >
         <DeleteOutline />

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/PropertyItem.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/PropertyItem.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent, useEffect, useState } from 'react';
+import React, { ChangeEventHandler, FocusEventHandler, KeyboardEvent, useEffect, useState } from 'react';
 import { IconButton } from '@material-ui/core';
 import { useDispatch } from 'react-redux';
 import { DeleteOutline } from '@material-ui/icons';
@@ -6,18 +6,18 @@ import type { ILanguage } from '../../types';
 import { getTranslation } from '../../utils/language';
 import { setRequired } from '../../features/editor/schemaEditorSlice';
 import { Checkbox, TextField } from '@altinn/altinn-design-system';
-import { getDomFriendlyID, getUniqueNumber } from '../../utils/ui-schema-utils';
 import classes from './PropertyItem.module.css';
 
 export interface IPropertyItemProps {
-  value: string;
   fullPath: string;
+  inputId: string;
   language: ILanguage;
-  required?: boolean;
   onChangeValue: (path: string, value: string) => void;
-  onDeleteField?: (path: string, key: string) => void;
+  onDeleteField: (path: string, key: string) => void;
+  onEnterKeyPress: () => void;
   readOnly?: boolean;
-  onEnterKeyPress?: () => void;
+  required?: boolean;
+  value: string;
 }
 
 export function PropertyItem(props: IPropertyItemProps) {
@@ -25,9 +25,9 @@ export function PropertyItem(props: IPropertyItemProps) {
   const dispatch = useDispatch();
 
   useEffect(() => setValue(props.value), [props.value]);
-  const onChangeValue = (e: any) => setValue(e.target.value);
+  const onChangeValue: ChangeEventHandler<HTMLInputElement> = (e) => setValue(e.target.value);
 
-  const onBlur = (e: any) => {
+  const onBlur: FocusEventHandler<HTMLInputElement> = (e) => {
     if (value !== props.value) {
       props.onChangeValue(props.fullPath, e.target.value);
     }
@@ -35,7 +35,7 @@ export function PropertyItem(props: IPropertyItemProps) {
 
   const onClickDelete = () => props.onDeleteField?.(props.fullPath, props.value);
 
-  const onChangeRequired = (e: any) =>
+  const onChangeRequired: ChangeEventHandler<HTMLInputElement> = (e) =>
     dispatch(
       setRequired({
         path: props.fullPath,
@@ -46,14 +46,12 @@ export function PropertyItem(props: IPropertyItemProps) {
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) =>
     e?.key === 'Enter' && props.onEnterKeyPress && props.onEnterKeyPress();
 
-  const baseId = getDomFriendlyID(props.fullPath, 'key-');
   return (
     <div className={classes.root}>
       <span className={classes.nameInputCell}>
         <TextField
-          id={`${baseId}-key-${getUniqueNumber()}`}
+          id={props.inputId}
           value={value}
-          autoFocus
           disabled={props.readOnly}
           onChange={onChangeValue}
           onBlur={onBlur}
@@ -62,20 +60,18 @@ export function PropertyItem(props: IPropertyItemProps) {
       </span>
       <Checkbox
         checked={props.required ?? false}
+        disabled={props.readOnly}
         onChange={onChangeRequired}
         name='checkedArray'
         label={getTranslation('required', props.language)}
       />
-      {props.onDeleteField && (
-        <IconButton
-          id={`${baseId}-delete-${getUniqueNumber()}`}
-          aria-label={getTranslation('delete_field', props.language)}
-          onClick={onClickDelete}
-          className={classes.delete}
-        >
-          <DeleteOutline />
-        </IconButton>
-      )}
+      <IconButton
+        aria-label={getTranslation('delete_field', props.language)}
+        onClick={onClickDelete}
+        className={classes.delete}
+      >
+        <DeleteOutline />
+      </IconButton>
     </div>
   );
 }

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/hooks/usePrevious.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/hooks/usePrevious.ts
@@ -1,0 +1,10 @@
+import { useEffect, useRef } from 'react';
+
+export function usePrevious<T>(value: T) {
+  const ref = useRef<T>();
+  useEffect(
+    () => { ref.current = value },
+    [value]
+  );
+  return ref.current;
+}

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/utils/ui-schema-utils.ts
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/utils/ui-schema-utils.ts
@@ -1,5 +1,5 @@
-export const getDomFriendlyID = (input: string, postfix?: string): string =>
-  input.replace(/\//g, '').replace('#', '') + (postfix ? '-' + postfix : '');
+export const getDomFriendlyID = (input: string, suffix?: string): string =>
+  input.replace(/\//g, '').replace('#', '') + (suffix ? '-' + suffix : '');
 
 export const isValidName = (name: string) => Boolean(name.match(/^[a-zA-ZæÆøØåÅ][a-zA-Z0-9_.\-æÆøØåÅ ]*$/));
 

--- a/src/studio/src/designer/frontend/packages/schema-editor/test/renderWithRedux.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/test/renderWithRedux.tsx
@@ -8,5 +8,9 @@ export const renderWithRedux = (element: JSX.Element, state?: any) => {
   const store = configureStore()(state ?? {});
   const user = userEvent.setup();
   const renderResult = render(<Provider store={store}>{element}</Provider>);
-  return { store, user, renderResult };
+  const rerenderWithRedux = (element: JSX.Element, newState?: any) => {
+    const newStore = configureStore()(newState ?? {});
+    renderResult.rerender(<Provider store={newStore}>{element}</Provider>);
+  };
+  return { store, user, renderResult, rerenderWithRedux };
 };


### PR DESCRIPTION
## Description
Since the `PropertyIem` components rerender with a new key when their name is changed, the `autoFocus` property in the TextField component doesn't serve its intended purpose. This is what causes the strange focus behaviour in the "fields" tab. I have fixed it by adding a `useProvious` hook, which is used to compare the number of fields between each rerender and focus and select the text in the last field if the number has increased.

## Related Issue(s)
- #9066

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
