### PR TITLE
Remove receipt info text in ui-editor

### DIFF
--- a/frontend/packages/ux-editor/src/containers/FormDesigner.tsx
+++ b/frontend/packages/ux-editor/src/containers/FormDesigner.tsx
@@ -12,7 +12,6 @@ import { makeGetLayoutOrderSelector } from '../selectors/getLayoutData';
 import { deepCopy } from 'app-shared/pure';
 import classes from './FormDesigner.module.css';
 import { LeftMenu } from '../components/leftMenu/LeftMenu';
-import { Warning } from '@navikt/ds-icons';
 import { useText } from '../hooks';
 import { useParams } from 'react-router-dom';
 
@@ -95,11 +94,6 @@ export const FormDesigner = ({
           </div>
           <div className={classes.mainContent + ' ' + classes.item}>
             <h1 className={classes.pageHeader}>{selectedLayout}</h1>
-            {selectedLayout === 'Kvittering' && (
-              <p className={classes.warningMessage}>
-                <Warning /> Denne funksjonaliteten er ennå ikke implementert i appene.
-              </p>
-            )}
             <DesignView
               order={order}
               activeList={activeList}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Infotext on the receipt layout page in the ui-editor, saying that custom receipt is not implemented in the apps yet, is outdated, hence it is removed.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
