### PR TITLE
Fix failing Cypress test

### DIFF
--- a/src/test/cypress/e2e/integration/usecase/usecase.js
+++ b/src/test/cypress/e2e/integration/usecase/usecase.js
@@ -27,7 +27,6 @@ context(
 
     it('Navigation', () => {
       cy.get(designer.aboutApp.repoName)
-        .find('input')
         .invoke('val')
         .should('contain', Cypress.env('deployApp').split('/')[1]);
       cy.get(designer.appMenu.edit).should('be.visible').click();


### PR DESCRIPTION
## Description
`designer.aboutApp.repoName` is now the id of the input itself, it's not a wrapper as before.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
