### PR TITLE
Localtest: Sort files in directoryBrowser by LastModified

### DIFF
--- a/src/development/LocalTest/Helpers/SortedHtmlDirectoryFormatter.cs
+++ b/src/development/LocalTest/Helpers/SortedHtmlDirectoryFormatter.cs
@@ -1,0 +1,16 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
+
+namespace LocalTest.Helpers;
+
+public class SortedHtmlDirectoryFormatter : HtmlDirectoryFormatter
+{
+    public SortedHtmlDirectoryFormatter() : base(HtmlEncoder.Default) { }
+
+    public override Task GenerateContentAsync(HttpContext context, IEnumerable<IFileInfo> contents)
+    {
+        var sorted = contents.OrderByDescending(f => f.LastModified);
+        return base.GenerateContentAsync(context, sorted);
+    }
+}

--- a/src/development/LocalTest/Startup.cs
+++ b/src/development/LocalTest/Startup.cs
@@ -23,6 +23,7 @@ using AltinnCore.Authentication.Constants;
 using AltinnCore.Authentication.JwtCookie;
 using LocalTest.Clients.CdnAltinnOrgs;
 using LocalTest.Configuration;
+using LocalTest.Helpers;
 using LocalTest.Services.Authentication.Implementation;
 using LocalTest.Services.Authentication.Interface;
 using LocalTest.Services.Authorization.Implementation;
@@ -208,7 +209,8 @@ namespace LocalTest
             app.UseDirectoryBrowser(new DirectoryBrowserOptions
             {
                 FileProvider = new PhysicalFileProvider(localPlatformSettings.Value.LocalTestingStorageBasePath),
-                RequestPath = "/LocalPlatformStorage"
+                RequestPath = "/LocalPlatformStorage",
+                Formatter = new SortedHtmlDirectoryFormatter(),
             });
             app.UseStaticFiles();
 


### PR DESCRIPTION
Sorting by guid does not make any sense.

![image](https://user-images.githubusercontent.com/131616/212030405-0777a15e-5206-4e3e-ba5f-eab0642cfc63.png)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
