### PR TITLE
show correct value when disabled

### DIFF
--- a/src/studio/src/designer/frontend/shared/components/AltinnDropdown.tsx
+++ b/src/studio/src/designer/frontend/shared/components/AltinnDropdown.tsx
@@ -66,6 +66,21 @@ type DropdownOption = {
   label: string;
 };
 
+const getDisplayValue = (selectedValue: string, options: (string | DropdownOption)[]) => {
+  const result = options.find((i: string | DropdownOption) => {
+    if (typeof i === 'object') {
+      return i.value === selectedValue;
+    }
+    return i === selectedValue;
+  });
+
+  if (typeof result === 'object') {
+    return result.label;
+  }
+
+  return result;
+}
+
 export const AltinnDropdown = ({
   inputHeader,
   inputDescription,
@@ -113,7 +128,7 @@ export const AltinnDropdown = ({
       <FormControl classes={formControlClasses} fullWidth={true} id={id}>
         <TextField
           select={!disabled}
-          value={selectedValue}
+          value={disabled ? getDisplayValue(selectedValue, dropdownItems) : selectedValue}
           onChange={handleChange}
           disabled={disabled}
           InputProps={inputPropsClasses}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The failing unit test `CreateService -> should prefill owner when there are no available orgs, and the only available user is the logged in use` uncovered an issue with the AltinnDropdown component, which displays `value` instead of `label` when the component is disabled.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
