### PR TITLE
replace useParams hook

### DIFF
--- a/frontend/app-development/sharedResources/applicationMetadata/put/putAppMetadataSagas.ts
+++ b/frontend/app-development/sharedResources/applicationMetadata/put/putAppMetadataSagas.ts
@@ -4,8 +4,8 @@ import { put as axiosPut } from 'app-shared/utils/networking';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { ApplicationMetadataActions } from '../applicationMetadataSlice';
 import type { IPutApplicationMetadata } from '../applicationMetadataSlice';
-import { useParams } from 'react-router-dom';
 import { appMetadataPath } from 'app-shared/api-paths';
+import { _useParamsClassCompHack } from 'app-shared/utils/_useParamsClassCompHack';
 
 export function* putApplicationMetadataSaga(
   action: PayloadAction<IPutApplicationMetadata>
@@ -13,7 +13,7 @@ export function* putApplicationMetadataSaga(
   const { applicationMetadata } = action.payload;
   try {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const { org, app } = useParams();
+    const { org, app } = _useParamsClassCompHack();
     const result = yield call(axiosPut, appMetadataPath(org, app), applicationMetadata);
     yield put(
       ApplicationMetadataActions.putApplicationMetadataFulfilled({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The useParams hook was used in the saga saving the access management values to applicationMetadata. This hook is not allowed to use outside of a functional react component. Replaced with the class component hack.

## Related Issue(s)
- #9979

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
