### PR TITLE
Bug/cypress use case dev pipeline problem

### DIFF
--- a/frontend/testing/cypress/use-cases-prod.yaml
+++ b/frontend/testing/cypress/use-cases-prod.yaml
@@ -29,17 +29,13 @@ steps:
   condition: succeededOrFailed()
 
 - bash: |
-   yarn --immutable
-
-   yarn run cy:prunecache
-
-   yarn run cy:cachelist
-
-   yarn run cy:version
-
-   yarn run cy:verify
-
-   yarn run cy:run -s 'src/integration/usecase/usecase.js' -e environment=$(environment),useCaseUserPwd=$(userPassword)
+    yarn --immutable
+    npx cypress install
+    yarn run cy:prunecache
+    yarn run cy:cachelist
+    yarn run cy:version
+    yarn run cy:verify
+    yarn run cy:run -s 'src/integration/usecase/usecase.js' -e environment=$(environment),useCaseUserPwd=$(userPassword)
 
   workingDirectory: '$(cypressTestDir)'
   displayName: 'Studio Tests'

--- a/frontend/testing/cypress/use-cases.yaml
+++ b/frontend/testing/cypress/use-cases.yaml
@@ -3,8 +3,7 @@ pool:
 
 name: $(environment)_Studio_Usecases_$(Date:ddMMyyyy)_$(Date:HHmm)
 
-trigger:
-- bug/cypress-use-case-dev-pipeline-problem
+trigger: none
 
 pr: none
 

--- a/frontend/testing/cypress/use-cases.yaml
+++ b/frontend/testing/cypress/use-cases.yaml
@@ -3,7 +3,8 @@ pool:
 
 name: $(environment)_Studio_Usecases_$(Date:ddMMyyyy)_$(Date:HHmm)
 
-trigger: none
+trigger:
+- bug/cypress-use-case-dev-pipeline-problem
 
 pr: none
 
@@ -29,17 +30,13 @@ steps:
   condition: succeededOrFailed()
 
 - bash: |
-   yarn --immutable
-
-   yarn run cy:prunecache
-
-   yarn run cy:cachelist
-
-   yarn run cy:version
-
-   yarn run cy:verify
-
-   yarn run cy:run -s 'src/integration/usecase/usecase.js' -e environment=$(environment),useCaseUserPwd=$(userPassword)
+    yarn --immutable
+    npx cypress install
+    yarn run cy:prunecache
+    yarn run cy:cachelist
+    yarn run cy:version
+    yarn run cy:verify
+    yarn run cy:run -s 'src/integration/usecase/usecase.js' -e environment=$(environment),useCaseUserPwd=$(userPassword)
 
   workingDirectory: '$(cypressTestDir)'
   displayName: 'Studio Tests'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The use-case tests didn't run after updating cypress. Reason for this was probably some kind of cache that is in Azure Pipelines that manually had to be updated. `cypress install` doesn't attemt to reinstall Cypress if the command is called multiple times, so it can just be called on each run. Total runtime is still around 2 minutes, which is great anyway for a periodic job.

## Related Issue(s)
- #9344 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
