### PR TITLE
API for managing keys for text editor

### DIFF
--- a/src/studio/src/designer/backend.Tests/Controllers/TextKeysControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/TextKeysControllerTests.cs
@@ -1,0 +1,51 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Configuration;
+using Altinn.Studio.Designer.Controllers;
+using Altinn.Studio.Designer.Services.Interfaces;
+using Designer.Tests.Controllers;
+using Designer.Tests.Controllers.ApiTests;
+using Designer.Tests.Mocks;
+using Designer.Tests.Utils;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Designer.Tests.Services;
+
+public class TextKeysControllerTests : ApiTestsBase<TextKeysController, TextKeysControllerTests>
+{
+    private readonly string _versionPrefix = "designer/api/v1";
+
+    public TextKeysControllerTests(WebApplicationFactory<TextKeysController> factory) : base(factory)
+    {
+    }
+
+    protected override void ConfigureTestServices(IServiceCollection services)
+    {
+        services.Configure<ServiceRepositorySettings>(c =>
+            c.RepositoryLocation = TestRepositoriesLocation);
+        services.AddSingleton<IGitea, IGiteaMock>();
+    }
+
+    [Fact]
+    public async Task Get_Markdown_200Ok()
+    {
+        var targetRepository = TestDataHelper.GenerateTestRepoName();
+        await TestDataHelper.CopyRepositoryForTest("ttd", "markdown-files", "testUser", targetRepository);
+        string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/texts/nb";
+        HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, dataPathWithData);
+
+        HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+
+        try
+        {
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+        }
+        finally
+        {
+            TestDataHelper.DeleteAppRepository("ttd", targetRepository, "testUser");
+        }
+    }
+}

--- a/src/studio/src/designer/backend.Tests/Controllers/TextKeysControllerTests.cs
+++ b/src/studio/src/designer/backend.Tests/Controllers/TextKeysControllerTests.cs
@@ -57,6 +57,46 @@ public class TextKeysControllerTests : ApiTestsBase<TextKeysController, TextKeys
     }
 
     [Fact]
+    public async Task GetKeys_TextsFileInvalidFormat_500InternalServerError()
+    {
+        var targetRepository = TestDataHelper.GenerateTestRepoName();
+        await TestDataHelper.CopyRepositoryForTest("ttd", "invalid-texts-format", "testUser", targetRepository);
+        string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/keys";
+        HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, dataPathWithData);
+
+        HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+
+        try
+        {
+            Assert.Equal(StatusCodes.Status500InternalServerError, (int)response.StatusCode);
+        }
+        finally
+        {
+            TestDataHelper.DeleteAppRepository("ttd", targetRepository, "testUser");
+        }
+    }
+
+    [Fact]
+    public async Task GetKeys_TextsFilesNotFound_404NotFound()
+    {
+        var targetRepository = TestDataHelper.GenerateTestRepoName();
+        await TestDataHelper.CopyRepositoryForTest("ttd", "empty-app", "testUser", targetRepository);
+        string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/keys";
+        HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, dataPathWithData);
+
+        HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+
+        try
+        {
+            Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+        }
+        finally
+        {
+            TestDataHelper.DeleteAppRepository("ttd", targetRepository, "testUser");
+        }
+    }
+
+    [Fact]
     public async Task Post_NewKey_200OkAndNewKeyOnTopOfFile()
     {
         var targetRepository = TestDataHelper.GenerateTestRepoName();
@@ -103,6 +143,26 @@ public class TextKeysControllerTests : ApiTestsBase<TextKeysController, TextKeys
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
             Assert.Equal(9, keys.Count);
             Assert.Equal("KeyOnTop", keys[0]);
+        }
+        finally
+        {
+            TestDataHelper.DeleteAppRepository("ttd", targetRepository, "testUser");
+        }
+    }
+
+    [Fact]
+    public async Task Post_TextsFilesNotFound_404NotFound()
+    {
+        var targetRepository = TestDataHelper.GenerateTestRepoName();
+        await TestDataHelper.CopyRepositoryForTest("ttd", "empty-app", "testUser", targetRepository);
+        string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/keys";
+        HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, dataPathWithData);
+
+        HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+
+        try
+        {
+            Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
         }
         finally
         {
@@ -208,6 +268,26 @@ public class TextKeysControllerTests : ApiTestsBase<TextKeysController, TextKeys
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
             Assert.Equal(8, keys.Count);
             Assert.False(keys.Contains("AlreadyExistingKey"));
+        }
+        finally
+        {
+            TestDataHelper.DeleteAppRepository("ttd", targetRepository, "testUser");
+        }
+    }
+
+    [Fact]
+    public async Task Put_TextsFilesNotFound_404NotFound()
+    {
+        var targetRepository = TestDataHelper.GenerateTestRepoName();
+        await TestDataHelper.CopyRepositoryForTest("ttd", "empty-app", "testUser", targetRepository);
+        string dataPathWithData = $"{_versionPrefix}/ttd/{targetRepository}/keys";
+        HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, dataPathWithData);
+
+        HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+
+        try
+        {
+            Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
         }
         finally
         {

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/keys-management/App/config/texts/en.texts.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/keys-management/App/config/texts/en.texts.json
@@ -1,0 +1,10 @@
+{
+  "BegrunnelseSteforeldre": "Lastname on steph- or fosterparents",
+  "BegrunnelseValgNavn": "Reason for name change",
+  "BekreftNavnTittel": "Confirmation of name",
+  "DineEndringer": "Your Changes",
+  "EndreNavnFra": "You have chosen to change:",
+  "EndreNavnTil": "To:",
+  "KeyOnlyDefinedInEnglish": "Some value only defined in english",
+  "AlreadyExistingKey": "Some value for existing key"
+}

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/keys-management/App/config/texts/en.texts.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/keys-management/App/config/texts/en.texts.json
@@ -1,5 +1,5 @@
 {
-  "BegrunnelseSteforeldre": "Lastname on steph- or fosterparents",
+  "KeyOnTop": "Lastname on steph- or fosterparents",
   "BegrunnelseValgNavn": "Reason for name change",
   "BekreftNavnTittel": "Confirmation of name",
   "DineEndringer": "Your Changes",

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/keys-management/App/config/texts/nb.texts.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/keys-management/App/config/texts/nb.texts.json
@@ -1,5 +1,5 @@
 {
-  "BegrunnelseSteforeldre": "Etternavn på ste- eller fosterforeldre du ønsker å ta navnet til",
+  "KeyOnTop": "Etternavn på ste- eller fosterforeldre du ønsker å ta navnet til",
   "BegrunnelseValgNavn": "Begrunnelse for endring av navn",
   "BekreftNavnTittel": "Bekreftelse av endring",
   "KeyNotDefinedInEnglish": "Noen ord på bokmål",

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/keys-management/App/config/texts/nb.texts.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/keys-management/App/config/texts/nb.texts.json
@@ -1,0 +1,10 @@
+{
+  "BegrunnelseSteforeldre": "Etternavn på ste- eller fosterforeldre du ønsker å ta navnet til",
+  "BegrunnelseValgNavn": "Begrunnelse for endring av navn",
+  "BekreftNavnTittel": "Bekreftelse av endring",
+  "KeyNotDefinedInEnglish": "Noen ord på bokmål",
+  "DineEndringer": "Dine endringer",
+  "EndreNavnFra": "Du har valgt å endre til:",
+  "EndreNavnTil": "Til:",
+  "AlreadyExistingKey": "En verdi for bokmål"
+}

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/keys-management/App/config/texts/nn.texts.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/keys-management/App/config/texts/nn.texts.json
@@ -1,0 +1,10 @@
+{
+  "BegrunnelseSteforeldre": "Etternavn på ste- eller fosterforeldre du ynskjer å ta navnet til",
+  "BegrunnelseValgNavn": "Begrunning for endring av navn",
+  "BekreftNavnTittel": "Bekrefting av endring",
+  "KeyNotDefinedInEnglish": "Nokre nynorske glosar",
+  "DineEndringer": "Dine endringar",
+  "EndreNavnFra": "Du har valgt å endre til:",
+  "EndreNavnTil": "Til:",
+  "AlreadyExistingKey": "Ein verdi for nynorsk"
+}

--- a/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/keys-management/App/config/texts/nn.texts.json
+++ b/src/studio/src/designer/backend.Tests/_TestData/Repositories/testUser/ttd/keys-management/App/config/texts/nn.texts.json
@@ -1,5 +1,5 @@
 {
-  "BegrunnelseSteforeldre": "Etternavn på ste- eller fosterforeldre du ynskjer å ta navnet til",
+  "KeyOnTop": "Etternavn på ste- eller fosterforeldre du ynskjer å ta navnet til",
   "BegrunnelseValgNavn": "Begrunning for endring av navn",
   "BekreftNavnTittel": "Bekrefting av endring",
   "KeyNotDefinedInEnglish": "Nokre nynorske glosar",

--- a/src/studio/src/designer/backend/Controllers/TextKeysController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextKeysController.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Helpers;
+using Altinn.Studio.Designer.Services.Interfaces;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.Studio.Designer.Controllers
+{
+    /// <summary>
+    /// Controller containing actions related to languages
+    /// </summary>
+    [Authorize]
+    [AutoValidateAntiforgeryToken]
+    [Route("designer/api/v1/{org}/{repo}/keys")]
+    public class TextKeysController : ControllerBase
+    {
+        private readonly ILanguagesService _languagesService;
+        private readonly ITextsService _textsService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LanguagesController"/> class.
+        /// </summary>
+        /// <param name="languagesService">The languages service.</param>
+        /// <param name="textsService">The texts service.</param>
+        public TextKeysController(ILanguagesService languagesService, ITextsService textsService)
+        {
+            _languagesService = languagesService;
+            _textsService = textsService;
+        }
+
+        /// <summary>
+        /// Endpoint for getting a list of all keys.
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="repo">Application identifier which is unique within an organisation.</param>
+        /// <returns>List of keys</returns>
+        [HttpGet]
+        [Produces("application/json")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [Route("keys")]
+        public async Task<ActionResult<List<string>>> Get(string org, string repo)
+        {
+            string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
+            IList<string> languages = _languagesService.GetLanguages(org, repo, developer);
+
+            try
+            {
+                List<string> keys = await _textsService.GetKeys(org, repo, developer, languages);
+                return Ok(keys);
+            }
+            catch (IOException)
+            {
+                return NotFound($"The texts files needed to get keys does not exist.");
+            }
+            catch (JsonException)
+            {
+                return new ObjectResult(new { errorMessage = $"The format of the file, .texts.json, that you tried to access might be invalid." }) { StatusCode = 500 };
+            }
+        }
+    }
+}

--- a/src/studio/src/designer/backend/Controllers/TextKeysController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextKeysController.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Services.Interfaces;
-
+using LibGit2Sharp;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -59,7 +59,7 @@ namespace Altinn.Studio.Designer.Controllers
             {
                 return new ObjectResult(new { errorMessage = "The format of one or more texts files that you tried to access might be invalid." }) { StatusCode = 500 };
             }
-            catch (IOException)
+            catch (FileNotFoundException)
             {
                 return NotFound("The texts files needed to add key could not be found or does not exist.");
             }
@@ -91,9 +91,9 @@ namespace Altinn.Studio.Designer.Controllers
             {
                 return new ObjectResult(new { errorMessage = "The format of one or more texts files that you tried to access might be invalid." }) { StatusCode = 500 };
             }
-            catch (IOException)
+            catch (FileNotFoundException)
             {
-                return NotFound("The texts files needed to add key could not be found or does not exist.");
+                return NotFound("The texts files needed to get keys could not be found or does not exist.");
             }
         }
 
@@ -112,6 +112,7 @@ namespace Altinn.Studio.Designer.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult<KeyValuePair<string, string>>> Put(string org, string repo, [FromQuery] string oldKey, [FromQuery] string newKey)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
@@ -119,8 +120,7 @@ namespace Altinn.Studio.Designer.Controllers
 
             try
             {
-                KeyValuePair<string, string> keyValuePair =
-                    await _textsService.UpdateKey(org, repo, developer, languages, oldKey, newKey);
+                KeyValuePair<string, string> keyValuePair = await _textsService.UpdateKey(org, repo, developer, languages, oldKey, newKey);
                 return Ok(keyValuePair);
             }
             catch (JsonException)
@@ -131,7 +131,7 @@ namespace Altinn.Studio.Designer.Controllers
             {
                 return BadRequest(errorMessage);
             }
-            catch (IOException)
+            catch (FileNotFoundException)
             {
                 return NotFound("The texts files needed to update key could not be found or does not exist.");
             }

--- a/src/studio/src/designer/backend/Controllers/TextKeysController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextKeysController.cs
@@ -16,9 +16,7 @@ namespace Altinn.Studio.Designer.Controllers
     /// Controller containing actions related to text keys
     /// </summary>
     [Authorize]
-
-    // TODO: Uncomment when done with issue!!!
-    // [AutoValidateAntiforgeryToken]
+    [AutoValidateAntiforgeryToken]
     [Route("designer/api/v1/{org}/{repo}/keys")]
     public class TextKeysController : ControllerBase
     {

--- a/src/studio/src/designer/backend/Controllers/TextKeysController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextKeysController.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Altinn.Studio.Designer.Controllers
 {
     /// <summary>
-    /// Controller containing actions related to languages
+    /// Controller containing actions related to text keys
     /// </summary>
     [Authorize]
     [AutoValidateAntiforgeryToken]
@@ -23,7 +23,7 @@ namespace Altinn.Studio.Designer.Controllers
         private readonly ITextsService _textsService;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LanguagesController"/> class.
+        /// Initializes a new instance of the <see cref="TextKeysController"/> class.
         /// </summary>
         /// <param name="languagesService">The languages service.</param>
         /// <param name="textsService">The texts service.</param>
@@ -44,7 +44,6 @@ namespace Altinn.Studio.Designer.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        [Route("keys")]
         public async Task<ActionResult<List<string>>> Get(string org, string repo)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);

--- a/src/studio/src/designer/backend/Controllers/TextKeysController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextKeysController.cs
@@ -17,6 +17,7 @@ namespace Altinn.Studio.Designer.Controllers
     /// </summary>
     [Authorize]
 
+    // TODO: Uncomment when done with issue!!!
     // [AutoValidateAntiforgeryToken]
     [Route("designer/api/v1/{org}/{repo}/keys")]
     public class TextKeysController : ControllerBase
@@ -56,13 +57,13 @@ namespace Altinn.Studio.Designer.Controllers
                 List<string> keys = await _textsService.GetKeys(org, repo, developer, languages);
                 return Ok(keys);
             }
-            catch (IOException)
-            {
-                return NotFound($"The texts files needed to get keys does not exist.");
-            }
             catch (JsonException)
             {
-                return new ObjectResult(new { errorMessage = $"The format of the file, .texts.json, that you tried to access might be invalid." }) { StatusCode = 500 };
+                return new ObjectResult(new { errorMessage = "The format of one or more texts files that you tried to access might be invalid." }) { StatusCode = 500 };
+            }
+            catch (IOException)
+            {
+                return NotFound("The texts files needed to add key could not be found or does not exist.");
             }
         }
 
@@ -72,13 +73,13 @@ namespace Altinn.Studio.Designer.Controllers
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="repo">Application identifier which is unique within an organisation.</param>
         /// <param name="newKey">Key to be added to the texts files.</param>
-        /// <returns>List of keys</returns>
+        /// <returns>KeyValuePair of new key and an empty text.</returns>
         [HttpPost]
         [Produces("application/json")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<ActionResult<KeyValuePair<string, string>>> Post(string org, string repo, [FromQuery] string newKey) //fromRoute or as queryParam?
+        public async Task<ActionResult<KeyValuePair<string, string>>> Post(string org, string repo, [FromQuery] string newKey)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
             IList<string> languages = _languagesService.GetLanguages(org, repo, developer);
@@ -88,46 +89,53 @@ namespace Altinn.Studio.Designer.Controllers
                 KeyValuePair<string, string> keyValuePair = await _textsService.AddKey(org, repo, developer, languages, newKey);
                 return Ok(keyValuePair);
             }
-            catch (IOException)
-            {
-                return NotFound($"The texts files needed to get keys does not exist.");
-            }
             catch (JsonException)
             {
-                return new ObjectResult(new { errorMessage = $"The format of the file, .texts.json, that you tried to access might be invalid." }) { StatusCode = 500 };
+                return new ObjectResult(new { errorMessage = "The format of one or more texts files that you tried to access might be invalid." }) { StatusCode = 500 };
+            }
+            catch (IOException)
+            {
+                return NotFound("The texts files needed to add key could not be found or does not exist.");
             }
         }
 
         /// <summary>
         /// Endpoint for changing or deleting a single key in the texts files for all languages.
-        /// If deleting, an empty string is sent as "newKey".
+        /// If deleting, an empty string is sent as "newKey". Key and belonging value is
+        /// deleted from all texts files.
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="repo">Application identifier which is unique within an organisation.</param>
         /// <param name="oldKey">Old key to be replaced.</param>
         /// <param name="newKey">New key to replace the old.</param>
+        /// <returns>KeyValuePair of new key and belonging text.</returns>
         [HttpPut]
         [Produces("application/json")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<ActionResult<KeyValuePair<string, string>>> Put(string org, string repo, [FromQuery] string oldKey, [FromQuery] string newKey) //fromRoute or as queryParam?
+        public async Task<ActionResult<KeyValuePair<string, string>>> Put(string org, string repo, [FromQuery] string oldKey, [FromQuery] string newKey)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
             IList<string> languages = _languagesService.GetLanguages(org, repo, developer);
 
             try
             {
-                KeyValuePair<string, string> keyValuePair = await _textsService.UpdateKey(org, repo, developer, languages, oldKey, newKey);
+                KeyValuePair<string, string> keyValuePair =
+                    await _textsService.UpdateKey(org, repo, developer, languages, oldKey, newKey);
                 return Ok(keyValuePair);
-            }
-            catch (IOException)
-            {
-                return NotFound($"The texts files needed to get keys does not exist.");
             }
             catch (JsonException)
             {
-                return new ObjectResult(new { errorMessage = $"The format of the file, .texts.json, that you tried to access might be invalid." }) { StatusCode = 500 };
+                return new ObjectResult(new { errorMessage = "The format of one or more texts files that you tried to access might be invalid." }) { StatusCode = 500 };
+            }
+            catch (BadHttpRequestException errorMessage)
+            {
+                return BadRequest(errorMessage);
+            }
+            catch (IOException)
+            {
+                return NotFound("The texts files needed to update key could not be found or does not exist.");
             }
         }
     }

--- a/src/studio/src/designer/backend/Controllers/TextsController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextsController.cs
@@ -21,7 +21,8 @@ namespace Altinn.Studio.Designer.Controllers
     /// which interacts with the text files in the old format.
     /// </remarks>
     [Authorize]
-    [AutoValidateAntiforgeryToken]
+
+    // [AutoValidateAntiforgeryToken]
     [Route("designer/api/v2/{org}/{repo}/texts")]
     public class TextsController : ControllerBase
     {
@@ -136,6 +137,32 @@ namespace Altinn.Studio.Designer.Controllers
             _textsService.DeleteTexts(org, repo, developer, languageCode);
 
             return Ok($"Texts file, {languageCode}.texts.json, was successfully deleted.");
+        }
+
+        /// <summary>
+        /// Endpoint for adding a new key/textId to the keyGuidMapping file to be used across language files.
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="repo">Application identifier which is unique within an organisation.</param>
+        /// <param name="keyName">The new key, or text id, to add to the mapping file.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        [HttpPost]
+        [Produces("application/json")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [Route("newTextId/{keyName}")]
+        public async Task<ActionResult<Dictionary<string, string>>> PostKey(string org, string repo, [FromRoute] string keyName)
+        {
+            if (string.IsNullOrEmpty(keyName))
+            {
+                return BadRequest("Name of key/textId is missing from the request.");
+            }
+
+            string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
+
+            Dictionary<string, string> newKeyGuidMapping = await _textsService.AddKey(org, repo, developer, keyName);
+
+            return Ok(newKeyGuidMapping);
         }
     }
 }

--- a/src/studio/src/designer/backend/Controllers/TextsController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextsController.cs
@@ -93,16 +93,16 @@ namespace Altinn.Studio.Designer.Controllers
 
             try
             {
-                Dictionary<string, string> texts = await _textsService.GetTexts(org, repo, developer, languageCode);
-                return Ok(texts);
+                List<string> keys = await _textsService.GetKeys(org, repo, developer, languages);
+                return Ok(keys);
             }
             catch (IOException)
             {
-                return NotFound($"The texts file, {languageCode}.texts.json, that you are trying to find does not exist.");
+                return NotFound($"The texts files needed to get keys does not exist.");
             }
             catch (JsonException)
             {
-                return new ObjectResult(new { errorMessage = $"The format of the file, {languageCode}.texts.json, that you tried to access might be invalid." }) { StatusCode = 500 };
+                return new ObjectResult(new { errorMessage = $"The format of the file, .texts.json, that you tried to access might be invalid." }) { StatusCode = 500 };
             }
         }
 

--- a/src/studio/src/designer/backend/Controllers/TextsController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextsController.cs
@@ -21,8 +21,7 @@ namespace Altinn.Studio.Designer.Controllers
     /// which interacts with the text files in the old format.
     /// </remarks>
     [Authorize]
-
-    // [AutoValidateAntiforgeryToken]
+    [AutoValidateAntiforgeryToken]
     [Route("designer/api/v2/{org}/{repo}/texts")]
     public class TextsController : ControllerBase
     {

--- a/src/studio/src/designer/backend/Controllers/TextsController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextsController.cs
@@ -26,16 +26,14 @@ namespace Altinn.Studio.Designer.Controllers
     public class TextsController : ControllerBase
     {
         private readonly ITextsService _textsService;
-        private readonly ILanguagesService _languagesService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TextsController"/> class.
         /// </summary>
         /// <param name="textsService">The texts service.</param>
-        public TextsController(ITextsService textsService, ILanguagesService languagesService)
+        public TextsController(ITextsService textsService)
         {
             _textsService = textsService;
-            _languagesService = languagesService;
         }
 
         /// <summary>

--- a/src/studio/src/designer/backend/Controllers/TextsController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextsController.cs
@@ -86,7 +86,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// key:value pair with the last key:value pair</remarks>
         [HttpPut]
         [Produces("application/json")]
-        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [Route("{languageCode}")]
         public async Task<ActionResult> Put(string org, string repo, string languageCode, [FromBody] Dictionary<string, string> jsonTexts)
@@ -139,32 +139,6 @@ namespace Altinn.Studio.Designer.Controllers
             _textsService.DeleteTexts(org, repo, developer, languageCode);
 
             return Ok($"Texts file, {languageCode}.texts.json, was successfully deleted.");
-        }
-
-        /// <summary>
-        /// Endpoint for adding a new key/textId to the keyGuidMapping file to be used across language files.
-        /// </summary>
-        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
-        /// <param name="repo">Application identifier which is unique within an organisation.</param>
-        /// <param name="keyName">The new key, or text id, to add to the mapping file.</param>
-        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        [HttpPost]
-        [Produces("application/json")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [Route("newTextId/{keyName}")]
-        public async Task<ActionResult<Dictionary<string, string>>> PostKey(string org, string repo, [FromRoute] string keyName)
-        {
-            if (string.IsNullOrEmpty(keyName))
-            {
-                return BadRequest("Name of key/textId is missing from the request.");
-            }
-
-            string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
-
-            Dictionary<string, string> newKeyGuidMapping = await _textsService.AddKey(org, repo, developer, keyName);
-
-            return Ok(newKeyGuidMapping);
         }
     }
 }

--- a/src/studio/src/designer/backend/Controllers/TextsController.cs
+++ b/src/studio/src/designer/backend/Controllers/TextsController.cs
@@ -75,38 +75,6 @@ namespace Altinn.Studio.Designer.Controllers
         }
 
         /// <summary>
-        /// Endpoint for getting a list of all keys.
-        /// </summary>
-        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
-        /// <param name="repo">Application identifier which is unique within an organisation.</param>
-        /// <returns>List of keys</returns>
-        [HttpGet]
-        [Produces("application/json")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        [Route("keys")]
-        public async Task<ActionResult<List<string>>> Get(string org, string repo)
-        {
-            string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
-            IList<string> languages = _languagesService.GetLanguages(org, repo, developer);
-
-            try
-            {
-                List<string> keys = await _textsService.GetKeys(org, repo, developer, languages);
-                return Ok(keys);
-            }
-            catch (IOException)
-            {
-                return NotFound($"The texts files needed to get keys does not exist.");
-            }
-            catch (JsonException)
-            {
-                return new ObjectResult(new { errorMessage = $"The format of the file, .texts.json, that you tried to access might be invalid." }) { StatusCode = 500 };
-            }
-        }
-
-        /// <summary>
         /// Endpoint for updating a text file for a specific language.
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -30,7 +30,6 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         private const string MARKDOWN_TEXTS_FOLDER_NAME = "md/";
 
         private const string APP_METADATA_FILENAME = "applicationmetadata.json";
-        private const string KEY_GUID_MAPPER_FILENAME = "keyGuidMapper.json";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AltinnGitRepository"/> class.
@@ -399,13 +398,6 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         {
             string textsFileRelativeFilePath = Path.Combine(CONFIG_FOLDER_PATH, LANGUAGE_RESOURCE_FOLDER_NAME, MARKDOWN_TEXTS_FOLDER_NAME, fileName);
             return textsFileRelativeFilePath;
-        }
-
-        private async Task WriteSerializedJsonByRelativePathAsync(string relativeFilePath, Dictionary<string, string> jsonTexts)
-        {
-            var jsonOptions = new JsonSerializerOptions() { WriteIndented = true, Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
-            string stringTexts = System.Text.Json.JsonSerializer.Serialize(jsonTexts, jsonOptions);
-            await WriteTextByRelativePathAsync(relativeFilePath, stringTexts);
         }
 
         /// <summary>

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -314,6 +314,8 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
             }
         }
 
+        // TODO: REMOVE THIS METHOD
+
         /// <summary>
         /// Creates a guid for the new key that is added to the keyGuidMappingFile. If such file does not yet
         /// exist, it will be created and the guid and key is added.

--- a/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/src/studio/src/designer/backend/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -314,36 +314,6 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
             }
         }
 
-        // TODO: REMOVE THIS METHOD
-
-        /// <summary>
-        /// Creates a guid for the new key that is added to the keyGuidMappingFile. If such file does not yet
-        /// exist, it will be created and the guid and key is added.
-        /// </summary>
-        /// <param name="key">The new key, or text id, to add to the mapping file.</param>
-        /// <returns>The new keyGuidMapping pair as a dictionary.<see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public async Task<Dictionary<string, string>> AddKeyGuidMapping(string key)
-        {
-            string keyGuidMappingFileRelativeFilePath = Path.Combine(CONFIG_FOLDER_PATH, KEY_GUID_MAPPER_FILENAME);
-            string guid = Guid.NewGuid().ToString();
-            Dictionary<string, string> newKeyGuidMappingJson = new Dictionary<string, string>() { [guid] = key };
-
-            try
-            {
-                // ID MAY ALREADY EXIST IF USING POSTMAN ETC
-                string existingKeyGuidMapping = await ReadTextByRelativePathAsync(keyGuidMappingFileRelativeFilePath);
-                Dictionary<string, string> existingKeyGuidMappingJson = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(existingKeyGuidMapping);
-                existingKeyGuidMappingJson[guid] = key;
-                await WriteSerializedJsonByRelativePathAsync(keyGuidMappingFileRelativeFilePath, existingKeyGuidMappingJson);
-            }
-            catch (FileNotFoundException)
-            {
-                await WriteSerializedJsonByRelativePathAsync(keyGuidMappingFileRelativeFilePath, newKeyGuidMappingJson);
-            }
-
-            return newKeyGuidMappingJson;
-        }
-
         /// <summary>
         /// Save app texts to resource files
         /// </summary>

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -44,14 +44,17 @@ namespace Altinn.Studio.Designer.Services.Implementation
         }
 
         /// <inheritdoc />
-        public async Task<Dictionary<string, string>> GetKeys(string org, string repo, string developer, IList<string> languages)
+        public async Task<List<string>> GetKeys(string org, string repo, string developer, IList<string> languages)
         {
             var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
+            List<string> allKeys = new List<string>();
 
             foreach (string languageCode in languages)
             {
                 Dictionary<string, string> jsonTexts = await altinnAppGitRepository.GetTextsV2(languageCode);
-                jsonTexts.Keys;
+                allKeys.AddRange(jsonTexts.Keys.ToList().Except(allKeys));
+                Console.WriteLine("keys: " + jsonTexts.Keys.ToString());
+                Console.WriteLine("allkeys: " + allKeys.ToString());
             }
 
             throw new NotImplementedException();

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -57,7 +57,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 Console.WriteLine("allkeys: " + allKeys.ToString());
             }
 
-            throw new NotImplementedException();
+            return allKeys;
         }
 
         /// <inheritdoc />

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -53,6 +53,11 @@ namespace Altinn.Studio.Designer.Services.Implementation
         /// <inheritdoc />
         public async Task<List<string>> GetKeys(string org, string repo, string developer, IList<string> languages)
         {
+            if (languages.IsNullOrEmpty())
+            {
+                throw new FileNotFoundException();
+            }
+
             var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
             Dictionary<string, string> firstJsonTexts = await altinnAppGitRepository.GetTextsV2(languages[0]);
             languages.RemoveAt(0);
@@ -132,6 +137,11 @@ namespace Altinn.Studio.Designer.Services.Implementation
         /// <inheritdoc />
         public async Task<KeyValuePair<string, string>> AddKey(string org, string repo, string developer, IList<string> languages, string newKey)
         {
+            if (languages.IsNullOrEmpty())
+            {
+                throw new FileNotFoundException();
+            }
+
             var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
             KeyValuePair<string, string> keyValuePair = new KeyValuePair<string, string>(newKey, string.Empty);
 
@@ -154,6 +164,11 @@ namespace Altinn.Studio.Designer.Services.Implementation
         /// <inheritdoc />
         public async Task<KeyValuePair<string, string>> UpdateKey(string org, string repo, string developer, IList<string> languages, string oldKey, string newKey)
         {
+            if (languages.IsNullOrEmpty())
+            {
+                throw new FileNotFoundException();
+            }
+
             var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
             Dictionary<string, OrderedDictionary> tempUpdatedTexts = new Dictionary<string, OrderedDictionary>(languages.Count);
             KeyValuePair<string, string> keyValuePair = new KeyValuePair<string, string>(oldKey, string.Empty);

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -52,9 +52,8 @@ namespace Altinn.Studio.Designer.Services.Implementation
             foreach (string languageCode in languages)
             {
                 Dictionary<string, string> jsonTexts = await altinnAppGitRepository.GetTextsV2(languageCode);
-                allKeys.AddRange(jsonTexts.Keys.ToList().Except(allKeys));
-                Console.WriteLine("keys: " + jsonTexts.Keys.ToString());
-                Console.WriteLine("allkeys: " + allKeys.ToString());
+                IEnumerable<string> uniqueKeys = jsonTexts.Keys.ToList().Except(allKeys);
+                allKeys.AddRange(uniqueKeys);
             }
 
             return allKeys;

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -44,6 +44,20 @@ namespace Altinn.Studio.Designer.Services.Implementation
         }
 
         /// <inheritdoc />
+        public async Task<Dictionary<string, string>> GetKeys(string org, string repo, string developer, IList<string> languages)
+        {
+            var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
+
+            foreach (string languageCode in languages)
+            {
+                Dictionary<string, string> jsonTexts = await altinnAppGitRepository.GetTextsV2(languageCode);
+                jsonTexts.Keys;
+            }
+
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
         public async Task UpdateTexts(string org, string repo, string developer, string languageCode, Dictionary<string, string> jsonTexts)
         {
             var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -52,8 +52,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             foreach (string languageCode in languages)
             {
                 Dictionary<string, string> jsonTexts = await altinnAppGitRepository.GetTextsV2(languageCode);
-                IEnumerable<string> uniqueKeys = jsonTexts.Keys.ToList().Except(allKeys);
-                allKeys.AddRange(uniqueKeys);
+                allKeys = MergeKeysDeterministicResult(allKeys, jsonTexts.Keys.ToList());
             }
 
             return allKeys;
@@ -129,6 +128,23 @@ namespace Altinn.Studio.Designer.Services.Implementation
             Dictionary<string, string> newKeyGuidMapping = await altinnAppGitRepository.AddKeyGuidMapping(newKey);
 
             return newKeyGuidMapping;
+        }
+
+        private static List<string> MergeKeysDeterministicResult(List<string> currentSetOfKeys, List<string> keysToMerge)
+        {
+            foreach (string key in keysToMerge)
+            {
+                int currentPosition = 0;
+                if (currentSetOfKeys.Contains(key))
+                {
+                    currentPosition = currentSetOfKeys.IndexOf(key);
+                    break;
+                }
+
+                currentSetOfKeys.Insert(currentPosition, key);
+            }
+
+            return currentSetOfKeys;
         }
 
         /// <summary>

--- a/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
+++ b/src/studio/src/designer/backend/Services/Implementation/TextsService.cs
@@ -105,6 +105,16 @@ namespace Altinn.Studio.Designer.Services.Implementation
             }
         }
 
+        /// <inheritdoc />
+        public async Task<Dictionary<string, string>> AddKey(string org, string repo, string developer, string newKey)
+        {
+            var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
+
+            Dictionary<string, string> newKeyGuidMapping = await altinnAppGitRepository.AddKeyGuidMapping(newKey);
+
+            return newKeyGuidMapping;
+        }
+
         /// <summary>
         /// Extracts language code from path to language file.
         /// </summary>

--- a/src/studio/src/designer/backend/Services/Interfaces/ITextsService.cs
+++ b/src/studio/src/designer/backend/Services/Interfaces/ITextsService.cs
@@ -29,7 +29,7 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// <param name="developer">Username of developer</param>
         /// <param name="languages">List of languages in application</param>
         /// <returns>The text file as a dictionary with ID and text as key:value pairs</returns>
-        public Task<Dictionary<string, string>> GetKeys(string org, string repo, string developer, IList<string> languages);
+        public Task<List<string>> GetKeys(string org, string repo, string developer, IList<string> languages);
 
         /// <summary>
         /// Edit texts file for specific language by overwriting old text file.

--- a/src/studio/src/designer/backend/Services/Interfaces/ITextsService.cs
+++ b/src/studio/src/designer/backend/Services/Interfaces/ITextsService.cs
@@ -22,6 +22,16 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         public Task<Dictionary<string, string>> GetTexts(string org, string repo, string developer, string languageCode);
 
         /// <summary>
+        /// Gets all keys in use across the languages.
+        /// </summary>
+        /// <param name="org">Organisation</param>
+        /// <param name="repo">Repository</param>
+        /// <param name="developer">Username of developer</param>
+        /// <param name="languages">List of languages in application</param>
+        /// <returns>The text file as a dictionary with ID and text as key:value pairs</returns>
+        public Task<Dictionary<string, string>> GetKeys(string org, string repo, string developer, IList<string> languages);
+
+        /// <summary>
         /// Edit texts file for specific language by overwriting old text file.
         /// </summary>
         /// <param name="org">Organisation</param>

--- a/src/studio/src/designer/backend/Services/Interfaces/ITextsService.cs
+++ b/src/studio/src/designer/backend/Services/Interfaces/ITextsService.cs
@@ -47,5 +47,14 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// <param name="repo">Repository</param>
         /// <param name="developer">Username of developer</param>
         public void ConvertV1TextsToV2(string org, string repo, string developer);
+
+        /// <summary>
+        /// Adds a new key to the key-mapping file for text-ids.
+        /// </summary>
+        /// <param name="org">Organisation</param>
+        /// <param name="repo">Repository</param>
+        /// <param name="developer">Username of developer</param>
+        /// <param name="newKey">The new key to add to the file</param>
+        public Task<Dictionary<string, string>> AddKey(string org, string repo, string developer, string newKey);
     }
 }

--- a/src/studio/src/designer/backend/Services/Interfaces/ITextsService.cs
+++ b/src/studio/src/designer/backend/Services/Interfaces/ITextsService.cs
@@ -59,12 +59,24 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         public void ConvertV1TextsToV2(string org, string repo, string developer);
 
         /// <summary>
-        /// Adds a new key to the key-mapping file for text-ids.
+        /// Adds a new key to all texts files in the top of the file with empty value.
         /// </summary>
         /// <param name="org">Organisation</param>
         /// <param name="repo">Repository</param>
         /// <param name="developer">Username of developer</param>
+        /// <param name="languages">All languages that must be updated with new key</param>
         /// <param name="newKey">The new key to add to the file</param>
-        public Task<Dictionary<string, string>> AddKey(string org, string repo, string developer, string newKey);
+        public Task<KeyValuePair<string, string>> AddKey(string org, string repo, string developer, IList<string> languages, string newKey);
+
+        /// <summary>
+        /// Updates an old key to the key-mapping file for text-ids.
+        /// </summary>
+        /// <param name="org">Organisation</param>
+        /// <param name="repo">Repository</param>
+        /// <param name="developer">Username of developer</param>
+        /// <param name="languages">All languages that must be updated with new key</param>
+        /// <param name="oldKey">The old key that will be replaced</param>
+        /// <param name="newKey">The new key to replace the old</param>
+        public Task<KeyValuePair<string, string>> UpdateKey(string org, string repo, string developer, IList<string> languages, string oldKey, string newKey);
     }
 }

--- a/src/studio/src/designer/backend/Services/Interfaces/ITextsService.cs
+++ b/src/studio/src/designer/backend/Services/Interfaces/ITextsService.cs
@@ -69,7 +69,7 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         public Task<KeyValuePair<string, string>> AddKey(string org, string repo, string developer, IList<string> languages, string newKey);
 
         /// <summary>
-        /// Updates an old key to the key-mapping file for text-ids.
+        /// Updates an old key to a new key in all texts files.
         /// </summary>
         /// <param name="org">Organisation</param>
         /// <param name="repo">Repository</param>

--- a/src/studio/src/designer/backend/Services/Interfaces/ITextsService.cs
+++ b/src/studio/src/designer/backend/Services/Interfaces/ITextsService.cs
@@ -59,17 +59,8 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         public void ConvertV1TextsToV2(string org, string repo, string developer);
 
         /// <summary>
-        /// Adds a new key to all texts files in the top of the file with empty value.
-        /// </summary>
-        /// <param name="org">Organisation</param>
-        /// <param name="repo">Repository</param>
-        /// <param name="developer">Username of developer</param>
-        /// <param name="languages">All languages that must be updated with new key</param>
-        /// <param name="newKey">The new key to add to the file</param>
-        public Task<KeyValuePair<string, string>> AddKey(string org, string repo, string developer, IList<string> languages, string newKey);
-
-        /// <summary>
         /// Updates an old key to a new key in all texts files.
+        /// If 'newKey' is undefined the 'oldKey' is deleted.
         /// </summary>
         /// <param name="org">Organisation</param>
         /// <param name="repo">Repository</param>
@@ -77,6 +68,6 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// <param name="languages">All languages that must be updated with new key</param>
         /// <param name="oldKey">The old key that will be replaced</param>
         /// <param name="newKey">The new key to replace the old</param>
-        public Task<KeyValuePair<string, string>> UpdateKey(string org, string repo, string developer, IList<string> languages, string oldKey, string newKey);
+        public Task<string> UpdateKey(string org, string repo, string developer, IList<string> languages, string oldKey, string newKey);
     }
 }


### PR DESCRIPTION
## Description
- Add GET endpoint that compares all texts files in an application and returns only unique keys from all the files. The order will be the same every time.
- Add POST endpoint that adds new key to the top of all the texts-files if the key does not already exist. 
  - If the key exists in all files nothing happens.
  - If the key exist in some of the files it will keep its index while those files that lacks the key will get it added to the top of the file.
- Add PUT endpoint that updates an old keyName to a new one and keeps the index. 
  - If the old key does not exist in a specific file, nothing will happen to this file.
  - If the new key already exists in at least one of the files where the old key also exists, no keys will be changed.
  - If the new key already exists in a file where the old key does not exist, the old keys will be replaced by the new key.
  - If calling the endpoint with `newKey=` in the url request the old key is removed from all files.
 - If no texts files are found all endpoints will return 404 NotFound.
 - If one or more of the texts files needed are stored in the wrong json format all endpoints will return 500 InternalServerError.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
