### PR TITLE
use correct property to find deployed version

### DIFF
--- a/frontend/app-development/features/appPublish/components/appDeploymentComponent.tsx
+++ b/frontend/app-development/features/appPublish/components/appDeploymentComponent.tsx
@@ -57,7 +57,7 @@ export const AppDeploymentComponent = ({
 
   const appDeployedVersion =
     deploymentList && deploymentList.items && deploymentList.items.length > 0
-      ? deploymentList.items[0].version
+      ? deploymentList.items[0].tagName
       : undefined;
   const { org, app } = useParams();
   const mutation = useCreateDeployMutation(org, app);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Seems like the deployments endpoint has changed its response, and the property we used to access the deployed version no longer exists (or has been replaced with a new property `tagName`). 

## Related Issue(s)
- #9973 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
