### PR TITLE
Add interfaces to XmlSchema<-->JsonSchema converters

### DIFF
--- a/src/studio/src/designer/DataModeling/Converter/Interfaces/IJsonSchemaToXmlSchemaConverter.cs
+++ b/src/studio/src/designer/DataModeling/Converter/Interfaces/IJsonSchemaToXmlSchemaConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Xml.Schema;
+using Json.Schema;
+
+namespace Altinn.Studio.DataModeling.Converter.Interfaces
+{
+    /// <summary>
+    /// Interface for converting Json schema to Xml schema
+    /// </summary>
+    public interface IJsonSchemaToXmlSchemaConverter
+    {
+        /// <summary>
+        /// Converts a <see cref="JsonSchema"/> to a matching <see cref="XmlSchema"/>
+        /// </summary>
+        /// <param name="schema">The schema to convert</param>
+        XmlSchema Convert(JsonSchema schema);
+
+        /// <summary>
+        /// Converts a <see cref="JsonSchema"/> to a matching <see cref="XmlSchema"/>
+        /// </summary>
+        /// <param name="schema">The schema to convert</param>
+        /// <param name = "schemaUri" > Uri that represents the unique id of the Json Schema.</param>
+        /// <returns>XmlSchema genrated based on the Json Schema.</returns>
+        XmlSchema Convert(JsonSchema schema, Uri schemaUri);
+    }
+}

--- a/src/studio/src/designer/DataModeling/Converter/Interfaces/IXmlSchemaToJsonSchemaConverter.cs
+++ b/src/studio/src/designer/DataModeling/Converter/Interfaces/IXmlSchemaToJsonSchemaConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Xml.Schema;
+using Json.Schema;
+
+namespace Altinn.Studio.DataModeling.Converter.Interfaces
+{
+    /// <summary>
+    /// Interface for converting Xml schema to Json schema
+    /// </summary>
+    public interface IXmlSchemaToJsonSchemaConverter
+    {
+        /// <summary>
+        /// Convert a schema into the give type
+        /// </summary>
+        /// <param name="schema">The object to visit</param>
+        JsonSchema Convert(XmlSchema schema);
+
+        /// <summary>
+        /// Convert a schema into the give type
+        /// </summary>
+        /// <param name="schema">The object to visit</param>
+        /// <param name="schemaUri">Uri that represents the unique id of the Json Schema.</param>
+        JsonSchema Convert(XmlSchema schema, Uri schemaUri);
+    }
+}

--- a/src/studio/src/designer/DataModeling/Converter/Json/JsonSchemaToXmlSchemaConverter.cs
+++ b/src/studio/src/designer/DataModeling/Converter/Json/JsonSchemaToXmlSchemaConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Xml.Schema;
+using Altinn.Studio.DataModeling.Converter.Interfaces;
 using Altinn.Studio.DataModeling.Converter.Json.Strategy;
 using Altinn.Studio.DataModeling.Json;
 using Json.Schema;
@@ -9,7 +10,7 @@ namespace Altinn.Studio.DataModeling.Converter.Json
     /// <summary>
     /// Class for converting Json schema to Xml Schema
     /// </summary>
-    public class JsonSchemaToXmlSchemaConverter
+    public class JsonSchemaToXmlSchemaConverter : IJsonSchemaToXmlSchemaConverter
     {
         private readonly IJsonSchemaNormalizer _normalizer;
 
@@ -27,22 +28,14 @@ namespace Altinn.Studio.DataModeling.Converter.Json
             _normalizer = normalizer;
         }
 
-        /// <summary>
-        /// Converts a <see cref="JsonSchema"/> to a matching <see cref="XmlSchema"/>
-        /// </summary>
-        /// <param name="schema">The schema to convert</param>
+        /// <inheritdoc/>
         public XmlSchema Convert(JsonSchema schema)
         {
             var uri = new Uri("schema.json", UriKind.Relative);
             return Convert(schema, uri);
         }
 
-        /// <summary>
-        /// Converts a <see cref="JsonSchema"/> to a matching <see cref="XmlSchema"/>
-        /// </summary>
-        /// <param name="schema">The schema to convert</param>
-        /// <param name = "schemaUri" > Uri that represents the unique id of the Json Schema.</param>
-        /// <returns>XmlSchema genrated based on the Json Schema.</returns>
+        /// <inheritdoc/>
         public XmlSchema Convert(JsonSchema schema, Uri schemaUri)
         {
             _jsonSchema = _normalizer.Normalize(schema);
@@ -51,7 +44,7 @@ namespace Altinn.Studio.DataModeling.Converter.Json
             ConvertUsingStrategy();
             return _xmlSchema;
         }
-        
+
         /// <summary>
         /// Use the selected strategy to convert the Json Schema to Xml Schema
         /// </summary>

--- a/src/studio/src/designer/DataModeling/Converter/Xml/XmlSchemaToJsonSchemaConverter.cs
+++ b/src/studio/src/designer/DataModeling/Converter/Xml/XmlSchemaToJsonSchemaConverter.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Xml;
 using System.Xml.Schema;
-
+using Altinn.Studio.DataModeling.Converter.Interfaces;
 using Altinn.Studio.DataModeling.Json;
 using Altinn.Studio.DataModeling.Json.Formats;
 using Altinn.Studio.DataModeling.Json.Keywords;
@@ -20,25 +20,18 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
     /// <summary>
     /// Visitor class for converting XML schema to Json Schema, this will produce a Json Schema with custom keywords to preserve XML schema information
     /// </summary>
-    public class XmlSchemaToJsonSchemaConverter
+    public class XmlSchemaToJsonSchemaConverter : IXmlSchemaToJsonSchemaConverter
     {
         private const string XmlSchemaNamespace = "http://www.w3.org/2001/XMLSchema";
 
-        /// <summary>
-        /// Convert a schema into the give type
-        /// </summary>
-        /// <param name="schema">The object to visit</param>
+        /// <inheritdoc/>
         public JsonSchema Convert(XmlSchema schema)
         {
             var uri = new Uri("schema.json", UriKind.Relative);
             return Convert(schema, uri);
         }
 
-        /// <summary>
-        /// Convert a schema into the give type
-        /// </summary>
-        /// <param name="schema">The object to visit</param>
-        /// <param name="schemaUri">Uri that represents the unique id of the Json Schema.</param>
+        /// <inheritdoc/>
         public JsonSchema Convert(XmlSchema schema, Uri schemaUri)
         {
             var schemaSet = new XmlSchemaSet();

--- a/src/studio/src/designer/backend.Tests/Services/SchemaModelServiceTests.cs
+++ b/src/studio/src/designer/backend.Tests/Services/SchemaModelServiceTests.cs
@@ -31,7 +31,7 @@ namespace Designer.Tests.Services
             {
                 var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(TestDataHelper.GetTestDataRepositoriesRootDirectory());
 
-                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings);
+                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings, TestDataHelper.XmlSchemaToJsonSchemaConverter, TestDataHelper.JsonSchemaToXmlSchemaConverter);
                 var schemaFiles = schemaModelService.GetSchemaFiles(org, targetRepository, developer);
                 schemaFiles.Should().HaveCount(7);
 
@@ -69,7 +69,7 @@ namespace Designer.Tests.Services
             {
                 var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(TestDataHelper.GetTestDataRepositoriesRootDirectory());
 
-                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings);
+                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings, TestDataHelper.XmlSchemaToJsonSchemaConverter, TestDataHelper.JsonSchemaToXmlSchemaConverter);
                 var schemaFiles = schemaModelService.GetSchemaFiles(org, targetRepository, developer);
                 schemaFiles.Should().HaveCount(6);
 
@@ -102,7 +102,7 @@ namespace Designer.Tests.Services
                 var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(TestDataHelper.GetTestDataRepositoriesRootDirectory());
 
                 // Act
-                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings);
+                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings, TestDataHelper.XmlSchemaToJsonSchemaConverter, TestDataHelper.JsonSchemaToXmlSchemaConverter);
                 var expectedSchemaUpdates = @"{""properties"":{""root"":{""$ref"":""#/definitions/rootType""}},""definitions"":{""rootType"":{""properties"":{""keyword"":{""type"":""string""}}}}}";
                 await schemaModelService.UpdateSchema(org, targetRepository, developer, $"App/models/HvemErHvem_SERES.schema.json", expectedSchemaUpdates);
 
@@ -151,7 +151,7 @@ namespace Designer.Tests.Services
             try
             {
                 var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(TestDataHelper.GetTestDataRepositoriesRootDirectory());
-                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings);
+                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings, TestDataHelper.XmlSchemaToJsonSchemaConverter, TestDataHelper.JsonSchemaToXmlSchemaConverter);
                 var xsdStream = TestDataHelper.LoadDataFromEmbeddedResource("Designer.Tests._TestData.Model.Xsd.Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES.xsd");
                 xsdStream.Seek(0, System.IO.SeekOrigin.Begin);
                 var schemaName = "Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES";
@@ -188,7 +188,7 @@ namespace Designer.Tests.Services
             try
             {
                 var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(TestDataHelper.GetTestDataRepositoriesRootDirectory());
-                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings);
+                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings, TestDataHelper.XmlSchemaToJsonSchemaConverter, TestDataHelper.JsonSchemaToXmlSchemaConverter);
                 var xsdStream = TestDataHelper.LoadDataFromEmbeddedResource("Designer.Tests._TestData.Model.Xsd.Skjema-1603-12392.xsd");
                 xsdStream.Seek(0, System.IO.SeekOrigin.Begin);
                 var schemaName = "Skjema-1603-12392";
@@ -230,7 +230,7 @@ namespace Designer.Tests.Services
             try
             {
                 var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(TestDataHelper.GetTestDataRepositoriesRootDirectory());
-                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings);
+                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings, TestDataHelper.XmlSchemaToJsonSchemaConverter, TestDataHelper.JsonSchemaToXmlSchemaConverter);
                 var xsdStream = TestDataHelper.LoadDataFromEmbeddedResource("Designer.Tests._TestData.Model.Xsd.Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES.xsd");
                 xsdStream.Seek(0, System.IO.SeekOrigin.Begin);
                 var schemaName = "Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES";
@@ -258,7 +258,7 @@ namespace Designer.Tests.Services
         public void GetSchemaUri_ValidNameProvided_ShouldReturnUri(string org, string repository, string schemaName, string relativePath, string repositoryBaseUrl)
         {
             var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(TestDataHelper.GetTestDataRepositoriesRootDirectory());
-            var schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings);
+            var schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings, TestDataHelper.XmlSchemaToJsonSchemaConverter, TestDataHelper.JsonSchemaToXmlSchemaConverter);
 
             var schemaUri = schemaModelService.GetSchemaUri(org, repository, schemaName, relativePath);
 
@@ -278,7 +278,7 @@ namespace Designer.Tests.Services
             try
             {
                 var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(TestDataHelper.GetTestDataRepositoriesRootDirectory());
-                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings);
+                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings, TestDataHelper.XmlSchemaToJsonSchemaConverter, TestDataHelper.JsonSchemaToXmlSchemaConverter);
                 var xsdStream = TestDataHelper.LoadDataFromEmbeddedResource("Designer.Tests._TestData.Model.Xsd.SimpleInvalidNonSeresSchema.xsd");
                 var schemaName = "SimpleInvalidNonSeresSchema";
                 var fileName = $"{schemaName}.xsd";
@@ -309,7 +309,7 @@ namespace Designer.Tests.Services
             try
             {
                 var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(TestDataHelper.GetTestDataRepositoriesRootDirectory());
-                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings);
+                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings, TestDataHelper.XmlSchemaToJsonSchemaConverter, TestDataHelper.JsonSchemaToXmlSchemaConverter);
                 var xsdStream = TestDataHelper.LoadDataFromEmbeddedResource("Designer.Tests._TestData.Model.Xsd.SimpleValidNonSeresSchema.xsd");
                 var schemaName = "SimpleValidNonSeresSchema";
                 var fileName = $"{schemaName}.xsd";
@@ -346,7 +346,7 @@ namespace Designer.Tests.Services
             try
             {
                 var altinnGitRepositoryFactory = new AltinnGitRepositoryFactory(TestDataHelper.GetTestDataRepositoriesRootDirectory());
-                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings);
+                ISchemaModelService schemaModelService = new SchemaModelService(altinnGitRepositoryFactory, TestDataHelper.LogFactory, TestDataHelper.ServiceRepositorySettings, TestDataHelper.XmlSchemaToJsonSchemaConverter, TestDataHelper.JsonSchemaToXmlSchemaConverter);
                 var xsdStream = TestDataHelper.LoadDataFromEmbeddedResource("Designer.Tests._TestData.Model.Xsd.OED.xsd");
                 var schemaName = "OED_M";
                 var fileName = $"{schemaName}.xsd";

--- a/src/studio/src/designer/backend.Tests/Services/SourceControlLoggingDecoratorTests.cs
+++ b/src/studio/src/designer/backend.Tests/Services/SourceControlLoggingDecoratorTests.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Altinn.Studio.DataModeling.Converter.Interfaces;
+using Altinn.Studio.DataModeling.Converter.Json;
+using Altinn.Studio.DataModeling.Converter.Xml;
 using Altinn.Studio.Designer;
 using Altinn.Studio.Designer.Helpers.Extensions;
 using Altinn.Studio.Designer.Models;
@@ -50,13 +53,13 @@ namespace Designer.Tests.Services
         public void DecoratedISourceControlService_Status_LogsErrorWithAdditionalInfo()
         {
             (ISourceControl service, Mock<ILogger<SourceControlLoggingDecorator>> loggerMock) = GetService();
-                        
+
             try
             {
                 service.Status("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -72,7 +75,7 @@ namespace Designer.Tests.Services
                 service.CloneRemoteRepository("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -88,7 +91,7 @@ namespace Designer.Tests.Services
                 service.CloneRemoteRepository("org_should_not_exists", "repo_should_not_exists", "destination_path_should_not_exists", "branch_name_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -104,7 +107,7 @@ namespace Designer.Tests.Services
                 service.DeleteRepository("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -120,7 +123,7 @@ namespace Designer.Tests.Services
                 service.StageChange("org_should_not_exists", "repo_should_not_exists", "file_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -136,7 +139,7 @@ namespace Designer.Tests.Services
                 service.AbortMerge("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -152,7 +155,7 @@ namespace Designer.Tests.Services
                 service.CheckoutLatestCommitForSpecificFile("org_should_not_exists", "repo_should_not_exists", "file_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -168,7 +171,7 @@ namespace Designer.Tests.Services
                 service.CheckRemoteUpdates("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -184,7 +187,7 @@ namespace Designer.Tests.Services
                 service.Commit(new CommitInfo() { Org = "org_should_not_exists", Repository = "repo_should_not_exists", Message = "should_not_be_commited" });
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -248,7 +251,7 @@ namespace Designer.Tests.Services
                 service.FetchRemoteChanges("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -264,7 +267,7 @@ namespace Designer.Tests.Services
                 service.GetInitialCommit("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -280,7 +283,7 @@ namespace Designer.Tests.Services
                 service.GetLatestCommitForCurrentUser("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -296,7 +299,7 @@ namespace Designer.Tests.Services
                 service.IsLocalRepo("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {             
+            {
             }
 
             loggerMock.Verify();
@@ -312,7 +315,7 @@ namespace Designer.Tests.Services
                 service.Log("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -328,7 +331,7 @@ namespace Designer.Tests.Services
                 service.PullRemoteChanges("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -344,7 +347,7 @@ namespace Designer.Tests.Services
                 service.Push("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -360,7 +363,7 @@ namespace Designer.Tests.Services
                 service.PushChangesForRepository(new CommitInfo() { Org = "org_should_not_exists", Repository = "repo_should_not_exists", Message = "should_not_be_commited" });
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -376,7 +379,7 @@ namespace Designer.Tests.Services
                 service.RepositoryStatus("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -392,7 +395,7 @@ namespace Designer.Tests.Services
                 service.ResetCommit("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();
@@ -408,7 +411,7 @@ namespace Designer.Tests.Services
                 service.VerifyCloneExists("org_should_not_exists", "repo_should_not_exists");
             }
             catch
-            {                
+            {
             }
 
             loggerMock.Verify();

--- a/src/studio/src/designer/backend.Tests/Utils/TestDataHelper.cs
+++ b/src/studio/src/designer/backend.Tests/Utils/TestDataHelper.cs
@@ -5,6 +5,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Schema;
+using Altinn.Studio.DataModeling.Converter.Interfaces;
+using Altinn.Studio.DataModeling.Converter.Json;
+using Altinn.Studio.DataModeling.Converter.Xml;
+using Altinn.Studio.DataModeling.Json;
 using Altinn.Studio.Designer.Configuration;
 using Manatee.Json;
 using Manatee.Json.Schema;
@@ -322,6 +326,17 @@ namespace Designer.Tests.Utils
         }
 
         public static IOptions<ServiceRepositorySettings> ServiceRepositorySettings { get; } = GetServiceRepositorySettings();
+
+        public static (IXmlSchemaToJsonSchemaConverter XmlSchemaToJsonSchemaConverter, IJsonSchemaToXmlSchemaConverter JsonSchemaToXmlSchemaConverter) GetXmlAndJsonConverters()
+        {
+            IXmlSchemaToJsonSchemaConverter xmlSchemaToJsonSchemaConverter = new XmlSchemaToJsonSchemaConverter();
+            IJsonSchemaToXmlSchemaConverter jsonSchemaToXmlSchemaConverter = new JsonSchemaToXmlSchemaConverter(new JsonSchemaNormalizer());
+            return (xmlSchemaToJsonSchemaConverter, jsonSchemaToXmlSchemaConverter);
+        }
+
+        public static IXmlSchemaToJsonSchemaConverter XmlSchemaToJsonSchemaConverter { get; } = GetXmlAndJsonConverters().XmlSchemaToJsonSchemaConverter;
+
+        public static IJsonSchemaToXmlSchemaConverter JsonSchemaToXmlSchemaConverter { get; } = GetXmlAndJsonConverters().JsonSchemaToXmlSchemaConverter;
 
         /// <summary>
         /// File.ReadAllBytes alternative to avoid read and/or write locking

--- a/src/studio/src/designer/backend.Tests/Utils/TestDataHelper.cs
+++ b/src/studio/src/designer/backend.Tests/Utils/TestDataHelper.cs
@@ -327,16 +327,9 @@ namespace Designer.Tests.Utils
 
         public static IOptions<ServiceRepositorySettings> ServiceRepositorySettings { get; } = GetServiceRepositorySettings();
 
-        public static (IXmlSchemaToJsonSchemaConverter XmlSchemaToJsonSchemaConverter, IJsonSchemaToXmlSchemaConverter JsonSchemaToXmlSchemaConverter) GetXmlAndJsonConverters()
-        {
-            IXmlSchemaToJsonSchemaConverter xmlSchemaToJsonSchemaConverter = new XmlSchemaToJsonSchemaConverter();
-            IJsonSchemaToXmlSchemaConverter jsonSchemaToXmlSchemaConverter = new JsonSchemaToXmlSchemaConverter(new JsonSchemaNormalizer());
-            return (xmlSchemaToJsonSchemaConverter, jsonSchemaToXmlSchemaConverter);
-        }
+        public static IXmlSchemaToJsonSchemaConverter XmlSchemaToJsonSchemaConverter => new XmlSchemaToJsonSchemaConverter();
 
-        public static IXmlSchemaToJsonSchemaConverter XmlSchemaToJsonSchemaConverter { get; } = GetXmlAndJsonConverters().XmlSchemaToJsonSchemaConverter;
-
-        public static IJsonSchemaToXmlSchemaConverter JsonSchemaToXmlSchemaConverter { get; } = GetXmlAndJsonConverters().JsonSchemaToXmlSchemaConverter;
+        public static IJsonSchemaToXmlSchemaConverter JsonSchemaToXmlSchemaConverter => new JsonSchemaToXmlSchemaConverter(new JsonSchemaNormalizer());
 
         /// <summary>
         /// File.ReadAllBytes alternative to avoid read and/or write locking

--- a/src/studio/src/designer/backend/Infrastructure/ServiceRegistration.cs
+++ b/src/studio/src/designer/backend/Infrastructure/ServiceRegistration.cs
@@ -1,4 +1,8 @@
 using Altinn.Common.AccessTokenClient.Services;
+using Altinn.Studio.DataModeling.Converter.Interfaces;
+using Altinn.Studio.DataModeling.Converter.Json;
+using Altinn.Studio.DataModeling.Converter.Xml;
+using Altinn.Studio.DataModeling.Json;
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Factories;
 using Altinn.Studio.Designer.Repository;
@@ -44,6 +48,9 @@ namespace Altinn.Studio.Designer.Infrastructure
             services.AddTransient<ISigningCredentialsResolver, SigningCredentialsResolver>();
             services.AddTransient<ILanguagesService, LanguagesService>();
             services.AddTransient<ITextsService, TextsService>();
+            services.AddTransient<IXmlSchemaToJsonSchemaConverter, XmlSchemaToJsonSchemaConverter>();
+            services.AddTransient<IJsonSchemaToXmlSchemaConverter, JsonSchemaToXmlSchemaConverter>();
+            services.AddTransient<IJsonSchemaNormalizer, JsonSchemaNormalizer>();
 
             return services;
         }


### PR DESCRIPTION
## Description
- Add interface for xmlSchemaToJsonSchemaconverter
- Add interface for jsoSchemaToXmlSchemaconverter
- Inject interfaces in `SchemaModelSerivce.cs` constructor
- Remove all `new` keywords and use injected interface instead.
- Add mapping of interfaces to `ServiceRegistration` method in `Program.cs`

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
