### PR TITLE
When app developer deletes data model, there is no "no datamodel" message

### DIFF
--- a/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
+++ b/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import configureStore from 'redux-mock-store';
+import { userEvent } from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { DataModelling, shouldSelectFirstEntry } from './DataModelling';
 import { LoadingState } from './sagas/metadata';
@@ -17,8 +18,8 @@ Object.defineProperty(window, 'matchMedia', {
     removeListener: jest.fn(), // deprecated
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
+    dispatchEvent: jest.fn()
+  }))
 });
 
 const modelName = 'some-existing-model';
@@ -29,34 +30,34 @@ const defaultInitialState = {
       {
         repositoryRelativeUrl: `/App/models/${modelName}.schema.json`,
         fileName: `${modelName}.schema.json`,
-        fileType: '.json',
+        fileType: '.json'
       },
       {
         repositoryRelativeUrl: `/App/models/${modelName2}.schema.json`,
         fileName: `${modelName2}.schema.json`,
-        fileType: '.json',
-      },
+        fileType: '.json'
+      }
     ],
-    loadState: LoadingState.ModelsLoaded,
+    loadState: LoadingState.ModelsLoaded
   },
   dataModelling: {
     schema: {},
-    saving: false,
-  },
+    saving: false
+  }
 };
 const initialStoreCall = {
   type: 'dataModelling/fetchDataModel',
   payload: {
     metadata: {
       label: modelName,
-      value: defaultInitialState.dataModelsMetadataState.dataModelsMetadata[0],
-    },
-  },
+      value: defaultInitialState.dataModelsMetadataState.dataModelsMetadata[0]
+    }
+  }
 };
 
 const render = (
   state: {
-    [K in keyof typeof defaultInitialState]?: Partial<typeof defaultInitialState[K]>;
+    [K in keyof typeof defaultInitialState]?: Partial<(typeof defaultInitialState)[K]>;
   } = {}
 ) => {
   const dataModelsMetadataState = state?.dataModelsMetadataState;
@@ -65,12 +66,12 @@ const render = (
   const initialState = {
     dataModelsMetadataState: {
       ...defaultInitialState.dataModelsMetadataState,
-      ...dataModelsMetadataState,
+      ...dataModelsMetadataState
     },
     dataModelling: {
       ...defaultInitialState.dataModelling,
-      ...dataModelling,
-    },
+      ...dataModelling
+    }
   };
 
   const store = configureStore()(initialState);
@@ -82,7 +83,7 @@ const render = (
         language={{
           'administration.first': 'some text',
           'administration.second': 'other text',
-          'app_data_modelling.landing_dialog_header': 'Dialog header',
+          'app_data_modelling.landing_dialog_header': 'Dialog header'
         }}
         org='test-org'
         repo='test-repo'
@@ -110,12 +111,12 @@ describe('DataModelling', () => {
               value: {
                 repositoryRelativeUrl: '',
                 fileName: 'option 1.xsd',
-                fileType: '.xsd',
-              },
-            },
+                fileType: '.xsd'
+              }
+            }
           ],
           selectedOption: undefined,
-          metadataLoadingState: LoadingState.ModelsLoaded,
+          metadataLoadingState: LoadingState.ModelsLoaded
         })
       ).toBe(true);
     });
@@ -129,14 +130,14 @@ describe('DataModelling', () => {
               value: {
                 repositoryRelativeUrl: '',
                 fileName: 'option 1.xsd',
-                fileType: '.xsd',
-              },
-            },
+                fileType: '.xsd'
+              }
+            }
           ],
           selectedOption: {
-            label: 'some-label',
+            label: 'some-label'
           },
-          metadataLoadingState: LoadingState.ModelsLoaded,
+          metadataLoadingState: LoadingState.ModelsLoaded
         })
       ).toBe(false);
     });
@@ -150,12 +151,12 @@ describe('DataModelling', () => {
               value: {
                 repositoryRelativeUrl: '',
                 fileName: 'option 1.xsd',
-                fileType: '.xsd',
-              },
-            },
+                fileType: '.xsd'
+              }
+            }
           ],
           selectedOption: undefined,
-          metadataLoadingState: LoadingState.LoadingModels,
+          metadataLoadingState: LoadingState.LoadingModels
         })
       ).toBe(false);
     });
@@ -164,7 +165,7 @@ describe('DataModelling', () => {
       expect(
         shouldSelectFirstEntry({
           selectedOption: undefined,
-          metadataLoadingState: LoadingState.ModelsLoaded,
+          metadataLoadingState: LoadingState.ModelsLoaded
         })
       ).toBe(false);
     });
@@ -174,7 +175,7 @@ describe('DataModelling', () => {
         shouldSelectFirstEntry({
           metadataOptions: [],
           selectedOption: undefined,
-          metadataLoadingState: LoadingState.ModelsLoaded,
+          metadataLoadingState: LoadingState.ModelsLoaded
         })
       ).toBe(false);
     });
@@ -184,6 +185,24 @@ describe('DataModelling', () => {
     // make sure setting to turn off info dialog is cleared
     localStorage.removeItem(LOCAL_STORAGE_KEY);
     render();
+    const dialogHeader = screen.queryByText('schema_editor.info_dialog_title');
+    expect(dialogHeader).toBeInTheDocument();
+  });
+
+  it('Should show info dialog by default when loading the page', () => {
+    // make sure setting to turn off info dialog is cleared
+    localStorage.removeItem(LOCAL_STORAGE_KEY);
+    render();
+    const dialogHeader = screen.queryByText('schema_editor.info_dialog_title');
+    expect(dialogHeader).toBeInTheDocument();
+  });
+
+  it('should display no data-models message when schema is undefined and loadState is loaded', async () => {
+    localStorage.removeItem(LOCAL_STORAGE_KEY);
+    render({
+      dataModelling: { schema: undefined },
+      dataModelsMetadataState: { loadState: LoadingState.ModelsLoaded }
+    });
     const dialogHeader = screen.queryByText('schema_editor.info_dialog_title');
     expect(dialogHeader).toBeInTheDocument();
   });
@@ -207,7 +226,7 @@ describe('DataModelling', () => {
     // make sure setting to turn off info dialog is set
     setLocalStorageItem('hideIntroPage', true);
     render({
-      dataModelsMetadataState: { loadState: LoadingState.LoadingModels },
+      dataModelsMetadataState: { loadState: LoadingState.LoadingModels }
     });
     expect(screen.queryByText('Dialog header')).not.toBeInTheDocument();
   });
@@ -216,7 +235,7 @@ describe('DataModelling', () => {
     // make sure setting to turn off info dialog is set
     setLocalStorageItem('hideIntroPage', true);
     render({
-      dataModelsMetadataState: { loadState: LoadingState.LoadingModels },
+      dataModelsMetadataState: { loadState: LoadingState.LoadingModels }
     });
     expect(screen.queryByText('Dialog header')).not.toBeInTheDocument();
   });
@@ -226,7 +245,7 @@ describe('DataModelling', () => {
     setLocalStorageItem('hideIntroPage', true);
     const schema = {
       properties: { SomeSchema: { $ref: '#/$defs/Something' } },
-      $defs: { Something: { type: 'string' } },
+      $defs: { Something: { type: 'string' } }
     };
     render({ dataModelling: { schema } });
     expect(screen.queryByText('Dialog header')).not.toBeInTheDocument();

--- a/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
+++ b/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
@@ -218,7 +218,7 @@ describe('DataModelling', () => {
   it('Should show start dialog when no models are present and intro page is closed', () => {
     // make sure setting to turn off info dialog is set
     setLocalStorageItem('hideIntroPage', true);
-    render();
+    render({ dataModelling: { schema: undefined }});
     expect(screen.queryByText('Dialog header')).toBeInTheDocument();
   });
 

--- a/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
+++ b/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
@@ -35,14 +35,14 @@ const defaultInitialState = {
         repositoryRelativeUrl: `/App/models/${modelName2}.schema.json`,
         fileName: `${modelName2}.schema.json`,
         fileType: '.json',
-      }
+      },
     ],
     loadState: LoadingState.ModelsLoaded,
   },
   dataModelling: {
     schema: {},
     saving: false,
-  }
+  },
 };
 const initialStoreCall = {
   type: 'dataModelling/fetchDataModel',
@@ -69,8 +69,8 @@ const render = (
     },
     dataModelling: {
       ...defaultInitialState.dataModelling,
-      ...dataModelling
-    }
+      ...dataModelling,
+    },
   };
 
   const store = configureStore()(initialState);

--- a/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
+++ b/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import configureStore from 'redux-mock-store';
-import { userEvent } from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { DataModelling, shouldSelectFirstEntry } from './DataModelling';
 import { LoadingState } from './sagas/metadata';

--- a/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
+++ b/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
@@ -17,7 +17,7 @@ Object.defineProperty(window, 'matchMedia', {
     removeListener: jest.fn(), // deprecated
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn()
+    dispatchEvent: jest.fn(),
   }))
 });
 
@@ -29,12 +29,12 @@ const defaultInitialState = {
       {
         repositoryRelativeUrl: `/App/models/${modelName}.schema.json`,
         fileName: `${modelName}.schema.json`,
-        fileType: '.json'
+        fileType: '.json',
       },
       {
         repositoryRelativeUrl: `/App/models/${modelName2}.schema.json`,
         fileName: `${modelName2}.schema.json`,
-        fileType: '.json'
+        fileType: '.json',
       }
     ],
     loadState: LoadingState.ModelsLoaded
@@ -49,7 +49,7 @@ const initialStoreCall = {
   payload: {
     metadata: {
       label: modelName,
-      value: defaultInitialState.dataModelsMetadataState.dataModelsMetadata[0]
+      value: defaultInitialState.dataModelsMetadataState.dataModelsMetadata[0],
     }
   }
 };
@@ -65,7 +65,7 @@ const render = (
   const initialState = {
     dataModelsMetadataState: {
       ...defaultInitialState.dataModelsMetadataState,
-      ...dataModelsMetadataState
+      ...dataModelsMetadataState,
     },
     dataModelling: {
       ...defaultInitialState.dataModelling,
@@ -82,7 +82,7 @@ const render = (
         language={{
           'administration.first': 'some text',
           'administration.second': 'other text',
-          'app_data_modelling.landing_dialog_header': 'Dialog header'
+          'app_data_modelling.landing_dialog_header': 'Dialog header',
         }}
         org='test-org'
         repo='test-repo'
@@ -110,12 +110,12 @@ describe('DataModelling', () => {
               value: {
                 repositoryRelativeUrl: '',
                 fileName: 'option 1.xsd',
-                fileType: '.xsd'
+                fileType: '.xsd',
               }
             }
           ],
           selectedOption: undefined,
-          metadataLoadingState: LoadingState.ModelsLoaded
+          metadataLoadingState: LoadingState.ModelsLoaded,
         })
       ).toBe(true);
     });
@@ -129,14 +129,14 @@ describe('DataModelling', () => {
               value: {
                 repositoryRelativeUrl: '',
                 fileName: 'option 1.xsd',
-                fileType: '.xsd'
+                fileType: '.xsd',
               }
             }
           ],
           selectedOption: {
-            label: 'some-label'
+            label: 'some-label',
           },
-          metadataLoadingState: LoadingState.ModelsLoaded
+          metadataLoadingState: LoadingState.ModelsLoaded,
         })
       ).toBe(false);
     });
@@ -150,12 +150,12 @@ describe('DataModelling', () => {
               value: {
                 repositoryRelativeUrl: '',
                 fileName: 'option 1.xsd',
-                fileType: '.xsd'
+                fileType: '.xsd',
               }
             }
           ],
           selectedOption: undefined,
-          metadataLoadingState: LoadingState.LoadingModels
+          metadataLoadingState: LoadingState.LoadingModels,
         })
       ).toBe(false);
     });
@@ -164,7 +164,7 @@ describe('DataModelling', () => {
       expect(
         shouldSelectFirstEntry({
           selectedOption: undefined,
-          metadataLoadingState: LoadingState.ModelsLoaded
+          metadataLoadingState: LoadingState.ModelsLoaded,
         })
       ).toBe(false);
     });
@@ -174,7 +174,7 @@ describe('DataModelling', () => {
         shouldSelectFirstEntry({
           metadataOptions: [],
           selectedOption: undefined,
-          metadataLoadingState: LoadingState.ModelsLoaded
+          metadataLoadingState: LoadingState.ModelsLoaded,
         })
       ).toBe(false);
     });
@@ -225,7 +225,7 @@ describe('DataModelling', () => {
     // make sure setting to turn off info dialog is set
     setLocalStorageItem('hideIntroPage', true);
     render({
-      dataModelsMetadataState: { loadState: LoadingState.LoadingModels }
+      dataModelsMetadataState: { loadState: LoadingState.LoadingModels },
     });
     expect(screen.queryByText('Dialog header')).not.toBeInTheDocument();
   });
@@ -234,7 +234,7 @@ describe('DataModelling', () => {
     // make sure setting to turn off info dialog is set
     setLocalStorageItem('hideIntroPage', true);
     render({
-      dataModelsMetadataState: { loadState: LoadingState.LoadingModels }
+      dataModelsMetadataState: { loadState: LoadingState.LoadingModels },
     });
     expect(screen.queryByText('Dialog header')).not.toBeInTheDocument();
   });
@@ -244,7 +244,7 @@ describe('DataModelling', () => {
     setLocalStorageItem('hideIntroPage', true);
     const schema = {
       properties: { SomeSchema: { $ref: '#/$defs/Something' } },
-      $defs: { Something: { type: 'string' } }
+      $defs: { Something: { type: 'string' } },
     };
     render({ dataModelling: { schema } });
     expect(screen.queryByText('Dialog header')).not.toBeInTheDocument();

--- a/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
+++ b/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
@@ -188,14 +188,6 @@ describe('DataModelling', () => {
     expect(dialogHeader).toBeInTheDocument();
   });
 
-  it('Should show info dialog by default when loading the page', () => {
-    // make sure setting to turn off info dialog is cleared
-    localStorage.removeItem(LOCAL_STORAGE_KEY);
-    render();
-    const dialogHeader = screen.queryByText('schema_editor.info_dialog_title');
-    expect(dialogHeader).toBeInTheDocument();
-  });
-
   it('should display no data-models message when schema is undefined and loadState is loaded', async () => {
     localStorage.removeItem(LOCAL_STORAGE_KEY);
     render({

--- a/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
+++ b/frontend/packages/shared/src/features/dataModelling/DataModelling.test.tsx
@@ -18,7 +18,7 @@ Object.defineProperty(window, 'matchMedia', {
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
-  }))
+  })),
 });
 
 const modelName = 'some-existing-model';
@@ -37,11 +37,11 @@ const defaultInitialState = {
         fileType: '.json',
       }
     ],
-    loadState: LoadingState.ModelsLoaded
+    loadState: LoadingState.ModelsLoaded,
   },
   dataModelling: {
     schema: {},
-    saving: false
+    saving: false,
   }
 };
 const initialStoreCall = {
@@ -50,8 +50,8 @@ const initialStoreCall = {
     metadata: {
       label: modelName,
       value: defaultInitialState.dataModelsMetadataState.dataModelsMetadata[0],
-    }
-  }
+    },
+  },
 };
 
 const render = (
@@ -111,8 +111,8 @@ describe('DataModelling', () => {
                 repositoryRelativeUrl: '',
                 fileName: 'option 1.xsd',
                 fileType: '.xsd',
-              }
-            }
+              },
+            },
           ],
           selectedOption: undefined,
           metadataLoadingState: LoadingState.ModelsLoaded,
@@ -130,8 +130,8 @@ describe('DataModelling', () => {
                 repositoryRelativeUrl: '',
                 fileName: 'option 1.xsd',
                 fileType: '.xsd',
-              }
-            }
+              },
+            },
           ],
           selectedOption: {
             label: 'some-label',
@@ -151,8 +151,8 @@ describe('DataModelling', () => {
                 repositoryRelativeUrl: '',
                 fileName: 'option 1.xsd',
                 fileType: '.xsd',
-              }
-            }
+              },
+            },
           ],
           selectedOption: undefined,
           metadataLoadingState: LoadingState.LoadingModels,
@@ -200,7 +200,7 @@ describe('DataModelling', () => {
     localStorage.removeItem(LOCAL_STORAGE_KEY);
     render({
       dataModelling: { schema: undefined },
-      dataModelsMetadataState: { loadState: LoadingState.ModelsLoaded }
+      dataModelsMetadataState: { loadState: LoadingState.ModelsLoaded },
     });
     const dialogHeader = screen.queryByText('schema_editor.info_dialog_title');
     expect(dialogHeader).toBeInTheDocument();

--- a/frontend/packages/shared/src/features/dataModelling/DataModelling.tsx
+++ b/frontend/packages/shared/src/features/dataModelling/DataModelling.tsx
@@ -144,7 +144,7 @@ export function DataModelling({
     dispatch(DataModelsMetadataActions.getDataModelsMetadata());
   };
 
-  const shouldDisplayLandingPage = landingDialogState === LandingDialogState.DialogIsVisible;
+  const shouldDisplayLandingPage = landingDialogState === LandingDialogState.DialogIsVisible || jsonSchema === undefined;
 
   const [hideIntroPage, setHideIntroPage] = useState(
     () => getLocalStorageItem('hideIntroPage') ?? false

--- a/frontend/packages/shared/src/features/dataModelling/DataModelling.tsx
+++ b/frontend/packages/shared/src/features/dataModelling/DataModelling.tsx
@@ -34,12 +34,6 @@ type shouldSelectFirstEntryProps = {
   metadataLoadingState: LoadingState;
 };
 
-enum LandingDialogState {
-  DatamodelsNotLoaded = 'DATAMODELS_NOT_LOADED',
-  DialogIsVisible = 'DIALOG_IS_VISIBLE',
-  DialogShouldNotBeShown = 'DIALOG_SHOULD_NOT_BE_SHOWN',
-}
-
 export const shouldSelectFirstEntry = ({
   metadataOptions,
   selectedOption,
@@ -56,7 +50,7 @@ export function DataModelling({
   language,
   org,
   repo,
-  createPathOption,
+  createPathOption = false,
 }: IDataModellingContainerProps): JSX.Element {
   const dispatch = useDispatch();
   const jsonSchema = useSelector((state: any) => state.dataModelling.schema);
@@ -78,7 +72,7 @@ export function DataModelling({
       shouldSelectFirstEntry({
         metadataOptions,
         selectedOption,
-        metadataLoadingState,
+        metadataLoadingState
       })
     ) {
       setSelectedOption(metadataOptions[0].options[0]);
@@ -109,22 +103,6 @@ export function DataModelling({
     }
   }, [selectedOption, dispatch]);
 
-  const [landingDialogState, setLandingDialogState] = useState<LandingDialogState>(
-    LandingDialogState.DatamodelsNotLoaded
-  );
-
-  const closeLandingPage = () => setLandingDialogState(LandingDialogState.DialogShouldNotBeShown);
-
-  useEffect(() => {
-    if (metadataLoadingState === LoadingState.ModelsLoaded) {
-      if (jsonSchema && Object.keys(jsonSchema).length) {
-        setLandingDialogState(LandingDialogState.DialogShouldNotBeShown);
-      } else if (landingDialogState === LandingDialogState.DatamodelsNotLoaded) {
-        setLandingDialogState(LandingDialogState.DialogIsVisible);
-      }
-    }
-  }, [jsonSchema, landingDialogState, metadataLoadingState]);
-
   const handleSaveSchema = (schema: any) =>
     dispatch(saveDataModel({ schema, metadata: selectedOption }));
   const handleDeleteSchema = () => dispatch(deleteDataModel({ metadata: selectedOption }));
@@ -144,8 +122,6 @@ export function DataModelling({
     dispatch(DataModelsMetadataActions.getDataModelsMetadata());
   };
 
-  const shouldDisplayLandingPage = landingDialogState === LandingDialogState.DialogIsVisible || jsonSchema === undefined;
-
   const [hideIntroPage, setHideIntroPage] = useState(
     () => getLocalStorageItem('hideIntroPage') ?? false
   );
@@ -156,6 +132,8 @@ export function DataModelling({
   const toggleEditMode = () => setEditMode(setLocalStorageItem('editMode', !editMode));
 
   const t = (key: string) => getLanguageFromKey(key, language);
+
+  const shouldDisplayLandingPage = !jsonSchema && hideIntroPage;
 
   return (
     <>
@@ -208,7 +186,6 @@ export function DataModelling({
               repo={repo}
               handleXSDUploaded={handleXSDUploaded}
               handleCreateModelClick={handleCreateNewFromLandingPage}
-              closeLandingPage={closeLandingPage}
             />
           )
         }
@@ -243,7 +220,3 @@ export function DataModelling({
     </>
   );
 }
-
-DataModelling.defaultProps = {
-  createPathOption: false,
-};

--- a/frontend/packages/shared/src/features/dataModelling/components/LandingPagePanel.tsx
+++ b/frontend/packages/shared/src/features/dataModelling/components/LandingPagePanel.tsx
@@ -10,14 +10,12 @@ export interface LandingPageProps {
   repo: string;
   handleXSDUploaded: (filename: string) => void;
   handleCreateModelClick: () => void;
-  closeLandingPage: () => void;
 }
 
 export function LandingPagePanel({
   language,
   org,
   repo,
-  closeLandingPage,
   handleXSDUploaded,
   handleCreateModelClick,
 }: LandingPageProps) {
@@ -30,9 +28,8 @@ export function LandingPagePanel({
       <div className={classes.buttons}>
         <XSDUpload
           language={language}
-          onXSDUploaded={(filename) => {
+          onXSDUploaded={(filename): void => {
             handleXSDUploaded(filename);
-            closeLandingPage();
           }}
           org={org}
           repo={repo}
@@ -46,9 +43,8 @@ export function LandingPagePanel({
         <AltinnButton
           btnText={t('app_data_modelling.landing_dialog_create')}
           secondaryButton
-          onClickFunction={() => {
+          onClickFunction={(): void => {
             handleCreateModelClick();
-            closeLandingPage();
           }}
         />
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed the bug and make sure to always display no data-model message when there is no model to display. Some small refactoring has been done to make the code more maintainable.

## Related Issue(s)
- #9712

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
