### PR TITLE
Install Cypress deps before Studio prod testing

### DIFF
--- a/frontend/testing/cypress/use-cases-prod.yaml
+++ b/frontend/testing/cypress/use-cases-prod.yaml
@@ -29,6 +29,7 @@ steps:
   condition: succeededOrFailed()
 
 - bash: |
+    sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
     yarn --immutable
     npx cypress install
     yarn run cy:prunecache


### PR DESCRIPTION
Try to getting rid of the dreaded `Your system is missing the dependency: Xvfb` errors we've been experiencing.
Fix seems to be working for dev.

https://docs.cypress.io/guides/getting-started/installing-cypress#Linux-Prerequisites
