### PR TITLE
9140 consolidate all api paths in frontend

### DIFF
--- a/src/studio/src/designer/frontend/.prettierignore
+++ b/src/studio/src/designer/frontend/.prettierignore
@@ -1,0 +1,1 @@
+./shared/api-paths.js

--- a/src/studio/src/designer/frontend/app-development/App.tsx
+++ b/src/studio/src/designer/frontend/app-development/App.tsx
@@ -10,7 +10,6 @@ import { fetchRepoStatus } from './features/handleMergeConflict/handleMergeConfl
 import { makeGetRepoStatusSelector } from './features/handleMergeConflict/handleMergeConflictSelectors';
 import { ApplicationMetadataActions } from './sharedResources/applicationMetadata/applicationMetadataSlice';
 import { fetchLanguage } from './utils/fetchLanguage/languageSlice';
-import { repoStatusUrl } from './utils/urlHelper';
 import {
   fetchRemainingSession,
   keepAliveSession,
@@ -26,6 +25,13 @@ import classes from './App.module.css';
 import { useAppDispatch, useAppSelector } from './common/hooks';
 import { getRepositoryType } from './utils/repository';
 import { RepositoryType } from './types/global';
+import {
+  frontendLangPath,
+  repoInitialCommitPath,
+  repoMetaPath, repoStatusPath,
+  serviceConfigPath,
+  serviceNamePath,
+} from 'app-shared/api-paths';
 
 const theme = createTheme(altinnTheme);
 
@@ -53,7 +59,7 @@ export function App() {
   useEffect(() => {
     dispatch(
       fetchLanguage({
-        url: `${window.location.origin}/designer/frontend/lang/nb.json`,
+        url: frontendLangPath('nb'),
       }),
     );
     dispatch(DataModelsMetadataActions.getDataModelsMetadata());
@@ -67,25 +73,25 @@ export function App() {
     if (app && org) {
       dispatch(
         HandleServiceInformationActions.fetchService({
-          url: `${window.location.origin}/designer/api/v1/repos/${org}/${app}`,
+          url: repoMetaPath(org, app),
         }),
       );
       dispatch(
         HandleServiceInformationActions.fetchInitialCommit({
-          url: `${window.location.origin}/designer/api/v1/repos/${org}/${app}/initialcommit`,
+          url: repoInitialCommitPath(org, app),
         }),
       );
 
       if (repositoryType === RepositoryType.App) {
         dispatch(
           HandleServiceInformationActions.fetchServiceName({
-            url: `${window.location.origin}/designer/${org}/${app}/Text/GetServiceName`,
+            url: serviceNamePath(org, app),
           }),
         );
 
         dispatch(
           HandleServiceInformationActions.fetchServiceConfig({
-            url: `${window.location.origin}/designer/${org}/${app}/Config/GetServiceConfig`,
+            url: serviceConfigPath(org, app),
           }),
         );
       }
@@ -106,7 +112,7 @@ export function App() {
       if (event.data === postMessages.forceRepoStatusCheck) {
         dispatch(
           fetchRepoStatus({
-            url: repoStatusUrl,
+            url: repoStatusPath(org,app),
             org,
             repo: app,
           }),

--- a/src/studio/src/designer/frontend/app-development/features/administration/components/DownloadRepoModal.tsx
+++ b/src/studio/src/designer/frontend/app-development/features/administration/components/DownloadRepoModal.tsx
@@ -4,6 +4,7 @@ import { Button, ButtonColor, ButtonVariant } from '@altinn/altinn-design-system
 import { getLanguageFromKey } from 'app-shared/utils/language';
 import classes from './RepoModal.module.css';
 import { useParams } from 'react-router-dom';
+import { repoDownloadPath } from "app-shared/api-paths";
 
 interface IDownloadRepoModalProps {
   anchorRef: React.MutableRefObject<Element>;
@@ -34,18 +35,8 @@ export function DownloadRepoModal(props: IDownloadRepoModalProps) {
         <div className={classes.modalContainer}>
           <h2>{t('administration.download_repo_heading')}</h2>
           <p>{t('administration.download_repo_info')}</p>
-          <p>
-            <a href={`/designer/api/v1/repos/${org}/${app}/contents.zip`}>
-              {t('administration.download_repo_changes')}
-            </a>
-          </p>
-          <p>
-            <a
-              href={`/designer/api/v1/repos/${org}/${app}/contents.zip?full=true`}
-            >
-              {t('administration.download_repo_full')}
-            </a>
-          </p>
+          <p><a href={repoDownloadPath(org,app)}>{t('administration.download_repo_changes')}</a></p>
+          <p><a href={repoDownloadPath(org,app,true)}>{t('administration.download_repo_full')}</a></p>
           <div className={classes.buttonContainer}>
             <Button
                 color={ButtonColor.Secondary}

--- a/src/studio/src/designer/frontend/app-development/features/appPublish/components/appReleaseComponent.tsx
+++ b/src/studio/src/designer/frontend/app-development/features/appPublish/components/appReleaseComponent.tsx
@@ -14,10 +14,11 @@ import {
   BuildStatus,
 } from '../../../sharedResources/appRelease/types';
 import {
-  getGitCommitLink,
   getReleaseBuildPipelineLink,
 } from '../../../utils/urlHelper';
 import { useAppSelector } from '../../../common/hooks';
+import {gitCommitPath} from "app-shared/api-paths";
+import {useParams} from "react-router-dom";
 
 const styles = createStyles({
   releaseWrapper: {
@@ -104,7 +105,7 @@ function ReleaseComponent(props: IAppReleaseComponent) {
     }
     return release.body;
   }
-
+  const {org,app} = useParams();
   return (
     <Grid container={true} direction='row' className={classes.releaseWrapper}>
       <Grid container={true} direction='row' justifyContent='space-between'>
@@ -143,7 +144,7 @@ function ReleaseComponent(props: IAppReleaseComponent) {
         <Grid item={true}>
           <Typography className={classes.releaseText}>
             <a
-              href={getGitCommitLink(release.targetCommitish)}
+              href={gitCommitPath(org,app,release.targetCommitish)}
               target='_blank'
               rel='noopener noreferrer'
             >

--- a/src/studio/src/designer/frontend/app-development/features/appPublish/containers/releaseContainer.tsx
+++ b/src/studio/src/designer/frontend/app-development/features/appPublish/containers/releaseContainer.tsx
@@ -25,17 +25,13 @@ import {
 import type { IRepoStatusState } from '../../../sharedResources/repoStatus/repoStatusSlice';
 import { RepoStatusActions } from '../../../sharedResources/repoStatus/repoStatusSlice';
 import { fetchLanguage } from '../../../utils/fetchLanguage/languageSlice';
-import {
-  getGitCommitLink,
-  languageUrl,
-  repoStatusUrl,
-} from '../../../utils/urlHelper';
 import type { IHandleMergeConflictState } from '../../handleMergeConflict/handleMergeConflictSlice';
 import { fetchRepoStatus } from '../../handleMergeConflict/handleMergeConflictSlice';
 import ReleaseComponent from '../components/appReleaseComponent';
 import CreateReleaseComponent from '../components/createAppReleaseComponent';
 import { useParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../../common/hooks';
+import {frontendLangPath, gitCommitPath, repoStatusPath} from "app-shared/api-paths";
 
 const theme = createTheme(AltinnStudioTheme);
 
@@ -149,12 +145,12 @@ function AppReleaseContainer(props: IAppReleaseContainer) {
   useEffect(() => {
     dispatch(AppReleaseActions.getAppReleaseStartInterval());
     if (!language) {
-      dispatch(fetchLanguage({ url: languageUrl }));
+      dispatch(fetchLanguage({ url: frontendLangPath("nb") }));
     }
     dispatch(RepoStatusActions.getMasterRepoStatus({ org, repo: app }));
     dispatch(
       fetchRepoStatus({
-        url: repoStatusUrl,
+        url: repoStatusPath(org,app),
         org,
         repo: app,
       }),
@@ -393,7 +389,7 @@ function AppReleaseContainer(props: IAppReleaseContainer) {
           {getLanguageFromKey('app_release.release_title', language)} &nbsp;
           {repoStatus.branch.master ? (
             <a
-              href={getGitCommitLink(repoStatus.branch.master.commit.id)}
+              href={gitCommitPath(org,app,repoStatus.branch.master.commit.id)}
               target='_blank'
               rel='noopener noreferrer'
             >
@@ -412,7 +408,7 @@ function AppReleaseContainer(props: IAppReleaseContainer) {
           &nbsp;
           {getLanguageFromKey('general.contains', language)}
           &nbsp;
-          <a href={getGitCommitLink(repoStatus.branch.master.commit.id)}>
+          <a href={gitCommitPath(org,app,repoStatus.branch.master.commit.id)}>
             {getLanguageFromKey('app_release.release_title_link', language)}
           </a>
         </>

--- a/src/studio/src/designer/frontend/app-development/features/appPublish/pages/InfoCard.tsx
+++ b/src/studio/src/designer/frontend/app-development/features/appPublish/pages/InfoCard.tsx
@@ -21,7 +21,7 @@ export const InfoCard = (
         >
           <div className={classes.textContainer}>
             <h1 className={classes.header}>{props.headerText}</h1>
-            <p className={classes.breadText}>{props.children}</p>
+            <div className={classes.breadText}>{props.children}</div>
           </div>
           <div className={classes.imageContainer}>
             <Illustration />

--- a/src/studio/src/designer/frontend/app-development/features/handleMergeConflict/HandleMergeConflictContainer.tsx
+++ b/src/studio/src/designer/frontend/app-development/features/handleMergeConflict/HandleMergeConflictContainer.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import FileEditor from 'app-shared/file-editor/FileEditor';
 import altinnTheme from 'app-shared/theme/altinnStudioTheme';
 import { getLanguageFromKey } from 'app-shared/utils/language';
-import VersionControlHeader from 'app-shared/version-control/versionControlHeader';
+import { VersionControlContainer } from 'app-shared/version-control/versionControlHeader';
 import { makeGetRepoStatusSelector } from './handleMergeConflictSelectors';
 import HandleMergeConflictAbortComponent from './components/HandleMergeConflictAbort';
 import HandleMergeConflictDiscardChangesComponent from './components/HandleMergeConflictDiscardChanges';
@@ -115,7 +115,7 @@ export class HandleMergeConflictContainer extends React.Component<
             >
               <Grid item={true} xs={12}>
                 {repoStatus.hasMergeConflict ? null : (
-                  <VersionControlHeader language={language} />
+                  <VersionControlContainer language={language} />
                 )}
 
                 <Typography variant='h1'>

--- a/src/studio/src/designer/frontend/app-development/features/handleMergeConflict/components/HandleMergeConflictAbort.tsx
+++ b/src/studio/src/designer/frontend/app-development/features/handleMergeConflict/components/HandleMergeConflictAbort.tsx
@@ -5,6 +5,7 @@ import { getLanguageFromKey } from 'app-shared/utils/language';
 import { get } from 'app-shared/utils/networking';
 import postMessages from 'app-shared/utils/postMessages';
 import { _useParamsClassCompHack } from 'app-shared/utils/_useParamsClassCompHack';
+import {abortmergePath} from "app-shared/api-paths";
 
 interface IHandleMergeConflictAbortProps {
   language: any;
@@ -66,11 +67,6 @@ export class HandleMergeConflictAbort extends React.Component<
 
   public AbortConfirmed = async () => {
     const { org, app } = _useParamsClassCompHack();
-
-    const abortUrl =
-      `${window.location.origin}` +
-      `/designer/api/v1/repos/${org}/${app}/abortmerge`;
-
     // Try to abort merge and catch error
     // If successfull merge abort then initiate forceRepoStatusCheck
     try {
@@ -83,7 +79,7 @@ export class HandleMergeConflictAbort extends React.Component<
         },
       });
 
-      const abortRes = await get(abortUrl);
+      const abortRes = await get(abortmergePath(org,app));
       this.setState({
         networkingRes: abortRes,
         popoverState: {

--- a/src/studio/src/designer/frontend/app-development/features/handleMergeConflict/components/HandleMergeConflictDiscardChanges.tsx
+++ b/src/studio/src/designer/frontend/app-development/features/handleMergeConflict/components/HandleMergeConflictDiscardChanges.tsx
@@ -8,6 +8,7 @@ import { getLanguageFromKey } from 'app-shared/utils/language';
 import { get } from 'app-shared/utils/networking';
 import postMessages from 'app-shared/utils/postMessages';
 import { _useParamsClassCompHack } from 'app-shared/utils/_useParamsClassCompHack';
+import {discardChangesPath} from "app-shared/api-paths";
 
 const theme = createTheme(altinnTheme);
 
@@ -94,10 +95,7 @@ class HandleMergeConflictDiscardChanges extends React.Component<
         },
       });
 
-      const discardUrl =
-        `${window.location.origin}/` +
-        `/designer/api/v1/repos/${org}/${app}/discard`;
-      const discardRes = await get(discardUrl);
+      const discardRes = await get(discardChangesPath(org,app));
 
       this.setState({
         networkingRes: discardRes,

--- a/src/studio/src/designer/frontend/app-development/layout/AppBar/AppBar.tsx
+++ b/src/studio/src/designer/frontend/app-development/layout/AppBar/AppBar.tsx
@@ -9,7 +9,7 @@ import {
 import { createStyles, makeStyles } from '@mui/styles';
 import classNames from 'classnames';
 import { Link, useParams } from 'react-router-dom';
-import { altinnImgLogoHeaderUrl } from 'app-shared/utils/urlHelper';
+import { altinnImgLogoHeaderUrl } from 'app-shared/cdn-paths';
 import type { IMenuItem } from 'app-shared/navigation/drawer/drawerMenuSettings';
 import TabletDrawerMenu from 'app-shared/navigation/drawer/TabletDrawerMenu';
 import { getTopBarMenu } from './appBarConfig';
@@ -156,7 +156,7 @@ export const AppBar = ({
                   className={classes.aImgStyling}
                 >
                   <img
-                    src={altinnImgLogoHeaderUrl}
+                    src={altinnImgLogoHeaderUrl()}
                     alt='Altinn logo'
                   />
                 </a>

--- a/src/studio/src/designer/frontend/app-development/layout/AppBar/AppBar.tsx
+++ b/src/studio/src/designer/frontend/app-development/layout/AppBar/AppBar.tsx
@@ -15,7 +15,7 @@ import TabletDrawerMenu from 'app-shared/navigation/drawer/TabletDrawerMenu';
 import { getTopBarMenu } from './appBarConfig';
 import ProfileMenu from 'app-shared/navigation/main-header/profileMenu';
 import { getLanguageFromKey } from 'app-shared/utils/language';
-import VersionControlHeader from 'app-shared/version-control/versionControlHeader';
+import { VersionControlContainer } from 'app-shared/version-control/versionControlHeader';
 import { useAppSelector } from '../../common/hooks';
 import { getRepositoryType } from '../../utils/repository';
 
@@ -229,7 +229,7 @@ export const AppBar = ({
                     xs
                     item
                   >
-                    <VersionControlHeader language={language} />
+                    <VersionControlContainer language={language} />
                   </Grid>
                   {menu.map((item) => (
                     <Grid

--- a/src/studio/src/designer/frontend/app-development/sharedResources/configuration/getEnvironments/getEnvironmentsSagas.ts
+++ b/src/studio/src/designer/frontend/app-development/sharedResources/configuration/getEnvironments/getEnvironmentsSagas.ts
@@ -2,12 +2,12 @@ import { SagaIterator } from 'redux-saga';
 import { call, fork, put, takeLatest } from 'redux-saga/effects';
 import { get } from 'app-shared/utils/networking';
 import { ConfigurationActions } from '../configurationSlice';
-import { environmentsConfigUrl } from '../../../utils/urlHelper';
+import {environmentsConfigUrl} from "app-shared/cdn-paths";
 
 // GET ENVIRONMENTS
 function* getEnvironmentsSaga(): SagaIterator {
   try {
-    const result = yield call(get, environmentsConfigUrl);
+    const result = yield call(get, environmentsConfigUrl());
     yield put(ConfigurationActions.getEnvironmentsFulfilled({ result }));
   } catch (error) {
     yield put(ConfigurationActions.getEnvironmentsRejected({ error }));

--- a/src/studio/src/designer/frontend/app-development/sharedResources/configuration/getOrgs/getOrgsSagas.ts
+++ b/src/studio/src/designer/frontend/app-development/sharedResources/configuration/getOrgs/getOrgsSagas.ts
@@ -2,11 +2,11 @@ import { SagaIterator } from 'redux-saga';
 import { call, put, takeLatest } from 'redux-saga/effects';
 import { get } from 'app-shared/utils/networking';
 import { ConfigurationActions } from '../configurationSlice';
-import { orgsListUrl } from '../../../utils/urlHelper';
+import {orgsListUrl} from "app-shared/cdn-paths";
 
 function* getOrgsSagas(): SagaIterator {
   try {
-    const result: any = yield call(get, orgsListUrl);
+    const result: any = yield call(get, orgsListUrl());
     const orgObject = result.orgs;
     yield put(ConfigurationActions.getOrgsFulfilled({ orgs: orgObject }));
   } catch (error) {

--- a/src/studio/src/designer/frontend/app-development/sharedResources/repoStatus/get/getMasterRepoStatusSagas.ts
+++ b/src/studio/src/designer/frontend/app-development/sharedResources/repoStatus/get/getMasterRepoStatusSagas.ts
@@ -4,17 +4,14 @@ import { get } from 'app-shared/utils/networking';
 import { PayloadAction } from '@reduxjs/toolkit';
 import { RepoStatusActions } from '../repoStatusSlice';
 import type { IRepoStatusAction } from '../repoStatusSlice';
+import { masterRepoStatusPath } from 'app-shared/api-paths';
 
 // GET MASTER REPO
 export function* getMasterRepoStatusSaga({
   payload: { org, repo },
 }: PayloadAction<IRepoStatusAction>): SagaIterator {
   try {
-    const result = yield call(
-      get,
-      `/designer/api/v1/repos/${org}/${repo}/branches/branch?branch=master`,
-    );
-
+    const result = yield call(get, masterRepoStatusPath(org, repo));
     yield put(RepoStatusActions.getMasterRepoStatusFulfilled({ result }));
   } catch (error) {
     yield put(RepoStatusActions.getMasterRepoStatusRejected({ error }));
@@ -27,4 +24,3 @@ export function* watchGetMasterRepoStatusSaga(): SagaIterator {
     getMasterRepoStatusSaga,
   );
 }
-

--- a/src/studio/src/designer/frontend/app-development/sharedResources/repoStatus/reset/resetLocalRepoSagas.ts
+++ b/src/studio/src/designer/frontend/app-development/sharedResources/repoStatus/reset/resetLocalRepoSagas.ts
@@ -5,22 +5,19 @@ import { get } from 'app-shared/utils/networking';
 import { RepoStatusActions } from '../repoStatusSlice';
 import type { IRepoStatusAction } from '../repoStatusSlice';
 import { fetchRepoStatus } from '../../../features/handleMergeConflict/handleMergeConflictSlice';
-import { repoStatusUrl } from '../../../utils/urlHelper';
 import postMessages from 'app-shared/utils/postMessages';
+import { repoResetPAth, repoStatusPath } from 'app-shared/api-paths';
 
 // GET MASTER REPO
 export function* resetLocalRepoSaga({
   payload: { org, repo },
 }: PayloadAction<IRepoStatusAction>): SagaIterator {
   try {
-    const result = yield call(
-      get,
-      `/designer/api/v1/repos/${org}/${repo}/reset`,
-    );
+    const result = yield call(get, repoResetPAth(org, repo));
 
     yield put(
       fetchRepoStatus({
-        url: repoStatusUrl,
+        url: repoStatusPath(org, repo),
         org,
         repo,
       }),
@@ -35,4 +32,3 @@ export function* resetLocalRepoSaga({
 export function* watchResetLocalRepoSaga(): SagaIterator {
   yield takeLatest(RepoStatusActions.resetLocalRepo, resetLocalRepoSaga);
 }
-

--- a/src/studio/src/designer/frontend/app-development/sharedResources/user/session/sessionSagas.ts
+++ b/src/studio/src/designer/frontend/app-development/sharedResources/user/session/sessionSagas.ts
@@ -2,12 +2,6 @@ import { get, post } from 'app-shared/utils/networking';
 import { SagaIterator } from 'redux-saga';
 import { call, delay, put, takeLatest } from 'redux-saga/effects';
 import {
-  giteaSignOutUrl,
-  keepAliveUrl,
-  remainingSessionTimeUrl,
-  studioSignOutUrl,
-} from '../../../utils/urlHelper';
-import {
   fetchRemainingSession,
   fetchRemainingSessionFulfilled,
   fetchRemainingSessionRejected,
@@ -16,10 +10,19 @@ import {
   keepAliveSessionRejected,
   signOutUser,
 } from '../userSlice';
+import {
+  keepAlivePath,
+  remainingSessionTimePath,
+  userLogoutAfterPath,
+  userLogoutPath,
+} from 'app-shared/api-paths';
 
 export function* fetchRemainingSessionSaga(): SagaIterator {
   try {
-    const remainingMinutes: number = yield call(get, remainingSessionTimeUrl);
+    const remainingMinutes: number = yield call(
+      get,
+      remainingSessionTimePath(),
+    );
     if (remainingMinutes < 0) {
       throw Error('negative remaining session time');
     }
@@ -42,7 +45,7 @@ export function* watchFetchRemainingSessionSaga(): SagaIterator {
 
 export function* keepAliveSessionSaga(): SagaIterator {
   try {
-    const remainingMinutes = yield call(get, keepAliveUrl);
+    const remainingMinutes = yield call(get, keepAlivePath());
     yield put(keepAliveSessionFulfilled({ remainingMinutes }));
     yield delay(10 * 60 * 1000);
     yield put(fetchRemainingSession());
@@ -61,8 +64,8 @@ export function* watchKeepAliveSaga(): SagaIterator {
 
 export function* signOutUserSaga(): SagaIterator {
   try {
-    yield call(post, giteaSignOutUrl);
-    window.location.assign(studioSignOutUrl);
+    yield call(post, userLogoutPath());
+    window.location.assign(userLogoutAfterPath());
   } catch (error) {
     console.error(error);
   }

--- a/src/studio/src/designer/frontend/app-development/utils/urlHelper.ts
+++ b/src/studio/src/designer/frontend/app-development/utils/urlHelper.ts
@@ -1,28 +1,16 @@
 import { _useParamsClassCompHack } from 'app-shared/utils/_useParamsClassCompHack';
 
 const { org, app } = _useParamsClassCompHack();
-const cdn = 'https://altinncdn.no';
 const desingerApi = `${window.location.origin}/designer/api`;
 
-export const repoStatusUrl = `${window.location.origin}/designer/api/v1/repos/${org}/${app}/status`;
-export const languageUrl = `${window.location.origin}/designer/frontend/lang`;
-export const giteaSignOutUrl = `${window.location.origin}/repos/user/logout`;
-export const studioSignOutUrl = `${window.location.origin}/Home/Logout`;
 export const appDeploymentsUrl = `${desingerApi}/v1/${org}/${app}/Deployments`;
-export const keepAliveUrl = `${desingerApi}/v1/session/keepalive`;
 export const fetchDeployPermissionsUrl = `${desingerApi}/v1/${org}/${app}/deployments/permissions`;
-export const remainingSessionTimeUrl = `${desingerApi}/v1/session/remaining`;
 export const releasesPostUrl = `${desingerApi}/v1/${org}/${app}/releases`;
 export const releasesGetUrl = `${releasesPostUrl}?sortDirection=Descending`;
-export const orgsListUrl = `${cdn}/orgs/altinn-orgs.json`;
-export const environmentsConfigUrl = `${cdn}/config/environments.json`;
 export const applicationMetadataUrl = `${window.location.origin}/designer/api/v1/${org}/${app}`;
 
 export const getReleaseBuildPipelineLink = (buildId: string) =>
   `https://dev.azure.com/brreg/altinn-studio/_build/results?buildId=${buildId}`;
-
-export const getGitCommitLink = (commitId: string) =>
-  `${origin}/repos/${org}/${app}/commit/${commitId}`;
 
 export const getAzureDevopsBuildResultUrl = (buildId: string | number) =>
   `https://dev.azure.com/brreg/altinn-studio/_build/results?buildId=${buildId}`;

--- a/src/studio/src/designer/frontend/dashboard/dashboardTestUtils.tsx
+++ b/src/studio/src/designer/frontend/dashboard/dashboardTestUtils.tsx
@@ -7,6 +7,11 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { HashRouter as Router } from 'react-router-dom';
 import { AppStore, RootState, setupStore } from './app/store';
+import {
+  orgsListPath,
+  repoSearchPath,
+  userStarredListPath,
+} from 'app-shared/api-paths';
 
 interface ExtendedRenderOptions extends Omit<RenderOptions, 'queries'> {
   preloadedState?: PreloadedState<RootState>;
@@ -39,7 +44,7 @@ export const renderWithProviders = (
 };
 
 export const handlers = [
-  rest.get('http://localhost/designer/api/v1/orgs', (req, res, ctx) => {
+  rest.get(orgsListPath(), (req, res, ctx) => {
     const mockApiResponse = [
       {
         avatar_url: 'avatar.png',
@@ -53,11 +58,11 @@ export const handlers = [
     ];
     return res(ctx.json(mockApiResponse));
   }),
-  rest.get('http://localhost/designer/api/v1/user/starred', (req, res, ctx) => {
+  rest.get(userStarredListPath(), (req, res, ctx) => {
     const mockApiResponse: any = [];
     return res(ctx.json(mockApiResponse));
   }),
-  rest.get('http://localhost/designer/api/v1/repos/search', (req, res, ctx) => {
+  rest.get(repoSearchPath(), (req, res, ctx) => {
     const mockApiResponse: any = [];
     return res(ctx.json(mockApiResponse));
   }),

--- a/src/studio/src/designer/frontend/dashboard/features/createService/CreateService.test.tsx
+++ b/src/studio/src/designer/frontend/dashboard/features/createService/CreateService.test.tsx
@@ -15,6 +15,7 @@ import {
 
 import { SelectedContextType } from 'app-shared/navigation/main-header/Header';
 import { CreateService } from './CreateService';
+import {orgsListPath} from "app-shared/api-paths";
 
 const server = setupServer(...handlers);
 
@@ -64,7 +65,7 @@ describe('CreateService', () => {
   it('should prefill owner when there are no available orgs, and the only available user is the logged in user', async () => {
     server.use(
       rest.get(
-        'http://localhost/designer/api/v1/orgs',
+          orgsListPath(),
         async (req, res, ctx) => {
           return res(ctx.json([]));
         }

--- a/src/studio/src/designer/frontend/dashboard/services/repoApi.ts
+++ b/src/studio/src/designer/frontend/dashboard/services/repoApi.ts
@@ -1,6 +1,6 @@
 import { designerApi, TagTypes } from './designerApi';
 import type { IRepository } from 'app-shared/types/global';
-import { repoSearchPath, reposList } from 'app-shared/api-paths';
+import { repoSearchPath, reposListPath } from 'app-shared/api-paths';
 
 type Filters = {
   uid?: number;
@@ -86,7 +86,7 @@ export const repoApi = designerApi.injectEndpoints({
     addRepo: builder.mutation<IRepository, AddQuery>({
       query: ({ owner, repoName, modelType }) => {
         return {
-          url: reposList(owner),
+          url: reposListPath(owner),
           method: 'POST',
           params: {
             repository: repoName,

--- a/src/studio/src/designer/frontend/mockend/src/index.js
+++ b/src/studio/src/designer/frontend/mockend/src/index.js
@@ -2,23 +2,20 @@
 require = require('esm')(module /*, options*/);
 const bodyParser = require('body-parser');
 
-const createDatamodel = require('./routes/create-model');
-const getDatamodel = require('./routes/get-datamodel');
-const getDatamodels = require('./routes/get-datamodels');
-const getIndexHtml = require('./routes/get-index-html');
-const getRepoData = require('./routes/get-repo-data');
-const putDatamodel = require('./routes/put-datamodel');
-const delDatamodel = require('./routes/del-datamodel');
-const userCurrent = require('./routes/user-current');
-
-const { APP_DEVELOPMENT_BASENAME } = require('../../constants.js');
+const { APP_DEVELOPMENT_BASENAME, DASHBOARD_BASENAME } = require('../../constants.js');
 const { ensureStorageDir } = require('./utils');
-const { DASHBOARD_BASENAME } = require('../../constants');
-const { userCurrentPath } = require('../../shared/api-paths');
+const {
+  userCurrentPath,
+  datamodelsPath,
+  createDatamodelPath,
+  remainingSessionTimePath,
+  repoInitialCommitPath,
+  frontendLangPath,
+  repoMetaPath,
+  serviceConfigPath,
+  serviceNamePath,
+} = require('../../shared/api-paths');
 
-/**
- * Request URL: http://localhost:8080/designer/api/my-org/my-app/datamodels?modelPath=App%2Fmodels%2Fny-modell.schema.json
- */
 module.exports = (middlewares, devServer) => {
   if (!devServer) {
     throw new Error('webpack-dev-server is not defined');
@@ -30,37 +27,20 @@ module.exports = (middlewares, devServer) => {
   const startUrl =
     process.env.npm_package_name === 'dashboard' ? DASHBOARD_BASENAME : `${APP_DEVELOPMENT_BASENAME}/someorg/someapp`;
 
+  app.delete(datamodelsPath(':owner', ':repo'), require('./routes/del-datamodel'));
   app.get('/', (req, res) => res.redirect(startUrl));
-  app.get(userCurrentPath(), (req, res) => res.send(userCurrent()));
-
-  app.get('/designer/:owner/:repo', (req, res) => res.send(getIndexHtml()));
-  app.get('/designer/:owner/:repo/Config/GetServiceConfig', (req, res) => res.sendStatus(204));
-  app.get('/designer/:owner/:repo/Text/GetServiceName', (req, res) => res.send(req.params.repo.toUpperCase()));
-  app.get('/designer/api/:owner/:repo/datamodels', (req, res) => res.json(getDatamodels()));
-  app.get('/designer/api/:owner/:repo/datamodelsApp/models/:filename', (req, res) =>
-    res.json(getDatamodel(req.params.filename))
-  );
-  app.get('/designer/frontend/lang/:file', (req, res) => res.json(require(`../../language/src/${req.params.file}`)));
-  app.get('/designer/api/v1/repos/:owner/:repo', (req, res) =>
-    res.json(getRepoData(req.headers.host, req.params.owner, req.params.repo))
-  );
-  app.get('/designer/api/v1/repos/:owner/:repo/initialcommit', (req, res) => res.sendStatus(204));
-  app.get('/designer/api/v1/session/remaining', (req, res) => res.send('9999'));
-  app.post('/designer/api/:owner/:repo/datamodels/post', (req, res) => {
-    const { modelName } = req.body;
-    res.status(201);
-    res.json(createDatamodel(modelName));
-  });
-  app.put('/designer/api/:owner/:repo/datamodels', (req, res) => {
-    const { modelPath } = req.query;
-    res.status(200);
-    res.json(putDatamodel(modelPath, req.body));
-  });
-  app.delete('/designer/api/:owner/:repo/datamodels', (req, res) => {
-    const { modelPath } = req.query;
-    res.status(200);
-    res.json(delDatamodel(modelPath));
-  });
+  app.get('/designer/:owner/:repo', require('./routes/get-index-html'));
+  app.get('/designer/api/:owner/:repo/datamodelsApp/models/:filename', require('./routes/get-datamodel'));
+  app.get(datamodelsPath(':owner', ':repo'), require('./routes/get-datamodels'));
+  app.get(frontendLangPath(':locale'), (req, res) => res.json(require(`../../language/src/${req.params.locale}.json`)));
+  app.get(remainingSessionTimePath(), (req, res) => res.send('9999'));
+  app.get(repoInitialCommitPath(':owner', ':repo'), (req, res) => res.sendStatus(204));
+  app.get(repoMetaPath(':owner', ':repo'), require('./routes/get-repo-data'));
+  app.get(serviceConfigPath(':owner', ':repo'), (req, res) => res.sendStatus(204));
+  app.get(serviceNamePath(':owner', ':repo'), (req, res) => res.send(req.params.repo.toUpperCase()));
+  app.get(userCurrentPath(), require('./routes/user-current'));
+  app.post(createDatamodelPath(':owner', ':repo'), require('./routes/create-model'));
+  app.put(datamodelsPath(':owner', ':repo'), require('./routes/put-datamodel'));
 
   return middlewares;
 };

--- a/src/studio/src/designer/frontend/mockend/src/index.js
+++ b/src/studio/src/designer/frontend/mockend/src/index.js
@@ -15,6 +15,7 @@ const {
   serviceConfigPath,
   serviceNamePath,
 } = require('../../shared/api-paths');
+const { datamodelGetPath, datamodelPath} = require('app-shared/api-paths');
 
 module.exports = (middlewares, devServer) => {
   if (!devServer) {
@@ -27,10 +28,10 @@ module.exports = (middlewares, devServer) => {
   const startUrl =
     process.env.npm_package_name === 'dashboard' ? DASHBOARD_BASENAME : `${APP_DEVELOPMENT_BASENAME}/someorg/someapp`;
 
-  app.delete(datamodelsPath(':owner', ':repo'), require('./routes/del-datamodel'));
+  app.delete(datamodelPath(':owner', ':repo'), require('./routes/del-datamodel'));
   app.get('/', (req, res) => res.redirect(startUrl));
   app.get('/designer/:owner/:repo', require('./routes/get-index-html'));
-  app.get('/designer/api/:owner/:repo/datamodelsApp/models/:filename', require('./routes/get-datamodel'));
+  app.get(datamodelGetPath(':owner', ':repo', '/App/models/:filename'), require('./routes/get-datamodel'));
   app.get(datamodelsPath(':owner', ':repo'), require('./routes/get-datamodels'));
   app.get(frontendLangPath(':locale'), (req, res) => res.json(require(`../../language/src/${req.params.locale}.json`)));
   app.get(remainingSessionTimePath(), (req, res) => res.send('9999'));

--- a/src/studio/src/designer/frontend/mockend/src/routes/create-model.js
+++ b/src/studio/src/designer/frontend/mockend/src/routes/create-model.js
@@ -10,9 +10,12 @@ const getModel = (modelname) => {
   return template.replaceAll('__modelname__', modelname).replaceAll('__datamodelid__', crypto.randomUUID());
 };
 
-module.exports = (modelname) => {
-  const filepath = getStoragePath(modelname + '.schema.json');
-  const newSchema = getModel(modelname);
+module.exports = (req, res) => {
+  const { modelName } = req.body;
+  const filepath = getStoragePath(`${modelName}.schema.json`);
+  const newSchema = getModel(modelName);
   fs.writeFileSync(filepath, newSchema, 'utf-8');
-  return JSON.parse(newSchema);
+  const content = JSON.parse(newSchema);
+  res.status(201);
+  res.json(content);
 };

--- a/src/studio/src/designer/frontend/mockend/src/routes/del-datamodel.js
+++ b/src/studio/src/designer/frontend/mockend/src/routes/del-datamodel.js
@@ -1,7 +1,10 @@
 const fs = require('fs');
 const { getStoragePath } = require('../utils');
 
-module.exports = (modelpath) => {
-  const filepath = getStoragePath(modelpath.split('/').pop());
-  return fs.unlinkSync(filepath);
+module.exports = (req, res) => {
+  const { modelPath } = req.query;
+  const filepath = getStoragePath(modelPath.split('/').pop());
+  res.status(200);
+  fs.unlinkSync(filepath);
+  res.json();
 };

--- a/src/studio/src/designer/frontend/mockend/src/routes/get-datamodel.js
+++ b/src/studio/src/designer/frontend/mockend/src/routes/get-datamodel.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const { getStoragePath } = require('../utils');
 
-module.exports = (filename) => {
-  const filepath = getStoragePath(filename);
-  return JSON.parse(fs.readFileSync(filepath, 'utf-8'));
+module.exports = (req, res) => {
+  const filepath = getStoragePath(req.params.filename);
+  const content = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
+  res.json(content);
 };

--- a/src/studio/src/designer/frontend/mockend/src/routes/get-datamodels.js
+++ b/src/studio/src/designer/frontend/mockend/src/routes/get-datamodels.js
@@ -9,7 +9,7 @@ module.exports = (req, res) => {
   const files = fs.readdirSync(directory);
   const out = [];
   files.forEach((fileName) => {
-    const repositoryRelativeUrl = 'App/models/' + fileName;
+    const repositoryRelativeUrl = '/App/models/' + fileName;
     const filePath = path.resolve(directory, fileName);
     out.push({
       filePath,

--- a/src/studio/src/designer/frontend/mockend/src/routes/get-datamodels.js
+++ b/src/studio/src/designer/frontend/mockend/src/routes/get-datamodels.js
@@ -4,7 +4,7 @@ const { getStoragePath } = require('../utils');
 /**
  * Returns all datamodels
  */
-module.exports = () => {
+module.exports = (req, res) => {
   const directory = getStoragePath('.');
   const files = fs.readdirSync(directory);
   const out = [];
@@ -22,5 +22,5 @@ module.exports = () => {
       lastChanged: '2022-09-06T10:14:19.2423776+02:00',
     });
   });
-  return out;
+  res.json(out);
 };

--- a/src/studio/src/designer/frontend/mockend/src/routes/get-index-html.js
+++ b/src/studio/src/designer/frontend/mockend/src/routes/get-index-html.js
@@ -8,4 +8,4 @@ const fs = require('fs');
 const filepath = path.resolve(__dirname, '..', '..', '..', 'app-development', 'public', 'index.html');
 const indexHtml = fs.readFileSync(filepath, 'utf-8');
 
-module.exports = () => indexHtml;
+module.exports = (req, res) => res.send(indexHtml);

--- a/src/studio/src/designer/frontend/mockend/src/routes/get-repo-data.js
+++ b/src/studio/src/designer/frontend/mockend/src/routes/get-repo-data.js
@@ -4,7 +4,10 @@ const templatePath = path.resolve(__dirname, '..', 'templates', 'repo-data.templ
 
 const template = fs.readFileSync(templatePath, 'utf-8');
 
-module.exports = (hostname, owner, reponame) =>
-  JSON.parse(
-    template.replaceAll('__hostname__', hostname).replaceAll('__owner__', owner).replaceAll('__repo__', reponame),
+module.exports = (req, res) => {
+  const { owner, repo } = req.params;
+  const content = JSON.parse(
+    template.replaceAll('__hostname__', req.headers.host).replaceAll('__owner__', owner).replaceAll('__repo__', repo)
   );
+  res.json(content);
+};

--- a/src/studio/src/designer/frontend/mockend/src/routes/put-datamodel.js
+++ b/src/studio/src/designer/frontend/mockend/src/routes/put-datamodel.js
@@ -2,14 +2,16 @@ const fs = require('fs');
 const prettier = require('prettier');
 const { getStoragePath } = require('../utils');
 
-module.exports = (modelpath, jsonSchema) => {
-  const filename = modelpath.split('/').pop();
+module.exports = (req, res) => {
+  const { modelPath } = req.query;
+  const filename = modelPath.split('/').pop();
   const filepath = getStoragePath(filename);
-  const content = JSON.stringify(jsonSchema);
+  const content = JSON.stringify(req.body);
   const contentFormatted = prettier.format(content, {
     parser: 'json',
     printWidth: 120,
   });
   fs.writeFileSync(filepath, contentFormatted, 'utf-8');
-  return jsonSchema;
+  res.status(200);
+  res.json(content);
 };

--- a/src/studio/src/designer/frontend/mockend/src/routes/user-current.js
+++ b/src/studio/src/designer/frontend/mockend/src/routes/user-current.js
@@ -1,7 +1,8 @@
-module.exports = () => ({
-  avatar_url: 'https://i.pravatar.cc/290',
-  email: 'tom.tucker@example.com',
-  full_name: '',
-  id: 3,
-  login: 'tomtucker',
-});
+module.exports = (req, res) =>
+  res.json({
+    avatar_url: 'https://i.pravatar.cc/290',
+    email: 'tom.tucker@example.com',
+    full_name: '',
+    id: 3,
+    login: 'tomtucker',
+  });

--- a/src/studio/src/designer/frontend/packages/schema-model/src/index.ts
+++ b/src/studio/src/designer/frontend/packages/schema-model/src/index.ts
@@ -8,8 +8,8 @@ export {
   castRestrictionType,
 } from './lib/restrictions';
 export { ROOT_POINTER } from './lib/constants';
-export type { UiSchemaNode, UiSchemaNodes } from './lib/types';
-export { ObjectKind, Keywords, FieldType, CombinationKind, StringFormat, Dict } from './lib/types';
+export type { UiSchemaNode, UiSchemaNodes, Dict } from './lib/types';
+export { ObjectKind, Keywords, FieldType, CombinationKind, StringFormat } from './lib/types';
 export {
   createNodeBase,
   replaceLastPointerSegment,

--- a/src/studio/src/designer/frontend/shared/api-paths.js
+++ b/src/studio/src/designer/frontend/shared/api-paths.js
@@ -1,11 +1,71 @@
+import { stringify as s } from 'query-string';
+
+export const abortmergePath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/abortmerge`;
+export const createDatamodelPath = (owner, repo) => `/designer/api/${owner}/${repo}/datamodels/post`;
+export const datamodelXsdPath = (owner, repo) => `/designer/${owner}/${repo}/Model/GetXsd`;
+export const datamodelsPath = (owner, repo) => `/designer/api/${owner}/${repo}/datamodels`;
+export const datamodelsUploadPath = (owner, repo) => `/designer/api/${owner}/${repo}/datamodels/upload`;
+export const discardChangesPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/discard`;
 export const frontendLangPath = (locale) => `/designer/frontend/lang/${locale}.json`;
+export const getDatamodelPath = (owner, repo, modelPath) => `/designer/api/${owner}/${repo}/datamodels?${s({ modelPath })}`;
+export const gitCommitPath = (owner, repo, commitId) => `/repos/${owner}/${repo}/commit/${commitId}`;
+export const keepAlivePath = () => `/designer/api/v1/session/keepalive`;
 export const orgsListPath = () => '/designer/api/v1/orgs';
+export const remainingSessionTimePath = () => `/designer/api/v1/session/remaining`;
+export const repoCommitPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/commit`;
+export const repoInitialCommitPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/initialcommit`;
+export const repoMetaPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}`;
+export const repoPullPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/pull`;
+export const repoPushPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/push`;
+export const repoResetPAth = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/reset`;
 export const repoSearchPath = () => '/designer/api/v1/repos/search';
-export const reposList = (owner) => `/designer/api/v1/repos/${owner}`;
+export const repoStatusPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/status`;
+export const reposListPath = (owner) => `/designer/api/v1/repos/${owner}`;
+export const repositoryGitPath = (owner, repo) => `/repos/${owner}/${repo}.git`;
+export const repositoryPath = (owner, repo) => `/repos/${owner}/${repo}`;
+export const saveDatamodelPath = (owner, repo, modelPath) => `/designer/api/${owner}/${repo}/datamodels?${s({ modelPath })}`;
+export const serviceConfigPath = (owner, repo) => `/designer/${owner}/${repo}/Config/GetServiceConfig`;
+export const serviceNamePath = (owner, repo) => `/designer/${owner}/${repo}/Text/GetServiceName`;
+export const setServiceConfigPath = (owner, repo) => `/designer/${owner}/${repo}/Config/SetServiceConfig`;
+export const setServiceNamePath = (owner, repo) => `/designer/${owner}/${repo}/Text/SetServiceName`;
 export const userCurrentPath = () => '/designer/api/v1/user/current';
 export const userLogoutAfterPath = () => '/Home/Logout';
 export const userLogoutPath = () => '/repos/user/logout';
 export const userReposPath = () => '/designer/api/v1/user/repos';
 export const userStarredListPath = () => '/designer/api/v1/user/starred';
 export const userStarredRepoPath = (owner, repo) => `/designer/api/v1/user/starred/${owner}/${repo}`;
-export const copyAppPath = (owner, sourceRepo, targetRepo) => `/designer/api/v1/repos/copyapp?org=${owner}&sourceRepository=${sourceRepo}&targetRepository=${targetRepo}`
+export const textResourcesPath = (owner, repo, langcode) => `/designer/${owner}/${repo}/UIEditor/GetTextResources/${langcode}`;
+export const masterRepoStatusPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/branches/branch?branch=master`;
+
+export const copyAppPath = (org, sourceRepository, targetRepository) =>
+  `/designer/api/v1/repos/copyapp?${s({
+    org,
+    sourceRepository,
+    targetRepository,
+  })}`;
+
+export const getServiceFilesPath = (owner, repo, fileEditorMode) =>
+  `/designer/${owner}/${repo}/ServiceDevelopment/GetServiceFiles?${s({
+    fileEditorMode,
+  })}`;
+
+export const getServiceFilePath = (owner, repo, fileEditorMode, fileName) =>
+  `/designer/${owner}/${repo}/ServiceDevelopment/GetServiceFile?${s({
+    fileEditorMode,
+    fileName,
+  })}`;
+
+export const saveServiceFilePath = (
+  owner,
+  repo,
+  fileEditorMode,
+  fileName,
+  stageFile,
+) =>
+  `/designer/${owner}/${repo}/ServiceDevelopment/SaveServiceFile?${s({
+    fileEditorMode,
+    fileName,
+    stageFile,
+  })}`;
+
+

--- a/src/studio/src/designer/frontend/shared/api-paths.js
+++ b/src/studio/src/designer/frontend/shared/api-paths.js
@@ -2,14 +2,16 @@ import { stringify as s } from 'query-string';
 
 export const abortmergePath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/abortmerge`;
 export const createDatamodelPath = (owner, repo) => `/designer/api/${owner}/${repo}/datamodels/post`;
+export const datamodelGetPath = (owner, repo, modelPath) => `/designer/api/${owner}/${repo}/datamodels${modelPath}`;
+export const datamodelPath = (owner, repo, modelPath) => `/designer/api/${owner}/${repo}/datamodels?${s({ modelPath })}`;
 export const datamodelXsdPath = (owner, repo) => `/designer/${owner}/${repo}/Model/GetXsd`;
 export const datamodelsPath = (owner, repo) => `/designer/api/${owner}/${repo}/datamodels`;
 export const datamodelsUploadPath = (owner, repo) => `/designer/api/${owner}/${repo}/datamodels/upload`;
 export const discardChangesPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/discard`;
 export const frontendLangPath = (locale) => `/designer/frontend/lang/${locale}.json`;
-export const getDatamodelPath = (owner, repo, modelPath) => `/designer/api/${owner}/${repo}/datamodels?${s({ modelPath })}`;
 export const gitCommitPath = (owner, repo, commitId) => `/repos/${owner}/${repo}/commit/${commitId}`;
 export const keepAlivePath = () => `/designer/api/v1/session/keepalive`;
+export const masterRepoStatusPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/branches/branch?branch=master`;
 export const orgsListPath = () => '/designer/api/v1/orgs';
 export const remainingSessionTimePath = () => `/designer/api/v1/session/remaining`;
 export const repoCommitPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/commit`;
@@ -24,19 +26,17 @@ export const repoStatusPath = (owner, repo) => `/designer/api/v1/repos/${owner}/
 export const reposListPath = (owner) => `/designer/api/v1/repos/${owner}`;
 export const repositoryGitPath = (owner, repo) => `/repos/${owner}/${repo}.git`;
 export const repositoryPath = (owner, repo) => `/repos/${owner}/${repo}`;
-export const saveDatamodelPath = (owner, repo, modelPath) => `/designer/api/${owner}/${repo}/datamodels?${s({ modelPath })}`;
 export const serviceConfigPath = (owner, repo) => `/designer/${owner}/${repo}/Config/GetServiceConfig`;
 export const serviceNamePath = (owner, repo) => `/designer/${owner}/${repo}/Text/GetServiceName`;
 export const setServiceConfigPath = (owner, repo) => `/designer/${owner}/${repo}/Config/SetServiceConfig`;
 export const setServiceNamePath = (owner, repo) => `/designer/${owner}/${repo}/Text/SetServiceName`;
+export const textResourcesPath = (owner, repo, langcode) => `/designer/${owner}/${repo}/UIEditor/GetTextResources/${langcode}`;
 export const userCurrentPath = () => '/designer/api/v1/user/current';
 export const userLogoutAfterPath = () => '/Home/Logout';
 export const userLogoutPath = () => '/repos/user/logout';
 export const userReposPath = () => '/designer/api/v1/user/repos';
 export const userStarredListPath = () => '/designer/api/v1/user/starred';
 export const userStarredRepoPath = (owner, repo) => `/designer/api/v1/user/starred/${owner}/${repo}`;
-export const textResourcesPath = (owner, repo, langcode) => `/designer/${owner}/${repo}/UIEditor/GetTextResources/${langcode}`;
-export const masterRepoStatusPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/branches/branch?branch=master`;
 
 export const copyAppPath = (org, sourceRepository, targetRepository) =>
   `/designer/api/v1/repos/copyapp?${s({

--- a/src/studio/src/designer/frontend/shared/api-paths.js
+++ b/src/studio/src/designer/frontend/shared/api-paths.js
@@ -13,6 +13,7 @@ export const keepAlivePath = () => `/designer/api/v1/session/keepalive`;
 export const orgsListPath = () => '/designer/api/v1/orgs';
 export const remainingSessionTimePath = () => `/designer/api/v1/session/remaining`;
 export const repoCommitPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/commit`;
+export const repoDownloadPath = (owner, repo, full) => `/designer/api/v1/repos/${owner}/${repo}/contents.zip?${s({ full })}`
 export const repoInitialCommitPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/initialcommit`;
 export const repoMetaPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}`;
 export const repoPullPath = (owner, repo) => `/designer/api/v1/repos/${owner}/${repo}/pull`;

--- a/src/studio/src/designer/frontend/shared/cdn-paths.js
+++ b/src/studio/src/designer/frontend/shared/cdn-paths.js
@@ -1,16 +1,6 @@
-export const layoutSchemaUrl = () =>
-  `https://altinncdn.no/schemas/json/layout/layout.schema.v1.json`;
-
-export const layoutSettingsSchemaUrl = () =>
-  `https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json`;
-
+export const layoutSchemaUrl = () => `https://altinncdn.no/schemas/json/layout/layout.schema.v1.json`;
+export const layoutSettingsSchemaUrl = () => `https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json`;
 export const orgsListUrl = () => `https://altinncdn.no/orgs/altinn-orgs.json`;
-
-export const environmentsConfigUrl = () =>
-  `https://altinncdn.no/config/environments.json`;
-
-export const altinnImgLogoHeaderUrl = () =>
-  `https://altinncdn.no/img/Altinn-logo-blue.svg`;
-
-export const widgetUrl = () =>
-  'https://altinncdn.no/altinn-apps/widgets/message.json';
+export const environmentsConfigUrl = () => `https://altinncdn.no/config/environments.json`;
+export const altinnImgLogoHeaderUrl = () => `https://altinncdn.no/img/Altinn-logo-blue.svg`;
+export const widgetUrl = () => 'https://altinncdn.no/altinn-apps/widgets/message.json';

--- a/src/studio/src/designer/frontend/shared/cdn-paths.js
+++ b/src/studio/src/designer/frontend/shared/cdn-paths.js
@@ -1,0 +1,16 @@
+export const layoutSchemaUrl = () =>
+  `https://altinncdn.no/schemas/json/layout/layout.schema.v1.json`;
+
+export const layoutSettingsSchemaUrl = () =>
+  `https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json`;
+
+export const orgsListUrl = () => `https://altinncdn.no/orgs/altinn-orgs.json`;
+
+export const environmentsConfigUrl = () =>
+  `https://altinncdn.no/config/environments.json`;
+
+export const altinnImgLogoHeaderUrl = () =>
+  `https://altinncdn.no/img/Altinn-logo-blue.svg`;
+
+export const widgetUrl = () =>
+  'https://altinncdn.no/altinn-apps/widgets/message.json';

--- a/src/studio/src/designer/frontend/shared/features/dataModelling/DataModelling.tsx
+++ b/src/studio/src/designer/frontend/shared/features/dataModelling/DataModelling.tsx
@@ -18,7 +18,7 @@ import { CreateNewWrapper } from './components/CreateNewWrapper';
 import { DeleteWrapper } from './components/DeleteWrapper';
 import { SchemaSelect } from './components/SchemaSelect';
 import { XSDUpload } from './components/XSDUpload';
-import {saveDatamodelPath} from "../../api-paths";
+import {datamodelPath} from "../../api-paths";
 
 
 interface IDataModellingContainerProps extends React.PropsWithChildren<any> {
@@ -183,7 +183,7 @@ export function DataModelling({ language, org, repo, createPathOption }: IDataMo
         language={language}
         schema={jsonSchema}
         onSaveSchema={handleSaveSchema}
-        saveUrl={saveDatamodelPath(org,repo,selectedOption?.value?.repositoryRelativeUrl)}
+        saveUrl={datamodelPath(org,repo,selectedOption?.value?.repositoryRelativeUrl)}
         name={selectedOption?.label}
         loading={metadataLoadingState === LoadingState.LoadingModels}
         LandingPagePanel={

--- a/src/studio/src/designer/frontend/shared/features/dataModelling/DataModelling.tsx
+++ b/src/studio/src/designer/frontend/shared/features/dataModelling/DataModelling.tsx
@@ -18,7 +18,8 @@ import { CreateNewWrapper } from './components/CreateNewWrapper';
 import { DeleteWrapper } from './components/DeleteWrapper';
 import { SchemaSelect } from './components/SchemaSelect';
 import { XSDUpload } from './components/XSDUpload';
-import { sharedUrls } from '../../utils/urlHelper';
+import {saveDatamodelPath} from "../../api-paths";
+
 
 interface IDataModellingContainerProps extends React.PropsWithChildren<any> {
   language: ILanguage;
@@ -141,7 +142,6 @@ export function DataModelling({ language, org, repo, createPathOption }: IDataMo
   const toggleEditMode = () => setEditMode(setLocalStorageItem('editMode', !editMode));
 
   const t = (key: string) => getLanguageFromKey(key, language);
-  const saveModelUrl = sharedUrls().saveDataModelUrl(selectedOption?.value?.repositoryRelativeUrl);
 
   return (
     <>
@@ -183,7 +183,7 @@ export function DataModelling({ language, org, repo, createPathOption }: IDataMo
         language={language}
         schema={jsonSchema}
         onSaveSchema={handleSaveSchema}
-        saveUrl={saveModelUrl}
+        saveUrl={saveDatamodelPath(org,repo,selectedOption?.value?.repositoryRelativeUrl)}
         name={selectedOption?.label}
         loading={metadataLoadingState === LoadingState.LoadingModels}
         LandingPagePanel={

--- a/src/studio/src/designer/frontend/shared/features/dataModelling/components/XSDUpload.tsx
+++ b/src/studio/src/designer/frontend/shared/features/dataModelling/components/XSDUpload.tsx
@@ -3,6 +3,7 @@ import { AltinnSpinner, FileSelector } from '../../../components';
 import { getLanguageFromKey } from '../../../utils/language';
 import axios from 'axios';
 import ErrorPopover from '../../../components/ErrorPopover';
+import {datamodelsUploadPath} from "../../../api-paths";
 
 export interface IXSDUploadProps {
   disabled?: boolean;
@@ -20,10 +21,9 @@ export const XSDUpload = ({ disabled, language, onXSDUploaded, org, repo, submit
   const uploadButton = React.useRef(null);
 
   const handleUpload = (formData: FormData, fileName: string) => {
-    const XSDUploadUrl = `${window.location.origin}/designer/api/${org}/${repo}/datamodels/upload`;
     setUploading(true);
     axios
-      .post(XSDUploadUrl, formData, {
+      .post(datamodelsUploadPath(org,repo), formData, {
         headers: {
           'Content-Type': 'multipart/form-data',
         },

--- a/src/studio/src/designer/frontend/shared/features/dataModelling/sagas/dataModellingSagas.ts
+++ b/src/studio/src/designer/frontend/shared/features/dataModelling/sagas/dataModellingSagas.ts
@@ -2,7 +2,6 @@ import { SagaIterator } from 'redux-saga';
 import { call, put, takeLatest } from 'redux-saga/effects';
 import type { IJsonSchema } from '@altinn/schema-editor/types';
 import { del, get, post, put as networkPut } from '../../../utils/networking';
-import { sharedUrls } from '../../../utils/urlHelper';
 import {
   createDataModel,
   createDataModelFulfilled,
@@ -19,12 +18,19 @@ import {
   saveDataModelRejected,
 } from './dataModellingSlice';
 import { DataModelsMetadataActions } from './metadata';
+import {
+  createDatamodelPath,
+  getDatamodelPath,
+  saveDatamodelPath,
+} from '../../../api-paths';
+import { _useParamsClassCompHack } from '../../../utils/_useParamsClassCompHack';
 
 export function* fetchDataModelSaga(action: IDataModelAction): SagaIterator {
   const { metadata } = action.payload;
   try {
     const modelPath = metadata?.value?.repositoryRelativeUrl;
-    const result = yield call(get, sharedUrls().getDataModelUrl(modelPath));
+    const { org, app } = _useParamsClassCompHack();
+    const result = yield call(get, getDatamodelPath(org, app, modelPath));
     yield put(fetchDataModelFulfilled({ schema: result }));
   } catch (err) {
     yield put(fetchDataModelRejected({ error: err }));
@@ -38,8 +44,9 @@ export function* watchFetchDataModelSaga(): SagaIterator {
 function* saveDataModelSaga(action: IDataModelAction) {
   const { schema, metadata } = action.payload;
   try {
+    const { org, app } = _useParamsClassCompHack();
     const modelPath = metadata?.value?.repositoryRelativeUrl;
-    yield call(networkPut, sharedUrls().saveDataModelUrl(modelPath), schema);
+    yield call(networkPut, saveDatamodelPath(org, app, modelPath), schema);
     yield put(saveDataModelFulfilled());
   } catch (err) {
     yield put(saveDataModelRejected({ error: err }));
@@ -53,8 +60,13 @@ export function* watchSaveDataModelSaga(): SagaIterator {
 function* createDataModelSaga(action: IDataModelAction) {
   const { name, relativePath } = action.payload;
   const body = { modelName: name, relativeDirectory: relativePath };
+  const { org, app } = _useParamsClassCompHack();
   try {
-    const schema: IJsonSchema = yield call(post, sharedUrls().createDataModelUrl, body);
+    const schema: IJsonSchema = yield call(
+      post,
+      createDatamodelPath(org, app),
+      body,
+    );
     yield put(DataModelsMetadataActions.getDataModelsMetadata());
     yield put(createDataModelFulfilled({ schema }));
   } catch (err) {
@@ -69,8 +81,9 @@ export function* watchCreateDataModelSaga(): SagaIterator {
 function* deleteDataModelSaga(action: IDataModelAction): SagaIterator {
   const { metadata } = action.payload;
   try {
+    const { org, app } = _useParamsClassCompHack();
     const modelPath = metadata?.value?.repositoryRelativeUrl;
-    yield call(del, sharedUrls().saveDataModelUrl(modelPath));
+    yield call(del, saveDatamodelPath(org, app, modelPath));
     yield put(DataModelsMetadataActions.getDataModelsMetadata());
     yield put(deleteDataModelFulfilled());
   } catch (err) {

--- a/src/studio/src/designer/frontend/shared/features/dataModelling/sagas/dataModellingSagas.ts
+++ b/src/studio/src/designer/frontend/shared/features/dataModelling/sagas/dataModellingSagas.ts
@@ -20,8 +20,8 @@ import {
 import { DataModelsMetadataActions } from './metadata';
 import {
   createDatamodelPath,
-  getDatamodelPath,
-  saveDatamodelPath,
+  datamodelPath,
+  datamodelGetPath,
 } from '../../../api-paths';
 import { _useParamsClassCompHack } from '../../../utils/_useParamsClassCompHack';
 
@@ -30,7 +30,7 @@ export function* fetchDataModelSaga(action: IDataModelAction): SagaIterator {
   try {
     const modelPath = metadata?.value?.repositoryRelativeUrl;
     const { org, app } = _useParamsClassCompHack();
-    const result = yield call(get, getDatamodelPath(org, app, modelPath));
+    const result = yield call(get, datamodelGetPath(org, app, modelPath));
     yield put(fetchDataModelFulfilled({ schema: result }));
   } catch (err) {
     yield put(fetchDataModelRejected({ error: err }));
@@ -46,7 +46,7 @@ function* saveDataModelSaga(action: IDataModelAction) {
   try {
     const { org, app } = _useParamsClassCompHack();
     const modelPath = metadata?.value?.repositoryRelativeUrl;
-    yield call(networkPut, saveDatamodelPath(org, app, modelPath), schema);
+    yield call(networkPut, datamodelPath(org, app, modelPath), schema);
     yield put(saveDataModelFulfilled());
   } catch (err) {
     yield put(saveDataModelRejected({ error: err }));
@@ -83,7 +83,7 @@ function* deleteDataModelSaga(action: IDataModelAction): SagaIterator {
   try {
     const { org, app } = _useParamsClassCompHack();
     const modelPath = metadata?.value?.repositoryRelativeUrl;
-    yield call(del, saveDatamodelPath(org, app, modelPath));
+    yield call(del, datamodelPath(org, app, modelPath));
     yield put(DataModelsMetadataActions.getDataModelsMetadata());
     yield put(deleteDataModelFulfilled());
   } catch (err) {

--- a/src/studio/src/designer/frontend/shared/features/dataModelling/sagas/metadata/get/getDataModelsMetadataSagas.ts
+++ b/src/studio/src/designer/frontend/shared/features/dataModelling/sagas/metadata/get/getDataModelsMetadataSagas.ts
@@ -1,13 +1,14 @@
 import { SagaIterator } from 'redux-saga';
 import { call, put, takeLatest } from 'redux-saga/effects';
 import { get } from '../../../../../utils/networking';
-import { sharedUrls } from '../../../../../utils/urlHelper';
 import { DataModelsMetadataActions } from '../dataModelsMetadataSlice';
+import { datamodelsPath } from '../../../../../api-paths';
+import { _useParamsClassCompHack } from '../../../../../utils/_useParamsClassCompHack';
 
 function* getDataModelsMetadataSaga(): SagaIterator {
   try {
-    // yield call(get, sharedUrls().ensureCloneApi);
-    const dataModelsMetadata = yield call(get, sharedUrls().dataModelsApi);
+    const { org, app } = _useParamsClassCompHack();
+    const dataModelsMetadata = yield call(get, datamodelsPath(org, app));
     yield put(
       DataModelsMetadataActions.getDataModelsMetadataFulfilled({
         dataModelsMetadata,

--- a/src/studio/src/designer/frontend/shared/file-editor/FileEditor.tsx
+++ b/src/studio/src/designer/frontend/shared/file-editor/FileEditor.tsx
@@ -182,7 +182,6 @@ class FileEditor extends React.Component<
       isLoading: true,
     });
     const { org, app } = _useParamsClassCompHack();
-    getServiceFilesPath(org, app, this.props.mode);
     get(getServiceFilePath(org, app, this.props.mode, fileName)).then(
       (logicFileContent) => {
         this.setState((prevState: IFileEditorState) => {
@@ -213,14 +212,8 @@ class FileEditor extends React.Component<
     }
     const { org, app } = _useParamsClassCompHack();
     const saveRes: any = await post(
-      saveServiceFilePath(
-        org,
-        app,
-        this.props.mode,
-        this.state.selectedFile,
-        stageFile,
-      ),
-      this.state.value,
+        saveServiceFilePath(org, app, this.props.mode, this.state.selectedFile, stageFile),
+        this.state.value,
       {
         headers: {
           'Content-type': 'text/plain;charset=utf-8',

--- a/src/studio/src/designer/frontend/shared/file-editor/FileEditor.tsx
+++ b/src/studio/src/designer/frontend/shared/file-editor/FileEditor.tsx
@@ -9,6 +9,11 @@ import AltinnButton from '../components/AltinnButton';
 import { get, post } from '../utils/networking';
 import postMessages from '../utils/postMessages';
 import { _useParamsClassCompHack } from 'app-shared/utils/_useParamsClassCompHack';
+import {
+  getServiceFilePath,
+  getServiceFilesPath,
+  saveServiceFilePath,
+} from '../api-paths';
 
 const theme = createTheme(altinnTheme);
 
@@ -149,10 +154,7 @@ class FileEditor extends React.Component<
   public componentDidMount() {
     if (!this.props.loadFile) {
       const { org, app } = _useParamsClassCompHack();
-      get(
-        `${window.location.origin}/designer/${org}/${app}/ServiceDevelopment` +
-          `/GetServiceFiles?fileEditorMode=${this.props.mode}`,
-      ).then((response) => {
+      get(getServiceFilesPath(org, app, this.props.mode)).then((response) => {
         const files = response.split(',');
         this.loadFileContent(files[0]);
         this.setState((prevState: IFileEditorState) => {
@@ -180,20 +182,20 @@ class FileEditor extends React.Component<
       isLoading: true,
     });
     const { org, app } = _useParamsClassCompHack();
-    get(
-      `${window.location.origin}/designer/${org}/${app}/ServiceDevelopment` +
-        `/GetServiceFile?fileEditorMode=${this.props.mode}&fileName=${fileName}`,
-    ).then((logicFileContent) => {
-      this.setState((prevState: IFileEditorState) => {
-        return {
-          ...prevState,
-          isLoading: false,
-          selectedFile: fileName,
-          value: logicFileContent,
-          valueOriginal: logicFileContent,
-        };
-      });
-    });
+    getServiceFilesPath(org, app, this.props.mode);
+    get(getServiceFilePath(org, app, this.props.mode, fileName)).then(
+      (logicFileContent) => {
+        this.setState((prevState: IFileEditorState) => {
+          return {
+            ...prevState,
+            isLoading: false,
+            selectedFile: fileName,
+            value: logicFileContent,
+            valueOriginal: logicFileContent,
+          };
+        });
+      },
+    );
   };
 
   public switchFile = (e: any) => {
@@ -209,17 +211,22 @@ class FileEditor extends React.Component<
     ) {
       stageFile = true;
     }
-
     const { org, app } = _useParamsClassCompHack();
-    const postUrl =
-      `${window.location.origin}/designer/${org}/${app}/ServiceDevelopment` +
-      `/SaveServiceFile?fileEditorMode=${this.props.mode}&fileName=${this.state.selectedFile}&stageFile=${stageFile}`;
-
-    const saveRes: any = await post(postUrl, this.state.value, {
-      headers: {
-        'Content-type': 'text/plain;charset=utf-8',
+    const saveRes: any = await post(
+      saveServiceFilePath(
+        org,
+        app,
+        this.props.mode,
+        this.state.selectedFile,
+        stageFile,
+      ),
+      this.state.value,
+      {
+        headers: {
+          'Content-type': 'text/plain;charset=utf-8',
+        },
       },
-    });
+    );
 
     if (saveRes.isSuccessStatusCode === false) {
       console.error('save error', saveRes);

--- a/src/studio/src/designer/frontend/shared/navigation/main-header/HeaderMenu.tsx
+++ b/src/studio/src/designer/frontend/shared/navigation/main-header/HeaderMenu.tsx
@@ -70,11 +70,7 @@ export function HeaderMenu({ language }: HeaderMenuProps) {
 
   return (
     <>
-      <Grid
-        container
-        spacing={2}
-        alignItems='center'
-      >
+      <Grid container spacing={2} alignItems='center'>
         <Grid item>
           <Typography className={classes.typography}>
             {user.full_name || user.login}{' '}

--- a/src/studio/src/designer/frontend/shared/navigation/main-header/HeaderMenu.tsx
+++ b/src/studio/src/designer/frontend/shared/navigation/main-header/HeaderMenu.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import {
   Avatar,
   Divider,
@@ -10,9 +10,10 @@ import {
 import { makeStyles } from '@mui/styles';
 import { AltinnMenu } from '../../components';
 import { post } from '../../utils/networking';
-import { sharedUrls } from '../../utils/urlHelper';
 import { getOrgNameById, HeaderContext, SelectedContextType } from './Header';
 import { getLanguageFromKey } from '../../utils/language';
+import { repositoryPath } from '../../api-paths';
+import { useParams } from 'react-router-dom';
 
 const useStyles = makeStyles(() => ({
   avatar: {
@@ -38,10 +39,11 @@ export type HeaderMenuProps = {
 
 export function HeaderMenu({ language }: HeaderMenuProps) {
   const classes = useStyles();
-  const [menuAnchorEl, setMenuAnchorEl] = React.useState<null | Element>(null);
+  const [menuAnchorEl, setMenuAnchorEl] = useState<null | Element>(null);
   const { user, selectedContext, selectableOrgs, setSelectedContext } =
-    React.useContext(HeaderContext);
-
+    useContext(HeaderContext);
+  const t = (key: string) => getLanguageFromKey(key, language);
+  const { org, app } = useParams();
   const openMenu = (e: React.MouseEvent) => {
     e.stopPropagation();
     setMenuAnchorEl(e.currentTarget);
@@ -68,14 +70,18 @@ export function HeaderMenu({ language }: HeaderMenuProps) {
 
   return (
     <>
-      <Grid container spacing={2} alignItems='center'>
+      <Grid
+        container
+        spacing={2}
+        alignItems='center'
+      >
         <Grid item>
           <Typography className={classes.typography}>
             {user.full_name || user.login}{' '}
             {selectedContext !== SelectedContextType.All &&
               selectedContext !== SelectedContextType.Self && (
                 <>
-                  <br /> {getLanguageFromKey('shared.header_for', language)}{' '}
+                  <br /> {t('shared.header_for')}{' '}
                   {getOrgNameById(selectedContext as number, selectableOrgs)}
                 </>
               )}
@@ -90,7 +96,7 @@ export function HeaderMenu({ language }: HeaderMenuProps) {
             <Avatar
               src={user.avatar_url}
               className={classes.avatar}
-              alt={getLanguageFromKey('shared.header_button_alt', language)}
+              alt={t('shared.header_button_alt')}
             />
           </IconButton>
         </Grid>
@@ -105,7 +111,7 @@ export function HeaderMenu({ language }: HeaderMenuProps) {
           selected={selectedContext === SelectedContextType.All}
           onClick={() => handleSetSelectedContext(SelectedContextType.All)}
         >
-          {getLanguageFromKey('shared.header_all', language)}
+          {t('shared.header_all')}
         </MenuItem>
         {selectableOrgs?.map((org) => {
           return (
@@ -127,18 +133,24 @@ export function HeaderMenu({ language }: HeaderMenuProps) {
           {user.full_name || user.login}
         </MenuItem>
         <Divider />
-        <MenuItem key='placeholder' style={{ display: 'none' }} />
+        <MenuItem
+          key='placeholder'
+          style={{ display: 'none' }}
+        />
         <MenuItem id='menu-gitea'>
           <a
-            href={sharedUrls().repositoryUrl}
+            href={repositoryPath(org, app)}
             target='_blank'
             rel='noopener noreferrer'
           >
-            {getLanguageFromKey('shared.header_go_to_gitea', language)}
+            {t('shared.header_go_to_gitea')}
           </a>
         </MenuItem>
-        <MenuItem id='menu-logout' onClick={handleLogout}>
-          {getLanguageFromKey('shared.header_logout', language)}
+        <MenuItem
+          id='menu-logout'
+          onClick={handleLogout}
+        >
+          {t('shared.header_logout')}
         </MenuItem>
       </AltinnMenu>
     </>

--- a/src/studio/src/designer/frontend/shared/navigation/main-header/profileMenu.tsx
+++ b/src/studio/src/designer/frontend/shared/navigation/main-header/profileMenu.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { IconButton, Menu, MenuItem } from '@mui/material';
 import { withStyles } from '@mui/styles';
-import { altinnDocsUrl, sharedUrls } from '../../utils/urlHelper';
+import { altinnDocsUrl } from '../../utils/urlHelper';
 import { post } from '../../utils/networking';
 import { AccountCircle } from '@mui/icons-material';
 import { _useParamsClassCompHack } from 'app-shared/utils/_useParamsClassCompHack';
+import {repositoryPath} from "../../api-paths";
 
 export interface IProfileMenuComponentProps {
   showlogout?: boolean;
@@ -67,7 +68,7 @@ class ProfileMenuComponent extends React.Component<
   public render() {
     const { anchorEl } = this.state;
     const { classes, showlogout } = this.props;
-
+    const { org, app } = _useParamsClassCompHack();
     return (
       <div>
         <IconButton
@@ -102,7 +103,7 @@ class ProfileMenuComponent extends React.Component<
           {this.shouldShowRepositoryLink() && (
             <MenuItem className={classes.menuItem}>
               <a
-                href={sharedUrls().repositoryUrl}
+                href={repositoryPath(org,app)}
                 target='_blank'
                 rel='noopener noreferrer'
               >

--- a/src/studio/src/designer/frontend/shared/package.json
+++ b/src/studio/src/designer/frontend/shared/package.json
@@ -16,6 +16,7 @@
     "marked": "4.2.2",
     "moment": "2.29.4",
     "monaco-editor": "0.34.1",
+    "query-string": "7.1.1",
     "react": "18.2.0",
     "react-content-loader": "6.2.0",
     "react-dom": "18.2.0",

--- a/src/studio/src/designer/frontend/shared/paths.test.ts
+++ b/src/studio/src/designer/frontend/shared/paths.test.ts
@@ -1,0 +1,8 @@
+import {repoDownloadPath} from "./api-paths";
+
+
+test("that params works as intende",()=>{
+    const url = repoDownloadPath("org","app", true);
+    expect(url.endsWith("full=true")).toBeTruthy();
+});
+

--- a/src/studio/src/designer/frontend/shared/primitives/index.tsx
+++ b/src/studio/src/designer/frontend/shared/primitives/index.tsx
@@ -1,11 +1,17 @@
 export { Divider } from './Divider';
 import React, { ReactNode } from 'react';
 import classes from './Primitives.module.css';
+import classnames from 'classnames';
 
 interface Props {
   children: ReactNode;
+  className?: string;
 }
 
-export const SimpleContainer = ({ children }: Props) => {
-  return <div className={classes.simpleContainer}>{children}</div>;
+export const SimpleContainer = ({ children, className }: Props) => {
+  return (
+    <div className={classnames(classes.simpleContainer, className)}>
+      {children}
+    </div>
+  );
 };

--- a/src/studio/src/designer/frontend/shared/utils/urlHelper.test.ts
+++ b/src/studio/src/designer/frontend/shared/utils/urlHelper.test.ts
@@ -1,4 +1,4 @@
-import { returnUrlToMessagebox, sharedUrls } from './urlHelper';
+import { returnUrlToMessagebox } from './urlHelper';
 import {
   APP_DEVELOPMENT_BASENAME,
   DASHBOARD_BASENAME,
@@ -12,29 +12,14 @@ describe('Shared urlHelper.ts', () => {
       window.location = oldWindowLocation;
     });
 
-    const runUrlTests = () => {
-      expect(sharedUrls().dataModelsApi).toBe(
-        'https://altinn3.no/designer/api/org/repo/datamodels',
-      );
-      expect(sharedUrls().dataModelUploadPageUrl).toContain(
-        `${APP_DEVELOPMENT_BASENAME}/org/repo/datamodel`,
-      );
-      expect(sharedUrls().dataModelXsdUrl).toContain(
-        '/designer/org/repo/Model/GetXsd',
-      );
-      expect(sharedUrls().repositoryGitUrl).toContain('/repos/org/repo.git');
-      expect(sharedUrls().repositoryUrl).toContain('/repos/org/repo');
-    };
 
     test('sharedUrls generates expected urls on an app-development location', () => {
       delete window.location;
-
       window.location = {
         ...oldWindowLocation,
         origin: 'https://altinn3.no',
         pathname: `${APP_DEVELOPMENT_BASENAME}/org/repo`,
       };
-      runUrlTests();
     });
 
     test.skip('sharedUrls generates expected urls on a the dashboard location', () => {
@@ -44,7 +29,6 @@ describe('Shared urlHelper.ts', () => {
         origin: 'https://altinn3.no',
         pathname: `${DASHBOARD_BASENAME}/datamodelling/org/repo`,
       };
-      runUrlTests();
     });
   });
 

--- a/src/studio/src/designer/frontend/shared/utils/urlHelper.ts
+++ b/src/studio/src/designer/frontend/shared/utils/urlHelper.ts
@@ -1,32 +1,9 @@
-import conditionalPath from 'app-shared/utils/conditionalPath';
 import { _useParamsClassCompHack } from 'app-shared/utils/_useParamsClassCompHack';
 import { APP_DEVELOPMENT_BASENAME } from 'app-shared/constants';
 
-const cdn = 'https://altinncdn.no';
-export const altinnImgLogoHeaderUrl = `${cdn}/img/Altinn-logo-blue.svg`;
 export const altinnDocsUrl = 'https://docs.altinn.studio/';
 
-export const sharedUrls = () => {
-  const { org, app } = _useParamsClassCompHack();
-  const origin = window.location.origin;
-  const designerApi = `${origin}/designer/api`;
-  const orgRepoChunk = conditionalPath(org, app);
-  const dataModelsApi = `${designerApi}/${orgRepoChunk}/datamodels`;
-
-  return {
-    ensureCloneApi: `${origin}/designer/${orgRepoChunk}`,
-    dataModelsApi,
-    dataModelUploadPageUrl: `${origin}${APP_DEVELOPMENT_BASENAME}/${orgRepoChunk}/datamodel`,
-    dataModelXsdUrl: `${origin}/designer/${orgRepoChunk}/Model/GetXsd`,
-    repositoryGitUrl: `${origin}/repos/${orgRepoChunk}.git`,
-    repositoryUrl: `${origin}/repos/${orgRepoChunk}`,
-    createDataModelUrl: `${dataModelsApi}/post`,
-    getDataModelUrl: (pathToModelFile: string) =>
-      `${dataModelsApi}${pathToModelFile}`,
-    saveDataModelUrl: (pathToModelFile: string) =>
-      `${dataModelsApi}?modelPath=${encodeURIComponent(pathToModelFile)}`,
-  };
-};
+export const dataModelUploadPageUrl = (org, app) => `${APP_DEVELOPMENT_BASENAME}/${org}/${app}/datamodel`
 
 export const returnUrlToMessagebox = (url: string): string => {
   const { org, app } = _useParamsClassCompHack();

--- a/src/studio/src/designer/frontend/shared/version-control/cloneModal.module.css
+++ b/src/studio/src/designer/frontend/shared/version-control/cloneModal.module.css
@@ -1,0 +1,16 @@
+.modalContainer {
+  padding: 24px;
+  width: 319px;
+}
+
+.itemSeparator {
+  padding-bottom: 12px;
+}
+
+.sectionSeparator {
+  padding-bottom: 32px;
+}
+
+.blackText {
+  color: black;
+}

--- a/src/studio/src/designer/frontend/shared/version-control/cloneModal.test.tsx
+++ b/src/studio/src/designer/frontend/shared/version-control/cloneModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CloneModal from './cloneModal';
+import {CloneModal} from './cloneModal';
 import type { ICloneModalProps } from './cloneModal';
 import { render as rtlRender, screen } from '@testing-library/react';
 

--- a/src/studio/src/designer/frontend/shared/version-control/versionControlHeader.test.tsx
+++ b/src/studio/src/designer/frontend/shared/version-control/versionControlHeader.test.tsx
@@ -3,8 +3,8 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { render, screen, waitFor} from '@testing-library/react';
 import { VersionControlContainer } from './versionControlHeader';
-import { sharedUrls } from '../utils/urlHelper';
-import { setWindowLocationForTests, TEST_DOMAIN } from "../../testing/testUtils"
+import { setWindowLocationForTests } from "../../testing/testUtils"
+import {datamodelXsdPath, repoMetaPath} from "../api-paths";
 
 
 setWindowLocationForTests('test-org', 'test-app');
@@ -13,7 +13,7 @@ export const versionControllHeaderApiCalls = jest.fn();
 
 const handlers = [
   rest.get(
-      `${TEST_DOMAIN}/designer/api/v1/repos/test-org/test-app`,
+      repoMetaPath("test-org","test-app"),
     (req, res, ctx) => {
       versionControllHeaderApiCalls();
       return res(
@@ -26,7 +26,7 @@ const handlers = [
       );
     },
   ),
-  rest.get(sharedUrls().dataModelXsdUrl, (req, res, ctx) => {
+  rest.get(datamodelXsdPath("test-org","test-app"), (req, res, ctx) => {
     versionControllHeaderApiCalls();
     return res(ctx.status(200), ctx.json({}));
   }),

--- a/src/studio/src/designer/frontend/shared/version-control/versionControlHeader.test.tsx
+++ b/src/studio/src/designer/frontend/shared/version-control/versionControlHeader.test.tsx
@@ -3,17 +3,24 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { render, screen, waitFor} from '@testing-library/react';
 import { VersionControlContainer } from './versionControlHeader';
-import { setWindowLocationForTests } from "../../testing/testUtils"
+import {setWindowLocationForTests, TEST_DOMAIN} from "../../testing/testUtils"
 import {datamodelXsdPath, repoMetaPath} from "../api-paths";
 
-
 setWindowLocationForTests('test-org', 'test-app');
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
+  useParams: () => ({
+    org:"test-org",
+    app:"test-app",
+  }),
+}));
 
 export const versionControllHeaderApiCalls = jest.fn();
 
 const handlers = [
   rest.get(
-      repoMetaPath("test-org","test-app"),
+      TEST_DOMAIN + repoMetaPath("test-org","test-app"),
     (req, res, ctx) => {
       versionControllHeaderApiCalls();
       return res(
@@ -26,7 +33,7 @@ const handlers = [
       );
     },
   ),
-  rest.get(datamodelXsdPath("test-org","test-app"), (req, res, ctx) => {
+  rest.get(TEST_DOMAIN + datamodelXsdPath("test-org","test-app"), (req, res, ctx) => {
     versionControllHeaderApiCalls();
     return res(ctx.status(200), ctx.json({}));
   }),

--- a/src/studio/src/designer/frontend/shared/version-control/versionControlHeader.tsx
+++ b/src/studio/src/designer/frontend/shared/version-control/versionControlHeader.tsx
@@ -10,9 +10,15 @@ import postMessages from '../utils/postMessages';
 import FetchChangesComponent from './fetchChanges';
 import ShareChangesComponent from './shareChanges';
 import CloneButton from './cloneButton';
-import CloneModal from './cloneModal';
+import { CloneModal } from './cloneModal';
 import SyncModalComponent from './syncModal';
 import { _useParamsClassCompHack } from 'app-shared/utils/_useParamsClassCompHack';
+import {
+  repoCommitPath,
+  repoMetaPath,
+  repoPullPath,
+  repoPushPath, repoStatusPath,
+} from '../api-paths';
 
 export interface IVersionControlHeaderProps extends WithStyles<typeof styles> {
   language: any;
@@ -85,7 +91,7 @@ class VersionControlHeader extends React.Component<
 
   public async componentDidMount() {
     this.componentIsMounted = true;
-    if(this.state.hasPushRight === undefined){
+    if (this.state.hasPushRight === undefined) {
       await this.getRepoPermissions();
     }
   }
@@ -96,9 +102,10 @@ class VersionControlHeader extends React.Component<
 
   public getRepoPermissions = async () => {
     const { org, app } = _useParamsClassCompHack();
-    const url = `${window.location.origin}/designer/api/v1/repos/${org}/${app}`;
     try {
-      const currentRepo = await get(url, { cancelToken: this.source.token });
+      const currentRepo = await get(repoMetaPath(org, app), {
+        cancelToken: this.source.token,
+      });
       this.setState({
         hasPushRight: currentRepo.permissions.push,
       });
@@ -116,8 +123,7 @@ class VersionControlHeader extends React.Component<
 
   public getStatus(callbackFunc?: any) {
     const { org, app } = _useParamsClassCompHack();
-    const url = `${window.location.origin}/designer/api/v1/repos/${org}/${app}/status`;
-    get(url)
+    get(repoStatusPath(org,app))
       .then((result: IGitStatus) => {
         if (this.componentIsMounted) {
           this.setState({
@@ -169,9 +175,7 @@ class VersionControlHeader extends React.Component<
     });
 
     const { org, app } = _useParamsClassCompHack();
-    const url = `${window.location.origin}/designer/api/v1/repos/${org}/${app}/pull`;
-
-    get(url)
+    get(repoPullPath(org, app))
       .then((result: any) => {
         if (this.componentIsMounted) {
           if (result.repositoryStatus === 'Ok') {
@@ -354,9 +358,8 @@ class VersionControlHeader extends React.Component<
     });
 
     const { org, app } = _useParamsClassCompHack();
-    const url = `${window.location.origin}/designer/api/v1/repos/${org}/${app}/push`;
 
-    post(url)
+    post(repoPushPath(org, app))
       .then(() => {
         if (this.componentIsMounted) {
           this.setState({
@@ -418,12 +421,9 @@ class VersionControlHeader extends React.Component<
       org,
       repository: app,
     });
-
-    const url = `${window.location.origin}/designer/api/v1/repos/${org}/${app}/commit`;
-    const pullUrl = `${window.location.origin}/designer/api/v1/repos/${org}/${app}/pull`;
-    post(url, bodyData, options)
+    post(repoCommitPath(org, app), bodyData, options)
       .then(() => {
-        get(pullUrl)
+        get(repoPullPath(org, app))
           .then((result: any) => {
             if (this.componentIsMounted) {
               // if pull was successfull, show app updated message
@@ -578,10 +578,10 @@ class VersionControlHeader extends React.Component<
             </Grid>
             {this.renderSyncModalComponent()}
             <CloneModal
-                anchorEl={this.state.cloneModalAnchor}
-                open={this.state.cloneModalOpen}
-                onClose={this.closeCloneModal}
-                language={this.props.language}
+              anchorEl={this.state.cloneModalAnchor}
+              open={this.state.cloneModalOpen}
+              onClose={this.closeCloneModal}
+              language={this.props.language}
             />
           </Grid>
         ) : type === 'fetchButton' ? (

--- a/src/studio/src/designer/frontend/shared/version-control/versionControlHeader.tsx
+++ b/src/studio/src/designer/frontend/shared/version-control/versionControlHeader.tsx
@@ -611,6 +611,4 @@ class VersionControlHeader extends React.Component<
   }
 }
 
-export default withStyles(styles)(VersionControlHeader);
-
 export const VersionControlContainer = withStyles(styles)(VersionControlHeader);

--- a/src/studio/src/designer/frontend/ux-editor/App.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/App.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, { useEffect } from 'react';
 import postMessages from 'app-shared/utils/postMessages';
 import { useDispatch } from 'react-redux';
 import { ErrorMessageComponent } from './components/message/ErrorMessageComponent';
@@ -20,7 +20,7 @@ import {textResourcesPath} from "app-shared/api-paths";
 
 export function App() {
   const dispatch = useDispatch();
-  const {org,app} = useParams()
+  const {org,app} = useParams();
   useEffect(() => {
     const fetchFiles = () => {
       dispatch(fetchDataModel());

--- a/src/studio/src/designer/frontend/ux-editor/App.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import postMessages from 'app-shared/utils/postMessages';
 import { useDispatch } from 'react-redux';
 import { ErrorMessageComponent } from './components/message/ErrorMessageComponent';
@@ -6,12 +6,12 @@ import FormDesigner from './containers/FormDesigner';
 import { FormLayoutActions } from './features/formDesigner/formLayout/formLayoutSlice';
 import { loadTextResources } from './features/appData/textResources/textResourcesSlice';
 import { fetchWidgets, fetchWidgetSettings } from './features/widgets/widgetsSlice';
-import { getTextResourcesUrl } from './utils/urlHelper';
 import { fetchDataModel } from './features/appData/dataModel/dataModelSlice';
 import { fetchLanguage } from './features/appData/language/languageSlice';
 import { fetchRuleModel } from './features/appData/ruleModel/ruleModelSlice';
 import { fetchServiceConfiguration } from './features/serviceConfigurations/serviceConfigurationSlice';
-
+import { useParams} from "react-router-dom";
+import {textResourcesPath} from "app-shared/api-paths";
 /**
  * This is the main React component responsible for controlling
  * the mode of the application and loading initial data for the
@@ -20,14 +20,13 @@ import { fetchServiceConfiguration } from './features/serviceConfigurations/serv
 
 export function App() {
   const dispatch = useDispatch();
-
-  React.useEffect(() => {
+  const {org,app} = useParams()
+  useEffect(() => {
     const fetchFiles = () => {
       dispatch(fetchDataModel());
       dispatch(FormLayoutActions.fetchFormLayout());
-
       const languageCode = 'nb';
-      dispatch(loadTextResources({ url: getTextResourcesUrl(languageCode) }));
+      dispatch(loadTextResources({ url: textResourcesPath(org,app,languageCode) }));
       dispatch(fetchServiceConfiguration());
       dispatch(fetchRuleModel());
       dispatch(fetchLanguage({ languageCode }));
@@ -56,5 +55,3 @@ export function App() {
     </div>
   );
 }
-
-export default App;

--- a/src/studio/src/designer/frontend/ux-editor/SubApp.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/SubApp.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import AppComponent from './App';
+import { App } from './App';
 import { run } from './sagas';
 import { store } from './store';
 import './styles/index.css';
@@ -22,7 +22,7 @@ export default class SubApp extends React.Component<any, any> {
   public render() {
     return (
       <Provider store={store}>
-        <AppComponent />
+        <App />
       </Provider>
     );
   }

--- a/src/studio/src/designer/frontend/ux-editor/features/appData/appDataSagas.ts
+++ b/src/studio/src/designer/frontend/ux-editor/features/appData/appDataSagas.ts
@@ -14,7 +14,6 @@ import {
 import {
   getAddTextResourcesUrl,
   getFetchDataModelUrl,
-  getFetchLanguageUrl,
   getFetchRuleModelUrl,
 } from '../../utils/urlHelper';
 import {
@@ -37,6 +36,7 @@ import type {
   IDataModelFieldElement,
   IRuleModelFieldElement,
 } from '../../types/global';
+import {frontendLangPath} from "app-shared/api-paths";
 
 function* fetchDataModelSaga(): SagaIterator {
   try {
@@ -117,7 +117,7 @@ export function* fetchLanguageSaga({
 }: PayloadAction<IFetchLanguage>): SagaIterator {
   try {
     const { languageCode } = payload;
-    const language = yield call(get, getFetchLanguageUrl(languageCode));
+    const language = yield call(get, frontendLangPath(languageCode));
     yield put(fetchLanguageFulfilled({ language }));
   } catch (error) {
     yield put(fetchLanguageRejected({ error }));

--- a/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formLayout/formLayoutSagas.ts
+++ b/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formLayout/formLayoutSagas.ts
@@ -13,13 +13,14 @@ import {
   getDeleteApplicationMetadataUrl,
   getDeleteForLayoutUrl,
   getFetchFormLayoutUrl,
-  getLayoutSchemaUrl,
   getLayoutSettingsUrl,
   getSaveFormLayoutUrl,
   getSaveLayoutSettingsUrl,
   getUpdateApplicationMetadataUrl,
   getUpLayNmeUrl,
 } from '../../../utils/urlHelper';
+import {layoutSchemaUrl} from 'app-shared/cdn-paths';
+
 import { ComponentTypes } from '../../../components';
 import {
   IAddApplicationMetadataAction,
@@ -231,7 +232,7 @@ function* saveFormLayoutSaga(): SagaIterator {
     const layouts = yield select((state: IAppState) => state.formDesigner.layout.layouts);
     const selectedLayout = yield select((state: IAppState) => state.formDesigner.layout.selectedLayout);
     const convertedLayout = {
-      $schema: getLayoutSchemaUrl(),
+      $schema: layoutSchemaUrl(),
       data: {
         layout: convertInternalToLayoutFormat(layouts[selectedLayout]),
       },

--- a/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formLayout/formLayoutSlice.ts
+++ b/src/studio/src/designer/frontend/ux-editor/features/formDesigner/formLayout/formLayoutSlice.ts
@@ -1,6 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { actions, moduleName } from './formLayoutActions';
-import { getLayoutSettingsSchemaUrl } from '../../../utils/urlHelper';
 import { sortArray } from '../../../utils/arrayHelpers/arrayLogic';
 import type {
   IAddActiveFormContainerAction,
@@ -28,6 +27,7 @@ import type {
 } from '../formDesignerTypes';
 import type { ILayoutSettings } from 'app-shared/types/global';
 import type { IFormDesignerLayout } from '../../../types/global';
+import {layoutSettingsSchemaUrl} from "app-shared/cdn-paths";
 
 export interface IFormLayoutState extends IFormDesignerLayout {
   fetching: boolean;
@@ -52,7 +52,7 @@ const initialState: IFormLayoutState = {
   activeList: [],
   selectedLayout: 'default',
   layoutSettings: {
-    $schema: getLayoutSettingsSchemaUrl(),
+    $schema: layoutSettingsSchemaUrl(),
     pages: { order: [] },
   },
 };

--- a/src/studio/src/designer/frontend/ux-editor/features/widgets/widgetsSlice.ts
+++ b/src/studio/src/designer/frontend/ux-editor/features/widgets/widgetsSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { widgetSettings } from '../../utils/widgetSettings';
 import type { IWidget } from '../../types/global';
+import {widgetUrl} from "app-shared/cdn-paths";
 
 export interface IWidgetState {
   widgets: IWidget[];
@@ -14,7 +14,7 @@ export interface IFetchWidgetFulfilled {
 
 const initialState: IWidgetState = {
   widgets: [],
-  urls: widgetSettings.widgetUrls,
+  urls: [widgetUrl()],
   error: null,
 };
 

--- a/src/studio/src/designer/frontend/ux-editor/index.tsx
+++ b/src/studio/src/designer/frontend/ux-editor/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
-import AppComponent from './App';
+import {App} from './App';
 import { run } from './sagas';
 import { store } from './store';
 import './styles/index.css';
@@ -16,6 +16,6 @@ const root = createRoot(container);
 
 root.render(
   <Provider store={store}>
-    <AppComponent />
+    <App />
   </Provider>,
 );

--- a/src/studio/src/designer/frontend/ux-editor/utils/urlHelper.ts
+++ b/src/studio/src/designer/frontend/ux-editor/utils/urlHelper.ts
@@ -1,9 +1,7 @@
 import { _useParamsClassCompHack } from 'app-shared/utils/_useParamsClassCompHack';
 
 const { org, app } = _useParamsClassCompHack();
-const bp = `${window.location.origin}/designer`;
 const basePath = `${window.location.origin}/designer/${org}/${app}`;
-const cdnPath = 'https://altinncdn.no/schemas/json/layout';
 
 export const getAddApplicationMetadataUrl = (): string => `${basePath}/UIEditor/AddMetadataForAttachment`;
 export const getAddTextResourcesUrl = (): string => `${basePath}/UIEditor/AddTextResources`;
@@ -11,16 +9,12 @@ export const getDeleteApplicationMetadataUrl = (): string => `${basePath}/UIEdit
 export const getDeleteForLayoutUrl = (layout: string): string => `${basePath}/UIEditor/DeleteFormLayout/${layout}`;
 export const getFetchDataModelUrl = () => `${basePath}/Model/GetJson`;
 export const getFetchFormLayoutUrl = (): string => `${basePath}/UIEditor/GetFormLayout`;
-export const getFetchLanguageUrl = (languageCode: string) => `${bp}/frontend/lang/${languageCode}.json`;
 export const getFetchRuleConfigurationUrl = () => `${basePath}/UIEditor/GetJsonFile?fileName=RuleConfiguration.json`;
 export const getFetchRuleModelUrl = () => `${basePath}/UIEditor/GetRuleHandler`;
-export const getLayoutSchemaUrl = (): string => `${cdnPath}/layout.schema.v1.json`;
-export const getLayoutSettingsSchemaUrl = () => `${cdnPath}/layoutSettings.schema.v1.json`;
 export const getLayoutSettingsUrl = (): string => `${basePath}/UIEditor/GetLayoutSettings`;
 export const getSaveFormLayoutUrl = (layoutName: string): string => `${basePath}/UIEditor/SaveFormLayout/${layoutName}`;
 export const getSaveLayoutSettingsUrl = (): string => `${basePath}/UIEditor/SaveLayoutSettings`;
 export const getSveSerConfUrl = (): string => `${basePath}/UIEditor/SaveJsonFile?fileName=RuleConfiguration.json`;
-export const getTextResourcesUrl = (languageCode: string) => `${basePath}/UIEditor/GetTextResources/${languageCode}`;
 export const getUpLayNmeUrl = (layoutName: string) => `${basePath}/UIEditor/UpdateFormLayoutName/${layoutName}`;
 export const getUpdateApplicationMetadataUrl = (): string => `${basePath}/UIEditor/UpdateMetadataForAttachment`;
 export const getWidgetsSettingsUrl = (): string => `${basePath}/UIEditor/GetWidgetSettings`;

--- a/src/studio/src/designer/frontend/ux-editor/utils/widgetSettings.ts
+++ b/src/studio/src/designer/frontend/ux-editor/utils/widgetSettings.ts
@@ -1,3 +1,0 @@
-export const widgetSettings = {
-  widgetUrls: ['https://altinncdn.no/altinn-apps/widgets/message.json'],
-};

--- a/src/studio/src/designer/frontend/webpack.common.js
+++ b/src/studio/src/designer/frontend/webpack.common.js
@@ -26,6 +26,7 @@ module.exports = {
     rules: [
       {
         test: /\.svg$/i,
+        enforce: 'pre',
         issuer: /\.[jt]sx?$/,
         use: ['@svgr/webpack'],
       },

--- a/src/studio/src/designer/frontend/webpack.config.dev.js
+++ b/src/studio/src/designer/frontend/webpack.config.dev.js
@@ -17,12 +17,6 @@ module.exports = {
     rules: [
       ...commonConfig.module.rules,
       {
-        test: /\.svg$/,
-        use: {
-          loader: 'svg-inline-loader',
-        },
-      },
-      {
         enforce: 'pre',
         test: /\.js$/,
         loader: 'source-map-loader',

--- a/src/studio/src/designer/frontend/yarn.lock
+++ b/src/studio/src/designer/frontend/yarn.lock
@@ -4752,6 +4752,7 @@ __metadata:
     marked: 4.2.2
     moment: 2.29.4
     monaco-editor: 0.34.1
+    query-string: 7.1.1
     react: 18.2.0
     react-content-loader: 6.2.0
     react-dom: 18.2.0
@@ -6207,6 +6208,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decode-uri-component@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "decode-uri-component@npm:0.2.0"
+  checksum: f3749344ab9305ffcfe4bfe300e2dbb61fc6359e2b736812100a3b1b6db0a5668cba31a05e4b45d4d63dbf1a18dfa354cd3ca5bb3ededddabb8cd293f4404f94
+  languageName: node
+  linkType: hard
+
 "decompress-response@npm:^3.3.0":
   version: 3.3.0
   resolution: "decompress-response@npm:3.3.0"
@@ -7485,6 +7493,13 @@ __metadata:
   dependencies:
     to-regex-range: ^5.0.1
   checksum: cc283f4e65b504259e64fd969bcf4def4eb08d85565e906b7d36516e87819db52029a76b6363d0f02d0d532f0033c9603b9e2d943d56ee3b0d4f7ad3328ff917
+  languageName: node
+  linkType: hard
+
+"filter-obj@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "filter-obj@npm:1.1.0"
+  checksum: cf2104a7c45ff48e7f505b78a3991c8f7f30f28bd8106ef582721f321f1c6277f7751aacd5d83026cb079d9d5091082f588d14a72e7c5d720ece79118fa61e10
   languageName: node
   linkType: hard
 
@@ -11617,6 +11632,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"query-string@npm:7.1.1":
+  version: 7.1.1
+  resolution: "query-string@npm:7.1.1"
+  dependencies:
+    decode-uri-component: ^0.2.0
+    filter-obj: ^1.1.0
+    split-on-first: ^1.0.0
+    strict-uri-encode: ^2.0.0
+  checksum: b227d1f588ae93f9f0ad078c6b811295fa151dc5a160a03bb2bac5fa0e6919cb1daa570aad1d288e77c8e89fde5362ba505b1014e6e793da9b1e885b59a690a6
+  languageName: node
+  linkType: hard
+
 "querystringify@npm:^2.1.1":
   version: 2.2.0
   resolution: "querystringify@npm:2.2.0"
@@ -12942,6 +12969,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"split-on-first@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "split-on-first@npm:1.1.0"
+  checksum: 16ff85b54ddcf17f9147210a4022529b343edbcbea4ce977c8f30e38408b8d6e0f25f92cd35b86a524d4797f455e29ab89eb8db787f3c10708e0b47ebf528d30
+  languageName: node
+  linkType: hard
+
 "split@npm:0.3":
   version: 0.3.3
   resolution: "split@npm:0.3.3"
@@ -13049,6 +13083,13 @@ __metadata:
   dependencies:
     events: ^3.3.0
   checksum: 6ac06fe72a6ee6ae64d20f1dd42838ea67342f1b5f32b03b3050d73ee6ecee44b4d5c4ed2965a7154b47991e215f373d4e789e2b2be2769cd80e356126c2ca53
+  languageName: node
+  linkType: hard
+
+"strict-uri-encode@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "strict-uri-encode@npm:2.0.0"
+  checksum: eaac4cf978b6fbd480f1092cab8b233c9b949bcabfc9b598dd79a758f7243c28765ef7639c876fa72940dac687181b35486ea01ff7df3e65ce3848c64822c581
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To prepare for this task I have collected so much of the paths that is resolvable in one place. There are still paths that are used by sagas that we can't move as it requires a refactoring. In short we need the `org` and `app` values sent with the payload along with the other params instead of being read from the url-path. 

## Related Issue(s)
- #9140 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
