### PR TITLE
fix bug and add validation for duplicate values

### DIFF
--- a/frontend/language/src/en.json
+++ b/frontend/language/src/en.json
@@ -581,6 +581,7 @@
   "schema_editor.enum": "Valid values",
   "schema_editor.enum_empty": "The list is empty—all values will be approved.",
   "schema_editor.enum_legend": "List of valid values",
+  "schema_editor.enum_error_duplicate": "The values must be unique.",
   "schema_editor.field": "Field",
   "schema_editor.field_name": "Field name",
   "schema_editor.fields": "Fields",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -606,6 +606,7 @@
   "schema_editor.enum": "Gyldige verdier",
   "schema_editor.enum_empty": "Listen er tom – alle verdier vil bli godtatt.",
   "schema_editor.enum_legend": "Liste med gyldige verdier",
+  "schema_editor.enum_error_duplicate": "Verdiene må være unike.",
   "schema_editor.field": "Objekt",
   "schema_editor.field_name": "Navn på felt",
   "schema_editor.fields": "Felter",

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/EnumField.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/EnumField.tsx
@@ -14,6 +14,7 @@ export interface IEnumFieldProps {
   language: ILanguage;
   readOnly?: boolean;
   fullWidth?: boolean;
+  isValid?: boolean;
   onChange: (value: string, oldValue?: string) => void;
   onDelete?: (path: string, key: string) => void;
   onEnterKeyPress?: () => void;
@@ -48,6 +49,7 @@ export const EnumField = (props: IEnumFieldProps) => {
         onBlur={onBlur}
         onKeyDown={onKeyDown}
         autoFocus
+        isValid={props.isValid}
       />
       {props.onDelete && (
         <IconButton

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/ItemRestrictions.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/ItemRestrictions.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent } from 'react';
+import { MouseEvent, useState } from 'react';
 import React from 'react';
 import { getTranslation } from '../../utils/language';
 import type { ILanguage } from '../../types';
@@ -25,6 +25,7 @@ import {
   ButtonVariant,
   Checkbox,
   FieldSet,
+  ErrorMessage,
 } from '@digdir/design-system-react';
 import { Divider } from 'app-shared/primitives';
 import { Add } from '@navikt/ds-icons';
@@ -51,6 +52,9 @@ export const ItemRestrictions = ({
   language,
 }: ItemRestrictionsProps) => {
   const dispatch = useDispatch();
+
+  const [enumError, setEnumError] = useState<string>(null);
+
   const handleRequiredChanged = (e: any) => {
     const { checked } = e.target;
     if (checked !== isRequired) {
@@ -75,14 +79,22 @@ export const ItemRestrictions = ({
   const onChangeRestrictions = (path: string, changedRestrictions: Dict) =>
     dispatch(setRestrictions({ path, restrictions: changedRestrictions }));
 
-  const onChangeEnumValue = (value: string, oldValue?: string) =>
-    dispatch(
-      addEnum({
-        path: pointer,
-        value,
-        oldValue,
-      })
-    );
+  const onChangeEnumValue = (value: string, oldValue?: string) => {
+    if (value === oldValue) return;
+
+    if (enums.includes(value)) {
+      setEnumError(value);
+    } else {
+      setEnumError(null);
+      dispatch(
+        addEnum({
+          path: pointer,
+          value,
+          oldValue,
+        })
+      );
+    }
+  };
 
   const onDeleteEnumClick = (path: string, value: string) => dispatch(deleteEnum({ path, value }));
 
@@ -129,6 +141,11 @@ export const ItemRestrictions = ({
           <Divider inMenu />
           <FieldSet legend={t('enum_legend')}>
             {!enums?.length && <p className={classes.emptyEnumMessage}>{t('enum_empty')}</p>}
+            {enumError !== null && (
+              <ErrorMessage>
+                <p>{t('enum_error_duplicate')}</p>
+              </ErrorMessage>
+            )}
             {enums?.map((value: string, index) => (
               <EnumField
                 fullWidth={true}
@@ -139,6 +156,7 @@ export const ItemRestrictions = ({
                 onEnterKeyPress={dispatchAddEnum}
                 path={pointer}
                 value={value}
+                isValid={enumError !== value}
               />
             ))}
             <div className={classes.addEnumButton}>

--- a/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
+++ b/frontend/packages/schema-editor/src/features/editor/schemaEditorSlice.ts
@@ -43,10 +43,10 @@ const schemaEditorSlice = createSlice({
       const { path, value, oldValue } = action.payload;
       const addToItem = getNodeByPointer(state.uiSchema, path);
       addToItem.enum = addToItem.enum ?? [];
-      if (!oldValue) {
+      if (oldValue === null || oldValue === undefined) {
         addToItem.enum.push(value);
       }
-      if (oldValue && addToItem.enum.includes(oldValue)) {
+      if (addToItem.enum.includes(oldValue)) {
         addToItem.enum[addToItem.enum.indexOf(oldValue)] = value;
       }
       if (!addToItem.enum.includes(value)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There was an issue with the checks for existence of `oldValue`, which just checked if the oldValue was truthy. For cases where `oldValue` was `''` or `0`, this check failed even though it should have passed. This caused the weird behaviour that displayed in the bug description.

Also added a simple validation of uniqueness of the items, since the jsonschema will not save when the items are not unique.

## Related Issue(s)
- #9842 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
