### PR TITLE
fix: use non escaped url in location header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -382,3 +382,5 @@ src/Altinn.Apps/AppTemplates/AspNet/App/Properties/launchSettings.json
 src/studio/src/designer/backend.Tests/_TestData/Repositories/*/*/test-repo_*/**
 src/studio/src/designer/backend.Tests/_TestData/Remote/*/test-repo_*/**
 src/studio/.env
+
+src/studio/.devcontainer/**

--- a/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/AddXsdTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/AddXsdTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Designer.Tests.Controllers.DataModelsController;
 
-public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>
+public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>, IDisposable
 {
     private const string VersionPrefix = "/designer/api";
 
@@ -30,6 +30,16 @@ public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>
         services.AddSingleton<IGitea, IGiteaMock>();
     }
 
+    private string CreatedFolderPath { get; set; }
+
+    public void Dispose()
+    {
+        if (!string.IsNullOrWhiteSpace(CreatedFolderPath))
+        {
+            TestDataHelper.DeleteDirectory(CreatedFolderPath);
+        }
+    }
+
     [Fact]
     public async Task AddXsd_AppRepo_PreferredXsd_ShouldReturnCreated()
     {
@@ -39,7 +49,7 @@ public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>
         var developer = "testUser";
         var targetRepository = TestDataHelper.GenerateTestRepoName();
 
-        await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
+        CreatedFolderPath = await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
         var url = $"{VersionPrefix}/{org}/{targetRepository}/datamodels/upload";
 
         var fileStream = TestDataHelper.LoadDataFromEmbeddedResource(
@@ -54,15 +64,8 @@ public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>
             Content = formData
         };
 
-        try
-        {
-            var response = await HttpClient.Value.SendAsync(httpRequestMessage);
-            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        }
-        finally
-        {
-            TestDataHelper.DeleteAppRepository(org, targetRepository, developer);
-        }
+        var response = await HttpClient.Value.SendAsync(httpRequestMessage);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
     [Fact]
@@ -74,7 +77,7 @@ public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>
         var developer = "testUser";
         var targetRepository = TestDataHelper.GenerateTestRepoName();
 
-        await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
+        CreatedFolderPath = await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
         var url = $"{VersionPrefix}/{org}/{targetRepository}/datamodels/upload";
 
         var fileStream = TestDataHelper.LoadDataFromEmbeddedResource(
@@ -89,15 +92,8 @@ public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>
             Content = formData
         };
 
-        try
-        {
-            var response = await HttpClient.Value.SendAsync(httpRequestMessage);
-            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        }
-        finally
-        {
-            TestDataHelper.DeleteAppRepository(org, targetRepository, developer);
-        }
+        var response = await HttpClient.Value.SendAsync(httpRequestMessage);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
     [Fact]
@@ -109,7 +105,7 @@ public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>
         var developer = "testUser";
         var targetRepository = TestDataHelper.GenerateTestRepoName();
 
-        await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
+        CreatedFolderPath = await TestDataHelper.CopyRepositoryForTest(org, sourceRepository, developer, targetRepository);
         var url = $"{VersionPrefix}/{org}/{targetRepository}/datamodels/upload";
 
         var fileStream = TestDataHelper.LoadDataFromEmbeddedResource(
@@ -124,14 +120,7 @@ public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>
             Content = formData
         };
 
-        try
-        {
-            var response = await HttpClient.Value.SendAsync(httpRequestMessage);
-            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        }
-        finally
-        {
-            TestDataHelper.DeleteAppRepository(org, targetRepository, developer);
-        }
+        var response = await HttpClient.Value.SendAsync(httpRequestMessage);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 }

--- a/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/AddXsdTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/DataModelsController/AddXsdTests.cs
@@ -97,7 +97,7 @@ public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>, IDis
     }
 
     [Fact]
-    public async Task AddXsd_DatamodelsRepo_ShouldReturnCreated()
+    public async Task AddXsd_DatamodelsRepo_NonAsciiName_ShouldReturnCreated()
     {
         // Arrange
         var org = "ttd";
@@ -113,7 +113,7 @@ public class AddXsdTests : ApiTestsBase<DatamodelsController, AddXsdTests>, IDis
         var formData = new MultipartFormDataContent();
         var streamContent = new StreamContent(fileStream);
         streamContent.Headers.ContentType = MediaTypeHeaderValue.Parse("multipart/form-data");
-        formData.Add(streamContent, "file", "Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES.xsd");
+        formData.Add(streamContent, "file", "Kursdomene_HvemErHvem_M_ÅåØøæÆ.xsd");
 
         var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, url)
         {

--- a/src/studio/src/designer/backend/Controllers/DatamodelsController.cs
+++ b/src/studio/src/designer/backend/Controllers/DatamodelsController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -170,7 +171,7 @@ namespace Altinn.Studio.Designer.Controllers
 
             var jsonSchema = await _schemaModelService.BuildSchemaFromXsd(org, repository, developer, fileName, thefile.OpenReadStream());
 
-            return Created(fileName, jsonSchema);
+            return Created(Uri.EscapeDataString(fileName), jsonSchema);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Escape non ascii characters for xsd upload endpoint

## Description
<!--- Describe your changes in detail -->
- filename escaped in the response

## Related Issue(s)
- #9258 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
