### PR TITLE
chore/disable renovate for unmaintained code

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,7 @@
     }
   ],
   "ignorePaths": [
-    "testdata/**"
+    "testdata/**",
+    "src/**"
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

To avoid clutter in the teams code flow we are disabling renovate for that unmaintained code that will either be moved or deleted.

## Related Issue(s)
- #8058 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
