### PR TITLE
Check for ClassRef to set default TaskId

### DIFF
--- a/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -443,7 +443,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 application.DataTypes = new List<DataType>();
             }
 
-            DataType existingLogicElement = application.DataTypes.FirstOrDefault((d) => d.AppLogic != null);
+            DataType existingLogicElement = application.DataTypes.FirstOrDefault((d) => d.AppLogic?.ClassRef != null);
             DataType logicElement = application.DataTypes.SingleOrDefault(d => d.Id == dataTypeId);
 
             if (logicElement == null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated the check that decides if data model data type should be set with default taskId. 
The old check was outdated, resulting in data type sometimes not getting taskId set even when there were no other data types for data model defined in applicationMetadata.

Note: This change fixes something that is itself a temporary workaround. When we integrate process support in studio, setting `taskId` should be something that can be done via GUI.

## Related Issue(s)
- #9549 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
