### PR TITLE
Delay replacement of [ORG] and [APP] in policy.xml

### DIFF
--- a/backend/src/Designer/Services/Implementation/AuthorizationPolicyService.cs
+++ b/backend/src/Designer/Services/Implementation/AuthorizationPolicyService.cs
@@ -45,6 +45,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             FileSystemObject policyFile = await GetAuthorizationPolicyFileFromGitea(org, app, shortCommitId);
             byte[] data = Convert.FromBase64String(policyFile.Content);
             string policyFileContent = Encoding.UTF8.GetString(data);
+            policyFileContent = policyFileContent.Replace("[ORG]", org).Replace("[APP]", app);
             await _authorizationPolicyClient.SavePolicy(org, app, policyFileContent, deploymentEnvironment);
         }
 

--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -1592,8 +1592,6 @@ namespace Altinn.Studio.Designer.Services.Implementation
             string policyPath = Path.Combine(path, _generalSettings.AuthorizationPolicyTemplate);
             string authorizationPolicyData = File.ReadAllText(policyPath, Encoding.UTF8);
 
-            // Replace "org" and "app" in the authorization policy file.
-            authorizationPolicyData = authorizationPolicyData.Replace("[ORG]", org).Replace("[APP]", app);
             File.WriteAllText(policyPath, authorizationPolicyData, Encoding.UTF8);
         }
 

--- a/src/development/LocalTest/Services/Authorization/Implementation/PolicyRetrievalPoint.cs
+++ b/src/development/LocalTest/Services/Authorization/Implementation/PolicyRetrievalPoint.cs
@@ -37,6 +37,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             var app = request.GetResourceAttributes().Attributes.Where(a => a.AttributeId.ToString() == XacmlRequestAttribute.AppAttribute).Select(a => a.AttributeValues.FirstOrDefault()).FirstOrDefault().Value;
             var org = request.GetResourceAttributes().Attributes.Where(a => a.AttributeId.ToString() == XacmlRequestAttribute.OrgAttribute).Select(a => a.AttributeValues.FirstOrDefault()).FirstOrDefault().Value;
             string policyString = await _localApp.GetXACMLPolicy($"{org}/{app}");
+            policyString = policyString.Replace("[ORG]", org).Replace("[APP]", app);
             return ParsePolicyContent(policyString);
         }
 
@@ -45,7 +46,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         {
             throw new NotImplementedException();
         }
-              
+
         public static XacmlPolicy ParsePolicyContent(string policyContent)
         {
             XacmlPolicy policy;


### PR DESCRIPTION
Working with `policy.xml` is a pain, but if we delay the replacment of `[ORG]` and `[APP]` it would be easier to rename apps and copy snippets between apps.

## Related Issue(s)
- https://github.com/Altinn/altinn-studio/issues/9461

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (must wait until deployment script is done)
