### PR TITLE
10004 implement text editor as specified by sketches

### DIFF
--- a/frontend/app-development/config/routes.tsx
+++ b/frontend/app-development/config/routes.tsx
@@ -1,7 +1,7 @@
 import { SubApp } from '../../packages/ux-editor/src/SubApp';
 import { AccessControlContainer } from '../features/accessControl/containers/AccessControlContainer';
 import { Administration } from '../features/administration/components/Administration';
-import { TextEditor } from '../features/textEditor';
+import { TextEditor } from '../features/textEditor/TextEditor';
 import DataModellingContainer from '../features/dataModelling/containers/DataModellingContainer';
 import { TopBarMenu } from '../layout/AppBar/appBarConfig';
 import { DeployPage } from '../features/appPublish/pages/deployPage';

--- a/frontend/app-development/features/textEditor/TextEditor.tsx
+++ b/frontend/app-development/features/textEditor/TextEditor.tsx
@@ -7,86 +7,117 @@ import { AltinnSpinner } from 'app-shared/components';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import classes from './TextEditor.module.css';
 import { getLocalStorage, setLocalStorage } from 'app-shared/utils/localStorage';
-import { TextResourceIdMutation } from '@altinn/text-editor/src/types';
+import { TextResourceIdMutation, UpsertTextResourcesMutation } from '@altinn/text-editor/src/types';
 import { useTranslation } from 'react-i18next';
 import {
   useAddLanguageMutation,
   useDeleteLanguageMutation,
+  useReloadTextResourceFiles,
   useTextIdMutation,
   useTextLanguages,
-  useTextResources,
+  useTextResourceFiles,
   useTranslationByLangCodeMutation,
+  useUpsertTextResourcesMutation,
 } from '../../query-hooks/text';
 
 const storageGroupName = 'textEditorStorage';
+
 export const TextEditor = () => {
-  const [searchParams, setSearchParams] = useSearchParams({ lang: defaultLangCode });
-  const selectedLangCode = searchParams.get('lang');
+  const [searchParams, setSearchParams] = useSearchParams({ lang: '', search: '' });
+  const selectedLangCodes = searchParams.get('lang').split('-');
   const getSearchQuery = () => searchParams.get('search') || '';
   const { org, app } = useParams();
-  const { data: appLangCodes } = useTextLanguages(org, app);
 
-  const setSelectedLangCode = (lang: string) => {
-    const params: any = { lang };
+  const { data: appLangCodes } = useTextLanguages(org, app);
+  const results = useTextResourceFiles(org, app, selectedLangCodes);
+  const reloadTextResourceFiles = useReloadTextResourceFiles(org, app);
+  const setSelectedLangCodes = async (langs: string[]) => {
+    const params: any = { lang: langs.join('-') };
     if (getSearchQuery().length > 0) {
-      params.search = getSearchQuery();
+      params.search = searchParams.get('search');
     }
-    setSearchParams(params);
+    await setSearchParams(params);
+    // Just do a reload of all textfiles to avoid hanging deleted texts and
+    // hanging new tekst.
+    await reloadTextResourceFiles();
   };
+
   const setSearchQuery = (search: string) => {
-    const params: any = { lang: selectedLangCode };
+    const params: any = { lang: searchParams.get('lang') };
     if (search.length > 0) {
       params.search = search;
     }
     setSearchParams(params);
   };
+  useEffect(() => {
+    if (appLangCodes && !appLangCodes.includes(selectedLangCodes[0])) {
+      setSelectedLangCodes([defaultLangCode]).then();
+    }
+  }, [appLangCodes, selectedLangCodes]);
 
-  const {
-    data: translations,
-    isLoading: isInitialLoadingLang,
-    isFetching: isFetchingTranslations,
-    refetch: refetchTextLang,
-  } = useTextResources(org, app, selectedLangCode);
+  const [textResourceFiles, setTextResourceFiles] = useState<TextResourceFile[]>([]);
+
+  const isInitialLoadingLang = results.filter((r) => r.isLoading).length > 0;
+  const isFetchingTranslations = results.filter((r) => r.isFetching).length > 0;
+
+  useEffect(
+    () =>
+      setTextResourceFiles(results.filter((r) => r.data).map((r) => r.data) as TextResourceFile[]),
+    [isInitialLoadingLang, isFetchingTranslations]
+  );
 
   const { t } = useTranslation();
-
-  /*
-   * Temporary fix to make sure to have the latest text-resources fetched.
-   * This issue will be fixed when we have implemented React Query with shared state/cache
-   */
-  useEffect(() => {
-    refetchTextLang().then();
-  }, [refetchTextLang]);
 
   const [hideIntroPage, setHideIntroPage] = useState(
     () => getLocalStorage(storageGroupName, 'hideTextsIntroPage') ?? false
   );
 
   const { mutate: addLanguageMutation } = useAddLanguageMutation(org, app);
-  const handleAddLanguage = (langCode: LangCode) =>
+  const handleAddLanguage = (language: LangCode) =>
     addLanguageMutation({
-      langCode,
-      resources: translations.resources.map(({ id, value }) => ({
+      language,
+      resources: textResourceFiles[0].resources.map(({ id, value }) => ({
         id,
         value: ['appName', 'ServiceName'].includes(id) ? value : '',
       })),
     });
 
   const { mutate: deleteLanguageMutation } = useDeleteLanguageMutation(org, app);
-  const handleDeleteLanguage = (langCode: LangCode) => deleteLanguageMutation({ langCode });
-
-  const { mutate: transMutation } = useTranslationByLangCodeMutation(org, app, selectedLangCode);
-  const handleTranslationChange = (data: TextResourceFile) => transMutation(data);
-
+  const { mutate: transMutation } = useTranslationByLangCodeMutation(org, app, selectedLangCodes);
   const { mutate: textIdMutation } = useTextIdMutation(org, app);
-  const handleTextIdChange = (data: TextResourceIdMutation) => textIdMutation([data]);
 
   const handleHideIntroPageButtonClick = () =>
     setHideIntroPage(setLocalStorage(storageGroupName, 'hideTextsIntroPage', true));
 
-  if (isInitialLoadingLang) {
+  const { mutate: textResourceMutation } = useUpsertTextResourcesMutation(org, app);
+  const upsertTextResource = (data: UpsertTextResourcesMutation) => {
+    textResourceMutation(data);
+    let itsAnInsert = true;
+    textResourceFiles.forEach((file) =>
+      file.resources.forEach((entry) => {
+        if (entry.id === data.textId && file.language === data.language) {
+          entry.value = data.translation;
+          itsAnInsert = false;
+        }
+      })
+    );
+    // It's an insert
+    if (itsAnInsert && data.language === selectedLangCodes[0]) {
+      textResourceFiles.forEach((file) =>
+        file.resources.push({
+          id: data.textId,
+          value: '',
+          variables: null,
+        })
+      );
+    }
+    setTextResourceFiles(textResourceFiles);
+  };
+
+  if (isInitialLoadingLang || isFetchingTranslations || textResourceFiles.length === 0) {
     return <AltinnSpinner />;
   }
+
   return (
     <>
       <PopoverPanel
@@ -122,22 +153,16 @@ export const TextEditor = () => {
         </span>
       </PopoverPanel>
       <TextEditorImpl
-        selectedLangCode={selectedLangCode}
+        addLanguage={handleAddLanguage}
+        availableLanguages={appLangCodes}
+        deleteLanguage={(langCode: LangCode) => deleteLanguageMutation({ langCode })}
         searchQuery={getSearchQuery()}
-        setSelectedLangCode={setSelectedLangCode}
         setSearchQuery={setSearchQuery}
-        availableLangCodes={appLangCodes}
-        translations={
-          translations || {
-            language: selectedLangCode,
-            resources: [],
-          }
-        }
-        isFetchingTranslations={isFetchingTranslations}
-        onTranslationChange={handleTranslationChange}
-        onTextIdChange={handleTextIdChange}
-        onAddLang={handleAddLanguage}
-        onDeleteLang={handleDeleteLanguage}
+        setSelectedLangCodes={setSelectedLangCodes}
+        textResourceFiles={textResourceFiles || []}
+        updateTextId={(data: TextResourceIdMutation) => textIdMutation([data])}
+        upsertTextResource={upsertTextResource}
+        upsertTextResourceFile={(data: TextResourceFile) => transMutation(data)}
       />
     </>
   );

--- a/frontend/app-development/features/textEditor/index.ts
+++ b/frontend/app-development/features/textEditor/index.ts
@@ -1,1 +1,0 @@
-export { TextEditor } from './TextEditor';

--- a/frontend/app-development/queries/mutations.ts
+++ b/frontend/app-development/queries/mutations.ts
@@ -8,6 +8,11 @@ import {
   textResourceIdsPath,
 } from 'app-shared/api-paths';
 
+const headers = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json',
+};
+
 export const createRelease = (org, app, payload) => post(releasesPath(org, app), payload);
 
 export const createDeployment = (org, app, payload) => post(deploymentsPath(org, app), payload);
@@ -15,20 +20,18 @@ export const createDeployment = (org, app, payload) => post(deploymentsPath(org,
 export const pushRepoChanges = (org, app) => post(repoPushPath(org, app));
 
 export const createRepoCommit = (org, app, payload) =>
-  post(repoCommitPath(org, app), payload, {
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-  });
+  post(repoCommitPath(org, app), payload, { headers });
 
-export const updateTranslationByLangCode = (org, app, langCode, payload) =>
-  post(textResourcesPath(org, app, langCode), payload);
+export const updateTranslationByLangCode = (org, app, language, payload) =>
+  post(textResourcesPath(org, app, language), payload);
 
 export const updateTextId = (org, app, payload) => put(textResourceIdsPath(org, app), payload);
 
-export const addLanguageCode = (org, app, langCode, payload) =>
-  post(textResourcesPath(org, app, langCode), payload);
+export const addLanguageCode = (org, app, language, payload) =>
+  post(textResourcesPath(org, app, language), payload);
 
-export const deleteLanguageCode = (org, app, langCode) =>
-  del(textResourcesPath(org, app, langCode));
+export const deleteLanguageCode = (org, app, language) =>
+  del(textResourcesPath(org, app, language));
+
+export const upsertTextResources = (org, app, language, payload) =>
+  put(textResourcesPath(org, app, language), payload);

--- a/frontend/packages/shared/src/components/molecules/AltinnPopoverSimple.tsx
+++ b/frontend/packages/shared/src/components/molecules/AltinnPopoverSimple.tsx
@@ -71,7 +71,7 @@ export const AltinnPopoverSimple = (props: IAltinnPopoverProps) => {
               color={ButtonColor.Inverted}
               onClick={handleButtonClose}
             >
-              <span className={classes.borderBottom}>{props.btnCancelText}</span>
+              {props.btnCancelText}
             </Button>
           )}
         </ButtonContainer>

--- a/frontend/packages/shared/src/primitives/Primitives.module.css
+++ b/frontend/packages/shared/src/primitives/Primitives.module.css
@@ -10,4 +10,5 @@
   gap: 12px;
   padding-top: 12px;
   padding-bottom: 12px;
+  align-items: center;
 }

--- a/frontend/packages/text-editor/src/RightMenu.tsx
+++ b/frontend/packages/text-editor/src/RightMenu.tsx
@@ -8,32 +8,34 @@ import {
   Button,
   ButtonColor,
   ButtonVariant,
+  Checkbox,
   FieldSet,
-  RadioButton,
 } from '@digdir/design-system-react';
 import { defaultLangCode } from './constants';
+import { removeArrayElement } from 'app-shared/pure';
 
 export interface RightMenuProps {
-  selectedLangCode: string;
-  onSelectedLangChange: (langCode: LangCode) => void;
-  availableLangCodes: string[];
-  onAddLang: (langCode: LangCode) => void;
-  onDeleteLang: (langCode: LangCode) => void;
+  addLanguage: (langCode: LangCode) => void;
+  availableLanguages: string[];
+  deleteLanguage: (langCode: LangCode) => void;
+  selectedLanguages: string[];
+  setSelectedLanguages: (langCode: LangCode[]) => void;
 }
 
 export const RightMenu = ({
-  selectedLangCode,
-  onSelectedLangChange,
-  availableLangCodes,
-  onAddLang,
-  onDeleteLang,
+  addLanguage,
+  availableLanguages,
+  deleteLanguage,
+  selectedLanguages,
+  setSelectedLanguages,
 }: RightMenuProps) => {
-  const addLangOptions = langOptions.filter((x) => !availableLangCodes.includes(x.value));
-  const canDeleteLang = (code) => availableLangCodes.length > 1 && code !== defaultLangCode;
-  const handleSelectChange = ({ target }: React.ChangeEvent<HTMLInputElement>) =>
-    onSelectedLangChange(target.value);
+  const addLangOptions = langOptions.filter((x) => !availableLanguages.includes(x.value));
+  const canDeleteLang = (code) => availableLanguages.length > 1 && code !== defaultLangCode;
+  const handleSelectChange = async ({ target }: React.ChangeEvent<HTMLInputElement>) =>
+    target.checked
+      ? setSelectedLanguages([...selectedLanguages, target.name])
+      : setSelectedLanguages(removeArrayElement(selectedLanguages, target.name));
 
-  // TODO: is fetching translations
   return (
     <aside className={classes.RightMenu__sidebar}>
       <div className={classes.RightMenu__verticalContent}>
@@ -48,20 +50,19 @@ export const RightMenu = ({
       <div className={classes.RightMenu__verticalContent}>
         <FieldSet legend='Aktive språk:'>
           <div className={classes.RightMenu__radioGroup}>
-            {availableLangCodes?.map((langCode) => (
+            {availableLanguages?.map((langCode) => (
               <div key={langCode} className={classes.RightMenu__radio}>
-                <RadioButton
-                  value={langCode}
+                <Checkbox
                   label={getLangName({ code: langCode })}
-                  name={'activeLangs'}
+                  name={langCode}
                   onChange={handleSelectChange}
-                  checked={langCode === selectedLangCode}
+                  checked={selectedLanguages.includes(langCode)}
                 />
                 <Button
                   variant={canDeleteLang(langCode) ? ButtonVariant.Filled : ButtonVariant.Outline}
                   data-testid={`delete-${langCode}`}
                   color={ButtonColor.Danger}
-                  onClick={() => onDeleteLang(langCode)}
+                  onClick={() => deleteLanguage(langCode)}
                   disabled={!canDeleteLang(langCode)}
                 >
                   Delete
@@ -73,7 +74,7 @@ export const RightMenu = ({
       </div>
       <div className={classes.RightMenu__verticalContent}>
         <div className={classes['LangEditor__title-sm']}>Legg til språk:</div>
-        <LangSelector onAddLang={onAddLang} options={addLangOptions} />
+        <LangSelector onAddLang={addLanguage} options={addLangOptions} />
       </div>
     </aside>
   );

--- a/frontend/packages/text-editor/src/TextEditor.module.css
+++ b/frontend/packages/text-editor/src/TextEditor.module.css
@@ -59,6 +59,10 @@
   justify-content: space-between;
 }
 
+.TextEditor__body {
+  margin-left: 2rem;
+}
+
 .TextEditor__main {
   padding-top: 2rem;
   margin: 0 auto;

--- a/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -4,6 +4,7 @@ import type { TextEditorProps } from './TextEditor';
 import { act, render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { TextResourceFile } from './types';
+import { textMock } from '../../../testing/mocks/i18nMock';
 
 describe('TextEditor', () => {
   const norwegianTranslation: TextResourceFile = {
@@ -22,29 +23,29 @@ describe('TextEditor', () => {
 
   const renderTextEditor = (props: Partial<TextEditorProps> = {}) => {
     const user = userEvent.setup();
-    const allProps = {
-      availableLangCodes: ['nb', 'en'],
-      translations: norwegianTranslation,
-      selectedLangCode: 'nb',
+    const allProps: TextEditorProps = {
+      addLanguage: jest.fn(),
+      availableLanguages: ['nb', 'en'],
+      deleteLanguage: jest.fn(),
       searchQuery: undefined,
-      setSelectedLangCode: jest.fn(),
       setSearchQuery: jest.fn(),
-      onAddLang: jest.fn(),
-      onTranslationChange: jest.fn(),
-      onDeleteLang: jest.fn(),
-      onTextIdChange: jest.fn(),
+      setSelectedLangCodes: jest.fn(),
+      textResourceFiles: [norwegianTranslation],
+      updateTextId: jest.fn(),
+      upsertTextResource: jest.fn(),
+      upsertTextResourceFile: jest.fn(),
       ...props,
-    } as TextEditorProps;
+    };
     rtlRender(<TextEditor {...allProps} />);
     return { user };
   };
 
-  it('fires onTranslationChange when Add new is clicked', async () => {
+  it('fires upsertTextResource when Add new is clicked', async () => {
     jest.spyOn(global.Math, 'random').mockReturnValue(0);
 
-    const onTranslationChange = jest.fn();
+    const upsertTextResource = jest.fn();
     const { user } = renderTextEditor({
-      onTranslationChange: onTranslationChange,
+      upsertTextResource,
     });
     const addBtn = screen.getByRole('button', {
       name: /ny tekst/i,
@@ -52,15 +53,10 @@ describe('TextEditor', () => {
 
     await act(() => user.click(addBtn));
 
-    expect(onTranslationChange).toHaveBeenCalledWith({
+    expect(upsertTextResource).toHaveBeenCalledWith({
       language: 'nb',
-      resources: [
-        ...norwegianTranslation.resources,
-        {
-          id: 'id_1000',
-          value: '',
-        },
-      ],
+      textId: 'id_1000',
+      translation: '',
     });
     jest.spyOn(global.Math, 'random').mockRestore();
   });
@@ -68,7 +64,7 @@ describe('TextEditor', () => {
   it('fires onDeleteLang when Delete lang is clicked', async () => {
     const handleDeleteLang = jest.fn();
     const { user } = renderTextEditor({
-      onDeleteLang: handleDeleteLang,
+      deleteLanguage: handleDeleteLang,
     });
     const deleteBtn = screen.getByTestId('delete-en');
 
@@ -78,14 +74,14 @@ describe('TextEditor', () => {
   });
 
   it('calls setSelectedLang code when lang is changed', async () => {
-    const setSelectedLangCode = jest.fn((lang: string) => lang);
+    const setSelectedLangCodes = jest.fn((langs: string[]) => langs);
     const { user } = renderTextEditor({
-      setSelectedLangCode,
+      setSelectedLangCodes: setSelectedLangCodes,
     });
-    const norwegianRadio = screen.getByRole('radio', {
+    const norwegianRadio = screen.getByRole('checkbox', {
       name: /norsk bokmål/i,
     });
-    const englishRadio = screen.getByRole('radio', {
+    const englishRadio = screen.getByRole('checkbox', {
       name: /engelsk/i,
     });
     expect(norwegianRadio).toBeChecked();
@@ -93,63 +89,72 @@ describe('TextEditor', () => {
 
     await act(() => user.click(englishRadio));
 
-    expect(setSelectedLangCode).toHaveBeenCalledWith('en');
+    expect(setSelectedLangCodes).toHaveBeenCalledWith(['nb', 'en']);
   });
 
-  it('sets the language to nb (default) if no language is selected', async () => {
-    const setSelectedLangCode = jest.fn((lang: string) => lang);
-    renderTextEditor({
-      setSelectedLangCode,
-      selectedLangCode: undefined,
-    });
-    expect(setSelectedLangCode).toHaveBeenCalledWith('nb');
-  });
   it('signals correctly when a translation is changed', async () => {
-    const onTranslationChange = jest.fn();
+    const upsertTextResource = jest.fn();
     const { user } = renderTextEditor({
-      onTranslationChange,
+      upsertTextResource,
     });
     const translationsToChange = screen.getAllByRole('textbox', {
-      name: /norsk bokmål/i,
+      name: 'nb translation',
     });
     expect(translationsToChange).toHaveLength(2);
     const changedTranslations = [...norwegianTranslation.resources];
     changedTranslations[0].value = 'new translation';
     await act(() => user.tripleClick(translationsToChange[0])); // select all text
     await act(() => user.keyboard(`${changedTranslations[0].value}{TAB}`)); // type new text and blur
-    const mutatedTranslation = { ...norwegianTranslation, resources: changedTranslations };
-    expect(onTranslationChange).toHaveBeenCalledWith(mutatedTranslation);
+    expect(upsertTextResource).toHaveBeenCalledWith({
+      language: 'nb',
+      textId: 'textId1',
+      translation: 'new translation',
+    });
   });
 
   describe('text-id mutation', () => {
     const deleteSomething = async (onTextIdChange = jest.fn()) => {
       const { user } = renderTextEditor({
-        onTextIdChange,
+        updateTextId: onTextIdChange,
       });
       const result = screen.getAllByRole('button', {
-        name: /Slett textId/i,
+        name: textMock('schema_editor.delete'),
       });
       expect(result).toHaveLength(2);
 
       await act(() => user.click(result[0]));
       await screen.findByRole('dialog');
-      await act(() => user.click(
-        screen.getByRole('button', { name: /schema_editor.textRow-confirm-cancel-popover/ })
-      ));
+      await act(() =>
+        user.click(
+          screen.getByRole('button', {
+            name: textMock('schema_editor.textRow-confirm-cancel-popover'),
+          })
+        )
+      );
 
-      expect(onTextIdChange).toHaveBeenCalledWith({ oldId: norwegianTranslation.resources[0].id });
+      await expect(onTextIdChange).toHaveBeenCalledWith({
+        oldId: norwegianTranslation.resources[0].id,
+      });
     };
 
     const getInputs = (name: RegExp) => screen.getAllByRole('textbox', { name });
+
     const makeChangesToTextIds = async (onTextIdChange = jest.fn()) => {
       const { user } = renderTextEditor({
-        onTextIdChange,
+        updateTextId: onTextIdChange,
       });
-      const textIdInputs = getInputs(/ID/i);
-      expect(textIdInputs).toHaveLength(2);
-      await act(() => user.tripleClick(textIdInputs[0])); // select all text
+
+      const editKeyButton = await screen.getAllByRole('button', {
+        name: 'toggle-textkey-edit',
+      })[0];
+      await act(() => user.click(editKeyButton));
+
+      const textIdInputs = getInputs(/tekst key edit/i);
+      expect(textIdInputs).toHaveLength(1);
+      await user.tripleClick(textIdInputs[0]); // select all text
       await act(() => user.keyboard('new-key{TAB}')); // type new text and blur
-      expect(onTextIdChange).toHaveBeenCalledWith({
+
+      await expect(onTextIdChange).toHaveBeenCalledWith({
         oldId: norwegianTranslation.resources[0].id,
         newId: 'new-key',
       });
@@ -162,38 +167,33 @@ describe('TextEditor', () => {
       });
       return { error, onTextIdChange };
     };
+
     it('signals that a textId has changed', async () => {
       await makeChangesToTextIds();
-      const textIdRefsAfter1 = screen.getAllByText(/textid/i);
-      const textIdRefsAfter2 = screen.getAllByText(/new-key/i);
+      const textIdRefsAfter1 = screen.getAllByText('textId2');
       expect(textIdRefsAfter1).toHaveLength(1); // The id is also on the delete button
-      expect(textIdRefsAfter2).toHaveLength(1);
     });
 
-    it('removes an entry from the rendered list of entries', async () => {
-      await deleteSomething();
-      const resultAfter = screen.getAllByRole('button', {
-        name: /Slett textId/i,
-      });
-      expect(resultAfter).toHaveLength(1);
-    });
+    it('removes an entry from the rendered list of entries', () => deleteSomething());
 
     it('reverts the text-id if there was an error on change', async () => {
       const { error, onTextIdChange } = setupError();
       const original = await makeChangesToTextIds(onTextIdChange);
       expect(error).toHaveBeenCalledWith('Renaming text-id failed:\n', 'some error');
-      const textIdRefsAfter1 = screen.getAllByText(/textid/i);
+      const textIdRefsAfter1 = screen.getAllByText('textId2');
+      expect(textIdRefsAfter1).toHaveLength(1);
+
       const textIdRefsAfter2 = screen.queryAllByText(/new-key/i);
-      expect(textIdRefsAfter1).toHaveLength(2); // The id is also on the delete button
       expect(textIdRefsAfter2).toHaveLength(0);
-      expect(getInputs(/ID/i)).toEqual(original);
+      expect(getInputs(/tekst key edit/i)).toEqual(original);
     });
+
     it('reverts to the previous IDs if an entry could not be deleted', async () => {
       const { error, onTextIdChange } = setupError();
       await deleteSomething(onTextIdChange);
       expect(error).toHaveBeenCalledWith('Deleting text failed:\n', 'some error');
       const resultAfter = screen.getAllByRole('button', {
-        name: /Slett textId/i,
+        name: textMock('schema_editor.delete'),
       });
       expect(resultAfter).toHaveLength(2);
     });

--- a/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -78,16 +78,16 @@ describe('TextEditor', () => {
     const { user } = renderTextEditor({
       setSelectedLangCodes: setSelectedLangCodes,
     });
-    const norwegianRadio = screen.getByRole('checkbox', {
+    const norwegianCheckbox = screen.getByRole('checkbox', {
       name: /norsk bokmål/i,
     });
-    const englishRadio = screen.getByRole('checkbox', {
+    const englishCheckbox = screen.getByRole('checkbox', {
       name: /engelsk/i,
     });
-    expect(norwegianRadio).toBeChecked();
-    expect(englishRadio).not.toBeChecked();
+    expect(norwegianCheckbox).toBeChecked();
+    expect(englishCheckbox).not.toBeChecked();
 
-    await act(() => user.click(englishRadio));
+    await act(() => user.click(englishCheckbox));
 
     expect(setSelectedLangCodes).toHaveBeenCalledWith(['nb', 'en']);
   });

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -1,95 +1,78 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useMemo } from 'react';
 import classes from './TextEditor.module.css';
 import type {
   LangCode,
-  TextResourceEntry,
   TextResourceFile,
   TextResourceEntryDeletion,
   TextResourceIdMutation,
+  UpsertTextResourcesMutation,
 } from './types';
-import { AltinnSpinner } from 'app-shared/components';
 import { SearchField } from '@altinn/altinn-design-system';
 import { Button, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
 import { RightMenu } from './RightMenu';
-import { getRandNumber } from './utils';
-import { mapTextResources, upsertTextEntry } from './mutations';
+import { getRandNumber, mapResourceFilesToTableRows } from './utils';
 import { defaultLangCode } from './constants';
 import { TextList } from './TextList';
+import ISO6391 from 'iso-639-1';
 
 export interface TextEditorProps {
-  translations: TextResourceFile;
-  isFetchingTranslations: boolean;
-  onTranslationChange: (translations: TextResourceFile) => void;
-  onTextIdChange: (mutation: TextResourceIdMutation) => void;
-  selectedLangCode: string;
+  addLanguage: (language: LangCode) => void;
+  availableLanguages: string[];
+  deleteLanguage: (language: LangCode) => void;
   searchQuery: string;
-  setSelectedLangCode: (langCode: LangCode) => void;
   setSearchQuery: (searchQuery: string) => void;
-  availableLangCodes: string[];
-  onAddLang: (langCode: LangCode) => void;
-  onDeleteLang: (langCode: LangCode) => void;
+  setSelectedLangCodes: (language: LangCode[]) => void;
+  textResourceFiles: TextResourceFile[];
+  updateTextId: (data: TextResourceIdMutation) => void;
+  upsertTextResource: (data: UpsertTextResourcesMutation) => void;
+  upsertTextResourceFile: (data: TextResourceFile) => void;
 }
 
 export const TextEditor = ({
-  translations,
-  selectedLangCode,
+  availableLanguages,
+  addLanguage,
+  deleteLanguage,
+  updateTextId,
   searchQuery,
-  onTranslationChange,
-  onTextIdChange,
-  isFetchingTranslations,
-  setSelectedLangCode,
   setSearchQuery,
-  availableLangCodes,
-  onAddLang,
-  onDeleteLang,
+  setSelectedLangCodes,
+  textResourceFiles,
+  upsertTextResourceFile,
+  upsertTextResource,
 }: TextEditorProps) => {
-  const { resources } = translations;
-  const [textIds, setTextIds] = useState(resources.map(({ id }) => id) || []);
-  const getUpdatedTexts = useCallback(() => mapTextResources(resources), [resources]);
-  const [texts, setTexts] = useState(getUpdatedTexts());
-  useEffect(() => {
-    if (!availableLangCodes?.includes(selectedLangCode)) {
-      setSelectedLangCode(defaultLangCode);
-    }
-  }, [setSelectedLangCode, selectedLangCode, availableLangCodes]);
-  useEffect(() => {
-    setTexts(getUpdatedTexts());
-  }, [getUpdatedTexts, resources]);
+  const resourceRows = mapResourceFilesToTableRows(textResourceFiles);
+  const selectedLangCodes = textResourceFiles.map((translation) => translation.language);
+
+  const availableLangCodesFiltered = useMemo(
+    () => availableLanguages.filter((code) => ISO6391.validate(code)),
+    [availableLanguages]
+  );
 
   const handleAddNewEntryClick = () => {
-    const newId = `id_${getRandNumber()}`;
-    setSearchQuery('');
-    onTranslationChange(
-      upsertTextEntry(translations, {
-        id: newId,
-        value: '',
-      })
+    const textId = `id_${getRandNumber()}`;
+    availableLangCodesFiltered.forEach((language) =>
+      upsertTextResource({ language, textId, translation: '' })
     );
-    setTextIds([newId, ...textIds]);
+    setSearchQuery('');
   };
+
   const removeEntry = ({ textId }: TextResourceEntryDeletion) => {
-    const mutatedIds = textIds.filter((v) => v !== textId);
     try {
-      onTextIdChange({ oldId: textId });
-      setTextIds(mutatedIds);
+      updateTextId({ oldId: textId });
     } catch (e: unknown) {
       console.error('Deleting text failed:\n', e);
     }
   };
-  const upsertEntry = (entry: TextResourceEntry) =>
-    onTranslationChange(upsertTextEntry(translations, entry));
+
   const updateEntryId = ({ oldId, newId }: TextResourceIdMutation) => {
-    const mutatingIds = [...textIds];
-    const idx = mutatingIds.findIndex((v) => v === oldId);
-    mutatingIds[idx] = newId;
     try {
-      onTextIdChange({ oldId, newId });
-      setTextIds(mutatingIds);
+      updateTextId({ oldId, newId });
     } catch (e: unknown) {
       console.error('Renaming text-id failed:\n', e);
     }
   };
   const handleSearchChange = (event: any) => setSearchQuery(event.target.value);
+
   return (
     <div className={classes.TextEditor}>
       <div className={classes.TextEditor__main}>
@@ -98,7 +81,6 @@ export const TextEditor = ({
             variant={ButtonVariant.Filled}
             color={ButtonColor.Primary}
             onClick={handleAddNewEntryClick}
-            disabled={isFetchingTranslations}
             data-testid='text-editor-btn-add'
           >
             Ny tekst
@@ -111,23 +93,22 @@ export const TextEditor = ({
             />
           </div>
         </div>
-        <TextList
-          textIds={textIds}
-          selectedLangCode={selectedLangCode}
-          searchQuery={searchQuery}
-          texts={texts}
-          upsertEntry={upsertEntry}
-          removeEntry={removeEntry}
-          updateEntryId={updateEntryId}
-        />
-        {isFetchingTranslations ? <AltinnSpinner /> : null}
+        <div className={classes.TextEditor__body}>
+          <TextList
+            removeEntry={removeEntry}
+            resourceRows={resourceRows}
+            searchQuery={searchQuery}
+            updateEntryId={updateEntryId}
+            upsertTextResource={upsertTextResource}
+          />
+        </div>
       </div>
       <RightMenu
-        onAddLang={onAddLang}
-        onDeleteLang={onDeleteLang}
-        selectedLangCode={selectedLangCode}
-        onSelectedLangChange={setSelectedLangCode}
-        availableLangCodes={availableLangCodes || [defaultLangCode]}
+        addLanguage={addLanguage}
+        availableLanguages={availableLangCodesFiltered || [defaultLangCode]}
+        deleteLanguage={deleteLanguage}
+        selectedLanguages={selectedLangCodes}
+        setSelectedLanguages={setSelectedLangCodes}
       />
     </div>
   );

--- a/frontend/packages/text-editor/src/TextEntry.tsx
+++ b/frontend/packages/text-editor/src/TextEntry.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { TextTableRowEntry, UpsertTextResourcesMutation } from './types';
+import { TextField } from '@digdir/design-system-react';
+import { Variables } from './Variables';
+
+export interface TextEntryProps extends TextTableRowEntry {
+  textId: string;
+  upsertTextResource: (data: UpsertTextResourcesMutation) => void;
+}
+
+export const TextEntry = ({ textId, lang, translation, upsertTextResource }: TextEntryProps) => {
+  const [textEntryValue, setTextEntryValue] = useState(translation);
+  const variables = [];
+  const handleTextEntryChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setTextEntryValue(e.currentTarget.value);
+
+  const handleTextEntryBlur = () =>
+    upsertTextResource({ language: lang, translation: textEntryValue, textId });
+
+  return (
+    <>
+      <TextField
+        aria-label={lang + ' translation'}
+        value={textEntryValue}
+        onBlur={handleTextEntryBlur}
+        onChange={handleTextEntryChange}
+      />
+      <Variables variables={variables} />
+    </>
+  );
+};

--- a/frontend/packages/text-editor/src/TextList.test.tsx
+++ b/frontend/packages/text-editor/src/TextList.test.tsx
@@ -1,40 +1,56 @@
 import React from 'react';
-import type { TextResourceMap } from './types';
 import userEvent from '@testing-library/user-event';
 import type { TextListProps } from './TextList';
 import { TextList } from './TextList';
 import { screen, render as rtlRender, act } from '@testing-library/react';
+import { TextTableRow } from './types';
 
 const renderTextList = (props: Partial<TextListProps> = {}) => {
-  const texts: TextResourceMap = {
-    a: {
-      value: 'value1',
+  const resourceRows: TextTableRow[] = [
+    {
+      textKey: 'a',
+      translations: [
+        {
+          lang: 'nb',
+          translation: 'value1',
+        },
+      ],
     },
-    b: {
-      value: 'value2',
+    {
+      textKey: 'b',
+      translations: [
+        {
+          lang: 'nb',
+          translation: 'value2',
+        },
+      ],
     },
-    c: {
-      value: 'value3',
+    {
+      textKey: 'c',
+      translations: [
+        {
+          lang: 'nb',
+          translation: 'value3',
+        },
+      ],
     },
-    d: {
-      value: 'value4',
+    {
+      textKey: 'd',
+      translations: [
+        {
+          lang: 'nb',
+          translation: 'value4',
+        },
+      ],
     },
-    e: {
-      value: 'value5',
-    },
-    f: {
-      value: 'value6',
-    },
-  };
+  ];
 
   const allProps: TextListProps = {
-    textIds: ['a', 'b', 'c', 'd', 'e', 'f'],
-    selectedLangCode: 'nb',
+    resourceRows,
     searchQuery: undefined,
-    texts,
     updateEntryId: (_arg) => undefined,
     removeEntry: (_arg) => undefined,
-    upsertEntry: (_entry) => undefined,
+    upsertTextResource: (_entry) => undefined,
     ...props,
   };
   const user = userEvent.setup();
@@ -46,27 +62,28 @@ describe('TextList', () => {
     const updateEntryId = jest.fn();
     const { user, rerender, initPros } = renderTextList({ updateEntryId });
     rerender(<TextList {...initPros} />);
+    const toggleEditButton = screen.getAllByRole('button', { name: 'toggle-textkey-edit' });
+    await act(() => user.click(toggleEditButton[0]));
     const idInputs = screen.getAllByRole('textbox', {
-      name: /id/i,
+      name: 'tekst key edit',
     });
     await act(() => user.dblClick(idInputs[0]));
     await act(() => user.keyboard('a-updated{TAB}'));
     expect(updateEntryId).toHaveBeenCalledWith({ newId: 'a-updated', oldId: 'a' });
-    await act(() => user.keyboard('{TAB}{TAB}b-updated{TAB}'));
-    expect(updateEntryId).toHaveBeenCalledWith({ newId: 'b-updated', oldId: 'b' });
-    await act(() => user.keyboard('{TAB}{TAB}{TAB}{TAB}{TAB}{TAB}{TAB}{TAB}e-updated{TAB}'));
-    expect(updateEntryId).toHaveBeenCalledWith({ newId: 'e-updated', oldId: 'e' });
   });
+
   test('that the user is warned when an id already exists', async () => {
     const updateEntryId = jest.fn();
     const { user, rerender, initPros } = renderTextList({ updateEntryId });
     rerender(<TextList {...initPros} />);
+    const toggleEditButton = screen.getAllByRole('button', { name: 'toggle-textkey-edit' });
+    await act(() => user.click(toggleEditButton[0]));
     const idInputs = screen.getAllByRole('textbox', {
-      name: /id/i,
+      name: 'tekst key edit',
     });
     const errorMsg = 'Denne IDen finnes allerede';
-    await act(() => user.dblClick(idInputs[1]));
-    await act(() => user.keyboard('a'));
+    await act(() => user.dblClick(idInputs[0]));
+    await act(() => user.keyboard('b'));
     const error = screen.getByRole('alertdialog');
     expect(error).toBeInTheDocument();
     expect(screen.getByText(errorMsg)).not.toBeNull();
@@ -77,6 +94,6 @@ describe('TextList', () => {
     await act(() => user.keyboard('{TAB}'));
     expect(updateEntryId).not.toHaveBeenCalled();
     await act(() => user.keyboard('{SHIFT>}{TAB}{/SHIFT}{END}2{TAB}'));
-    expect(updateEntryId).toHaveBeenCalledWith({ oldId: 'b', newId: 'a2' });
+    expect(updateEntryId).toHaveBeenCalledWith({ oldId: 'a', newId: 'b2' });
   });
 });

--- a/frontend/packages/text-editor/src/TextRow.module.css
+++ b/frontend/packages/text-editor/src/TextRow.module.css
@@ -29,3 +29,8 @@
   display: flex;
   gap: 8px;
 }
+
+.smallIcon {
+  height: 16px;
+  width: 16px;
+}

--- a/frontend/packages/text-editor/src/TextRow.test.tsx
+++ b/frontend/packages/text-editor/src/TextRow.test.tsx
@@ -1,36 +1,46 @@
 import React from 'react';
-import type { LangRowProps } from './TextRow';
-import type { TextDetail } from './types';
+import type { TextRowProps } from './TextRow';
 import userEvent from '@testing-library/user-event';
 import { TextRow } from './TextRow';
 import { screen, render as rtlRender, waitFor, act } from '@testing-library/react';
 import { textMock } from '../../../testing/mocks/i18nMock';
+import { TextTableRowEntry } from './types';
+import { Table, TableBody } from '@digdir/design-system-react';
 
 describe('TextRow', () => {
-  const renderTextRow = (props: Partial<LangRowProps> = {}) => {
-    const textData: TextDetail = {
-      value: 'value1',
-    };
+  const renderTextRow = (props: Partial<TextRowProps> = {}) => {
+    const textRowEntries: TextTableRowEntry[] = [
+      {
+        lang: 'nb',
+        translation: 'value1',
+      },
+    ];
 
-    const allProps: LangRowProps = {
-      textId: 'key1',
-      langName: 'Norsk',
-      textData,
-      upsertEntry: (_args) => undefined,
-      removeEntry: (_args) => undefined,
-      updateEntryId: (_args) => undefined,
+    const allProps: TextRowProps = {
       idExists: (_arg) => false,
+      removeEntry: (_args) => undefined,
+      textId: 'key1',
+      textRowEntries,
+      variables: [],
+      updateEntryId: (_args) => undefined,
+      upsertTextResource: (_args) => undefined,
       ...props,
     };
     const user = userEvent.setup();
-    rtlRender(<TextRow {...allProps} />);
+    rtlRender(
+      <Table>
+        <TableBody>
+          <TextRow {...allProps} />
+        </TableBody>
+      </Table>
+    );
     return { user };
   };
 
   test('Popover should be closed when the user clicks the cancel button', async () => {
     const { user } = renderTextRow();
 
-    const deleteButton = screen.getByRole('button', { name: /Slett/ });
+    const deleteButton = screen.getByRole('button', { name: textMock('schema_editor.delete') });
     await act(() => user.click(deleteButton));
 
     const cancelPopoverButton = screen.getByRole('button', {
@@ -42,24 +52,25 @@ describe('TextRow', () => {
   });
 
   test('upsertEntry should be called when changing text', async () => {
-    const upsertEntry = jest.fn();
-    const { user } = renderTextRow({ upsertEntry });
+    const upsertTextResource = jest.fn();
+    const { user } = renderTextRow({ upsertTextResource });
     const valueInput = screen.getByRole('textbox', {
-      name: /norsk/i,
+      name: 'nb translation',
     });
 
     await act(() => user.type(valueInput, '-updated'));
     await act(() => user.keyboard('{TAB}'));
 
-    expect(upsertEntry).toHaveBeenCalledWith({
-      id: 'key1',
-      value: 'value1-updated',
+    expect(upsertTextResource).toHaveBeenCalledWith({
+      language: 'nb',
+      textId: 'key1',
+      translation: 'value1-updated',
     });
   });
 
   test('Popover should be shown when the user clicks the delete button', async () => {
     const { user } = renderTextRow();
-    const deleteButton = screen.getByRole('button', { name: /Slett/ });
+    const deleteButton = screen.getByRole('button', { name: textMock('schema_editor.delete') });
     await act(() => user.click(deleteButton));
     const popover = screen.getByRole('dialog');
     expect(popover).toBeInTheDocument();
@@ -68,7 +79,7 @@ describe('TextRow', () => {
   test('removeEntry should be called when deleting an entry', async () => {
     const removeEntry = jest.fn();
     const { user } = renderTextRow({ removeEntry });
-    const deleteButton = screen.getByRole('button', { name: /Slett/ });
+    const deleteButton = screen.getByRole('button', { name: textMock('schema_editor.delete') });
     await act(() => user.click(deleteButton));
     const confirmDeleteButton = screen.getByRole('button', {
       name: /schema_editor.textRow-confirm-cancel-popover/,
@@ -80,8 +91,13 @@ describe('TextRow', () => {
   test('that the user is warned if an illegal character is used', async () => {
     const updateEntryId = jest.fn();
     const { user } = renderTextRow({ updateEntryId });
+    const toggleKeyEditButton = screen.getByRole('button', {
+      name: 'toggle-textkey-edit',
+    });
+    await act(() => user.click(toggleKeyEditButton));
+
     const idInput = screen.getByRole('textbox', {
-      name: /id/i,
+      name: 'tekst key edit',
     });
     const emptyMsg = 'TextId kan ikke være tom';
     const illegalCharMsg = 'Det er ikke tillat med mellomrom i en textId';
@@ -94,12 +110,5 @@ describe('TextRow', () => {
     expect(screen.queryByText(emptyMsg)).toBeNull();
     await act(() => user.keyboard(' '));
     expect(screen.getByText(illegalCharMsg)).toBeInTheDocument();
-  });
-  test('that the text area has 3 rows', async () => {
-    renderTextRow();
-    const valueInput = screen.getByRole('textbox', {
-      name: /norsk/i,
-    });
-    expect((valueInput as HTMLTextAreaElement).rows).toEqual(3);
   });
 });

--- a/frontend/packages/text-editor/src/TextRow.tsx
+++ b/frontend/packages/text-editor/src/TextRow.tsx
@@ -97,7 +97,7 @@ export const TextRow = ({
           )}
           <Button
             aria-label={'toggle-textkey-edit'}
-            icon={<PencilIcon style={{ height: '16px', width: '16px' }} />}
+            icon={<PencilIcon className={classes.smallIcon} />}
             variant={ButtonVariant.Quiet}
             size={ButtonSize.Small}
             onClick={() => setTextIdEditOpen(!textIdEditOpen)}

--- a/frontend/packages/text-editor/src/Variables.test.tsx
+++ b/frontend/packages/text-editor/src/Variables.test.tsx
@@ -6,8 +6,6 @@ import { screen, render as rtlRender } from '@testing-library/react';
 const renderVariables = (props: Partial<VariablesProps> = {}) => {
   const allProps: VariablesProps = {
     variables: [],
-    infoboxOpen: false,
-    setInfoboxOpen: (open: boolean) => open,
     ...props,
   };
   rtlRender(<Variables {...allProps} />);

--- a/frontend/packages/text-editor/src/Variables.tsx
+++ b/frontend/packages/text-editor/src/Variables.tsx
@@ -2,16 +2,15 @@ import classes from './Variables.module.css';
 import { PanelVariant, PopoverPanel } from '@altinn/altinn-design-system';
 import { Button, ButtonSize, ButtonVariant } from '@digdir/design-system-react';
 import { InformationSquareFillIcon } from '@navikt/aksel-icons';
-import React from 'react';
+import React, { useState } from 'react';
 import type { TextResourceVariable } from './types';
 
 export type VariablesProps = {
   variables: TextResourceVariable[];
-  infoboxOpen: boolean;
-  setInfoboxOpen: (open: boolean) => void;
 };
 
-export const Variables = ({ variables, infoboxOpen, setInfoboxOpen }: VariablesProps) => {
+export const Variables = ({ variables }: VariablesProps) => {
+  const [infoboxOpen, setInfoboxOpen] = useState(false);
   return (
     <div title={'Det er ikke lagt til støtte for redigering av variabler i Studio.'}>
       {variables.map((variable) => (

--- a/frontend/packages/text-editor/src/types.d.ts
+++ b/frontend/packages/text-editor/src/types.d.ts
@@ -36,3 +36,21 @@ type Language = {
   label?: string;
   value: LangCode;
 };
+
+type TextTableRow = {
+  textKey: string;
+  variables?: TextResourceVariable[];
+  translations: TextTableRowEntry[];
+  usages?: any;
+};
+
+type TextTableRowEntry = {
+  lang: LangCode;
+  translation: string;
+};
+
+export interface UpsertTextResourcesMutation {
+  textId: string;
+  language: string;
+  translation: string;
+}

--- a/frontend/packages/text-editor/src/utils.test.ts
+++ b/frontend/packages/text-editor/src/utils.test.ts
@@ -1,4 +1,5 @@
-import { filterFunction, getLangName, getRandNumber } from './utils';
+import { filterFunction, getLangName, getRandNumber, mapResourceFilesToTableRows } from './utils';
+import { TextResourceFile } from './types';
 
 describe('getLangName', () => {
   it('should return empty string when language code is undefined', () => {
@@ -41,11 +42,37 @@ describe('getRandNumber', () => {
 });
 
 test('that filter function works as intended', () => {
-  expect(filterFunction('test', 'spock', 'ock')).toBe(true);
-  expect(filterFunction('test', 'spock', 'rock')).toBe(false);
-  expect(filterFunction('test', 'spock', '')).toBe(true);
-  expect(filterFunction('test', 'spock', 'test')).toBe(true);
-  expect(filterFunction('test', 'spock', 'testen')).toBe(false);
-  expect(filterFunction('test', 'spock', undefined)).toBe(true);
+  const entry = [{ lang: 'nb', translation: 'spock' }];
+  expect(filterFunction('test', entry, 'ock')).toBe(true);
+  expect(filterFunction('test', entry, 'rock')).toBe(false);
+  expect(filterFunction('test', entry, '')).toBe(true);
+  expect(filterFunction('test', entry, 'test')).toBe(true);
+  expect(filterFunction('test', entry, 'testen')).toBe(false);
+  expect(filterFunction('test', entry, undefined)).toBe(true);
   expect(filterFunction('test', undefined, undefined)).toBe(true);
+});
+
+test('that we can map two resource files to a text table', () => {
+  const file1: TextResourceFile = {
+    language: 'nb',
+    resources: [
+      {
+        id: 'my-key',
+        value: 'Min nøkkel',
+      },
+    ],
+  };
+  const file2: TextResourceFile = {
+    language: 'en',
+    resources: [
+      {
+        id: 'my-key',
+        value: 'My key',
+      },
+    ],
+  };
+  const rows = mapResourceFilesToTableRows([file1, file2]);
+  expect(rows).toHaveLength(1);
+  expect(rows[0].textKey).toBe('my-key');
+  expect(rows[0].translations).toHaveLength(2);
 });

--- a/frontend/packages/text-editor/src/utils.ts
+++ b/frontend/packages/text-editor/src/utils.ts
@@ -47,21 +47,11 @@ export const filterFunction = (
   id: string | undefined,
   textTableRowEntries: TextTableRowEntry[] | undefined,
   searchQuery: string | undefined
-) => {
-  if (!searchQuery) {
-    return true;
-  } else if (searchQuery.length < 1) {
-    return true;
-  } else if (id?.toLowerCase().includes(searchQuery.toLowerCase())) {
-    return true;
-  } else if (
-    textTableRowEntries.filter((entry) => entry.translation.includes(searchQuery)).length > 0
-  ) {
-    return true;
-  } else {
-    return false;
-  }
-};
+) =>
+  !searchQuery ||
+  searchQuery.length < 1 ||
+  id?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+  textTableRowEntries.filter((entry) => entry.translation.includes(searchQuery)).length > 0;
 
 export const mapResourceFilesToTableRows = (files: TextResourceFile[]): TextTableRow[] => {
   const rows = new Map();

--- a/frontend/packages/ux-editor/src/testing/mocks.tsx
+++ b/frontend/packages/ux-editor/src/testing/mocks.tsx
@@ -7,7 +7,10 @@ import type { ReactNode } from 'react';
 import { IServiceConfigurationState } from '../features/serviceConfigurations/serviceConfigurationTypes';
 import { Provider } from 'react-redux';
 import { render, renderHook } from '@testing-library/react';
-import { ServicesContextProps, ServicesContextProvider } from '../../../../app-development/common/ServiceContext';
+import {
+  ServicesContextProps,
+  ServicesContextProvider,
+} from '../../../../app-development/common/ServiceContext';
 
 export const textResourcesMock: ITextResourcesState = {
   currentEditId: undefined,
@@ -58,7 +61,7 @@ export const appStateMock: IAppState = {
   widgets: null,
 };
 
-export const queriesMock: ServicesContextProps = {
+export const queriesMock: Partial<ServicesContextProps> = {
   addLanguageCode: jest.fn(),
   createDeployment: jest.fn(),
   createRelease: jest.fn(),
@@ -80,7 +83,7 @@ export const queriesMock: ServicesContextProps = {
   pushRepoChanges: jest.fn(),
   updateTextId: jest.fn(),
   updateTranslationByLangCode: jest.fn(),
-}
+};
 
 export const renderWithMockStore =
   (state: Partial<IAppState> = {}, queries: Partial<ServicesContextProps> = {}) =>

--- a/frontend/packages/ux-editor/src/testing/mocks.tsx
+++ b/frontend/packages/ux-editor/src/testing/mocks.tsx
@@ -61,7 +61,7 @@ export const appStateMock: IAppState = {
   widgets: null,
 };
 
-export const queriesMock: Partial<ServicesContextProps> = {
+export const queriesMock: ServicesContextProps = {
   addLanguageCode: jest.fn(),
   createDeployment: jest.fn(),
   createRelease: jest.fn(),
@@ -83,6 +83,7 @@ export const queriesMock: Partial<ServicesContextProps> = {
   pushRepoChanges: jest.fn(),
   updateTextId: jest.fn(),
   updateTranslationByLangCode: jest.fn(),
+  upsertTextResources: jest.fn(),
 };
 
 export const renderWithMockStore =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements parts of the issue #10004 but the hard parts. This changes this page to be able to display two languages or more side by side. What this PR doesn't solve:

* Translation keys: #10117 
* Multiselect with checkoxes on the side
* Top Menu, we are keeping the right menu as it works well until we have gotten the needed components in the design system
* Toggle Rich textedit, or at least toggle the fields to text-areas. This can be solved in multiple ways. Opening a textarea is one... opening a popup with a rich editor might also be an alternativ here.

## Related Issue(s)
- #10004 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
