### PR TITLE
Fixed bug to make it possible to regret changing text-id.

### DIFF
--- a/frontend/packages/text-editor/src/TextList.tsx
+++ b/frontend/packages/text-editor/src/TextList.tsx
@@ -1,6 +1,6 @@
 import classes from './TextEditor.module.css';
 import { TextRow } from './TextRow';
-import React from 'react';
+import React, { useEffect } from 'react';
 import type {
   TextResourceEntry,
   TextResourceEntryDeletion,
@@ -26,7 +26,14 @@ export const TextList = ({
   ...rest
 }: TextListProps) => {
   const langName = getLangName({ code: selectedLangCode });
-  const idExits = (entryId: string) => textIds.includes(entryId);
+
+  const idExits = (textId: string, textEntryValue: string): boolean => {
+    const isSameField = texts[textId]?.value === textEntryValue;
+
+    // combined textId with text-value to decide whether the key exists or not.
+    return textIds.includes(textId) && !isSameField;
+  };
+
   return (
     <ul className={classes.TextEditor__body}>
       {textIds
@@ -36,7 +43,7 @@ export const TextList = ({
             key={`${selectedLangCode}.${id}`}
             textId={id}
             langName={langName}
-            idExists={idExits}
+            idExists={(textId) => idExits(textId, texts[id]?.value)}
             textData={texts[id]}
             {...rest}
           />

--- a/frontend/packages/text-editor/src/TextList.tsx
+++ b/frontend/packages/text-editor/src/TextList.tsx
@@ -1,6 +1,6 @@
+import React from 'react';
 import classes from './TextEditor.module.css';
 import { TextRow } from './TextRow';
-import React, { useEffect } from 'react';
 import type {
   TextResourceEntry,
   TextResourceEntryDeletion,

--- a/frontend/packages/text-editor/src/TextRow.tsx
+++ b/frontend/packages/text-editor/src/TextRow.tsx
@@ -46,22 +46,20 @@ export const TextRow = ({
   };
   const isIllegalId = (textIdToCheck: string) => Boolean(textIdToCheck.toLowerCase().match(' ')); // TODO: create matcher
 
-  const validateTextId = (textIdToValidate: string): { error: string } => {
-    const createValidationResult = (errorText: string) => ({ error: errorText });
-
+  const validateTextId = (textIdToValidate: string): string => {
     if (!textIdToValidate) {
-      return createValidationResult('TextId kan ikke være tom');
+      return 'TextId kan ikke være tom';
     }
 
     if (idExists(textIdToValidate)) {
-      return createValidationResult('Denne IDen finnes allerede');
+      return 'Denne IDen finnes allerede';
     }
 
     if (isIllegalId(textIdToValidate)) {
-      return createValidationResult('Det er ikke tillat med mellomrom i en textId');
+      return 'Det er ikke tillat med mellomrom i en textId';
     }
 
-    return createValidationResult('');
+    return '';
   };
 
   const handleTextIdChange = (event: React.ChangeEvent<HTMLInputElement>): void => {

--- a/frontend/packages/text-editor/src/TextRow.tsx
+++ b/frontend/packages/text-editor/src/TextRow.tsx
@@ -46,19 +46,32 @@ export const TextRow = ({
   };
   const isIllegalId = (textIdToCheck: string) => Boolean(textIdToCheck.toLowerCase().match(' ')); // TODO: create matcher
 
-  const handleTextIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.currentTarget.value;
-    if (!newValue) {
-      setKeyError('TextId kan ikke være tom');
-    } else if (idExists(newValue)) {
-      setKeyError('Denne IDen finnes allerede');
-    } else if (isIllegalId(newValue)) {
-      setKeyError('Det er ikke tillat med mellomrom i en textId');
-    } else {
-      setKeyError('');
+  const validateTextId = (textIdToValidate: string): { error: string } => {
+    const createValidationResult = (errorText: string) => ({ error: errorText });
+
+    if (!textIdToValidate) {
+      return createValidationResult('TextId kan ikke være tom');
     }
-    setTextIdValue(newValue || '');
+
+    if (idExists(textIdToValidate)) {
+      return createValidationResult('Denne IDen finnes allerede');
+    }
+
+    if (isIllegalId(textIdToValidate)) {
+      return createValidationResult('Det er ikke tillat med mellomrom i en textId');
+    }
+
+    return createValidationResult('');
   };
+
+  const handleTextIdChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const newTextId = event.currentTarget.value;
+    const validation = validateTextId(newTextId);
+
+    setKeyError(validation.error);
+    setTextIdValue(newTextId);
+  };
+
   const handleTextIdBlur = () => {
     if (!keyError && textId !== textIdValue) {
       updateEntryId({ oldId: textId, newId: textIdValue });

--- a/frontend/packages/text-editor/src/TextRow.tsx
+++ b/frontend/packages/text-editor/src/TextRow.tsx
@@ -64,9 +64,9 @@ export const TextRow = ({
 
   const handleTextIdChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const newTextId = event.currentTarget.value;
-    const validation = validateTextId(newTextId);
+    const validationResult = validateTextId(newTextId);
 
-    setKeyError(validation.error);
+    setKeyError(validationResult);
     setTextIdValue(newTextId);
   };
 


### PR DESCRIPTION
## Description
Make sure that it's possible to regret changing text-id. The best strategy I could think of to figure out if the user is changing the same text-id or adding a new one, was to combine the text-id with the text value within the state. Cannot use the index, because the index changes due to adding or deleting fields.

## Related Issue(s)
- #9812

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
