### PR TITLE
Fix partyId for new TestData users

### DIFF
--- a/src/development/TestData/authorization/partylist/1001.json
+++ b/src/development/TestData/authorization/partylist/1001.json
@@ -1,6 +1,6 @@
 [
     {
-      "partyId": "1001",
+      "partyId": "510001",
       "partyTypeName": 1,
       "ssn": "01899699552",
       "name": "Pengelens Partner",
@@ -11,4 +11,3 @@
       "childParties": null
     }
   ]
-  

--- a/src/development/TestData/authorization/partylist/1002.json
+++ b/src/development/TestData/authorization/partylist/1002.json
@@ -1,6 +1,6 @@
 [
     {
-      "partyId": "1002",
+      "partyId": "510002",
       "partyTypeName": 1,
       "ssn": "17858296439",
       "name": "Gjentagende Forelder",
@@ -11,4 +11,3 @@
       "childParties": null
     }
   ]
-  

--- a/src/development/TestData/authorization/partylist/1003.json
+++ b/src/development/TestData/authorization/partylist/1003.json
@@ -1,6 +1,6 @@
 [
     {
-      "partyId": "1003",
+      "partyId": "510003",
       "partyTypeName": 1,
       "ssn": "08829698278",
       "name": "Rik Forelder",
@@ -11,4 +11,3 @@
       "childParties": null
     }
   ]
-  


### PR DESCRIPTION
The new users added in https://github.com/Altinn/altinn-studio/pull/9092, confused `userId` with `partyId`. It causes issues for our testing that was really hard to track down. I independently discovered this issue while working on https://github.com/Altinn/altinn-studio/pull/9179, but didn't feel confident that this was actually wrong, as it didn't cause issues.

## Related Issue(s)
- https://github.com/Altinn/altinn-studio/pull/9092
cc @RonnyB71 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
