### PR TITLE
fix: min/max items keywords invalid usage fix

### DIFF
--- a/src/studio/src/designer/DataModeling.Tests/Assertions/JsonSchemaAssertions.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Assertions/JsonSchemaAssertions.cs
@@ -278,6 +278,12 @@ namespace DataModeling.Tests.Assertions
                 case XsdTextKeyword expectedKeyword:
                     KeywordEqual(expectedKeyword, (XsdTextKeyword)actual);
                     break;
+                case XsdMinOccursKeyword expectedKeyword:
+                    KeywordEqual(expectedKeyword, (XsdMinOccursKeyword)actual);
+                    break;
+                case XsdMaxOccursKeyword expectedKeyword:
+                    KeywordEqual(expectedKeyword, (XsdMaxOccursKeyword)actual);
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(expected.GetType().Name, "Unknown Json Schema Keyword");
             }
@@ -743,6 +749,16 @@ namespace DataModeling.Tests.Assertions
         }
 
         private static void KeywordEqual(XsdTextKeyword expected, XsdTextKeyword actual)
+        {
+            Assert.True(expected.Equals(actual));
+        }
+
+        private static void KeywordEqual(XsdMinOccursKeyword expected, XsdMinOccursKeyword actual)
+        {
+            Assert.True(expected.Equals(actual));
+        }
+
+        private static void KeywordEqual(XsdMaxOccursKeyword expected, XsdMaxOccursKeyword actual)
         {
             Assert.True(expected.Equals(actual));
         }

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/BaseClasses/ConverterTestBase.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/BaseClasses/ConverterTestBase.cs
@@ -7,10 +7,10 @@ using Altinn.Studio.DataModeling.Utils;
 using FluentAssertions;
 using Json.Schema;
 
-namespace DataModeling.Tests.Json.Keywords.FormatRange.Converter;
+namespace DataModeling.Tests.Json.Keywords.BaseClasses;
 
-public abstract class FormatRangeConverterTestBase<TTestType, TKeywordType> : FluentTestsBase<TTestType>
-where TTestType : FormatRangeConverterTestBase<TTestType, TKeywordType>
+public abstract class ConverterTestBase<TTestType, TKeywordType> : FluentTestsBase<TTestType>
+where TTestType : ConverterTestBase<TTestType, TKeywordType>
 where TKeywordType : IJsonSchemaKeyword
 {
     protected JsonSchema JsonSchema { get; set; }
@@ -21,20 +21,12 @@ where TKeywordType : IJsonSchemaKeyword
 
     protected abstract JsonConverter<TKeywordType> Converter { get;  }
 
-    protected FormatRangeConverterTestBase()
+    protected ConverterTestBase()
     {
         JsonSchemaKeywords.RegisterXsdKeywords();
     }
 
-    protected abstract TKeywordType CreateKeywordWithValue(string value);
-
-    protected TTestType KeywordCreatedWithValue(string value)
-    {
-        Keyword = CreateKeywordWithValue(value);
-        return this as TTestType;
-    }
-
-    protected TTestType XsdTextKeywordWrittenToStream()
+    protected TTestType KeywordWrittenToStream()
     {
         SerializedKeyword = new MemoryStream();
         var jsonWriter = new Utf8JsonWriter(SerializedKeyword);
@@ -53,7 +45,7 @@ where TKeywordType : IJsonSchemaKeyword
         return this as TTestType;
     }
 
-    protected TTestType XsdTextKeywordReadFromSchema()
+    protected TTestType KeywordReadFromSchema()
     {
         Keyword = JsonSchema.GetKeyword<TKeywordType>();
         return this as TTestType;

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/BaseClasses/KeywordTestsBase.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/BaseClasses/KeywordTestsBase.cs
@@ -1,21 +1,13 @@
 ﻿using Json.Schema;
 using Xunit;
 
-namespace DataModeling.Tests.Json.Keywords.FormatRange.Keyword;
+namespace DataModeling.Tests.Json.Keywords.BaseClasses;
 
-public abstract class FormatRangeKeywordTestsBase<TTestType, TKeywordType> : FluentTestsBase<TTestType>
-    where TTestType : FormatRangeKeywordTestsBase<TTestType, TKeywordType>
+public abstract class KeywordTestsBase<TTestType, TKeywordType> : FluentTestsBase<TTestType>
+    where TTestType : KeywordTestsBase<TTestType, TKeywordType>
     where TKeywordType : IJsonSchemaKeyword
 {
     protected TKeywordType Keyword { get; set; }
-
-    protected abstract TKeywordType CreateKeywordWithValue(string value);
-
-    protected TTestType KeywordCreatedWithValue(string value)
-    {
-        Keyword = CreateKeywordWithValue(value);
-        return this as TTestType;
-    }
 
     protected TTestType KeywordShouldEqual(TKeywordType expectedKeyword)
     {

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/BaseClasses/ValueKeywordConverterTestBase.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/BaseClasses/ValueKeywordConverterTestBase.cs
@@ -1,0 +1,16 @@
+﻿using Json.Schema;
+
+namespace DataModeling.Tests.Json.Keywords.BaseClasses;
+
+public abstract class ValueKeywordConverterTestBase<TTestType, TKeywordType, TValueType> : ConverterTestBase<TTestType, TKeywordType>
+where TTestType : ValueKeywordConverterTestBase<TTestType, TKeywordType, TValueType>
+where TKeywordType : IJsonSchemaKeyword
+{
+    protected abstract TKeywordType CreateKeywordWithValue(TValueType value);
+
+    protected TTestType KeywordCreatedWithValue(TValueType value)
+    {
+        Keyword = CreateKeywordWithValue(value);
+        return this as TTestType;
+    }
+}

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/BaseClasses/ValueKeywordTestsBase.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/BaseClasses/ValueKeywordTestsBase.cs
@@ -1,0 +1,16 @@
+﻿using Json.Schema;
+
+namespace DataModeling.Tests.Json.Keywords.BaseClasses;
+
+public abstract class ValueKeywordTestsBase<TTestType, TKeywordType, TValueType> : KeywordTestsBase<TTestType, TKeywordType>
+    where TTestType : KeywordTestsBase<TTestType, TKeywordType>
+    where TKeywordType : IJsonSchemaKeyword
+{
+    protected abstract TKeywordType CreateKeywordWithValue(TValueType value);
+
+    protected TTestType KeywordCreatedWithValue(TValueType value)
+    {
+        Keyword = CreateKeywordWithValue(value);
+        return this as TTestType;
+    }
+}

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatExclusiveMaximumKeywordJsonConverterConverterTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatExclusiveMaximumKeywordJsonConverterConverterTests.cs
@@ -1,29 +1,27 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
 using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Converter;
 
-public class FormatExclusiveMaximumKeywordJsonConverterConverterTests : FormatRangeConverterTestBase<FormatExclusiveMaximumKeywordJsonConverterConverterTests, FormatExclusiveMaximumKeyword>
+public class FormatExclusiveMaximumKeywordJsonConverterConverterTests : ValueKeywordConverterTestBase<FormatExclusiveMaximumKeywordJsonConverterConverterTests, FormatExclusiveMaximumKeyword, string>
 {
     private const string KeywordPlaceholder = "formatExclusiveMaximum";
 
     protected override JsonConverter<FormatExclusiveMaximumKeyword> Converter
         => new FormatExclusiveMaximumKeyword.FormatExclusiveMaximumKeywordJsonConverter();
 
-    protected override FormatExclusiveMaximumKeyword CreateKeywordWithValue(string value)
-    {
-        return new FormatExclusiveMaximumKeyword(value);
-    }
+    protected override FormatExclusiveMaximumKeyword CreateKeywordWithValue(string value) => new(value);
 
     [Theory]
     [InlineData("2022-10-17")]
     public void Write_ValidStructure_ShouldWriteToJson(string value)
     {
         Given.That.KeywordCreatedWithValue(value)
-            .When.XsdTextKeywordWrittenToStream()
+            .When.KeywordWrittenToStream()
             .Then.SerializedKeywordShouldBe($@"{{""{KeywordPlaceholder}"":""{value}""}}");
     }
 
@@ -36,7 +34,7 @@ public class FormatExclusiveMaximumKeywordJsonConverterConverterTests : FormatRa
             }}";
 
         Given.That.JsonSchemaLoaded(jsonSchema)
-            .When.XsdTextKeywordReadFromSchema()
+            .When.KeywordReadFromSchema()
             .Then.Keyword.Should().NotBeNull();
 
         And.Keyword.Value.Should().Be(value);

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatExclusiveMinimumKeywordJsonConverterConverterTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatExclusiveMinimumKeywordJsonConverterConverterTests.cs
@@ -1,29 +1,27 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
 using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Converter;
 
-public class FormatExclusiveMinimumKeywordJsonConverterConverterTests: FormatRangeConverterTestBase<FormatExclusiveMinimumKeywordJsonConverterConverterTests, FormatExclusiveMinimumKeyword>
+public class FormatExclusiveMinimumKeywordJsonConverterConverterTests: ValueKeywordConverterTestBase<FormatExclusiveMinimumKeywordJsonConverterConverterTests, FormatExclusiveMinimumKeyword, string>
 {
     private const string KeywordPlaceholder = "formatExclusiveMinimum";
 
     protected override JsonConverter<FormatExclusiveMinimumKeyword> Converter
     => new FormatExclusiveMinimumKeyword.FormatExclusiveMinimumKeywordJsonConverter();
 
-    protected override FormatExclusiveMinimumKeyword CreateKeywordWithValue(string value)
-    {
-        return new FormatExclusiveMinimumKeyword(value);
-    }
+    protected override FormatExclusiveMinimumKeyword CreateKeywordWithValue(string value) => new(value);
 
     [Theory]
     [InlineData("2022-10-17")]
     public void Write_ValidStructure_ShouldWriteToJson(string value)
     {
         Given.That.KeywordCreatedWithValue(value)
-            .When.XsdTextKeywordWrittenToStream()
+            .When.KeywordWrittenToStream()
             .Then.SerializedKeywordShouldBe($@"{{""{KeywordPlaceholder}"":""{value}""}}");
     }
 
@@ -36,7 +34,7 @@ public class FormatExclusiveMinimumKeywordJsonConverterConverterTests: FormatRan
             }}";
 
         Given.That.JsonSchemaLoaded(jsonSchema)
-            .When.XsdTextKeywordReadFromSchema()
+            .When.KeywordReadFromSchema()
             .Then.Keyword.Should().NotBeNull();
 
         And.Keyword.Value.Should().Be(value);

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatMaximumKeywordJsonConverterConverterTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatMaximumKeywordJsonConverterConverterTests.cs
@@ -1,12 +1,13 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
 using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Converter;
 
-public class FormatMaximumKeywordJsonConverterConverterTests : FormatRangeConverterTestBase<FormatMaximumKeywordJsonConverterConverterTests, FormatMaximumKeyword>
+public class FormatMaximumKeywordJsonConverterConverterTests : ValueKeywordConverterTestBase<FormatMaximumKeywordJsonConverterConverterTests, FormatMaximumKeyword, string>
 {
     private const string KeywordPlaceholder = "formatMaximum";
 
@@ -20,7 +21,7 @@ public class FormatMaximumKeywordJsonConverterConverterTests : FormatRangeConver
     public void Write_ValidStructure_ShouldWriteToJson(string value)
     {
         Given.That.KeywordCreatedWithValue(value)
-            .When.XsdTextKeywordWrittenToStream()
+            .When.KeywordWrittenToStream()
             .Then.SerializedKeywordShouldBe($@"{{""{KeywordPlaceholder}"":""{value}""}}");
     }
 
@@ -33,7 +34,7 @@ public class FormatMaximumKeywordJsonConverterConverterTests : FormatRangeConver
             }}";
 
         Given.That.JsonSchemaLoaded(jsonSchema)
-            .When.XsdTextKeywordReadFromSchema()
+            .When.KeywordReadFromSchema()
             .Then.Keyword.Should().NotBeNull();
 
         And.Keyword.Value.Should().Be(value);

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatMinimumKeywordJsonConverterConverterTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatMinimumKeywordJsonConverterConverterTests.cs
@@ -1,29 +1,27 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
 using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Converter;
 
-public class FormatMinimumKeywordJsonConverterConverterTests : FormatRangeConverterTestBase<FormatMinimumKeywordJsonConverterConverterTests, FormatMinimumKeyword>
+public class FormatMinimumKeywordJsonConverterConverterTests : ValueKeywordConverterTestBase<FormatMinimumKeywordJsonConverterConverterTests, FormatMinimumKeyword, string>
 {
     private const string KeywordPlaceholder = "formatMinimum";
 
     protected override JsonConverter<FormatMinimumKeyword> Converter
         => new FormatMinimumKeyword.FormatMinimumKeywordJsonConverter();
 
-    protected override FormatMinimumKeyword CreateKeywordWithValue(string value)
-    {
-        return new FormatMinimumKeyword(value);
-    }
+    protected override FormatMinimumKeyword CreateKeywordWithValue(string value) => new(value);
 
     [Theory]
     [InlineData("2022-10-17")]
     public void Write_ValidStructure_ShouldWriteToJson(string value)
     {
         Given.That.KeywordCreatedWithValue(value)
-            .When.XsdTextKeywordWrittenToStream()
+            .When.KeywordWrittenToStream()
             .Then.SerializedKeywordShouldBe($@"{{""{KeywordPlaceholder}"":""{value}""}}");
     }
 
@@ -36,7 +34,7 @@ public class FormatMinimumKeywordJsonConverterConverterTests : FormatRangeConver
             }}";
 
         Given.That.JsonSchemaLoaded(jsonSchema)
-            .When.XsdTextKeywordReadFromSchema()
+            .When.KeywordReadFromSchema()
             .Then.Keyword.Should().NotBeNull();
 
         And.Keyword.Value.Should().Be(value);

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatExclusiveMaximumKeywordTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatExclusiveMaximumKeywordTests.cs
@@ -1,10 +1,11 @@
 ﻿using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
 using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Keyword;
 
-public class FormatExclusiveMaximumKeywordTests: FormatRangeKeywordTestsBase<FormatExclusiveMaximumKeywordTests, FormatExclusiveMaximumKeyword>
+public class FormatExclusiveMaximumKeywordTests: ValueKeywordTestsBase<FormatExclusiveMaximumKeywordTests, FormatExclusiveMaximumKeyword, string>
 {
     protected override FormatExclusiveMaximumKeyword CreateKeywordWithValue(string value) => new(value);
 

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatExclusiveMinimumKeywordTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatExclusiveMinimumKeywordTests.cs
@@ -1,10 +1,11 @@
 ﻿using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
 using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Keyword;
 
-public class FormatExclusiveMinimumKeywordTests: FormatRangeKeywordTestsBase<FormatExclusiveMinimumKeywordTests, FormatExclusiveMinimumKeyword>
+public class FormatExclusiveMinimumKeywordTests: ValueKeywordTestsBase<FormatExclusiveMinimumKeywordTests, FormatExclusiveMinimumKeyword, string>
 {
     protected override FormatExclusiveMinimumKeyword CreateKeywordWithValue(string value) => new(value);
 

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatMaximumKeywordTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatMaximumKeywordTests.cs
@@ -1,10 +1,11 @@
 ﻿using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
 using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Keyword;
 
-public class FormatMaximumKeywordTests: FormatRangeKeywordTestsBase<FormatMaximumKeywordTests, FormatMaximumKeyword>
+public class FormatMaximumKeywordTests: ValueKeywordTestsBase<FormatMaximumKeywordTests, FormatMaximumKeyword, string>
 {
     protected override FormatMaximumKeyword CreateKeywordWithValue(string value) => new(value);
 

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/OccursKeywords/Converter/XsdMaxOccursKeywordJsonConverterTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/OccursKeywords/Converter/XsdMaxOccursKeywordJsonConverterTests.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
+using FluentAssertions;
+using Xunit;
+
+namespace DataModeling.Tests.Json.Keywords.OccursKeywords.Converter
+{
+    public class XsdMaxOccursKeywordJsonConverterTests : ValueKeywordConverterTestBase<XsdMaxOccursKeywordJsonConverterTests, XsdMaxOccursKeyword, string>
+    {
+        private const string KeywordPlaceholder = "@xsdMaxOccurs";
+
+        protected override JsonConverter<XsdMaxOccursKeyword> Converter => new XsdMaxOccursKeyword.XsdMaxOccursKeywordJsonConverter();
+
+        protected override XsdMaxOccursKeyword CreateKeywordWithValue(string value) => new(value);
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("unbounded")]
+        public void Read_ValidJson_FromSchema(string value)
+        {
+            var jsonSchema = @$"{{
+                ""{KeywordPlaceholder}"": ""{value}""
+            }}";
+
+            Given.That.JsonSchemaLoaded(jsonSchema)
+                .When.KeywordReadFromSchema()
+                .Then.Keyword.Should().NotBeNull();
+
+            And.Keyword.Value.Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("unbounded")]
+        public void Write_ValidStructure_ShouldWriteToJson(string value)
+        {
+            Given.That.KeywordCreatedWithValue(value)
+                .When.KeywordWrittenToStream()
+                .Then.SerializedKeywordShouldBe($@"{{""{KeywordPlaceholder}"":""{value}""}}");
+        }
+
+        [Theory]
+        [InlineData("1")]
+        public void Read_InvalidJson_ShouldThrow(string value)
+        {
+            var jsonSchema = @$"{{
+                    ""{KeywordPlaceholder}"": {{
+                        ""value"": ""{value}""
+                }}";
+
+            var ex = Assert.Throws<JsonException>(() =>
+                Given.That.JsonSchemaLoaded(jsonSchema));
+            ex.Message.Should().Be("Expected string");
+        }
+    }
+}

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/OccursKeywords/Converter/XsdMinOccursKeywordJsonConverterTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/OccursKeywords/Converter/XsdMinOccursKeywordJsonConverterTests.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
+using FluentAssertions;
+using Xunit;
+
+namespace DataModeling.Tests.Json.Keywords.OccursKeywords.Converter
+{
+    public class XsdMinOccursKeywordJsonConverterTests : ValueKeywordConverterTestBase<XsdMinOccursKeywordJsonConverterTests, XsdMinOccursKeyword, int>
+    {
+        private const string KeywordPlaceholder = "@xsdMinOccurs";
+
+        protected override JsonConverter<XsdMinOccursKeyword> Converter => new XsdMinOccursKeyword.XsdMinOccursKeywordJsonConverter();
+
+        protected override XsdMinOccursKeyword CreateKeywordWithValue(int value) => new(value);
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(100)]
+        public void Read_ValidJson_FromSchema(int value)
+        {
+            var jsonSchema = @$"{{
+                ""{KeywordPlaceholder}"": {value}
+            }}";
+
+            Given.That.JsonSchemaLoaded(jsonSchema)
+                .When.KeywordReadFromSchema()
+                .Then.Keyword.Should().NotBeNull();
+
+            And.Keyword.Value.Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(100)]
+        public void Write_ValidStructure_ShouldWriteToJson(int value)
+        {
+            Given.That.KeywordCreatedWithValue(value)
+                .When.KeywordWrittenToStream()
+                .Then.SerializedKeywordShouldBe($@"{{""{KeywordPlaceholder}"":{value}}}");
+        }
+
+        [Theory]
+        [InlineData(1)]
+        public void Read_InvalidJson_ShouldThrow(int value)
+        {
+            var jsonSchema = @$"{{
+                    ""{KeywordPlaceholder}"": {{
+                        ""value"": ""{value}""
+                }}";
+
+            var ex = Assert.Throws<JsonException>(() =>
+                Given.That.JsonSchemaLoaded(jsonSchema));
+            ex.Message.Should().Be("Expected number");
+        }
+    }
+}

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/OccursKeywords/Keyword/XsdMaxOccursKeywordTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/OccursKeywords/Keyword/XsdMaxOccursKeywordTests.cs
@@ -3,26 +3,32 @@ using DataModeling.Tests.Json.Keywords.BaseClasses;
 using FluentAssertions;
 using Xunit;
 
-namespace DataModeling.Tests.Json.Keywords.FormatRange.Keyword;
+namespace DataModeling.Tests.Json.Keywords.OccursKeywords.Keyword;
 
-public class FormatMinimumKeywordTests: ValueKeywordTestsBase<FormatMinimumKeywordTests, FormatMinimumKeyword, string>
+public class XsdMaxOccursKeywordTests: ValueKeywordTestsBase<XsdMaxOccursKeywordTests, XsdMaxOccursKeyword, string>
 {
-    protected override FormatMinimumKeyword CreateKeywordWithValue(string value) => new(value);
+    protected override XsdMaxOccursKeyword CreateKeywordWithValue(string value) => new(value);
 
     [Theory]
-    [InlineData("2022-10-18")]
+    [InlineData("0")]
+    [InlineData("1")]
+    [InlineData("100")]
+    [InlineData("unbounded")]
     public void CreatedKeyword_ShouldHaveValue(string value)
     {
-        Keyword = new FormatMinimumKeyword(value);
+        Keyword = new XsdMaxOccursKeyword(value);
         Keyword.Value.Should().Be(value);
     }
 
     [Theory]
-    [InlineData("2022-10-18")]
+    [InlineData("0")]
+    [InlineData("1")]
+    [InlineData("100")]
+    [InlineData("unbounded")]
     public void SameKeywords_Should_BeEqual(string value)
     {
-        var expectedKeyword = new FormatMinimumKeyword(value);
-        object expectedKeywordObject = new FormatMinimumKeyword(value);
+        var expectedKeyword = new XsdMaxOccursKeyword(value);
+        object expectedKeywordObject = new XsdMaxOccursKeyword(value);
 
         Given.That.KeywordCreatedWithValue(value)
             .Then.KeywordShouldEqual(expectedKeyword)
@@ -31,7 +37,10 @@ public class FormatMinimumKeywordTests: ValueKeywordTestsBase<FormatMinimumKeywo
     }
 
     [Theory]
-    [InlineData("2022-10-18")]
+    [InlineData("0")]
+    [InlineData("1")]
+    [InlineData("100")]
+    [InlineData("unbounded")]
     public void GetHashCode_ShouldBe_As_Value(string value)
     {
         var expectedHashCode = value.GetHashCode();

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/OccursKeywords/Keyword/XsdMinOccursKeywordTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/OccursKeywords/Keyword/XsdMinOccursKeywordTests.cs
@@ -1,0 +1,47 @@
+﻿using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
+using FluentAssertions;
+using Xunit;
+
+namespace DataModeling.Tests.Json.Keywords.OccursKeywords.Keyword;
+
+public class XsdMinOccursKeywordTests: ValueKeywordTestsBase<XsdMinOccursKeywordTests, XsdMinOccursKeyword, int>
+{
+    protected override XsdMinOccursKeyword CreateKeywordWithValue(int value) => new(value);
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(100)]
+    public void CreatedKeyword_ShouldHaveValue(int value)
+    {
+        Keyword = new XsdMinOccursKeyword(value);
+        Keyword.Value.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(100)]
+    public void SameKeywords_Should_BeEqual(int value)
+    {
+        var expectedKeyword = new XsdMinOccursKeyword(value);
+        object expectedKeywordObject = new XsdMinOccursKeyword(value);
+
+        Given.That.KeywordCreatedWithValue(value)
+            .Then.KeywordShouldEqual(expectedKeyword)
+            .And.KeywordShouldEqualObject(expectedKeywordObject)
+            .But.KeywordShouldNotEqual(null);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(100)]
+    public void GetHashCode_ShouldBe_As_Value(int value)
+    {
+        var expectedHashCode = value.GetHashCode();
+        Given.That.KeywordCreatedWithValue(value);
+        expectedHashCode.GetHashCode().Should().Be(Keyword.GetHashCode());
+    }
+}

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/XsdTextKeywordTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/XsdTextKeywordTests.cs
@@ -1,18 +1,19 @@
 ﻿using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
 using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords;
 
-public class XsdTextKeywordTests: FluentTestsBase<XsdTextKeywordTests>
+public class XsdTextKeywordTests: ValueKeywordTestsBase<XsdTextKeywordTests, XsdTextKeyword, bool>
 {
-    private XsdTextKeyword XsdTextKeyword { get; set; }
+    protected override XsdTextKeyword CreateKeywordWithValue(bool value) => new(value);
 
     [Fact]
     public void DefaultValue_ShouldBe_False()
     {
-        XsdTextKeyword = new XsdTextKeyword();
-        XsdTextKeyword.Value.Should().Be(false);
+        Keyword = new XsdTextKeyword();
+        Keyword.Value.Should().Be(false);
     }
 
     [Theory]
@@ -22,33 +23,9 @@ public class XsdTextKeywordTests: FluentTestsBase<XsdTextKeywordTests>
     {
         var expectedKeyword = new XsdTextKeyword(value);
         object expectedKeywordObject = new XsdTextKeyword(value);
-        Given.That.XsdTextKeywordCreatedWithValue(value)
-            .Then.XsdTextKeywordShouldEqual(expectedKeyword)
-            .And.XsdTextKeywordShouldEqualObject(expectedKeywordObject)
-            .But.XsdTextKeywordShouldNotEqual(null);
-    }
-
-    private XsdTextKeywordTests XsdTextKeywordCreatedWithValue(bool value)
-    {
-        XsdTextKeyword = new XsdTextKeyword(value);
-        return this;
-    }
-
-    private XsdTextKeywordTests XsdTextKeywordShouldEqual(XsdTextKeyword expectedKeyword)
-    {
-        Assert.True(XsdTextKeyword.Equals(expectedKeyword));
-        return this;
-    }
-
-    private XsdTextKeywordTests XsdTextKeywordShouldEqualObject(object obj)
-    {
-        Assert.True(XsdTextKeyword.Equals(obj));
-        return this;
-    }
-
-    private XsdTextKeywordTests XsdTextKeywordShouldNotEqual(XsdTextKeyword expectedKeyword)
-    {
-        Assert.False(XsdTextKeyword.Equals(expectedKeyword));
-        return this;
+        Given.That.KeywordCreatedWithValue(value)
+            .Then.KeywordShouldEqual(expectedKeyword)
+            .And.KeywordShouldEqualObject(expectedKeywordObject)
+            .But.KeywordShouldNotEqual(null);
     }
 }

--- a/src/studio/src/designer/DataModeling.Tests/XmlSchemaToJsonTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/XmlSchemaToJsonTests.cs
@@ -4,17 +4,12 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Xml.Schema;
-using Altinn.Studio.DataModeling.Converter.Json;
 using Altinn.Studio.DataModeling.Converter.Xml;
-using Altinn.Studio.DataModeling.Json;
 using Altinn.Studio.DataModeling.Json.Formats;
 using Altinn.Studio.DataModeling.Json.Keywords;
-
 using DataModeling.Tests.Assertions;
-
 using Json.More;
 using Json.Schema;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/General/ComplexSchema.json
+++ b/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/General/ComplexSchema.json
@@ -54,19 +54,21 @@
                 "email": {
                   "type": "array",
                   "items": {
-                    "type": "string",
-                    "minItems": 1
+                    "type": "string"
                   },
                   "@xsdType": "string",
-                  "minItems": 1
+                  "minItems": 1,
+                  "@xsdMinOccurs": 1,
+                  "@xsdMaxOccurs": "unbounded"
                 },
                 "contacts": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/$defs/contact",
-                    "maxItems": 10
+                    "$ref": "#/$defs/contact"
                   },
-                  "minItems": 0
+                  "maxItems": 10,
+                  "@xsdMinOccurs": 0,
+                  "@xsdMaxOccurs": "10"
                 }
               },
               "required": [
@@ -163,7 +165,7 @@
         "co": {
           "type": "string",
           "@xsdType": "string",
-          "minItems": 0
+          "@xsdMinOccurs": 0
         },
         "zipCode": {
           "type": "string",
@@ -199,7 +201,7 @@
             "co": {
               "type": "string",
               "@xsdType": "string",
-              "minItems": 0
+              "@xsdMinOccurs": 0
             },
             "zipCode": {
               "allOf": [
@@ -244,7 +246,7 @@
             "co": {
               "type": "string",
               "@xsdType": "string",
-              "minItems": 0
+              "@xsdMinOccurs": 0
             },
             "zipCode": {
               "allOf": [

--- a/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/General/NestedArrays.json
+++ b/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/General/NestedArrays.json
@@ -22,10 +22,11 @@
         "e2": {
           "type": "array",
           "items": {
-            "type": "string",
-            "maxItems": 100
+            "type": "string"
           },
-          "minItems": 0,
+          "maxItems": 100,
+          "@xsdMinOccurs": 0,
+          "@xsdMaxOccurs": "100",
           "@xsdType": "string"
         }
       },
@@ -49,7 +50,8 @@
               "items": {
                 "type": "string"
               },
-              "minItems": 0,
+              "@xsdMinOccurs": 0,
+              "@xsdMaxOccurs": "unbounded",
               "@xsdType": "string"
             }
           }
@@ -68,7 +70,8 @@
               "items": {
                 "type": "string"
               },
-              "minItems": 0,
+              "@xsdMinOccurs": 0,
+              "@xsdMaxOccurs": "unbounded",
               "@xsdType": "string"
             }
           }
@@ -87,7 +90,8 @@
               "items": {
                 "type": "string"
               },
-              "minItems": 0,
+              "@xsdMinOccurs": 0,
+              "@xsdMaxOccurs": "unbounded",
               "@xsdType": "string"
             }
           }

--- a/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/General/NillableAttribute.json
+++ b/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/General/NillableAttribute.json
@@ -27,7 +27,7 @@
         "minzero": {
           "type": "integer",
           "@xsdType": "int",
-          "minItems": 0
+          "@xsdMinOccurs": 0
         },
         "nilint": {
           "type": [
@@ -49,7 +49,7 @@
             "null"
           ],
           "@xsdType": "string",
-          "minItems": 0
+          "@xsdMinOccurs": 0
         },
         "refered": {
           "oneOf": [

--- a/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/Seres/SeresArray.json
+++ b/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/Seres/SeresArray.json
@@ -49,29 +49,31 @@
         "e1": {
           "type": "array",
           "items": {
-            "type": "string",
-            "minItems": 1
+            "type": "string"
           },
-          "@xsdType": "string"
+          "minItems": 1,
+          "@xsdType": "string",
+          "@xsdMaxOccurs": "unbounded"
         },
         "e2": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/simpleType"
           },
-          "minItems": 0
+          "@xsdMinOccurs": 0,
+          "@xsdMaxOccurs": "unbounded"
         },
         "e4": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/complexType",
-            "minItems": 1
-          }
+            "$ref": "#/$defs/complexType"
+          },
+          "minItems": 1,
+          "@xsdMaxOccurs": "unbounded"
         },
         "e5": {
           "type": "array",
           "items": {
-            "minItems": 1,
             "properties": {
               "fish": {
                 "type": "string",
@@ -86,7 +88,9 @@
               "fish",
               "stew"
             ]
-          }
+          },
+          "minItems": 1,
+          "@xsdMaxOccurs": "unbounded"
         }
       },
       "required": [

--- a/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/Seres/SeresNillable.json
+++ b/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/Seres/SeresNillable.json
@@ -153,7 +153,8 @@
               "ProcessContent": "None"
             }
           },
-          "minItems": 0
+          "@xsdMinOccurs": 0,
+          "@xsdMaxOccurs": "unbounded"
         },
         "code": {
           "type": [
@@ -161,7 +162,7 @@
             "null"
           ],
           "@xsdType": "string",
-          "minItems": 0
+          "@xsdMinOccurs": 0
         }
       }
     },
@@ -173,7 +174,7 @@
             "null"
           ],
           "@xsdType": "string",
-          "minItems": 0
+          "@xsdMinOccurs": 0
         },
         "email": {
           "type": [
@@ -181,7 +182,7 @@
             "null"
           ],
           "@xsdType": "string",
-          "minItems": 0
+          "@xsdMinOccurs": 0
         }
       }
     }

--- a/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/Seres/SeresSimpleTypeRestrictions.json
+++ b/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/Seres/SeresSimpleTypeRestrictions.json
@@ -80,7 +80,7 @@
     },
     "c0": {
       "$ref": "#/$defs/complexStructure",
-      "minItems": 0
+      "@xsdMinOccurs": 0
     }
   },
   "required": [

--- a/src/studio/src/designer/DataModeling/Converter/Json/Strategy/GeneralJsonSchemaConverter.cs
+++ b/src/studio/src/designer/DataModeling/Converter/Json/Strategy/GeneralJsonSchemaConverter.cs
@@ -1028,15 +1028,7 @@ namespace Altinn.Studio.DataModeling.Converter.Json.Strategy
                 SetRequired(subItem, required.Contains(name));
                 SetFixed(subItem, property.Keywords.GetKeyword<ConstKeyword>());
                 SetDefault(subItem, property.Keywords.GetKeyword<DefaultKeyword>());
-
-                if (subItem is XmlSchemaParticle particle)
-                {
-                    var minItemsKeyword = property.Keywords.GetKeyword<MinItemsKeyword>();
-                    if (minItemsKeyword != null)
-                    {
-                        particle.MinOccurs = minItemsKeyword.Value;
-                    }
-                }
+                CarryOccurs(subItem, property);
 
                 switch (subItem)
                 {
@@ -1055,6 +1047,24 @@ namespace Altinn.Studio.DataModeling.Converter.Json.Strategy
             }
         }
 
+        private static void CarryOccurs(XmlSchemaObject subItem, JsonSchema property)
+        {
+            if (subItem is not XmlSchemaParticle particle)
+            {
+                return;
+            }
+
+            if (property.Keywords.TryGetKeyword(out XsdMinOccursKeyword minOccursKeyword))
+            {
+                particle.MinOccurs = minOccursKeyword.Value;
+            }
+
+            if (property.Keywords.TryGetKeyword(out XsdMaxOccursKeyword maxOccursKeyword))
+            {
+                particle.MaxOccursString = maxOccursKeyword.Value;
+            }
+        }
+
         private XmlSchemaObject ConvertSubschema(JsonPointer path, JsonSchema schema)
         {
             var compatibleTypes = _metadata.GetCompatibleTypes(path);
@@ -1065,12 +1075,12 @@ namespace Altinn.Studio.DataModeling.Converter.Json.Strategy
             {
                 var itemSchema = schema.GetKeyword<ItemsKeyword>().SingleSchema;
 
-                if (itemSchema.TryGetKeyword(out MinItemsKeyword minItemsKeyword))
+                if (schema.TryGetKeyword(out MinItemsKeyword minItemsKeyword))
                 {
                     arrayMinOccurs = minItemsKeyword.Value.ToString();
                 }
 
-                arrayMaxOccurs = itemSchema.TryGetKeyword(out MaxItemsKeyword maxItemsKeyword) ? maxItemsKeyword.Value.ToString() : "unbounded";
+                arrayMaxOccurs = schema.TryGetKeyword(out MaxItemsKeyword maxItemsKeyword) ? maxItemsKeyword.Value.ToString() : "unbounded";
             }
 
             if (compatibleTypes.Contains(CompatibleXsdType.SimpleType))

--- a/src/studio/src/designer/DataModeling/Converter/Json/Strategy/GeneralJsonSchemaConverter.cs
+++ b/src/studio/src/designer/DataModeling/Converter/Json/Strategy/GeneralJsonSchemaConverter.cs
@@ -1073,8 +1073,6 @@ namespace Altinn.Studio.DataModeling.Converter.Json.Strategy
 
             if (compatibleTypes.Contains(CompatibleXsdType.Array))
             {
-                var itemSchema = schema.GetKeyword<ItemsKeyword>().SingleSchema;
-
                 if (schema.TryGetKeyword(out MinItemsKeyword minItemsKeyword))
                 {
                     arrayMinOccurs = minItemsKeyword.Value.ToString();

--- a/src/studio/src/designer/DataModeling/Converter/Xml/XmlSchemaToJsonSchemaConverter.cs
+++ b/src/studio/src/designer/DataModeling/Converter/Xml/XmlSchemaToJsonSchemaConverter.cs
@@ -972,12 +972,12 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
 
                     if (item.MinOccurs != 0)
                     {
-                        itemsBuilder.MinItems((uint)item.MinOccurs);
+                        builder.MinItems((uint)item.MinOccurs);
                     }
 
                     if (item.MaxOccursString != "unbounded")
                     {
-                        itemsBuilder.MaxItems((uint)item.MaxOccurs);
+                        builder.MaxItems((uint)item.MaxOccurs);
                     }
 
                     builder.Items(itemsBuilder);
@@ -985,7 +985,7 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
             }
 
             AddUnhandledAttributes(item, builder);
-            CarryMinOccursProperty(item, builder);
+            CarryOccursProperties(item, builder);
 
             return builder;
         }
@@ -1004,7 +1004,6 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
             JsonSchemaBuilder builder = new JsonSchemaBuilder();
 
             HandleSequence(item, optional, array, builder);
-            CarryMinOccursProperty(item, builder);
 
             return builder;
         }
@@ -1026,15 +1025,12 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
             {
                 case XmlSchemaChoice x:
                     HandleChoice(x, optional, array, builder);
-                    CarryMinOccursProperty(x, builder);
                     break;
                 case XmlSchemaAll x:
                     HandleAll(x, optional, array, builder);
-                    CarryMinOccursProperty(x, builder);
                     break;
                 case XmlSchemaSequence x:
                     HandleSequence(x, optional, array, builder);
-                    CarryMinOccursProperty(x, builder);
                     break;
             }
         }
@@ -1145,12 +1141,12 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
                 {
                     if (minOccurs > 0)
                     {
-                        typeBuilder.MinItems((uint)minOccurs);
+                        builder.MinItems((uint)minOccurs);
                     }
 
                     if (maxOccurs > 1 && maxOccurs < decimal.MaxValue)
                     {
-                        typeBuilder.MaxItems((uint)maxOccurs);
+                        builder.MaxItems((uint)maxOccurs);
                     }
 
                     JsonSchema itemsSchema = typeBuilder;
@@ -1297,11 +1293,16 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
             return decimal.TryParse(facetValue, NumberStyles.Float, CultureInfo.InvariantCulture, out dLength);
         }
 
-        private static void CarryMinOccursProperty(XmlSchemaParticle item, JsonSchemaBuilder builder)
+        private static void CarryOccursProperties(XmlSchemaParticle item, JsonSchemaBuilder builder)
         {
             if (!string.IsNullOrWhiteSpace(item.MinOccursString))
             {
-                builder.MinItems((uint)item.MinOccurs);
+                builder.XsdMinOccurs((int)item.MinOccurs);
+            }
+
+            if (!string.IsNullOrWhiteSpace(item.MaxOccursString))
+            {
+                builder.XsdMaxOccurs(item.MaxOccursString);
             }
         }
     }

--- a/src/studio/src/designer/DataModeling/Json/Keywords/XsdMaxOccursKeyword.cs
+++ b/src/studio/src/designer/DataModeling/Json/Keywords/XsdMaxOccursKeyword.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Json.Schema;
+
+namespace Altinn.Studio.DataModeling.Json.Keywords;
+
+/// <summary>
+/// Adds @xsdMaxOccurs keyword to schema.
+/// </summary>
+[SchemaKeyword(Name)]
+[SchemaDraft(Draft.Draft6)]
+[SchemaDraft(Draft.Draft7)]
+[SchemaDraft(Draft.Draft201909)]
+[SchemaDraft(Draft.Draft202012)]
+[JsonConverter(typeof(XsdMaxOccursKeywordJsonConverter))]
+public class XsdMaxOccursKeyword: IJsonSchemaKeyword, IEquatable<XsdMaxOccursKeyword>
+{
+    /// <summary>
+    /// The name of the keyword
+    /// </summary>
+    private const string Name = "@xsdMaxOccurs";
+
+    /// <summary>
+    /// Content
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create instance with defined value
+    /// </summary>
+    public XsdMaxOccursKeyword(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Always validates as true
+    /// </summary>
+    public void Validate(ValidationContext context)
+    {
+        // No validation defined for this keyword.
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(XsdMaxOccursKeyword other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return ReferenceEquals(this, other) || Equals(Value, other.Value);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object obj)
+    {
+        return Equals(obj as XsdMaxOccursKeyword);
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        return Value.GetHashCode();
+    }
+
+    /// <summary>
+    /// Serializer for the @xsdMaxOccurs keyword
+    /// </summary>
+    public class XsdMaxOccursKeywordJsonConverter : JsonConverter<XsdMaxOccursKeyword>
+    {
+        /// <inheritdoc/>
+        public override XsdMaxOccursKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                throw new JsonException("Expected string");
+            }
+
+            return new XsdMaxOccursKeyword(reader.GetString());
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, XsdMaxOccursKeyword value, JsonSerializerOptions options)
+        {
+            writer.WriteString(Name, value.Value);
+        }
+    }
+}

--- a/src/studio/src/designer/DataModeling/Json/Keywords/XsdMaxOccursKeyword.cs
+++ b/src/studio/src/designer/DataModeling/Json/Keywords/XsdMaxOccursKeyword.cs
@@ -14,7 +14,7 @@ namespace Altinn.Studio.DataModeling.Json.Keywords;
 [SchemaDraft(Draft.Draft201909)]
 [SchemaDraft(Draft.Draft202012)]
 [JsonConverter(typeof(XsdMaxOccursKeywordJsonConverter))]
-public class XsdMaxOccursKeyword: IJsonSchemaKeyword, IEquatable<XsdMaxOccursKeyword>
+public sealed class XsdMaxOccursKeyword: IJsonSchemaKeyword, IEquatable<XsdMaxOccursKeyword>
 {
     /// <summary>
     /// The name of the keyword

--- a/src/studio/src/designer/DataModeling/Json/Keywords/XsdMinOccursKeyword.cs
+++ b/src/studio/src/designer/DataModeling/Json/Keywords/XsdMinOccursKeyword.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Json.Schema;
+
+namespace Altinn.Studio.DataModeling.Json.Keywords;
+
+/// <summary>
+/// Adds @xsdMinOccurs keyword to schema.
+/// </summary>
+[SchemaKeyword(Name)]
+[SchemaDraft(Draft.Draft6)]
+[SchemaDraft(Draft.Draft7)]
+[SchemaDraft(Draft.Draft201909)]
+[SchemaDraft(Draft.Draft202012)]
+[JsonConverter(typeof(XsdMinOccursKeywordJsonConverter))]
+public class XsdMinOccursKeyword: IJsonSchemaKeyword, IEquatable<XsdMinOccursKeyword>
+{
+    /// <summary>
+    /// The name of the keyword
+    /// </summary>
+    private const string Name = "@xsdMinOccurs";
+
+    /// <summary>
+    /// Content
+    /// </summary>
+    public int Value { get; }
+
+    /// <summary>
+    /// Create instance with defined value
+    /// </summary>
+    public XsdMinOccursKeyword(int value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Always validates as true
+    /// </summary>
+    public void Validate(ValidationContext context)
+    {
+        // No validation defined for this keyword.
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(XsdMinOccursKeyword other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return ReferenceEquals(this, other) || Equals(Value, other.Value);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object obj)
+    {
+        return Equals(obj as XsdMinOccursKeyword);
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        return Value.GetHashCode();
+    }
+
+    /// <summary>
+    /// Serializer for the @xsdMinOccurs keyword
+    /// </summary>
+    public class XsdMinOccursKeywordJsonConverter : JsonConverter<XsdMinOccursKeyword>
+    {
+        /// <inheritdoc/>
+        public override XsdMinOccursKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.Number)
+            {
+                throw new JsonException("Expected number");
+            }
+
+            return new XsdMinOccursKeyword(reader.GetInt32());
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, XsdMinOccursKeyword value, JsonSerializerOptions options)
+        {
+            writer.WriteNumber(Name, value.Value);
+        }
+    }
+}

--- a/src/studio/src/designer/DataModeling/Json/Keywords/XsdMinOccursKeyword.cs
+++ b/src/studio/src/designer/DataModeling/Json/Keywords/XsdMinOccursKeyword.cs
@@ -14,7 +14,7 @@ namespace Altinn.Studio.DataModeling.Json.Keywords;
 [SchemaDraft(Draft.Draft201909)]
 [SchemaDraft(Draft.Draft202012)]
 [JsonConverter(typeof(XsdMinOccursKeywordJsonConverter))]
-public class XsdMinOccursKeyword: IJsonSchemaKeyword, IEquatable<XsdMinOccursKeyword>
+public sealed class XsdMinOccursKeyword: IJsonSchemaKeyword, IEquatable<XsdMinOccursKeyword>
 {
     /// <summary>
     /// The name of the keyword

--- a/src/studio/src/designer/DataModeling/Utils/JsonSchemaXsdExtensions.cs
+++ b/src/studio/src/designer/DataModeling/Utils/JsonSchemaXsdExtensions.cs
@@ -191,5 +191,29 @@ namespace Altinn.Studio.DataModeling.Utils
             builder.Add(new FormatMaximumKeyword(value));
             return builder;
         }
+
+        /// <summary>
+        /// Adds <see cref="XsdMinOccursKeyword"/> keyword to builder
+        /// </summary>
+        /// <param name="builder">The <see cref="JsonSchemaBuilder"/></param>
+        /// <param name="value">MinOccurs value</param>
+        /// <returns>The <see cref="JsonSchemaBuilder"/> used for chaining</returns>
+        public static JsonSchemaBuilder XsdMinOccurs(this JsonSchemaBuilder builder, int value)
+        {
+            builder.Add(new XsdMinOccursKeyword(value));
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds <see cref="XsdMaxOccursKeyword"/> keyword to builder
+        /// </summary>
+        /// <param name="builder">The <see cref="JsonSchemaBuilder"/></param>
+        /// <param name="value">MaxOccurs value</param>
+        /// <returns>The <see cref="JsonSchemaBuilder"/> used for chaining</returns>
+        public static JsonSchemaBuilder XsdMaxOccurs(this JsonSchemaBuilder builder, string value)
+        {
+            builder.Add(new XsdMaxOccursKeyword(value));
+            return builder;
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix invalid usage of minItems and minItems keywords

## Description
<!--- Describe your changes in detail -->
- Moved restricted minItems and maxItems keywords from items node
#### Example:
```json
 "someArray": {
                "type": "array",
                "items": {
                  "type": "string",
                  "minItems": 1,
                  "maxItems": 1
                }
          }
```
to 
```json
 "someArray": {
                "type": "array",
                "items": {
                  "type": "string"
                },
                "minItems": 1,
                "maxItems": 1
          }
```
- Removed usage of minItems keyword from non-array types.
- Introduced @xsdMaxOccurs and @xsdMinOccurs keywords.
- Keyword tests refactored
- Test data fixed

## Related Issue(s)
- #9129 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
