### PR TITLE
bug/datamodelling crashes when item is deleted from root

### DIFF
--- a/frontend/packages/schema-model/src/lib/mutations/remove-node.test.ts
+++ b/frontend/packages/schema-model/src/lib/mutations/remove-node.test.ts
@@ -54,7 +54,27 @@ test('that removeNodeByPointer throws error on unknown pointer', () => {
   const uiSchemaNodes = buildUiSchema(testComplexSchema);
   expect(() => removeNodeByPointer(uiSchemaNodes, 'fdasdfas')).toThrowError();
 });
+
 test('that removeNodeByPointer throws error on unknown pointer', () => {
   const uiSchemaNodes = buildUiSchema(testComplexSchema);
   expect(() => renameNodePointer(uiSchemaNodes, 'fdasdfas', 'asdfsadfsaasdf')).toThrowError();
+});
+
+test('that we can remove a node with names that start on the same ', () => {
+  const uiSchemaNodes = buildUiSchema({
+    [Keywords.Properties]: {
+      name0: {
+        [Keywords.Type]: FieldType.String,
+      },
+      name: {
+        [Keywords.Type]: FieldType.String,
+      },
+    },
+  });
+  const mutatedSchema = removeNodeByPointer(
+    uiSchemaNodes,
+    makePointer(Keywords.Properties, 'name')
+  );
+  const jsonSchema = buildJsonSchema(mutatedSchema);
+  expect(jsonSchema).toStrictEqual({ properties: { name0: { type: 'string' } } });
 });

--- a/frontend/packages/schema-model/src/lib/mutations/remove-node.ts
+++ b/frontend/packages/schema-model/src/lib/mutations/remove-node.ts
@@ -28,11 +28,17 @@ export const removeNodeByPointer = (
     throw new Error(`Can't remove ${pointer}, can't find parent node.`);
   }
 
-  // Remove itself decendants... just using the pointer
+  // Remove decendants... just using the pointer
   mutatedUiNodeMap = mutatedUiNodeMap.filter(
-    (uiNode: UiSchemaNode) => !uiNode.pointer.startsWith(justChildren ? `${pointer}/` : pointer)
+    (uiNode: UiSchemaNode) => !uiNode.pointer.startsWith(`${pointer}/`)
   );
 
+  // Removing itself...
+  if (!justChildren) {
+    mutatedUiNodeMap = mutatedUiNodeMap.filter(
+      (uiNode: UiSchemaNode) => uiNode.pointer !== pointer
+    );
+  }
   // dealing with combinations, updating their children is a little more tricky.
   if (parentNode.objectKind === ObjectKind.Combination) {
     parentNode.children.forEach((oldPointerBase, index) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Minor, hard to spot bug on datamodelling. Dunno if it's reported earlier. When having two elements with similar names it crashes when removing the item that starts on the same pointer.


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
