### PR TITLE
Bugfix - added label for variant-select

### DIFF
--- a/frontend/language/src/en.json
+++ b/frontend/language/src/en.json
@@ -724,7 +724,7 @@
   "ux_editor.component_paragraph": "Paragraph",
   "ux_editor.component_radio_button": "Radio Button",
   "ux_editor.component_text_area": "Long answer",
-  "ux_editor.component_information_panel": "Panel",
+  "ux_editor.component_information_panel": "Informative message",
   "ux_editor.component_unknown": "Unknown component",
   "ux_editor.conditional_rendering_connection_header": "Conditional Rendering Connections",
   "ux_editor.container_empty": "Empty, drag something in here...",
@@ -874,6 +874,7 @@
   "validation_errors.min": "Minimum valid value is {0}",
   "validation_errors.minLength": "Use {0} or more characters",
   "validation_errors.pattern": "Wrong format or value",
+  "ux_editor.choose_variant": "Choose message variant",
   "ux_editor.info": "Information",
   "ux_editor.warning": "Warning",
   "ux_editor.success": "Success"

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -756,7 +756,7 @@
   "ux_editor.component_paragraph": "Paragraf",
   "ux_editor.component_radio_button": "Radioknapp",
   "ux_editor.component_text_area": "Langt svar",
-  "ux_editor.component_information_panel": "Panel",
+  "ux_editor.component_information_panel": "Informativ melding",
   "ux_editor.component_unknown": "Ukjent komponent",
   "ux_editor.conditional_rendering_connection_header": "Betingede renderingstilkoblinger",
   "ux_editor.container_empty": "Tomt, dra noe inn her...",
@@ -910,6 +910,7 @@
   "validation_errors.min": "Minste gyldig verdi er {0}",
   "validation_errors.minLength": "Bruk {0} eller flere tegn",
   "validation_errors.pattern": "Feil format eller verdi",
+  "ux_editor.choose_variant": "Velg meldingstype",
   "ux_editor.info": "Informasjon",
   "ux_editor.warning": "Advarsel",
   "ux_editor.success": "Vellykket"

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/ComponentSpecificContent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/ComponentSpecificContent.tsx
@@ -13,7 +13,7 @@ export function ComponentSpecificContent({
   component,
   handleComponentChange
 }: IGenericEditComponent) {
-  const t = useText();
+  const translate = useText();
 
   switch (component.type) {
     case ComponentTypes.NavigationButtons:
@@ -45,8 +45,9 @@ export function ComponentSpecificContent({
     case ComponentTypes.Panel: {
       return (
         <SelectComponent
+          label={translate('ux_editor.choose_variant')}
           optionKey='variant'
-          options={[t('ux_editor.info'), t('ux_editor.warning'), t('ux_editor.success')]}
+          options={[translate('ux_editor.info'), translate('ux_editor.warning'), translate('ux_editor.success')]}
           component={component}
           handleComponentChange={handleComponentChange}
         />

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Select/SelectComponent.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Select/SelectComponent.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SelectComponent, SelectComponentProps } from './SelectComponent';
 
 const renderSelectComponent = ({
+  label,
   component,
   optionKey,
   options,
@@ -13,6 +14,7 @@ const renderSelectComponent = ({
 
   render(
     <SelectComponent
+      label={label}
       component={component}
       optionKey={optionKey}
       options={options}
@@ -23,11 +25,14 @@ const renderSelectComponent = ({
   return { user };
 };
 
-test('should render SelectComponent with 3 options', async () => {
+test('should render SelectComponent with label and 3 options', async () => {
   const { user } = renderSelectComponent({
+    label: 'Choose variant',
     optionKey: 'variant',
     options: ['success', 'error', 'warning']
   });
+
+  expect(screen.getByLabelText('Choose variant')).toBeInTheDocument();
 
   await user.click(screen.getByRole('combobox'));
   expect(screen.getAllByRole('option')).toHaveLength(3);
@@ -36,6 +41,7 @@ test('should render SelectComponent with 3 options', async () => {
 test('should be able to select option "small" and the "optionKey" should be "size"', async () => {
   const onSelectChange = jest.fn();
   const { user } = renderSelectComponent({
+    label: 'Choose size',
     optionKey: 'size',
     options: ['small', 'medium', 'large'],
     handleComponentChange: onSelectChange

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Select/SelectComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Select/SelectComponent.tsx
@@ -8,10 +8,12 @@ type Option = {
 };
 
 export interface SelectComponentProps extends IGenericEditComponent {
+  label: string;
   optionKey: string;
   options: string[];
 }
 export const SelectComponent = ({
+  label,
   component,
   optionKey,
   options,
@@ -28,7 +30,7 @@ export const SelectComponent = ({
 
   return (
     <FieldSet>
-      <Select options={mappedOptions} onChange={handleSelectChange} />
+      <Select label={label} options={mappedOptions} onChange={handleSelectChange} />
     </FieldSet>
   );
 };


### PR DESCRIPTION

## Description
Variant-select within the Informative message component did not have a label.

## Related Issue(s)
- #9521 [9521](https://github.com/Altinn/altinn-studio/issues/9521)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
