### PR TITLE
Fix call to set node type

### DIFF
--- a/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
@@ -95,7 +95,7 @@ export function ItemDataComponent(props: IItemDataComponentProps) {
 
   const onChangeRef = (path: string, ref: string) => dispatch(setRef({ path, ref }));
 
-  const onChangeFieldType = (pointer: string, type: FieldType) =>
+  const onChangeFieldType = (type: FieldType) =>
     dispatch(setType({ path: pointer, type }));
 
   const onChangeNullable = (event: ChangeEvent<HTMLInputElement>): void => {
@@ -171,7 +171,7 @@ export function ItemDataComponent(props: IItemDataComponentProps) {
       {objectKind === ObjectKind.Field && (
         <Select
           label={t('type')}
-          onChange={(type: FieldType) => onChangeFieldType(pointer, type)}
+          onChange={(type: FieldType) => onChangeFieldType(type)}
           options={getTypeOptions(t)}
           value={fieldType as string}
         />

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
@@ -107,7 +107,7 @@ export function ItemDataComponent(props: IItemDataComponentProps) {
       return;
     }
 
-    childNodes.forEach((childNode: UiSchemaNode) => {
+    getChildNodes().forEach((childNode: UiSchemaNode) => {
       if (childNode.fieldType === FieldType.Null) {
         dispatch(deleteCombinationItem({ path: childNode.pointer }));
       }
@@ -171,7 +171,7 @@ export function ItemDataComponent(props: IItemDataComponentProps) {
       {objectKind === ObjectKind.Field && (
         <Select
           label={t('type')}
-          onChange={(type: FieldType) => onChangeFieldType(type)}
+          onChange={(type: FieldType) => onChangeFieldType(pointer, type)}
           options={getTypeOptions(t)}
           value={fieldType as string}
         />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A function call was missing a required parameter. This was shown very clearly as an error in my IDE, not sure why this was not caught build-time.

Also updated a referene to`childNode` - definition of that variable was also removed with the recent refactoring, and replaced with this `getChildNodes` function. However this reference was not updated. This should also have been caught build-time imo. I think we need to look at our build and if it actually does type-checking.

## Related Issue(s)
- #9759 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
