### PR TITLE
Add caseswitching in preselect and text for preselect dropdown

### DIFF
--- a/frontend/language/src/en.json
+++ b/frontend/language/src/en.json
@@ -748,6 +748,7 @@
   "ux_editor.component_container": "Container",
   "ux_editor.component_datepicker": "Datepicker",
   "ux_editor.component_dropdown": "Drop-down-list",
+  "ux_editor.component_dropdown_set_preselected": "Set pre-selected value in dropdown list",
   "ux_editor.component_file_upload": "Attachment",
   "ux_editor.component_group": "Group",
   "ux_editor.component_header": "Title",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -779,6 +779,7 @@
   "ux_editor.component_container": "Container",
   "ux_editor.component_datepicker": "Dato",
   "ux_editor.component_dropdown": "Nedtrekksliste",
+  "ux_editor.component_dropdown_set_preselected": "Sett forhåndsvalgt verdi for nedtrekksliste",
   "ux_editor.component_file_upload": "Vedlegg",
   "ux_editor.component_file_upload_with_tag": "Vedlegg med merking",
   "ux_editor.component_group": "Gruppe",

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditPreselectedIndex.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditPreselectedIndex.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import type {
-  IFormGenericOptionsComponent,
-} from '../../../types/global';
+import type { IFormGenericOptionsComponent } from '../../../types/global';
 import { TextField } from '@digdir/design-system-react';
-import { IGenericEditComponent } from '../componentConfig';
+import type { IGenericEditComponent } from '../componentConfig';
 import { useText } from '../../../hooks';
 
 export function EditPreselectedIndex({ component, handleComponentChange }: IGenericEditComponent) {
@@ -16,20 +14,28 @@ export function EditPreselectedIndex({ component, handleComponentChange }: IGene
     });
   };
 
+  function textSwitch(param) {
+    switch (param) {
+      case 'Checkboxes':
+        return t('ux_editor.modal_check_box_set_preselected');
+      case 'RadioButtons':
+        return t('ux_editor.modal_radio_button_set_preselected');
+      case 'Dropdown':
+        return t('ux_editor.component_dropdown_set_preselected');
+      default:
+        return 'Unknown component';
+    }
+  }
+
   return (
     <div>
       <TextField
         defaultValue={(component as IFormGenericOptionsComponent).preselectedOptionIndex}
         formatting={{ number: {} }}
-        label={
-          component.type === 'Checkboxes'
-            ? t('ux_editor.modal_check_box_set_preselected')
-            : t('ux_editor.modal_radio_button_set_preselected')
-        }
+        label={textSwitch(component.type)}
         onChange={handlePreselectedOptionChange}
         placeholder={t('ux_editor.modal_selection_set_preselected_placeholder')}
       />
     </div>
-
   );
 }

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditPreselectedIndex.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditPreselectedIndex.tsx
@@ -16,11 +16,11 @@ export function EditPreselectedIndex({ component, handleComponentChange }: IGene
 
   function textSwitch(param) {
     switch (param) {
-      case 'Checkboxes':
+      case ComponentTypes.Checkboxes:
         return t('ux_editor.modal_check_box_set_preselected');
-      case 'RadioButtons':
+      case ComponentTypes.RadioButtons:
         return t('ux_editor.modal_radio_button_set_preselected');
-      case 'Dropdown':
+      case ComponentTypes.Dropdown:
         return t('ux_editor.component_dropdown_set_preselected');
       default:
         return 'Unknown component';

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditPreselectedIndex.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditPreselectedIndex.tsx
@@ -3,6 +3,7 @@ import type { IFormGenericOptionsComponent } from '../../../types/global';
 import { TextField } from '@digdir/design-system-react';
 import type { IGenericEditComponent } from '../componentConfig';
 import { useText } from '../../../hooks';
+import { ComponentTypes } from '../../';
 
 export function EditPreselectedIndex({ component, handleComponentChange }: IGenericEditComponent) {
   const t = useText();
@@ -14,16 +15,16 @@ export function EditPreselectedIndex({ component, handleComponentChange }: IGene
     });
   };
 
-  function textSwitch(param) {
-    switch (param) {
+  const mapComponentTypeToText = (componentType: ComponentTypes) => {
+    switch (componentType) {
       case ComponentTypes.Checkboxes:
         return t('ux_editor.modal_check_box_set_preselected');
-      case ComponentTypes.RadioButtons:
-        return t('ux_editor.modal_radio_button_set_preselected');
-      case ComponentTypes.Dropdown:
-        return t('ux_editor.component_dropdown_set_preselected');
-      default:
-        return 'Unknown component';
+        case ComponentTypes.RadioButtons:
+          return t('ux_editor.modal_radio_button_set_preselected');
+          case ComponentTypes.Dropdown:
+            return t('ux_editor.component_dropdown_set_preselected');
+            default:
+              return 'Unknown component';
     }
   }
 
@@ -32,7 +33,7 @@ export function EditPreselectedIndex({ component, handleComponentChange }: IGene
       <TextField
         defaultValue={(component as IFormGenericOptionsComponent).preselectedOptionIndex}
         formatting={{ number: {} }}
-        label={textSwitch(component.type)}
+        label={mapComponentTypeToText(component.type)}
         onChange={handlePreselectedOptionChange}
         placeholder={t('ux_editor.modal_selection_set_preselected_placeholder')}
       />


### PR DESCRIPTION
## Description
- Add new global texts for preselect title for dropdown component in both english and norwegian
- Add a caseswitching function in react preselect component 

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
