### PR TITLE
Changed ClockSkew for AccessToken validation from Zero to 60 seconds.

### DIFF
--- a/src/Altinn.Common/Altinn.Common.AccessToken/Altinn.Common.AccessToken/Altinn.Common.AccessToken.csproj
+++ b/src/Altinn.Common/Altinn.Common.AccessToken/Altinn.Common.AccessToken/Altinn.Common.AccessToken.csproj
@@ -4,13 +4,12 @@
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
-    <!-- SonarCloud requires a ProjectGuid to separate projects. -->
-    <ProjectGuid>{C219A8A8-B936-453C-AC34-01454A0D1792}</ProjectGuid>
-    <AssemblyVersion>1.1.2</AssemblyVersion>
+    <AssemblyVersion>1.2.0</AssemblyVersion>
+    <FileVersion>1.2.0</FileVersion>
 
     <!-- NuGet package properties -->
     <PackageId>Altinn.Common.AccessToken</PackageId>
-    <PackageVersion>1.1.2</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <PackageTags>Altinn;AccessToken</PackageTags>
     <Description>
       Package to verify Access Tokens from client. Require public certificates stored in Azure KeyVault.
@@ -23,13 +22,16 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IsPackable>true</IsPackable>
+
+    <!-- SonarCloud requires a ProjectGuid to separate projects. -->
+    <ProjectGuid>{C219A8A8-B936-453C-AC34-01454A0D1792}</ProjectGuid>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.23.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.25.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Altinn.Common/Altinn.Common.AccessToken/Altinn.Common.AccessToken/Services/AccessTokenValidator.cs
+++ b/src/Altinn.Common/Altinn.Common.AccessToken/Altinn.Common.AccessToken/Services/AccessTokenValidator.cs
@@ -63,7 +63,7 @@ namespace Altinn.Common.AccessToken.Services
                 ValidateAudience = false,
                 RequireExpirationTime = true,
                 ValidateLifetime = true,
-                ClockSkew = TimeSpan.Zero
+                ClockSkew = TimeSpan.FromSeconds(60)
             };
 
             tokenValidationParameters.IssuerSigningKeys = await _signingKeysResolver.GetSigningKeys(issuer);

--- a/src/Altinn.Common/Altinn.Common.AccessToken/Altinn.Common.AccessTokenClient/Altinn.Common.AccessTokenClient.csproj
+++ b/src/Altinn.Common/Altinn.Common.AccessToken/Altinn.Common.AccessTokenClient/Altinn.Common.AccessTokenClient.csproj
@@ -4,14 +4,12 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
-    <!-- SonarCloud requires a ProjectGuid to separate projects. -->
-    <ProjectGuid>{454ED0A7-05B0-4D99-A05E-0B526219DC05}</ProjectGuid>
-    <AssemblyVersion>1.0.6</AssemblyVersion>
-    <FileVersion>1.0.6</FileVersion>
+    <AssemblyVersion>1.1.0</AssemblyVersion>
+    <FileVersion>1.1.0</FileVersion>
 
     <!-- NuGet package properties -->
     <PackageId>Altinn.Common.AccessTokenClient</PackageId>
-    <PackageVersion>1.0.6</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
     <PackageTags>Altinn;AccessTokenClient</PackageTags>
     <Description>
       Package to generate access tokens to use against Altinn Platform.
@@ -25,6 +23,9 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IsPackable>true</IsPackable>
+    
+    <!-- SonarCloud requires a ProjectGuid to separate projects. -->
+    <ProjectGuid>{454ED0A7-05B0-4D99-A05E-0B526219DC05}</ProjectGuid>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,7 +34,7 @@
     <!-- Upgrade to 5.x.x causes function-apps to fail. -->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.29" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.23.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.25.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
## Description
Changed the ClockSkew for when we're vallidating AccessTokens. The accepted clock difference has been increased from Zero ot 60 seconds.  This is to remove all Not Yet valid errors we've been having.

In this issue I also bomped two packages. 

## Related Issue(s)
- altinn/altinn-platform#279

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
