### PR TITLE
fix: give custom keywords least priority in calculation of occurs attributes

### DIFF
--- a/src/studio/src/designer/DataModeling/Converter/Json/Strategy/GeneralJsonSchemaConverter.cs
+++ b/src/studio/src/designer/DataModeling/Converter/Json/Strategy/GeneralJsonSchemaConverter.cs
@@ -1101,7 +1101,7 @@ namespace Altinn.Studio.DataModeling.Converter.Json.Strategy
                 SetRequired(subItem, required.Contains(name));
                 SetFixed(subItem, property.Keywords.GetKeyword<ConstKeyword>());
                 SetDefault(subItem, property.Keywords.GetKeyword<DefaultKeyword>());
-                CarryOccurs(subItem, property);
+                CarryXsdOccursIfNotSet(subItem, property);
 
                 switch (subItem)
                 {
@@ -1120,19 +1120,24 @@ namespace Altinn.Studio.DataModeling.Converter.Json.Strategy
             }
         }
 
-        private static void CarryOccurs(XmlSchemaObject subItem, JsonSchema property)
+        /// <summary>
+        /// Carries explicitly defined default values for minOccurs and maxOccurs from the original xsd if they were defined.
+        /// XsdMinOccursKeyword and XsdMaxOccursKeyword have least priority so they won't be took into consideration if minOccurs and maxOccurs were previously calculated.
+        /// Example: <xsd:element name="foo" type="xsd:string" minOccurs="1" maxOccurs="1" /> Will setup minOccurs and maxOccurs to 1 and 1 respectively when converting back to xsd.
+        /// </summary>
+        private static void CarryXsdOccursIfNotSet(XmlSchemaObject subItem, JsonSchema property)
         {
             if (subItem is not XmlSchemaParticle particle)
             {
                 return;
             }
 
-            if (property.Keywords.TryGetKeyword(out XsdMinOccursKeyword minOccursKeyword))
+            if (property.Keywords.TryGetKeyword(out XsdMinOccursKeyword minOccursKeyword) && particle.MinOccursString is null)
             {
                 particle.MinOccurs = minOccursKeyword.Value;
             }
 
-            if (property.Keywords.TryGetKeyword(out XsdMaxOccursKeyword maxOccursKeyword))
+            if (property.Keywords.TryGetKeyword(out XsdMaxOccursKeyword maxOccursKeyword) && particle.MaxOccursString is null)
             {
                 particle.MaxOccursString = maxOccursKeyword.Value;
             }

--- a/src/studio/src/designer/DataModeling/Converter/Json/Strategy/GeneralJsonSchemaConverter.cs
+++ b/src/studio/src/designer/DataModeling/Converter/Json/Strategy/GeneralJsonSchemaConverter.cs
@@ -1123,7 +1123,6 @@ namespace Altinn.Studio.DataModeling.Converter.Json.Strategy
         /// <summary>
         /// Carries explicitly defined default values for minOccurs and maxOccurs from the original xsd if they were defined.
         /// XsdMinOccursKeyword and XsdMaxOccursKeyword have least priority so they won't be took into consideration if minOccurs and maxOccurs were previously calculated.
-        /// Example: <xsd:element name="foo" type="xsd:string" minOccurs="1" maxOccurs="1" /> Will setup minOccurs and maxOccurs to 1 and 1 respectively when converting back to xsd.
         /// </summary>
         private static void CarryXsdOccursIfNotSet(XmlSchemaObject subItem, JsonSchema property)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Use custom keywrods only if min/max occurs are not calculated before

## Related Issue(s)
- #9435 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
