### PR TITLE
Change text from "Save" to "Generate models"

### DIFF
--- a/src/studio/src/designer/frontend/language/src/en.json
+++ b/src/studio/src/designer/frontend/language/src/en.json
@@ -411,6 +411,7 @@
   "schema_editor.format_uri-reference": "URI or relative reference",
   "schema_editor.format_uri-template": "URI template",
   "schema_editor.format_uuid": "UUID",
+  "schema_editor.generate_model_files": "Generate models",
   "schema_editor.go_to_type": "Go to type",
   "schema_editor.import": "Import",
   "schema_editor.info_dialog_1": "Welcome to the new data models page. You can upload XSD datamodels here like before.",

--- a/src/studio/src/designer/frontend/language/src/nb.json
+++ b/src/studio/src/designer/frontend/language/src/nb.json
@@ -436,6 +436,7 @@
   "schema_editor.format_uri-reference": "URI eller relativ referanse",
   "schema_editor.format_uri-template": "URI-mal",
   "schema_editor.format_uuid": "UUID",
+  "schema_editor.generate_model_files": "Generer modeller",
   "schema_editor.go_to_type": "Gå til type",
   "schema_editor.import": "Importer",
   "schema_editor.info_dialog_1": "Velkommen til den nye siden for datamodellering. Her kan du laste opp XSD datamodell som før.",

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TopToolbar.test.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TopToolbar.test.tsx
@@ -32,9 +32,7 @@ test('handles a click on the save button', async () => {
   const { saveAction, user } = renderToolbar(<></>);
   const topToolbar = screen.getByRole('toolbar');
   expect(topToolbar).toBeDefined();
-  const saveButton = screen.getByRole('button', {
-    name: 'save_data_model',
-  });
+  const saveButton = screen.getByTestId('save-model-button');
   expect(saveButton).toBeDefined();
   await user.click(saveButton);
   expect(saveAction).toBeCalledTimes(1);

--- a/src/studio/src/designer/frontend/packages/schema-editor/src/components/TopToolbar.tsx
+++ b/src/studio/src/designer/frontend/packages/schema-editor/src/components/TopToolbar.tsx
@@ -29,11 +29,11 @@ export function TopToolbar({
         id='save-model-button'
         onClick={saveAction || (() => undefined)}
         disabled={!editMode || !saveAction}
-        faIcon='fa fa-floppy'
+        faIcon='ai ai-document'
         iconSize={24}
         className={classes.saveButton}
       >
-        {t('save_data_model')}
+        {t('generate_model_files')}
       </TopToolbarButton>
       {toggleEditMode && (
         <ToggleButtonGroup selectedValue={editMode ? 'edit' : 'view'} onChange={toggleEditMode}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change the text on the "save" button from "Save" to "Generate models" - since we have autosave, and the button actually performs model generation.

## Related Issue(s)
- #6871 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
