### PR TITLE
Feat/ensure unique component id accross layoutset

### DIFF
--- a/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSagas.ts
+++ b/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSagas.ts
@@ -44,13 +44,15 @@ import {
 
 const selectCurrentLayout = (state: IAppState): IFormLayout =>
   state.formDesigner.layout.layouts[state.formDesigner.layout.selectedLayout];
+const selectLayouts = (state: IAppState) => state.formDesigner.layout.layouts;
 
 function* addFormComponentSaga({ payload }: PayloadAction<IAddFormComponentAction>): SagaIterator {
   try {
     let { containerId, position } = payload;
     const { org, app, component, callback } = payload;
     const currentLayout: IFormLayout = yield select(selectCurrentLayout);
-    const id: string = generateComponentId(component.type, currentLayout);
+    const layouts: IFormLayouts = yield select(selectLayouts);
+    const id: string = generateComponentId(component.type, layouts);
 
     if (!containerId) {
       // if not containerId set it to base-container

--- a/frontend/packages/ux-editor/src/utils/generateId.test.tsx
+++ b/frontend/packages/ux-editor/src/utils/generateId.test.tsx
@@ -1,28 +1,48 @@
-import { IFormLayout } from '../types/global';
+import { IFormLayouts } from '../types/global';
 import { generateComponentId, generateTextResourceId } from './generateId';
 
 describe('generateComponentId', () => {
-  const layout: IFormLayout = {
-    containers: {
-      container: {
-        index: 0,
-        itemType: 'CONTAINER',
+  const layouts: IFormLayouts = {
+    layout1: {
+      containers: {
+        container1: {
+          index: 0,
+          itemType: 'CONTAINER',
+        },
+      },
+      components: {
+        'Input-1bd34': {
+          id: 'Input-1bd34',
+          type: 'Input',
+        },
+      },
+      order: {
+        container: ['Input-1bd34'],
       },
     },
-    components: {
-      'Input-1bd34': {
-        id: 'Input-1bd34',
-        type: 'Input',
+    layout2: {
+      containers: {
+        container2: {
+          index: 0,
+          itemType: 'CONTAINER',
+        },
       },
-    },
-    order: {
-      container: ['Input-1bd34'],
+      components: {
+        'Input-abfr34': {
+          id: 'Input-abfr34',
+          type: 'Input',
+        },
+      },
+      order: {
+        container: ['Input-abfr34'],
+      },
     },
   };
-  it('should generate unique component id within provided layout', () => {
-    const newId = generateComponentId('Input', layout);
+  it('should generate unique component id within provided layouts', () => {
+    const newId = generateComponentId('Input', layouts);
     expect(newId.startsWith('Input')).toBeTruthy();
-    expect(layout.components[newId]).toBeUndefined();
+    expect(layouts.layout1.components[newId]).toBeUndefined();
+    expect(layouts.layout2.components[newId]).toBeUndefined();
   });
 });
 

--- a/frontend/packages/ux-editor/src/utils/generateId.ts
+++ b/frontend/packages/ux-editor/src/utils/generateId.ts
@@ -1,4 +1,4 @@
-import { IFormLayout } from '../types/global';
+import { IFormLayouts } from '../types/global';
 import { generateRandomId } from 'app-shared/utils/generateRandomId';
 
 export const generateTextResourceId = (
@@ -9,14 +9,18 @@ export const generateTextResourceId = (
   return `${layoutName}.${componentId}.${textKey}`;
 };
 
-export const generateComponentId = (componentType: string, layout: IFormLayout) => {
+export const generateComponentId = (componentType: string, layouts: IFormLayouts) => {
+  const layoutNames = Object.keys(layouts);
   let existsInLayout = true;
   let componentId = '';
 
-  // ensure generated ID is unique within the provided layout
+  // ensure generated ID is unique within the provided layouts
   while (existsInLayout) {
     componentId = `${componentType}-${generateRandomId(6)}`;
-    existsInLayout = !!layout.components[componentId];
+    layoutNames.forEach((layoutName) => {
+      existsInLayout = !!layouts[layoutName].components[componentId];
+    });
   }
+
   return componentId;
 };

--- a/frontend/testing/cypress/use-cases.yaml
+++ b/frontend/testing/cypress/use-cases.yaml
@@ -16,7 +16,7 @@ schedules:
   displayName: Bruksmønster
   branches:
     include:
-    - master
+    - production
   always: true
 
 steps:

--- a/frontend/testing/cypress/use-cases.yaml
+++ b/frontend/testing/cypress/use-cases.yaml
@@ -8,44 +8,50 @@ trigger: none
 pr: none
 
 variables:
-  cyCacheDir: "/home/AzDevOps/.cache/Cypress"
-  cypressTestDir: "$(Build.SourcesDirectory)/frontend/testing/cypress"
+  cyCacheDir: '/home/AzDevOps/.cache/Cypress'
+  cypressTestDir: '$(Build.SourcesDirectory)/frontend/testing/cypress'
 
 schedules:
-- cron: "10,25,40,55 * * * *"
-  displayName: Bruksmønster
-  branches:
-    include:
-    - production
-  always: true
+  - cron: '10,25,40,55 * * * *'
+    displayName: Bruksmønster
+    branches:
+      include:
+        - production
+    always: true
 
 steps:
-- task: DeleteFiles@1
-  displayName: 'Delete test results'
-  inputs:
-    SourceFolder: '$(cypressTestDir)/reports'
-    Contents: |
-      *.xml
-  condition: succeededOrFailed()
+  - task: DeleteFiles@1
+    displayName: 'Delete test results'
+    inputs:
+      SourceFolder: '$(cypressTestDir)/reports'
+      Contents: |
+        *.xml
+    condition: succeededOrFailed()
 
-- bash: |
-    yarn --immutable
-    npx cypress install
-    yarn run cy:prunecache
-    yarn run cy:cachelist
-    yarn run cy:version
-    yarn run cy:verify
-    yarn run cy:run -s 'src/integration/usecase/usecase.js' -e environment=$(environment),useCaseUserPwd=$(userPassword)
+  - bash: |
+      yarn --immutable
 
-  workingDirectory: '$(cypressTestDir)'
-  displayName: 'Studio Tests'
+      yarn run cy:prunecache
 
-- task: PublishTestResults@2
-  displayName: 'Publish Test Results'
-  inputs:
-    testResultsFiles: '*.xml'
-    searchFolder: '$(cypressTestDir)/reports'
-    mergeTestResults: true
-    failTaskOnFailedTests: true
-    testRunTitle: '$(environment)_studio_use_cases'
-  condition: succeededOrFailed()
+      yarn run cy:cachelist
+
+      yarn run cy:version
+
+      yarn cypress install
+
+      yarn run cy:verify
+
+      yarn run cy:run -s 'e2e/integration/usecase/usecase.js' -e environment=$(environment),useCaseUserPwd=$(userPassword)
+
+    workingDirectory: '$(cypressTestDir)'
+    displayName: 'Studio Tests'
+
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results'
+    inputs:
+      testResultsFiles: '*.xml'
+      searchFolder: '$(cypressTestDir)/reports'
+      mergeTestResults: true
+      failTaskOnFailedTests: true
+      testRunTitle: '$(environment)_studio_use_cases'
+    condition: succeededOrFailed()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
It has been brought to my attention that componentId should be unique accross a layoutset, not just within one layout. While it is unlikely that we will generate a multiple equal componentIds accross different layouts, it is not impossible. Therefore I have updated the code generating the id, to check all layouts instead of just the selected layout.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
