### PR TITLE
Replace text field in Altinn popover

### DIFF
--- a/frontend/packages/shared/src/components/AltinnPopover.module.css
+++ b/frontend/packages/shared/src/components/AltinnPopover.module.css
@@ -28,15 +28,6 @@
   background: #022F51;
 }
 
-.commitMessageField {
-  border: 1px solid #0062BA;
-  box-sizing: border-box;
-  font-size: 16px !Important;
-  line-height: 1.3;
-  margin-top: 10px;
-  min-height: 88px;
-}
-
 .doneLoadingIcon {
   color: #12AA64;
   margin-left: auto;

--- a/frontend/packages/shared/src/components/AltinnPopover.tsx
+++ b/frontend/packages/shared/src/components/AltinnPopover.tsx
@@ -4,13 +4,13 @@ import {
   CircularProgress,
   Grid,
   Popover,
-  TextField,
   Typography,
 } from '@mui/material';
 import classNames from 'classnames';
 import classes from './AltinnPopover.module.css';
+import { TextArea } from '@digdir/design-system-react';
 
-export interface IAltinnPopoverProvidedProps {
+export interface AltinnPopoverProps {
   anchorEl: any;
   anchorOrigin?: {
     horizontal: 'left' | 'center' | 'right' | number;
@@ -21,7 +21,6 @@ export interface IAltinnPopoverProvidedProps {
   btnCancelText?: string;
   btnPrimaryId?: string;
   btnSecondaryId?: string;
-  classes: any;
   descriptionText?: string;
   handleClose: () => void;
   header?: string;
@@ -35,7 +34,7 @@ export interface IAltinnPopoverProvidedProps {
   };
 }
 
-const AltinnPopoverComponent = (props: any) => {
+const AltinnPopoverComponent = (props: AltinnPopoverProps) => {
 
   const [commitMessage, setCommitMessage] = React.useState('');
 
@@ -96,17 +95,10 @@ const AltinnPopoverComponent = (props: any) => {
           {renderSpinnerOrDoneIcon()}
 
           {props.shouldShowCommitBox && (
-            <TextField
-              multiline={true}
+            <TextArea
               value={commitMessage}
               rows={3}
               onChange={handleChange}
-              InputProps={{
-                disableUnderline: true,
-                classes: {
-                  input: classes.commitMessageField,
-                },
-              }}
             />
           )}
 


### PR DESCRIPTION
## Description
Replaced the last remaining text field from Material UI. 

## Related Issue(s)
- #9262 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
