### PR TITLE
Fix size of text resource buttons

### DIFF
--- a/frontend/packages/ux-editor/src/components/AddOption.module.css
+++ b/frontend/packages/ux-editor/src/components/AddOption.module.css
@@ -27,4 +27,5 @@
 
 .addButton {
   margin-left: calc(var(--component-button-space-padding-x-small) * -2 / 3); /* Align button icon with the checkboxes or radio buttons above */
+  margin-top: calc((var(--component-button-size-icon-small) - var(--component-button-size-height-small)) / 2); /* Compensate for the additional spacing caused by the button padding, so that the spacing between the icon and the options becomes equal to the spacing between the options themselves */
 }

--- a/frontend/packages/ux-editor/src/components/TextResource.module.css
+++ b/frontend/packages/ux-editor/src/components/TextResource.module.css
@@ -31,16 +31,33 @@
 }
 
 .textResource {
+  align-items: stretch;
   display: inline-flex;
-  align-items: center;
-  gap: 1rem;
+}
+
+.buttonsWrapper {
+  display: inline-block;
+  position: relative;
+}
+
+.buttons {
+  display: inline-flex;
+  gap: 0.5rem;
+  left: 0;
+  margin-left: 1rem;
+  position: relative;
+  top: 0;
+}
+
+.previewMode .buttons {
+  position: absolute;
 }
 
 .button {
   --icon-size: 1em;
-  height: 1.5em;
-  width: 1.5em;
+  height: 1.5em !important;
   padding: 0.25em !important;
+  width: 1.5em;
 }
 
 .placeholder {

--- a/frontend/packages/ux-editor/src/components/TextResource.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResource.tsx
@@ -96,45 +96,46 @@ export const TextResource = ({
         </span>
       )}
       <span className={classes.textResource}>
-        {textResource?.value ? (
-          <>
-            <span>{textResource.value}</span>
+        {textResource?.value
+          ? <span>{textResource.value}</span>
+          : <span className={classes.placeholder}>{placeholder}</span>}
+        <span className={classes.buttonsWrapper}>
+          <span className={classes.buttons}>
+            {textResource?.value ? (
+              <Button
+                aria-label={t('general.edit')}
+                className={classes.button}
+                color={ButtonColor.Secondary}
+                disabled={isEditing}
+                icon={<Edit/>}
+                onClick={handleEditButtonClick}
+                title={t('general.edit')}
+                variant={ButtonVariant.Quiet}
+              />
+            ) : (
+              <Button
+                aria-label={t('general.add')}
+                className={classes.button}
+                color={ButtonColor.Secondary}
+                disabled={isEditing}
+                icon={<Add />}
+                onClick={handleEditButtonClick}
+                title={t('general.add')}
+                variant={ButtonVariant.Quiet}
+              />
+            )}
             <Button
-              aria-label={t('general.edit')}
+              aria-label={t('general.search')}
               className={classes.button}
               color={ButtonColor.Secondary}
-              disabled={isEditing}
-              icon={<Edit/>}
-              onClick={handleEditButtonClick}
-              title={t('general.edit')}
+              disabled={isSearchMode}
+              icon={<Search />}
+              onClick={() => setIsSearchMode(true)}
+              title={t('general.search')}
               variant={ButtonVariant.Quiet}
             />
-          </>
-        ) : (
-          <>
-            <span className={classes.placeholder}>{placeholder}</span>
-            <Button
-              aria-label={t('general.add')}
-              className={classes.button}
-              color={ButtonColor.Secondary}
-              disabled={isEditing}
-              icon={<Add />}
-              onClick={handleEditButtonClick}
-              title={t('general.add')}
-              variant={ButtonVariant.Quiet}
-            />
-          </>
-        )}
-        <Button
-          aria-label={t('general.search')}
-          className={classes.button}
-          color={ButtonColor.Secondary}
-          disabled={isSearchMode}
-          icon={<Search />}
-          onClick={() => setIsSearchMode(true)}
-          title={t('general.search')}
-          variant={ButtonVariant.Quiet}
-        />
+          </span>
+        </span>
       </span>
     </span>
   );

--- a/frontend/packages/ux-editor/src/containers/ComponentPreview/CheckboxGroupPreview/CheckboxGroupPreview.module.css
+++ b/frontend/packages/ux-editor/src/containers/ComponentPreview/CheckboxGroupPreview/CheckboxGroupPreview.module.css
@@ -2,7 +2,7 @@
   align-items: flex-start;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: var(--component-checkbox-group-space-gap-y-small);
 }
 
 .addCheckbox {

--- a/frontend/packages/ux-editor/src/containers/ComponentPreview/RadioGroupPreview/RadioGroupPreview.module.css
+++ b/frontend/packages/ux-editor/src/containers/ComponentPreview/RadioGroupPreview/RadioGroupPreview.module.css
@@ -2,7 +2,7 @@
   align-items: flex-start;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: var(--component-checkbox-group-space-gap-y-small);
 }
 
 .addRadioButton {


### PR DESCRIPTION
## Description
- Fixed the height of text resource buttons
- Made the positioning of the buttons absolute in preview mode, so that they do not disturb the design
- Adjusted the spacing between the "add option" button and the options in preview mode

## Related Issue(s)
- #9694

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
