### PR TITLE
1501 help tooltip found in the ui editor has some design flaws

### DIFF
--- a/frontend/packages/ux-editor/src/components/toolbar/InformationPanelComponent.module.css
+++ b/frontend/packages/ux-editor/src/components/toolbar/InformationPanelComponent.module.css
@@ -25,5 +25,5 @@
   width: 20px;
 }
 .informationIcon path {
-  fill: #17c96b;
+  fill: #0062ba;
 }

--- a/frontend/packages/ux-editor/src/components/toolbar/InformationPanelComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/toolbar/InformationPanelComponent.tsx
@@ -2,13 +2,12 @@ import React from 'react';
 import classNames from 'classnames';
 import classes from './InformationPanelComponent.module.css';
 import type { ComponentTypes } from '..';
-import { Divider } from 'app-shared/primitives';
 import { InformationColored } from '@navikt/ds-icons';
 import { Popover } from '@mui/material';
-import { SearchField } from '@altinn/altinn-design-system';
+
 import {
   getComponentHelperTextByComponentType,
-  getComponentTitleByComponentType
+  getComponentTitleByComponentType,
 } from '../../utils/language';
 
 export interface IInformationPanelProvidedProps {
@@ -26,7 +25,7 @@ export const InformationPanelComponent = ({
   language,
   onClose,
   selectedComponent,
-  thirdPartyLibrary
+  thirdPartyLibrary,
 }: IInformationPanelProvidedProps) => (
   <Popover
     anchorEl={anchorElement}
@@ -37,8 +36,6 @@ export const InformationPanelComponent = ({
     transformOrigin={{ vertical: 'top', horizontal: 'left' }}
     classes={{ paper: classNames(classes.informationPanel) }}
   >
-    <SearchField id={'component-search'} placeholder={'Søk'} />
-    <Divider />
     <div className={classNames(classes.informationPanelHeader)}>
       {getComponentTitleByComponentType(selectedComponent, language)}
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a part of the bug raid.

@Febakke new color for the icon is #0062ba as its fits better with other infopanel design we have seen in the scetches. Searchfield is removed, and links are checked and they work. We have also discussed that we want to implement at periodic test that checks all open links so that we avoid broken links in the future.

![image](https://user-images.githubusercontent.com/589907/213405477-abd5d7c7-65cb-49f0-88db-3c08ea23ea23.png)

## Related Issue(s)
- #1501 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
