### PR TITLE
check for datamodel on open clone modal

### DIFF
--- a/frontend/packages/shared/src/version-control/CloneModal.tsx
+++ b/frontend/packages/shared/src/version-control/CloneModal.tsx
@@ -43,7 +43,7 @@ export function CloneModal(props: ICloneModalProps) {
     return () => {
       source.cancel('Component got unmounted.');
     };
-  }, [app, org]);
+  }, [app, org, props.anchorEl]);
   const t = (key: string) => getLanguageFromKey(key, props.language);
   const open = Boolean(props.anchorEl);
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Trigger check for datamodel when clone modal is opened to catch newly added data model

## Related Issue(s)
- #9317 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
