### PR TITLE
Update password in appsettings to match postgres init config

### DIFF
--- a/backend/src/Designer/appsettings.json
+++ b/backend/src/Designer/appsettings.json
@@ -39,7 +39,7 @@
     "AdminConnectionString": "Host=localhost;Port=5432;Username=designer_admin;Password={0};Database=designerdb",
     "ConnectionString": "Host=localhost;Port=5432;Username=designer;Password={0};Database=designerdb",
     "DesignerDbAdminPwd": "Password",
-    "DesignerDbPwd": "Password"
+    "DesignerDbPwd": "designer"
   },
   "CertificateSettings": {
     "CertificatePwd": "qwer1234",


### PR DESCRIPTION
## Description
When running backend locally the password set in appsettings.json was not matching the password set in postgres init file.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
