### PR TITLE
Added partylist endpoint for register localtest

### DIFF
--- a/src/development/LocalTest/Controllers/Register/PartiesController.cs
+++ b/src/development/LocalTest/Controllers/Register/PartiesController.cs
@@ -71,5 +71,33 @@ namespace Altinn.Platform.Register.Controllers
 
             return Ok(party);
         }
+
+        /// <summary>
+        /// Gets the party list for the given user.
+        /// </summary>
+        /// <param name="partyIds">List of partyIds for parties to retrieve.</param>
+        /// <returns>List of parties based on the partyIds.</returns>
+        [HttpPost("partylist")]
+        public async Task<ActionResult<List<Party>>> GetPartyListForPartyIds([FromBody] List<int> partyIds)
+        {
+
+            List<Party> parties;
+
+            try
+            {
+                parties = await _partiesWrapper.GetPartyList(partyIds);
+            }
+            catch (Exception e)
+            {
+                return BadRequest(e.Message);
+            }
+
+            if (parties == null || parties.Count < 1)
+            {
+                return NotFound();
+            }
+
+            return Ok(parties);
+        }
     }
 }

--- a/src/development/LocalTest/Services/Register/Implementation/PartiesWrapper.cs
+++ b/src/development/LocalTest/Services/Register/Implementation/PartiesWrapper.cs
@@ -52,6 +52,21 @@ namespace LocalTest.Services.Register.Implementation
             return party?.PartyId ?? -1;
         }
 
+        /// <inheritdoc />
+        public async Task<List<Party>> GetPartyList(List<int> partyIds)
+        {
+            var data = await _testDataService.GetTestData();
+            List<Party> filteredList = new List<Party>();
+            foreach (int partyId in partyIds.Distinct())
+            {
+                Party? party = data.Register.Party.TryGetValue(partyId.ToString()!, out var value) ? value : null;
+                await AddPersonOrOrganization(party);
+                filteredList.Add(party);
+            }
+
+            return filteredList;
+        }
+
         private async Task<Party?> FindParty(string lookupValue)
         {
             var data = await _testDataService.GetTestData();

--- a/src/development/LocalTest/Services/Register/Interface/IParties.cs
+++ b/src/development/LocalTest/Services/Register/Interface/IParties.cs
@@ -16,6 +16,13 @@ namespace LocalTest.Services.Register.Interface
         Task<Party?> GetParty(int partyId);
 
         /// <summary>
+        /// Method that fetches  party list based on list of party ids
+        /// </summary>
+        /// <param name="partyIds">The party id list</param>
+        /// <returns></returns>
+        Task<List<Party?>> GetPartyList(List<int> partyIds);
+
+        /// <summary>
         /// Method that looks up a party id based on social security number or organisation number.
         /// </summary>
         /// <param name="lookupValue">SSN or org number</param>

--- a/src/development/TestData/authorization/resources/Appid_123.json
+++ b/src/development/TestData/authorization/resources/Appid_123.json
@@ -13,7 +13,11 @@
 	"validFrom": "2020-03-06T09:41:15.817",
 	"identifier": "appid-123",
 	"isComplete": false,
-	"description": null,
+	"description": {
+		"en": "Automation Regression",
+		"nb": "Automation Regression",
+		"nn": "Automation Regression"
+	},
 	"resourceType": "MaskinportenSchema",
 	"thematicArea": null,
 	"isPublicService": true,
@@ -51,6 +55,11 @@
 	],
 	"hasCompetentAuthority": {
 		"orgcode": "SKD",
-		"organization": "974761076"
+		"organization": "974761076",
+		"name": {
+		  "en": "Accenture Norway",
+		  "nb-no": "Accenture Norge",
+		  "nn-no": "Accenture Norge"
+		}
 	}
 }

--- a/src/development/TestData/authorization/resources/Appid_400.json
+++ b/src/development/TestData/authorization/resources/Appid_400.json
@@ -13,7 +13,11 @@
 	"validFrom": "2020-03-04T18:04:27.27",
 	"identifier": "appid-400",
 	"isComplete": false,
-	"description": null,
+	"description": {
+		"en": "Humbug Registry",
+		"nb": "Tulleregisteret",
+		"nn": "Tulleregisteret"
+	},
 	"resourceType": "MaskinportenSchema",
 	"thematicArea": null,
 	"isPublicService": true,

--- a/src/development/TestData/authorization/resources/Appid_401.json
+++ b/src/development/TestData/authorization/resources/Appid_401.json
@@ -13,7 +13,11 @@
 	"validFrom": "2020-03-04T18:04:27.27",
 	"identifier": "appid-401",
 	"isComplete": false,
-	"description": null,
+	"description": {
+		"en": "The Flowergarden",
+		"nb": "Blomsterhagen",
+		"nn": "Blomsterhagen"
+	},
 	"resourceType": "MaskinportenSchema",
 	"thematicArea": null,
 	"isPublicService": true,

--- a/src/development/TestData/authorization/resources/Appid_402.json
+++ b/src/development/TestData/authorization/resources/Appid_402.json
@@ -13,7 +13,11 @@
 	"validFrom": "2020-03-04T18:04:27.27",
 	"identifier": "appid-402",
 	"isComplete": false,
-	"description": null,
+	"description": {
+		"en": "The Magic Closet",
+		"nb": "Det magiske klesskapet",
+		"nn": "Det magiske klesskapet"
+	},
 	"resourceType": "MaskinportenSchema",
 	"thematicArea": null,
 	"isPublicService": true,

--- a/src/development/TestData/authorization/resources/Appid_403.json
+++ b/src/development/TestData/authorization/resources/Appid_403.json
@@ -13,7 +13,11 @@
 	"validFrom": "2020-03-04T18:04:27.27",
 	"identifier": "appid-403",
 	"isComplete": false,
-	"description": null,
+	"description": {
+		"en": "The Shortcut",
+		"nb": "Snarveien",
+		"nn": "Snarvegen"
+	},
 	"resourceType": "MaskinportenSchema",
 	"thematicArea": null,
 	"isPublicService": true,

--- a/src/development/TestData/authorization/resources/Appid_43.json
+++ b/src/development/TestData/authorization/resources/Appid_43.json
@@ -13,7 +13,11 @@
 	"validFrom": "2020-03-04T18:04:27.27",
 	"identifier": "appid-43",
 	"isComplete": false,
-	"description": null,
+	"description": {
+		"en": "Aa-registeret OTP API",
+		"nb": "Aa-registeret OTP API",
+		"nn": "Aa-registeret OTP API"
+	},
 	"resourceType": "MaskinportenSchema",
 	"thematicArea": null,
 	"isPublicService": true,


### PR DESCRIPTION
Access management uses a partylist endpoint in register api. This needs to be avaialable in localtest for local testing

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
