### PR TITLE
fix: total digits restriction keyword

### DIFF
--- a/src/studio/src/designer/DataModeling.Tests/Assertions/JsonSchemaAssertions.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Assertions/JsonSchemaAssertions.cs
@@ -284,6 +284,9 @@ namespace DataModeling.Tests.Assertions
                 case XsdMaxOccursKeyword expectedKeyword:
                     KeywordEqual(expectedKeyword, (XsdMaxOccursKeyword)actual);
                     break;
+                case XsdTotalDigitsKeyword expectedKeyword:
+                    KeywordEqual(expectedKeyword, (XsdTotalDigitsKeyword)actual);
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(expected.GetType().Name, "Unknown Json Schema Keyword");
             }
@@ -759,6 +762,11 @@ namespace DataModeling.Tests.Assertions
         }
 
         private static void KeywordEqual(XsdMaxOccursKeyword expected, XsdMaxOccursKeyword actual)
+        {
+            Assert.True(expected.Equals(actual));
+        }
+
+        private static void KeywordEqual(XsdTotalDigitsKeyword expected, XsdTotalDigitsKeyword actual)
         {
             Assert.True(expected.Equals(actual));
         }

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/BaseClasses/KeywordTestsBase.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/BaseClasses/KeywordTestsBase.cs
@@ -1,4 +1,5 @@
-﻿using Json.Schema;
+﻿using Altinn.Studio.DataModeling.Json.Keywords;
+using Json.Schema;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.BaseClasses;
@@ -8,6 +9,11 @@ public abstract class KeywordTestsBase<TTestType, TKeywordType> : FluentTestsBas
     where TKeywordType : IJsonSchemaKeyword
 {
     protected TKeywordType Keyword { get; set; }
+
+    protected KeywordTestsBase()
+    {
+        JsonSchemaKeywords.RegisterXsdKeywords();
+    }
 
     protected TTestType KeywordShouldEqual(TKeywordType expectedKeyword)
     {

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordJsonConverterTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordJsonConverterTests.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
+using FluentAssertions;
+using Xunit;
+
+namespace DataModeling.Tests.Json.Keywords
+{
+    public class XsdTotalDigitsKeywordJsonConverterTests : ValueKeywordConverterTestBase<XsdTotalDigitsKeywordJsonConverterTests, XsdTotalDigitsKeyword, uint>
+    {
+        private const string KeywordPlaceholder = "@xsdTotalDigits";
+
+        protected override JsonConverter<XsdTotalDigitsKeyword> Converter => new XsdTotalDigitsKeyword.XsdTotalDigitsKeywordJsonConverter();
+
+        protected override XsdTotalDigitsKeyword CreateKeywordWithValue(uint value) => new(value);
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(100)]
+        public void Read_ValidJson_FromSchema(uint value)
+        {
+            var jsonSchema = @$"{{
+                ""{KeywordPlaceholder}"": {value}
+            }}";
+
+            Given.That.JsonSchemaLoaded(jsonSchema)
+                .When.KeywordReadFromSchema()
+                .Then.Keyword.Should().NotBeNull();
+
+            And.Keyword.Value.Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(100)]
+        public void Write_ValidStructure_ShouldWriteToJson(uint value)
+        {
+            Given.That.KeywordCreatedWithValue(value)
+                .When.KeywordWrittenToStream()
+                .Then.SerializedKeywordShouldBe($@"{{""{KeywordPlaceholder}"":{value}}}");
+        }
+
+        [Theory]
+        [InlineData(1)]
+        public void Read_InvalidJson_ShouldThrow(uint value)
+        {
+            var jsonSchema = @$"{{
+                    ""{KeywordPlaceholder}"": {{
+                        ""value"": ""{value}""
+                }}";
+
+            var ex = Assert.Throws<JsonException>(() =>
+                Given.That.JsonSchemaLoaded(jsonSchema));
+            ex.Message.Should().Be("Expected number");
+        }
+    }
+}

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordJsonConverterTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordJsonConverterTests.cs
@@ -9,7 +9,7 @@ namespace DataModeling.Tests.Json.Keywords
 {
     public class XsdTotalDigitsKeywordJsonConverterTests : ValueKeywordConverterTestBase<XsdTotalDigitsKeywordJsonConverterTests, XsdTotalDigitsKeyword, uint>
     {
-        private const string KeywordPlaceholder = "@xsdTotalDigits";
+        private const string KeywordPlaceholder = "totalDigits";
 
         protected override JsonConverter<XsdTotalDigitsKeyword> Converter => new XsdTotalDigitsKeyword.XsdTotalDigitsKeywordJsonConverter();
 

--- a/src/studio/src/designer/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordTests.cs
@@ -1,0 +1,44 @@
+﻿using Altinn.Studio.DataModeling.Json.Keywords;
+using DataModeling.Tests.Json.Keywords.BaseClasses;
+using FluentAssertions;
+using Xunit;
+
+namespace DataModeling.Tests.Json.Keywords;
+
+public class XsdTotalDigitsKeywordTests: ValueKeywordTestsBase<XsdTotalDigitsKeywordTests, XsdTotalDigitsKeyword, uint>
+{
+    protected override XsdTotalDigitsKeyword CreateKeywordWithValue(uint value) => new(value);
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    public void CreatedKeyword_ShouldHaveValue(uint value)
+    {
+        Keyword = new XsdTotalDigitsKeyword(value);
+        Keyword.Value.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    public void SameKeywords_Should_BeEqual(uint value)
+    {
+        var expectedKeyword = new XsdTotalDigitsKeyword(value);
+        object expectedKeywordObject = new XsdTotalDigitsKeyword(value);
+
+        Given.That.KeywordCreatedWithValue(value)
+            .Then.KeywordShouldEqual(expectedKeyword)
+            .And.KeywordShouldEqualObject(expectedKeywordObject)
+            .But.KeywordShouldNotEqual(null);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    public void GetHashCode_ShouldBe_As_Value(uint value)
+    {
+        var expectedHashCode = value.GetHashCode();
+        Given.That.KeywordCreatedWithValue(value);
+        expectedHashCode.GetHashCode().Should().Be(Keyword.GetHashCode());
+    }
+}

--- a/src/studio/src/designer/DataModeling.Tests/Utils/RestrictionHelperTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Utils/RestrictionHelperTests.cs
@@ -7,15 +7,50 @@ namespace DataModeling.Tests.Utils;
 public class RestrictionHelperTests
 {
     [Theory]
-    [InlineData("11111", 5)]
-    [InlineData("123.22", 5)]
+    [InlineData("11111", 8)]
+    [InlineData("123.22", 6)]
     [InlineData("2344.2", 5)]
-    [InlineData("1.0001", 5)]
+    [InlineData("1.0001", 10)]
     [InlineData("12.333", 5)]
-    public void TotalDigitsRegexString_ShouldMatch(string input, uint totalDigits)
+    public void TotalDigitsDecimalRegexString_ShouldMatch(string input, uint totalDigits)
     {
-        var regex = new Regex(RestrictionsHelper.TotalDigitsRegexString(totalDigits));
+        var regex = new Regex(RestrictionsHelper.TotalDigitsDecimalRegexString(totalDigits));
 
         Assert.Matches(regex, input);
+    }
+
+    [Theory]
+    [InlineData("111111", 3)]
+    [InlineData("123.223", 4)]
+    [InlineData("2344.22", 4)]
+    [InlineData("1.011", 3)]
+    [InlineData("12.33", 3)]
+    public void TotalDigitsDecimalRegexString_ShouldNotMatch_Too_Long(string input, uint totalDigits)
+    {
+        var regex = new Regex(RestrictionsHelper.TotalDigitsDecimalRegexString(totalDigits));
+
+        Assert.DoesNotMatch(regex, input);
+    }
+
+    [Theory]
+    [InlineData("11111", 5)]
+    [InlineData("12341234", 8)]
+    [InlineData("1234", 4)]
+    public void TotalDigitsRegexInteger_ShouldMatch(string input, uint totalDigits)
+    {
+        var regex = new Regex(RestrictionsHelper.TotalDigitsIntegerRegexString(totalDigits));
+
+        Assert.Matches(regex, input);
+    }
+
+    [Theory]
+    [InlineData("1111123", 5)]
+    [InlineData("12374628964", 8)]
+    [InlineData("123.1", 4)]
+    public void TotalDigitsRegexInteger_ShouldNotMatch_Too_Long_Or_Decimal(string input, uint totalDigits)
+    {
+        var regex = new Regex(RestrictionsHelper.TotalDigitsIntegerRegexString(totalDigits));
+
+        Assert.DoesNotMatch(regex, input);
     }
 }

--- a/src/studio/src/designer/DataModeling.Tests/Utils/RestrictionHelperTests.cs
+++ b/src/studio/src/designer/DataModeling.Tests/Utils/RestrictionHelperTests.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.RegularExpressions;
+using Altinn.Studio.DataModeling.Utils;
+using Xunit;
+
+namespace DataModeling.Tests.Utils;
+
+public class RestrictionHelperTests
+{
+    [Theory]
+    [InlineData("11111", 5)]
+    [InlineData("123.22", 5)]
+    [InlineData("2344.2", 5)]
+    [InlineData("1.0001", 5)]
+    [InlineData("12.333", 5)]
+    public void TotalDigitsRegexString_ShouldMatch(string input, uint totalDigits)
+    {
+        var regex = new Regex(RestrictionsHelper.TotalDigitsRegexString(totalDigits));
+
+        Assert.Matches(regex, input);
+    }
+}

--- a/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/General/SimpleTypeRestrictions.json
+++ b/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/General/SimpleTypeRestrictions.json
@@ -121,7 +121,7 @@
           "@xsdType": "decimal"
         },
         {
-          "@xsdTotalDigits": 10,
+          "totalDigits": 10,
           "maximum": 100,
           "minimum": -100
         }
@@ -134,7 +134,7 @@
           "@xsdType": "decimal"
         },
         {
-          "@xsdTotalDigits": 10,
+          "totalDigits": 10,
           "exclusiveMaximum": 100,
           "exclusiveMinimum": -100
         }

--- a/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/General/SimpleTypeRestrictions.json
+++ b/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/General/SimpleTypeRestrictions.json
@@ -121,7 +121,7 @@
           "@xsdType": "decimal"
         },
         {
-          "maxLength": 10,
+          "@xsdTotalDigits": 10,
           "maximum": 100,
           "minimum": -100
         }
@@ -134,7 +134,7 @@
           "@xsdType": "decimal"
         },
         {
-          "maxLength": 10,
+          "@xsdTotalDigits": 10,
           "exclusiveMaximum": 100,
           "exclusiveMinimum": -100
         }

--- a/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/Seres/SeresSimpleTypeRestrictions.json
+++ b/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/Seres/SeresSimpleTypeRestrictions.json
@@ -191,7 +191,7 @@
           "@xsdType": "decimal"
         },
         {
-          "@xsdTotalDigits": 10,
+          "totalDigits": 10,
           "maximum": 100,
           "minimum": -100.3
         }
@@ -204,7 +204,7 @@
           "@xsdType": "decimal"
         },
         {
-          "@xsdTotalDigits": 10,
+          "totalDigits": 10,
           "exclusiveMaximum": 100.5,
           "exclusiveMinimum": -100
         }

--- a/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/Seres/SeresSimpleTypeRestrictions.json
+++ b/src/studio/src/designer/DataModeling.Tests/_TestData/Model/JsonSchema/Seres/SeresSimpleTypeRestrictions.json
@@ -191,7 +191,7 @@
           "@xsdType": "decimal"
         },
         {
-          "maxLength": 10,
+          "@xsdTotalDigits": 10,
           "maximum": 100,
           "minimum": -100.3
         }
@@ -204,7 +204,7 @@
           "@xsdType": "decimal"
         },
         {
-          "maxLength": 10,
+          "@xsdTotalDigits": 10,
           "exclusiveMaximum": 100.5,
           "exclusiveMinimum": -100
         }

--- a/src/studio/src/designer/DataModeling/Converter/Json/Strategy/GeneralJsonSchemaConverter.cs
+++ b/src/studio/src/designer/DataModeling/Converter/Json/Strategy/GeneralJsonSchemaConverter.cs
@@ -778,6 +778,10 @@ namespace Altinn.Studio.DataModeling.Converter.Json.Strategy
                         keywords.MarkAsHandled<FormatMaximumKeyword>();
                         facets.Add(new XmlSchemaMaxInclusiveFacet() { Value = formatMaximum.Value.ToString(NumberFormatInfo.InvariantInfo) });
                         break;
+                    case XsdTotalDigitsKeyword totalDigitsKeyword:
+                        keywords.MarkAsHandled<XsdTotalDigitsKeyword>();
+                        facets.Add(new XmlSchemaTotalDigitsFacet() { Value = totalDigitsKeyword.Value.ToString(NumberFormatInfo.InvariantInfo) });
+                        break;
                     default:
                         continue;
                 }

--- a/src/studio/src/designer/DataModeling/Converter/Json/Strategy/JsonSchemaAnalyzer.cs
+++ b/src/studio/src/designer/DataModeling/Converter/Json/Strategy/JsonSchemaAnalyzer.cs
@@ -840,6 +840,10 @@ namespace Altinn.Studio.DataModeling.Converter.Json.Strategy
                     case FormatExclusiveMaximumKeyword:
                         continue;
 
+                    // Add totalDigits restriction
+                    case XsdTotalDigitsKeyword:
+                        continue;
+
                     default:
                         return false;
                 }

--- a/src/studio/src/designer/DataModeling/Converter/Xml/XmlSchemaToJsonSchemaConverter.cs
+++ b/src/studio/src/designer/DataModeling/Converter/Xml/XmlSchemaToJsonSchemaConverter.cs
@@ -356,7 +356,7 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
 
                     break;
                 case XmlSchemaMaxExclusiveFacet:
-                    if (FormatRangeHelper.IsRestrictionOnDateType(facet))
+                    if (RestrictionsHelper.IsRestrictionOnDateType(facet))
                     {
                         builder.FormatExclusiveMaximum(facet.Value);
                     }
@@ -367,7 +367,7 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
 
                     break;
                 case XmlSchemaMaxInclusiveFacet:
-                    if (FormatRangeHelper.IsRestrictionOnDateType(facet))
+                    if (RestrictionsHelper.IsRestrictionOnDateType(facet))
                     {
                         builder.FormatMaximum(facet.Value);
                     }
@@ -385,7 +385,7 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
 
                     break;
                 case XmlSchemaMinExclusiveFacet:
-                    if (FormatRangeHelper.IsRestrictionOnDateType(facet))
+                    if (RestrictionsHelper.IsRestrictionOnDateType(facet))
                     {
                         builder.FormatExclusiveMinimum(facet.Value);
                     }
@@ -396,7 +396,7 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
 
                     break;
                 case XmlSchemaMinInclusiveFacet:
-                    if (FormatRangeHelper.IsRestrictionOnDateType(facet))
+                    if (RestrictionsHelper.IsRestrictionOnDateType(facet))
                     {
                         builder.FormatMinimum(facet.Value);
                     }
@@ -416,7 +416,7 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
                 case XmlSchemaTotalDigitsFacet:
                     if (!string.IsNullOrWhiteSpace(facet.Value) && uint.TryParse(facet.Value, out uiLength))
                     {
-                        builder.MaxLength(uiLength);
+                        builder.XsdTotalDigits(uiLength);
                     }
 
                     break;

--- a/src/studio/src/designer/DataModeling/Json/Keywords/FormatExclusiveMaximumKeyword.cs
+++ b/src/studio/src/designer/DataModeling/Json/Keywords/FormatExclusiveMaximumKeyword.cs
@@ -71,7 +71,7 @@ public sealed class FormatExclusiveMaximumKeyword: IJsonSchemaKeyword, IEquatabl
     public class FormatExclusiveMaximumKeywordJsonConverter : JsonConverter<FormatExclusiveMaximumKeyword>
     {
         /// <summary>
-        /// Read @xsdType keyword from json schema
+        /// Read formatExclusiveMaximum keyword from json schema
         /// </summary>
         public override FormatExclusiveMaximumKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/src/studio/src/designer/DataModeling/Json/Keywords/FormatExclusiveMinimumKeyword.cs
+++ b/src/studio/src/designer/DataModeling/Json/Keywords/FormatExclusiveMinimumKeyword.cs
@@ -71,7 +71,7 @@ public sealed class FormatExclusiveMinimumKeyword: IJsonSchemaKeyword, IEquatabl
     public class FormatExclusiveMinimumKeywordJsonConverter : JsonConverter<FormatExclusiveMinimumKeyword>
     {
         /// <summary>
-        /// Read @xsdType keyword from json schema
+        /// Read formatExclusiveMaximum keyword from json schema
         /// </summary>
         public override FormatExclusiveMinimumKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/src/studio/src/designer/DataModeling/Json/Keywords/FormatMaximumKeyword.cs
+++ b/src/studio/src/designer/DataModeling/Json/Keywords/FormatMaximumKeyword.cs
@@ -71,7 +71,7 @@ public sealed class FormatMaximumKeyword: IJsonSchemaKeyword, IEquatable<FormatM
     public class FormatMaximumKeywordJsonConverter : JsonConverter<FormatMaximumKeyword>
     {
         /// <summary>
-        /// Read @xsdType keyword from json schema
+        /// Read formatMaximum keyword from json schema
         /// </summary>
         public override FormatMaximumKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/src/studio/src/designer/DataModeling/Json/Keywords/FormatMinimumKeyword.cs
+++ b/src/studio/src/designer/DataModeling/Json/Keywords/FormatMinimumKeyword.cs
@@ -71,7 +71,7 @@ public sealed class FormatMinimumKeyword: IJsonSchemaKeyword, IEquatable<FormatM
     public class FormatMinimumKeywordJsonConverter : JsonConverter<FormatMinimumKeyword>
     {
         /// <summary>
-        /// Read @xsdType keyword from json schema
+        /// Read formatExclusiveMaximum keyword from json schema
         /// </summary>
         public override FormatMinimumKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/src/studio/src/designer/DataModeling/Json/Keywords/XsdTotalDigitsKeyword.cs
+++ b/src/studio/src/designer/DataModeling/Json/Keywords/XsdTotalDigitsKeyword.cs
@@ -24,7 +24,7 @@ public sealed class XsdTotalDigitsKeyword: IJsonSchemaKeyword, IEquatable<XsdTot
     /// <summary>
     /// The name of the keyword
     /// </summary>
-    private const string Name = "@xsdTotalDigits";
+    private const string Name = "totalDigits";
 
     /// <summary>
     /// Content

--- a/src/studio/src/designer/DataModeling/Json/Keywords/XsdTotalDigitsKeyword.cs
+++ b/src/studio/src/designer/DataModeling/Json/Keywords/XsdTotalDigitsKeyword.cs
@@ -61,7 +61,7 @@ public sealed class XsdTotalDigitsKeyword: IJsonSchemaKeyword, IEquatable<XsdTot
             return;
         }
 
-        if (!new Regex(TotalDigitsRegexString(Value)).IsMatch(number.Value.ToString("G", NumberFormatInfo.InvariantInfo)))
+        if (!new Regex(TotalDigitsDecimalRegexString(Value)).IsMatch(number.Value.ToString("G", NumberFormatInfo.InvariantInfo)))
         {
             context.LocalResult.Fail();
         }

--- a/src/studio/src/designer/DataModeling/Json/Keywords/XsdTotalDigitsKeyword.cs
+++ b/src/studio/src/designer/DataModeling/Json/Keywords/XsdTotalDigitsKeyword.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Json.More;
+using Json.Schema;
+using static Altinn.Studio.DataModeling.Utils.RestrictionsHelper;
+
+namespace Altinn.Studio.DataModeling.Json.Keywords;
+
+/// <summary>
+/// Equivalent of totalDigits restriction in json schema
+/// </summary>
+[SchemaKeyword(Name)]
+[SchemaPriority(int.MinValue)]
+[SchemaDraft(Draft.Draft6)]
+[SchemaDraft(Draft.Draft7)]
+[SchemaDraft(Draft.Draft201909)]
+[SchemaDraft(Draft.Draft202012)]
+[JsonConverter(typeof(XsdTotalDigitsKeywordJsonConverter))]
+public sealed class XsdTotalDigitsKeyword: IJsonSchemaKeyword, IEquatable<XsdTotalDigitsKeyword>
+{
+    /// <summary>
+    /// The name of the keyword
+    /// </summary>
+    private const string Name = "@xsdTotalDigits";
+
+    /// <summary>
+    /// Content
+    /// </summary>
+    public uint Value { get; }
+
+    /// <summary>
+    /// Creates instance with provided value
+    /// </summary>
+    /// <param name="value">totalDigits</param>
+    public XsdTotalDigitsKeyword(uint value)
+    {
+        Value = value;
+    }
+
+    /// <inheritdoc />
+    public void Validate(ValidationContext context)
+    {
+        context.EnterKeyword(Name);
+        var schemaValueType = context.LocalInstance.GetSchemaValueType();
+        if (schemaValueType is not (SchemaValueType.Number or SchemaValueType.Integer))
+        {
+            context.LocalResult.Pass();
+            context.WrongValueKind(schemaValueType);
+            return;
+        }
+
+        var number = context.LocalInstance!.AsValue().GetNumber();
+
+        if (number is null)
+        {
+            context.LocalResult.Fail();
+            context.ExitKeyword(Name, context.LocalResult.IsValid);
+            return;
+        }
+
+        if (!new Regex(TotalDigitsRegexString(Value)).IsMatch(number.Value.ToString("G", NumberFormatInfo.InvariantInfo)))
+        {
+            context.LocalResult.Fail();
+        }
+        else
+        {
+            context.LocalResult.Pass();
+        }
+
+        context.ExitKeyword(Name, context.LocalResult.IsValid);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(XsdTotalDigitsKeyword other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return ReferenceEquals(this, other) || Equals(Value, other.Value);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object obj)
+    {
+        return Equals(obj as XsdTotalDigitsKeyword);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return Value.GetHashCode();
+    }
+
+    /// <summary>
+    /// Serializer for the XsdTotalDigitsKeyword keyword
+    /// </summary>
+    public class XsdTotalDigitsKeywordJsonConverter : JsonConverter<XsdTotalDigitsKeyword>
+    {
+        /// <inheritdoc />
+        public override XsdTotalDigitsKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.Number)
+            {
+                throw new JsonException("Expected number");
+            }
+
+            return new XsdTotalDigitsKeyword(reader.GetUInt32());
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, XsdTotalDigitsKeyword value, JsonSerializerOptions options)
+        {
+            writer.WriteNumber(Name, value.Value);
+        }
+    }
+}

--- a/src/studio/src/designer/DataModeling/Utils/JsonSchemaXsdExtensions.cs
+++ b/src/studio/src/designer/DataModeling/Utils/JsonSchemaXsdExtensions.cs
@@ -215,5 +215,17 @@ namespace Altinn.Studio.DataModeling.Utils
             builder.Add(new XsdMaxOccursKeyword(value));
             return builder;
         }
+
+        /// <summary>
+        /// Adds <see cref="XsdTotalDigitsKeyword"/> keyword to builder
+        /// </summary>
+        /// <param name="builder">The <see cref="JsonSchemaBuilder"/></param>
+        /// <param name="value">MaxOccurs value</param>
+        /// <returns>The <see cref="JsonSchemaBuilder"/> used for chaining</returns>
+        public static JsonSchemaBuilder XsdTotalDigits(this JsonSchemaBuilder builder, uint value)
+        {
+            builder.Add(new XsdTotalDigitsKeyword(value));
+            return builder;
+        }
     }
 }

--- a/src/studio/src/designer/DataModeling/Utils/RestrictionsHelper.cs
+++ b/src/studio/src/designer/DataModeling/Utils/RestrictionsHelper.cs
@@ -7,7 +7,7 @@ namespace Altinn.Studio.DataModeling.Utils;
 /// <summary>
 /// Utilities for
 /// </summary>
-public static class FormatRangeHelper
+public static class RestrictionsHelper
 {
     private static readonly IReadOnlyCollection<string> DateTypes = new List<string>
     {
@@ -34,4 +34,12 @@ public static class FormatRangeHelper
 
         return DateTypes.Contains(parent?.BaseTypeName?.Name);
     }
+
+    /// <summary>
+    /// Gets the regex for total digits restriction. Note that for decimal data type total digits is
+    /// number of digits both after and before the decimal point, not counting the decimal point itself.
+    /// </summary>
+    /// <param name="value">Total digits value</param>
+    /// <returns>Regex string for total digits</returns>
+    public static string TotalDigitsRegexString(uint value) => $@"^(([0-9]){{1}}(\.)?){{{value}}}$";
 }

--- a/src/studio/src/designer/DataModeling/Utils/RestrictionsHelper.cs
+++ b/src/studio/src/designer/DataModeling/Utils/RestrictionsHelper.cs
@@ -36,10 +36,16 @@ public static class RestrictionsHelper
     }
 
     /// <summary>
-    /// Gets the regex for total digits restriction. Note that for decimal data type total digits is
-    /// number of digits both after and before the decimal point, not counting the decimal point itself.
+    /// Gets the regex for total digits restriction for integers.
     /// </summary>
     /// <param name="value">Total digits value</param>
     /// <returns>Regex string for total digits</returns>
-    public static string TotalDigitsRegexString(uint value) => $@"^(([0-9]){{1}}(\.)?){{{value}}}$";
+    public static string TotalDigitsIntegerRegexString(uint value) => $@"^[0-9]{{0,{value}}}$";
+
+    /// <summary>
+    /// Gets the regex for total digits restriction for decimal data type.
+    /// </summary>
+    /// <param name="value">Total digits value</param>
+    /// <returns>Regex string for total digits</returns>
+    public static string TotalDigitsDecimalRegexString(uint value) => $@"^(([0-9]){{1}}(\.)?){{0,{value}}}$";
 }

--- a/src/studio/src/designer/backend.Tests/Assertions/TypeAssertions.cs
+++ b/src/studio/src/designer/backend.Tests/Assertions/TypeAssertions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using Designer.Tests.Utils;
 using FluentAssertions;
 using Xunit;
 
@@ -13,7 +14,7 @@ public static class TypeAssertions
 {
     public static void IsEquivalentTo(Type expected, Type actual)
     {
-        if (expected.IsPrimitive || expected == typeof(string) || expected == typeof(DateTime))
+        if (expected.IsPrimitive || expected == typeof(string) || expected == typeof(DateTime) || expected == typeof(decimal))
         {
             expected.Should().Be(actual);
             return;
@@ -78,10 +79,13 @@ public static class TypeAssertions
     {
         expected.Name.Should().Be(actual.Name);
         IsEquivalentTo(expected.PropertyType, actual.PropertyType);
+        IsEquivalentTo(expected.CustomAttributes, actual.CustomAttributes);
     }
 
     private static void IsEquivalentTo(IEnumerable<CustomAttributeData> expected, IEnumerable<CustomAttributeData> actual)
     {
+        expected.Count().Should().Be(actual.Count());
+
         foreach (var item in expected)
         {
             Assert.Single(actual.Where(x => x.ToString() == item.ToString()));
@@ -92,4 +96,28 @@ public static class TypeAssertions
     {
         expected.Should().Be(actual);
     }
+
+    public static void PropertyShouldContainCustomAnnotationAndHaveTypeType(Type type, string propertyName, string propertyType, string expectedAnnotationString)
+    {
+        var property = type.Properties().Single(x => x.Name == propertyName);
+        var simpleCompiledAssembly = Compiler.CompileToAssembly(DynamicAnnotationClassString(propertyName, propertyType, expectedAnnotationString));
+        var expectedProperty = simpleCompiledAssembly.Types().First().Properties().Single();
+        IsEquivalentTo(expectedProperty.PropertyType,  property.PropertyType);
+        var expectedAnnotation = expectedProperty.CustomAttributes.Single();
+        Assert.Single(expectedProperty.CustomAttributes.Where(x => x.ToString() == expectedAnnotation.ToString()));
+    }
+
+    private static string DynamicAnnotationClassString(string propertyName, string propertyType, string annotation) =>
+        $@"
+            using System;
+            using System.ComponentModel.DataAnnotations;
+            namespace TextAnnotationClassProp
+            {{
+                public class DynamicAnnotationClass
+                {{
+                    {annotation}
+                    public {propertyType} {propertyName} {{ get; set; }}
+                }}
+            }}
+         ";
 }

--- a/src/studio/src/designer/backend.Tests/_TestData/Model/Xsd/SimpleTypeRestrictions.xsd
+++ b/src/studio/src/designer/backend.Tests/_TestData/Model/Xsd/SimpleTypeRestrictions.xsd
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xsd:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <xsd:element name="Root">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="t1" type="stringMinMaxLengthRestrictions" />
+        <xsd:element name="t2" type="stringLengthRestrictions" />
+        <xsd:element name="t3" type="stringEnumRestrictions" />
+        <xsd:element name="t4" type="stringPatternRestrictions" />
+        <xsd:element name="n1" type="numberRestrictions" />
+        <xsd:element name="n2" type="numberRestrictions2" />
+        <xsd:element name="i1" type="intRestrictions" />
+        <xsd:element name="i2" type="integerRestrictions" />
+        <xsd:element name="f1" type="numberRestrictionsFractional0" />
+        <xsd:element name="f2" type="numberRestrictionsFractional1" />
+        <xsd:element name="f3" type="numberRestrictionsFractional2" />
+        <xsd:element name="f4" type="numberRestrictionsFractional3" />
+        <xsd:element name="f5" type="numberRestrictionsFractional4" />
+        <xsd:element name="f6" type="numberRestrictionsFractional5" />
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:simpleType name="stringMinMaxLengthRestrictions">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="20" />
+      <xsd:minLength value="5" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="stringLengthRestrictions">
+    <xsd:restriction base="xsd:string">
+      <xsd:length value="10" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="stringEnumRestrictions">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="v1" />
+      <xsd:enumeration value="v2" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="stringPatternRestrictions">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="^\d\.\d\.\d$" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="numberRestrictions">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:totalDigits value="10" />
+      <xsd:maxInclusive value="100" />
+      <xsd:minInclusive value="-100" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="numberRestrictions2">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:totalDigits value="10" />
+      <xsd:maxExclusive value="100" />
+      <xsd:minExclusive value="-100" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="integerRestrictions">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="10" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="intRestrictions">
+    <xsd:restriction base="xsd:int">
+      <xsd:totalDigits value="10" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="numberRestrictionsFractional0">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:fractionDigits value="0" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="numberRestrictionsFractional1">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:fractionDigits value="1" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="numberRestrictionsFractional2">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:fractionDigits value="2" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="numberRestrictionsFractional3">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:fractionDigits value="3" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="numberRestrictionsFractional4">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:fractionDigits value="4" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="numberRestrictionsFractional5">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:fractionDigits value="5" />
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/src/studio/src/designer/backend/Factories/ModelFactory/JsonMetadataParser.cs
+++ b/src/studio/src/designer/backend/Factories/ModelFactory/JsonMetadataParser.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-
 using Altinn.Studio.Designer.Constants;
 using Altinn.Studio.Designer.ModelMetadatalModels;
+using static Altinn.Studio.DataModeling.Utils.RestrictionsHelper;
 
 namespace Altinn.Studio.Designer.Factories.ModelFactory
 {
@@ -235,6 +235,16 @@ namespace Altinn.Studio.Designer.Factories.ModelFactory
                 {
                     classBuilder.AppendLine("    [RegularExpression(@\"" + element.Restrictions["pattern"].Value + "\"" + errorMessage + ")]");
                 }
+
+                if (element.Restrictions.ContainsKey("@xsdTotalDigits"))
+                {
+                    var totalDigitsValue = uint.Parse(element.Restrictions["@xsdTotalDigits"].Value);
+                    var regexString = element.XsdValueType == BaseValueType.Decimal
+                        ? TotalDigitsDecimalRegexString(totalDigitsValue)
+                        : TotalDigitsIntegerRegexString(totalDigitsValue);
+                    classBuilder.AppendLine(
+                        $@"    [RegularExpression(@""{regexString}""{errorMessage})]");
+                }
             }
 
             if (element.IsReadOnly)
@@ -253,20 +263,22 @@ namespace Altinn.Studio.Designer.Factories.ModelFactory
                     classBuilder.AppendLine("    [Range(Double.MinValue,Double.MaxValue" + errorMessage + ")]");
                     break;
                 case BaseValueType.Int:
-                case BaseValueType.Integer:
                     classBuilder.AppendLine("    [Range(Int32.MinValue,Int32.MaxValue" + errorMessage + ")]");
                     break;
+                case BaseValueType.Integer:
+                    classBuilder.AppendLine("    [Range(Double.MinValue,Double.MaxValue" + errorMessage + ")]");
+                    break;
                 case BaseValueType.NegativeInteger:
-                    classBuilder.AppendLine("    [Range(Int32.MinValue,-1" + errorMessage + ")]");
+                    classBuilder.AppendLine("    [Range(Double.MinValue,-1" + errorMessage + ")]");
                     break;
                 case BaseValueType.NonPositiveInteger:
-                    classBuilder.AppendLine("    [Range(Int32.MinValue,0" + errorMessage + ")]");
+                    classBuilder.AppendLine("    [Range(Double.MinValue,0" + errorMessage + ")]");
                     break;
                 case BaseValueType.NonNegativeInteger:
-                    classBuilder.AppendLine("    [Range(0,Int32.MaxValue" + errorMessage + ")]");
+                    classBuilder.AppendLine("    [Range(0,Double.MaxValue" + errorMessage + ")]");
                     break;
                 case BaseValueType.PositiveInteger:
-                    classBuilder.AppendLine("    [Range(1,Int32.MaxValue" + errorMessage + ")]");
+                    classBuilder.AppendLine("    [Range(1,Double.MaxValue" + errorMessage + ")]");
                     break;
                 case BaseValueType.GYear:
                     classBuilder.AppendLine("    [RegularExpression(@\"^[0-9]{4}$\"" + errorMessage + ")]");

--- a/src/studio/src/designer/backend/Factories/ModelFactory/JsonMetadataParser.cs
+++ b/src/studio/src/designer/backend/Factories/ModelFactory/JsonMetadataParser.cs
@@ -236,9 +236,9 @@ namespace Altinn.Studio.Designer.Factories.ModelFactory
                     classBuilder.AppendLine("    [RegularExpression(@\"" + element.Restrictions["pattern"].Value + "\"" + errorMessage + ")]");
                 }
 
-                if (element.Restrictions.ContainsKey("@xsdTotalDigits"))
+                if (element.Restrictions.ContainsKey("totalDigits"))
                 {
-                    var totalDigitsValue = uint.Parse(element.Restrictions["@xsdTotalDigits"].Value);
+                    var totalDigitsValue = uint.Parse(element.Restrictions["totalDigits"].Value);
                     var regexString = element.XsdValueType == BaseValueType.Decimal
                         ? TotalDigitsDecimalRegexString(totalDigitsValue)
                         : TotalDigitsIntegerRegexString(totalDigitsValue);

--- a/src/studio/src/designer/backend/Factories/ModelFactory/JsonSchemaToMetamodelConverter.cs
+++ b/src/studio/src/designer/backend/Factories/ModelFactory/JsonSchemaToMetamodelConverter.cs
@@ -593,6 +593,15 @@ namespace Altinn.Studio.Designer.Factories.ModelFactory
             {
                 parseSuccess = Enum.TryParse(xsdTypeKeyword.Value, true, out parsedBaseValueType);
             }
+            else if (subSchema.TryGetKeyword(out AllOfKeyword allOfKeyword))
+            {
+                xsdTypeKeyword = allOfKeyword.GetSubschemas().FirstOrDefault(s => s.HasKeyword<TypeKeyword>())
+                    ?.GetKeyword<XsdTypeKeyword>();
+                if (xsdTypeKeyword is not null)
+                {
+                    parseSuccess = Enum.TryParse(xsdTypeKeyword.Value, true, out parsedBaseValueType);
+                }
+            }
 
             baseValueType = parsedBaseValueType;
             return parseSuccess;

--- a/src/studio/src/designer/backend/Factories/ModelFactory/MetamodelRestrictionUtils.cs
+++ b/src/studio/src/designer/backend/Factories/ModelFactory/MetamodelRestrictionUtils.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using Altinn.Studio.DataModeling.Json.Keywords;
 using Altinn.Studio.DataModeling.Utils;
 using Altinn.Studio.Designer.Extensions;
 using Altinn.Studio.Designer.ModelMetadatalModels;
@@ -143,6 +144,11 @@ public static class MetamodelRestrictionUtils
         {
             restrictions.AddRestrictionFromKeyword(exclusiveMinimum);
         }
+
+        if (allOfKeyword.TryGetKeywordFromSubSchemas(out XsdTotalDigitsKeyword totalDigitsKeyword))
+        {
+            restrictions.AddRestrictionFromKeyword(totalDigitsKeyword);
+        }
     }
 
     private static bool TryGetKeywordFromSubSchemas<T>(this IJsonSchemaKeyword allOfKeyword, out T keyword)
@@ -171,10 +177,11 @@ public static class MetamodelRestrictionUtils
             MaxLengthKeyword kw => kw.Value.ToString(),
             PatternKeyword kw => kw.Value.ToString(),
             MinLengthKeyword kw => kw.Value.ToString(),
-            MaximumKeyword kw => kw.Value.ToString(CultureInfo.CurrentCulture),
-            MinimumKeyword kw => kw.Value.ToString(CultureInfo.CurrentCulture),
-            ExclusiveMaximumKeyword kw => kw.Value.ToString(CultureInfo.CurrentCulture),
-            ExclusiveMinimumKeyword kw => kw.Value.ToString(CultureInfo.CurrentCulture),
+            MaximumKeyword kw => kw.Value.ToString(CultureInfo.InvariantCulture),
+            MinimumKeyword kw => kw.Value.ToString(CultureInfo.InvariantCulture),
+            ExclusiveMaximumKeyword kw => kw.Value.ToString(CultureInfo.InvariantCulture),
+            ExclusiveMinimumKeyword kw => kw.Value.ToString(CultureInfo.InvariantCulture),
+            XsdTotalDigitsKeyword kw => kw.Value.ToString(CultureInfo.InvariantCulture),
             _ => throw new Exception("Not supported keyword type")
 
         };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Created TotalDigitsKeyword
If totalDigits keyword is present in xsd, c# class will be annotated with RegularExpression

## Related Issue(s)
- #9122

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
