### PR TITLE
sync appname

### DIFF
--- a/backend/src/Designer/Controllers/ConfigController.cs
+++ b/backend/src/Designer/Controllers/ConfigController.cs
@@ -159,7 +159,7 @@ namespace Altinn.Studio.Designer.Controllers
             }
 
             System.IO.File.WriteAllText(serviceConfigPath, JObject.FromObject(serviceConfigurationObject).ToString(), Encoding.UTF8);
-            _repository.UpdateServiceInformationInApplication(org, app, serviceConfigurationObject);
+            _repository.UpdateAppTitleInAppMetadata(org, app, "nb", serviceConfigurationObject.ServiceName);
         }
     }
 }

--- a/backend/src/Designer/Controllers/TextController.cs
+++ b/backend/src/Designer/Controllers/TextController.cs
@@ -140,7 +140,7 @@ namespace Altinn.Studio.Designer.Controllers
             // updating application metadata with appTitle.
             JToken appTitleToken = resources.FirstOrDefault(x => x.Value<string>("id") == "appName" || x.Value<string>("id") == "ServiceName");
 
-            if (!(appTitleToken == null) && !(string.IsNullOrEmpty(appTitleToken.Value<string>("value"))))
+            if ((appTitleToken != null) && !(string.IsNullOrEmpty(appTitleToken.Value<string>("value"))))
             {
                 string appTitle = appTitleToken.Value<string>("value");
                 _repository.UpdateAppTitleInAppMetadata(org, app, languageCode, appTitle);
@@ -177,7 +177,8 @@ namespace Altinn.Studio.Designer.Controllers
 
                 TextResource textResourceObject = new TextResource
                 {
-                    Language = languageCode, Resources = new List<TextResourceElement>()
+                    Language = languageCode,
+                    Resources = new List<TextResourceElement>()
                 };
 
                 if (System.IO.File.Exists(textResourceDirectoryPath))

--- a/backend/src/Designer/Models/ResourceCollection.cs
+++ b/backend/src/Designer/Models/ResourceCollection.cs
@@ -45,5 +45,23 @@ namespace Altinn.Studio.Designer.Models
                 Resources.Add(new Resource { Id = id, Value = value ?? string.Empty });
             }
         }
+
+        /// <summary>
+        /// Deletes text resource in the Resources list.
+        /// </summary>
+        /// <param name="id"> The id. </param>
+        /// <exception cref="ArgumentException">id missing</exception>
+        public void Delete(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("Argument null or whitespace", nameof(id));
+            }
+
+            if (Resources.Any(r => r.Id == id))
+            {
+                Resources.Remove(Resources.Find(r => r.Id == id));
+            }
+        }
     }
 }

--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -1361,41 +1361,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
         }
 
         /// <inheritdoc/>
-        public bool UpdateServiceInformationInApplication(string org, string app, ServiceConfiguration applicationInformation)
-        {
-            try
-            {
-                PlatformStorageModels.Application existingApplicationMetadata = GetApplication(org, app);
-
-                if (existingApplicationMetadata.Title == null)
-                {
-                    existingApplicationMetadata.Title = new Dictionary<string, string>();
-                }
-
-                if (existingApplicationMetadata.Title.ContainsKey("nb"))
-                {
-                    existingApplicationMetadata.Title["nb"] = applicationInformation.ServiceName;
-                }
-                else
-                {
-                    existingApplicationMetadata.Title.Add("nb", applicationInformation.ServiceName);
-                }
-
-                string metadataAsJson = JsonConvert.SerializeObject(existingApplicationMetadata, Formatting.Indented);
-                string filePath = _settings.GetAppMetadataFilePath(org, app, AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext));
-
-                File.WriteAllText(filePath, metadataAsJson, Encoding.UTF8);
-            }
-            catch
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        /// <inheritdoc/>
-        public void UpdateAppTitle(string org, string app, string languageId, string title)
+        public void UpdateAppTitleInAppMetadata(string org, string app, string languageId, string title)
         {
             PlatformStorageModels.Application appMetadata = GetApplication(org, app);
 

--- a/backend/src/Designer/Services/Interfaces/IRepository.cs
+++ b/backend/src/Designer/Services/Interfaces/IRepository.cs
@@ -417,15 +417,6 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         bool DeleteMetadataForAttachment(string org, string app, string id);
 
         /// <summary>
-        /// Updates the application information in Application metadata
-        /// </summary>
-        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
-        /// <param name="app">Application identifier which is unique within an organisation.</param>
-        /// <param name="applicationInformation">the application information to be updated</param>
-        /// <returns>true if the information is updated successfully</returns>
-        bool UpdateServiceInformationInApplication(string org, string app, ServiceConfiguration applicationInformation);
-
-        /// <summary>
         /// Returns the application metadata for an application.
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
@@ -456,7 +447,7 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <param name="languageId"> the language id</param>
         /// <param name="title"> new application title </param>
-        void UpdateAppTitle(string org, string app, string languageId, string title);
+        void UpdateAppTitleInAppMetadata(string org, string app, string languageId, string title);
 
         /// <summary>
         /// Gets the prefill json file


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Seems like an issue we thought was closed, was actually not closable since we did not test on an app that was _old enough_. 

- In order for older apps to not include the old application name key `serviceName` in addition to the new `appName` in the text resource file when editing the name from the about page, we delete any occurences of `serviceName` in the text-resource file when editing the appName from the about page through the endpoint `/text/setServiceName`

Some exceptions messages is also added when trying to edit the appName key and when trying to set an empty string as the appName

- Also some redundant code is deleted.

## Related Issue(s)
- #7960 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
