### PR TITLE
removed api from route to storage api

### DIFF
--- a/backend/src/Designer/TypedHttpClients/AltinnStorage/AltinnStorageTextResourceClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnStorage/AltinnStorageTextResourceClient.cs
@@ -68,12 +68,12 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
 
         private Uri CreatePostUri(EnvironmentModel environmentModel, string org, string app)
         {
-            return new Uri($"https://{environmentModel.PlatformPrefix}.{environmentModel.Hostname}/{_platformSettings.ApiStorageApplicationUri}api/{org}/{app}/texts");
+            return new Uri($"https://{environmentModel.PlatformPrefix}.{environmentModel.Hostname}/{_platformSettings.ApiStorageApplicationUri}/{org}/{app}/texts");
         }
 
         private Uri CreateGetAndPutUri(EnvironmentModel environmentModel, string org, string app, string language)
         {
-            return new Uri($"https://{environmentModel.PlatformPrefix}.{environmentModel.Hostname}/{_platformSettings.ApiStorageApplicationUri}api/{org}/{app}/texts/{language}");
+            return new Uri($"https://{environmentModel.PlatformPrefix}.{environmentModel.Hostname}/{_platformSettings.ApiStorageApplicationUri}/{org}/{app}/texts/{language}");
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
remove `api` that was added to path to storage api's by mistake, which was causing deploy to fail.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
