### PR TITLE
Hide dropdown selector for app, when http only support 1 app

### DIFF
--- a/src/development/LocalTest/Models/StartAppModel.cs
+++ b/src/development/LocalTest/Models/StartAppModel.cs
@@ -83,7 +83,7 @@ namespace LocalTest.Models
         /// <summary>
         /// List of selectable Apps for dropdown
         /// </summary>
-        public IEnumerable<SelectListItem> TestApps { get; set; }
+        public List<SelectListItem> TestApps { get; set; }
 
         /// <summary>
         /// List of possible authentication levels

--- a/src/development/LocalTest/Views/Home/Index.cshtml
+++ b/src/development/LocalTest/Views/Home/Index.cshtml
@@ -73,10 +73,13 @@
         <label for="exampleInputEmail1">Select test users</label>
         @Html.DropDownListFor(model => model.UserId, Model.TestUsers, new { Class = "form-control" })
       </div>
-      <div class="form-group">
-        <label for="exampleInputEmail1">Select app to test found in @Model.AppPath</label>
-        @Html.DropDownListFor(model => model.AppPathSelection, Model.TestApps, new { Class = "form-control" })
-      </div>
+      @if(!Model.AppModeIsHttp)
+      {
+        <div class="form-group">
+          <label for="exampleInputEmail1">Select app to test found in @Model.AppPath</label>
+          @Html.DropDownListFor(model => model.AppPathSelection, Model.TestApps, new { Class = "form-control" })
+        </div>
+      }
       <div class="form-group">
         <label for="exampleInputEmail1">Select your authentication level</label>
         @Html.DropDownListFor(model => model.AuthenticationLevel, Model.AuthenticationLevels, new { Class = "form-control" })


### PR DESCRIPTION
Write the app name in the header instead
![image](https://user-images.githubusercontent.com/131616/211806889-2801772f-1787-479c-987d-c598a3c6864f.png)


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
