### PR TITLE
The studio crashes with a blank screen when no links to data model options are available

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/SelectDataModelComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/SelectDataModelComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Select from 'react-select';
+import { UseText } from '../../hooks';
 import type { IAppState, IDataModelFieldElement } from '../../types/global';
 
 export interface ISelectDataModelProps extends IProvidedProps {
@@ -10,9 +11,9 @@ export interface ISelectDataModelProps extends IProvidedProps {
 export interface IProvidedProps {
   selectedElement: string;
   onDataModelChange: (dataModelField: string) => void;
-  noOptionsMessage?: () => string;
+  noOptionsMessage?: string;
   hideRestrictions?: boolean;
-  language: any;
+  t: UseText;
   selectGroup?: boolean;
 }
 
@@ -49,7 +50,7 @@ export class SelectDataModel extends React.Component<ISelectDataModelProps, ISel
         <li className='a-dotted'>
           <div className='row'>
             <div className='col-12'>
-              {this.props.language['ux_editor.modal_restrictions_helper']}
+              {this.props.t('ux_editor.modal_restrictions_helper')}
             </div>
           </div>
         </li>
@@ -61,7 +62,7 @@ export class SelectDataModel extends React.Component<ISelectDataModelProps, ISel
     return Object.keys(selected.restrictions).length === 0 ? (
       <li className='a-dotted'>
         <div className='row'>
-          <div className='col-12'>{this.props.language['ux_editor.modal_restrictions_empty']}</div>
+          <div className='col-12'>{this.props.t('ux_editor.modal_restrictions_empty')}</div>
         </div>
       </li>
     ) : (
@@ -96,19 +97,21 @@ export class SelectDataModel extends React.Component<ISelectDataModelProps, ISel
         options={dataModelElementNames}
         defaultValue={{ value: selectedElement, label: selectedElement }}
         onChange={this.onDataModelChange}
-        noOptionsMessage={noOptionsMessage}
+        noOptionsMessage={(): string => noOptionsMessage}
       />
     );
   }
 }
 
-const mapStateToProps = (state: IAppState, props: IProvidedProps): ISelectDataModelProps => {
+const mapStateToProps = (
+  state: IAppState,
+  props: IProvidedProps
+): Omit<ISelectDataModelProps, 't'> => {
   return {
     selectedElement: props.selectedElement,
     onDataModelChange: props.onDataModelChange,
     noOptionsMessage: props.noOptionsMessage,
-    dataModelElements: state.appData.dataModel.model,
-    language: state.appData.languageState.language,
+    dataModelElements: state.appData.dataModel.model
   };
 };
 

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.tsx
@@ -4,7 +4,6 @@ import type { IAppState } from '../../../types/global';
 import type { IGenericEditComponent } from '../componentConfig';
 import { getMinOccursFromDataModel, getXsdDataTypeFromDataModel } from '../../../utils/datamodel';
 import { ComponentTypes } from '../../index';
-import { useText } from '../../../hooks';
 import { textSelector } from '../../../selectors/textSelectors';
 
 export interface EditDataModelBindingsProps extends IGenericEditComponent {
@@ -19,24 +18,23 @@ export interface EditDataModelBindingsProps extends IGenericEditComponent {
 export const EditDataModelBindings = ({
   component,
   handleComponentChange,
-  renderOptions,
+  renderOptions
 }: EditDataModelBindingsProps) => {
   const language = useSelector(textSelector);
   const dataModel = useSelector((state: IAppState) => state.appData.dataModel.model);
-  const t = useText();
 
   const handleDataModelChange = (selectedDataModelElement: string, key = 'simpleBinding') => {
     handleComponentChange({
       ...component,
       dataModelBindings: {
         ...component.dataModelBindings,
-        [key]: selectedDataModelElement,
+        [key]: selectedDataModelElement
       },
       required: getMinOccursFromDataModel(selectedDataModelElement, dataModel) > 0,
       timeStamp:
         component.type === ComponentTypes.Datepicker
           ? getXsdDataTypeFromDataModel(selectedDataModelElement, dataModel) === 'DateTime'
-          : undefined,
+          : undefined
     });
   };
 
@@ -44,7 +42,6 @@ export const EditDataModelBindings = ({
     dataModelBinding: component.dataModelBindings,
     onDataModelChange: handleDataModelChange,
     language,
-    t,
-    ...renderOptions,
+    ...renderOptions
   });
 };

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.tsx
@@ -18,7 +18,7 @@ export interface EditDataModelBindingsProps extends IGenericEditComponent {
 export const EditDataModelBindings = ({
   component,
   handleComponentChange,
-  renderOptions
+  renderOptions,
 }: EditDataModelBindingsProps) => {
   const language = useSelector(textSelector);
   const dataModel = useSelector((state: IAppState) => state.appData.dataModel.model);
@@ -28,13 +28,13 @@ export const EditDataModelBindings = ({
       ...component,
       dataModelBindings: {
         ...component.dataModelBindings,
-        [key]: selectedDataModelElement
+        [key]: selectedDataModelElement,
       },
       required: getMinOccursFromDataModel(selectedDataModelElement, dataModel) > 0,
       timeStamp:
         component.type === ComponentTypes.Datepicker
           ? getXsdDataTypeFromDataModel(selectedDataModelElement, dataModel) === 'DateTime'
-          : undefined
+          : undefined,
     });
   };
 
@@ -42,6 +42,6 @@ export const EditDataModelBindings = ({
     dataModelBinding: component.dataModelBindings,
     onDataModelChange: handleDataModelChange,
     language,
-    ...renderOptions
+    ...renderOptions,
   });
 };

--- a/frontend/packages/ux-editor/src/containers/Container.tsx
+++ b/frontend/packages/ux-editor/src/containers/Container.tsx
@@ -442,7 +442,6 @@ export class ContainerComponent extends Component<IContainerProps, IContainerSta
             {renderSelectGroupDataModelBinding(
               tmpContainer.dataModelBindings,
               this.handleDataModelGroupChange,
-              language,
               'group'
             )}
             <div>

--- a/frontend/packages/ux-editor/src/hooks/index.ts
+++ b/frontend/packages/ux-editor/src/hooks/index.ts
@@ -1,2 +1,2 @@
-export type { UseTextResult } from './useText';
+export type { UseText } from './useText';
 export { useText } from './useText';

--- a/frontend/packages/ux-editor/src/hooks/index.ts
+++ b/frontend/packages/ux-editor/src/hooks/index.ts
@@ -1,1 +1,2 @@
+export type { UseTextResult } from './useText';
 export { useText } from './useText';

--- a/frontend/packages/ux-editor/src/hooks/useText.ts
+++ b/frontend/packages/ux-editor/src/hooks/useText.ts
@@ -2,10 +2,8 @@ import { useSelector } from 'react-redux';
 import { textSelector } from '../selectors/textSelectors';
 import { getLanguageFromKey } from 'app-shared/utils/language';
 
-export interface UseTextResult {
-  (key: string): string;
-}
-export const useText = (): UseTextResult => {
+export type UseText = (key: string) => string;
+export const useText = (): UseText => {
   const texts = useSelector(textSelector);
   return (key: string) => getLanguageFromKey(key, texts);
 };

--- a/frontend/packages/ux-editor/src/hooks/useText.ts
+++ b/frontend/packages/ux-editor/src/hooks/useText.ts
@@ -2,7 +2,10 @@ import { useSelector } from 'react-redux';
 import { textSelector } from '../selectors/textSelectors';
 import { getLanguageFromKey } from 'app-shared/utils/language';
 
-export const useText = () => {
+export interface UseTextResult {
+  (key: string): string;
+}
+export const useText = (): UseTextResult => {
   const texts = useSelector(textSelector);
   return (key: string) => getLanguageFromKey(key, texts);
 };

--- a/frontend/packages/ux-editor/src/utils/render.tsx
+++ b/frontend/packages/ux-editor/src/utils/render.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { Typography } from '@mui/material';
 import { SelectDataModelComponent } from '../components/config/SelectDataModelComponent';
 import type { IDataModelBindings } from '../types/global';
+import { useText } from '../hooks';
+import type { UseText } from '../hooks';
+
 
 export const styles = {
   inputHelper: {
@@ -48,9 +51,7 @@ export const PropertyLabel = ({ textKey, htmlFor }: IPropertyLabelProps) => {
   );
 };
 
-export function noOptionsMessage(language: any): string {
-  return language['general.no_options'];
-}
+const getNoOptionsMessage = (t: UseText): string => t('general.no_options');
 
 export interface IRenderSelectDataModelBinding {
   dataModelBinding: IDataModelBindings;
@@ -60,10 +61,9 @@ export interface IRenderSelectDataModelBinding {
   returnValue?: any;
   key?: string;
   uniqueKey?: any;
-  t: (key: string) => any;
 }
 
-export function renderSelectDataModelBinding({
+export const renderSelectDataModelBinding = ({
   dataModelBinding,
   onDataModelChange,
   language,
@@ -71,8 +71,8 @@ export function renderSelectDataModelBinding({
   returnValue,
   key = 'simpleBinding',
   uniqueKey,
-  t,
-}: IRenderSelectDataModelBinding): JSX.Element {
+}: IRenderSelectDataModelBinding): JSX.Element => {
+  const t = useText();
   const onDMChange = (dataModelField: any) => onDataModelChange(dataModelField, returnValue);
   return (
     <div key={uniqueKey || ''}>
@@ -87,29 +87,30 @@ export function renderSelectDataModelBinding({
         selectedElement={dataModelBinding[key]}
         onDataModelChange={onDMChange}
         language={language}
-        noOptionsMessage={t('general.no_options')}
+        noOptionsMessage={(): string => getNoOptionsMessage(t)}
       />
     </div>
   );
-}
+};
 
-export function renderSelectGroupDataModelBinding(
+export const renderSelectGroupDataModelBinding = (
   dataModelBinding: IDataModelBindings,
   onDataModelChange: any,
   language: any,
-  key = 'simpleBinding',
-): JSX.Element {
+  key = 'simpleBinding'
+): JSX.Element => {
+  const t = useText();
   return (
     <div>
-      <PropertyLabel textKey={language['ux_editor.modal_properties_data_model_helper']}/>
+      <PropertyLabel textKey={language['ux_editor.modal_properties_data_model_helper']} />
 
       <SelectDataModelComponent
         selectedElement={dataModelBinding[key]}
         onDataModelChange={(dataModelField) => onDataModelChange(dataModelField, key)}
         language={language}
         selectGroup={true}
-        noOptionsMessage={() => noOptionsMessage(language)}
+        noOptionsMessage={(): string => getNoOptionsMessage(t)}
       />
     </div>
   );
-}
+};

--- a/frontend/packages/ux-editor/src/utils/render.tsx
+++ b/frontend/packages/ux-editor/src/utils/render.tsx
@@ -3,8 +3,6 @@ import { Typography } from '@mui/material';
 import { SelectDataModelComponent } from '../components/config/SelectDataModelComponent';
 import type { IDataModelBindings } from '../types/global';
 import { useText } from '../hooks';
-import type { UseText } from '../hooks';
-
 
 export const styles = {
   inputHelper: {
@@ -51,12 +49,9 @@ export const PropertyLabel = ({ textKey, htmlFor }: IPropertyLabelProps) => {
   );
 };
 
-const getNoOptionsMessage = (t: UseText): string => t('general.no_options');
-
 export interface IRenderSelectDataModelBinding {
   dataModelBinding: IDataModelBindings;
   onDataModelChange: any;
-  language: any;
   label?: string;
   returnValue?: any;
   key?: string;
@@ -66,7 +61,6 @@ export interface IRenderSelectDataModelBinding {
 export const renderSelectDataModelBinding = ({
   dataModelBinding,
   onDataModelChange,
-  language,
   label,
   returnValue,
   key = 'simpleBinding',
@@ -86,8 +80,8 @@ export const renderSelectDataModelBinding = ({
       <SelectDataModelComponent
         selectedElement={dataModelBinding[key]}
         onDataModelChange={onDMChange}
-        language={language}
-        noOptionsMessage={(): string => getNoOptionsMessage(t)}
+        t={t}
+        noOptionsMessage={t('general.no_options')}
       />
     </div>
   );
@@ -96,20 +90,19 @@ export const renderSelectDataModelBinding = ({
 export const renderSelectGroupDataModelBinding = (
   dataModelBinding: IDataModelBindings,
   onDataModelChange: any,
-  language: any,
   key = 'simpleBinding'
 ): JSX.Element => {
   const t = useText();
   return (
     <div>
-      <PropertyLabel textKey={language['ux_editor.modal_properties_data_model_helper']} />
+      <PropertyLabel textKey={t('ux_editor.modal_properties_data_model_helper')} />
 
       <SelectDataModelComponent
         selectedElement={dataModelBinding[key]}
         onDataModelChange={(dataModelField) => onDataModelChange(dataModelField, key)}
-        language={language}
+        t={t}
         selectGroup={true}
-        noOptionsMessage={(): string => getNoOptionsMessage(t)}
+        noOptionsMessage={t('general.no_options')}
       />
     </div>
   );


### PR DESCRIPTION
## Description
The studio crashes with a blank screen when no links to data model options are available. Fixed by providing the correct type to  SelectDataModelComponent.noOptionsMessage, which expected a function instead of a string.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
