### PR TITLE
Bug/9679 body text panel component

### DIFF
--- a/frontend/language/src/en.json
+++ b/frontend/language/src/en.json
@@ -888,6 +888,7 @@
   "ux_editor.modal_text": "Text",
   "ux_editor.modal_text_input": "Choose text",
   "ux_editor.modal_text_key": "Text key",
+  "ux_editor.modal_text_resource_body": "Text content",
   "ux_editor.radios_description_add": "Add descrption",
   "ux_editor.radios_description_placeholder": "No description",
   "ux_editor.radios_legend_add": "Add title",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -924,6 +924,7 @@
   "ux_editor.modal_text": "Tekst",
   "ux_editor.modal_text_input": "Velg tekst",
   "ux_editor.modal_text_key": "Tekstnøkkel",
+  "ux_editor.modal_text_resource_body": "Tekstinnhold",
   "ux_editor.radios_description_add": "Legg til beskrivelse",
   "ux_editor.radios_description_placeholder": "Ingen beskrivelse",
   "ux_editor.radios_legend_add": "Legg til tittel",

--- a/frontend/packages/ux-editor/src/components/config/componentConfig.ts
+++ b/frontend/packages/ux-editor/src/components/config/componentConfig.ts
@@ -71,7 +71,7 @@ export const componentSpecificEditConfig: IComponentEditConfig = {
   ],
   [ComponentTypes.AddressComponent]: [EditSettings.Title],
   [ComponentTypes.FileUploadWithTag]: [EditSettings.Title, EditSettings.Description],
-  [ComponentTypes.Panel]: [EditSettings.Title, EditSettings.Description],
+  [ComponentTypes.Panel]: [EditSettings.Title],
   [ComponentTypes.Map]: [EditSettings.ReadOnly],
 };
 

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/ComponentSpecificContent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/ComponentSpecificContent.tsx
@@ -10,6 +10,7 @@ import { ComponentTypes } from '../..';
 import { useText } from '../../../hooks';
 import type { IFormImageComponent } from '../../../types/global';
 import { MapComponent } from './Map';
+import { EditTextResourceBinding } from '../editModal/EditTextResourceBinding';
 
 export function ComponentSpecificContent({
   component,
@@ -47,6 +48,12 @@ export function ComponentSpecificContent({
     case ComponentTypes.Panel: {
       return (
         <>
+          <EditTextResourceBinding
+            component={component}
+            handleComponentChange={handleComponentChange}
+            textKey='body'
+            labelKey='ux_editor.modal_text_resource_body'
+          />
           <CheckboxComponent
             label={t('ux_editor.show_icon')}
             defaultValue={true}

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditDescription.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditDescription.tsx
@@ -1,26 +1,18 @@
 import React from 'react';
 import type { IGenericEditComponent } from '../componentConfig';
-import { TextResource } from '../../TextResource';
-import { useText } from '../../../hooks';
+import { EditTextResourceBinding } from './EditTextResourceBinding';
 
 export const EditDescription = ({
   component,
   handleComponentChange,
 }: IGenericEditComponent) => {
-  const t = useText();
-  const handleIdChange = (id: string) => handleComponentChange({
-    ...component,
-    textResourceBindings: {
-      ...component.textResourceBindings,
-      description: id,
-    }
-  });
   return (
-    <TextResource
-      handleIdChange={handleIdChange}
-      label={t('ux_editor.modal_properties_description')}
-      placeholder={t('ux_editor.modal_properties_description_add')}
-      textResourceId={component.textResourceBindings?.description}
+    <EditTextResourceBinding
+      component={component}
+      handleComponentChange={handleComponentChange}
+      textKey='description'
+      labelKey='ux_editor.modal_properties_description'
+      placeholderKey='ux_editor.modal_properties_description_add'
     />
   );
 };

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditTextResourceBinding.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditTextResourceBinding.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { EditTextResourceBinding, EditTextResourceBindingProps } from './EditTextResourceBinding';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithMockStore, languageStateMock, appDataMock, textResourcesMock } from '../../../testing/mocks';
+import { FormComponentType, ITextResource } from '../../../types/global';
+
+describe(('EditTextResourceBindings component'), () => {
+  const addText = 'Legg til';
+  const searchText = 'Søk';
+  const mockComponent = {
+    id: 'test-id',
+    textResourceBindings: {
+      test: 'test-text',
+    }
+  } as FormComponentType;
+
+  const language: Record<string, string> = {
+    'ux_editor.modal_text': 'Tekst',
+    'general.add': addText,
+    'general.search': searchText,
+  };
+
+  const textResources: ITextResource[] = [
+    {
+      id: 'test-text',
+      value: 'This is a test'
+    }
+  ];
+
+  test('that it renders', async () => {
+    renderEditTextResourceBindingsComponent({});
+    const label = screen.getByText('Tekst');
+    const textResourceValue = screen.getByText('This is a test');
+    expect(label).toBeInTheDocument();
+    expect(textResourceValue).toBeInTheDocument();
+  });
+
+  test('that handleComponentChange is called when adding a new text', async () => {
+    const handleComponentChange = jest.fn();
+    const { user } = renderEditTextResourceBindingsComponent({ handleComponentChange, textKey: 'does-not-exist' });
+    await act(() => user.click(screen.getByLabelText(addText)));
+    expect(handleComponentChange).toBeCalledTimes(1);
+  });
+
+  test('that handleComponentChange is called when choosing existing text', async () => {
+    const handleComponentChange = jest.fn();
+    const { user } = renderEditTextResourceBindingsComponent({ handleComponentChange, textKey: 'does-not-exist' });
+
+    // Click search button
+    await act(() => user.click(screen.getByLabelText(searchText)));
+
+    // Select with existing texts should be shown
+    const selectText = screen.getByTestId('select-root');
+    expect(selectText).toBeInTheDocument();
+
+    // Select text from available options
+    await act(() => user.click(screen.getByRole('option', { name: textResources[0].id })));
+
+    expect(handleComponentChange).toBeCalledTimes(1);
+    expect(handleComponentChange).toBeCalledWith({
+      ...mockComponent,
+      textResourceBindings: {
+        ...mockComponent.textResourceBindings,
+        'does-not-exist': 'test-text'
+      }
+    });
+  });
+
+  const renderEditTextResourceBindingsComponent = ({
+    component = mockComponent,
+    handleComponentChange = () => {},
+    textKey = 'test',
+    labelKey = 'ux_editor.modal_text',
+  }: Partial<EditTextResourceBindingProps>) => {
+    const user = userEvent.setup();
+    renderWithMockStore({
+      appData: {
+        ...appDataMock,
+        textResources: {
+          ...textResourcesMock,
+          resources: {
+            nb: textResources
+          }
+        },
+        languageState: {
+          ...languageStateMock,
+          language,
+        }
+      }
+    })(<EditTextResourceBinding
+          component={component}
+          handleComponentChange={handleComponentChange}
+          textKey={textKey}
+          labelKey={labelKey}
+      />);
+    return { user };
+  };
+});

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditTextResourceBinding.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditTextResourceBinding.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import type { IGenericEditComponent } from '../componentConfig';
+import { TextResource } from '../../TextResource';
+import { useText } from '../../../hooks';
+import { TranslationKey } from 'language/type';
+
+export interface EditTextResourceBindingProps extends IGenericEditComponent {
+  textKey: string;
+  labelKey: TranslationKey;
+  descriptionKey?: TranslationKey;
+  placeholderKey?: TranslationKey;
+}
+
+export const EditTextResourceBinding = ({
+  component,
+  handleComponentChange,
+  textKey,
+  labelKey,
+  descriptionKey,
+  placeholderKey,
+}: EditTextResourceBindingProps) => {
+  const t = useText();
+  const handleTextResourceChange = (value: string) => handleComponentChange({
+    ...component,
+    textResourceBindings: {
+      ...component.textResourceBindings,
+      [textKey]: value,
+    }
+  });
+  return (
+    <TextResource
+      handleIdChange={handleTextResourceChange}
+      label={t(labelKey)}
+      description={t(descriptionKey)}
+      placeholder={t(placeholderKey)}
+      textResourceId={component.textResourceBindings ? component.textResourceBindings[textKey] : undefined}
+    />
+  );
+};

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditTitle.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditTitle.tsx
@@ -1,25 +1,17 @@
 import React from 'react';
 import type { IGenericEditComponent } from '../componentConfig';
-import { TextResource } from '../../TextResource';
-import { useText } from '../../../hooks';
+import { EditTextResourceBinding } from './EditTextResourceBinding';
 
 export const EditTitle = ({
   component,
   handleComponentChange,
 }: IGenericEditComponent) => {
-  const t = useText();
-  const handleIdChange = (id: string) => handleComponentChange({
-    ...component,
-    textResourceBindings: {
-      ...component.textResourceBindings,
-      title: id,
-    }
-  });
   return (
-    <TextResource
-      handleIdChange={handleIdChange}
-      label={t('ux_editor.modal_properties_label')}
-      textResourceId={component.textResourceBindings?.title}
+    <EditTextResourceBinding
+      component={component}
+      handleComponentChange={handleComponentChange}
+      textKey='title'
+      labelKey='ux_editor.modal_properties_label'
     />
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaced `description` text resource with `body` for Panel component.
Added a generic `EditTextResourceBindings` component that can be used for other text keys later
 - updated EditTitle and EditDescription components to use generic component as base

## Related Issue(s)
- #9679 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
