### PR TITLE
Add DateOfDeath to Altinn.Platform.Register.Models.Person

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.Models/Models/Altinn.Platform.Models.csproj
+++ b/src/Altinn.Platform/Altinn.Platform.Models/Models/Altinn.Platform.Models.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>1.1.2.0</AssemblyVersion>
-    <FileVersion>1.1.2.0</FileVersion>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
     <!-- SonarCloud needs this -->
     <ProjectGuid>{B72A146D-719D-4E2A-B931-C2ACBA72EF4F}</ProjectGuid>
   </PropertyGroup>
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <!-- NuGet package properties -->
     <PackageId>Altinn.Platform.Models</PackageId>
-    <PackageVersion>1.1.2</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <PackageTags>Altinn;Studio;Platform;Models;Register;Profile;Authorization</PackageTags>
     <Description>
       Altinn.Platform.Models is a package for models used by platform register and profile.

--- a/src/Altinn.Platform/Altinn.Platform.Models/Models/Register/Models/Person.cs
+++ b/src/Altinn.Platform/Altinn.Platform.Models/Models/Register/Models/Person.cs
@@ -89,5 +89,10 @@ namespace Altinn.Platform.Register.Models
         /// Gets a persons address city
         /// </summary>
         public string AddressCity { get; set; }
+
+        /// <summary>
+        /// Gets a persons date of death. Null if not dead.
+        /// </summary>
+        public DateTime? DateOfDeath { get; set; }
     }
 }


### PR DESCRIPTION
Adds DateOfDeath to Altinn.Platform.Register.Models.Person

## Description
This adds a `DateTime?` property to the `Person` model, which will be set to the Date of Death as mapped from SBLBridge. See https://dev.azure.com/digdir/_git/Altinn/pullrequest/6259?_a=overview for corresponding change in Altinn2.

## Related Issue(s)
- #9803

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
