### PR TITLE
chore/disabling typecheck on frontend build

### DIFF
--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -1,0 +1,30 @@
+name: "My Shared Steps"
+description: "Doing yarn installs with propper caching"
+runs:
+  using: "composite"
+  steps:
+    - name: 'Setting up Node'
+      uses: actions/setup-node@v3
+
+    - name: "Getting yarn cache directory path"
+      working-directory: frontend
+      id: yarn-cache-dir-path
+      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - uses: actions/cache@v3
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: 'Installing Dependencies'
+      working-directory: frontend
+      run: yarn install --immutable --inline-builds
+      shell: bash
+      env:
+        YARN_ENABLE_GLOBAL_CACHE: 'false'
+        YARN_NM_MODE: 'hardlinks-local'
+        HUSKY: '0'

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -15,8 +15,8 @@ env:
   CYPRESS_INSTALL_BINARY: 0
 
 jobs:
-  test:
-    name: Lint, Test and build
+  typecheck:
+    name: "Typechecking and linting"
     runs-on: ubuntu-latest
     steps:
       - name: 'Checking Out Code'
@@ -24,33 +24,45 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
-
-      - name: Get yarn cache directory path
-        working-directory: frontend
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - name: 'Installing Dependencies'
+        uses: ./.github/actions/yarn-install
+
+      - name: 'Doing the typecheck'
         working-directory: frontend
-        run: yarn install --immutable --inline-builds
-        env:
-          YARN_ENABLE_GLOBAL_CACHE: 'false'
-          YARN_NM_MODE: 'hardlinks-local'
-          HUSKY: '0'
+        run: yarn typecheck
 
       - name: 'Running Eslint'
         working-directory: frontend
         run: yarn lint
 
+  test:
+    name: "Testing"
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checking Out Code'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: 'Installing Dependencies'
+        uses: ./.github/actions/yarn-install
+
       - name: 'Running Unit Tests'
         working-directory: frontend
         run: yarn test:ci
+
+  build:
+    name: "Building"
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checking Out Code'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: 'Installing Dependencies'
+        uses: ./.github/actions/yarn-install
+
+      - name: "Building"
+        working-directory: frontend
+        run: yarn build

--- a/frontend/app-development/package.json
+++ b/frontend/app-development/package.json
@@ -40,12 +40,12 @@
   "license": "3-Clause BSD",
   "private": true,
   "scripts": {
-    "build": "yarn typeCheck:once && cross-env NODE_ENV=production webpack --config ../webpack.config.prod.js",
+    "build": "cross-env NODE_ENV=production webpack --config ../webpack.config.prod.js",
     "build-with-profile": "yarn build --profile --json > stats.json",
     "bundle-size": "npx webpack-bundle-analyzer ./stats.json",
-    "start": "yarn typeCheck:watch & cross-env NODE_ENV=development webpack-dev-server --config ../webpack.config.dev.js --mode development",
+    "start": "yarn typecheck:watch & cross-env NODE_ENV=development webpack-dev-server --config ../webpack.config.dev.js --mode development",
     "test": "jest --maxWorkers=50%",
-    "typeCheck:once": "tsc --noEmit",
-    "typeCheck:watch": "tsc --noEmit -w"
+    "typecheck:watch": "tsc --noEmit -w",
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/frontend/app-preview/package.json
+++ b/frontend/app-preview/package.json
@@ -29,11 +29,11 @@
   "license": "3-Clause BSD",
   "private": true,
   "scripts": {
-    "build": "yarn typeCheck:once && cross-env NODE_ENV=production webpack --config ../webpack.config.prod.js",
+    "build": "cross-env NODE_ENV=production webpack --config ../webpack.config.prod.js",
     "build-with-profile": "yarn build --profile --json > stats.json",
-    "start": "yarn typeCheck:watch & cross-env NODE_ENV=development webpack-dev-server --config ../webpack.config.dev.js --mode development",
+    "start": "yarn typecheck:watch & cross-env NODE_ENV=development webpack-dev-server --config ../webpack.config.dev.js --mode development",
     "test": "jest --maxWorkers=50%",
-    "typeCheck:once": "tsc --noEmit",
-    "typeCheck:watch": "tsc --noEmit -w"
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit -w"
   }
 }

--- a/frontend/dashboard/package.json
+++ b/frontend/dashboard/package.json
@@ -32,11 +32,10 @@
   "license": "3-Clause BSD",
   "private": true,
   "scripts": {
-    "build": "yarn typeCheck:once && cross-env NODE_ENV=production webpack --config ../webpack.config.prod.js",
-    "compile-ts": "tsc",
-    "start": "yarn typeCheck:watch & cross-env NODE_ENV=development webpack-dev-server --config ../webpack.config.dev.js --mode development",
+    "build": "cross-env NODE_ENV=production webpack --config ../webpack.config.prod.js",
+    "start": "yarn typecheck:watch & cross-env NODE_ENV=development webpack-dev-server --config ../webpack.config.dev.js --mode development",
     "test": "jest --maxWorkers=50%",
-    "typeCheck:once": "tsc --noEmit",
-    "typeCheck:watch": "tsc --noEmit -w"
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit -w"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,8 @@
     "stats": "node stats.js",
     "syncpack": "npx syncpack fix-mismatches && npx syncpack format && npx syncpack set-semver-ranges",
     "test": "jest --maxWorkers=50%",
-    "test:ci": "jest --ci --max-workers=2 --cacheDirectory=$(yarn config get cacheFolder)"
+    "test:ci": "jest --ci --max-workers=2 --cacheDirectory=$(yarn config get cacheFolder)",
+    "typecheck": "yarn workspaces foreach -p run typecheck"
   },
   "syncpack": {
     "semverRange": ""

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -39,7 +39,6 @@
   },
   "private": true,
   "scripts": {
-    "compile-ts": "npx tsc --noEmit",
     "test": "jest --maxWorkers=50%"
   }
 }

--- a/frontend/packages/ux-editor/package.json
+++ b/frontend/packages/ux-editor/package.json
@@ -31,7 +31,6 @@
     "webpack": "5.75.0"
   },
   "scripts": {
-    "compile-ts": "tsc",
     "test": "jest --maxWorkers=50%"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Building the docker-image is a bit slow. To improve speed and make it easier for us to spot mistakes the pipeline is splitted into three distinct lanes, and building the code is done on every push.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
