### PR TITLE
Remove receipt.title from text resources in new apps

### DIFF
--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -962,7 +962,6 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
                 TextResource textResource = await altinnAppGitRepository.GetTextV1("nb");
                 textResource.Resources.Add(new TextResourceElement() { Id = "appName", Value = serviceConfig.ServiceName });
-                textResource.Resources.Add(new TextResourceElement() { Id = "receipt.title", Value = $"{serviceConfig.ServiceName} er nå sendt inn" });
                 var jsonSerializerSettings = new JsonSerializerSettings
                 {
                     Formatting = Formatting.Indented,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Since receipt is no longer a part of app-template the receipt.title text should also be removed from the text resource file

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
