### PR TITLE
Ensure that the text resources are updated across the app

### DIFF
--- a/frontend/app-development/features/administration/handleServiceInformationSlice.ts
+++ b/frontend/app-development/features/administration/handleServiceInformationSlice.ts
@@ -142,6 +142,10 @@ const handleServiceInformationSlice = createSlice({
       state.error = error;
       state.serviceNameObj.saving = false;
     },
+    updateAppNameWithinState: (state, action: PayloadAction<IFetchServiceNameFulfilled>) => {
+      const { serviceName } = action.payload;
+      state.serviceNameObj.name = serviceName;
+    },
   },
 });
 

--- a/frontend/app-development/features/textEditor/TextEditor.tsx
+++ b/frontend/app-development/features/textEditor/TextEditor.tsx
@@ -67,7 +67,7 @@ export const TextEditor = ({ language }: TextEditorProps) => {
   const t = (key: string) => getLanguageFromKey(key, language);
 
   /*
-   * Temporary fix to make sure to have latest text-resources fetched and available.
+   * Temporary fix to make sure to have the latest text-resources fetched.
    * This issue will be fixed when we have implemented React Query with shared state/cache
    */
   useEffect(() => {
@@ -81,7 +81,7 @@ export const TextEditor = ({ language }: TextEditorProps) => {
     return <AltinnSpinner />;
   }
 
-  const handleAddLanguage = (langCode: LangCode) => {
+  const handleAddLanguage = (langCode: LangCode) =>
     addLanguage({
       ...orgApp,
       langCode,
@@ -90,7 +90,6 @@ export const TextEditor = ({ language }: TextEditorProps) => {
         value: '',
       })),
     });
-  };
 
   const handleDeleteLanguage = (langCode: LangCode) =>
     deleteLanguage({

--- a/frontend/app-development/features/textEditor/TextEditor.tsx
+++ b/frontend/app-development/features/textEditor/TextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { LangCode, TextResourceFile } from '@altinn/text-editor';
 import { TextEditor as TextEditorImpl, defaultLangCode } from '@altinn/text-editor';
 import { PanelVariant, PopoverPanel } from '@altinn/altinn-design-system';
@@ -9,7 +9,8 @@ import { useGetLanguagesQuery } from '../../services/languagesApi';
 import {
   useAddByLangCodeMutation,
   useDeleteByLangCodeMutation,
-  useGetAppTextsByLangCodeQuery, useUpdateTextIdMutation,
+  useGetAppTextsByLangCodeQuery,
+  useUpdateTextIdMutation,
   useUpdateTranslationByLangCodeMutation,
 } from '../../services/textsApi';
 import { Link, useSearchParams } from 'react-router-dom';
@@ -49,6 +50,7 @@ export const TextEditor = ({ language }: TextEditorProps) => {
     data: translations,
     isLoading: isInitialLoadingLang,
     isFetching: isFetchingTranslations,
+    refetch: refetchTextLang,
   } = useGetAppTextsByLangCodeQuery(
     {
       ...orgApp,
@@ -64,6 +66,14 @@ export const TextEditor = ({ language }: TextEditorProps) => {
 
   const t = (key: string) => getLanguageFromKey(key, language);
 
+  /*
+   * Temporary fix to make sure to have latest text-resources fetched and available.
+   * This issue will be fixed when we have implemented React Query with shared state/cache
+   */
+  useEffect(() => {
+    refetchTextLang();
+  }, [refetchTextLang]);
+
   const [hideIntroPage, setHideIntroPage] = useState(
     () => getLocalStorage(storageGroupName, 'hideTextsIntroPage') ?? false
   );
@@ -71,7 +81,7 @@ export const TextEditor = ({ language }: TextEditorProps) => {
     return <AltinnSpinner />;
   }
 
-  const handleAddLanguage = (langCode: LangCode) =>
+  const handleAddLanguage = (langCode: LangCode) => {
     addLanguage({
       ...orgApp,
       langCode,
@@ -80,6 +90,7 @@ export const TextEditor = ({ language }: TextEditorProps) => {
         value: '',
       })),
     });
+  };
 
   const handleDeleteLanguage = (langCode: LangCode) =>
     deleteLanguage({

--- a/frontend/app-development/services/textsApi.ts
+++ b/frontend/app-development/services/textsApi.ts
@@ -3,6 +3,7 @@ import type { TextResourceFile, TextResourceEntry } from '@altinn/text-editor';
 import { Tags } from './tags';
 import { languagesApi } from './languagesApi';
 import { textResourceIdsPath, textResourcesPath } from 'app-shared/api-paths';
+import { TextResourceIdMutation } from "@altinn/text-editor/src/types";
 import { HandleServiceInformationActions } from 'app-development/features/administration/handleServiceInformationSlice';
 
 type OrgApp = {

--- a/frontend/app-development/services/textsApi.ts
+++ b/frontend/app-development/services/textsApi.ts
@@ -3,7 +3,7 @@ import type { TextResourceFile, TextResourceEntry } from '@altinn/text-editor';
 import { Tags } from './tags';
 import { languagesApi } from './languagesApi';
 import { textResourceIdsPath, textResourcesPath } from 'app-shared/api-paths';
-import { TextResourceIdMutation } from "@altinn/text-editor/src/types";
+import { HandleServiceInformationActions } from 'app-development/features/administration/handleServiceInformationSlice';
 
 type OrgApp = {
   org: string;
@@ -49,7 +49,11 @@ export const textsApi = appDevelopmentApi.injectEndpoints({
           textsApi.util.updateQueryData('getAppTextsByLangCode', { org, app, langCode }, () => data)
         );
         try {
-          await queryFulfilled;
+          const changedAppName = data.resources.find(({ id }) => id === 'appName');
+          if (changedAppName) {
+            const serviceName = changedAppName.value;
+            dispatch(HandleServiceInformationActions.updateAppNameWithinState({ serviceName }));
+          }
         } catch {
           dispatch(textsApi.util.invalidateTags([{ type: Tags.Translations, id: langCode }]));
         }


### PR DESCRIPTION
## Description
a temporary fix to ensure that the text resources are updated across the app. We have one redux-store and one toolkit-query cache which is not in sync. This will be permanently fixed when we implement React Query with shared QueryClient/cache. 

## Related Issue(s)
- #9703
- #9734

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
