### PR TITLE
feat: ignore generated test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -376,3 +376,6 @@ nb-configuration.xml
 .idea
 src/Altinn.Apps/AppTemplates/AspNet/App/Properties/launchSettings.json
 *.iml
+
+## Test repositories
+src/studio/src/designer/backend.Tests/_TestData/Repositories/*/*/test-repo_*/**

--- a/.gitignore
+++ b/.gitignore
@@ -379,3 +379,4 @@ src/Altinn.Apps/AppTemplates/AspNet/App/Properties/launchSettings.json
 
 ## Test repositories
 src/studio/src/designer/backend.Tests/_TestData/Repositories/*/*/test-repo_*/**
+src/studio/src/designer/backend.Tests/_TestData/Remote/*/test-repo_*/**

--- a/src/studio/src/designer/DataModeling/DataModeling.csproj
+++ b/src/studio/src/designer/DataModeling/DataModeling.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-      <PackageReference Include="JsonSchema.Net" Version="3.3.0" />
+      <PackageReference Include="JsonSchema.Net" Version="3.3.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/AddXsdTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/AddXsdTests.cs
@@ -37,7 +37,7 @@ public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>
         var org = "ttd";
         var sourceRepository = "empty-app";
         var developer = "testUser";
-        var targetRepository = Guid.NewGuid().ToString();
+        var targetRepository = TestDataHelper.GenerateTestRepoName();
 
         await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
         var url = $"{VersionPrefix}/{org}/{targetRepository}/datamodels/upload";
@@ -72,7 +72,7 @@ public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>
         var org = "ttd";
         var sourceRepository = "empty-app-pref-json";
         var developer = "testUser";
-        var targetRepository = Guid.NewGuid().ToString();
+        var targetRepository = TestDataHelper.GenerateTestRepoName();
 
         await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
         var url = $"{VersionPrefix}/{org}/{targetRepository}/datamodels/upload";
@@ -107,7 +107,7 @@ public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>
         var org = "ttd";
         var sourceRepository = "empty-datamodels";
         var developer = "testUser";
-        var targetRepository = Guid.NewGuid().ToString();
+        var targetRepository = TestDataHelper.GenerateTestRepoName();
 
         await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
         var url = $"{VersionPrefix}/{org}/{targetRepository}/datamodels/upload";

--- a/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/PostTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/PostTests.cs
@@ -42,7 +42,7 @@ public class PostTests : ApiTestsBase<DatamodelsController, PostTests>
         // Arrange
         var org = "ttd";
         var developer = "testUser";
-        var targetRepository = Guid.NewGuid().ToString();
+        var targetRepository = TestDataHelper.GenerateTestRepoName();
 
         await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
         var url = $"{VersionPrefix}/{org}/{targetRepository}/Datamodels/Post";

--- a/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
@@ -21,13 +21,12 @@ using Altinn.Studio.Designer.ModelMetadatalModels;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Mocks;
+using Designer.Tests.Utils;
 using FluentAssertions;
 using Json.Schema;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 using Xunit;
-using static Designer.Tests.Utils.TestDataHelper;
 
 namespace Designer.Tests.Controllers.DataModelsController;
 
@@ -52,7 +51,7 @@ public class PutDatamodelTests : ApiTestsBase<DatamodelsController, PutDatamodel
 
     public PutDatamodelTests(WebApplicationFactory<DatamodelsController> factory) : base(factory)
     {
-        TargetTestRepository = GenerateTestRepoName();
+        TargetTestRepository = TestDataHelper.GenerateTestRepoName();
     }
 
     protected override void ConfigureTestServices(IServiceCollection services)
@@ -69,7 +68,7 @@ public class PutDatamodelTests : ApiTestsBase<DatamodelsController, PutDatamodel
     {
         if (TestFilesCopied)
         {
-            DeleteAppRepository(TestOrg, TargetTestRepository, TestDeveloper);
+            TestDataHelper.DeleteAppRepository(TestOrg, TargetTestRepository, TestDeveloper);
         }
     }
 
@@ -96,7 +95,7 @@ public class PutDatamodelTests : ApiTestsBase<DatamodelsController, PutDatamodel
 
     private async Task RepositoryCopiedForTest(string org, string repository, string developer, string targetRepository)
     {
-        await CopyRepositoryForTest(org, repository, developer, targetRepository);
+        await TestDataHelper.CopyRepositoryForTest(org, repository, developer, targetRepository);
         TestFilesCopied = true;
     }
 

--- a/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
@@ -52,7 +52,7 @@ public class PutDatamodelTests : ApiTestsBase<DatamodelsController, PutDatamodel
 
     public PutDatamodelTests(WebApplicationFactory<DatamodelsController> factory) : base(factory)
     {
-        TargetTestRepository = Guid.NewGuid().ToString();
+        TargetTestRepository = GenerateTestRepoName();
     }
 
     protected override void ConfigureTestServices(IServiceCollection services)

--- a/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/UploadTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/UploadTests.cs
@@ -37,7 +37,7 @@ public class UploadTests: ApiTestsBase<DatamodelsController, UploadTests>
         var org = "ttd";
         var sourceRepository = "empty-datamodels";
         var developer = "testUser";
-        var targetRepository = Guid.NewGuid().ToString();
+        var targetRepository = TestDataHelper.GenerateTestRepoName();
 
         await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
         var url = $"{VersionPrefix}/{org}/{targetRepository}/Datamodels";

--- a/src/studio/src/designer/backend.Tests/Controllers/RepositorySettingsControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/RepositorySettingsControllerTests.cs
@@ -37,7 +37,7 @@ namespace Designer.Tests.Controllers
             var org = "ttd";
             var sourceRepository = "xyz-datamodels";
             var developer = "testUser";
-            var targetRepository = $"{Guid.NewGuid()}-datamodels";
+            var targetRepository = TestDataHelper.GenerateTestRepoName("-datamodels");
             await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
 
             string requestUrl = $"/designer/api/v1/{org}/{targetRepository}/repositorysettings";
@@ -77,7 +77,7 @@ namespace Designer.Tests.Controllers
             var org = "ttd";
             var sourceRepository = "xyz-datamodels";
             var developer = "testUser";
-            var targetRepository = $"{Guid.NewGuid()}-datamodels";
+            var targetRepository = TestDataHelper.GenerateTestRepoName("-datamodels");
             await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
 
             string requestUrl = $"/designer/api/v1/{org}/{targetRepository}/repositorysettings";

--- a/src/studio/src/designer/backend.Tests/Controllers/TextsControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/TextsControllerTests.cs
@@ -53,7 +53,7 @@ namespace Designer.Tests.Controllers
         [Fact]
         public async Task Get_Markdown_200Ok()
         {
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
             await TestDataHelper.CopyRepositoryForTest("ttd", "markdown-files", "testUser", targetRepository);
             string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/texts/nb";
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, dataPathWithData);
@@ -102,7 +102,7 @@ namespace Designer.Tests.Controllers
         [Fact]
         public async Task Put_UpdateNbTexts_200OK()
         {
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
             await TestDataHelper.CopyRepositoryForTest("ttd", "new-texts-format", "testUser", targetRepository);
             string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/texts/nb";
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, dataPathWithData);
@@ -123,7 +123,7 @@ namespace Designer.Tests.Controllers
         [Fact]
         public async Task Put_Markdown_200OK()
         {
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
             await TestDataHelper.CopyRepositoryForTest("ttd", "markdown-files", "testUser", targetRepository);
             string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/texts/nb";
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, dataPathWithData);
@@ -144,7 +144,7 @@ namespace Designer.Tests.Controllers
         [Fact]
         public async Task Put_ConvertTexts_204NoContent()
         {
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
             await TestDataHelper.CopyRepositoryForTest("ttd", "convert-texts", "testUser", targetRepository);
             string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/texts/convert";
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, dataPathWithData);
@@ -165,7 +165,7 @@ namespace Designer.Tests.Controllers
         [Fact]
         public async Task Put_UpdateInvalidFormat_400BadRequest()
         {
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
             await TestDataHelper.CopyRepositoryForTest("ttd", "new-texts-format", "testUser", targetRepository);
             string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/texts/nb";
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, dataPathWithData);
@@ -189,7 +189,7 @@ namespace Designer.Tests.Controllers
         [Fact]
         public async Task Delete_200Ok()
         {
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
             await TestDataHelper.CopyRepositoryForTest("ttd", "new-texts-format", "testUser", targetRepository);
             string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/texts/nb";
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, dataPathWithData);
@@ -212,7 +212,7 @@ namespace Designer.Tests.Controllers
         [Fact]
         public async Task Delete_Markdown_200Ok()
         {
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
             await TestDataHelper.CopyRepositoryForTest("ttd", "markdown-files", "testUser", targetRepository);
             string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/texts/nb";
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, dataPathWithData);

--- a/src/studio/src/designer/backend.Tests/Designer.Tests.csproj
+++ b/src/studio/src/designer/backend.Tests/Designer.Tests.csproj
@@ -5,6 +5,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <TestRepoPrefix>test-repo_</TestRepoPrefix>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Basic.Reference.Assemblies" Version="1.2.4" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
@@ -43,15 +47,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="_TestData\Repositories\testUser\ttd\3d59addc-09f0-429a-8a92-e85dbbcf27f6\**" />
     <Content Remove="_TestData\**\*.*" />
+    <Compile Remove="_TestData\Repositories\*\*\$(TestRepoPrefix)*\**" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="_TestData\**\*.*" />
+    <EmbeddedResource Remove="_TestData\Repositories\*\*\$(TestRepoPrefix)*\**" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Remove="_TestData\Repositories\testUser\ttd\3d59addc-09f0-429a-8a92-e85dbbcf27f6\**" />
-    <None Remove="_TestData\Repositories\testUser\ttd\3d59addc-09f0-429a-8a92-e85dbbcf27f6\**" />
+    <None Remove="_TestData\Repositories\*\*\$(TestRepoPrefix)*\**" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="_TestData\FileSystemObjects\ttd\apps-test\App\config\texts\3e1099738e0d15490390a01c74b2abc16282d85f\directoryList.json" />

--- a/src/studio/src/designer/backend.Tests/Designer.Tests.csproj
+++ b/src/studio/src/designer/backend.Tests/Designer.Tests.csproj
@@ -49,13 +49,16 @@
   <ItemGroup>
     <Content Remove="_TestData\**\*.*" />
     <Compile Remove="_TestData\Repositories\*\*\$(TestRepoPrefix)*\**" />
+    <Compile Remove="_TestData\Remote\*\$(TestRepoPrefix)*\**" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="_TestData\**\*.*" />
     <EmbeddedResource Remove="_TestData\Repositories\*\*\$(TestRepoPrefix)*\**" />
+    <EmbeddedResource Remove="_TestData\Remote\*\$(TestRepoPrefix)*\**" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="_TestData\Repositories\*\*\$(TestRepoPrefix)*\**" />
+    <None Remove="_TestData\Remote\*\$(TestRepoPrefix)*\**" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="_TestData\FileSystemObjects\ttd\apps-test\App\config\texts\3e1099738e0d15490390a01c74b2abc16282d85f\directoryList.json" />

--- a/src/studio/src/designer/backend.Tests/Infrastructure/GitRepository/AltinnGitRepositoryTests.cs
+++ b/src/studio/src/designer/backend.Tests/Infrastructure/GitRepository/AltinnGitRepositoryTests.cs
@@ -108,7 +108,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
             var org = "ttd";
             var sourceRepository = "hvem-er-hvem";
             var developer = "testUser";
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
 
             await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
 

--- a/src/studio/src/designer/backend.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
+++ b/src/studio/src/designer/backend.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
@@ -17,7 +17,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
         public async Task WriteTextByRelativePathAsync_ValidText_ShouldReadBackEqual(string expectedContent)
         {
             string repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
-            string repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", Guid.NewGuid().ToString(), "testUser");
+            string repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", TestDataHelper.GenerateTestRepoName(), "testUser");
             var gitRepository = new Altinn.Studio.Designer.Infrastructure.GitRepository.GitRepository(repositoriesRootDirectory, repositoryDirectory);
 
             var filename = $"{Guid.NewGuid()}.json";
@@ -89,7 +89,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
         public async Task WriteTextByRelativePathAsync_PathDontExist_ShouldCreateDirectory()
         {
             var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
-            var repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", Guid.NewGuid().ToString(), "testUser");
+            var repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", TestDataHelper.GenerateTestRepoName(), "testUser");
             var gitRepository = new Altinn.Studio.Designer.Infrastructure.GitRepository.GitRepository(repositoriesRootDirectory, repositoryDirectory);
 
             var relativeFileUrl = "test_directory/should/be/created/deleteme.txt";

--- a/src/studio/src/designer/backend.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
+++ b/src/studio/src/designer/backend.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
@@ -45,7 +45,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
             var org = "ttd";
             var sourceRepository = "hvem-er-hvem";
             var developer = "testUser";
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
 
             string repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
             var repositoryDirectory = await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);

--- a/src/studio/src/designer/backend.Tests/Services/RepositorySITests.cs
+++ b/src/studio/src/designer/backend.Tests/Services/RepositorySITests.cs
@@ -158,29 +158,37 @@ namespace Designer.Tests.Services
             // Arrange
             string developer = "testUser";
             string org = "ttd";
-            string sourceRepository = "apps-test";
-            string targetRepository = "apps-test-2021";
+            string origRemoteRepo = "apps-test";
+            string origRepo = "apps-test-2021";
+            string workingRemoteRepositoryName = TestDataHelper.GenerateTestRepoName(origRemoteRepo);
+            string targetRepositoryName = TestDataHelper.GenerateTestRepoName(origRepo);
+            var workingRemoteDirPath = string.Empty;
+            var createdTargetRepoPath = string.Empty;
             try
             {
-            PrepareRemoteTestData(org, sourceRepository);
-            TestDataHelper.CleanUpRemoteRepository("ttd", "apps-test-2021");
-            await TestDataHelper.CleanUpReplacedRepositories(org, targetRepository, developer);
+                workingRemoteDirPath = await TestDataHelper.CopyRemoteRepositoryForTest(org, origRemoteRepo, workingRemoteRepositoryName);
+                createdTargetRepoPath = await TestDataHelper.CopyRepositoryForTest(org, origRepo, developer, targetRepositoryName);
+                PrepareRemoteTestData(org, workingRemoteRepositoryName);
+                TestDataHelper.CleanUpRemoteRepository(org, targetRepositoryName);
+                await TestDataHelper.CleanUpReplacedRepositories(org, targetRepositoryName, developer);
 
-            RepositorySI sut = GetServiceForTest(developer);
+                RepositorySI sut = GetServiceForTest(developer);
 
-            // Act
-            await sut.CopyRepository(org, sourceRepository, targetRepository, developer);
+                // Act
+                await sut.CopyRepository(org, workingRemoteRepositoryName, targetRepositoryName, developer);
 
-            // Assert
-            string developerClonePath = Path.Combine(TestDataHelper.GetTestDataRepositoriesRootDirectory(), developer, org);
-            int actualCloneCount = Directory.GetDirectories(developerClonePath).Count(d => d.Contains("apps-test-2021"));
-            Assert.Equal(2, actualCloneCount);
+                // Assert
+                string developerClonePath = Path.Combine(TestDataHelper.GetTestDataRepositoriesRootDirectory(), developer, org);
+                int actualCloneCount = Directory.GetDirectories(developerClonePath).Count(d => d.Contains(targetRepositoryName));
+                Assert.Equal(2, actualCloneCount);
             }
             finally
             {
-                TestDataHelper.CleanUpRemoteRepository("ttd", "apps-test-2021");
-                await TestDataHelper.CleanUpReplacedRepositories(org, targetRepository, developer);
-                CleanUpRemoteTestData(org, sourceRepository);
+                TestDataHelper.CleanUpRemoteRepository(org, targetRepositoryName);
+                await TestDataHelper.CleanUpReplacedRepositories(org, targetRepositoryName, developer);
+                CleanUpRemoteTestData(org, workingRemoteRepositoryName);
+                TestDataHelper.DeleteDirectory(createdTargetRepoPath);
+                TestDataHelper.DeleteDirectory(workingRemoteDirPath);
             }
         }
 
@@ -190,18 +198,21 @@ namespace Designer.Tests.Services
             // Arrange
             string developer = "testUser";
             string org = "ttd";
-            string sourceRepository = "apps-test";
-            string targetRepository = "apps-test-clone";
+            string origRemoteRepo = "apps-test";
+            string workingSourceRepoName = TestDataHelper.GenerateTestRepoName(origRemoteRepo);
+            string targetRepository = TestDataHelper.GenerateTestRepoName("apps-test-clone");
             string expectedRepoPath = TestDataHelper.GetTestDataRepositoryDirectory(org, targetRepository, developer);
+            var workingRemoteDirPath = string.Empty;
 
             try
             {
-                PrepareRemoteTestData(org, sourceRepository);
+                workingRemoteDirPath = await TestDataHelper.CopyRemoteRepositoryForTest(org, origRemoteRepo, workingSourceRepoName);
+                PrepareRemoteTestData(org, workingSourceRepoName);
 
                 RepositorySI sut = GetServiceForTest(developer);
 
                 // Act
-                await sut.CopyRepository(org, sourceRepository, targetRepository, developer);
+                await sut.CopyRepository(org, workingSourceRepoName, targetRepository, developer);
 
                 // Assert
                 string appMetadataString = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
@@ -209,20 +220,21 @@ namespace Designer.Tests.Services
                 string developerClonePath = Path.Combine(TestDataHelper.GetTestDataRepositoriesRootDirectory(), developer, org);
 
                 Assert.True(Directory.Exists(expectedRepoPath));
-                Assert.Contains("\"id\": \"ttd/apps-test-clone\"", appMetadataString);
-                Assert.Contains("https://dev.altinn.studio/repos/ttd/apps-test-clone.git", gitConfigString);
+                Assert.Contains($"\"id\": \"ttd/{targetRepository}\"", appMetadataString);
+                Assert.Contains($"https://dev.altinn.studio/repos/{org}/{origRemoteRepo}.git", gitConfigString);
                 Assert.DoesNotContain(Directory.GetDirectories(developerClonePath), a => a.Contains("_COPY_OF_ORIGIN_"));
             }
             finally
             {
-                string path = TestDataHelper.GetTestDataRepositoryDirectory("ttd", "apps-test-clone", "testUser");
+                string path = TestDataHelper.GetTestDataRepositoryDirectory("ttd", targetRepository, developer);
                 TestDataHelper.CleanUpRemoteRepository(org, targetRepository);
                 if (Directory.Exists(path))
                 {
                     Directory.Delete(path, true);
                 }
 
-                CleanUpRemoteTestData(org, sourceRepository);
+                CleanUpRemoteTestData(org, workingSourceRepoName);
+                TestDataHelper.DeleteDirectory(workingRemoteDirPath);
             }
         }
 

--- a/src/studio/src/designer/backend.Tests/Services/RepositorySITests.cs
+++ b/src/studio/src/designer/backend.Tests/Services/RepositorySITests.cs
@@ -109,7 +109,7 @@ namespace Designer.Tests.Services
         public async Task CreateRepository_DoesNotExists_ShouldCreate()
         {
             string org = "ttd";
-            string repositoryName = Guid.NewGuid().ToString();
+            string repositoryName = TestDataHelper.GenerateTestRepoName();
             string developer = "testUser";
 
             var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();

--- a/src/studio/src/designer/backend.Tests/Services/RepositorySITests.cs
+++ b/src/studio/src/designer/backend.Tests/Services/RepositorySITests.cs
@@ -226,7 +226,7 @@ namespace Designer.Tests.Services
             }
             finally
             {
-                string path = TestDataHelper.GetTestDataRepositoryDirectory("ttd", targetRepository, developer);
+                string path = TestDataHelper.GetTestDataRepositoryDirectory(org, targetRepository, developer);
                 TestDataHelper.CleanUpRemoteRepository(org, targetRepository);
                 if (Directory.Exists(path))
                 {

--- a/src/studio/src/designer/backend.Tests/Services/SchemaModelServiceTests.cs
+++ b/src/studio/src/designer/backend.Tests/Services/SchemaModelServiceTests.cs
@@ -26,7 +26,7 @@ namespace Designer.Tests.Services
             var org = "ttd";
             var sourceRepository = "hvem-er-hvem";
             var developer = "testUser";
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
 
             await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
             try
@@ -64,7 +64,7 @@ namespace Designer.Tests.Services
             var org = "ttd";
             var sourceRepository = "xyz-datamodels";
             var developer = "testUser";
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
 
             await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
             try
@@ -96,7 +96,7 @@ namespace Designer.Tests.Services
             var org = "ttd";
             var sourceRepository = "hvem-er-hvem";
             var developer = "testUser";
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
 
             await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
             try
@@ -148,7 +148,7 @@ namespace Designer.Tests.Services
             var org = "ttd";
             var sourceRepository = "empty-app";
             var developer = "testUser";
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
 
             await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
             try
@@ -185,7 +185,7 @@ namespace Designer.Tests.Services
             var org = "ttd";
             var sourceRepository = "empty-app";
             var developer = "testUser";
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
 
             await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
             try
@@ -227,7 +227,7 @@ namespace Designer.Tests.Services
             var org = "ttd";
             var sourceRepository = "empty-datamodels";
             var developer = "testUser";
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
 
             await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
             try
@@ -275,7 +275,7 @@ namespace Designer.Tests.Services
             var org = "ttd";
             var sourceRepository = "empty-app-pref-json";
             var developer = "testUser";
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
 
             await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
             try
@@ -306,7 +306,7 @@ namespace Designer.Tests.Services
             var org = "ttd";
             var sourceRepository = "empty-app-pref-json";
             var developer = "testUser";
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
 
             await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
             try
@@ -343,7 +343,7 @@ namespace Designer.Tests.Services
             var org = "ttd";
             var sourceRepository = "empty-app";
             var developer = "testUser";
-            var targetRepository = Guid.NewGuid().ToString();
+            var targetRepository = TestDataHelper.GenerateTestRepoName();
 
             await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
             try

--- a/src/studio/src/designer/backend.Tests/Services/SourceControlSITest.cs
+++ b/src/studio/src/designer/backend.Tests/Services/SourceControlSITest.cs
@@ -30,10 +30,11 @@ namespace Designer.Tests.Services
         {
             // Arrange
             string org = "ttd";
-            string app = "app-for-deletion";
+            string origApp = "hvem-er-hvem";
+            string app = TestDataHelper.GenerateTestRepoName(origApp);
             string developer = "testUser";
 
-            await PrepareTestData(org, app, developer);
+            await TestDataHelper.CopyRepositoryForTest(org, origApp, developer, app);
 
             Mock<IGitea> mock = new Mock<IGitea>();
             mock.Setup(m => m.DeleteRepository(It.IsAny<string>(), It.IsAny<string>()))
@@ -71,12 +72,6 @@ namespace Designer.Tests.Services
 
             // Assert
             mock.VerifyAll();
-        }
-
-        private static async Task PrepareTestData(string org, string app, string developer)
-        {
-            string source = TestDataHelper.GetTestDataRepositoryDirectory(org, app, developer);
-            await TestDataHelper.CopyDirectory($"{source}.pretest", source, true);
         }
 
         private static HttpContext GetHttpContextForTestUser(string userName)

--- a/src/studio/src/designer/backend.Tests/Utils/TestDataHelper.cs
+++ b/src/studio/src/designer/backend.Tests/Utils/TestDataHelper.cs
@@ -135,6 +135,8 @@ namespace Designer.Tests.Utils
             return Path.Combine(remoteRepositoryRootDirectory, org, repository);
         }
 
+        public static string GenerateTestRepoName(string suffix = null) => $"test-repo_{Guid.NewGuid()}{suffix}";
+
         public async static Task<string> CopyRepositoryForTest(string org, string repository, string developer, string targetRepsository)
         {
             var sourceAppRepository = GetTestDataRepositoryDirectory(org, repository, developer);

--- a/src/studio/src/designer/backend.Tests/Utils/TestDataHelper.cs
+++ b/src/studio/src/designer/backend.Tests/Utils/TestDataHelper.cs
@@ -135,6 +135,11 @@ namespace Designer.Tests.Utils
             return Path.Combine(remoteRepositoryRootDirectory, org, repository);
         }
 
+        /// <summary>
+        /// Generates test repository name that will be excluded from project and will be git ignored.
+        /// </summary>
+        /// <param name="suffix">If provided appends suffix to test repo.</param>
+        /// <returns>Test repository name.</returns>
         public static string GenerateTestRepoName(string suffix = null) => $"test-repo_{Guid.NewGuid()}{suffix}";
 
         public async static Task<string> CopyRepositoryForTest(string org, string repository, string developer, string targetRepsository)
@@ -143,6 +148,16 @@ namespace Designer.Tests.Utils
             var targetDirectory = Path.Combine(GetTestDataRepositoriesRootDirectory(), developer, org, targetRepsository);
 
             await CopyDirectory(sourceAppRepository, targetDirectory);
+
+            return targetDirectory;
+        }
+
+        public static async Task<string> CopyRemoteRepositoryForTest(string org, string repository, string targetRepository)
+        {
+            var sourceRemoteRepository = GetTestDataRemoteRepository(org, repository);
+            var targetDirectory = Path.Combine(GetTestDataRemoteRepositoryRootDirectory(), org, targetRepository);
+
+            await CopyDirectory(sourceRemoteRepository, targetDirectory);
 
             return targetDirectory;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Logic of lot of the tests were to clone some test app ,and at the end of the test to delete those generated test files.
Problem with that approach was if tests stops in the middle of execution. Lot of non git-ignored files were produced and those files were not excluded from .net project.

## Description
<!--- Describe your changes in detail -->
- Test repositories that begin with "test-repo_" are git ignored and excluded from project
- Tests changed to use mentioned pattern for generated test data

## Related Issue(s)
- #9240

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
