### PR TITLE
change all refs to altinn3.no changed to go to altinn.localhost

### DIFF
--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -22,12 +22,7 @@ purposes. See deployment for notes on how to deploy the project on a live system
 4. A code editor - we like [Visual Studio Code][5]
    - Also install [recommended extensions][6] (f.ex. [C#][7])
 5. [Docker Desktop][8]
-6. Update hosts file (`C:/Windows/System32/drivers/etc/hosts`) by adding the following values as an local administrator:
-   ```txt
-   localhost altinn3.no
-   127.0.0.1 altinn3.no
-   ```
-   _On MacOS add the same values to values `/private/etc/hosts` with `sudo nano /private/etc/hosts` in treminal._
+6. _On MacOS add `127.0.0.1 altinn.localhost` to `/private/etc/hosts` to enable access from Safari.
 7. If you are running Docker Desktop in Hyper-V mode you need to make sure your C drive is shared with Docker, Docker
    Settings -> Shared Drives The File sharing tab is only available in Hyper-V mode, because in WSL 2 mode and Windows
    container mode all files are automatically shared by Windows.
@@ -50,7 +45,7 @@ Run all parts of the solution in containers (Make sure docker is running)
 docker-compose up -d --build
 ```
 
-The solution is now available locally at [altinn3.no](http://altinn3.no). (Just create a new user for testing. No email
+The solution is now available locally at [local.altinn.studio](http://local.altinn.studio). (Just create a new user for testing. No email
 verification required)
 
 If you make changes and want to rebuild a specific project using docker-compose this can be done using

--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -45,7 +45,7 @@ Run all parts of the solution in containers (Make sure docker is running)
 docker-compose up -d --build
 ```
 
-The solution is now available locally at [local.altinn.studio](http://local.altinn.studio). (Just create a new user for testing. No email
+The solution is now available locally at [altinn.localhost](http://altinn.localhost). (Just create a new user for testing. No email
 verification required)
 
 If you make changes and want to rebuild a specific project using docker-compose this can be done using
@@ -180,7 +180,7 @@ This project is licensed under the 3-Clause BSD License - see the [LICENSE.md](L
 [7]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp
 [8]: https://www.docker.com/products/docker-desktop
 [9]: https://github.com/Altinn/altinn-studio
-[10]: http://altinn3.no
+[10]: http://altinn.localhost
 [11]: https://reactjs.org/
 [12]: https://redux.js.org/
 [13]: https://docs.microsoft.com/en-us/dotnet/core/

--- a/src/studio/docker-compose.yml
+++ b/src/studio/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - ServiceRepositorySettings:ApiEndPoint=http://altinn-repositories:3000/api/v1/
       - ServiceRepositorySettings:ApiEndPointHost=altinn-repositories
       - ServiceRepositorySettings:RepositoryBaseURL=http://altinn-repositories:3000
-      - ServiceRepositorySettings:GiteaLoginUrl=http://altinn3.no/repos/user/login
+      - ServiceRepositorySettings:GiteaLoginUrl=http://local.altinn.studio/repos/user/login
       - GeneralSettings:TemplateLocation=/Templates
       - GeneralSettings:DeploymentLocation=/Templates/deployment
       - GeneralSettings:LanguageFilesLocation=Languages/
@@ -62,7 +62,7 @@ services:
       - GeneralSettings:DeploymentLocation=Templates/AspNet/deployment
       - GeneralSettings:AppLocation=Templates/AspNet/App
       - GeneralSettings:IntegrationTestsLocation=Templates/AspNet/App.IntegrationTests
-      - GeneralSettings:AltinnStudioEndpoint=http://altinn3.no/
+      - GeneralSettings:AltinnStudioEndpoint=http://local.altinn.studio/
       - TestdataRepositorySettings:RepositoryLocation=/Testdata
     ports:
       - "6000:6000"
@@ -89,9 +89,9 @@ services:
       - USER_UID=1000
       - USER_GID=1000
       - GITEA____RUN_MODE=prod
-      - GITEA__server__SSH_DOMAIN=altinn3.no
-      - GITEA__server__DOMAIN=altinn3.no
-      - GITEA__server__ROOT_URL=http://altinn3.no/repos
+      - GITEA__server__SSH_DOMAIN=local.altinn.studio
+      - GITEA__server__DOMAIN=local.altinn.studio
+      - GITEA__server__ROOT_URL=http://local.altinn.studio/repos
       - GITEA__session__COOKIE_SECURE=false
       - GITEA__designer__LFS_JWT_SECRET=MRlYoCcrcHmcKzUoQwaK6vKO3o4FPEJ74em5JnPRii0
       - GITEA__database__DB_TYPE=sqlite3

--- a/src/studio/docker-compose.yml
+++ b/src/studio/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - ServiceRepositorySettings:ApiEndPoint=http://altinn-repositories:3000/api/v1/
       - ServiceRepositorySettings:ApiEndPointHost=altinn-repositories
       - ServiceRepositorySettings:RepositoryBaseURL=http://altinn-repositories:3000
-      - ServiceRepositorySettings:GiteaLoginUrl=http://local.altinn.studio/repos/user/login
+      - ServiceRepositorySettings:GiteaLoginUrl=http://altinn.localhost/repos/user/login
       - GeneralSettings:TemplateLocation=/Templates
       - GeneralSettings:DeploymentLocation=/Templates/deployment
       - GeneralSettings:LanguageFilesLocation=Languages/
@@ -62,7 +62,7 @@ services:
       - GeneralSettings:DeploymentLocation=Templates/AspNet/deployment
       - GeneralSettings:AppLocation=Templates/AspNet/App
       - GeneralSettings:IntegrationTestsLocation=Templates/AspNet/App.IntegrationTests
-      - GeneralSettings:AltinnStudioEndpoint=http://local.altinn.studio/
+      - GeneralSettings:AltinnStudioEndpoint=http://altinn.localhost/
       - TestdataRepositorySettings:RepositoryLocation=/Testdata
     ports:
       - "6000:6000"
@@ -89,9 +89,9 @@ services:
       - USER_UID=1000
       - USER_GID=1000
       - GITEA____RUN_MODE=prod
-      - GITEA__server__SSH_DOMAIN=local.altinn.studio
-      - GITEA__server__DOMAIN=local.altinn.studio
-      - GITEA__server__ROOT_URL=http://local.altinn.studio/repos
+      - GITEA__server__SSH_DOMAIN=altinn.localhost
+      - GITEA__server__DOMAIN=altinn.localhost
+      - GITEA__server__ROOT_URL=http://altinn.localhost/repos
       - GITEA__session__COOKIE_SECURE=false
       - GITEA__designer__LFS_JWT_SECRET=MRlYoCcrcHmcKzUoQwaK6vKO3o4FPEJ74em5JnPRii0
       - GITEA__database__DB_TYPE=sqlite3

--- a/src/studio/src/designer/backend.Tests/Services/GiteaAPIWrapperTest.cs
+++ b/src/studio/src/designer/backend.Tests/Services/GiteaAPIWrapperTest.cs
@@ -46,7 +46,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://altinn3.no/repos/api/v1")
+                BaseAddress = new Uri("http://local.altinn.studio/repos/api/v1")
             };
 
             GiteaAPIWrapper sut = GetServiceForTest("testUser", httpClient);
@@ -78,7 +78,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://altinn3.no/repos/api/v1")
+                BaseAddress = new Uri("http://local.altinn.studio/repos/api/v1")
             };
 
             GiteaAPIWrapper sut = GetServiceForTest("testUser", httpClient);
@@ -118,7 +118,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://altinn3.no/repos/api/v1")
+                BaseAddress = new Uri("http://local.altinn.studio/repos/api/v1")
             };
 
             GiteaAPIWrapper giteaApi = GetServiceForTest("testUser", httpClient);
@@ -159,7 +159,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://altinn3.no/repos/api/v1")
+                BaseAddress = new Uri("http://local.altinn.studio/repos/api/v1")
             };
 
             GiteaAPIWrapper giteaApi = GetServiceForTest("testUser", httpClient);
@@ -193,7 +193,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://altinn3.no/repos/api/v1")
+                BaseAddress = new Uri("http://local.altinn.studio/repos/api/v1")
             };
 
             GiteaAPIWrapper giteaApi = GetServiceForTest("testUser", httpClient);
@@ -227,7 +227,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://altinn3.no/designer/api/v1/user/starred")
+                BaseAddress = new Uri("http://local.altinn.studio/designer/api/v1/user/starred")
             };
 
             GiteaAPIWrapper giteaApi = GetServiceForTest("testUser", httpClient);
@@ -259,7 +259,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://altinn3.no/designer/api/v1/user/starred")
+                BaseAddress = new Uri("http://local.altinn.studio/designer/api/v1/user/starred")
             };
 
             GiteaAPIWrapper giteaApi = GetServiceForTest("testUser", httpClient);
@@ -292,7 +292,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://altinn3.no/designer/api/v1/user/starred")
+                BaseAddress = new Uri("http://local.altinn.studio/designer/api/v1/user/starred")
             };
 
             GiteaAPIWrapper giteaApi = GetServiceForTest("testUser", httpClient);
@@ -346,7 +346,7 @@ namespace Designer.Tests.Services
             // Injecting the mock handler into a real http client
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://altinn3.no/designer/api/v1/")
+                BaseAddress = new Uri("http://local.altinn.studio/designer/api/v1/")
             };
 
             // Passing the test specific mock setup in, sprinkles a bit more mock setup and returns a valid GiteaAPIWrapper

--- a/src/studio/src/designer/backend.Tests/Services/GiteaAPIWrapperTest.cs
+++ b/src/studio/src/designer/backend.Tests/Services/GiteaAPIWrapperTest.cs
@@ -46,7 +46,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://local.altinn.studio/repos/api/v1")
+                BaseAddress = new Uri("http://altinn.localhost/repos/api/v1")
             };
 
             GiteaAPIWrapper sut = GetServiceForTest("testUser", httpClient);
@@ -78,7 +78,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://local.altinn.studio/repos/api/v1")
+                BaseAddress = new Uri("http://altinn.localhost/repos/api/v1")
             };
 
             GiteaAPIWrapper sut = GetServiceForTest("testUser", httpClient);
@@ -118,7 +118,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://local.altinn.studio/repos/api/v1")
+                BaseAddress = new Uri("http://altinn.localhost/repos/api/v1")
             };
 
             GiteaAPIWrapper giteaApi = GetServiceForTest("testUser", httpClient);
@@ -159,7 +159,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://local.altinn.studio/repos/api/v1")
+                BaseAddress = new Uri("http://altinn.localhost/repos/api/v1")
             };
 
             GiteaAPIWrapper giteaApi = GetServiceForTest("testUser", httpClient);
@@ -193,7 +193,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://local.altinn.studio/repos/api/v1")
+                BaseAddress = new Uri("http://altinn.localhost/repos/api/v1")
             };
 
             GiteaAPIWrapper giteaApi = GetServiceForTest("testUser", httpClient);
@@ -227,7 +227,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://local.altinn.studio/designer/api/v1/user/starred")
+                BaseAddress = new Uri("http://altinn.localhost/designer/api/v1/user/starred")
             };
 
             GiteaAPIWrapper giteaApi = GetServiceForTest("testUser", httpClient);
@@ -259,7 +259,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://local.altinn.studio/designer/api/v1/user/starred")
+                BaseAddress = new Uri("http://altinn.localhost/designer/api/v1/user/starred")
             };
 
             GiteaAPIWrapper giteaApi = GetServiceForTest("testUser", httpClient);
@@ -292,7 +292,7 @@ namespace Designer.Tests.Services
             // use real http client with mocked handler here
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://local.altinn.studio/designer/api/v1/user/starred")
+                BaseAddress = new Uri("http://altinn.localhost/designer/api/v1/user/starred")
             };
 
             GiteaAPIWrapper giteaApi = GetServiceForTest("testUser", httpClient);
@@ -346,7 +346,7 @@ namespace Designer.Tests.Services
             // Injecting the mock handler into a real http client
             var httpClient = new HttpClient(handlerMock.Object)
             {
-                BaseAddress = new Uri("http://local.altinn.studio/designer/api/v1/")
+                BaseAddress = new Uri("http://altinn.localhost/designer/api/v1/")
             };
 
             // Passing the test specific mock setup in, sprinkles a bit more mock setup and returns a valid GiteaAPIWrapper

--- a/src/studio/src/designer/backend.Tests/Services/SchemaModelServiceTests.cs
+++ b/src/studio/src/designer/backend.Tests/Services/SchemaModelServiceTests.cs
@@ -255,8 +255,8 @@ namespace Designer.Tests.Services
         }
 
         [Theory]
-        [InlineData("ttd", "apprepo", "test", "", "http://altinn3.no/repos")]
-        [InlineData("ttd", "apprepo", "test", "/path/to/folder/", "http://altinn3.no/repos")]
+        [InlineData("ttd", "apprepo", "test", "", "http://local.altinn.studio/repos")]
+        [InlineData("ttd", "apprepo", "test", "/path/to/folder/", "http://local.altinn.studio/repos")]
         public void GetSchemaUri_ValidNameProvided_ShouldReturnUri(string org, string repository, string schemaName, string relativePath, string repositoryBaseUrl)
         {
             var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(TestDataHelper.GetTestDataRepositoriesRootDirectory());

--- a/src/studio/src/designer/backend.Tests/Services/SchemaModelServiceTests.cs
+++ b/src/studio/src/designer/backend.Tests/Services/SchemaModelServiceTests.cs
@@ -255,8 +255,8 @@ namespace Designer.Tests.Services
         }
 
         [Theory]
-        [InlineData("ttd", "apprepo", "test", "", "http://local.altinn.studio/repos")]
-        [InlineData("ttd", "apprepo", "test", "/path/to/folder/", "http://local.altinn.studio/repos")]
+        [InlineData("ttd", "apprepo", "test", "", "http://altinn.localhost/repos")]
+        [InlineData("ttd", "apprepo", "test", "/path/to/folder/", "http://altinn.localhost/repos")]
         public void GetSchemaUri_ValidNameProvided_ShouldReturnUri(string org, string repository, string schemaName, string relativePath, string repositoryBaseUrl)
         {
             var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(TestDataHelper.GetTestDataRepositoriesRootDirectory());

--- a/src/studio/src/designer/backend.Tests/Utils/TestDataHelper.cs
+++ b/src/studio/src/designer/backend.Tests/Utils/TestDataHelper.cs
@@ -338,7 +338,7 @@ namespace Designer.Tests.Utils
         public static IOptions<ServiceRepositorySettings> GetServiceRepositorySettings()
         {
             IOptions<ServiceRepositorySettings> options = Options.Create(new ServiceRepositorySettings());
-            options.Value.RepositoryBaseURL = @"http://altinn3.no/repos";
+            options.Value.RepositoryBaseURL = @"http://local.altinn.studio/repos";
             return options;
         }
 

--- a/src/studio/src/designer/backend.Tests/Utils/TestDataHelper.cs
+++ b/src/studio/src/designer/backend.Tests/Utils/TestDataHelper.cs
@@ -338,7 +338,7 @@ namespace Designer.Tests.Utils
         public static IOptions<ServiceRepositorySettings> GetServiceRepositorySettings()
         {
             IOptions<ServiceRepositorySettings> options = Options.Create(new ServiceRepositorySettings());
-            options.Value.RepositoryBaseURL = @"http://local.altinn.studio/repos";
+            options.Value.RepositoryBaseURL = @"http://altinn.localhost/repos";
             return options;
         }
 

--- a/src/studio/src/designer/backend.Tests/_TestData/Remote/ttd/apps-test/App/appsettings.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Remote/ttd/apps-test/App/appsettings.json
@@ -13,9 +13,9 @@
     "RegisterEventsWithEventsComponent": true
   },
   "GeneralSettings": {
-    "HostName": "altinn3.no",
+    "HostName": "local.altinn.studio",
     "SoftValidationPrefix": "*WARNING*",
-    "AltinnStudioEndpoint": "http://altinn3.no/",
+    "AltinnStudioEndpoint": "http://local.altinn.studio/",
     "AltinnPartyCookieName": "AltinnPartyId"
   },
   "PlatformSettings": {

--- a/src/studio/src/designer/backend.Tests/_TestData/Remote/ttd/apps-test/App/appsettings.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Remote/ttd/apps-test/App/appsettings.json
@@ -13,9 +13,9 @@
     "RegisterEventsWithEventsComponent": true
   },
   "GeneralSettings": {
-    "HostName": "local.altinn.studio",
+    "HostName": "altinn.localhost",
     "SoftValidationPrefix": "*WARNING*",
-    "AltinnStudioEndpoint": "http://local.altinn.studio/",
+    "AltinnStudioEndpoint": "http://altinn.localhost/",
     "AltinnPartyCookieName": "AltinnPartyId"
   },
   "PlatformSettings": {

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/apps-test-2021/App/appsettings.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/apps-test-2021/App/appsettings.json
@@ -13,9 +13,9 @@
     "RegisterEventsWithEventsComponent": true
   },
   "GeneralSettings": {
-    "HostName": "altinn3.no",
+    "HostName": "local.altinn.studio",
     "SoftValidationPrefix": "*WARNING*",
-    "AltinnStudioEndpoint": "http://altinn3.no/",
+    "AltinnStudioEndpoint": "http://local.altinn.studio/",
     "AltinnPartyCookieName": "AltinnPartyId"
   },
   "PlatformSettings": {

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/apps-test-2021/App/appsettings.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/apps-test-2021/App/appsettings.json
@@ -13,9 +13,9 @@
     "RegisterEventsWithEventsComponent": true
   },
   "GeneralSettings": {
-    "HostName": "local.altinn.studio",
+    "HostName": "altinn.localhost",
     "SoftValidationPrefix": "*WARNING*",
-    "AltinnStudioEndpoint": "http://local.altinn.studio/",
+    "AltinnStudioEndpoint": "http://altinn.localhost/",
     "AltinnPartyCookieName": "AltinnPartyId"
   },
   "PlatformSettings": {

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/apps-test/App/appsettings.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/apps-test/App/appsettings.json
@@ -13,9 +13,9 @@
     "RegisterEventsWithEventsComponent": true
   },
   "GeneralSettings": {
-    "HostName": "altinn3.no",
+    "HostName": "local.altinn.studio",
     "SoftValidationPrefix": "*WARNING*",
-    "AltinnStudioEndpoint": "http://altinn3.no/",
+    "AltinnStudioEndpoint": "http://local.altinn.studio/",
     "AltinnPartyCookieName": "AltinnPartyId"
   },
   "PlatformSettings": {

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/apps-test/App/appsettings.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/apps-test/App/appsettings.json
@@ -13,9 +13,9 @@
     "RegisterEventsWithEventsComponent": true
   },
   "GeneralSettings": {
-    "HostName": "local.altinn.studio",
+    "HostName": "altinn.localhost",
     "SoftValidationPrefix": "*WARNING*",
-    "AltinnStudioEndpoint": "http://local.altinn.studio/",
+    "AltinnStudioEndpoint": "http://altinn.localhost/",
     "AltinnPartyCookieName": "AltinnPartyId"
   },
   "PlatformSettings": {

--- a/src/studio/src/designer/backend/Properties/launchSettings.json
+++ b/src/studio/src/designer/backend/Properties/launchSettings.json
@@ -18,7 +18,7 @@
     "AltinnCoreDesigner": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://altinn3.no/",
+      "launchUrl": "http://local.altinn.studio/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/studio/src/designer/backend/Properties/launchSettings.json
+++ b/src/studio/src/designer/backend/Properties/launchSettings.json
@@ -18,7 +18,7 @@
     "AltinnCoreDesigner": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://local.altinn.studio/",
+      "launchUrl": "http://altinn.localhost/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -26,7 +26,7 @@
     "AltinnStudioOsX": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://altinn3.no/",
+      "launchUrl": "http://altinn.localhost/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ServiceRepositorySettings__RepositoryLocation": "/tmp/altinn/repos/",

--- a/src/studio/src/designer/backend/RepositoryClient/CustomApi/UserApiClient.cs
+++ b/src/studio/src/designer/backend/RepositoryClient/CustomApi/UserApiClient.cs
@@ -32,8 +32,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.CustomApi
             Altinn.Studio.Designer.RepositoryClient.Model.User user;
             DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(Altinn.Studio.Designer.RepositoryClient.Model.User));
 
-            Uri giteaUrl = new Uri("http://altinn3.no:3000/api/v1/user");
-            Cookie cookie = new Cookie(giteaCoookieId, giteaSession, "/", "altinn3.no");
+            Uri giteaUrl = new Uri("http://local.altinn.studio:3000/api/v1/user");
+            Cookie cookie = new Cookie(giteaCoookieId, giteaSession, "/", "local.altinn.studio");
             CookieContainer cookieContainer = new CookieContainer();
             cookieContainer.Add(cookie);
             HttpClientHandler handler = new HttpClientHandler() { CookieContainer = cookieContainer };

--- a/src/studio/src/designer/backend/RepositoryClient/CustomApi/UserApiClient.cs
+++ b/src/studio/src/designer/backend/RepositoryClient/CustomApi/UserApiClient.cs
@@ -32,8 +32,8 @@ namespace Altinn.Studio.Designer.RepositoryClient.CustomApi
             Altinn.Studio.Designer.RepositoryClient.Model.User user;
             DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(Altinn.Studio.Designer.RepositoryClient.Model.User));
 
-            Uri giteaUrl = new Uri("http://local.altinn.studio:3000/api/v1/user");
-            Cookie cookie = new Cookie(giteaCoookieId, giteaSession, "/", "local.altinn.studio");
+            Uri giteaUrl = new Uri("http://altinn.localhost:3000/api/v1/user");
+            Cookie cookie = new Cookie(giteaCoookieId, giteaSession, "/", "altinn.localhost");
             CookieContainer cookieContainer = new CookieContainer();
             cookieContainer.Add(cookie);
             HttpClientHandler handler = new HttpClientHandler() { CookieContainer = cookieContainer };

--- a/src/studio/src/designer/backend/appsettings.json
+++ b/src/studio/src/designer/backend/appsettings.json
@@ -7,7 +7,7 @@
     "ApiEndPointHost": "altinn3.no",
     "RepositoryBaseURL": "http://altinn3.no/repos",
     "GiteaCookieName": "i_like_gitea",
-    "GiteaLoginUrl": "http://altinn3.no/repos/user/login"
+    "GiteaLoginUrl": "http://local.altinn.studio/repos/user/login"
   },
   "TestdataRepositorySettings": {
     "RepositoryLocation": "../Testdata"
@@ -19,7 +19,7 @@
     "SubscriptionKeyHeaderName": "Ocp-Apim-Subscription-Key"
   },
   "GeneralSettings": {
-    "HostName": "altinn3.no",
+    "HostName": "local.altinn.studio",
     "LanguageFilesLocation": "./Languages/ini/",
     "AltinnPartyCookieName": "AltinnPartyId",
     "TemplateLocation": "../../../AppTemplates/AspNet",

--- a/src/studio/src/designer/backend/appsettings.json
+++ b/src/studio/src/designer/backend/appsettings.json
@@ -3,11 +3,11 @@
     "DatabaseConnectionString": "Data Source=AltinnCoreDatabase.sqlite"
   },
   "ServiceRepositorySettings": {
-    "ApiEndPoint": "http://altinn3.no/repos/api/v1/",
-    "ApiEndPointHost": "altinn3.no",
-    "RepositoryBaseURL": "http://altinn3.no/repos",
+    "ApiEndPoint": "http://altinn.localhost/repos/api/v1/",
+    "ApiEndPointHost": "altinn.localhost",
+    "RepositoryBaseURL": "http://altinn.localhost/repos",
     "GiteaCookieName": "i_like_gitea",
-    "GiteaLoginUrl": "http://local.altinn.studio/repos/user/login"
+    "GiteaLoginUrl": "http://altinn.localhost/repos/user/login"
   },
   "TestdataRepositorySettings": {
     "RepositoryLocation": "../Testdata"
@@ -19,7 +19,7 @@
     "SubscriptionKeyHeaderName": "Ocp-Apim-Subscription-Key"
   },
   "GeneralSettings": {
-    "HostName": "local.altinn.studio",
+    "HostName": "altinn.localhost",
     "LanguageFilesLocation": "./Languages/ini/",
     "AltinnPartyCookieName": "AltinnPartyId",
     "TemplateLocation": "../../../AppTemplates/AspNet",

--- a/src/studio/src/designer/frontend/packages/shared/src/utils/attachmentsUtils.test.ts
+++ b/src/studio/src/designer/frontend/packages/shared/src/utils/attachmentsUtils.test.ts
@@ -6,7 +6,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
     id: '50001/c1572504-9fb6-4829-9652-3ca9c82dabb9',
     instanceOwnerId: '50001',
     selfLinks: {
-      apps: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9',
+      apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9',
     },
     appId: 'matsgm/tjeneste-190814-1426',
     org: 'matsgm',
@@ -32,7 +32,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
         selfLinks: {
-          apps: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
+          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
         },
         size: 0,
         isLocked: false,
@@ -49,7 +49,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/03e06136-88be-4866-a216-7959afe46137',
         selfLinks: {
-          apps: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/03e06136-88be-4866-a216-7959afe46137',
+          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/03e06136-88be-4866-a216-7959afe46137',
         },
         size: 4194304,
         isLocked: false,
@@ -66,7 +66,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/11943e38-9fc4-43f6-84c4-12e529eebd28',
         selfLinks: {
-          apps: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/11943e38-9fc4-43f6-84c4-12e529eebd28',
+          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/11943e38-9fc4-43f6-84c4-12e529eebd28',
         },
         size: 8388608,
         isLocked: false,
@@ -83,7 +83,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/092f032d-f54f-49c1-ae42-ebc0d10a2fcb',
         selfLinks: {
-          apps: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/092f032d-f54f-49c1-ae42-ebc0d10a2fcb',
+          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/092f032d-f54f-49c1-ae42-ebc0d10a2fcb',
         },
         size: 2097152,
         isLocked: false,
@@ -100,7 +100,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/8698103b-fad1-4665-85c6-bf88a75ad708',
         selfLinks: {
-          apps: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/8698103b-fad1-4665-85c6-bf88a75ad708',
+          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/8698103b-fad1-4665-85c6-bf88a75ad708',
         },
         size: 4194304,
         isLocked: false,
@@ -117,7 +117,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/e950864d-e304-41ca-a60c-0c5019166df8',
         selfLinks: {
-          apps: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/e950864d-e304-41ca-a60c-0c5019166df8',
+          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/e950864d-e304-41ca-a60c-0c5019166df8',
         },
         size: 8388608,
         isLocked: false,
@@ -134,7 +134,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
         selfLinks: {
-          apps: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
+          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
         },
         size: 2097152,
         isLocked: false,
@@ -150,32 +150,32 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
     {
       iconClass: 'reg reg-attachment',
       name: '4mb.txt',
-      url: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/03e06136-88be-4866-a216-7959afe46137',
+      url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/03e06136-88be-4866-a216-7959afe46137',
     },
     {
       iconClass: 'reg reg-attachment',
       name: '8mb.txt',
-      url: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/11943e38-9fc4-43f6-84c4-12e529eebd28',
+      url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/11943e38-9fc4-43f6-84c4-12e529eebd28',
     },
     {
       iconClass: 'reg reg-attachment',
       name: '2mb.txt',
-      url: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/092f032d-f54f-49c1-ae42-ebc0d10a2fcb',
+      url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/092f032d-f54f-49c1-ae42-ebc0d10a2fcb',
     },
     {
       iconClass: 'reg reg-attachment',
       name: '4mb.txt',
-      url: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/8698103b-fad1-4665-85c6-bf88a75ad708',
+      url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/8698103b-fad1-4665-85c6-bf88a75ad708',
     },
     {
       iconClass: 'reg reg-attachment',
       name: '8mb.txt',
-      url: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/e950864d-e304-41ca-a60c-0c5019166df8',
+      url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/e950864d-e304-41ca-a60c-0c5019166df8',
     },
     {
       iconClass: 'reg reg-attachment',
       name: '2mb.txt',
-      url: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
+      url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
     },
   ];
 
@@ -197,7 +197,7 @@ test('getInstancePdf() returns correct attachement', () => {
       storageUrl:
         'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
       selfLinks: {
-        apps: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
+        apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
       },
       size: 0,
       isLocked: false,
@@ -214,7 +214,7 @@ test('getInstancePdf() returns correct attachement', () => {
       storageUrl:
         'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
       selfLinks: {
-        apps: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
+        apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
       },
       size: 2097152,
       isLocked: false,
@@ -228,7 +228,7 @@ test('getInstancePdf() returns correct attachement', () => {
   const expectedResult = {
     iconClass: 'reg reg-attachment',
     name: 'kvittering.pdf',
-    url: 'https://altinn3.no/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
+    url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
   };
 
   expect(getInstancePdf(data as unknown as IData[])).toEqual(expectedResult);

--- a/src/studio/src/designer/frontend/packages/shared/src/utils/attachmentsUtils.test.ts
+++ b/src/studio/src/designer/frontend/packages/shared/src/utils/attachmentsUtils.test.ts
@@ -6,7 +6,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
     id: '50001/c1572504-9fb6-4829-9652-3ca9c82dabb9',
     instanceOwnerId: '50001',
     selfLinks: {
-      apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9',
+      apps: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9',
     },
     appId: 'matsgm/tjeneste-190814-1426',
     org: 'matsgm',
@@ -32,7 +32,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
         selfLinks: {
-          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
+          apps: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
         },
         size: 0,
         isLocked: false,
@@ -49,7 +49,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/03e06136-88be-4866-a216-7959afe46137',
         selfLinks: {
-          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/03e06136-88be-4866-a216-7959afe46137',
+          apps: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/03e06136-88be-4866-a216-7959afe46137',
         },
         size: 4194304,
         isLocked: false,
@@ -66,7 +66,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/11943e38-9fc4-43f6-84c4-12e529eebd28',
         selfLinks: {
-          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/11943e38-9fc4-43f6-84c4-12e529eebd28',
+          apps: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/11943e38-9fc4-43f6-84c4-12e529eebd28',
         },
         size: 8388608,
         isLocked: false,
@@ -83,7 +83,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/092f032d-f54f-49c1-ae42-ebc0d10a2fcb',
         selfLinks: {
-          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/092f032d-f54f-49c1-ae42-ebc0d10a2fcb',
+          apps: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/092f032d-f54f-49c1-ae42-ebc0d10a2fcb',
         },
         size: 2097152,
         isLocked: false,
@@ -100,7 +100,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/8698103b-fad1-4665-85c6-bf88a75ad708',
         selfLinks: {
-          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/8698103b-fad1-4665-85c6-bf88a75ad708',
+          apps: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/8698103b-fad1-4665-85c6-bf88a75ad708',
         },
         size: 4194304,
         isLocked: false,
@@ -117,7 +117,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/e950864d-e304-41ca-a60c-0c5019166df8',
         selfLinks: {
-          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/e950864d-e304-41ca-a60c-0c5019166df8',
+          apps: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/e950864d-e304-41ca-a60c-0c5019166df8',
         },
         size: 8388608,
         isLocked: false,
@@ -134,7 +134,7 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
         storageUrl:
           'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
         selfLinks: {
-          apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
+          apps: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
         },
         size: 2097152,
         isLocked: false,
@@ -150,32 +150,32 @@ test('mapInstanceAttachments() returns correct attachment array', () => {
     {
       iconClass: 'reg reg-attachment',
       name: '4mb.txt',
-      url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/03e06136-88be-4866-a216-7959afe46137',
+      url: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/03e06136-88be-4866-a216-7959afe46137',
     },
     {
       iconClass: 'reg reg-attachment',
       name: '8mb.txt',
-      url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/11943e38-9fc4-43f6-84c4-12e529eebd28',
+      url: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/11943e38-9fc4-43f6-84c4-12e529eebd28',
     },
     {
       iconClass: 'reg reg-attachment',
       name: '2mb.txt',
-      url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/092f032d-f54f-49c1-ae42-ebc0d10a2fcb',
+      url: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/092f032d-f54f-49c1-ae42-ebc0d10a2fcb',
     },
     {
       iconClass: 'reg reg-attachment',
       name: '4mb.txt',
-      url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/8698103b-fad1-4665-85c6-bf88a75ad708',
+      url: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/8698103b-fad1-4665-85c6-bf88a75ad708',
     },
     {
       iconClass: 'reg reg-attachment',
       name: '8mb.txt',
-      url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/e950864d-e304-41ca-a60c-0c5019166df8',
+      url: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/e950864d-e304-41ca-a60c-0c5019166df8',
     },
     {
       iconClass: 'reg reg-attachment',
       name: '2mb.txt',
-      url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
+      url: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
     },
   ];
 
@@ -197,7 +197,7 @@ test('getInstancePdf() returns correct attachement', () => {
       storageUrl:
         'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
       selfLinks: {
-        apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
+        apps: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
       },
       size: 0,
       isLocked: false,
@@ -214,7 +214,7 @@ test('getInstancePdf() returns correct attachement', () => {
       storageUrl:
         'tjeneste-190814-1426/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
       selfLinks: {
-        apps: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
+        apps: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/005d5bc3-a315-4705-9b06-3788fed86da1',
       },
       size: 2097152,
       isLocked: false,
@@ -228,7 +228,7 @@ test('getInstancePdf() returns correct attachement', () => {
   const expectedResult = {
     iconClass: 'reg reg-attachment',
     name: 'kvittering.pdf',
-    url: 'https://local.altinn.studio/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
+    url: 'https://altinn.localhost/matsgm/tjeneste-190814-1426/instances/50001/c1572504-9fb6-4829-9652-3ca9c82dabb9/data/585b2f4e-5ecb-417b-9d01-82b6e889e1d1',
   };
 
   expect(getInstancePdf(data as unknown as IData[])).toEqual(expectedResult);

--- a/src/studio/src/designer/frontend/packages/shared/src/utils/urlHelper.test.ts
+++ b/src/studio/src/designer/frontend/packages/shared/src/utils/urlHelper.test.ts
@@ -13,7 +13,7 @@ describe('Shared urlHelper.ts', () => {
       delete window.location;
       window.location = {
         ...oldWindowLocation,
-        origin: 'https://altinn3.no',
+        origin: 'https://local.altinn.studio',
         pathname: `${APP_DEVELOPMENT_BASENAME}/org/repo`,
       };
     });
@@ -22,7 +22,7 @@ describe('Shared urlHelper.ts', () => {
       delete window.location;
       window.location = {
         ...oldWindowLocation,
-        origin: 'https://altinn3.no',
+        origin: 'https://local.altinn.studio',
         pathname: `${DASHBOARD_BASENAME}/datamodelling/org/repo`,
       };
     });
@@ -40,8 +40,8 @@ describe('Shared urlHelper.ts', () => {
     });
 
     test('returnUrlToMessagebox() returning studio messagebox', () => {
-      const origin = 'https://altinn3.no/tdd/tjeneste-20190826-1130';
-      expect(returnUrlToMessagebox(origin)).toContain('altinn3.no');
+      const origin = 'https://local.altinn.studio/tdd/tjeneste-20190826-1130';
+      expect(returnUrlToMessagebox(origin)).toContain('local.altinn.studio');
     });
 
     test('returnUrlToMessagebox() returning null when unknown origin', () => {

--- a/src/studio/src/designer/frontend/packages/shared/src/utils/urlHelper.test.ts
+++ b/src/studio/src/designer/frontend/packages/shared/src/utils/urlHelper.test.ts
@@ -13,7 +13,7 @@ describe('Shared urlHelper.ts', () => {
       delete window.location;
       window.location = {
         ...oldWindowLocation,
-        origin: 'https://local.altinn.studio',
+        origin: 'https://altinn.localhost',
         pathname: `${APP_DEVELOPMENT_BASENAME}/org/repo`,
       };
     });
@@ -22,7 +22,7 @@ describe('Shared urlHelper.ts', () => {
       delete window.location;
       window.location = {
         ...oldWindowLocation,
-        origin: 'https://local.altinn.studio',
+        origin: 'https://altinn.localhost',
         pathname: `${DASHBOARD_BASENAME}/datamodelling/org/repo`,
       };
     });
@@ -40,8 +40,8 @@ describe('Shared urlHelper.ts', () => {
     });
 
     test('returnUrlToMessagebox() returning studio messagebox', () => {
-      const origin = 'https://local.altinn.studio/tdd/tjeneste-20190826-1130';
-      expect(returnUrlToMessagebox(origin)).toContain('local.altinn.studio');
+      const origin = 'https://altinn.localhost/tdd/tjeneste-20190826-1130';
+      expect(returnUrlToMessagebox(origin)).toContain('altinn.localhost');
     });
 
     test('returnUrlToMessagebox() returning null when unknown origin', () => {

--- a/src/studio/src/designer/frontend/packages/shared/src/utils/urlHelper.ts
+++ b/src/studio/src/designer/frontend/packages/shared/src/utils/urlHelper.ts
@@ -10,7 +10,7 @@ export const returnUrlToMessagebox = (url: string): string => {
   const { org, app } = _useParamsClassCompHack();
   const baseHostnameAltinnProd = 'altinn.no';
   const baseHostnameAltinnTest = 'altinn.cloud';
-  const baseHostnameAltinnStudio = 'altinn3.no';
+  const baseHostnameAltinnStudio = 'local.altinn.studio';
   const pathToMessageBox = 'ui/messagebox';
   const prodRegex = new RegExp(baseHostnameAltinnProd);
   const testRegex = new RegExp(baseHostnameAltinnTest);

--- a/src/studio/src/designer/frontend/packages/shared/src/utils/urlHelper.ts
+++ b/src/studio/src/designer/frontend/packages/shared/src/utils/urlHelper.ts
@@ -10,7 +10,7 @@ export const returnUrlToMessagebox = (url: string): string => {
   const { org, app } = _useParamsClassCompHack();
   const baseHostnameAltinnProd = 'altinn.no';
   const baseHostnameAltinnTest = 'altinn.cloud';
-  const baseHostnameAltinnStudio = 'local.altinn.studio';
+  const baseHostnameAltinnStudio = 'altinn.localhost';
   const pathToMessageBox = 'ui/messagebox';
   const prodRegex = new RegExp(baseHostnameAltinnProd);
   const testRegex = new RegExp(baseHostnameAltinnTest);

--- a/src/studio/src/load-balancer/nginx.conf.conf
+++ b/src/studio/src/load-balancer/nginx.conf.conf
@@ -24,7 +24,7 @@ http {
 	    set $dev_app_development $DEVELOP_APP_DEVELOPMENT;
 
 		listen 80;
-		server_name altinn3.no localhost;
+		server_name altinn.localhost localhost;
 
 		proxy_cookie_path ~*^/.* /;
 		proxy_redirect off;

--- a/src/test/cypress/README.md
+++ b/src/test/cypress/README.md
@@ -28,10 +28,10 @@ Start the solution by following the procedure [here](https://github.com/Altinn/a
 
 You need login credentials for the first user created in local studio, since this user has automatically got admin rights.
 If you have issues logging in as this user, the simplest solution is to delete the `altinn-repositories` container and the Gitea volumes in Docker, and then rebuild the container.
-Then you can start all over and create a new, first user from http://altinn3.no.
+Then you can start all over and create a new, first user from http://local.altinn.studio.
 
 After logging in as the admin user, you need to create an access token.
-This is done under the applications pane in the Gitea user settings; http://altinn3.no/repos/user/settings/applications.
+This is done under the applications pane in the Gitea user settings; http://local.altinn.studio/repos/user/settings/applications.
 
 Create a new file name `cypress.env.json` under `src\test\cypress` with the data created above.
 

--- a/src/test/cypress/README.md
+++ b/src/test/cypress/README.md
@@ -28,10 +28,10 @@ Start the solution by following the procedure [here](https://github.com/Altinn/a
 
 You need login credentials for the first user created in local studio, since this user has automatically got admin rights.
 If you have issues logging in as this user, the simplest solution is to delete the `altinn-repositories` container and the Gitea volumes in Docker, and then rebuild the container.
-Then you can start all over and create a new, first user from http://local.altinn.studio.
+Then you can start all over and create a new, first user from http://altinn.localhost.
 
 After logging in as the admin user, you need to create an access token.
-This is done under the applications pane in the Gitea user settings; http://local.altinn.studio/repos/user/settings/applications.
+This is done under the applications pane in the Gitea user settings; http://altinn.localhost/repos/user/settings/applications.
 
 Create a new file name `cypress.env.json` under `src\test\cypress` with the data created above.
 

--- a/src/test/cypress/e2e/config/local.json
+++ b/src/test/cypress/e2e/config/local.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://on.cypress.io/cypress.schema.json",
-  "baseUrl": "http://altinn3.no",
+  "baseUrl": "http://local.altinn.studio",
   "env": {
     "autoTestUser": "testuser",
     "autoTestUserPwd": "Studio@123",

--- a/src/test/cypress/e2e/config/local.json
+++ b/src/test/cypress/e2e/config/local.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://on.cypress.io/cypress.schema.json",
-  "baseUrl": "http://local.altinn.studio",
+  "baseUrl": "http://altinn.localhost",
   "env": {
     "autoTestUser": "testuser",
     "autoTestUserPwd": "Studio@123",


### PR DESCRIPTION
## Description
As with using local.altinn.cloud on the app-frontend-react project we need to make it simpler to do run studio locally as well.
Therefore this pull-request will remove the need of editing the hostfile, (unless you want to test on Safari,) and update the Altinn Studio url from altinn3.no to [`altinn.localhost`](http://altinn.localhost). 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] The documentation is updated in the readme.md files by removing the altinn3.no mentions.
