### PR TITLE
Add support for new pdf service in localtest

### DIFF
--- a/src/development/docker-compose.yml
+++ b/src/development/docker-compose.yml
@@ -35,6 +35,16 @@ services:
       context: ./../Altinn.Platform/Altinn.Platform.PDF/
     extra_hosts:
       - "host.docker.internal:host-gateway"
+  altinn_pdf_service:
+    container_name: altinn-pdf-service
+    image: browserless/chrome:1-puppeteer-19.2.2
+    restart: always
+    networks:
+      - altinntestlocal_network
+    ports:
+      - "3000:3000"
+    extra_hosts:
+      - "${TEST_DOMAIN:-local.altinn.cloud}:host-gateway"
   altinn_localtest:
     container_name: localtest
     image: localtest:latest

--- a/src/development/docker-compose.yml
+++ b/src/development/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     networks:
       - altinntestlocal_network
     ports:
-      - "3000:3000"
+      - "5300:3000"
     extra_hosts:
       - "${TEST_DOMAIN:-local.altinn.cloud}:host-gateway"
   altinn_localtest:

--- a/src/development/loadbalancer/nginx.conf
+++ b/src/development/loadbalancer/nginx.conf
@@ -49,6 +49,10 @@ http {
         server host.docker.internal:5060;
     }
 
+    upstream pdfservice {
+        server host.docker.internal:3000;
+    }
+
     upstream accessmanagementcomp {
         server host.docker.internal:5117;
     }
@@ -94,6 +98,10 @@ http {
     location /storage/ {
 			  proxy_pass		      http://localtest/storage/;
 		}
+
+    location /pdfservice/ {
+        proxy_pass          http://pdfservice/;
+    }
 
     location /localtestresources/ {
 			  proxy_pass		      http://localtest/localtestresources/;

--- a/src/development/loadbalancer/nginx.conf
+++ b/src/development/loadbalancer/nginx.conf
@@ -50,7 +50,7 @@ http {
     }
 
     upstream pdfservice {
-        server host.docker.internal:3000;
+        server host.docker.internal:5300;
     }
 
     upstream accessmanagementcomp {


### PR DESCRIPTION
## Description
Deploy new PDF service in localtest to prepare the localtest environment for when we start working on the switch to it on app-lib-dotnet

## Related Issue(s)
- #9457 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
