### PR TITLE
use correct CSS class name

### DIFF
--- a/frontend/packages/text-editor/src/LangSelector.tsx
+++ b/frontend/packages/text-editor/src/LangSelector.tsx
@@ -30,7 +30,7 @@ export const LangSelector = ({ onAddLang, options }: ILangSelectorProps) => {
     'data-value': selectedOption.value,
   };
   return (
-    <div className={classes.LangSelector}>
+    <div className={classes.LanguageSelector}>
       <Select
         hideLabel={true}
         onChange={handleSelectOnChange}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The component used the class `LangSelector`, but the actual CSS class was named `LanguageSelector`. This resulted in no CSS being loaded for the component. Switched to use the latter name, as it is more verbose.

## Related Issue(s)
- #9727 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
