### PR TITLE
separate config for prod use case tests

### DIFF
--- a/frontend/testing/cypress/use-cases-prod.yaml
+++ b/frontend/testing/cypress/use-cases-prod.yaml
@@ -1,0 +1,55 @@
+pool:
+  name: altinn-vmss-testagent
+
+name: $(environment)_Studio_Usecases_$(Date:ddMMyyyy)_$(Date:HHmm)
+
+trigger: none
+
+pr: none
+
+variables:
+  cyCacheDir: "/home/AzDevOps/.cache/Cypress"
+  cypressTestDir: "$(Build.SourcesDirectory)/frontend/testing/cypress"
+
+schedules:
+- cron: "10,25,40,55 * * * *"
+  displayName: Bruksmønster
+  branches:
+    include:
+    - production
+  always: true
+
+steps:
+- task: DeleteFiles@1
+  displayName: 'Delete test results'
+  inputs:
+    SourceFolder: '$(cypressTestDir)/reports'
+    Contents: |
+      *.xml
+  condition: succeededOrFailed()
+
+- bash: |
+   yarn --immutable
+
+   yarn run cy:prunecache
+
+   yarn run cy:cachelist
+
+   yarn run cy:version
+
+   yarn run cy:verify
+
+   yarn run cy:run -s 'src/integration/usecase/usecase.js' -e environment=$(environment),useCaseUserPwd=$(userPassword)
+
+  workingDirectory: '$(cypressTestDir)'
+  displayName: 'Studio Tests'
+
+- task: PublishTestResults@2
+  displayName: 'Publish Test Results'
+  inputs:
+    testResultsFiles: '*.xml'
+    searchFolder: '$(cypressTestDir)/reports'
+    mergeTestResults: true
+    failTaskOnFailedTests: true
+    testRunTitle: '$(environment)_studio_use_cases'
+  condition: succeededOrFailed()


### PR DESCRIPTION
Add separate config for running cypress use case tests in production. 