### PR TITLE
fix: array with props type generation

### DIFF
--- a/backend/src/DataModeling/Converter/Metadata/JsonSchemaToMetamodelConverter.cs
+++ b/backend/src/DataModeling/Converter/Metadata/JsonSchemaToMetamodelConverter.cs
@@ -334,7 +334,14 @@ namespace Altinn.Studio.DataModeling.Converter.Metadata
                 return;
             }
 
-            foreach (var keyword in singleSchema.Keywords)
+            // If the array has a properties keyword, the type should be created with the node name.
+            if (singleSchema!.Keywords.TryGetKeyword(out PropertiesKeyword propertiesKeyword) && propertiesKeyword.Properties.Any())
+            {
+                ProcessRegularType(path, subSchema, context);
+            }
+
+
+            foreach (var keyword in singleSchema.Keywords!)
             {
                 var keywordPath = path.Combine(JsonPointer.Parse($"/{keyword.Keyword()}"));
 

--- a/backend/tests/DataModeling.Tests/BaseClasses/CsharpModelConversionTestsBase.cs
+++ b/backend/tests/DataModeling.Tests/BaseClasses/CsharpModelConversionTestsBase.cs
@@ -50,11 +50,7 @@ namespace DataModeling.Tests.BaseClasses
             var strategy = JsonSchemaConverterStrategyFactory.SelectStrategy(LoadedJsonSchema);
             var metamodelConverter = new JsonSchemaToMetamodelConverter(strategy.GetAnalyzer());
 
-            string jsonSchemaString = JsonSerializer.Serialize(LoadedJsonSchema, new JsonSerializerOptions()
-            {
-                Encoder = JavaScriptEncoder.Create(UnicodeRanges.BasicLatin, UnicodeRanges.Latin1Supplement),
-                WriteIndented = true
-            });
+            string jsonSchemaString = SerializeJsonSchema(LoadedJsonSchema);
 
             ModelMetadata = metamodelConverter.Convert(jsonSchemaString);
             return this as TTestType;

--- a/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
+++ b/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
@@ -43,8 +43,8 @@ namespace DataModeling.Tests
         }
 
         [Theory]
-        [InlineData("Model/JsonSchema/General/NonXsdContextSchema.json")]
-        public void JsonSchemaShouldConvertToXsdAndCSharp(string jsonSchemaPath)
+        [InlineData("Model/JsonSchema/General/NonXsdContextSchema.json", "root", "arrayWithProps")]
+        public void JsonSchemaShouldConvertToXsdAndCSharp(string jsonSchemaPath, params string[] typesCreated)
         {
             Given.That.JsonSchemaLoaded(jsonSchemaPath)
                 .When.LoadedJsonSchemaConvertedToModelMetadata()
@@ -52,7 +52,8 @@ namespace DataModeling.Tests
                 .And.CSharpClassesCompiledToAssembly()
                 .Then.CompiledAssembly.Should().NotBeNull();
 
-            And.When.LoadedJsonSchemaConvertedToXsdSchema()
+            And.ClassesShouldBeGenerated(typesCreated)
+                .And.When.LoadedJsonSchemaConvertedToXsdSchema()
                 .Then.ConvertedXsdSchema.Should().NotBeNull();
         }
 
@@ -72,6 +73,17 @@ namespace DataModeling.Tests
         {
             var type = CompiledAssembly.Types().Single(type => type.Name == className);
             TypeAssertions.PropertyShouldContainCustomAnnotationAndHaveTypeType(type, propertyName, propertyType, annotationString);
+        }
+
+
+        private CsharpEnd2EndGenerationTests ClassesShouldBeGenerated(string[] classNames)
+        {
+            foreach (string className in classNames)
+            {
+                var type = CompiledAssembly.Types().Single(type => type.Name == className);
+                type.Should().NotBeNull();
+            }
+            return this;
         }
     }
 }

--- a/testdata/Model/JsonSchema/General/NonXsdContextSchema.json
+++ b/testdata/Model/JsonSchema/General/NonXsdContextSchema.json
@@ -37,16 +37,37 @@
     "integerField": {
       "type": "integer"
     },
-    "restrictionNumberFiled": {
+    "restrictionNumberField": {
       "type": "number",
       "minimum": 0,
       "maximum": 100
     },
-    "restrictionStringFiled": {
+    "restrictionStringField": {
       "type": "string",
       "minLength": 2,
       "maxLength": 10,
       "pattern": "^\\d*$"
+    },
+    "arrayWithProps": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "fish": {
+            "type": "string",
+            "@xsdType": "string"
+          },
+          "stew": {
+            "type": "string",
+            "@xsdType": "string"
+          }
+        },
+        "required": [
+          "fish",
+          "stew"
+        ]
+      },
+      "minItems": 1,
+      "@xsdMaxOccurs": "unbounded"
     }
   },
   "$defs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Generate c# type for arrays which contain only properties

## Related Issue(s)
- #9653 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
