### PR TITLE
Make nginx redirect localhost to studio.localhost

### DIFF
--- a/development/load-balancer/nginx.conf.conf
+++ b/development/load-balancer/nginx.conf.conf
@@ -17,6 +17,11 @@ http {
 	upstream repositories {
 		server host.docker.internal:3000;
 	}
+	server {
+		listen 80;
+		server_name localhost;
+		return 307 $scheme://studio.localhost;
+	}
 
 	server {
 	    set $dev_backend $DEVELOP_BACKEND;
@@ -24,7 +29,7 @@ http {
 	    set $dev_app_development $DEVELOP_APP_DEVELOPMENT;
 
 		listen 80;
-		server_name studio.localhost localhost;
+		server_name studio.localhost;
 
 		proxy_cookie_path ~*^/.* /;
 		proxy_redirect off;


### PR DESCRIPTION
I had to fire up altinn studio locally, to find error messages from the xsd upload functionality.

Worked fine, but I'd like to be able to write `localhost`, and get a redirect to the correct domain (not just a partially working solution where login fails).

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
