### PR TITLE
File upload is not removed from both form layout and applicationmetadatajson

### DIFF
--- a/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSagas.ts
+++ b/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSagas.ts
@@ -159,6 +159,7 @@ function* deleteFormComponentsSaga({
   try {
     const { components } = payload;
     const currentLayout: IFormLayout = yield select(selectCurrentLayout);
+
     for (const id of components) {
       const component = currentLayout.components[id];
       if (component?.type === 'FileUpload') {

--- a/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSlice.ts
+++ b/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSlice.ts
@@ -217,7 +217,7 @@ const formLayoutSlice = createSlice({
             containerId = cId;
           }
         });
-        delete selectedLayout.components[id];
+
         selectedLayout.order[containerId].splice(selectedLayout.order[containerId].indexOf(id), 1);
         state.unSavedChanges = true;
         state.error = null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
File upload was not removed from both formLayout and applicationmetadatajson. This is fixed within this PR. Because we ran `delete selectedLayout.components[id];` within formLayoutSlice, then the deleteFormComponentsSaga does not have the necessary data to be able to decide whether to delete the metadata for attachment or not. 

## Related Issue(s)
- #6395

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
