### PR TITLE
null check to support rendering empty group component

### DIFF
--- a/frontend/packages/ux-editor/src/utils/formLayout.ts
+++ b/frontend/packages/ux-editor/src/utils/formLayout.ts
@@ -18,7 +18,10 @@ import i18next from 'i18next';
 
 const { addFormComponent, addFormContainer, addWidget, updateActiveListOrder } = FormLayoutActions;
 
-export function convertFromLayoutToInternalFormat(formLayout: any[], hidden: any): IInternalLayouts {
+export function convertFromLayoutToInternalFormat(
+  formLayout: any[],
+  hidden: any
+): IInternalLayouts {
   const convertedLayout: IInternalLayouts = {
     containers: {},
     components: {},
@@ -65,9 +68,9 @@ export function topLevelComponents(layout: any[]) {
   layout.forEach((component) => {
     if (component.type === 'Group') {
       const childList = component.edit?.multiPage
-        ? component.children.map((childId) => childId.split(':')[1] || childId)
+        ? component.children?.map((childId) => childId.split(':')[1] || childId)
         : component.children;
-      childList.forEach((childId) => inGroup.add(childId));
+      childList?.forEach((childId) => inGroup.add(childId));
     }
   });
   return layout.filter((component) => !inGroup.has(component.id));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If a user adds a group component and then refreshes the page before adding any child components, the whole layout fails to render. Added some null checks to support rendering empty group.


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
