### PR TITLE
add info node to ensure datamodel works in app

### DIFF
--- a/backend/src/DataModeling/Templates/general.template.json
+++ b/backend/src/DataModeling/Templates/general.template.json
@@ -1,29 +1,35 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "{{id}}",
-  "type": "object",
-  "@xsdNamespaces": {
-    "xsd": "http://www.w3.org/2001/XMLSchema",
-    "xsi": "http://www.w3.org/2001/XMLSchema-instance",
-    "seres": "http://seres.no/xsd/forvaltningsdata"
-  },
-  "@xsdSchemaAttributes": {
-    "AttributeFormDefault": "Unqualified",
-    "ElementFormDefault": "Qualified",
-    "BlockDefault": "None",
-    "FinalDefault": "None"
-  },
-  "@xsdRootElement": "{{rootType}}",
-  "properties": {
-    "property1": {
-      "type": "string"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "{{id}}",
+    "type": "object",
+    "info": {
+        "rootNode": ""
     },
-    "property2": {
-      "type": "string"
+    "@xsdNamespaces": {
+        "xsd": "http://www.w3.org/2001/XMLSchema",
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "seres": "http://seres.no/xsd/forvaltningsdata"
     },
-    "property3": {
-      "type": "string"
-    }
-  },
-  "required": ["property1", "property2"]
+    "@xsdSchemaAttributes": {
+        "AttributeFormDefault": "Unqualified",
+        "ElementFormDefault": "Qualified",
+        "BlockDefault": "None",
+        "FinalDefault": "None"
+    },
+    "@xsdRootElement": "{{rootType}}",
+    "properties": {
+        "property1": {
+            "type": "string"
+        },
+        "property2": {
+            "type": "string"
+        },
+        "property3": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "property1",
+        "property2"
+    ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For the very basic json schema data models, the apps expect a specific structure unless "info.rootNode" property is specified. Adding this node to the general data model template.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
