### PR TITLE
9360 receipt editor navigation with query params

### DIFF
--- a/src/studio/src/designer/frontend/packages/shared/src/pure/utils.ts
+++ b/src/studio/src/designer/frontend/packages/shared/src/pure/utils.ts
@@ -1,2 +1,7 @@
 export const isNumeric = (str: string) => parseInt(str).toString() === str;
 export const deepCopy = (value: any) => JSON.parse(JSON.stringify(value));
+export const removeKey = (obj: any, key: string) => {
+  const copy = deepCopy(obj);
+  delete copy[key];
+  return copy;
+};

--- a/src/studio/src/designer/frontend/packages/ux-editor/src/App.tsx
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/App.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
 import postMessages from 'app-shared/utils/postMessages';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { ErrorMessageComponent } from './components/message/ErrorMessageComponent';
-import FormDesigner from './containers/FormDesigner';
+import { FormDesigner } from './containers/FormDesigner';
 import { FormLayoutActions } from './features/formDesigner/formLayout/formLayoutSlice';
 import { loadTextResources } from './features/appData/textResources/textResourcesSlice';
 import { fetchWidgets, fetchWidgetSettings } from './features/widgets/widgetsSlice';
@@ -10,8 +10,10 @@ import { fetchDataModel } from './features/appData/dataModel/dataModelSlice';
 import { fetchLanguage } from './features/appData/language/languageSlice';
 import { fetchRuleModel } from './features/appData/ruleModel/ruleModelSlice';
 import { fetchServiceConfiguration } from './features/serviceConfigurations/serviceConfigurationSlice';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { textResourcesPath } from 'app-shared/api-paths';
+import type { IAppState } from './types/global';
+import { deepCopy } from 'app-shared/pure';
 
 /**
  * This is the main React component responsible for controlling
@@ -22,11 +24,31 @@ import { textResourcesPath } from 'app-shared/api-paths';
 export function App() {
   const dispatch = useDispatch();
   const { org, app } = useParams();
+  const languageCode = 'nb';
+  const [searchParams, setSearchParams] = useSearchParams();
+  const layoutOrder = useSelector(
+    (state: IAppState) => state.formDesigner.layout.layoutSettings.pages.order
+  );
+  const selectedLayout = useSelector(
+    (state: IAppState) => state.formDesigner.layout.selectedLayout
+  );
+
+  // Set Layout to first layout in the page set if none is selected.
+  useEffect(() => {
+    if (!searchParams.has('layout') && layoutOrder[0]) {
+      setSearchParams({ ...deepCopy(searchParams), layout: layoutOrder[0] });
+    }
+    if (selectedLayout === 'default' && searchParams.has('layout')) {
+      dispatch(
+        FormLayoutActions.updateSelectedLayout({ selectedLayout: searchParams.get('layout') })
+      );
+    }
+  }, [dispatch, layoutOrder, searchParams, setSearchParams, selectedLayout]);
+
   useEffect(() => {
     const fetchFiles = () => {
       dispatch(fetchDataModel());
       dispatch(FormLayoutActions.fetchFormLayout());
-      const languageCode = 'nb';
       dispatch(loadTextResources({ url: textResourcesPath(org, app, languageCode) }));
       dispatch(fetchServiceConfiguration());
       dispatch(fetchRuleModel());

--- a/src/studio/src/designer/frontend/packages/ux-editor/src/components/rightMenu/RightMenu.tsx
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/components/rightMenu/RightMenu.tsx
@@ -9,6 +9,8 @@ import type { IAppState, LogicMode } from '../../types/global';
 import classes from './RightMenu.module.css';
 import { Add } from '@navikt/ds-icons';
 import { Button, ButtonVariant } from '@altinn/altinn-design-system';
+import { deepCopy } from 'app-shared/pure';
+import { useSearchParams } from 'react-router-dom';
 
 export interface IRightMenuProps {
   toggleFileEditor: (mode?: LogicMode) => void;
@@ -17,6 +19,7 @@ export interface IRightMenuProps {
 
 export default function RightMenu(props: IRightMenuProps) {
   const [conditionalModalOpen, setConditionalModalOpen] = React.useState<boolean>(false);
+  const [searchParams, setSearchParams] = useSearchParams();
   const [ruleModalOpen, setRuleModalOpen] = React.useState<boolean>(false);
   const layoutOrder = useSelector(
     (state: IAppState) => state.formDesigner.layout.layoutSettings.pages.order
@@ -34,6 +37,7 @@ export default function RightMenu(props: IRightMenuProps) {
   function handleAddPage() {
     const name = t('right_menu.page') + (layoutOrder.length + 1);
     dispatch(FormLayoutActions.addLayout({ layout: name }));
+    setSearchParams({ ...deepCopy(searchParams), layout: name });
   }
 
   return (
@@ -53,8 +57,7 @@ export default function RightMenu(props: IRightMenuProps) {
       </div>
       <div className={classes.headerSection}>{t('right_menu.dynamics')}</div>
       <div className={classes.contentSection}>
-        {t('right_menu.dynamics_description')}
-        &nbsp;
+        {t('right_menu.dynamics_description')}&nbsp;
         <a
           target='_blank'
           rel='noopener noreferrer'

--- a/src/studio/src/designer/frontend/packages/ux-editor/src/containers/Container.tsx
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/containers/Container.tsx
@@ -378,7 +378,7 @@ export class ContainerComponent extends Component<IContainerProps, IContainerSta
             <div className={classes.formGroupBar}>
               <Button
                 color={ButtonColor.Secondary}
-                icon={expanded ? <Collapse/> : <Expand/>}
+                icon={expanded ? <Collapse /> : <Expand />}
                 onClick={this.handleExpand}
                 variant={ButtonVariant.Quiet}
               />
@@ -500,18 +500,18 @@ export class ContainerComponent extends Component<IContainerProps, IContainerSta
   public renderHoverIcons = (): JSX.Element => (
     <>
       <Button
-        icon={<Delete/>}
+        icon={<Delete />}
         onClick={this.handleContainerDelete}
         variant={ButtonVariant.Quiet}
       />
-      <Button icon={<Edit/>} onClick={this.handleEditMode} variant={ButtonVariant.Quiet} />
+      <Button icon={<Edit />} onClick={this.handleEditMode} variant={ButtonVariant.Quiet} />
     </>
   );
 
   public renderEditIcons = (): JSX.Element => (
     <>
-      <Button icon={<Error/>} onClick={this.handleDiscard} variant={ButtonVariant.Quiet} />
-      <Button icon={<Success/>} onClick={this.handleDiscard} variant={ButtonVariant.Quiet} />
+      <Button icon={<Error />} onClick={this.handleDiscard} variant={ButtonVariant.Quiet} />
+      <Button icon={<Success />} onClick={this.handleDiscard} variant={ButtonVariant.Quiet} />
     </>
   );
 
@@ -600,16 +600,11 @@ const makeMapStateToProps = () => {
     return {
       ...props,
       activeList: state.formDesigner.layout.activeList,
-      isBaseContainer: props.isBaseContainer,
       components: GetLayoutComponentsSelector(state),
       containers: GetLayoutContainersSelector(state),
       dataModel: state.appData.dataModel.model,
       dataModelGroup: container?.dataModelGroup,
-      dispatch: props.dispatch,
-      dndEvents: props.dndEvents,
       formContainerActive: GetActiveFormContainer(state, props),
-      id: props.id,
-      index: props.index,
       itemOrder: !props.items ? itemOrder : props.items,
       language: state.appData.languageState.language,
       repeating: container?.repeating,

--- a/src/studio/src/designer/frontend/packages/ux-editor/src/containers/DesignView.tsx
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/containers/DesignView.tsx
@@ -164,6 +164,7 @@ export const DesignView = (initialState: IDesignerPreviewState) => {
   };
   const baseContainerId =
     Object.keys(state.layoutOrder).length > 0 ? Object.keys(state.layoutOrder)[0] : null;
+
   const dndEvents: EditorDndEvents = {
     moveItem,
     moveItemToBottom,

--- a/src/studio/src/designer/frontend/packages/ux-editor/src/containers/FormDesigner.tsx
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/containers/FormDesigner.tsx
@@ -16,6 +16,7 @@ import { fetchServiceConfiguration } from '../features/serviceConfigurations/ser
 import { FormLayoutActions } from '../features/formDesigner/formLayout/formLayoutSlice';
 import type { IAppState, IDataModelFieldElement, LogicMode } from '../types/global';
 import { makeGetLayoutOrderSelector } from '../selectors/getLayoutData';
+import { deepCopy } from 'app-shared/pure';
 
 const useTheme = createTheme(altinnTheme);
 
@@ -110,7 +111,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-function FormDesigner() {
+export function FormDesigner() {
   const classes = useStyles(useTheme);
   const dispatch = useDispatch();
 
@@ -163,14 +164,12 @@ function FormDesigner() {
 
   const activeList = useSelector((state: IAppState) => state.formDesigner.layout.activeList);
   const layoutOrder = useSelector((state: IAppState) =>
-    JSON.parse(
-      JSON.stringify(
-        state.formDesigner.layout.layouts[state.formDesigner.layout.selectedLayout]?.order || {}
-      )
+    deepCopy(
+      state.formDesigner.layout.layouts[state.formDesigner.layout.selectedLayout]?.order || {}
     )
   );
 
-  const order = useSelector((state: IAppState) => makeGetLayoutOrderSelector()(state));
+  const order = useSelector(makeGetLayoutOrderSelector());
 
   return (
     <DndProvider backend={HTML5Backend}>
@@ -225,5 +224,3 @@ function FormDesigner() {
     </DndProvider>
   );
 }
-
-export default FormDesigner;

--- a/src/studio/src/designer/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSagas.ts
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSagas.ts
@@ -224,7 +224,9 @@ function* fetchFormLayoutSaga(): SagaIterator {
         convertedLayouts[layoutName] = convertFromLayoutToInternalFormat(null);
       } else {
         try {
-          convertedLayouts[layoutName] = convertFromLayoutToInternalFormat(formLayouts[layoutName].data.layout);
+          convertedLayouts[layoutName] = convertFromLayoutToInternalFormat(
+            formLayouts[layoutName].data.layout
+          );
         } catch {
           invalidLayouts.push(layoutName);
         }
@@ -235,11 +237,6 @@ function* fetchFormLayoutSaga(): SagaIterator {
     FormLayoutActions.fetchFormLayoutFulfilled({
       formLayout: convertedLayouts,
       invalidLayouts,
-    })
-  );
-  yield put(
-    FormLayoutActions.updateSelectedLayout({
-      selectedLayout: Object.keys(convertedLayouts)[0],
     })
   );
   yield put(FormLayoutActions.deleteActiveListFulfilled());
@@ -441,10 +438,10 @@ export function* addLayoutSaga({ payload }: PayloadAction<IAddLayoutAction>): Sa
           selectedLayout: firstPageKey,
         })
       );
-      const hasNaviagtionButton = Object.keys(firstPage.components).some(
+      const hasNavigationButton = Object.keys(firstPage.components).some(
         (component: string) => firstPage.components[component].type === 'NavigationButtons'
       );
-      if (!hasNaviagtionButton) {
+      if (!hasNavigationButton) {
         yield put(
           FormLayoutActions.addFormComponent({
             component: { ...NavigationButtonComponent, id: uuidv4() },

--- a/src/studio/src/designer/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSlice.ts
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSlice.ts
@@ -357,16 +357,12 @@ const formLayoutSlice = createSlice({
 
         // update id in parent container order
         const selectedLayoutOrder = state.layouts[state.selectedLayout].order;
-        const parentContainer = Object.keys(selectedLayoutOrder).find((containerId) => {
-          return selectedLayoutOrder[containerId].indexOf(id) > -1;
-        });
+        const parentContainer = Object.keys(selectedLayoutOrder).find(
+          (containerId) => selectedLayoutOrder[containerId].indexOf(id) > -1
+        );
         const parentContainerOrder = selectedLayoutOrder[parentContainer];
         const containerIndex = parentContainerOrder.indexOf(id);
         parentContainerOrder[containerIndex] = newId;
-
-        // update id of the containers order array
-        // selectedLayoutOrder[newId] = selectedLayoutOrder[id];
-        // delete selectedLayoutOrder[id];
       } else {
         selectedLayoutComponents[id] = {
           ...selectedLayoutComponents[id],
@@ -394,6 +390,7 @@ const formLayoutSlice = createSlice({
       delete state.layouts[oldName];
       const pageOrder = state.layoutSettings.pages.order;
       pageOrder[pageOrder.indexOf(oldName)] = newName;
+      state.selectedLayout = newName;
     },
     updateLayoutNameRejected: (state, action: PayloadAction<IFormDesignerActionRejected>) => {
       const { error } = action.payload;

--- a/src/studio/src/designer/frontend/packages/ux-editor/src/features/formDesigner/widgets/addWidgetsSagas.ts
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/features/formDesigner/widgets/addWidgetsSagas.ts
@@ -10,9 +10,8 @@ import type { IAppState, IFormLayout } from '../../../types/global';
 
 const selectCurrentLayoutId = (state: IAppState): string =>
   state.formDesigner.layout.selectedLayout;
-const selectCurrentLayout = (state: IAppState) => {
-  return state.formDesigner.layout.layouts[state.formDesigner.layout.selectedLayout];
-};
+const selectCurrentLayout = (state: IAppState) =>
+  state.formDesigner.layout.layouts[state.formDesigner.layout.selectedLayout];
 
 function* addWidgetSaga(action: PayloadAction<IAddWidgetAction>): SagaIterator {
   try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds query parameter navigation. Due to some heavy binding between the selectedLayout and the state we are keeping the selectedLayout in the state. This should probably be cleaned at a later point so that the current selectedLayout is something that is managed by this `layout`-query parameter in its whole.

This is a pre-requisite for adding the "Confirmation on screen"-task. As this will make it possible to work on a particular page without loosing context as we refresh the page.

## Related Issue(s)
- #9218 
- #9302 
- #9348 
- #9312 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
