### PR TITLE
force lowercase in text search filter

### DIFF
--- a/frontend/packages/text-editor/src/utils.ts
+++ b/frontend/packages/text-editor/src/utils.ts
@@ -52,9 +52,9 @@ export const filterFunction = (
     return true;
   } else if (searchQuery.length < 1) {
     return true;
-  } else if (id?.includes(searchQuery)) {
+  } else if (id?.toLowerCase().includes(searchQuery.toLowerCase())) {
     return true;
-  } else if (value?.includes(searchQuery)) {
+  } else if (value?.toLowerCase().includes(searchQuery.toLowerCase())) {
     return true;
   } else {
     return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make texts search filter case insensitive so all texts and ids appear even though searchquery is only lowercase.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
