### PR TITLE
Replace Select components

### DIFF
--- a/src/studio/src/designer/frontend/app-development/package.json
+++ b/src/studio/src/designer/frontend/app-development/package.json
@@ -9,7 +9,7 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@altinn/altinn-design-system": "0.19.1",
+    "@altinn/altinn-design-system": "0.23.0",
     "@mui/material": "5.10.12",
     "@mui/styles": "5.10.10",
     "@reduxjs/toolkit": "1.9.0",

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../features/editor/schemaEditorSlice';
 import { ReferenceSelectionComponent } from './ReferenceSelectionComponent';
 import { getCombinationOptions, getTypeOptions } from './helpers/options';
-import { Checkbox, ErrorMessage, FieldSet, TextArea, TextField } from '@altinn/altinn-design-system';
+import { Checkbox, ErrorMessage, FieldSet, Select, TextArea, TextField } from '@altinn/altinn-design-system';
 import classes from './ItemDataComponent.module.css';
 import { ItemRestrictions } from './ItemRestrictions';
 import type { UiSchemaNode } from '@altinn/schema-model';
@@ -32,8 +32,6 @@ import {
 } from '@altinn/schema-model';
 import { getDomFriendlyID, isValidName } from '../../utils/ui-schema-utils';
 import { Divider } from '../common/Divider';
-import { Label } from '../common/Label';
-import { Select } from '../common/Select';
 
 export interface IItemDataComponentProps {
   selectedItem: UiSchemaNode;
@@ -118,19 +116,17 @@ export function ItemDataComponent({ language, selectedItem }: IItemDataComponent
   const t = (key: string) => getTranslation(key, language);
   const titleId = getDomFriendlyID(selectedNodePointer, { suffix: 'title' });
   const descriptionId = getDomFriendlyID(selectedNodePointer, { suffix: 'description' });
-  const selectId = getDomFriendlyID(selectedItem.pointer, { suffix: 'combi-sel' });
-  const typeId = getDomFriendlyID(selectedItem.pointer, { suffix: 'type-select' });
   return (
     <div className={classes.root}>
       {!selectedItem.isCombinationItem && (
         <div>
-          <Label htmlFor='selectedItemName'>{t('name')}</Label>
           <TextField
             aria-describedby='Selected Item Name'
             aria-errormessage={t(nameError)}
             aria-placeholder='Name'
             autoFocus
             id='selectedItemName'
+            label={t('name')}
             onBlur={handleChangeNodeName}
             onChange={onNameChange}
             placeholder='Name'
@@ -141,11 +137,10 @@ export function ItemDataComponent({ language, selectedItem }: IItemDataComponent
       )}
       {selectedItem.objectKind === ObjectKind.Field && (
         <Select
-          id={typeId}
           label={t('type')}
-          onChange={(type) => onChangeFieldType(selectedItem.pointer, type as FieldType)}
+          onChange={(type: string) => onChangeFieldType(selectedItem.pointer, type as FieldType)}
           options={getTypeOptions(t)}
-          value={fieldType}
+          value={fieldType as string}
         />
       )}
       {selectedItem.objectKind === ObjectKind.Reference && (
@@ -168,9 +163,8 @@ export function ItemDataComponent({ language, selectedItem }: IItemDataComponent
       )}
       {selectedItem.objectKind === ObjectKind.Combination && (
         <Select
-          id={selectId}
           label={t('type')}
-          onChange={(combination) => onChangeCombinationType(combination as CombinationKind)}
+          onChange={(combination: string) => onChangeCombinationType(combination as CombinationKind)}
           options={getCombinationOptions(t)}
           value={selectedItem.fieldType}
         />
@@ -188,18 +182,18 @@ export function ItemDataComponent({ language, selectedItem }: IItemDataComponent
       <Divider inMenu />
       <FieldSet legend={t('descriptive_fields')} className={classes.fieldSet}>
         <div>
-          <Label htmlFor={titleId}>{t('title')}</Label>
           <TextField
             id={titleId}
+            label={t('title')}
             onBlur={onChangeTitle}
             onChange={(e: ChangeEvent) => setItemTitle((e.target as HTMLInputElement)?.value)}
             value={title}
           />
         </div>
         <div>
-          <Label htmlFor={descriptionId}>{t('description')}</Label>
           <TextArea
             id={descriptionId}
+            label={t('description')}
             onBlur={onChangeDescription}
             onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setItemDescription(event.target.value)}
             style={{ height: 100 }}

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ReferenceSelectionComponent.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ReferenceSelectionComponent.test.tsx
@@ -62,13 +62,13 @@ test('All types should appear as options', () => {
 
 test('Type options should have correct values and labels', () => {
   renderReferenceSelectionComponent();
-  expect(screen.getByRole('option', { name: type1Name })).toHaveValue(type1.pointer);
-  expect(screen.getByRole('option', { name: type2Name })).toHaveValue(type2.pointer);
+  expect(screen.getByRole('option', { name: type1Name })).toHaveAttribute('value', type1.pointer);
+  expect(screen.getByRole('option', { name: type2Name })).toHaveAttribute('value', type2.pointer);
 });
 
 test('Empty option text appears', () => {
   renderReferenceSelectionComponent();
-  expect(screen.getByText(emptyOptionLabel)).toBeDefined();
+  expect(screen.getByRole('option', { name: emptyOptionLabel })).toBeDefined();
 });
 
 test('Empty option is selected by default', () => {
@@ -83,7 +83,7 @@ test('Referenced type is selected if given', () => {
 
 test('onChange handler is called with correct parameters when value changes', async () => {
   renderReferenceSelectionComponent();
-  await user.selectOptions(screen.getByRole('combobox'), type1.pointer);
+  await user.click(screen.getByRole('option', { name: type1Name }));
   expect(onChangeRef).toHaveBeenCalledTimes(1);
   expect(onChangeRef).toHaveBeenCalledWith(selectedNode.pointer, type1.pointer);
 });

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ReferenceSelectionComponent.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/ReferenceSelectionComponent.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import type { UiSchemaNode } from '@altinn/schema-model';
-import { Select } from '../common/Select';
 import { getDomFriendlyID } from '../../utils/ui-schema-utils';
 import { useSelector } from 'react-redux';
 import { ISchemaState } from '../../types';
 import { getRootNodes, Keywords } from '@altinn/schema-model';
 import classes from './ReferenceSelectionComponent.module.css';
+import { Select } from '@altinn/altinn-design-system';
 
 export interface IReferenceSelectionProps {
   buttonText: string;
@@ -26,17 +26,17 @@ export function ReferenceSelectionComponent({
 }: IReferenceSelectionProps) {
   const definitions: UiSchemaNode[] = useSelector((state: ISchemaState) => getRootNodes(state.uiSchema, true));
   const selectId = getDomFriendlyID(selectedNode.pointer, { suffix: 'ref-select' });
+  const emptyOption = { label: emptyOptionLabel, value: '' };
   return (
     <div>
       <Select
-        emptyOptionLabel={emptyOptionLabel}
-        id={selectId}
+        inputId={selectId}
         label={label}
-        onChange={(value) => onChangeRef(selectedNode.pointer, value)}
-        options={definitions.map(({ pointer }) => ({
+        onChange={(value: string) => onChangeRef(selectedNode.pointer, value)}
+        options={[emptyOption, ...definitions.map(({ pointer }) => ({
           value: pointer,
           label: pointer.replace(`#/${Keywords.Definitions}/`, ''),
-        }))}
+        }))]}
         value={selectedNode.ref || ''}
       />
       <button type='button' className={classes.navButton} onClick={onGoToDefButtonClick}>

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/RestrictionField.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/RestrictionField.tsx
@@ -1,7 +1,6 @@
 import React, { BaseSyntheticEvent, ChangeEvent } from 'react';
 import { TextField } from '@altinn/altinn-design-system';
 import { getDomFriendlyID } from '../../utils/ui-schema-utils';
-import { Label } from '../common/Label';
 
 export interface IRestrictionFieldProps {
   className?: string;
@@ -32,8 +31,14 @@ export const RestrictionField = ({
   };
   return (
     <div className={className}>
-      <Label htmlFor={fieldId}>{label}</Label>
-      <TextField id={fieldId} value={value ?? ''} onChange={handleChange} aria-label={label} readOnly={readOnly} />
+      <TextField
+        aria-label={label}
+        id={fieldId}
+        label={label}
+        onChange={handleChange}
+        readOnly={readOnly}
+        value={value ?? ''}
+      />
     </div>
   );
 };

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/restrictions/StringRestrictions.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/restrictions/StringRestrictions.test.tsx
@@ -68,9 +68,10 @@ test('Format selection appears with all options', () => {
   expect(screen.getByText(language[`schema_editor.format`])).toBeDefined();
   expect(screen.getByLabelText(language[`schema_editor.format`])).toBeDefined();
   Object.values(StringFormat).forEach((format) => {
-    expect(screen.getByRole('option', { name: language[`schema_editor.format_${format}`] })).toHaveValue(format);
+    expect(screen.getByRole('option', { name: language[`schema_editor.format_${format}`] }))
+      .toHaveAttribute('value', format);
   });
-  expect(screen.getByRole('option', { name: language['schema_editor.format_none'] })).toHaveValue('');
+  expect(screen.getByRole('option', { name: language['schema_editor.format_none'] })).toHaveAttribute('value', '');
 });
 
 test('Empty format option is selected by default', () => {
@@ -86,12 +87,12 @@ test('Given format option is selected', () => {
 
 test('onChangeRestrictionValue is called with correct input when format is changed', async () => {
   const { rerender } = renderStringRestrictions();
-  await user.selectOptions(screen.getByLabelText(language[`schema_editor.format`]), StringFormat.Date);
+  await user.click(screen.getByRole('option', { name: language[`schema_editor.format_${StringFormat.Date}`] }));
   expect(onChangeRestrictionValue).toHaveBeenCalledTimes(1);
   expect(onChangeRestrictionValue).toHaveBeenCalledWith(path, StrRestrictionKeys.format, StringFormat.Date);
   onChangeRestrictionValue.mockReset();
   rerender(<StringRestrictions {...defaultProps} />);
-  await user.selectOptions(screen.getByLabelText(language[`schema_editor.format`]), '');
+  await user.click(screen.getByRole('option', { name: language[`schema_editor.format_none`] }));
   expect(onChangeRestrictionValue).toHaveBeenCalledTimes(1);
   expect(onChangeRestrictionValue).toHaveBeenCalledWith(path, StrRestrictionKeys.format, undefined);
 });

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/restrictions/StringRestrictions.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/SchemaInspector/restrictions/StringRestrictions.tsx
@@ -3,12 +3,11 @@ import { RestrictionItemProps } from '../ItemRestrictions';
 import { RestrictionField } from '../RestrictionField';
 import { getTranslation } from '../../../utils/language';
 import classes from './StringRestrictions.module.css';
-import { FieldSet, TextField } from '@altinn/altinn-design-system';
+import { FieldSet, Select, TextField } from '@altinn/altinn-design-system';
 import { StrRestrictionKeys } from '@altinn/schema-model';
 import { Divider } from '../../common/Divider';
 import { Label } from '../../common/Label';
 import { StringFormat } from '@altinn/schema-model/src/lib/types';
-import { Select } from '../../common/Select';
 import { getDomFriendlyID } from '../../../utils/ui-schema-utils';
 
 export function StringRestrictions({ language, onChangeRestrictionValue, path, restrictions }: RestrictionItemProps) {
@@ -24,19 +23,18 @@ export function StringRestrictions({ language, onChangeRestrictionValue, path, r
       setRegexTestValue(value);
     }
   };
+  const noFormatOption = { label: t('format_none'), value: '' };
   return (
     <>
       <Divider inMenu />
       <Select
-        emptyOptionLabel={t('format_none')}
-        id='format-select-input'
+        inputId='format-select-input'
         label={t('format')}
-        onChange={(val) => onChangeRestrictionValue(path, StrRestrictionKeys.format, val || undefined)}
-        options={Object.values(StringFormat).map((f) => ({
-          key: f,
+        onChange={(val: string) => onChangeRestrictionValue(path, StrRestrictionKeys.format, val || undefined)}
+        options={[noFormatOption, ...Object.values(StringFormat).map((f) => ({
           label: t(`format_${f}`),
-          value: f,
-        }))}
+          value: f as string,
+        }))]}
         value={restrictions[StrRestrictionKeys.format] || ''}
       />
       <div className={classes.lengthFields}>

--- a/src/studio/src/designer/frontend/shared/package.json
+++ b/src/studio/src/designer/frontend/shared/package.json
@@ -9,7 +9,7 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@altinn/altinn-design-system": "0.19.1",
+    "@altinn/altinn-design-system": "0.23.0",
     "@altinn/schema-editor": "0.1.0",
     "@mui/icons-material": "5.10.9",
     "@mui/material": "5.10.12",

--- a/src/studio/src/designer/frontend/yarn.lock
+++ b/src/studio/src/designer/frontend/yarn.lock
@@ -26,11 +26,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@altinn/altinn-design-system@npm:0.19.1":
-  version: 0.19.1
-  resolution: "@altinn/altinn-design-system@npm:0.19.1"
+"@altinn/altinn-design-system@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@altinn/altinn-design-system@npm:0.23.0"
   dependencies:
-    "@altinn/figma-design-tokens": ^4.2.0
+    "@altinn/figma-design-tokens": ^4.3.0
     "@navikt/ds-icons": ^1.3.38
     "@radix-ui/react-popover": ^1.0.0
     "@react-hookz/web": ^16.0.0
@@ -40,11 +40,11 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 33807342844f19065aac4cb542c8e99b4fe853096eafc69d0a179214e192dd446c2da7163be2206f9f486875159f276a94aa253f841121c6217385c85650230c
+  checksum: d5dd438a06bdb242f79b997a9696a4bad8388f3f750125ad8e7f1363e4d75c7d69a4bed4c269f3e2fe0c332d1fac3f9701d09d0008bfb99ad98e6816393a52e5
   languageName: node
   linkType: hard
 
-"@altinn/figma-design-tokens@npm:^4.2.0":
+"@altinn/figma-design-tokens@npm:^4.3.0":
   version: 4.3.0
   resolution: "@altinn/figma-design-tokens@npm:4.3.0"
   checksum: dac7b1b98a354bafa0ce627ae9fdf34215101fb57669576795d7b40c48dd41761b301ba62ec9026a99a5f21838aee6c4d26c851572ea8f334eb421c94b659a4d
@@ -4785,7 +4785,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app-development@workspace:app-development"
   dependencies:
-    "@altinn/altinn-design-system": 0.19.1
+    "@altinn/altinn-design-system": 0.23.0
     "@babel/core": 7.20.2
     "@babel/preset-env": 7.20.2
     "@babel/preset-react": 7.18.6
@@ -4833,7 +4833,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app-shared@workspace:shared"
   dependencies:
-    "@altinn/altinn-design-system": 0.19.1
+    "@altinn/altinn-design-system": 0.23.0
     "@altinn/schema-editor": 0.1.0
     "@mui/icons-material": 5.10.9
     "@mui/material": 5.10.12


### PR DESCRIPTION
## Description
Replacing some `Select` components with the one from the design system, and adding label props on text fields, as this is also implemented in the latest version of the design system.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
