### PR TITLE
Fix alignment of add option button

### DIFF
--- a/frontend/packages/ux-editor/src/components/AddOption.tsx
+++ b/frontend/packages/ux-editor/src/components/AddOption.tsx
@@ -97,17 +97,19 @@ export const AddOption = <T extends IFormGenericOptionsComponent>({
       </FieldSet>
     </div>
   ) : (
-    <Button
-      className={classes.addButton}
-      onClick={() => setIsAddMode(true)}
-      color={ButtonColor.Success}
-      title={t('ux_editor.add_option')}
-      variant={ButtonVariant.Quiet}
-    >
+    <div>
+      <Button
+        className={classes.addButton}
+        onClick={() => setIsAddMode(true)}
+        color={ButtonColor.Success}
+        title={t('ux_editor.add_option')}
+        variant={ButtonVariant.Quiet}
+      >
       <span className={addButtonClass}>
         <Add/>
       </span>
-      {t('ux_editor.add_option')}
-    </Button>
+        {t('ux_editor.add_option')}
+      </Button>
+    </div>
   );
 };


### PR DESCRIPTION
## Description
As a consequence of setting stretch-alignment on the container for another fix, the "add option" button also became stretched, while it should not. I solved this by wrapping it in a `div` block.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
