### PR TITLE
Bump spring-boot-starter-parent

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.PDF/pom.xml
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/pom.xml
@@ -33,7 +33,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.7</version>
+    <version>2.7.8</version>
   </parent>
   <dependencies>
     <dependency>


### PR DESCRIPTION
## Description
Bump the spring-boot-starter-parent package used by PDF. There is a newer version, but it's a major release with an upgrade guide. Not investing that time in the PDF generator today.
