### PR TITLE
bug/404 on missing js files after monaco editor removal

### DIFF
--- a/backend/src/Designer/Views/AppDevelopment/index.cshtml
+++ b/backend/src/Designer/Views/AppDevelopment/index.cshtml
@@ -14,7 +14,3 @@
 
 <link  href="/designer/frontend/app-development/app-development.css" asp-append-version="true" rel="stylesheet">
 <script src="/designer/frontend/app-development/app-development.js" asp-append-version="true" type="text/javascript"></script>
-<script src="/designer/frontend/app-development/1.app-development.js" asp-append-version="true" type="text/javascript"></script>
-<script src="/designer/frontend/app-development/2.app-development.js" asp-append-version="true" type="text/javascript"></script>
-<script src="/designer/frontend/app-development/3.app-development.js" asp-append-version="true" type="text/javascript"></script>
-<script src="/designer/frontend/app-development/4.app-development.js" asp-append-version="true" type="text/javascript"></script>

--- a/frontend/app-development/public/index.html
+++ b/frontend/app-development/public/index.html
@@ -20,10 +20,6 @@
       <link rel="stylesheet" href="/app-development.css">
       <div id="root" class="media-body flex-column d-flex"></div>
       <script src="/app-development.js" type="text/javascript"></script>
-      <script src="/1.app-development.js" type="text/javascript"></script>
-      <script src="/2.app-development.js" type="text/javascript"></script>
-      <script src="/3.app-development.js" type="text/javascript"></script>
-      <script src="/4.app-development.js" type="text/javascript"></script>
     </div>
   </body>
 </html>

--- a/frontend/app-development/store/index.ts
+++ b/frontend/app-development/store/index.ts
@@ -18,6 +18,7 @@ export const setupStore = (preloadedState?: PreloadedState<RootState>) => {
       return getDefaultMiddleware({
         serializableCheck: {
           ignoredActionPaths: ['payload.error', 'serviceInformation.error'],
+          warnAfter: 128,
         },
       }).concat(middlewares);
     },

--- a/frontend/webpack.config.prod.js
+++ b/frontend/webpack.config.prod.js
@@ -9,7 +9,7 @@ module.exports = {
     hints: false,
   },
   optimization: {
-    chunkIds: 'natural',
+    chunkIds: false,
     minimize: true,
     minimizer: [
       new TerserPlugin({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There has been some complaints about the missing js-files after the monaco-editor removal. This PR removes the whole chunkbased approach from webpack and thoose files. Cache busting is fixed by .NET.

## Related Issue(s)
- #9999 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
