### PR TITLE
Use relative redirect in LoginTestUser in LocalTest

### DIFF
--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -134,7 +134,7 @@ namespace LocalTest.Controllers
             // Ensure that the documentstorage in LocalTestingStorageBasePath is updated with the most recent app data
             await _applicationRepository.Update(app);
 
-            return Redirect($"{_generalSettings.GetBaseUrl}/{app.Id}/");
+            return Redirect($"/{app.Id}/");
         }
 
         /// <summary>


### PR DESCRIPTION
A user had an issue that the redirect in LoginTestUser went to the wrong port number. There is code in docker compose to set the port number correctly, but it is an issue when running localtest in the terminal outside docker, and using a relative redirect seems more correct.

This might cause issues if someone runs localtest without the nginx loadbalancer, but I don't think that is a supported setup.

https://altinn.slack.com/archives/C02EJ9HKQA3/p1667565182797519