### PR TITLE
fix path to backend

### DIFF
--- a/frontend/testing/mockend/src/routes/get-preview-html.js
+++ b/frontend/testing/mockend/src/routes/get-preview-html.js
@@ -4,11 +4,9 @@ const { projectRootDir } = require('../utils');
 
 const filepath = path.resolve(
   projectRootDir(),
-  'src',
-  'studio',
-  'src',
-  'designer',
   'backend',
+  'src',
+  'Designer',
   'wwwroot',
   'designer',
   'html',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Running studio frontend locally fails because of a reference to old backend path. This PR updates the path.
