### PR TITLE
Use a volume mount for TestData for Localtest in Docker

### DIFF
--- a/src/development/docker-compose.yml
+++ b/src/development/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-80}
       - GeneralSettings__HostName=${TEST_DOMAIN:-local.altinn.cloud}
     volumes:
+      - ./TestData:/TestData
       - ${ALTINN3LOCALSTORAGE_PATH:-AltinnPlatformLocal}:/AltinnPlatformLocal
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Use a docker Volume mount to always get the latest TestData when running LocalTest in docker.

