### PR TITLE
Fix: get default language from text-editor package when initializing.

### DIFF
--- a/frontend/app-development/features/textEditor/TextEditor.tsx
+++ b/frontend/app-development/features/textEditor/TextEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import type { LangCode, TextResourceFile } from '@altinn/text-editor';
-import { TextEditor as TextEditorImpl } from '@altinn/text-editor';
+import { TextEditor as TextEditorImpl, defaultLangCode } from '@altinn/text-editor';
 import { PanelVariant, PopoverPanel } from '@altinn/altinn-design-system';
 import { Button, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
 import { AltinnSpinner } from 'app-shared/components';
@@ -23,7 +23,7 @@ interface TextEditorProps extends React.PropsWithChildren<any> {
 }
 const storageGroupName = 'textEditorStorage';
 export const TextEditor = ({ language }: TextEditorProps) => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams({ lang: defaultLangCode });
   const selectedLangCode = searchParams.get('lang');
   const getSearchQuery = () => searchParams.get('search') || '';
   const orgApp = getOrgApp();

--- a/frontend/packages/text-editor/index.ts
+++ b/frontend/packages/text-editor/index.ts
@@ -1,2 +1,3 @@
 export { TextEditor } from './src/TextEditor';
+export { defaultLangCode } from './src/constants';
 export type { TextResourceFile, Language, LangCode, TextResourceEntry } from './src/types';

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -47,16 +47,15 @@ export const TextEditor = ({
   onAddLang,
   onDeleteLang,
 }: TextEditorProps) => {
-  const handleSelectedLangChange = (langCode: LangCode) => setSelectedLangCode(langCode);
   const { resources } = translations;
   const [textIds, setTextIds] = useState(resources.map(({ id }) => id) || []);
   const getUpdatedTexts = useCallback(() => mapTextResources(resources), [resources]);
   const [texts, setTexts] = useState(getUpdatedTexts());
   useEffect(() => {
-    if (!selectedLangCode) {
+    if (!availableLangCodes?.includes(selectedLangCode)) {
       setSelectedLangCode(defaultLangCode);
     }
-  }, [selectedLangCode, setSelectedLangCode]);
+  }, [setSelectedLangCode, selectedLangCode, availableLangCodes]);
   useEffect(() => {
     setTexts(getUpdatedTexts());
   }, [getUpdatedTexts, resources]);
@@ -89,7 +88,6 @@ export const TextEditor = ({
     mutatingIds[idx] = newId;
     setTextIds(mutatingIds);
   };
-
   const handleSearchChange = (event: any) => setSearchQuery(event.target.value);
   return (
     <div className={classes.TextEditor}>
@@ -126,7 +124,7 @@ export const TextEditor = ({
         onAddLang={onAddLang}
         onDeleteLang={onDeleteLang}
         selectedLangCode={selectedLangCode}
-        onSelectedLangChange={handleSelectedLangChange}
+        onSelectedLangChange={setSelectedLangCode}
         availableLangCodes={availableLangCodes || [defaultLangCode]}
       />
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a bug where first clicking on the "Tekst"-tab and navigating to a different tab, then navigating back resulted in an empty Text-Editor.

## Related Issue(s)
- This is the issue and the fix
