### PR TITLE
Fix button size in text resource component

### DIFF
--- a/frontend/packages/ux-editor/src/components/TextResource.module.css
+++ b/frontend/packages/ux-editor/src/components/TextResource.module.css
@@ -53,10 +53,11 @@
   position: absolute;
 }
 
-.button {
+.root .button {
+  /* .root must be set to make it override design system settings */
   --icon-size: 1em;
-  height: 1.5em !important;
-  padding: 0.25em !important;
+  height: 1.5em;
+  padding: 0.25em;
   width: 1.5em;
 }
 


### PR DESCRIPTION
## Description
The CSS `width` property did not override the design system setting. I have made the selector more specific to move it forward in the specificity order and remove the necessity of using `!important`.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
