### PR TITLE
Only add initial page when there are no existing layouts

### DIFF
--- a/frontend/packages/ux-editor/src/containers/FormDesigner.tsx
+++ b/frontend/packages/ux-editor/src/containers/FormDesigner.tsx
@@ -25,7 +25,7 @@ export const FormDesigner = ({
   activeList,
   layoutOrder,
   selectedLayout,
-  dataModel
+  dataModel,
 }: FormDesignerProps): JSX.Element => {
   const dispatch = useDispatch();
   const { org, app } = useParams();
@@ -37,14 +37,17 @@ export const FormDesigner = ({
 
   useEffect((): void => {
     const addInitialPage = (): void => {
-      const name = `${t('general.page')} 1`;
+      const name = `${t('general.page')}1`;
       dispatch(FormLayoutActions.addLayout({ layout: name, isReceiptPage: false, org, app }));
     };
 
-    if (selectedLayout === 'default') {
+    const layoutsExist = layoutOrder && !Object.keys(layoutOrder).length;
+    // Old apps might have selectedLayout='default' even when there exist a single layout.
+    // Should only add initial page if no layouts exist.
+    if (selectedLayout === 'default' && !layoutsExist) {
       addInitialPage();
     }
-  }, [app, dispatch, org, selectedLayout, t]);
+  }, [app, dispatch, org, selectedLayout, t, layoutOrder]);
 
   useEffect(() => {
     if (codeEditorOpen) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Initial page was added also in cases where there was an existing layout:
- old apps with a single layout file, but no settings file.
Updated code to check if there were any existing layouts explicitly.

Also updated the name of the initial/default page from `Side 1` to `Side1`.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
