### PR TITLE
Mark persons from testUsers.json with missing ssn as selfIdentified

### DIFF
--- a/src/development/LocalTest/Services/TestData/AppTestDataModel.cs
+++ b/src/development/LocalTest/Services/TestData/AppTestDataModel.cs
@@ -190,7 +190,7 @@ public class AppTestOrg
             PartyId = PartyId,
             OrgNumber = OrgNumber,
             IsDeleted = false,
-            PartyTypeName = Altinn.Platform.Register.Enums.PartyType.Organisation, // TODO: consider supporting bankrupt
+            PartyTypeName = Altinn.Platform.Register.Enums.PartyType.Organisation, // TODO: consider supporting bankrupt or subUnit
             Name = Name,
             ChildParties = childParties,
             //HelperFieldsSetLater
@@ -266,9 +266,9 @@ public class AppTestPerson
         {
             PartyId = PartyId,
             IsDeleted = false,
-            SSN = SSN,
+            SSN = string.IsNullOrEmpty(SSN) ? null : SSN,
             Name = GetFullName(),
-            PartyTypeName = Altinn.Platform.Register.Enums.PartyType.Person, // TODO: consider supporting selfIdentified
+            PartyTypeName = string.IsNullOrEmpty(SSN) ? Altinn.Platform.Register.Enums.PartyType.SelfIdentified : Altinn.Platform.Register.Enums.PartyType.Person,
             ChildParties = childParties,
             //HelperFieldsSetLater
             // OnlyHierarchyElementWithNoAccess =


### PR DESCRIPTION
Follow-up from 
- https://github.com/Altinn/altinn-studio/pull/9342

We need to test with self-identified users, and blank `SSN` field seems like a reasonable way to do it.
cc: @akselhmadslien

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
