### PR TITLE
Add statuscode to repository in giteawrapper

### DIFF
--- a/backend/src/Designer/Controllers/RepositoryController.cs
+++ b/backend/src/Designer/Controllers/RepositoryController.cs
@@ -143,35 +143,23 @@ namespace Altinn.Studio.Designer.Controllers
         [Route("create-app")]
         public async Task<ActionResult<RepositoryModel>> CreateApp([FromQuery] string org, [FromQuery] string repository)
         {
-            Console.WriteLine("Organization: " + org);
             try
             {
-                try
-                {
-                    Guard.AssertValidAppRepoName(repository);
-                }
-                catch (ArgumentException)
-                {
-                    return BadRequest($"{repository} is an invalid repository name.");
-                }
-
-                var config = new ServiceConfiguration { RepositoryName = repository, ServiceName = repository };
-
-                var repositoryResult = await _repository.CreateService(org, config);
-                if (repositoryResult.RepositoryCreatedStatus == HttpStatusCode.Created)
-                {
-                    return Created(repositoryResult.CloneUrl, repositoryResult);
-                }
-                else
-                {
-                    return StatusCode((int)repositoryResult.RepositoryCreatedStatus, repositoryResult);
-                }
+                Guard.AssertValidAppRepoName(repository);
             }
-            catch (Exception e)
+            catch (ArgumentException)
             {
-                Console.WriteLine(e.Message);
-                return BadRequest();
+                return BadRequest($"{repository} is an invalid repository name.");
             }
+
+            var config = new ServiceConfiguration { RepositoryName = repository, ServiceName = repository };
+
+            var repositoryResult = await _repository.CreateService(org, config);
+            if (repositoryResult.RepositoryCreatedStatus == HttpStatusCode.Created)
+            {
+                return Created(repositoryResult.CloneUrl, repositoryResult);
+            }
+            return StatusCode((int)repositoryResult.RepositoryCreatedStatus, repositoryResult);
         }
 
         /// <summary>

--- a/backend/src/Designer/Services/Implementation/GiteaAPIWrapper.cs
+++ b/backend/src/Designer/Services/Implementation/GiteaAPIWrapper.cs
@@ -18,7 +18,6 @@ using Altinn.Studio.Designer.Services.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Altinn.Studio.Designer.Services.Implementation
 {
@@ -108,11 +107,16 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 // The repository with the same name already exists, 409 from Gitea API
                 repository.RepositoryCreatedStatus = HttpStatusCode.Conflict;
             }
+            else if (response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                // The user is not part of a team with repo-creation permissions, 403 from Gitea API
+                _logger.LogError($"User {developer} - Create repository failed with statuscode {response.StatusCode} for {org} and repo-name {options.Name}. If this was not expected try updating team settings in gitea.");
+                repository.RepositoryCreatedStatus = HttpStatusCode.Forbidden;
+            }
             else
             {
-                _logger.LogError("User " + developer +
-                    " Create repository failed with statuscode " + response.StatusCode + " for " +
-                    org + " and repo-name " + options.Name);
+                _logger.LogError($"User {developer} - Create repository failed with statuscode {response.StatusCode} for {org} and repo-name {options.Name}.");
+                repository.RepositoryCreatedStatus = response.StatusCode;
             }
 
             return repository;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add extra information to logs when receiving forbidden response from gitea. 
- Make sure statuscode is added to repository before returning to controller to make it possible to see the statuscode when inspecting the browser.

![Screenshot 2023-02-23 at 10 47 43](https://user-images.githubusercontent.com/71079896/220872616-20b4d711-1e3d-4d00-b71f-0bfa114a04bc.png)

## Related Issue(s)
- #9905 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
