### PR TITLE
use window.location.href instead of useNavigate

### DIFF
--- a/frontend/dashboard/components/MakeCopyModal/MakeCopyModal.test.tsx
+++ b/frontend/dashboard/components/MakeCopyModal/MakeCopyModal.test.tsx
@@ -13,17 +13,27 @@ import { mockUseTranslation } from '../../../testing/mocks/i18nMock';
 const user = userEvent.setup();
 const org = 'org';
 const app = 'app';
+const originalWindowLocation = window.location;
 
-afterEach(() => jest.restoreAllMocks());
 jest.mock('app-shared/utils/networking', () => ({
   __esModule: true,
   ...jest.requireActual('app-shared/utils/networking'),
 }));
-jest.mock(
-  'react-i18next',
-  () => ({ useTranslation: () => mockUseTranslation() }),
-);
+jest.mock('react-i18next', () => ({ useTranslation: () => mockUseTranslation() }));
+
 describe('MakeCopyModal', () => {
+  beforeEach(() => {
+    delete window.location;
+    window.location = {
+      ...originalWindowLocation,
+      assign: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    window.location = originalWindowLocation;
+  });
   it('should show error message when clicking confirm without adding name', async () => {
     render();
 

--- a/frontend/dashboard/components/MakeCopyModal/MakeCopyModal.tsx
+++ b/frontend/dashboard/components/MakeCopyModal/MakeCopyModal.tsx
@@ -5,7 +5,6 @@ import { AltinnPopoverSimple } from 'app-shared/components/molecules/AltinnPopov
 import { post } from 'app-shared/utils/networking';
 import { DashboardActions } from '../../resources/fetchDashboardResources/dashboardSlice';
 import type { PopoverOrigin } from '@mui/material';
-import { useNavigate, RelativeRoutingType } from 'react-router-dom';
 import { APP_DEVELOPMENT_BASENAME } from 'app-shared/constants';
 import { validateRepoName } from '../../utils/repoUtils';
 import { useAppDispatch } from '../../hooks/useAppDispatch';
@@ -28,7 +27,6 @@ const transformAnchorOrigin: PopoverOrigin = {
 };
 
 export const MakeCopyModal = ({ anchorEl, handleClose, serviceFullName }: IMakeCopyModalProps) => {
-  const navigate = useNavigate();
   const [repoName, setRepoName] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/frontend/dashboard/components/MakeCopyModal/MakeCopyModal.tsx
+++ b/frontend/dashboard/components/MakeCopyModal/MakeCopyModal.tsx
@@ -5,7 +5,7 @@ import { AltinnPopoverSimple } from 'app-shared/components/molecules/AltinnPopov
 import { post } from 'app-shared/utils/networking';
 import { DashboardActions } from '../../resources/fetchDashboardResources/dashboardSlice';
 import type { PopoverOrigin } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, RelativeRoutingType } from 'react-router-dom';
 import { APP_DEVELOPMENT_BASENAME } from 'app-shared/constants';
 import { validateRepoName } from '../../utils/repoUtils';
 import { useAppDispatch } from '../../hooks/useAppDispatch';
@@ -41,7 +41,7 @@ export const MakeCopyModal = ({ anchorEl, handleClose, serviceFullName }: IMakeC
         const [org, app] = serviceFullName.split('/');
         await post(copyAppPath(org, app, repoName));
         dispatch(DashboardActions.fetchServices({ url: userReposPath() }));
-        navigate(`${APP_DEVELOPMENT_BASENAME}/${org}/${repoName}?copiedApp=true`);
+        window.location.href = `${APP_DEVELOPMENT_BASENAME}/${org}/${repoName}?copiedApp=true`;
       } catch (error) {
         error?.response?.status === 409
           ? setErrorMessage(t('dashboard.app_already_exist'))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
redirect after copying an existing app pushed the new path onto the existing one, resulting in `<hostname>/dashboard/editor/<org>/<app>`, which results in a blank page as this is not a recognized route.
Since dashboard and app-development are set up as two separate applications, any routes registered for `app-development` will not be found in `dashboard`. So using `useNavigate` hook does not work.Revert to using `window.location.href`.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
