### PR TITLE
10090 extend deploy and release mock to include kubernetes wrapper

### DIFF
--- a/backend/src/Designer/Repository/Models/AzureDeploymentsResponse.cs
+++ b/backend/src/Designer/Repository/Models/AzureDeploymentsResponse.cs
@@ -1,16 +1,16 @@
-using System.Collections.Generic;
+using System;
 using System.Text.Json.Serialization;
 
 namespace Altinn.Studio.Designer.Repository.Models
 {
-
-    public class AzureDeploymentsResponse
+    public class Deployment : IEquatable<Deployment>
     {
-        public List<Deployment> Deployment { get; set; }
-    }
 
-    public class Deployment
-    {
+        public bool Equals(Deployment other)
+        {
+            return other.Release == Release && other.Version == Version;
+        }
+
         [JsonPropertyName("release")]
         public string Release { get; set; }
         [JsonPropertyName("version")]

--- a/backend/src/Designer/TypedHttpClients/KubernetesWrapper/IKubernetesWrapperClient.cs
+++ b/backend/src/Designer/TypedHttpClients/KubernetesWrapper/IKubernetesWrapperClient.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Repository.Models;
 using Altinn.Studio.Designer.Services.Models;
@@ -6,5 +7,5 @@ namespace Altinn.Studio.Designer.TypedHttpClients.KubernetesWrapper;
 
 public interface IKubernetesWrapperClient
 {
-    Task<AzureDeploymentsResponse> GetDeploymentsInEnvAsync(string org, string app, EnvironmentModel env);
+    Task<IList<Deployment>> GetDeploymentsInEnvAsync(string org, EnvironmentModel env);
 }

--- a/backend/tests/Designer.Tests/Services/DeploymentServiceTest.cs
+++ b/backend/tests/Designer.Tests/Services/DeploymentServiceTest.cs
@@ -50,8 +50,10 @@ namespace Designer.Tests.Services
                 .ReturnsAsync(GetEnvironments("environments.json"));
             _applicationInformationService = new Mock<IApplicationInformationService>();
             _kubernetesWrapperClient = new Mock<IKubernetesWrapperClient>();
-            _kubernetesWrapperClient.Setup(req => req.GetDeploymentsInEnvAsync("ttd", "issue-6094", It.IsAny<EnvironmentModel>()))
+           /*
+            _kubernetesWrapperClient.Setup(req => req.GetDeploymentsInEnvAsync("ttd", It.IsAny<EnvironmentModel>()))
                 .ReturnsAsync(new AzureDeploymentsResponse());
+                */
         }
 
         [Fact]
@@ -141,7 +143,7 @@ namespace Designer.Tests.Services
         {
             // Arrange
             _deploymentRepository.Setup(r => r.Get("ttd", "issue-6094", It.IsAny<DocumentQueryModel>())).ReturnsAsync(GetDeployments("completedDeployments.json"));
-            _kubernetesWrapperClient.Setup(req => req.GetDeploymentsInEnvAsync("ttd", "issue-6094", It.IsAny<EnvironmentModel>())).Throws<HttpRequestException>();
+            _kubernetesWrapperClient.Setup(req => req.GetDeploymentsInEnvAsync("ttd", It.IsAny<EnvironmentModel>())).Throws<HttpRequestException>();
 
             DeploymentService deploymentService = new(
                 GetAzureDevOpsSettings(),

--- a/development/azure-devops-mock/environments.json
+++ b/development/azure-devops-mock/environments.json
@@ -3,7 +3,7 @@
     {
       "platformUrl": "http://host.docker.internal:6161",
       "appsUrl": "http://host.docker.internal:6161",
-      "hostname": "altinn-mock:6161",
+      "hostname": "host.docker.internal:6161",
       "appPrefix": "apps",
       "platformPrefix": "platform",
       "name": "production",
@@ -12,7 +12,7 @@
     {
       "platformUrl": "http://host.docker.internal:6161",
       "appsUrl": "http://host.docker.internal:6161",
-      "hostname": "altinn-mock:6161",
+      "hostname": "host.docker.internal:6161",
       "appPrefix": "apps",
       "platformPrefix": "platform",
       "name": "tt02",

--- a/development/azure-devops-mock/src/routes/builds.js
+++ b/development/azure-devops-mock/src/routes/builds.js
@@ -77,14 +77,17 @@ export const buildRoute = async (req, res) => {
 };
 
 export const kubernetesWrapperRoute = async (req, res) => {
-  const { envName } = req.query;
-  const deployed = deploys.find((deploy) => deploy.envName === envName);
-  const result = [];
-  if (deployed) {
+  const result = [
+    {
+      version: '1000',
+      release: 'this-app-is-not-an-app-just-a-placeholder',
+    },
+  ];
+  deploys.forEach((deploy) => {
     result.push({
-      version: deployed.tagName,
-      release: [deployed.org, deployed.app].join('-'),
+      version: deploy.tagName,
+      release: [deploy.org, deploy.app].join('-'),
     });
-  }
+  });
   res.json(result);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR solves a few issues around getting the environment status from our environments. This includes a minor update to the mock (which actually was correct implemented) and a hacky solution to be able to go against the mock endpoint and not the build url.

## Related Issue(s)
- #9921 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
