### PR TITLE
Fix width of add option box in preview mode

### DIFF
--- a/frontend/packages/ux-editor/src/components/AddOption.module.css
+++ b/frontend/packages/ux-editor/src/components/AddOption.module.css
@@ -3,7 +3,6 @@
   border-radius: 5px;
   border: 1px solid #c9c9c9;
   padding: 1rem;
-  width: 100%;
 }
 
 .fieldSetContent {

--- a/frontend/packages/ux-editor/src/containers/ComponentPreview/CheckboxGroupPreview/CheckboxGroupPreview.module.css
+++ b/frontend/packages/ux-editor/src/containers/ComponentPreview/CheckboxGroupPreview/CheckboxGroupPreview.module.css
@@ -1,5 +1,5 @@
 .root {
-  align-items: flex-start;
+  align-items: stretch;
   display: flex;
   flex-direction: column;
   gap: var(--component-checkbox-group-space-gap-y-small);

--- a/frontend/packages/ux-editor/src/containers/ComponentPreview/RadioGroupPreview/RadioGroupPreview.module.css
+++ b/frontend/packages/ux-editor/src/containers/ComponentPreview/RadioGroupPreview/RadioGroupPreview.module.css
@@ -1,5 +1,5 @@
 .root {
-  align-items: flex-start;
+  align-items: stretch;
   display: flex;
   flex-direction: column;
   gap: var(--component-checkbox-group-space-gap-y-small);


### PR DESCRIPTION
## Description
The `width: 100%` property makes the box too wide because of padding in the container. Setting `align-items: stretch` on the container solves the problem.

## Related Issue(s)
- #9742

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
