### PR TITLE
Definition conflicts between Chai and Jest

### DIFF
--- a/frontend/testing/cypress/tsconfig.json
+++ b/frontend/testing/cypress/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["es6", "dom", "es7", "esnext"],
+    "types": ["cypress", "node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/frontend/testing/cypress/tsconfig.json
+++ b/frontend/testing/cypress/tsconfig.json
@@ -4,5 +4,5 @@
     "lib": ["es6", "dom", "es7", "esnext"],
     "types": ["cypress", "node"]
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "**/*.js"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -25,5 +25,5 @@
   },
   "files": ["declaration.d.ts"],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "tmp"]
+  "exclude": ["node_modules", "tmp", "./testing/cypress/**"]
 }


### PR DESCRIPTION
## Description
Because of Cypress, we have definition conflicts between Chai and Jest within our workspaces. Due to the Cypress documentation, Chai is a global namespace, meaning that package managers like yarn or npm nest and include multiple definitions and which makes conflicts. 

To fix this issue I followed the Cypress documentation and added tsconfig.json for the Cypress project, instead of using the one on the root. Within the tsconfig.json on the root, I have ignored the Cypress project to make sure the Chai namespace will not be available globally.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
