### PR TITLE
TestData rewrite for LocalTest

### DIFF
--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -58,6 +58,32 @@ namespace LocalTest.Controllers
         }
 
         [AllowAnonymous]
+        public async Task<IActionResult> LocalTestUsersRaw()
+        {
+            var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
+
+            return Json(localData);
+        }
+
+        [AllowAnonymous]
+        public async Task<IActionResult> LocalTestUsers()
+        {
+            var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
+            var constructedAppData = AppTestDataModel.FromTestDataModel(localData);
+
+            return Json(constructedAppData);
+        }
+
+        [AllowAnonymous]
+        public async Task<IActionResult> LocalTestUsersRoundTrip()
+        {
+            var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
+            var constructedAppData = AppTestDataModel.FromTestDataModel(localData);
+
+            return Json(constructedAppData.GetTestDataModel());
+        }
+
+        [AllowAnonymous]
         public async Task<IActionResult> Index()
         {
             StartAppModel model = new StartAppModel();

--- a/src/development/LocalTest/Controllers/HomeController.cs
+++ b/src/development/LocalTest/Controllers/HomeController.cs
@@ -90,19 +90,19 @@ namespace LocalTest.Controllers
             try
             {
                 model.TestApps = await GetAppsList();
+                model.TestUsers = await GetTestUsersForList();
+                var defaultAuthLevel = _localPlatformSettings.LocalAppMode == "http" ? await GetAppAuthLevel(model.TestApps) : 2;
+                model.AuthenticationLevels = GetAuthenticationLevels(defaultAuthLevel);
             }
             catch (HttpRequestException e)
             {
                 model.HttpException = e;
             }
 
-            model.TestUsers = await GetTestUsersForList();
             model.AppPath = _localPlatformSettings.AppRepositoryBasePath;
             model.StaticTestDataPath = _localPlatformSettings.LocalTestingStaticTestDataPath;
             model.LocalAppUrl = _localPlatformSettings.LocalAppUrl;
-            var defaultAuthLevel = _localPlatformSettings.LocalAppMode == "http" ? await GetAppAuthLevel(model.TestApps) : 2;
             model.AppModeIsHttp = _localPlatformSettings.LocalAppMode == "http";
-            model.AuthenticationLevels = GetAuthenticationLevels(defaultAuthLevel);
             model.LocalFrontendUrl = HttpContext.Request.Cookies[FRONTEND_URL_COOKIE_NAME];
 
             if (!model.TestApps?.Any() ?? true)

--- a/src/development/LocalTest/LocalTest.csproj
+++ b/src/development/LocalTest/LocalTest.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>56f36ce2-b44b-415e-a8a5-f399a76e35b9</UserSecretsId>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/development/LocalTest/Services/Authorization/Implementation/PartiesService.cs
+++ b/src/development/LocalTest/Services/Authorization/Implementation/PartiesService.cs
@@ -1,37 +1,23 @@
+#nullable enable
 using Altinn.Platform.Authorization.Services.Interface;
 using Altinn.Platform.Register.Models;
-using LocalTest.Configuration;
-using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
+using LocalTest.Services.TestData;
 
 namespace LocalTest.Services.Authorization.Implementation
 {
     public class PartiesService : IParties
     {
-        private readonly LocalPlatformSettings _localPlatformSettings;
+        private readonly TestDataService _testDataService;
 
-        public PartiesService(IOptions<LocalPlatformSettings> localPlatformSettings)
+        public PartiesService(TestDataService testDataService)
         {
-            _localPlatformSettings = localPlatformSettings.Value;
+            _testDataService = testDataService;
         }
 
-        public Task<List<Party>> GetParties(int userId)
+        public async Task<List<Party>?> GetParties(int userId)
         {
-            string path = GetPartyListPath(userId);
-            
-            if (File.Exists(path))
-            {
-                string content = System.IO.File.ReadAllText(path);
-                List<Party> instance = (List<Party>)JsonConvert.DeserializeObject(content, typeof(List<Party>));
-                return Task.FromResult(instance);
-            }
-
-            return null;
+            var data = await _testDataService.GetTestData();
+            return data.Authorization.PartyList.TryGetValue(userId.ToString(), out var result) ? result : null;
         }
 
         public Task<bool> ValidateSelectedParty(int userId, int partyId)
@@ -39,10 +25,5 @@ namespace LocalTest.Services.Authorization.Implementation
             return Task.FromResult(true);
         }
 
-
-        private string GetPartyListPath(int userId)
-        {
-            return _localPlatformSettings.LocalTestingStaticTestDataPath + _localPlatformSettings.AuthorizationDataFolder + _localPlatformSettings.PartyListFolder + userId + ".json";
-        }
     }
 }

--- a/src/development/LocalTest/Services/Authorization/Interface/IClaims.cs
+++ b/src/development/LocalTest/Services/Authorization/Interface/IClaims.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
 using System.Security.Claims;
-using System.Threading.Tasks;
 
 namespace Altinn.Platform.Authorization.Services.Interface
 {

--- a/src/development/LocalTest/Services/Authorization/Interface/IParties.cs
+++ b/src/development/LocalTest/Services/Authorization/Interface/IParties.cs
@@ -1,6 +1,5 @@
+#nullable enable
 using Altinn.Platform.Register.Models;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Altinn.Platform.Authorization.Services.Interface
 {
@@ -14,7 +13,7 @@ namespace Altinn.Platform.Authorization.Services.Interface
         /// </summary>
         /// <param name="userId">The user id</param>
         /// <returns>list of parties that the logged in user can represent</returns>
-        Task<List<Party>> GetParties(int userId);
+        Task<List<Party>?> GetParties(int userId);
 
         /// <summary>
         /// Verifies that the selected party is contained in the user's party list

--- a/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppFile.cs
+++ b/src/development/LocalTest/Services/LocalApp/Implementation/LocalAppFile.cs
@@ -1,10 +1,7 @@
 #nullable enable
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
@@ -13,8 +10,7 @@ using Altinn.Platform.Storage.Interface.Models;
 using LocalTest.Configuration;
 using LocalTest.Helpers;
 using LocalTest.Services.LocalApp.Interface;
-using System.Net.Http;
-using System.Net;
+using LocalTest.Services.TestData;
 
 namespace LocalTest.Services.LocalApp.Implementation
 {
@@ -31,8 +27,13 @@ namespace LocalTest.Services.LocalApp.Implementation
             return await File.ReadAllTextAsync(Path.Join(GetAppPath(appId), $"App/config/authorization/policy.xml"));
         }
 
-        public async Task<Application?> GetApplicationMetadata(string appId)
+        public async Task<Application?> GetApplicationMetadata(string? appId)
         {
+            if(appId is null)
+            {
+                throw new ArgumentNullException(nameof(appId), "AppMode = file does not support null as appId");
+            }
+
             var filename = Path.Join(GetAppPath(appId), $"App/config/applicationmetadata.json");
             if (File.Exists(filename))
             {
@@ -142,5 +143,10 @@ namespace LocalTest.Services.LocalApp.Implementation
             }
         }
 
+        public Task<AppTestDataModel?> GetTestData()
+        {
+            // Not implemented, but empty result is vald, so better than NotImplementedException
+            return Task.FromResult<AppTestDataModel?>(null);
+        }
     }
 }

--- a/src/development/LocalTest/Services/LocalApp/Interface/ILocalApp.cs
+++ b/src/development/LocalTest/Services/LocalApp/Interface/ILocalApp.cs
@@ -1,8 +1,6 @@
 #nullable enable
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
+using LocalTest.Services.TestData;
 
 namespace LocalTest.Services.LocalApp.Interface
 {
@@ -10,12 +8,14 @@ namespace LocalTest.Services.LocalApp.Interface
     {
         Task<string?> GetXACMLPolicy(string appId);
 
-        Task<Application?> GetApplicationMetadata(string appId);
+        Task<Application?> GetApplicationMetadata(string? appId);
 
         Task<Dictionary<string, Application>> GetApplications();
 
         Task<TextResource?> GetTextResource(string org, string app, string language);
 
         Task<Instance?> Instantiate(string appId, Instance instance, string xmlPrefill, string xmlDataId);
+
+        Task<AppTestDataModel?> GetTestData();
     }
 }

--- a/src/development/LocalTest/Services/Profile/Interface/IUserProfiles.cs
+++ b/src/development/LocalTest/Services/Profile/Interface/IUserProfiles.cs
@@ -1,5 +1,5 @@
+#nullable enable
 using Altinn.Platform.Profile.Models;
-using System.Threading.Tasks;
 
 namespace LocalTest.Services.Profile.Interface
 {
@@ -13,6 +13,6 @@ namespace LocalTest.Services.Profile.Interface
         /// </summary>
         /// <param name="userId">The user id</param>
         /// <returns></returns>
-        Task<UserProfile> GetUser(int userId);
+        Task<UserProfile?> GetUser(int userId);
     }
 }

--- a/src/development/LocalTest/Services/Register/Implementation/OrganizationsWrapper.cs
+++ b/src/development/LocalTest/Services/Register/Implementation/OrganizationsWrapper.cs
@@ -1,10 +1,7 @@
-using System.IO;
-using System.Threading.Tasks;
+#nullable enable
 using Altinn.Platform.Register.Models;
-using LocalTest.Configuration;
 using LocalTest.Services.Register.Interface;
-using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
+using LocalTest.Services.TestData;
 
 namespace LocalTest.Services.Register.Implementation
 {
@@ -13,25 +10,18 @@ namespace LocalTest.Services.Register.Implementation
     /// </summary>
     public class OrganizationsWrapper : IOrganizations
     {
-        private readonly LocalPlatformSettings _localPlatformSettings;
+        private readonly TestDataService _testDataService;
 
-        public OrganizationsWrapper(IOptions<LocalPlatformSettings> localPlatformSettings)
+        public OrganizationsWrapper(TestDataService testDataService)
         {
-            _localPlatformSettings = localPlatformSettings.Value;
+            _testDataService = testDataService;
         }
 
         /// <inheritdoc />
-        public async Task<Organization> GetOrganization(string orgNr)
+        public async Task<Organization?> GetOrganization(string orgNr)
         {
-            Organization org = null;
-            string path = this._localPlatformSettings.LocalTestingStaticTestDataPath + "Register/Org/" + orgNr + ".json";
-            if (File.Exists(path)) // lgtm [cs/path-injection]
-            {
-                string content = File.ReadAllText(path); // lgtm [cs/path-injection]
-                org = (Organization)JsonConvert.DeserializeObject(content, typeof(Organization));
-            }
-
-            return await Task.FromResult(org);
+            var data = await _testDataService.GetTestData();
+            return data.Register.Org.TryGetValue(orgNr, out var value) ? value : null;
         }
     }
 }

--- a/src/development/LocalTest/Services/Register/Implementation/PersonsWrapper.cs
+++ b/src/development/LocalTest/Services/Register/Implementation/PersonsWrapper.cs
@@ -1,11 +1,7 @@
-using System;
-using System.IO;
-using System.Threading.Tasks;
+#nullable enable
 using Altinn.Platform.Register.Models;
-using LocalTest.Configuration;
 using LocalTest.Services.Register.Interface;
-using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
+using LocalTest.Services.TestData;
 
 namespace LocalTest.Services.Register.Implementation
 {
@@ -14,25 +10,18 @@ namespace LocalTest.Services.Register.Implementation
     /// </summary>
     public class PersonsWrapper : IPersons
     {
-        private readonly LocalPlatformSettings _localPlatformSettings;
+        private readonly TestDataService _testDataService;
 
-        public PersonsWrapper(IOptions<LocalPlatformSettings> localPlatformSettings)
+        public PersonsWrapper(TestDataService testDataService)
         {
-            _localPlatformSettings = localPlatformSettings.Value;
+            _testDataService = testDataService;
         }
 
         /// <inheritdoc />
-        public async Task<Person> GetPerson(string ssn)
+        public async Task<Person?> GetPerson(string ssn)
         {
-            Person person = null;
-            string path = this._localPlatformSettings.LocalTestingStaticTestDataPath + "Register/Person/" + ssn + ".json";
-            if (File.Exists(path))
-            {
-                string content = File.ReadAllText(path);
-                person = (Person)JsonConvert.DeserializeObject(content, typeof(Person));
-            }
-
-            return await Task.FromResult(person);
+            var data = await _testDataService.GetTestData();
+            return data.Register.Person.TryGetValue(ssn, out var value) ? value : null;
         }
     }
 }

--- a/src/development/LocalTest/Services/Register/Interface/IOrganizations.cs
+++ b/src/development/LocalTest/Services/Register/Interface/IOrganizations.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+#nullable enable
 using Altinn.Platform.Register.Models;
 
 namespace LocalTest.Services.Register.Interface
@@ -13,6 +13,6 @@ namespace LocalTest.Services.Register.Interface
         /// </summary>
         /// <param name="orgNr">The organization number</param>
         /// <returns></returns>
-        Task<Organization> GetOrganization(string orgNr);
+        Task<Organization?> GetOrganization(string orgNr);
     }
 }

--- a/src/development/LocalTest/Services/Register/Interface/IParties.cs
+++ b/src/development/LocalTest/Services/Register/Interface/IParties.cs
@@ -1,5 +1,5 @@
+#nullable enable
 using Altinn.Platform.Register.Models;
-using System.Threading.Tasks;
 
 namespace LocalTest.Services.Register.Interface
 {
@@ -13,7 +13,7 @@ namespace LocalTest.Services.Register.Interface
         /// </summary>
         /// <param name="partyId">The party id</param>
         /// <returns></returns>
-        Task<Party> GetParty(int partyId);
+        Task<Party?> GetParty(int partyId);
 
         /// <summary>
         /// Method that looks up a party id based on social security number or organisation number.
@@ -27,6 +27,6 @@ namespace LocalTest.Services.Register.Interface
         /// </summary>
         /// <param name="lookupValue">SSN or org number</param>
         /// <returns></returns>
-        Task<Party> LookupPartyBySSNOrOrgNo(string lookupValue);
+        Task<Party?> LookupPartyBySSNOrOrgNo(string lookupValue);
     }
 }

--- a/src/development/LocalTest/Services/Register/Interface/IPersons.cs
+++ b/src/development/LocalTest/Services/Register/Interface/IPersons.cs
@@ -1,5 +1,5 @@
+#nullable enable
 using Altinn.Platform.Register.Models;
-using System.Threading.Tasks;
 
 namespace LocalTest.Services.Register.Interface
 {
@@ -13,6 +13,6 @@ namespace LocalTest.Services.Register.Interface
         /// </summary>
         /// <param name="ssn">The persons ssn</param>
         /// <returns></returns>
-        Task<Person> GetPerson(string ssn);
+        Task<Person?> GetPerson(string ssn);
     }
 }

--- a/src/development/LocalTest/Services/TestData/AppTestDataModel.cs
+++ b/src/development/LocalTest/Services/TestData/AppTestDataModel.cs
@@ -1,0 +1,322 @@
+#nullable enable
+using Altinn.Platform.Authentication.Model;
+using Altinn.Platform.Profile.Models;
+using Altinn.Platform.Register.Models;
+using Authorization.Interface.Models;
+
+namespace LocalTest.Services.TestData;
+
+/// <summary>
+/// Simple model that directly matches the directory structure of the TestData folder
+/// Currently this is used internally for backwards compatibility reasons
+/// </summary>
+public class AppTestDataModel
+{
+    public List<AppTestPerson> Persons { get; set; } = default!;
+    public List<AppTestOrg> Orgs { get; set; } = default!;
+
+    public TestDataModel GetTestDataModel()
+    {
+        return new TestDataModel()
+        {
+            Authorization = GetTestDataAuthorization(),
+            Register = GetTestDataRegister(),
+            Profile = GetTestDataProfile(),
+        };
+    }
+    public TestDataRegister GetTestDataRegister()
+    {
+        var org = Orgs.Select(o => (Organization)o).ToDictionary(o => o.OrgNumber);
+        var party = GetParties();
+        var person = Persons.Select(p => (Person)p).ToDictionary(p => p.SSN);
+        return new TestDataRegister()
+        {
+            Org = org,
+            Party = party,
+            Person = person,
+        };
+    }
+
+    public TestDataProfile GetTestDataProfile()
+    {
+        var user = Persons.Select(p => p.ToUserProfile()).ToDictionary(p => p.UserId.ToString());
+
+        return new TestDataProfile()
+        {
+            User = user,
+        };
+    }
+
+    public TestDataAuthorization GetTestDataAuthorization()
+    {
+        var claims = Persons.Where(p => p.CustomClaims.Count > 0).ToDictionary(p => p.UserId.ToString(), p => p.CustomClaims);
+        var parties = GetOrgPartiesWithChildren();
+        var partyList = Persons
+            .ToDictionary(
+                p => p.UserId.ToString(),
+                p => {
+                    var partiesForUser = new List<Party>{p.ToParty()};
+                    partiesForUser.AddRange(p.PartyRoles.Keys.Select(partyId =>
+                        parties.TryGetValue(partyId.ToString(), out var value) ? value! : null!
+                    ));
+                    return partiesForUser.Where(p=>p is not null).ToList();
+                });
+        var roles = Persons.ToDictionary(p => p.UserId.ToString(), p => p.PartyRoles.ToDictionary(r => r.Key.ToString(), r => r.Value));
+
+        return new TestDataAuthorization
+        {
+            Claims = claims,
+            PartyList = partyList,
+            Roles = roles,
+        };
+    }
+
+    private Dictionary<string, Party> GetParties()
+    {
+        return Enumerable.Concat(
+                        Orgs.Select(o => o.ToParty()),
+                        Persons.Select(p => p.ToParty()))
+                    .ToDictionary(p => p.PartyId.ToString());
+    }
+    private Dictionary<string, Party> GetOrgPartiesWithChildren()
+    {
+        return Orgs.Select(p => p.ToParty(Orgs))
+                    .ToDictionary(p => p.PartyId.ToString());
+    }
+
+
+    public static AppTestDataModel FromTestDataModel(TestDataModel localData)
+    {
+        int negativePartyId = -1;
+        var constructedAppData = new AppTestDataModel()
+        {
+            Orgs = localData.Register.Org.Values.Select(org =>
+            {
+                var party = localData.Register.Party.Values.FirstOrDefault(p => p.OrgNumber == org.OrgNumber);
+                var parentParty = localData.Authorization.PartyList.Values.SelectMany(l => l).FirstOrDefault(p => p.ChildParties?.Any(cp => cp.PartyId == party?.PartyId) == true);
+                return new AppTestOrg()
+                {
+                    PartyId = party?.PartyId ?? negativePartyId--,
+                    ParentPartyId = parentParty?.PartyId,
+                    TelephoneNumber = org.TelephoneNumber,
+                    UnitStatus = org.UnitStatus,
+                    UnitType = party?.UnitType ?? org.UnitType, // These are inconsistent in the original TestData folder
+                    BusinessAddress = org.BusinessAddress,
+                    BusinessPostalCity = org.BusinessPostalCity,
+                    BusinessPostalCode = org.BusinessPostalCode,
+                    EMailAddress = org.EMailAddress,
+                    FaxNumber = org.FaxNumber,
+                    InternetAddress = org.InternetAddress,
+                    MailingAddress = org.MailingAddress,
+                    MailingPostalCity = org.MailingPostalCity,
+                    MailingPostalCode = org.MailingPostalCode,
+                    MobileNumber = org.MobileNumber,
+                    Name = org.Name,
+                    OrgNumber = org.OrgNumber,
+                };
+            }).ToList(),
+            Persons = localData.Register.Person.Values.Select(p =>
+            {
+                var party = localData.Register.Party.Values.First(party => party.SSN == p.SSN);
+                var profile = localData.Profile.User.Values.First(user => user.PartyId == party.PartyId);
+                var customClaims = localData.Authorization.Claims.TryGetValue(profile.UserId.ToString(), out var v) ? v : new();
+
+                var userRoles = localData.Authorization.Roles.TryGetValue(profile.UserId.ToString(), out var roles) ? roles : null;
+
+                return new AppTestPerson()
+                {
+
+                    PartyId = party.PartyId,
+                    AddressCity = p.AddressCity,
+                    AddressHouseLetter = p.AddressHouseLetter,
+                    AddressHouseNumber = p.AddressHouseNumber,
+                    AddressMunicipalName = p.AddressMunicipalName,
+                    AddressMunicipalNumber = p.AddressMunicipalNumber,
+                    AddressPostalCode = p.AddressPostalCode,
+                    AddressStreetName = p.AddressStreetName,
+                    Email = profile.Email,
+                    FirstName = p.FirstName,
+                    MiddleName = p.MiddleName,
+                    LastName = p.LastName,
+                    MailingAddress = p.MailingAddress,
+                    MailingPostalCity = p.MailingPostalCity,
+                    MailingPostalCode = p.MailingPostalCode,
+                    SSN = p.SSN,
+                    TelephoneNumber = p.TelephoneNumber,
+                    MobileNumber = p.MobileNumber,
+                    PartyRoles = userRoles?.ToDictionary(r => int.Parse(r.Key), r => r.Value) ?? new(),
+                    CustomClaims = customClaims,
+                    UserId = profile.UserId,
+                    Language = profile.ProfileSettingPreference?.Language,
+                    UserName = profile.UserName,
+                };
+            }).ToList(),
+        };
+        return constructedAppData;
+    }
+}
+
+public class AppTestOrg
+{
+    public int PartyId { get; set; }
+    public string OrgNumber { get; set; } = default!;
+
+    public int? ParentPartyId { get; set; }
+    public string? Name { get; set; }
+    public string? BusinessAddress { get; set; }
+    public string? BusinessPostalCity { get; set; }
+    public string? BusinessPostalCode { get; set; }
+    public string? EMailAddress { get; set; }
+    public string? FaxNumber { get; set; }
+    public string? InternetAddress { get; set; }
+    public string? MailingAddress { get; set; }
+    public string? MailingPostalCity { get; set; }
+    public string? MailingPostalCode { get; set; }
+    public string? MobileNumber { get; set; }
+    public string? TelephoneNumber { get; set; }
+    public string? UnitStatus { get; set; }
+    public string? UnitType { get; set; }
+
+    public Party ToParty(List<AppTestOrg>? potentialChildOrgs = null)
+    {
+        List<Party>? childParties = potentialChildOrgs?.Where(o=>o.ParentPartyId == PartyId).Select(o=>o.ToParty()).ToList();
+        if(childParties?.Count == 0)
+        {
+            childParties = null;
+        }
+
+        return new Party()
+        {
+            PartyId = PartyId,
+            OrgNumber = OrgNumber,
+            IsDeleted = false,
+            PartyTypeName = Altinn.Platform.Register.Enums.PartyType.Organisation, // TODO: consider supporting bankrupt
+            Name = Name,
+            ChildParties = childParties,
+            //HelperFieldsSetLater
+            // OnlyHierarchyElementWithNoAccess =
+            // Organization =
+            //RelantForPersonOnly
+            // Person =
+            // SSN =
+            //Unknown field
+            UnitType = UnitType
+        };
+    }
+    public static explicit operator Organization(AppTestOrg org) => new Organization()
+    {
+        OrgNumber = org.OrgNumber,
+        Name = org.Name,
+        BusinessAddress = org.BusinessAddress,
+        BusinessPostalCity = org.BusinessPostalCity,
+        BusinessPostalCode = org.BusinessPostalCode,
+        EMailAddress = org.EMailAddress,
+        FaxNumber = org.FaxNumber,
+        InternetAddress = org.InternetAddress,
+        MailingAddress = org.MailingAddress,
+        MailingPostalCity = org.MailingPostalCity,
+        MailingPostalCode = org.MailingPostalCode,
+        MobileNumber = org.MobileNumber,
+        TelephoneNumber = org.TelephoneNumber,
+        UnitStatus = org.UnitStatus,
+        UnitType = org.UnitType,
+    };
+}
+
+public class AppTestPerson
+{
+    public int PartyId { get; set; } = default!;
+    public string SSN { get; set; } = default!;
+    public string FirstName { get; set; } = default!;
+    public string MiddleName { get; set; } = default!;
+    public string LastName { get; set; } = default!;
+    public List<CustomClaim> CustomClaims { get; set; } = new();
+    public Dictionary<int, List<Role>> PartyRoles { get; set; } = new();
+    public string? AddressCity { get; set; }
+    public string? AddressHouseLetter { get; set; }
+    public string? AddressHouseNumber { get; set; }
+    public string? AddressMunicipalName { get; set; }
+    public string? AddressMunicipalNumber { get; set; }
+    public string? AddressPostalCode { get; set; }
+    public string? AddressStreetName { get; set; }
+    public string? MailingAddress { get; set; }
+    public string? MailingPostalCity { get; set; }
+    public string? MailingPostalCode { get; set; }
+    public string? MobileNumber { get; set; }
+    public string? TelephoneNumber { get; set; }
+    public string? Email { get; set; }
+    public int UserId { get; set; }
+    public string? Language { get; set; }
+    public string? UserName { get; set; }
+
+    public string GetFullName() => string.IsNullOrWhiteSpace(MiddleName) ? $"{FirstName} {LastName}" : $"{FirstName} {MiddleName} {LastName}";
+
+    public Party ToParty(List<AppTestOrg>? possibleChildParties = null)
+    {
+        List<Party>? childParties = null;
+        if (possibleChildParties is not null)
+        {
+            childParties = possibleChildParties.Where(o => o.ParentPartyId == PartyId).Select(o => o.ToParty()).ToList();
+            if (childParties?.Count == 0)
+            {
+                childParties = null;
+            }
+        }
+        return new Party()
+        {
+            PartyId = PartyId,
+            IsDeleted = false,
+            SSN = SSN,
+            Name = GetFullName(),
+            PartyTypeName = Altinn.Platform.Register.Enums.PartyType.Person, // TODO: consider supporting selfIdentified
+            ChildParties = childParties,
+            //HelperFieldsSetLater
+            // OnlyHierarchyElementWithNoAccess =
+            // Person =
+            //RelantForOrgOnly
+            // Organization =
+            // OrgNumber = org.OrgNumber,
+            //Unknown field
+            // UnitType =
+        };
+    }
+    public static explicit operator Person(AppTestPerson person) => new Person()
+    {
+        SSN = person.SSN,
+        Name = person.GetFullName(),
+        AddressCity = person.AddressCity,
+        AddressHouseLetter = person.AddressHouseLetter,
+        AddressHouseNumber = person.AddressHouseNumber,
+        AddressMunicipalName = person.AddressMunicipalName,
+        AddressMunicipalNumber = person.AddressMunicipalNumber,
+        AddressPostalCode = person.AddressPostalCode,
+        AddressStreetName = person.AddressStreetName,
+        FirstName = person.FirstName,
+        LastName = person.LastName,
+        MailingAddress = person.MailingAddress,
+        MailingPostalCity = person.MailingPostalCity,
+        MailingPostalCode = person.MailingPostalCode,
+        MiddleName = person.MiddleName,
+        MobileNumber = person.MobileNumber,
+        TelephoneNumber = person.TelephoneNumber,
+    };
+
+    public UserProfile ToUserProfile() => new UserProfile
+    {
+        PartyId = PartyId,
+        PhoneNumber = TelephoneNumber ?? MobileNumber,
+        Email = Email,
+        // ExternalIdentity,
+        Party = ToParty(),
+        ProfileSettingPreference = new()
+        {
+            // DoNotPromptForParty,
+            Language = Language,
+            // LanguageType,
+            // PreSelectedPartyId,
+        },
+        UserId = UserId,
+        UserName = UserName,
+        // UserType,
+    };
+}

--- a/src/development/LocalTest/Services/TestData/TestDataDiskReader.cs
+++ b/src/development/LocalTest/Services/TestData/TestDataDiskReader.cs
@@ -1,0 +1,61 @@
+#nullable enable
+using System.Text.Json;
+using Authorization.Interface.Models;
+
+namespace LocalTest.Services.TestData;
+
+public static class TestDataDiskReader
+{
+    private static JsonSerializerOptions _options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    {
+        Converters = {new System.Text.Json.Serialization.JsonStringEnumConverter()}
+    };
+
+    public static async Task<TestDataModel> ReadFromDisk(string testDataPath)
+    {
+        var testData = new TestDataModel();
+        await ReadFolderToDictionary(Path.Join(testDataPath, "authorization", "claims"), testData.Authorization.Claims);
+        await ReadRoles(testDataPath, testData);
+        await ReadFolderToDictionary(Path.Join(testDataPath, "authorization", "partyList"), testData.Authorization.PartyList);
+        await ReadFolderToDictionary(Path.Join(testDataPath, "Profile", "User"), testData.Profile.User);
+        await ReadFolderToDictionary(Path.Join(testDataPath, "Register", "Org"), testData.Register.Org);
+        await ReadFolderToDictionary(Path.Join(testDataPath, "Register", "Party"), testData.Register.Party);
+        await ReadFolderToDictionary(Path.Join(testDataPath, "Register", "Person"), testData.Register.Person);
+
+        return testData;
+    }
+
+    private static async Task ReadRoles(string testDataPath, TestDataModel testData)
+    {
+        var rolesFolder = new DirectoryInfo(Path.Join(testDataPath, "authorization", "roles"));
+        foreach (var userFolder in rolesFolder.GetDirectories())
+        {
+            var userId = userFolder.Name.Substring("User_".Length);
+            var roleDict = new Dictionary<string, List<Role>>();
+            foreach (var partiesFolder in userFolder.GetDirectories())
+            {
+                var party = partiesFolder.Name.Substring("party_".Length);
+                var fileBytes = await File.ReadAllBytesAsync(Path.Join(partiesFolder.FullName, "roles.json"));
+                var fileData = JsonSerializer.Deserialize<List<Role>>(fileBytes, _options)!;
+                roleDict[party] = fileData;
+            }
+            testData.Authorization.Roles[userId] = roleDict;
+        }
+    }
+
+    private static async Task ReadFolderToDictionary<T>(string folder, Dictionary<string, T> dict)
+    {
+        var directory = new DirectoryInfo(folder);
+        var files = directory.GetFiles();
+        var loadedFiles = await Task.WhenAll(files.Select(async file =>
+        {
+            var fileBytes = await File.ReadAllBytesAsync(file.FullName);
+            var fileData = JsonSerializer.Deserialize<T>(fileBytes, _options);
+            return KeyValuePair.Create(Path.GetFileNameWithoutExtension(file.Name), fileData!);
+        }));
+        foreach (var (filename, fileContent) in loadedFiles)
+        {
+            dict[filename] = fileContent;
+        }
+    }
+}

--- a/src/development/LocalTest/Services/TestData/TestDataModel.cs
+++ b/src/development/LocalTest/Services/TestData/TestDataModel.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using Altinn.Platform.Authentication.Model;
+using Altinn.Platform.Profile.Models;
+using Altinn.Platform.Register.Models;
+using Authorization.Interface.Models;
+
+namespace LocalTest.Services.TestData;
+
+/// <summary>
+/// Simple model that directly matches the directory structure of the TestData folder
+/// Currently this is used internally for backwards compatibility reasons
+/// </summary>
+public class TestDataModel
+{
+    public TestDataAuthorization Authorization { get; set; } = new();
+    public TestDataProfile Profile { get; set; } = new();
+    public TestDataRegister Register { get; set; } = new();
+}
+
+public class TestDataAuthorization
+{
+    public Dictionary<string, List<CustomClaim>> Claims { get; set; } = new();
+    public Dictionary<string, List<Party>> PartyList { get; set; } = new();
+    public Dictionary<string, Dictionary<string, List<Role>>> Roles { get; set; } = new();
+
+}
+
+public class TestDataProfile
+{
+    public Dictionary<string, UserProfile> User { get; set; } = new();
+}
+
+public class TestDataRegister
+{
+    public Dictionary<string, Organization> Org { get; set; } = new();
+    public Dictionary<string, Party> Party { get; set; } = new();
+    public Dictionary<string, Person> Person { get; set; } = new();
+}

--- a/src/development/LocalTest/Services/TestData/TestDataService.cs
+++ b/src/development/LocalTest/Services/TestData/TestDataService.cs
@@ -1,0 +1,33 @@
+#nullable enable
+using LocalTest.Configuration;
+using LocalTest.Services.LocalApp.Interface;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace LocalTest.Services.TestData;
+
+public class TestDataService
+{
+    private readonly ILocalApp _localApp;
+    private readonly LocalPlatformSettings _settings;
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<TestDataService> _logger;
+    public TestDataService(ILocalApp localApp, IOptions<LocalPlatformSettings> settings, IMemoryCache memoryCache, ILogger<TestDataService> logger)
+    {
+        _cache = memoryCache;
+        _localApp = localApp;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    public async Task<TestDataModel> GetTestData()
+    {
+        return await _cache.GetOrCreateAsync("TEST_DATA",
+            async (entry) =>
+            {
+                entry.SlidingExpiration = TimeSpan.FromSeconds(5);
+                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(30);
+                return await TestDataDiskReader.ReadFromDisk(_settings.LocalTestingStaticTestDataPath);
+            });
+    }
+}

--- a/src/development/LocalTest/Services/TestData/TestDataService.cs
+++ b/src/development/LocalTest/Services/TestData/TestDataService.cs
@@ -27,6 +27,21 @@ public class TestDataService
             {
                 entry.SlidingExpiration = TimeSpan.FromSeconds(5);
                 entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(30);
+
+                try
+                {
+                    var appData = await _localApp.GetTestData();
+
+                    if (appData is not null)
+                    {
+                        return appData.GetTestDataModel();
+                    }
+                }
+                catch (HttpRequestException e)
+                {
+                    _logger.LogInformation(e, "Fetching Test data from app failed.");
+                }
+
                 return await TestDataDiskReader.ReadFromDisk(_settings.LocalTestingStaticTestDataPath);
             });
     }

--- a/src/development/LocalTest/Startup.cs
+++ b/src/development/LocalTest/Startup.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json.Serialization;
 
@@ -36,6 +35,7 @@ using LocalTest.Services.Profile.Interface;
 using LocalTest.Services.Register.Implementation;
 using LocalTest.Services.Register.Interface;
 using LocalTest.Services.Storage.Implementation;
+using LocalTest.Services.TestData;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -103,6 +103,7 @@ namespace LocalTest
             services.AddTransient<IAuthorizationHandler, AppAccessHandler>();
             services.AddTransient<IAuthorizationHandler, ScopeAccessHandler>();
             services.AddTransient<IPersonLookup, PersonLookupService>();
+            services.AddTransient<TestDataService>();
 
             services.AddSingleton<IContextHandler, ContextHandler>();
             services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPoint>();

--- a/src/development/LocalTest/Startup.cs
+++ b/src/development/LocalTest/Startup.cs
@@ -69,6 +69,7 @@ namespace LocalTest
             services.AddControllers().AddJsonOptions(opt =>
             {
                 opt.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                opt.JsonSerializerOptions.WriteIndented = true;
             });
 
             services.Configure<Altinn.Common.PEP.Configuration.PepSettings>(Configuration.GetSection("PepSettings"));


### PR DESCRIPTION
Continuing on the work from #9179, I obviously wanted to load TestData from the app, so that apps can have their custom userbase, with correct info for what they really want to test. (eg custom roles..., specific organisations...)

### Main components
* `TestDataModel`: In memory representation of all the content of the current file structure
* `AppTestDataModel`: New simplified structure without data duplication (just `"persons"` and `"orgs"`). Also includes converters to and from `TestDataModel`, so I could verify correctness.
* Json schema for `AppTestDataModel`  https://github.com/Altinn/altinn-cdn/pull/118
* Logic in `LocalAppHttp` to fetch test users from the `wwwroot/testData.json` of the app on the url `{applicationmetadata.Id}/testData.json`. I don't see how to use this with `LocalAppFile`, because you typically don't know what appId is doing tasks with users.

Suggestions on naming very welcome!!

### Details and verification
The current layout of `TestData/` is really hard to edit. (I found a few inconsistencies where data is entered differently in multiple files). There would also need to be some logic in app-lib-dotnet, in order to read 53 files without an index. I created a new format with all the repetition removed and everything in a single file, and suggest this as the data format for apps specific userdata.

Verification of this kind of changes is pretty hard, so I had to make some tools to help me. The work in #9179 isn't very complicated, so I used that as a basis, and wrote converters to and from my new format, and 
compared the results. To facilitate this, I added 3 new endpoints in the home controller.

1. http://localhost:5101/home/LocalTestUsersRaw to see the raw datastructure from reading the 53 files.
2. http://localhost:5101/home/LocalTestUsers to see the generated new format
3. http://localhost:5101/home/LocalTestUsersRoundTrip to see the raw datastructure regenerated from the new format

See [SamplesLocalTestUsers.zip](https://github.com/Altinn/altinn-studio/files/10133002/SamplesLocalTestUsers.zip), If you don't want to build and run. There are some minor differences between the round trip data, and original, but I think those are errors in the dataset.

