### PR TITLE
Move receipt element in left menu

### DIFF
--- a/src/studio/src/designer/frontend/packages/ux-editor/src/components/leftMenu/ConfirmationPageElement.module.css
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/components/leftMenu/ConfirmationPageElement.module.css
@@ -1,7 +1,5 @@
-.warningbox {
-  padding-bottom: 10px;
-  padding-left: var(--toolbar-margin-left);
-  padding-top: 10px;
+.pageElementWrapper {
+  background-color: #E4FFF0;
 }
 
 .buttonWrapper {

--- a/src/studio/src/designer/frontend/packages/ux-editor/src/components/leftMenu/ConfirmationPageElement.tsx
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/components/leftMenu/ConfirmationPageElement.tsx
@@ -6,7 +6,6 @@ import { PageElement } from './PageElement';
 import { useDispatch, useSelector } from 'react-redux';
 import { deepCopy } from 'app-shared/pure';
 import { useSearchParams } from 'react-router-dom';
-import { Warning } from '@navikt/ds-icons';
 import classes from './ConfirmationPageElement.module.css';
 
 export function ConfirmationPageElement() {
@@ -20,12 +19,9 @@ export function ConfirmationPageElement() {
     setSearchParams({ ...deepCopy(searchParams), layout: 'Kvittering' });
   };
   return confirmationOnScreenName ? (
-      <>
-        <PageElement name={confirmationOnScreenName}/>
-        <div className={classes.warningbox}>
-          <Warning/> Denne funksjonaliteten er ennå ikke implementert i appene.
-        </div>
-      </>
+    <div className={classes.pageElementWrapper}>
+      <PageElement name={confirmationOnScreenName}/>
+    </div>
     ) : (
       <div className={classes.buttonWrapper}>
         <Button variant={ButtonVariant.Quiet} onClick={handleAddPage}>

--- a/src/studio/src/designer/frontend/packages/ux-editor/src/components/leftMenu/LeftMenu.tsx
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/components/leftMenu/LeftMenu.tsx
@@ -50,9 +50,9 @@ export const LeftMenu = () => {
     <div className={classes.pagesList}>
       <PagesContainer />
     </div>
+    {!_useIsProdHack() && <div className={classes.receipt}><ConfirmationPageElement /></div>}
     <div className={classes.toolbar}>
       {confirmationOnScreenName === selectedLayout ? <ConfPageToolbar/> : <DefaultToolbar/>}
     </div>
-    {!_useIsProdHack() && <div className={classes.receipt}><ConfirmationPageElement /></div>}
   </div>;
 };

--- a/src/studio/src/designer/frontend/packages/ux-editor/src/containers/FormDesigner.module.css
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/containers/FormDesigner.module.css
@@ -49,6 +49,10 @@
   margin: var(--margin-top) var(--margin-horizontal) 0 var(--margin-horizontal);
 }
 
+.warningMessage {
+  margin: 1rem var(--margin-horizontal);
+}
+
 .logicEditor {
   background-color: #022F5180;
   height: 100vh;

--- a/src/studio/src/designer/frontend/packages/ux-editor/src/containers/FormDesigner.tsx
+++ b/src/studio/src/designer/frontend/packages/ux-editor/src/containers/FormDesigner.tsx
@@ -13,6 +13,7 @@ import { makeGetLayoutOrderSelector } from '../selectors/getLayoutData';
 import { deepCopy } from 'app-shared/pure';
 import classes from './FormDesigner.module.css';
 import { LeftMenu } from '../components/leftMenu/LeftMenu';
+import { Warning } from '@navikt/ds-icons';
 
 export function FormDesigner() {
   const dispatch = useDispatch();
@@ -80,6 +81,11 @@ export function FormDesigner() {
           </div>
           <div className={classes.mainContent + ' ' + classes.item}>
             <h1 className={classes.pageHeader}>{selectedLayout}</h1>
+            {selectedLayout === 'Kvittering' && (
+              <p className={classes.warningMessage}>
+                <Warning/> Denne funksjonaliteten er ennå ikke implementert i appene.
+              </p>
+            )}
             <DesignView
               order={order}
               activeList={activeList}


### PR DESCRIPTION
## Description
Moved receipt element to correct place and the temporary warning to the middle section.

## Related Issue(s)
- #9218 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
