### PR TITLE
Localtest: Add service owner orgs as possible lookups in register api.

### DIFF
--- a/src/development/LocalTest/Clients/CdnAltinnOrgs/AltinnOrgsClient.cs
+++ b/src/development/LocalTest/Clients/CdnAltinnOrgs/AltinnOrgsClient.cs
@@ -2,6 +2,8 @@
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Altinn.Platform.Authentication.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace LocalTest.Clients.CdnAltinnOrgs;
 
@@ -12,15 +14,17 @@ public class AltinnOrgsClient
 {
     private static JsonSerializerOptions JSON_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web);
     private readonly HttpClient _client;
+    private readonly GeneralSettings _authOptions;
 
-    public AltinnOrgsClient(HttpClient client)
+    public AltinnOrgsClient(HttpClient client, IOptions<GeneralSettings> authOptions)
     {
         _client = client;
+        _authOptions = authOptions.Value;
     }
 
     public async Task<CdnOrgs> GetCdnOrgs()
     {
-        var orgsJson = await _client.GetByteArrayAsync("https://altinncdn.no/orgs/altinn-orgs.json");
+        var orgsJson = await _client.GetByteArrayAsync(_authOptions.GetOrganisationRepositoryLocation);
         return JsonSerializer.Deserialize<CdnOrgs>(orgsJson, JSON_OPTIONS) ?? throw new JsonException("altinn-orgs respones was \"null\"");
     }
 }

--- a/src/development/LocalTest/Services/Register/Implementation/OrganizationsWrapper.cs
+++ b/src/development/LocalTest/Services/Register/Implementation/OrganizationsWrapper.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using Altinn.Platform.Register.Models;
+using LocalTest.Clients.CdnAltinnOrgs;
 using LocalTest.Services.Register.Interface;
 using LocalTest.Services.TestData;
 
@@ -11,17 +12,36 @@ namespace LocalTest.Services.Register.Implementation
     public class OrganizationsWrapper : IOrganizations
     {
         private readonly TestDataService _testDataService;
+        private readonly AltinnOrgsClient _orgsClient;
 
-        public OrganizationsWrapper(TestDataService testDataService)
+        public OrganizationsWrapper(TestDataService testDataService, AltinnOrgsClient orgsClient)
         {
             _testDataService = testDataService;
+            _orgsClient = orgsClient;
         }
 
         /// <inheritdoc />
         public async Task<Organization?> GetOrganization(string orgNr)
         {
             var data = await _testDataService.GetTestData();
-            return data.Register.Org.TryGetValue(orgNr, out var value) ? value : null;
+
+            if (data.Register.Org.TryGetValue(orgNr, out var value))
+            {
+                return value;
+            }
+
+            // Make lookup work for all the orgs that has apps in altinn.
+            var cdnOrgs = await _orgsClient.GetCdnOrgs();
+            var cdnOrg = cdnOrgs?.Orgs?.Values.FirstOrDefault(org=>org.Orgnr == orgNr);
+            if(cdnOrg is not null)
+            {
+                return new Organization
+                {
+                    Name = cdnOrg.Name?.Nb,
+                    OrgNumber = cdnOrg.Orgnr,
+                };
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
This makes it possible to lookup the name of eg. Finanstilsynet based on orgNumber, even if it isn't in the local registry.

This will cause a difference in the display of active instances and make it more production like when they are initialized using the service owner user.
This will show:
![image](https://user-images.githubusercontent.com/131616/215870970-caf43a1c-d7bf-4a02-8dba-e43b5d2b2d12.png)

instead of 
![image](https://user-images.githubusercontent.com/131616/215870594-f05ae3fe-2121-474e-9e43-e98ffe499b4d.png)


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] Not sure if there is some documentation stating what org lookup should actually do.
