### PR TITLE
Schema editor crashes when deleting a node and then selecting a new node

### DIFF
--- a/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
@@ -75,21 +75,23 @@ export function ItemDataComponent({ language, selectedItem }: IItemDataComponent
 
   const onChangeRef = (path: string, ref: string) => dispatch(setRef({ path, ref }));
 
-  const onChangeFieldType = (pointer: string, type: FieldType) =>
+  const onChangeFieldType = (type: FieldType) =>
     dispatch(setType({ path: selectedItem.pointer, type }));
 
-  const onChangeNullable = (event: ChangeEvent) => {
-    if ((event.target as HTMLInputElement)?.checked) {
+  const onChangeNullable = (event: ChangeEvent<HTMLInputElement>): void => {
+    const isChecked = event.target.checked;
+    if (isChecked) {
       dispatch(
         addCombinationItem({ pointer: selectedItem.pointer, props: { fieldType: FieldType.Null } })
       );
-    } else {
-      childNodes.forEach((childNode: UiSchemaNode) => {
-        if (childNode.fieldType === FieldType.Null) {
-          dispatch(deleteCombinationItem({ path: childNode.pointer }));
-        }
-      });
+      return;
     }
+
+    childNodes.forEach((childNode: UiSchemaNode) => {
+      if (childNode.fieldType === FieldType.Null) {
+        dispatch(deleteCombinationItem({ path: childNode.pointer }));
+      }
+    });
   };
 
   const onChangeTitle = () => dispatch(setTitle({ path: selectedNodePointer, title }));
@@ -153,7 +155,7 @@ export function ItemDataComponent({ language, selectedItem }: IItemDataComponent
       {selectedItem.objectKind === ObjectKind.Field && (
         <Select
           label={t('type')}
-          onChange={(type: string) => onChangeFieldType(selectedItem.pointer, type as FieldType)}
+          onChange={(type: FieldType) => onChangeFieldType(type)}
           options={getTypeOptions(t)}
           value={fieldType as string}
         />

--- a/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
+++ b/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.test.ts
@@ -223,9 +223,8 @@ describe('SchemaEditorSlice', () => {
       );
     });
     nextState = reducer(nextState, deleteProperty(payload));
-    expect(() => {
-      getNodeByPointer(nextState.uiSchema, '#/$defs/Kontaktperson');
-    }).toThrowError();
+    const node = getNodeByPointer(nextState.uiSchema, '#/$defs/Kontaktperson');
+    expect(node).toBeUndefined();
 
     expect(hasNodePointer(nextState.uiSchema, '#/$defs/Kontaktperson')).toBeFalsy();
   });

--- a/frontend/packages/schema-model/src/lib/selectors.test.ts
+++ b/frontend/packages/schema-model/src/lib/selectors.test.ts
@@ -44,17 +44,15 @@ test('that we can getRootNode', () => {
   expect(rootNode.pointer).toBe(ROOT_POINTER);
 });
 
-test('that getNodeByPointer throws at undefined pointer', () => {
+test('should return undefined if getNodeByPointer cannot find node by pointer', () => {
   const uiSchemaNodes = buildUiSchema(testSchema);
-  expect(() => {
-    getNodeByPointer(uiSchemaNodes, makePointer('jibberish'));
-  }).toThrow();
+  const pointer = makePointer('badPointer');
+  const node = getNodeByPointer(uiSchemaNodes, pointer);
+  expect(node).toBeUndefined();
 });
 
-test('that getRootNode throws at undefined pointer', () => {
-  expect(() => {
-    getRootNode([]);
-  }).toThrow();
+test('should return undefined if getRootNode cannot find node by pointer', () => {
+  expect(getRootNode([])).toBeUndefined();
 });
 
 test('that we can get referred nodes', () => {

--- a/frontend/packages/schema-model/src/lib/selectors.ts
+++ b/frontend/packages/schema-model/src/lib/selectors.ts
@@ -12,12 +12,13 @@ export const getRootNodes = (uiSchemaNodes: UiSchemaNodes, defs: boolean): UiSch
   }
   return rootNodes;
 };
+
 export const getRootNode = (uiSchemaNodes: UiSchemaNodes): UiSchemaNode =>
   getNodeByPointer(uiSchemaNodes, ROOT_POINTER);
 
 const nodePointers: { uiSchemaNodes: UiSchemaNodes; cache: Map<string, UiSchemaNode> } = {
   uiSchemaNodes: [],
-  cache: new Map(),
+  cache: new Map<string, UiSchemaNode>(),
 };
 
 const getNodePointerCache = (uiSchemaNodes: UiSchemaNodes): Map<string, UiSchemaNode> => {
@@ -35,13 +36,9 @@ const getNodePointerCache = (uiSchemaNodes: UiSchemaNodes): Map<string, UiSchema
 export const hasNodePointer = (uiSchemaNodes: UiSchemaNodes, pointer: string): boolean =>
   getNodePointerCache(uiSchemaNodes).has(pointer);
 
-export const getNodeByPointer = (uiSchemaNodes: UiSchemaNodes, pointer: string): UiSchemaNode => {
+export const getNodeByPointer = (uiSchemaNodes: UiSchemaNodes, pointer: string): UiSchemaNode | undefined => {
   const uiSchemaNode = getNodePointerCache(uiSchemaNodes).get(pointer);
-  if (uiSchemaNode) {
-    return uiSchemaNode;
-  } else {
-    throw new Error(`Can't find node with pointer ${pointer}`);
-  }
+  return uiSchemaNode;
 };
 
 /**
@@ -63,6 +60,8 @@ export const getChildNodesByPointer = (
   pointer: string
 ): UiSchemaNode[] => {
   const parentNode = getNodeByPointer(uiSchemaNodes, pointer);
+  if (!parentNode) return [];
+
   return parentNode.children.map((childPointer) => getNodeByPointer(uiSchemaNodes, childPointer));
 };
 


### PR DESCRIPTION
## Description
The schema editor crashes when deleting a node and then selecting a new node. The reason was that Selector.ts was throwing an error if it could not find the node by the pointer. The **getNodeByPointer** should not throw when it does not find any node, because this complicates the code where the **getNodeByPointer** method is used. If the **getNodeByPointer** method is throwing we need to use try/catch to handle the error, if not the page will crash. It's not developer friendly, because it's difficult to know that this method needs to be error-handled with try/catch. 

To avoid the complications mentioned above. I changed the code to return undefined instead of throwing an error and avoid using try/catch to handle the error from the  **getNodeByPointer** method. 

## Related Issue(s)
- #9708

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
