### PR TITLE
Add functionality to select the party you want to represent in LocalTest

### DIFF
--- a/src/development/LocalTest/Models/StartAppModel.cs
+++ b/src/development/LocalTest/Models/StartAppModel.cs
@@ -55,9 +55,19 @@ namespace LocalTest.Models
         public HttpRequestException HttpException { get; set; }
 
         /// <summary>
-        /// Selected userId
+        /// Selected User and party separated by "."
         /// </summary>
-        public int UserId { get; set; }
+        public string UserSelect { get; set; }
+
+        /// <summary>
+        /// The userId part of <see cref="UserSelect" />
+        /// </summary>
+        public int UserId => int.TryParse(UserSelect?.Split(".").First(), out int result) ? result : 0;
+
+        /// <summary>
+        /// The partyId part of <see cref="UserSelect" />
+        /// </summary>
+        public int PartyId => int.TryParse(UserSelect?.Split(".").Last(), out int result) ? result : 0;
 
         /// <summary>
         /// Path for the selected app

--- a/src/development/LocalTest/Views/Home/Index.cshtml
+++ b/src/development/LocalTest/Views/Home/Index.cshtml
@@ -71,7 +71,7 @@
       @Html.AntiForgeryToken();
       <div class="form-group">
         <label for="exampleInputEmail1">Select test users</label>
-        @Html.DropDownListFor(model => model.UserId, Model.TestUsers, new { Class = "form-control" })
+        @Html.DropDownListFor(model => model.UserSelect, Model.TestUsers, new { Class = "form-control" })
       </div>
       <div class="form-group">
         <label for="exampleInputEmail1">Select app to test found in @Model.AppPath</label>
@@ -84,7 +84,7 @@
       @if(Model.AppModeIsHttp)
       {
         <div class="form-group">
-          <label for="prefill">Prefill xml. The first part of the filename must be "[orgnr]." or "[fnr]." (eg. "897069631.xml" or "897069631.TST-2345.xml")</label>
+          <label for="prefill">Prefill xml (use this to copy all the values from a <a href="/LocalPlatformStorage/blobs/@(Model.Org)/@(Model.App)">previous instance</a>)</label>
           <input class="form-control" type="file" id="prefill" name="prefill" accept=".xml"/>
         </div>
       }


### PR DESCRIPTION
Selecting an org as instanceowner in Localtest is buggy and hard, because you need to somehow trigger an error to display the org selection ui. This makes testing apps that should be used by both persons and orgs hard. When uploading a prefill, it is also  inconvenient to place restrictions on the filename.

![image](https://user-images.githubusercontent.com/131616/211905011-93a797b6-2f24-432c-938d-aa1e302486d0.png)



## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
