### PR TITLE
Add logging to RepositoryController

### DIFF
--- a/backend/src/Designer/Controllers/RepositoryController.cs
+++ b/backend/src/Designer/Controllers/RepositoryController.cs
@@ -145,27 +145,31 @@ namespace Altinn.Studio.Designer.Controllers
         {
             try
             {
-                Guard.AssertValidAppRepoName(repository);
-            }
-            catch (ArgumentException)
-            {
-                return BadRequest($"{repository} is an invalid repository name.");
-            }
+                try
+                {
+                    Guard.AssertValidAppRepoName(repository);
+                }
+                catch (ArgumentException)
+                {
+                    return BadRequest($"{repository} is an invalid repository name.");
+                }
 
-            var config = new ServiceConfiguration
-            {
-                RepositoryName = repository,
-                ServiceName = repository
-            };
+                var config = new ServiceConfiguration { RepositoryName = repository, ServiceName = repository };
 
-            var repositoryResult = await _repository.CreateService(org, config);
-            if (repositoryResult.RepositoryCreatedStatus == HttpStatusCode.Created)
-            {
-                return Created(repositoryResult.CloneUrl, repositoryResult);
+                var repositoryResult = await _repository.CreateService(org, config);
+                if (repositoryResult.RepositoryCreatedStatus == HttpStatusCode.Created)
+                {
+                    return Created(repositoryResult.CloneUrl, repositoryResult);
+                }
+                else
+                {
+                    return StatusCode((int)repositoryResult.RepositoryCreatedStatus, repositoryResult);
+                }
             }
-            else
+            catch (Exception e)
             {
-                return StatusCode((int)repositoryResult.RepositoryCreatedStatus, repositoryResult);
+                Console.WriteLine(e.Message);
+                return BadRequest();
             }
         }
 


### PR DESCRIPTION
## Description
Due to the [issues experienced when creating an application under an organisation](https://altinndevops.slack.com/archives/CDU1S3NLW/p1676893511749899) we need to add logging to the controller to see the actual error in Azure Portal. 

As for now it is likely to assume that it is something wrong with the request sent from the loadblanacer. Either that the loadbalancer can not interpret it correctly or that Studio backend cant interpret it. Since we cannot see any errorlogging in the designer pod in Azure or in dev.altinn.studio application insights we can either assume that the controller is not reached or that the controller simply is not designed to log the particular error.

This is the logs from the loadbalancer:
`
2023/02/21 12:24:08 [error] 21#21: *890981 upstream sent no valid HTTP/1.0 header while reading response header from upstream, client: 10.48.0.103, server: dev.altinn.studio, request: "POST /designer/api/repos/create-app?org=ttd&repository=testtestaaaaaaaaaaaa&datamodellingPreference=1 HTTP/2.0", upstream: "http://10.250.0.204:3000/designer/api/repos/create-app?org=ttd&repository=testtestaaaaaaaaaaaa&datamodellingPreference=1", host: "dev.altinn.studio", referrer: "https://dev.altinn.studio/dashboard/new"
`

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
