### PR TITLE
Add type selection to fields tab

### DIFF
--- a/src/studio/src/designer/backend/Languages/ini/en.ini
+++ b/src/studio/src/designer/backend/Languages/ini/en.ini
@@ -428,6 +428,7 @@ enum = Valid values
 enum_empty = The list is empty—all values will be approved.
 enum_legend = List of valid values
 field = Field
+field_name = Field name
 fields = Fields
 format = Format
 format_date = Date

--- a/src/studio/src/designer/backend/Languages/ini/nb.ini
+++ b/src/studio/src/designer/backend/Languages/ini/nb.ini
@@ -432,6 +432,7 @@ enum = Gyldige verdier
 enum_empty = Listen er tom – alle verdier vil bli godtatt.
 enum_legend = Liste med gyldige verdier
 field = Objekt
+field_name = Navn på felt
 fields = Felter
 format = Format
 format_date = Dato

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.module.css
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.module.css
@@ -1,5 +1,13 @@
 .root {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr auto auto auto;
+}
+
+.addButtonCell {
+  grid-column: 1 / 5;
+}
+
+.addButtonCell > * {
+  width: 100%;
 }

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
@@ -1,11 +1,11 @@
 import React, { BaseSyntheticEvent, useEffect } from 'react';
 import type { ILanguage, ISchemaState } from '../../types';
 import { PropertyItem } from './PropertyItem';
-import { addProperty, deleteProperty, setPropertyName } from '../../features/editor/schemaEditorSlice';
+import { addProperty, deleteProperty, setPropertyName, setType } from '../../features/editor/schemaEditorSlice';
 import { useDispatch, useSelector } from 'react-redux';
 import { getTranslation } from '../../utils/language';
 import type { UiSchemaNode } from '@altinn/schema-model';
-import { getChildNodesByPointer, getNodeDisplayName } from '@altinn/schema-model';
+import { FieldType, getChildNodesByPointer, getNodeDisplayName } from '@altinn/schema-model';
 import classes from './ItemFieldsTab.module.css';
 import { getDomFriendlyID } from '../../utils/ui-schema-utils';
 import { usePrevious } from '../../hooks/usePrevious';
@@ -42,6 +42,8 @@ export const ItemFieldsTab = ({ selectedItem, language }: ItemFieldsTabProps) =>
       }),
     );
 
+  const onChangeType = (path: string, type: FieldType) => dispatch(setType({ path, type }));
+
   const onDeleteObjectClick = (path: string) => dispatch(deleteProperty({ path }));
 
   const dispatchAddProperty = () =>
@@ -58,26 +60,40 @@ export const ItemFieldsTab = ({ selectedItem, language }: ItemFieldsTabProps) =>
     dispatchAddProperty();
   };
 
+  const t = (key: string) => getTranslation(key, language);
+
   return (
     <div className={classes.root}>
+      {childNodes.length && (
+        <>
+          <div>{t('field_name')}</div>
+          <div>{t('type')}</div>
+          <div>{t('required')}</div>
+          <div>{t('delete')}</div>
+        </>
+      )}
       {childNodes.map((childNode) => (
         <PropertyItem
           fullPath={childNode.pointer}
           inputId={propertyInputIdFromNode(childNode)}
           key={childNode.pointer}
           language={language}
+          onChangeType={onChangeType}
           onChangeValue={onChangePropertyName}
           onDeleteField={onDeleteObjectClick}
           onEnterKeyPress={dispatchAddProperty}
           readOnly={readonly}
           required={childNode.isRequired}
+          type={childNode.fieldType as FieldType}
           value={getNodeDisplayName(childNode)}
         />
       ))}
       {!readonly && (
-        <Button onClick={onAddPropertyClicked} variant={ButtonVariant.Secondary}>
-          {getTranslation('add_property', language)}
-        </Button>
+        <div className={classes.addButtonCell}>
+          <Button onClick={onAddPropertyClicked} variant={ButtonVariant.Secondary}>
+            {t('add_property')}
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/PropertyItem.module.css
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/PropertyItem.module.css
@@ -1,16 +1,20 @@
-.root {
-  align-items: center;
-  display: flex;
-  flex-direction: row;
-  gap: 2rem;
-  width: 100%;
+.gridItem {
+  place-self: center center;
 }
 
 .nameInputCell {
-  display: inline-block;
-  flex: 1;
+  place-self: stretch stretch;
 }
 
-.nameInputCell > div {
+.nameInputCell > * {
   width: 100%;
+  height: 100%;
+}
+
+.typeSelectCell {
+  justify-self: stretch;
+}
+
+.requiredCheckCell > * {
+  display: grid;
 }

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/PropertyItem.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/PropertyItem.test.tsx
@@ -2,26 +2,34 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import { IPropertyItemProps, PropertyItem } from './PropertyItem';
 import { renderWithRedux } from '../../../test/renderWithRedux';
+import { FieldType } from '@altinn/schema-model';
 
 // Test data:
-const textRequired = 'Required';
-const textDelete = 'Delete';
+const textDeleteField = 'Slett felt';
+const textFieldName = 'Navn på felt';
+const textRequired = 'Påkrevd';
+const textType = 'Type';
 const fullPath = 'test';
 const inputId = 'some-random-id';
+const type = FieldType.String;
 const value = '';
 const mockLanguage = {
   schema_editor: {
-    delete_field: textDelete,
+    delete_field: textDeleteField,
+    field_name: textFieldName,
     required: textRequired,
+    type: textType,
   },
 };
 const defaultProps: IPropertyItemProps = {
   fullPath,
   inputId,
   language: mockLanguage,
+  onChangeType: jest.fn(),
   onChangeValue: jest.fn(),
   onDeleteField: jest.fn(),
   onEnterKeyPress: jest.fn(),
+  type,
   value,
 };
 
@@ -52,6 +60,11 @@ test('Text input field is disabled when the "readOnly" prop is true', () => {
 test('Text input field is not disabled when the "readOnly" prop is false', () => {
   renderPropertyItem({ readOnly: false });
   expect(screen.getByRole('textbox')).not.toBeDisabled();
+});
+
+test('Text input field is correctly labelled', () => {
+  renderPropertyItem();
+  expect(screen.getByRole('textbox')).toHaveAccessibleName(textFieldName);
 });
 
 test('onChangeValue is called on blur when text changes', async () => {
@@ -93,6 +106,24 @@ test('Name input field has given id', async () => {
   expect(container.querySelector(`#${inputId}`)).toBeDefined();
 });
 
+test('Given type is selected', async () => {
+  renderPropertyItem();
+  expect(screen.getByRole('combobox')).toHaveValue(type);
+});
+
+test('onChangeType is called with correct parameters when type changes', async () => {
+  const onChangeType = jest.fn();
+  const { user } = renderPropertyItem({ onChangeType });
+  await user.selectOptions(screen.getByRole('combobox'), FieldType.Integer);
+  expect(onChangeType).toHaveBeenCalledTimes(1);
+  expect(onChangeType).toHaveBeenCalledWith(fullPath, FieldType.Integer);
+});
+
+test('"Type" select box is correctly labelled', async () => {
+  renderPropertyItem();
+  expect(screen.getByRole('combobox')).toHaveAccessibleName(textType);
+});
+
 test('"Required" checkbox appears', () => {
   renderPropertyItem();
   expect(screen.getByRole('checkbox')).toBeDefined();
@@ -111,11 +142,6 @@ test('"Required" checkbox is checked when "required" prop is true', () => {
 test('"Required" checkbox is not checked when "required" prop is false', () => {
   renderPropertyItem({ required: false });
   expect(screen.getByRole('checkbox')).not.toBeChecked();
-});
-
-test('"Required" label appears on screen', () => {
-  renderPropertyItem();
-  expect(screen.getByText(textRequired)).toBeDefined();
 });
 
 test('"Required" checkbox is enabled by default', () => {
@@ -147,5 +173,5 @@ test('onDeleteField is called when the delete button is clicked', async () => {
 
 test('Delete button is labelled with the delete text', async () => {
   renderPropertyItem();
-  expect(screen.getByRole('button')).toHaveAccessibleName(textDelete);
+  expect(screen.getByRole('button')).toHaveAccessibleName(textDeleteField);
 });

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/PropertyItem.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/PropertyItem.tsx
@@ -7,16 +7,21 @@ import { Checkbox, TextField } from '@altinn/altinn-design-system';
 import classes from './PropertyItem.module.css';
 import { IconButton } from '../common/IconButton';
 import { IconImage } from '../common/Icon';
+import { Select } from '../common/Select';
+import { getTypeOptions } from './helpers/options';
+import { FieldType } from '@altinn/schema-model';
 
 export interface IPropertyItemProps {
   fullPath: string;
   inputId: string;
   language: ILanguage;
+  onChangeType: (path: string, type: FieldType) => void;
   onChangeValue: (path: string, value: string) => void;
   onDeleteField: (path: string, key: string) => void;
   onEnterKeyPress: () => void;
   readOnly?: boolean;
   required?: boolean;
+  type: FieldType;
   value: string;
 }
 
@@ -24,11 +29,13 @@ export function PropertyItem({
   fullPath,
   inputId,
   language,
+  onChangeType,
   onChangeValue,
   onDeleteField,
   onEnterKeyPress,
   readOnly,
   required,
+  type,
   value,
 }: IPropertyItemProps) {
   const [inputValue, setInputValue] = useState<string>(value || '');
@@ -58,9 +65,10 @@ export function PropertyItem({
   const t = (key: string) => getTranslation(key, language);
 
   return (
-    <div className={classes.root}>
-      <span className={classes.nameInputCell}>
+    <>
+      <div className={classes.nameInputCell + ' ' + classes.gridItem}>
         <TextField
+          aria-label={t('field_name')}
           id={inputId}
           value={inputValue}
           disabled={readOnly}
@@ -68,15 +76,25 @@ export function PropertyItem({
           onBlur={onBlur}
           onKeyDown={onKeyDown}
         />
-      </span>
-      <Checkbox
-        checked={required ?? false}
-        disabled={readOnly}
-        onChange={changeRequiredHandler}
-        name='checkedArray'
-        label={t('required')}
+      </div>
+      <Select
+        className={classes.typeSelectCell + ' ' + classes.gridItem}
+        hideLabel
+        id={`${inputId}-typeselect`}
+        label={t('type')}
+        onChange={(type) => onChangeType(fullPath, type as FieldType)}
+        options={getTypeOptions(t)}
+        value={type}
       />
+      <span className={classes.requiredCheckCell + ' ' + classes.gridItem}>
+        <Checkbox
+          checked={required ?? false}
+          disabled={readOnly}
+          onChange={changeRequiredHandler}
+          name='checkedArray'
+        />
+      </span>
       <IconButton ariaLabel={t('delete_field')} icon={IconImage.Wastebucket} onClick={deleteHandler} />
-    </div>
+    </>
   );
 }

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/common/Select.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/common/Select.test.tsx
@@ -63,3 +63,15 @@ test('Empty value option should appear with given label if set', async () => {
   renderSelect({ emptyOptionLabel });
   expect(screen.getByText(emptyOptionLabel)).toHaveValue('');
 });
+
+test('If hideLabel is true, the label should not be visible, but still accessible', () => {
+  renderSelect({ hideLabel: true });
+  expect(screen.queryByText(label)).toBeFalsy();
+  expect(screen.getByRole('combobox')).toHaveAccessibleName(label);
+});
+
+test('Select box should have given class', () => {
+  const className = 'test';
+  const { container } = renderSelect({ className });
+  expect(container.querySelector(`.${className}`)).toBeDefined();
+});

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/common/Select.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/common/Select.tsx
@@ -4,7 +4,9 @@ import { Label } from './Label';
 import classes from './Select.module.css';
 
 export interface SelectProps {
+  className?: string;
   emptyOptionLabel?: string;
+  hideLabel?: boolean;
   id: string;
   label: string;
   onChange: (value: string) => void;
@@ -12,12 +14,22 @@ export interface SelectProps {
   value?: string;
 }
 
-export const Select = ({ emptyOptionLabel, id, label, onChange, options, value }: SelectProps) => {
+export const Select = ({
+  className,
+  emptyOptionLabel,
+  hideLabel,
+  id,
+  label,
+  onChange,
+  options,
+  value,
+}: SelectProps) => {
   const allOptions = emptyOptionLabel === undefined ? options : [{value: '', label: emptyOptionLabel}, ...options];
   return (
-    <span>
-      <Label htmlFor={id}>{label}</Label>
+    <span className={className}>
+      {!hideLabel && <Label htmlFor={id}>{label}</Label>}
       <select
+        aria-label={hideLabel ? label : undefined}
         className={classes.select}
         id={id}
         onChange={(event) => onChange(event.target.value)}


### PR DESCRIPTION
## Description
Made it possible to choose type in the "fields" tab in the inspector.

## Related Issue(s)
- #9138

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
