### PR TITLE
better text keys when adding text from components

### DIFF
--- a/frontend/packages/ux-editor/src/components/TextResource.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResource.test.tsx
@@ -5,14 +5,19 @@ import { IAppDataState } from '../features/appData/appDataReducers';
 import { ITextResource } from '../types/global';
 import { ITextResourcesState } from '../features/appData/textResources/textResourcesSlice';
 import { TextResource, TextResourceProps } from './TextResource';
-import { appDataMock, languageStateMock, renderWithMockStore, textResourcesMock } from '../testing/mocks';
+import {
+  appDataMock,
+  languageStateMock,
+  renderWithMockStore,
+  textResourcesMock,
+} from '../testing/mocks';
 import { act, screen } from '@testing-library/react';
 
 const user = userEvent.setup();
 
 // Test data:
 const handleIdChange = jest.fn();
-const defaultProps: TextResourceProps = { handleIdChange }
+const defaultProps: TextResourceProps = { handleIdChange };
 const addText = 'Legg til';
 const editText = 'Rediger';
 const searchText = 'Søk';
@@ -34,7 +39,6 @@ const textResources = [
 ];
 
 describe('TextResource', () => {
-
   afterEach(jest.resetAllMocks);
 
   it('Renders add button when no resource id is given', () => {
@@ -46,6 +50,23 @@ describe('TextResource', () => {
     const { store } = render();
     await act(() => user.click(screen.getByLabelText(addText)));
     expect(handleIdChange).toHaveBeenCalledTimes(1);
+    const actions = store.getActions();
+    expect(actions).toHaveLength(2);
+    expect(actions[0].type).toBe('textResources/upsertTextResources');
+    expect(actions[1].type).toBe('textResources/setCurrentEditId');
+  });
+
+  it('Calls handleIdChange and dispatches correct actions with expected id when add button is clicked', async () => {
+    const { store } = render({
+      generateIdOptions: {
+        componentId: 'test-id',
+        layoutId: 'Page1',
+        textResourceKey: 'title',
+      },
+    });
+    await act(() => user.click(screen.getByLabelText(addText)));
+    expect(handleIdChange).toHaveBeenCalledTimes(1);
+    expect(handleIdChange).toHaveBeenCalledWith('Page1.test-id.title');
     const actions = store.getActions();
     expect(actions).toHaveLength(2);
     expect(actions[0].type).toBe('textResources/upsertTextResources');
@@ -167,27 +188,24 @@ const renderAndOpenSearchSection = async () => {
 };
 
 const render = (props?: Partial<TextResourceProps>, resources?: ITextResource[]) => {
-
   const languageState: ILanguageState = {
     ...languageStateMock,
-    language: texts
+    language: texts,
   };
 
   const mockedTextResources: ITextResourcesState = {
     ...textResourcesMock,
     resources: {
       ...textResourcesMock.resources,
-      nb: resources ?? []
-    }
+      nb: resources ?? [],
+    },
   };
 
   const appData: IAppDataState = {
     ...appDataMock,
     languageState,
-    textResources: mockedTextResources
+    textResources: mockedTextResources,
   };
 
-  return renderWithMockStore({ appData })(
-    <TextResource {...{ ...defaultProps, ...props }}/>
-  );
+  return renderWithMockStore({ appData })(<TextResource {...{ ...defaultProps, ...props }} />);
 };

--- a/frontend/packages/ux-editor/src/components/TextResource.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResource.tsx
@@ -3,14 +3,18 @@ import { Button, ButtonColor, ButtonVariant, Select } from '@digdir/design-syste
 import { Add, Close, Edit, Search } from '@navikt/ds-icons';
 import classes from './TextResource.module.css';
 import { useDispatch, useSelector } from 'react-redux';
-import { setCurrentEditId, upsertTextResources } from '../features/appData/textResources/textResourcesSlice';
+import {
+  setCurrentEditId,
+  upsertTextResources,
+} from '../features/appData/textResources/textResourcesSlice';
 import { DEFAULT_LANGUAGE } from 'app-shared/constants';
 import {
   getAllTextResourceIds,
   getCurrentEditId,
-  textResourceByLanguageAndIdSelector
+  textResourceByLanguageAndIdSelector,
 } from '../selectors/textResourceSelectors';
 import { generateRandomId } from 'app-shared/utils/generateRandomId';
+import { generateTextResourceId } from '../utils/generateId';
 import { useText } from '../hooks';
 import { prepend } from 'app-shared/utils/arrayUtils';
 import cn from 'classnames';
@@ -23,7 +27,21 @@ export interface TextResourceProps {
   placeholder?: string;
   previewMode?: boolean;
   textResourceId?: string;
+  generateIdOptions?: GenerateTextResourceIdOptions;
 }
+
+export interface GenerateTextResourceIdOptions {
+  componentId: string;
+  layoutId: string;
+  textResourceKey: string;
+}
+
+export const generateId = (options?: GenerateTextResourceIdOptions) => {
+  if (!options) {
+    return generateRandomId(12);
+  }
+  return generateTextResourceId(options.layoutId, options.componentId, options.textResourceKey);
+};
 
 export const TextResource = ({
   description,
@@ -32,20 +50,26 @@ export const TextResource = ({
   placeholder,
   previewMode,
   textResourceId,
+  generateIdOptions,
 }: TextResourceProps) => {
   const dispatch = useDispatch();
 
-  const textResource = useSelector(textResourceByLanguageAndIdSelector(DEFAULT_LANGUAGE, textResourceId));
+  const textResource = useSelector(
+    textResourceByLanguageAndIdSelector(DEFAULT_LANGUAGE, textResourceId)
+  );
   const textResourceIds = useSelector(getAllTextResourceIds);
   const t = useText();
   const [isSearchMode, setIsSearchMode] = useState(false);
   const { org, app } = useParams();
-  const addTextResource = (id: string) => dispatch(upsertTextResources({
-    language: DEFAULT_LANGUAGE,
-    textResources: { [id]: '' },
-    org,
-    app
-  }));
+  const addTextResource = (id: string) =>
+    dispatch(
+      upsertTextResources({
+        language: DEFAULT_LANGUAGE,
+        textResources: { [id]: '' },
+        org,
+        app,
+      })
+    );
 
   const editId = useSelector(getCurrentEditId);
   const setEditId = (id: string) => dispatch(setCurrentEditId(id));
@@ -55,7 +79,7 @@ export const TextResource = ({
     if (textResourceId) {
       setEditId(textResourceId);
     } else {
-      const id = generateRandomId(12);
+      const id = generateId(generateIdOptions);
       addTextResource(id);
       handleIdChange(id);
       setEditId(id);
@@ -68,12 +92,14 @@ export const TextResource = ({
   );
 
   return (
-    <span className={cn(
-      classes.root,
-      previewMode && classes.previewMode,
-      isEditing && classes.isEditing,
-      isSearchMode && classes.isSearching,
-    )}>
+    <span
+      className={cn(
+        classes.root,
+        previewMode && classes.previewMode,
+        isEditing && classes.isEditing,
+        isSearchMode && classes.isSearching
+      )}
+    >
       {label && <span className={classes.label}>{label}</span>}
       {description && <span className={classes.description}>{description}</span>}
       {isSearchMode && (
@@ -99,9 +125,11 @@ export const TextResource = ({
         </span>
       )}
       <span className={classes.textResource}>
-        {textResource?.value
-          ? <span>{textResource.value}</span>
-          : <span className={classes.placeholder}>{placeholder}</span>}
+        {textResource?.value ? (
+          <span>{textResource.value}</span>
+        ) : (
+          <span className={classes.placeholder}>{placeholder}</span>
+        )}
         <span className={classes.buttonsWrapper}>
           <span className={classes.buttons}>
             {textResource?.value ? (
@@ -110,7 +138,7 @@ export const TextResource = ({
                 className={classes.button}
                 color={ButtonColor.Secondary}
                 disabled={isEditing}
-                icon={<Edit/>}
+                icon={<Edit />}
                 onClick={handleEditButtonClick}
                 title={t('general.edit')}
                 variant={ButtonVariant.Quiet}
@@ -142,4 +170,4 @@ export const TextResource = ({
       </span>
     </span>
   );
-}
+};

--- a/frontend/packages/ux-editor/src/components/config/EditModalContent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/EditModalContent.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import type { EditSettings, IGenericEditComponent } from './componentConfig';
 import { ComponentTypes } from '../index';
-import type { FormComponentType, IThirdPartyComponent } from '../../types/global';
+import type { FormComponentType, IAppState, IThirdPartyComponent } from '../../types/global';
 import { EditComponentId } from './editModal/EditComponentId';
 import { componentSpecificEditConfig, configComponents } from './componentConfig';
 import { ComponentSpecificContent } from './componentSpecificContent';
 import { FieldSet } from '@digdir/design-system-react';
 import classes from './EditModalContent.module.css';
+import { useSelector } from 'react-redux';
 
 export interface IEditModalContentProps {
   cancelEdit?: () => void;
@@ -21,6 +22,9 @@ export const EditModalContent = ({
   handleComponentUpdate,
   thirdPartyComponentConfig,
 }: IEditModalContentProps) => {
+  const selectedLayout = useSelector(
+    (state: IAppState) => state.formDesigner.layout?.selectedLayout
+  );
   const renderFromComponentSpecificDefinition = (configDef: EditSettings[]) => {
     if (!configDef) return null;
 
@@ -45,14 +49,12 @@ export const EditModalContent = ({
 
   return (
     <FieldSet className={classes.root}>
-      <EditComponentId
-        component={component}
-        handleComponentUpdate={handleComponentUpdate}
-      />
+      <EditComponentId component={component} handleComponentUpdate={handleComponentUpdate} />
       {renderFromComponentSpecificDefinition(getConfigDefinitionForComponent())}
       <ComponentSpecificContent
         component={component}
         handleComponentChange={handleComponentUpdate}
+        layoutName={selectedLayout}
       />
     </FieldSet>
   );

--- a/frontend/packages/ux-editor/src/components/config/componentConfig.ts
+++ b/frontend/packages/ux-editor/src/components/config/componentConfig.ts
@@ -14,6 +14,7 @@ import { EditAutoComplete } from './editModal/EditAutoComplete';
 export interface IGenericEditComponent {
   component: FormComponentType;
   handleComponentChange: (component: FormComponentType) => void;
+  layoutName?: string;
 }
 
 export enum EditSettings {

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/ComponentSpecificContent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/ComponentSpecificContent.tsx
@@ -14,7 +14,8 @@ import { EditTextResourceBinding } from '../editModal/EditTextResourceBinding';
 
 export function ComponentSpecificContent({
   component,
-  handleComponentChange
+  handleComponentChange,
+  layoutName,
 }: IGenericEditComponent) {
   const t = useText();
 
@@ -22,25 +23,38 @@ export function ComponentSpecificContent({
     case ComponentTypes.NavigationButtons:
     case ComponentTypes.Button:
       return (
-        <ButtonComponent component={component} handleComponentChange={handleComponentChange} />
+        <ButtonComponent
+          component={component}
+          handleComponentChange={handleComponentChange}
+          layoutName={layoutName}
+        />
       );
 
     case ComponentTypes.AddressComponent:
       return (
-        <AddressComponent component={component} handleComponentChange={handleComponentChange} />
+        <AddressComponent
+          component={component}
+          handleComponentChange={handleComponentChange}
+          layoutName={layoutName}
+        />
       );
 
     case ComponentTypes.FileUpload:
     case ComponentTypes.FileUploadWithTag:
       return (
-        <FileUploadComponent component={component} handleComponentChange={handleComponentChange} />
+        <FileUploadComponent
+          component={component}
+          handleComponentChange={handleComponentChange}
+          layoutName={layoutName}
+        />
       );
 
     case ComponentTypes.Image: {
       return (
         <ImageComponent
           component={component as IFormImageComponent}
-          handleComponentUpdate={handleComponentChange}
+          handleComponentChange={handleComponentChange}
+          layoutName={layoutName}
         />
       );
     }

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/FileUpload/FileUploadComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/FileUpload/FileUploadComponent.tsx
@@ -4,7 +4,10 @@ import classes from './FileUploadComponent.module.css';
 import { EditTitle } from '../../editModal/EditTitle';
 import { useText } from '../../../../hooks';
 import { IGenericEditComponent } from '../../componentConfig';
-import { IFormFileUploaderComponent, IFormFileUploaderWithTagComponent } from '../../../../types/global';
+import {
+  IFormFileUploaderComponent,
+  IFormFileUploaderWithTagComponent,
+} from '../../../../types/global';
 import { EditDescription } from '../../editModal/EditDescription';
 import { TextResource } from '../../../TextResource';
 import { ComponentTypes } from '../../../index';
@@ -12,6 +15,7 @@ import { ComponentTypes } from '../../../index';
 export const FileUploadComponent = ({
   component,
   handleComponentChange,
+  layoutName,
 }: IGenericEditComponent) => {
   const t = useText();
 
@@ -74,64 +78,61 @@ export const FileUploadComponent = ({
 
   return (
     <FieldSet className={classes.fieldset}>
-      {
-        component.type === ComponentTypes.FileUpload ? (
-          <>
-            <RadioGroup
-              items={[
-                {
-                  label: t('ux_editor.modal_properties_file_upload_simple'),
-                  value: 'simple',
-                },
-                {
-                  label: t('ux_editor.modal_properties_file_upload_list'),
-                  value: 'list',
-                }
-              ]}
-              name={`${component.id}-display-mode`}
-              onChange={handleDisplayModeChange}
-              value={fileUploaderComponent.displayMode}
-              variant={RadioGroupVariant.Horizontal}
+      {component.type === ComponentTypes.FileUpload ? (
+        <>
+          <RadioGroup
+            items={[
+              {
+                label: t('ux_editor.modal_properties_file_upload_simple'),
+                value: 'simple',
+              },
+              {
+                label: t('ux_editor.modal_properties_file_upload_list'),
+                value: 'list',
+              },
+            ]}
+            name={`${component.id}-display-mode`}
+            onChange={handleDisplayModeChange}
+            value={fileUploaderComponent.displayMode}
+            variant={RadioGroupVariant.Horizontal}
+          />
+          <FieldSet className={classes.fieldset}>
+            <EditTitle component={component} handleComponentChange={handleComponentChange} />
+            <EditDescription component={component} handleComponentChange={handleComponentChange} />
+          </FieldSet>
+        </>
+      ) : (
+        <>
+          <TextResource
+            handleIdChange={handleTagTitleChange}
+            label={t('ux_editor.modal_properties_tag')}
+            placeholder={t('ux_editor.modal_properties_tag_add')}
+            textResourceId={component.textResourceBindings?.tagTitle}
+            generateIdOptions={{
+              componentId: component.id,
+              layoutId: layoutName,
+              textResourceKey: 'tagTitle',
+            }}
+          />
+          <div>
+            <TextField
+              id='modal-properties-code-list-id'
+              label={t('ux_editor.modal_properties_code_list_id')}
+              onChange={handleOptionsIdChange}
+              value={component.optionsId}
             />
-            <FieldSet className={classes.fieldset}>
-              <EditTitle
-                component={component}
-                handleComponentChange={handleComponentChange}
-              />
-              <EditDescription
-                component={component}
-                handleComponentChange={handleComponentChange}
-              />
-            </FieldSet>
-          </>
-        ) : (
-          <>
-            <TextResource
-              handleIdChange={handleTagTitleChange}
-              label={t('ux_editor.modal_properties_tag')}
-              placeholder={t('ux_editor.modal_properties_tag_add')}
-              textResourceId={component.textResourceBindings?.tagTitle}
-            />
-            <div>
-              <TextField
-                id='modal-properties-code-list-id'
-                label={t('ux_editor.modal_properties_code_list_id')}
-                onChange={handleOptionsIdChange}
-                value={component.optionsId}
-              />
-            </div>
-            <p>
-              <a
-                target='_blank'
-                rel='noopener noreferrer'
-                href='https://docs.altinn.studio/app/development/data/options/'
-              >
-                {t('ux_editor.modal_properties_code_list_read_more')}
-              </a>
-            </p>
-          </>
-        )
-      }
+          </div>
+          <p>
+            <a
+              target='_blank'
+              rel='noopener noreferrer'
+              href='https://docs.altinn.studio/app/development/data/options/'
+            >
+              {t('ux_editor.modal_properties_code_list_read_more')}
+            </a>
+          </p>
+        </>
+      )}
 
       <RadioGroup
         items={[
@@ -142,7 +143,7 @@ export const FileUploadComponent = ({
           {
             label: t('ux_editor.modal_properties_valid_file_endings_custom'),
             value: 'true',
-          }
+          },
         ]}
         name={`${component.id}-valid-file-endings`}
         onChange={handleHasCustomFileEndingsChange}
@@ -189,4 +190,4 @@ export const FileUploadComponent = ({
       </div>
     </FieldSet>
   );
-}
+};

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Image/ImageComponent.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Image/ImageComponent.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import type { IImageComponentProps } from './ImageComponent';
+import type { IGenericEditComponent } from '../../componentConfig';
 import { ImageComponent } from './ImageComponent';
 import { appDataMock, renderWithMockStore } from '../../../../testing/mocks';
 import { IAppDataState } from '../../../../features/appData/appDataReducers';
@@ -16,8 +16,8 @@ const componentData: IFormImageComponent = {
   textResourceBindings: {},
   type: ComponentTypes.Image,
   image: {
-    src: {}
-  }
+    src: {},
+  },
 };
 const texts = {
   'ux_editor.modal_properties_image_src_value_label': 'Source',
@@ -26,13 +26,13 @@ const texts = {
   'ux_editor.modal_properties_image_width_label': 'Width',
   'ux_editor.modal_properties_image_placement_left': 'Left',
   'ux_editor.modal_properties_image_placement_center': 'Center',
-  'ux_editor.modal_properties_image_placement_right': 'Right'
+  'ux_editor.modal_properties_image_placement_right': 'Right',
 };
-const render = (props: Partial<IImageComponentProps> = {}) => {
-  const allProps: IImageComponentProps = {
+const render = (props: Partial<IGenericEditComponent> = {}) => {
+  const allProps: IGenericEditComponent = {
     component: componentData,
-    handleComponentUpdate: jest.fn(),
-    ...props
+    handleComponentChange: jest.fn(),
+    ...props,
   };
 
   const appData: IAppDataState = {
@@ -42,14 +42,14 @@ const render = (props: Partial<IImageComponentProps> = {}) => {
       resources: {
         nb: [
           { id: 'altTextImg', value: 'Alternative text' },
-          { id: 'altTextImg2', value: 'Alternative text 2' }
-        ]
-      }
+          { id: 'altTextImg2', value: 'Alternative text 2' },
+        ],
+      },
     },
     languageState: {
       ...appDataMock.languageState,
-      language: texts
-    }
+      language: texts,
+    },
   };
 
   return renderWithMockStore({ appData })(<ImageComponent {...allProps} />);
@@ -59,10 +59,10 @@ describe('ImageComponent', () => {
   it('should call handleComponentUpdate callback with image src value for nb when image source input is changed', async () => {
     const handleUpdate = jest.fn();
     const imgSrc = 'placekitten.com/500/500';
-    render({ handleComponentUpdate: handleUpdate });
+    render({ handleComponentChange: handleUpdate });
 
     const srcInput = screen.getByRole('textbox', {
-      name: /source/i
+      name: /source/i,
     });
 
     await act(() => user.type(srcInput, imgSrc));
@@ -72,19 +72,19 @@ describe('ImageComponent', () => {
       image: {
         ...componentData.image,
         src: {
-          nb: imgSrc
-        }
-      }
+          nb: imgSrc,
+        },
+      },
     });
   });
 
   it('should call handleComponentUpdate callback with image width value when image width input is changed', async () => {
     const handleUpdate = jest.fn();
     const size = '250px';
-    render({ handleComponentUpdate: handleUpdate });
+    render({ handleComponentChange: handleUpdate });
 
     const widthInput = screen.getByRole('textbox', {
-      name: /width/i
+      name: /width/i,
     });
 
     await act(() => user.type(widthInput, size));
@@ -93,17 +93,17 @@ describe('ImageComponent', () => {
       ...componentData,
       image: {
         ...componentData.image,
-        width: size
-      }
+        width: size,
+      },
     });
   });
 
   it('should call handleComponentUpdate callback with alignment when placement select is changed', async () => {
     const handleUpdate = jest.fn();
-    render({ handleComponentUpdate: handleUpdate });
+    render({ handleComponentChange: handleUpdate });
 
     const placementInput = screen.getByRole('combobox', {
-      name: /placement/i
+      name: /placement/i,
     });
 
     await act(() => user.type(placementInput, 'L')); // Type something to trigger showing Select options
@@ -113,8 +113,8 @@ describe('ImageComponent', () => {
       ...componentData,
       image: {
         ...componentData.image,
-        align: 'flex-start'
-      }
+        align: 'flex-start',
+      },
     });
   });
 });

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Image/ImageComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Image/ImageComponent.tsx
@@ -1,22 +1,18 @@
 import React from 'react';
 import Select from 'react-select';
 import { selectStyles } from '../../../../utils/render';
-import type { FormComponentType, IFormImageComponent } from '../../../../types/global';
 import { FieldSet, TextField } from '@digdir/design-system-react';
 import classes from './ImageComponent.module.css';
 import { TextResource } from '../../../TextResource';
 import { useText } from '../../../../hooks';
 import { Label } from 'app-shared/components/Label';
-
-export interface IImageComponentProps {
-  component: IFormImageComponent;
-  handleComponentUpdate: (updatedComponent: FormComponentType) => void;
-}
+import { IGenericEditComponent } from '../../componentConfig';
 
 export const ImageComponent = ({
   component,
-  handleComponentUpdate,
-}: IImageComponentProps) => {
+  handleComponentChange,
+  layoutName,
+}: IGenericEditComponent) => {
   const t = useText();
   const alignOptions = [
     {
@@ -40,28 +36,28 @@ export const ImageComponent = ({
     const updatedComponent = { ...component };
     updatedComponent.image.align = e ? e.value : null;
 
-    handleComponentUpdate(updatedComponent);
+    handleComponentChange(updatedComponent);
   };
 
   const handleWidthChange = (e: any) => {
     const updatedComponent = { ...component };
     updatedComponent.image.width = e.target.value;
 
-    handleComponentUpdate(updatedComponent);
+    handleComponentChange(updatedComponent);
   };
 
   const handleAltTextChange = (id: string) => {
     const updatedComponent = { ...component };
     updatedComponent.textResourceBindings.altTextImg = id;
 
-    handleComponentUpdate(updatedComponent);
+    handleComponentChange(updatedComponent);
   };
 
   const handleSourceChange = (e: any) => {
     const updatedComponent = { ...component };
     updatedComponent.image.src.nb = e.target.value;
 
-    handleComponentUpdate(updatedComponent);
+    handleComponentChange(updatedComponent);
   };
 
   const placementSelectId = `image_placement-input-${component.id}`;
@@ -80,6 +76,11 @@ export const ImageComponent = ({
         handleIdChange={handleAltTextChange}
         label={t('ux_editor.modal_properties_image_alt_text_label')}
         textResourceId={component.textResourceBindings?.altTextImg}
+        generateIdOptions={{
+          componentId: component.id,
+          layoutId: layoutName,
+          textResourceKey: 'altTextImg',
+        }}
       />
       <div className={classes.widthAndPlacement}>
         <div className={classes.widthContainer}>

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditTextResourceBinding.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditTextResourceBinding.tsx
@@ -23,7 +23,7 @@ export const EditTextResourceBinding = ({
 }: EditTextResourceBindingProps) => {
   const t = useText();
   const selectedLayout = useSelector(
-    (state: IAppState) => state.formDesigner.layout.selectedLayout
+    (state: IAppState) => state.formDesigner?.layout?.selectedLayout
   );
 
   const handleTextResourceChange = (value: string) =>

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditTextResourceBinding.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditTextResourceBinding.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import type { IGenericEditComponent } from '../componentConfig';
 import { TextResource } from '../../TextResource';
 import { useText } from '../../../hooks';
 import { TranslationKey } from 'language/type';
+import { IAppState } from '../../../types/global';
 
 export interface EditTextResourceBindingProps extends IGenericEditComponent {
   textKey: string;
@@ -20,20 +22,32 @@ export const EditTextResourceBinding = ({
   placeholderKey,
 }: EditTextResourceBindingProps) => {
   const t = useText();
-  const handleTextResourceChange = (value: string) => handleComponentChange({
-    ...component,
-    textResourceBindings: {
-      ...component.textResourceBindings,
-      [textKey]: value,
-    }
-  });
+  const selectedLayout = useSelector(
+    (state: IAppState) => state.formDesigner.layout.selectedLayout
+  );
+
+  const handleTextResourceChange = (value: string) =>
+    handleComponentChange({
+      ...component,
+      textResourceBindings: {
+        ...component.textResourceBindings,
+        [textKey]: value,
+      },
+    });
   return (
     <TextResource
       handleIdChange={handleTextResourceChange}
       label={t(labelKey)}
       description={t(descriptionKey)}
       placeholder={t(placeholderKey)}
-      textResourceId={component.textResourceBindings ? component.textResourceBindings[textKey] : undefined}
+      textResourceId={
+        component.textResourceBindings ? component.textResourceBindings[textKey] : undefined
+      }
+      generateIdOptions={{
+        componentId: component.id,
+        layoutId: selectedLayout,
+        textResourceKey: textKey,
+      }}
     />
   );
 };

--- a/frontend/packages/ux-editor/src/containers/ComponentPreview/CheckboxGroupPreview/CheckboxGroupPreview.tsx
+++ b/frontend/packages/ux-editor/src/containers/ComponentPreview/CheckboxGroupPreview/CheckboxGroupPreview.tsx
@@ -8,7 +8,7 @@ import { useText } from '../../../hooks';
 import {
   changeComponentOptionLabel,
   changeDescriptionBinding,
-  changeTitleBinding
+  changeTitleBinding,
 } from '../../../utils/component';
 import { AddOption } from '../../../components/AddOption';
 import { TranslationKey } from 'language/type';
@@ -20,9 +20,10 @@ export interface CheckboxGroupPreviewProps extends IGenericEditComponent {
 export const CheckboxGroupPreview = ({
   component,
   handleComponentChange,
+  layoutName,
 }: CheckboxGroupPreviewProps) => {
   const t = useText();
-  const tCheckboxes = (key: string) => t((`ux_editor.checkboxes_${key}`) as TranslationKey);
+  const tCheckboxes = (key: string) => t(`ux_editor.checkboxes_${key}` as TranslationKey);
 
   const changeOptionLabel = (value: string, label: string) =>
     handleComponentChange(changeComponentOptionLabel(component, value, label));
@@ -36,33 +37,45 @@ export const CheckboxGroupPreview = ({
   return (
     <div className={classes.root}>
       <CheckboxGroup
-        legend={(
+        legend={
           <TextResource
             handleIdChange={changeLegend}
             placeholder={tCheckboxes('legend_placeholder')}
             previewMode
             textResourceId={component.textResourceBindings?.title}
+            generateIdOptions={{
+              componentId: component.id,
+              layoutId: layoutName,
+              textResourceKey: 'title',
+            }}
           />
-        )}
-        description={(
+        }
+        description={
           <TextResource
             handleIdChange={changeDescription}
             placeholder={tCheckboxes('description_placeholder')}
             previewMode
             textResourceId={component.textResourceBindings?.description}
+            generateIdOptions={{
+              componentId: component.id,
+              layoutId: layoutName,
+              textResourceKey: 'description',
+            }}
           />
-        )}
-        items={component.options?.map(({ value, label }) => ({
-          name: value,
-          label: (
-            <TextResource
-              handleIdChange={(id) => changeOptionLabel(value, id)}
-              placeholder={tCheckboxes('option_label_placeholder')}
-              previewMode
-              textResourceId={label}
-            />
-          ),
-        })) || []}
+        }
+        items={
+          component.options?.map(({ value, label }) => ({
+            name: value,
+            label: (
+              <TextResource
+                handleIdChange={(id) => changeOptionLabel(value, id)}
+                placeholder={tCheckboxes('option_label_placeholder')}
+                previewMode
+                textResourceId={label}
+              />
+            ),
+          })) || []
+        }
         presentation
       />
       {!component.optionsId && (

--- a/frontend/packages/ux-editor/src/containers/ComponentPreview/ComponentPreview.tsx
+++ b/frontend/packages/ux-editor/src/containers/ComponentPreview/ComponentPreview.tsx
@@ -9,20 +9,26 @@ export interface ComponentPreviewProps extends IGenericEditComponent {}
 
 export const ComponentPreview = ({
   component,
-  handleComponentChange
+  handleComponentChange,
+  layoutName,
 }: ComponentPreviewProps) => {
-
   switch (component.type) {
     case ComponentTypes.Checkboxes:
-      return <CheckboxGroupPreview
-        component={component as IFormCheckboxComponent}
-        handleComponentChange={handleComponentChange}
-      />;
+      return (
+        <CheckboxGroupPreview
+          component={component as IFormCheckboxComponent}
+          handleComponentChange={handleComponentChange}
+          layoutName={layoutName}
+        />
+      );
     case ComponentTypes.RadioButtons:
-      return <RadioGroupPreview
-        component={component as IFormRadioButtonComponent}
-        handleComponentChange={handleComponentChange}
-      />;
+      return (
+        <RadioGroupPreview
+          component={component as IFormRadioButtonComponent}
+          handleComponentChange={handleComponentChange}
+          layoutName={layoutName}
+        />
+      );
     default:
       return <p>Forhåndsvisning er ikke implementert for denne komponenten.</p>;
   }

--- a/frontend/packages/ux-editor/src/containers/ComponentPreview/RadioGroupPreview/RadioGroupPreview.tsx
+++ b/frontend/packages/ux-editor/src/containers/ComponentPreview/RadioGroupPreview/RadioGroupPreview.tsx
@@ -21,9 +21,10 @@ export interface RadioGroupPreviewProps extends IGenericEditComponent {
 export const RadioGroupPreview = ({
   component,
   handleComponentChange,
+  layoutName,
 }: RadioGroupPreviewProps) => {
   const t = useText();
-  const tRadios = (key: string) => t((`ux_editor.radios_${key}`) as TranslationKey);
+  const tRadios = (key: string) => t(`ux_editor.radios_${key}` as TranslationKey);
 
   const radioGroupName = useRef(generateRandomId(12));
 
@@ -39,33 +40,45 @@ export const RadioGroupPreview = ({
   return (
     <div className={classes.root}>
       <RadioGroup
-        legend={(
+        legend={
           <TextResource
             handleIdChange={changeLegend}
             placeholder={tRadios('legend_placeholder')}
             previewMode
             textResourceId={component.textResourceBindings?.title}
+            generateIdOptions={{
+              componentId: component.id,
+              layoutId: layoutName,
+              textResourceKey: 'title',
+            }}
           />
-        )}
-        description={(
+        }
+        description={
           <TextResource
             handleIdChange={changeDescription}
             placeholder={tRadios('description_placeholder')}
             previewMode
             textResourceId={component.textResourceBindings?.description}
+            generateIdOptions={{
+              componentId: component.id,
+              layoutId: layoutName,
+              textResourceKey: 'description',
+            }}
           />
-        )}
-        items={component.options?.map(({ value, label }) => ({
-          value,
-          label: (
-            <TextResource
-              handleIdChange={(id) => changeOptionLabel(value, id)}
-              placeholder={tRadios('option_label_placeholder')}
-              previewMode
-              textResourceId={label}
-            />
-          ),
-        })) || []}
+        }
+        items={
+          component.options?.map(({ value, label }) => ({
+            value,
+            label: (
+              <TextResource
+                handleIdChange={(id) => changeOptionLabel(value, id)}
+                placeholder={tRadios('option_label_placeholder')}
+                previewMode
+                textResourceId={label}
+              />
+            ),
+          })) || []
+        }
         name={radioGroupName.current}
         presentation
       />

--- a/frontend/packages/ux-editor/src/containers/EditContainer.tsx
+++ b/frontend/packages/ux-editor/src/containers/EditContainer.tsx
@@ -63,6 +63,9 @@ export function EditContainer(props: IEditContainerProps) {
   const language = useSelector(textSelector);
   const orderList = useSelector((state: IAppState) => GetLayoutOrderSelector(state));
   const textResources = useSelector(textResourcesByLanguageSelector(DEFAULT_LANGUAGE));
+  const selectedLayout = useSelector(
+    (state: IAppState) => state.formDesigner.layout?.selectedLayout
+  );
 
   const previewableComponents = [ComponentTypes.Checkboxes, ComponentTypes.RadioButtons]; // Todo: Remove this when all components become previewable. Until then, add components to this list when implementing preview mode.
 
@@ -114,7 +117,7 @@ export function EditContainer(props: IEditContainerProps) {
             newId: component.id,
             currentId: props.id,
             org,
-            app
+            app,
           })
         );
       }
@@ -164,6 +167,7 @@ export function EditContainer(props: IEditContainerProps) {
             <ComponentPreview
               component={component}
               handleComponentChange={handleComponentChangeAndSave}
+              layoutName={selectedLayout}
             />
           )}
           {isEditMode && component && (

--- a/frontend/packages/ux-editor/src/utils/formLayout.ts
+++ b/frontend/packages/ux-editor/src/utils/formLayout.ts
@@ -3,7 +3,6 @@ import type { IComponent } from '../components';
 import { ComponentTypes } from '../components';
 import { FormLayoutActions } from '../features/formDesigner/formLayout/formLayoutSlice';
 import { LayoutItemType } from '../types/global';
-import { getComponentTitleByComponentType } from './language';
 import { getLanguageFromKey } from 'app-shared/utils/language';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -211,12 +210,15 @@ export const mapComponentToToolbarElement = (
         component: {
           type: c.name,
           itemType: LayoutItemType.Component,
-          textResourceBindings: {
-            title:
-              c.name === 'Button'
-                ? getLanguageFromKey('ux_editor.modal_properties_button_type_submit', language)
-                : getComponentTitleByComponentType(c.name, language),
-          },
+          textResourceBindings:
+            c.name === 'Button'
+              ? {
+                  title: getLanguageFromKey(
+                    'ux_editor.modal_properties_button_type_submit',
+                    language
+                  ),
+                }
+              : {},
           dataModelBindings: {},
           ...JSON.parse(JSON.stringify(customProperties)),
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Extend "pretty" autogenerated textIds to also use human readable ids when adding texts directly from components.
_Prettier made some formatting fixes on some of the files, sorry about that._
The change is the following:
- Add an optional "generateIdOptions" object to the `TextResource`-component, that uses the options to generate a more readable id. If the options are not present, the old random-generate method is used instead.
- These options are componentId, selectedLayoutName and textKey, these are passed from parent component where possible.
- Did not use the "pretty" id's for options when added from a component at this point, as I'm not sure how to do that in a good way. 

## Related Issue(s)
- #9829

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
