### PR TITLE
Make sure the TypeScript code is type-checked 

### DIFF
--- a/frontend/app-development/features/handleMergeConflict/components/HandleMergeConflictFileList.test.tsx
+++ b/frontend/app-development/features/handleMergeConflict/components/HandleMergeConflictFileList.test.tsx
@@ -5,7 +5,6 @@ import userEvent from '@testing-library/user-event';
 
 const renderHandleMergeConflictFileList = (mockRepostatus?: any) => {
   const user = userEvent.setup();
-  const mockClasses: any = {};
   const mockLanguage: any = {};
   const repoStatus = mockRepostatus ?? {
     behindBy: 1,
@@ -31,7 +30,6 @@ const renderHandleMergeConflictFileList = (mockRepostatus?: any) => {
   const container = render(
     <HandleMergeConflictFileList
       changeSelectedFile={changeSelectedFile}
-      classes={mockClasses}
       language={mockLanguage}
       repoStatus={repoStatus}
     />

--- a/frontend/app-development/package.json
+++ b/frontend/app-development/package.json
@@ -37,12 +37,13 @@
   "license": "3-Clause BSD",
   "private": true,
   "scripts": {
-    "build": "cross-env NODE_ENV=production webpack --config ../webpack.config.prod.js",
+    "build": "yarn typeCheck:once && cross-env NODE_ENV=production webpack --config ../webpack.config.prod.js",
     "build-with-profile": "yarn build --profile --json > stats.json",
     "bundle-size": "npx webpack-bundle-analyzer ./stats.json",
     "depcheck": "echo Checking $npm_package_name && npx depcheck && echo ",
-    "start": "cross-env NODE_ENV=development webpack-dev-server --config ../webpack.config.dev.js --mode development",
+    "start": "yarn typeCheck:watch && cross-env NODE_ENV=development webpack-dev-server --config ../webpack.config.dev.js --mode development",
     "test": "jest --maxWorkers=50%",
-    "typecheck": "tsc --noEmit"
+    "typeCheck:watch": "tsc --noEmit -w",
+    "typeCheck:once": "tsc --noEmit"
   }
 }

--- a/frontend/app-preview/package.json
+++ b/frontend/app-preview/package.json
@@ -29,11 +29,12 @@
   "license": "3-Clause BSD",
   "private": true,
   "scripts": {
-    "build": "cross-env NODE_ENV=production webpack --config ../webpack.config.prod.js",
+    "build": "yarn typeCheck:once && cross-env NODE_ENV=production webpack --config ../webpack.config.prod.js",
     "build-with-profile": "yarn build --profile --json > stats.json",
     "depcheck": "echo Checking $npm_package_name && npx depcheck && echo ",
-    "start": "cross-env NODE_ENV=development webpack-dev-server --config ../webpack.config.dev.js --mode development",
+    "start": "yarn typeCheck:watch && cross-env NODE_ENV=development webpack-dev-server --config ../webpack.config.dev.js --mode development",
     "test": "jest --maxWorkers=50%",
-    "typecheck": "tsc --noEmit"
+    "typeCheck:watch": "tsc --noEmit -w",
+    "typeCheck:once": "tsc --noEmit"
   }
 }

--- a/frontend/dashboard/components/DataModelsRepoList/DatamodelsRepoList.tsx
+++ b/frontend/dashboard/components/DataModelsRepoList/DatamodelsRepoList.tsx
@@ -19,7 +19,7 @@ export const DatamodelsReposList = () => {
   const { data: starredRepos, isLoading: isLoadingStarred } = useGetUserStarredReposQuery();
 
   const { data: repos, isLoading: isLoadingOrgRepos } = useGetSearchQuery({
-    uid,
+    uid: uid as number,
     keyword: '-datamodels',
     page: 0
   });

--- a/frontend/dashboard/components/OrgRepoList/OrgReposList.tsx
+++ b/frontend/dashboard/components/OrgRepoList/OrgReposList.tsx
@@ -25,7 +25,7 @@ export const OrgReposList = () => {
   const [sortModel, setSortModel] = useState<GridSortModel>([{ field: 'name', sort: 'asc' }]);
   const { data: starredRepos, isLoading: isLoadingStarred } = useGetUserStarredReposQuery();
   const { data: repos, isLoading: isLoadingOrgRepos } = useGetSearchQuery({
-    uid,
+    uid: uid as number,
     page: page,
     sortby: sortModel?.[0]?.field,
     order: sortModel?.[0]?.sort,

--- a/frontend/dashboard/package.json
+++ b/frontend/dashboard/package.json
@@ -25,17 +25,19 @@
   "devDependencies": {
     "cross-env": "7.0.3",
     "jest": "29.4.1",
-    "tsc": "2.0.4",
+    "typescript": "4.9.5",
     "webpack": "5.75.0",
     "webpack-dev-server": "4.11.1"
   },
   "license": "3-Clause BSD",
   "private": true,
   "scripts": {
-    "build": "cross-env NODE_ENV=production webpack --config ../webpack.config.prod.js",
+    "build": "yarn typeCheck:once && cross-env NODE_ENV=production webpack --config ../webpack.config.prod.js",
     "compile-ts": "tsc",
     "depcheck": "echo Checking $npm_package_name && npx depcheck && echo ",
-    "start": "cross-env NODE_ENV=development webpack-dev-server --config ../webpack.config.dev.js --mode development",
-    "test": "jest --maxWorkers=50%"
+    "start": "yarn typeCheck:watch && cross-env NODE_ENV=development webpack-dev-server --config ../webpack.config.dev.js --mode development",
+    "test": "jest --maxWorkers=50%",
+    "typeCheck:watch": "tsc --noEmit -w",
+    "typeCheck:once": "tsc --noEmit"
   }
 }

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
@@ -69,6 +69,7 @@ export function ItemDataComponent(props: IItemDataComponentProps) {
 
   const getChildNodes = () =>
     pointer && pointer.endsWith(nodeName) ? getChildNodesByPointer(uiSchema, pointer) : [];
+
   const softValidateName = (nodeName: string) => {
     const error = !isValidName(nodeName) ? NameError.InvalidCharacter : NameError.NoError;
     setNameError(error);
@@ -95,7 +96,7 @@ export function ItemDataComponent(props: IItemDataComponentProps) {
 
   const onChangeRef = (path: string, ref: string) => dispatch(setRef({ path, ref }));
 
-  const onChangeFieldType = (pointer: string, type: FieldType) =>
+  const onChangeFieldType = (type: FieldType) =>
     dispatch(setType({ path: pointer, type }));
 
   const onChangeNullable = (event: ChangeEvent<HTMLInputElement>): void => {
@@ -107,7 +108,7 @@ export function ItemDataComponent(props: IItemDataComponentProps) {
       return;
     }
 
-    childNodes.forEach((childNode: UiSchemaNode) => {
+    getChildNodes().forEach((childNode: UiSchemaNode) => {
       if (childNode.fieldType === FieldType.Null) {
         dispatch(deleteCombinationItem({ path: childNode.pointer }));
       }

--- a/frontend/packages/shared/src/file-editor/MonacoEditorComponent.tsx
+++ b/frontend/packages/shared/src/file-editor/MonacoEditorComponent.tsx
@@ -4,7 +4,6 @@ import MonacoEditor from 'react-monaco-editor';
 import classes from './MonacoEditorComponent.module.css';
 
 export interface IMonacoEditorComponentProps {
-  classes: any;
   createCompletionSuggestions?: (monaco: any, filterText: string) => any[];
   escRef: any;
   heightPx?: any;

--- a/frontend/packages/ux-editor/src/components/config/ConditionalRenderingComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/ConditionalRenderingComponent.tsx
@@ -330,7 +330,6 @@ class ConditionalRendering extends React.Component<IConditionalRenderingComponen
                             onDataModelChange={this.handleParamDataChange.bind(null, paramName)}
                             selectedElement={this.state.conditionalRendering.inputParams[paramName]}
                             hideRestrictions={true}
-                            language={this.props.language}
                           />
                         </div>
                       </div>

--- a/frontend/packages/ux-editor/src/components/config/RuleComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/RuleComponent.tsx
@@ -179,7 +179,6 @@ class Rule extends React.Component<IRuleComponentProps, any> {
                             onDataModelChange={this.handleParamDataChange.bind(null, paramName)}
                             selectedElement={this.state.ruleConnection.inputParams[paramName]}
                             hideRestrictions={true}
-                            language={this.props.language}
                           />
                         </div>
                       </div>
@@ -218,7 +217,6 @@ class Rule extends React.Component<IRuleComponentProps, any> {
                       onDataModelChange={this.handleOutParamDataChange.bind(null, 'outParam0')}
                       selectedElement={this.state.ruleConnection.outParams.outParam0}
                       hideRestrictions={true}
-                      language={this.props.language}
                     />
                   </div>
                 </div>

--- a/frontend/packages/ux-editor/src/components/config/SelectDataModelComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/SelectDataModelComponent.tsx
@@ -28,7 +28,6 @@ export const SelectDataModelComponent = ({
   selectedElement,
   onDataModelChange,
   noOptionsMessage,
-  hideRestrictions,
   selectGroup,
 }: ISelectDataModelProps) => {
   const [selectedBinding, setSelectedBinding] = useState(selectedElement);

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Address/AddressComponent.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Address/AddressComponent.test.tsx
@@ -3,9 +3,11 @@ import { IGenericEditComponent } from '../../componentConfig';
 import { IFormAddressComponent } from '../../../../types/global';
 import { renderWithMockStore } from '../../../../testing/mocks';
 import { AddressComponent } from './AddressComponent';
+import { ComponentTypes } from '../../../';
 
 // Test data:
 const component: IFormAddressComponent = {
+  type: ComponentTypes.AddressComponent,
   dataModelBindings: {
     test: 'test'
   },

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Image/ImageComponent.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Image/ImageComponent.test.tsx
@@ -6,16 +6,18 @@ import type { IImageComponentProps } from './ImageComponent';
 import { ImageComponent } from './ImageComponent';
 import { appDataMock, renderWithMockStore } from '../../../../testing/mocks';
 import { IAppDataState } from '../../../../features/appData/appDataReducers';
+import type { IFormImageComponent } from '../../../../types/global';
+import { ComponentTypes } from '../../../';
 
 const user = userEvent.setup();
 
-const componentData = {
+const componentData: IFormImageComponent = {
   id: '4a66b4ea-13f1-4187-864a-fd4bb6e8cf88',
   textResourceBindings: {},
-  type: 'Image',
+  type: ComponentTypes.Image,
   image: {
-    src: {},
-  },
+    src: {}
+  }
 };
 const texts = {
   'ux_editor.modal_properties_image_src_value_label': 'Source',
@@ -24,13 +26,13 @@ const texts = {
   'ux_editor.modal_properties_image_width_label': 'Width',
   'ux_editor.modal_properties_image_placement_left': 'Left',
   'ux_editor.modal_properties_image_placement_center': 'Center',
-  'ux_editor.modal_properties_image_placement_right': 'Right',
+  'ux_editor.modal_properties_image_placement_right': 'Right'
 };
 const render = (props: Partial<IImageComponentProps> = {}) => {
   const allProps: IImageComponentProps = {
     component: componentData,
     handleComponentUpdate: jest.fn(),
-    ...props,
+    ...props
   };
 
   const appData: IAppDataState = {
@@ -40,14 +42,14 @@ const render = (props: Partial<IImageComponentProps> = {}) => {
       resources: {
         nb: [
           { id: 'altTextImg', value: 'Alternative text' },
-          { id: 'altTextImg2', value: 'Alternative text 2' },
+          { id: 'altTextImg2', value: 'Alternative text 2' }
         ]
       }
     },
     languageState: {
       ...appDataMock.languageState,
-      language: texts,
-    },
+      language: texts
+    }
   };
 
   return renderWithMockStore({ appData })(<ImageComponent {...allProps} />);
@@ -60,7 +62,7 @@ describe('ImageComponent', () => {
     render({ handleComponentUpdate: handleUpdate });
 
     const srcInput = screen.getByRole('textbox', {
-      name: /source/i,
+      name: /source/i
     });
 
     await act(() => user.type(srcInput, imgSrc));
@@ -70,9 +72,9 @@ describe('ImageComponent', () => {
       image: {
         ...componentData.image,
         src: {
-          nb: imgSrc,
-        },
-      },
+          nb: imgSrc
+        }
+      }
     });
   });
 
@@ -82,7 +84,7 @@ describe('ImageComponent', () => {
     render({ handleComponentUpdate: handleUpdate });
 
     const widthInput = screen.getByRole('textbox', {
-      name: /width/i,
+      name: /width/i
     });
 
     await act(() => user.type(widthInput, size));
@@ -91,8 +93,8 @@ describe('ImageComponent', () => {
       ...componentData,
       image: {
         ...componentData.image,
-        width: size,
-      },
+        width: size
+      }
     });
   });
 
@@ -101,7 +103,7 @@ describe('ImageComponent', () => {
     render({ handleComponentUpdate: handleUpdate });
 
     const placementInput = screen.getByRole('combobox', {
-      name: /placement/i,
+      name: /placement/i
     });
 
     await act(() => user.type(placementInput, 'L')); // Type something to trigger showing Select options
@@ -111,8 +113,8 @@ describe('ImageComponent', () => {
       ...componentData,
       image: {
         ...componentData.image,
-        align: 'flex-start',
-      },
+        align: 'flex-start'
+      }
     });
   });
 });

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditAutoComplete.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditAutoComplete.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { EditAutoComplete, getAutocompleteOptions } from './EditAutoComplete';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { FormComponentType } from '../../../types/global';
+
 
 test('should give options', () => {
   const options = getAutocompleteOptions('nam');
@@ -27,7 +29,7 @@ test('that is renders', async () => {
       unobserve: jest.fn(),
     }));
   const handleComponentChange = jest.fn();
-  const component = {};
+  const component = {} as FormComponentType;
   userEvent.setup();
   render(<EditAutoComplete handleComponentChange={handleComponentChange} component={component} />);
   const textbox = screen.getByRole('textbox');

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditAutoComplete.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditAutoComplete.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import type { IGenericEditComponent } from '../componentConfig';
-import { TextField, Popover, Button } from '@digdir/design-system-react';
+import { TextField, Popover, PopoverVariant, Button, ButtonSize, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
 
 const getLastWord = (value: string) => value.split(' ').pop();
 const stdAutocompleteOpts = [
@@ -98,7 +98,7 @@ export const EditAutoComplete = ({ component, handleComponentChange }: IGenericE
         value={value}
       />
       <Popover
-        variant='default'
+        variant={PopoverVariant.Default}
         open={options.length > 0}
         placement='bottom-start'
         arrow={false}
@@ -106,9 +106,9 @@ export const EditAutoComplete = ({ component, handleComponentChange }: IGenericE
       >
         {options.map((word) => (
           <Button
-            size='small'
-            color='inverted'
-            variant='quiet'
+            size={ButtonSize.Small}
+            color={ButtonColor.Inverted}
+            variant={ButtonVariant.Quiet}
             key={word}
             style={{ float: 'left' }}
             onClick={() => handleWordClick(word)}

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, screen, within } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 import { appDataMock, dataModelItemMock, dataModelStateMock, languageStateMock, renderWithMockStore, textResourcesMock } from '../../../testing/mocks';
 import { IAppDataState } from '../../../features/appData/appDataReducers';

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditPreselectedIndex.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditPreselectedIndex.tsx
@@ -33,7 +33,7 @@ export function EditPreselectedIndex({ component, handleComponentChange }: IGene
       <TextField
         defaultValue={(component as IFormGenericOptionsComponent).preselectedOptionIndex}
         formatting={{ number: {} }}
-        label={mapComponentTypeToText(component.type)}
+        label={mapComponentTypeToText(component.type as ComponentTypes)}
         onChange={handlePreselectedOptionChange}
         placeholder={t('ux_editor.modal_selection_set_preselected_placeholder')}
       />

--- a/frontend/packages/ux-editor/src/containers/ComponentPreview/CheckboxGroupPreview/CheckboxGroupPreview.tsx
+++ b/frontend/packages/ux-editor/src/containers/ComponentPreview/CheckboxGroupPreview/CheckboxGroupPreview.tsx
@@ -11,6 +11,7 @@ import {
   changeTitleBinding
 } from '../../../utils/component';
 import { AddOption } from '../../../components/AddOption';
+import { TranslationKey } from 'language/type';
 
 export interface CheckboxGroupPreviewProps extends IGenericEditComponent {
   component: IFormCheckboxComponent;
@@ -21,7 +22,7 @@ export const CheckboxGroupPreview = ({
   handleComponentChange,
 }: CheckboxGroupPreviewProps) => {
   const t = useText();
-  const tCheckboxes = (key: string) => t(`ux_editor.checkboxes_${key}`);
+  const tCheckboxes = (key: string) => t((`ux_editor.checkboxes_${key}`) as TranslationKey);
 
   const changeOptionLabel = (value: string, label: string) =>
     handleComponentChange(changeComponentOptionLabel(component, value, label));

--- a/frontend/packages/ux-editor/src/containers/ComponentPreview/RadioGroupPreview/RadioGroupPreview.tsx
+++ b/frontend/packages/ux-editor/src/containers/ComponentPreview/RadioGroupPreview/RadioGroupPreview.tsx
@@ -12,6 +12,7 @@ import {
   changeTitleBinding,
 } from '../../../utils/component';
 import { AddOption } from '../../../components/AddOption';
+import { TranslationKey } from 'language/type';
 
 export interface RadioGroupPreviewProps extends IGenericEditComponent {
   component: IFormRadioButtonComponent;
@@ -22,7 +23,7 @@ export const RadioGroupPreview = ({
   handleComponentChange,
 }: RadioGroupPreviewProps) => {
   const t = useText();
-  const tRadios = (key: string) => t(`ux_editor.radios_${key}`);
+  const tRadios = (key: string) => t((`ux_editor.radios_${key}`) as TranslationKey);
 
   const radioGroupName = useRef(generateRandomId(12));
 

--- a/frontend/packages/ux-editor/src/utils/render.tsx
+++ b/frontend/packages/ux-editor/src/utils/render.tsx
@@ -66,7 +66,6 @@ export const renderSelectGroupDataModelBinding = (
         inputId='dataModalHelper'
         selectedElement={dataModelBinding[key]}
         onDataModelChange={(dataModelField) => onDataModelChange(dataModelField, key)}
-        t={t}
         selectGroup={true}
         noOptionsMessage={t('general.no_options')}
       />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,6 +15,7 @@
     "noUnusedLocals": true,
     "esModuleInterop": true,
     "baseUrl": ".",
+    "skipLibCheck": true,
     "paths": {
       "app-shared/*": ["./packages/shared/src/*"],
       "@altinn/schema-editor/*": ["./packages/schema-editor/src/*"],

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5969,7 +5969,7 @@ __metadata:
     react-use: 17.4.0
     redux: 4.2.1
     redux-saga: 1.2.2
-    tsc: 2.0.4
+    typescript: 4.9.5
     webpack: 5.75.0
     webpack-dev-server: 4.11.1
   languageName: unknown


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The codebase was not type-checked when building for dev or prod. This PR has implemented **"tsc --noEmit"** to make sure the TypeScript code is type-checked before starting the dev-server or build for production. 

**!!IMPORTANT!! This PR should be merged after https://github.com/Altinn/altinn-studio/pull/9764, because the PR 9764 is reducing type-check errors from 1200 to 26. Many of the type-check errors was conflicting between jest and chai within .test.ts** 

EDIT: Also fixes #9759 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
