### PR TITLE
Fix compilation warnings in Localtest

### DIFF
--- a/src/development/LocalTest/Models/ResourceRegistry/CompetentAuthority.cs
+++ b/src/development/LocalTest/Models/ResourceRegistry/CompetentAuthority.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+#nullable enable
 
 namespace Altinn.ResourceRegistry.Core.Models
 {
@@ -14,12 +10,12 @@ namespace Altinn.ResourceRegistry.Core.Models
         /// <summary>
         /// The organization number
         /// </summary>
-        public string Organization { get; set; }
+        public string Organization { get; set; } = default!;
 
         /// <summary>
         /// The organization code
         /// </summary>
-        public string Orgcode { get; set; }
+        public string Orgcode { get; set; } = default!;
 
         /// <summary>
         /// The organization name. If not set it will be retrived from register based on Organization number

--- a/src/development/LocalTest/Models/ResourceRegistry/Keyword.cs
+++ b/src/development/LocalTest/Models/ResourceRegistry/Keyword.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Altinn.ResourceRegistry.Core.Models
+﻿namespace Altinn.ResourceRegistry.Core.Models
 {
     /// <summary>
     /// Model for defining keywords
@@ -14,7 +8,7 @@ namespace Altinn.ResourceRegistry.Core.Models
         /// <summary>
         /// The key word
         /// </summary>
-        public string Word { get; set; } 
+        public string Word { get; set; }
 
         /// <summary>
         /// Language of the key word

--- a/src/development/LocalTest/Models/ResourceRegistry/ResourceReference.cs
+++ b/src/development/LocalTest/Models/ResourceRegistry/ResourceReference.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿#nullable enable
+using System.Text.Json.Serialization;
 using Altinn.ResourceRegistry.Core.Enums;
 
 namespace Altinn.ResourceRegistry.Core.Models

--- a/src/development/LocalTest/Models/ResourceRegistry/ResourceSearch.cs
+++ b/src/development/LocalTest/Models/ResourceRegistry/ResourceSearch.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿#nullable enable
 using Altinn.ResourceRegistry.Core.Enums;
 
 namespace Altinn.ResourceRegistry.Core.Models
@@ -36,7 +32,7 @@ namespace Altinn.ResourceRegistry.Core.Models
         /// Keywords
         /// </summary>
         public string? Keyword { get; set; }
-        
+
         /// <summary>
         /// Include Expired
         /// </summary>

--- a/src/development/LocalTest/Models/ResourceRegistry/ServiceResource.cs
+++ b/src/development/LocalTest/Models/ResourceRegistry/ServiceResource.cs
@@ -1,7 +1,6 @@
+#nullable enable
 using Altinn.ResourceRegistry.Core.Enums;
 using Altinn.ResourceRegistry.Core.Models;
-using System;
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Altinn.ResourceRegistry.Models
@@ -14,37 +13,37 @@ namespace Altinn.ResourceRegistry.Models
         /// <summary>
         /// The identifier of the resource
         /// </summary>
-        public string Identifier { get; set; }
+        public string Identifier { get; set; } = default!;
 
         /// <summary>
         /// The title of service
         /// </summary>
-        public Dictionary<string, string> Title { get; set; }
+        public Dictionary<string, string> Title { get; set; } = default!;
 
         /// <summary>
         /// Description
         /// </summary>
-        public Dictionary<string, string> Description { get; set; }
+        public Dictionary<string, string> Description { get; set; } = default!;
 
         /// <summary>
         /// Description explaining the rights a recipient will receive if given access to the resource
         /// </summary>
-        public Dictionary<string, string> RightDescription { get; set;  }
+        public Dictionary<string, string> RightDescription { get; set;  } = default!;
 
         /// <summary>
         /// The homepage
         /// </summary>
-        public string Homepage { get; set; }    
+        public string Homepage { get; set; } = default!;
 
         /// <summary>
         /// The status
         /// </summary>
-        public string Status { get; set; }
+        public string Status { get; set; } = default!;
 
         /// <summary>
         /// When the resource is available from
         /// </summary>
-        public DateTime ValidFrom { get; set; } 
+        public DateTime ValidFrom { get; set; }
 
         /// <summary>
         /// When the resource is available to
@@ -54,7 +53,7 @@ namespace Altinn.ResourceRegistry.Models
         /// <summary>
         /// IsPartOf
         /// </summary>
-        public string IsPartOf { get; set; }
+        public string IsPartOf { get; set; } = default!;
 
         /// <summary>
         /// IsPublicService
@@ -69,7 +68,7 @@ namespace Altinn.ResourceRegistry.Models
         /// <summary>
         /// ResourceReference
         /// </summary>
-        public List<ResourceReference> ResourceReferences { get; set; }
+        public List<ResourceReference> ResourceReferences { get; set; } = default!;
 
         /// <summary>
         /// IsComplete
@@ -79,17 +78,17 @@ namespace Altinn.ResourceRegistry.Models
         /// <summary>
         /// HasCompetentAuthority
         /// </summary>
-        public CompetentAuthority HasCompetentAuthority { get; set; }
+        public CompetentAuthority HasCompetentAuthority { get; set; } = default!;
 
         /// <summary>
         /// Keywords
         /// </summary>
-        public List<Keyword> Keywords { get; set; }
+        public List<Keyword> Keywords { get; set; } = default!;
 
         /// <summary>
         /// Sector
         /// </summary>
-        public List<string> Sector { get; set; }
+        public List<string> Sector { get; set; } = default!;
 
         /// <summary>
         /// ResourceType

--- a/src/development/LocalTest/Services/ResourceRegistry/PolicyRepositoryMock.cs
+++ b/src/development/LocalTest/Services/ResourceRegistry/PolicyRepositoryMock.cs
@@ -7,15 +7,15 @@ namespace ResourceRegistryTest.Mocks
 {
     public class PolicyRepositoryMock : IPolicyRepository
     {
-        public async Task<Stream> GetPolicyAsync(string resourceId)
+        public Task<Stream> GetPolicyAsync(string resourceId)
         {
             resourceId = Path.Combine(GetPolicyContainerPath(), resourceId, "resourcepolicy.xml");
             if (File.Exists(resourceId))
             {
-                return new FileStream(resourceId, FileMode.Open, FileAccess.Read, FileShare.Read); 
+                return Task.FromResult((Stream)new FileStream(resourceId, FileMode.Open, FileAccess.Read, FileShare.Read));
             }
 
-            return null;
+            return Task.FromResult<Stream>(null);
         }
 
         public Task<Stream> GetPolicyVersionAsync(string filepath, string version)

--- a/src/development/LocalTest/Services/ResourceRegistry/RegisterResourceRepositoryMock.cs
+++ b/src/development/LocalTest/Services/ResourceRegistry/RegisterResourceRepositoryMock.cs
@@ -26,7 +26,7 @@ namespace ResourceRegistryTest.Mocks
             return await Task.FromResult<ServiceResource>(null);
         }
 
-        public async Task<ServiceResource> DeleteResource(string id)
+        public Task<ServiceResource> DeleteResource(string id)
         {
             throw new NotImplementedException();
         }
@@ -43,7 +43,7 @@ namespace ResourceRegistryTest.Mocks
             return null;
         }
 
-        public async Task<List<ServiceResource>> Search(ResourceSearch resourceSearch)
+        public Task<List<ServiceResource>> Search(ResourceSearch resourceSearch)
         {
             List<ServiceResource> resources = new List<ServiceResource>();
             string[] files =  Directory.GetFiles(GetResourcePath());
@@ -54,7 +54,7 @@ namespace ResourceRegistryTest.Mocks
                     try
                     {
                         string content = System.IO.File.ReadAllText(file);
-                        ServiceResource? resource = System.Text.Json.JsonSerializer.Deserialize<ServiceResource>(content, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }) as ServiceResource;
+                        var resource = System.Text.Json.JsonSerializer.Deserialize<ServiceResource>(content, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }) as ServiceResource;
                         if (resourceSearch.Id == null)
                         {
                             resources.Add(resource);
@@ -75,7 +75,7 @@ namespace ResourceRegistryTest.Mocks
                 }
             }
 
-            return resources;
+            return Task.FromResult(resources);
         }
 
         private string GetResourcePath(string id)

--- a/src/development/LocalTest/Services/ResourceRegistry/ResourceRegistryService.cs
+++ b/src/development/LocalTest/Services/ResourceRegistry/ResourceRegistryService.cs
@@ -62,7 +62,7 @@ namespace Altinn.ResourceRegistry.Core
         }
 
         /// <inheritdoc/>
-        public async Task<bool> StorePolicy(ServiceResource serviceResources, Stream fileStream)
+        public Task<bool> StorePolicy(ServiceResource serviceResources, Stream fileStream)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
It is hard to avoid introducing new build warnings, when there are existing warnings on the project. I fixed the following types of warnings in localtest:

* Make files with nullable declarations `#nullable enable` and add ` = default!;` on properties that now get warning
* Removed using statements that are not required with `implicit using`
* Remove `async` keywords on methods that does not `await`. Add `Task.FromResult()` appropriatly

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
