### PR TITLE
Use text area from the design system

### DIFF
--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.test.tsx
@@ -9,6 +9,7 @@ import {
   ObjectKind,
 } from '@altinn/schema-model';
 import React from 'react';
+import { screen } from '@testing-library/react';
 
 const mockLanguage = {
   schema_editor: {
@@ -79,4 +80,34 @@ test('addCombinationItem is called when "nullable" checkbox is checked', async (
   if (checkbox === null) fail();
   await user.click(checkbox);
   expect(store.getActions().some(({ type }) => type === 'schemaEditor/addCombinationItem')).toBeTruthy();
+});
+
+test('"Title" field appears', () => {
+  renderItemDataComponent();
+  expect(screen.getByLabelText(mockLanguage.schema_editor.title)).toBeDefined();
+});
+
+test('setTitle action is called with correct payload when the "title" field loses focus', async () => {
+  const { store, user } = renderItemDataComponent();
+  const inputField = screen.getByLabelText(mockLanguage.schema_editor.title);
+  await user.type(inputField, 'Lorem ipsum');
+  await user.tab();
+  const setTitleActions = store.getActions().filter(({ type }) => type === 'schemaEditor/setTitle');
+  expect(setTitleActions).toHaveLength(1);
+  expect(setTitleActions[0].payload.title).toEqual('Lorem ipsum');
+});
+
+test('"Description" text area appears', () => {
+  renderItemDataComponent();
+  expect(screen.getByLabelText(mockLanguage.schema_editor.description)).toBeDefined();
+});
+
+test('setDescription action is called with correct payload when the "description" text area loses focus', async () => {
+  const { store, user } = renderItemDataComponent();
+  const textArea = screen.getByLabelText(mockLanguage.schema_editor.description);
+  await user.type(textArea, 'Lorem ipsum dolor sit amet.');
+  await user.tab();
+  const setDescriptionActions = store.getActions().filter(({ type }) => type === 'schemaEditor/setDescription');
+  expect(setDescriptionActions).toHaveLength(1);
+  expect(setDescriptionActions[0].payload.description).toEqual('Lorem ipsum dolor sit amet.');
 });

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
@@ -1,5 +1,4 @@
-import { TextField as MaterialTextField } from '@material-ui/core';
-import React, { useEffect, useState } from 'react';
+import React, { ChangeEvent, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type { ILanguage, ISchemaState } from '../../types';
 import { NameError } from '../../types';
@@ -18,7 +17,7 @@ import {
 } from '../../features/editor/schemaEditorSlice';
 import { ReferenceSelectionComponent } from './ReferenceSelectionComponent';
 import { getCombinationOptions, getTypeOptions } from './helpers/options';
-import { Checkbox, ErrorMessage, FieldSet, TextField } from '@altinn/altinn-design-system';
+import { Checkbox, ErrorMessage, FieldSet, TextArea, TextField } from '@altinn/altinn-design-system';
 import classes from './ItemDataComponent.module.css';
 import { ItemRestrictions } from './ItemRestrictions';
 import type { UiSchemaNode } from '@altinn/schema-model';
@@ -193,15 +192,10 @@ export function ItemDataComponent({ language, selectedItem }: IItemDataComponent
         </div>
         <div>
           <Label htmlFor={descriptionId}>{t('description')}</Label>
-          <MaterialTextField
-            InputProps={{ disableUnderline: true }}
-            className={classes.field}
-            fullWidth
+          <TextArea
             id={descriptionId}
-            margin='normal'
-            multiline={true}
             onBlur={onChangeDescription}
-            onChange={(e) => setItemDescription(e.target.value)}
+            onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setItemDescription(event.target.value)}
             style={{ height: 100 }}
             value={description}
           />


### PR DESCRIPTION
## Description
Replacement of the old text area from Material UI with the one from our own design system.

## Related Issue(s)
- #9066

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
