### PR TITLE
Fix/unit test for schema model did not pass on file with description on root

### DIFF
--- a/frontend/packages/schema-model/src/lib/build-json-schema.ts
+++ b/frontend/packages/schema-model/src/lib/build-json-schema.ts
@@ -19,7 +19,13 @@ export const buildJsonSchema = (nodes: UiSchemaNodes): Dict => {
     !rootNode.implicitType ? rootNode.fieldType : undefined
   );
   JSONPointer.set(out, `/${Keywords.Required}`, findRequiredProps(nodes, rootNode.pointer));
-
+  const assignRootIfDefined = (keyword: Keywords) => {
+    const value = rootNode[keyword];
+    if (value !== undefined) {
+      JSONPointer.set(out, `/${keyword}`, value);
+    }
+  };
+  assignRootIfDefined(Keywords.Description);
   const sortedUiSchemaNodes = sortNodesByChildren(nodes);
 
   sortedUiSchemaNodes

--- a/frontend/packages/schema-model/src/lib/build-json-schema.ts
+++ b/frontend/packages/schema-model/src/lib/build-json-schema.ts
@@ -8,6 +8,7 @@ import { sortNodesByChildren } from './mutations/sort-nodes';
 import { ROOT_POINTER } from './constants';
 import { makePointer } from './utils';
 import { ArrRestrictionKeys } from './restrictions';
+import { assignRootIfDefined } from './build-utils';
 
 export const buildJsonSchema = (nodes: UiSchemaNodes): Dict => {
   const out: Dict = {};
@@ -19,13 +20,7 @@ export const buildJsonSchema = (nodes: UiSchemaNodes): Dict => {
     !rootNode.implicitType ? rootNode.fieldType : undefined
   );
   JSONPointer.set(out, `/${Keywords.Required}`, findRequiredProps(nodes, rootNode.pointer));
-  const assignRootIfDefined = (keyword: Keywords) => {
-    const value = rootNode[keyword];
-    if (value !== undefined) {
-      JSONPointer.set(out, `/${keyword}`, value);
-    }
-  };
-  assignRootIfDefined(Keywords.Description);
+  assignRootIfDefined(out, rootNode, Keywords.Description);
   const sortedUiSchemaNodes = sortNodesByChildren(nodes);
 
   sortedUiSchemaNodes

--- a/frontend/packages/schema-model/src/lib/build-utils.test.ts
+++ b/frontend/packages/schema-model/src/lib/build-utils.test.ts
@@ -1,0 +1,59 @@
+import { assignRootIfDefined } from './build-utils';
+import type { UiSchemaNode } from './types';
+import { Keywords } from './types';
+
+const base: UiSchemaNode = {
+  children: [],
+  custom: undefined,
+  fieldType: undefined,
+  implicitType: false,
+  isArray: false,
+  isCombinationItem: false,
+  isNillable: false,
+  isRequired: false,
+  objectKind: undefined,
+  pointer: '/',
+  restrictions: undefined,
+  description: undefined,
+};
+test('Does put defined on the out object', () => {
+  const testNodeWithDesc: UiSchemaNode = {
+    ...base,
+    description: 'some string',
+  };
+  const out = {};
+  Object.keys(testNodeWithDesc).forEach((key) =>
+    assignRootIfDefined(out, testNodeWithDesc, key as Keywords)
+  );
+  const expected = {
+    children: [],
+    implicitType: false,
+    isArray: false,
+    isCombinationItem: false,
+    isNillable: false,
+    isRequired: false,
+    pointer: '/',
+    description: 'some string',
+  };
+  expect(out).toEqual(expected);
+  expect(Object.keys(out)).toEqual(Object.keys(expected));
+  expect(Object.keys(out).length).not.toEqual(Object.keys(testNodeWithDesc).length);
+});
+test('Does not put undefined on the out object', () => {
+  const out = {};
+  Object.keys(base).forEach((key) =>
+    assignRootIfDefined(out, base, key as Keywords)
+  );
+  const expected = {
+    children: [],
+    implicitType: false,
+    isArray: false,
+    isCombinationItem: false,
+    isNillable: false,
+    isRequired: false,
+    pointer: '/',
+  };
+  expect(out).toEqual(expected);
+  expect(Object.keys(out)).toEqual(Object.keys(expected));
+  expect(Object.keys(out).length).not.toEqual(Object.keys(base).length);
+});

--- a/frontend/packages/schema-model/src/lib/build-utils.ts
+++ b/frontend/packages/schema-model/src/lib/build-utils.ts
@@ -1,0 +1,9 @@
+import type { Dict, Keywords, UiSchemaNode } from './types';
+import JSONPointer from 'jsonpointer';
+
+export const assignRootIfDefined = (out: Dict, node: UiSchemaNode, keyword: Keywords) => {
+  const value = node[keyword];
+  if (value !== undefined) {
+    JSONPointer.set(out, `/${keyword}`, value);
+  }
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`testdata\Model\JsonSchema\General\NonXsdContextSchema.json` has `description` on the rootNode.
I personally do not know the spec, but this is causing the tests on schema-model to fail.

This is a quick fix that addresses the issue.

### Note
The fix addresses the `description` field only. (And only makes the test pass) I suggest considering the fact that all "non-custom" fields, except for others that are explicitly added like this are stripped. So adding another field that is "known" on root, will make the test fail again.

#### Failing PR
This is the reason PR #9681 is failing the unit-tests, though pulling master and running the test locally also fails this test.