### PR TITLE
Bug/generate id for group fails

### DIFF
--- a/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSagas.ts
+++ b/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSagas.ts
@@ -104,8 +104,8 @@ export function* watchAddFormComponentSaga(): SagaIterator {
 function* addFormContainerSaga({ payload }: PayloadAction<IAddFormContainerAction>): SagaIterator {
   try {
     const { container, positionAfterId, addToId, callback, destinationIndex, org, app } = payload;
-    const layout = yield select(selectCurrentLayout);
-    const id = generateComponentId('Group', layout);
+    const layouts = yield select(selectLayouts);
+    const id = generateComponentId('Group', layouts);
     const currentLayout: IFormLayout = yield select(selectCurrentLayout);
     let baseContainerId;
     if (Object.keys(currentLayout.order) && Object.keys(currentLayout.order).length > 0) {

--- a/frontend/packages/ux-editor/src/utils/generateId.test.tsx
+++ b/frontend/packages/ux-editor/src/utils/generateId.test.tsx
@@ -17,7 +17,7 @@ describe('generateComponentId', () => {
         },
       },
       order: {
-        container: ['Input-1bd34'],
+        container1: ['Input-1bd34'],
       },
     },
     layout2: {
@@ -34,7 +34,7 @@ describe('generateComponentId', () => {
         },
       },
       order: {
-        container: ['Input-abfr34'],
+        container2: ['Input-abfr34'],
       },
     },
   };
@@ -43,6 +43,13 @@ describe('generateComponentId', () => {
     expect(newId.startsWith('Input')).toBeTruthy();
     expect(layouts.layout1.components[newId]).toBeUndefined();
     expect(layouts.layout2.components[newId]).toBeUndefined();
+  });
+
+  it('should generate unique component id for group component', () => {
+    const newId = generateComponentId('Group', layouts);
+    expect(newId.startsWith('Group')).toBeTruthy();
+    expect(layouts.layout1.containers[newId]).toBeUndefined();
+    expect(layouts.layout2.containers[newId]).toBeUndefined();
   });
 });
 

--- a/frontend/packages/ux-editor/src/utils/generateId.ts
+++ b/frontend/packages/ux-editor/src/utils/generateId.ts
@@ -1,5 +1,6 @@
 import { IFormLayouts } from '../types/global';
 import { generateRandomId } from 'app-shared/utils/generateRandomId';
+import { ComponentTypes } from '../components';
 
 export const generateTextResourceId = (
   layoutName: string,
@@ -18,7 +19,12 @@ export const generateComponentId = (componentType: string, layouts: IFormLayouts
   while (existsInLayout) {
     componentId = `${componentType}-${generateRandomId(6)}`;
     layoutNames.forEach((layoutName) => {
-      existsInLayout = !!layouts[layoutName].components[componentId];
+      const layout = layouts[layoutName];
+      if (componentType === ComponentTypes.Group) {
+        existsInLayout = !!layout.containers[componentId];
+      } else {
+        existsInLayout = !!layout.components[componentId];
+      }
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Input to `generateComponentId` for group component was wrong, which casued issues when trying to add a group component.
Also added support for checking uniqueness for group component id (which must be checked in the `containers` object of the layout, not `components`).

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
