### PR TITLE
RadioButton: fallback to empty array if options is not provided as iterable

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions.tsx
@@ -101,7 +101,7 @@ export function EditOptions({
   };
 
   const handleAddOption = () => {
-    const options = [...component.options];
+    const options = [...component.options || []];
     options.push({ label: '', value: '' });
     handleComponentChange({
       ...component,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Related Issue(s)
[Switching between "Kodelister" and "Manuelt" within RadioButton destroyed "Legg til flere" button](https://github.com/Altinn/altinn-studio/issues/9505)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
