### PR TITLE
bug/files missing in backends frontend code

### DIFF
--- a/src/studio/src/designer/frontend/language/copy-files-to-dist.js
+++ b/src/studio/src/designer/frontend/language/copy-files-to-dist.js
@@ -1,11 +1,14 @@
 const fs = require('fs');
 const path = require('path');
-
+const ensureDir = (dirPath) => {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath);
+  }
+  return dirPath;
+};
 const langFilesDir = path.resolve(__dirname, 'src');
-const distFileDir = path.resolve(__dirname, '..', 'dist', 'language');
-if (!fs.existsSync(distFileDir)) {
-  fs.mkdirSync(distFileDir);
-}
+const distDir = ensureDir(path.resolve(__dirname, '..', 'dist'));
+const distFileDir = ensureDir(path.resolve(distDir, 'language'));
 fs.readdirSync(langFilesDir).forEach((filename) =>
   fs.copyFileSync(
     path.resolve(langFilesDir, filename),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A minor issue, but if building (moving) the lang files to the dist-folder without the dist folder existance the solution failes due to the missing dist folder in the frontend. This PR fixes this issue.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
