### PR TITLE
chore/ignore mui x data grid from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,8 @@
   "ignorePaths": [
     "testdata/**",
     "src/**"
+  ],
+  "ignoreDeps": [
+    "@mui/x-data-grid"
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In our technical roadmap MUI-components should be replaced by the digdir designsystem. MUI Data Grid v6 have breaking changes.

## Related Issue(s)
- #9984 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
