### PR TITLE
use route params instead of applicationmetadata

### DIFF
--- a/src/studio/src/designer/frontend/app-development/features/dataModelling/containers/DataModellingContainer.test.tsx
+++ b/src/studio/src/designer/frontend/app-development/features/dataModelling/containers/DataModellingContainer.test.tsx
@@ -1,0 +1,14 @@
+import { APP_DEVELOPMENT_BASENAME } from '../../../../constants';
+import React from 'react';
+import { renderWithProviders } from '../../../test/testUtils';
+import DataModellingContainer from './DataModellingContainer';
+
+describe('DataModellingContainer', () => {
+  it('should render data modelling container', () => {
+    const utils = renderWithProviders(<DataModellingContainer language={{}} />, {
+      startUrl: `${APP_DEVELOPMENT_BASENAME}/test-org/test-app`,
+    });
+    const container = utils.getByTestId('data-modelling-container');
+    expect(container).toBeInTheDocument();
+  })
+})

--- a/src/studio/src/designer/frontend/app-development/features/dataModelling/containers/DataModellingContainer.tsx
+++ b/src/studio/src/designer/frontend/app-development/features/dataModelling/containers/DataModellingContainer.tsx
@@ -1,25 +1,22 @@
 import React from 'react';
 import { DataModelling } from 'app-shared/features';
-import { useAppSelector } from '../../../common/hooks';
 import classes from './DataModellingContainer.module.css';
+import { useParams } from 'react-router-dom';
 
 interface IDataModellingContainerProps {
   language: any;
 }
 
 const DataModellingContainer = ({ language }: IDataModellingContainerProps) => {
-  const [org, repo] = useAppSelector((state) => {
-    const id = state.applicationMetadataState.applicationMetadata.id;
-    return id?.split('/') || [];
-  });
+  const {org, app} = useParams();
 
   return (
-    <div className={classes.root}>
+    <div className={classes.root} id='data-modelling-container' data-testid='data-modelling-container'>
       <div className={classes.dataModellingWrapper}>
         <DataModelling
           language={language}
           org={org}
-          repo={repo}
+          repo={app}
         />
       </div>
     </div>

--- a/src/studio/src/designer/frontend/testing/setupTests.ts
+++ b/src/studio/src/designer/frontend/testing/setupTests.ts
@@ -7,3 +7,17 @@ import failOnConsole from 'jest-fail-on-console';
 failOnConsole( {
     shouldFailOnWarn: true,
 });
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use route params to set org/repo params instead of application metadata. This is consistent with how we do it in the rest of the solution

## Related Issue(s)
- #9293 - fixes this issue

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
