### PR TITLE
fix css so delete btn and search field are visible

### DIFF
--- a/frontend/packages/text-editor/src/TextEditor.module.css
+++ b/frontend/packages/text-editor/src/TextEditor.module.css
@@ -53,13 +53,13 @@
 .TextEditor__topRow {
   border-bottom: 1px solid #bcc7cc;
   margin-bottom: 2rem;
+  margin-left: 2rem;
   padding: 2rem 0;
-  display:flex;
+  display: flex;
   justify-content: space-between;
 }
 
 .TextEditor__main {
-  padding: 2rem 4rem;
   margin: 0 auto;
   width: 100%;
   background-color: #fff;

--- a/frontend/packages/text-editor/src/TextEditor.module.css
+++ b/frontend/packages/text-editor/src/TextEditor.module.css
@@ -60,6 +60,7 @@
 }
 
 .TextEditor__main {
+  padding-top: 2rem;
   margin: 0 auto;
   width: 100%;
   background-color: #fff;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Padding on `TextEditor_main` class was shifting the whole view to the right, causing the search field (partially) and the delete icon buttons to disappear off the page. Replaced all-over padding with padding-top only, and added padding-left to the top row to compensate.

This is the result of the changes:

<img width="1503" alt="Screenshot 2023-02-08 at 14 21 47" src="https://user-images.githubusercontent.com/1636323/217541982-8e98a248-01e2-4856-b4ff-9e14e99356c7.png">

## Related Issue(s)
- #9700 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
