### PR TITLE
Revert "chore(deps): update dependency cypress to v12 (#9415)"

### DIFF
--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "axe-core": "4.5.2",
-    "cypress": "12.0.2",
+    "cypress": "10.11.0",
     "cypress-axe": "1.1.0",
     "cypress-plugin-tab": "1.0.5",
     "eslint": "8.29.0",

--- a/src/test/cypress/yarn.lock
+++ b/src/test/cypress/yarn.lock
@@ -620,7 +620,7 @@ __metadata:
   resolution: "cypress-studio@workspace:."
   dependencies:
     axe-core: 4.5.2
-    cypress: 12.0.2
+    cypress: 10.11.0
     cypress-axe: 1.1.0
     cypress-plugin-tab: 1.0.5
     eslint: 8.29.0
@@ -632,9 +632,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"cypress@npm:12.0.2":
-  version: 12.0.2
-  resolution: "cypress@npm:12.0.2"
+"cypress@npm:10.11.0":
+  version: 10.11.0
+  resolution: "cypress@npm:10.11.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -680,7 +680,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: 9b5394749cd8363a62554fe03d64329c906df5ccf5f0f2899b68678c7c51eef0acf91d2b93c5ade8312e803d92f7972ef3265a489ab9caaf1a4100b731b9fee3
+  checksum: 938cc6a20f7eeace5c8e850d234904ee1651cbb36d94666fe600cf17ce964e73d4f7d8d944aab677491702a57364e6aceeb4fe8bcbd96147ff5e2b575a956fb2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This reverts commit a1a0fdec637ef7879c2baa6444276aec96fc6237.

## Description
Usecase tests failed with this update.
