### PR TITLE
Mock app-api endpoints in previewController

### DIFF
--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -1,9 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using Altinn.Platform.Profile.Models;
+using Altinn.Platform.Register.Enums;
+using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
+using LibGit2Sharp;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -15,22 +24,30 @@ namespace Altinn.Studio.Designer.Controllers
     /// </summary>
     [Authorize]
     [AutoValidateAntiforgeryToken]
-    [Route("preview/{org}/{app:regex(^(?!datamodels$)[[a-z]][[a-z0-9-]]{{1,28}}[[a-z0-9]]$)}")]
+    [Route("{org}/{app:regex(^(?!datamodels$)[[a-z]][[a-z0-9-]]{{1,28}}[[a-z0-9]]$)}")]
     public class PreviewController : Controller
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IAltinnGitRepositoryFactory _altinnGitRepositoryFactory;
+        private readonly ISchemaModelService _schemaModelService;
+        private readonly IPreviewService _previewService;
+        private Instance MockInstance { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PreviewController"/> class.
         /// </summary>
         /// <param name="httpContextAccessor"></param>
         /// <param name="altinnGitRepositoryFactory">IAltinnGitRepositoryFactory</param>
+        /// <param name="schemaModelService"></param>
+        /// <param name="previewService"></param>
         /// Factory class that knows how to create types of <see cref="AltinnGitRepository"/>
-        public PreviewController(IHttpContextAccessor httpContextAccessor, IAltinnGitRepositoryFactory altinnGitRepositoryFactory)
+        public PreviewController(IHttpContextAccessor httpContextAccessor, IAltinnGitRepositoryFactory altinnGitRepositoryFactory, ISchemaModelService schemaModelService, IPreviewService previewService)
         {
             _httpContextAccessor = httpContextAccessor;
             _altinnGitRepositoryFactory = altinnGitRepositoryFactory;
+            _schemaModelService = schemaModelService;
+            _previewService = previewService;
+            MockInstance = new Instance();
         }
 
         /// <summary>
@@ -38,26 +55,37 @@ namespace Altinn.Studio.Designer.Controllers
         /// </summary>
         /// <returns>default view for the app preview.</returns>
         [HttpGet]
-        [Route("gui/{*AllValues}")]
+        [Route("preview/{*AllValues}")]
         public IActionResult Index(string org, string app)
         {
+            string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
+            MockInstance = _previewService.CreateMockInstance(org, app, developer, 1);
             return View();
         }
 
+        /// <summary>
+        /// Get status if app is ready for preview
+        /// </summary>
+        [HttpGet]
+        [Route("preview-status")]
+        public ActionResult<string> PreviewStatus()
+        {
+            return Ok("Ready for preview");
+        }
 
         /// <summary>
         /// Action for getting the application metadata
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
-        /// <returns>A view with the React form builder</returns>
+        /// <returns>The application metadata for the app</returns>
         [HttpGet]
-        [Route("api/applicationmetadata")]
+        [Route("api/v1/applicationmetadata")]
         public async Task<ActionResult<Application>> ApplicationMetadata(string org, string app)
         {
+
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
-            AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
-            Application applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
+            Application applicationMetadata = await _previewService.GetApplication(org, app, developer);
             return Ok(applicationMetadata);
         }
 
@@ -66,12 +94,21 @@ namespace Altinn.Studio.Designer.Controllers
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
-        /// <returns>200 Ok</returns>
+        /// <returns>ApplicationSettings</returns>
         [HttpGet]
-        [Route("api/applicationsettings")]
-        public IActionResult ApplicationSettings(string org, string app)
+        [Route("api/v1/applicationsettings")]
+        public async Task<ActionResult<ApplicationSettings>> ApplicationSettings(string org, string app)
         {
-            return Ok();
+            string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
+            AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
+            Application applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
+            ApplicationSettings applicationSettings = new()
+            {
+                Id = applicationMetadata.Id,
+                Org = applicationMetadata.Org,
+                Title = applicationMetadata.Title
+            };
+            return Ok(applicationSettings);
         }
 
         /// <summary>
@@ -79,15 +116,48 @@ namespace Altinn.Studio.Designer.Controllers
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
-        /// <returns>layoutsets example file</returns>
+        /// <returns>layoutsets file, or a notfound response if app does not use layoutsets</returns>
         [HttpGet]
         [Route("api/layoutsets")]
         public async Task<ActionResult<LayoutSets>> LayoutSets(string org, string app)
         {
-            string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
-            AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
-            LayoutSets layoutSets = await altinnAppGitRepository.GetLayoutSetsFile();
-            return Ok(layoutSets);
+            try
+            {
+                string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
+                AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
+                LayoutSets layoutSets = await altinnAppGitRepository.GetLayoutSetsFile();
+                return Ok(layoutSets);
+            }
+            catch (NotFoundException)
+            {
+                return NotFound();
+            }
+
+        }
+
+        /// <summary>
+        /// Action for getting the layout settings for apps without layoutsets
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="app">Application identifier which is unique within an organisation.</param>
+        /// <returns>layoutsettings</returns>
+        [HttpGet]
+        [Route("api/layoutsettings")]
+        public async Task<ActionResult<string>> LayoutSettings(string org, string app)
+        {
+            try
+            {
+                string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
+                AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
+                JsonNode layoutSettings = await altinnAppGitRepository.GetLayoutSettingsAndCreateNewIfNotFound(null);
+                byte[] layoutSettingsContent = JsonSerializer.SerializeToUtf8Bytes(layoutSettings);
+                return new FileContentResult(layoutSettingsContent, MimeTypeMap.GetMimeType(".json"));
+            }
+            catch (NotFoundException)
+            {
+                return NotFound();
+            }
+
         }
 
         /// <summary>
@@ -97,8 +167,8 @@ namespace Altinn.Studio.Designer.Controllers
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <returns>Empty object</returns>
         [HttpGet]
-        [Route("api/data/anonymous")]
-        public IActionResult DataModel(string org, string app)
+        [Route("api/v1/data/anonymous")]
+        public IActionResult Anonymous(string org, string app)
         {
             string user = @"{}";
             return Content(user);
@@ -124,25 +194,23 @@ namespace Altinn.Studio.Designer.Controllers
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <returns>An example user</returns>
         [HttpGet]
-        [Route("api/profile/user")]
+        [Route("api/v1/profile/user")]
         public IActionResult CurrentUser(string org, string app)
         {
-            string user = @"{
-                ""userId"": 1001,
-                ""userName"": ""PengelensPartner"",
-                ""phoneNumber"": ""12345678"",
-                ""email"": ""test@test.com"",
-                ""partyId"": 500000,
-                ""party"": {
+            // TODO: return actual current testuser when tenor testusers are available
+            UserProfile userProfile = new()
+            {
+                UserId = 1024,
+                UserName = "previewUser",
+                PhoneNumber = "12345678",
+                Email = "test@test.com",
+                PartyId = 1,
+                Party = new(),
+                UserType = 0,
+                ProfileSettingPreference = new() { Language = "nb" }
+            };
 
-                },
-                ""userType"": 0,
-                ""profileSettingPreference"": {
-                    ""language"": ""nb""
-                }
-            }";
-
-            return Ok(user);
+            return Ok(userProfile);
         }
 
         /// <summary>
@@ -155,19 +223,21 @@ namespace Altinn.Studio.Designer.Controllers
         [Route("api/authorization/parties/current")]
         public IActionResult CurrentParty(string org, string app)
         {
-            string party = @"{
-            ""partyId"": ""500000"",
-            ""partyTypeName"": 2,
-            ""orgNumber"": ""897069650"",
-            ""ssn"": null,
-            ""unitType"": ""AS"",
-            ""name"": ""DDG Fitness"",
-            ""isDeleted"": false,
-            ""onlyHierarchyElementWithNoAccess"": false,
-            ""person"": null,
-            ""organisation"": null,
-            ""childParties"": null
-        }";
+            // TODO: return actual current party when tenor testusers are available
+            Party party = new()
+            {
+                PartyId = 1,
+                PartyTypeName = PartyType.Organisation,
+                OrgNumber = "1",
+                SSN = null,
+                UnitType = "AS",
+                Name = "Preview AS",
+                IsDeleted = false,
+                OnlyHierarchyElementWithNoAccess = false,
+                Person = null,
+                Organization = null,
+                ChildParties = null
+            };
             return Ok(party);
         }
 
@@ -178,20 +248,20 @@ namespace Altinn.Studio.Designer.Controllers
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <returns>bool</returns>
         [HttpPost]
-        [Route("api/parties/validateInstantiation")]
+        [Route("api/v1/parties/validateInstantiation")]
         public IActionResult ValidateInstantiation(string org, string app)
         {
             return Content(@"{""valid"": true}");
         }
 
         /// <summary>
-        /// Action for providing an example response to the nb text resource file
+        /// Action for getting the nb text resource file
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <returns>Nb text resource file</returns>
         [HttpGet]
-        [Route("api/texts/nb")]
+        [Route("api/v1/texts/nb")]
         public async Task<ActionResult<Models.TextResource>> Language(string org, string app)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
@@ -201,13 +271,91 @@ namespace Altinn.Studio.Designer.Controllers
         }
 
         /// <summary>
-        /// Action for mocking a response to getting all text resource files
+        /// Action for getting the mocked instance object
         /// </summary>
+        /// <returns>Mocked instance object</returns>
+        [HttpGet]
+        [Route("instances/undefined")]
+        public ActionResult GetInstance(string org, string app)
+        {
+            // consider to use an actual generated instanceID instead of undefined
+            return Ok(MockInstance);
+        }
+
+        /// <summary>
+        /// Action for creating the mocked instance object
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="app">Application identifier which is unique within an organisation.</param>
+        /// <param name="instanceOwnerPartyId"></param>
+        /// <returns>The mocked instance object</returns>
+        [HttpPost]
+        [Route("instances")]
+        public async Task<ActionResult> Instances(string org, string app, [FromQuery] int? instanceOwnerPartyId)
+        {
+            // consider generating a test id
+            string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
+            Instance mockInstance = _previewService.CreateMockInstance(org, app, developer, instanceOwnerPartyId);
+            Application mockApplicationMetadata = await _previewService.GetApplication(org, app, developer);
+            DataType dataType = mockApplicationMetadata.DataTypes.Find(element => !string.IsNullOrEmpty(element.AppLogic?.ClassRef) && element.TaskId == "Task_1");
+            mockInstance.Data[0].DataType = dataType.Id;
+            MockInstance = mockInstance;
+            return Ok(mockInstance);
+        }
+
+        /// <summary>
+        /// Action for getting the json schema for the datamodel for the default datatask test-datatask-id
+        /// </summary>
+        /// <remarks>/1/test-id/ is the instanceId which is a combination of partyId + / + hash id of the instance</remarks>
+        /// <remarks>Only for apps that does not use layoutsets. Must be adapted</remarks>
+        /// <returns>Json schema for datamodel for datatask test-datatask-id</returns>
+        [HttpGet]
+        [Route("instances/1/test-id/data/test-datatask-id")]
+        public async Task<ActionResult> GetFormData(string org, string app)
+        {
+            string modelPath = "/App/models/datamodel.schema.json";
+            string decodedPath = Uri.UnescapeDataString(modelPath);
+            string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
+            string formData = await _schemaModelService.GetSchema(org, app, developer, decodedPath);
+            return Ok(formData);
+        }
+
+        /// <summary>
+        /// Action for getting a mocked response for the current task connected to the instance
+        /// </summary>
+        /// <returns>The processState object on the global mockInstance object</returns>
+        [HttpGet]
+        [Route("instances/undefined/process")]
+        public ActionResult Process()
+        {
+            ProcessState processState = new() { CurrentTask = new() { AltinnTaskType = "data", ElementId = "Task_1" } };
+            MockInstance.Process = processState;
+            //string process = @"{""currentTask"": {""altinnTaskType"": ""data"", ""elementId"": ""Task_1""}}";
+            return Ok(processState);
+        }
+
+        /// <summary>
+        /// Action for getting a mocked response for the next task connected to the instance
+        /// </summary>
+        /// <returns>The processState object on the global mockInstance object</returns>
+        [HttpGet]
+        [Route("instances/undefined/process/next")]
+        public ActionResult ProcessNext()
+        {
+            ProcessState processState = MockInstance.Process;
+            //string process = @"{""currentTask"": {""altinnTaskType"": ""data"", ""elementId"": ""Task_1""}}";
+            return Ok(processState);
+        }
+
+        /// <summary>
+        /// Action for mocking a response to getting all text resources
+        /// </summary>
+        /// <remarks>Hardcoded to only serve norwegian bokmal resource file</remarks>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <returns>Single text resource file</returns>
         [HttpGet]
-        [Route("api/textresources")]
+        [Route("api/v1/textresources")]
         public async Task<ActionResult<Models.TextResource>> TextResources(string org, string app)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
@@ -217,20 +365,89 @@ namespace Altinn.Studio.Designer.Controllers
         }
 
         /// <summary>
-        /// Action for getting the requested datamodel as jsonschema
+        /// Action for getting the datamodel as jsonschema
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
-        /// <param name="modelname">Modelname identifier which is unique within an organisation.</param>
         /// <returns>datamodel as json schema</returns>
         [HttpGet]
-        [Route("api/jsonschema/{modelname}")]
-        public async Task<ActionResult<string>> Datamodel(string org, string app, string modelname)
+        [Route("api/jsonschema/datamodel")]
+        public async Task<ActionResult<string>> Datamodel(string org, string app)
         {
-            string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
+            // consider use method to get all json and return an expected one based on applicationmetadata?
+            string modelPath = "/App/models/datamodel.schema.json";
+            var decodedPath = Uri.UnescapeDataString(modelPath);
+
+            string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
+            var json = await _schemaModelService.GetSchema(org, app, developer, decodedPath);
+
+            return Ok(json);
+        }
+
+        /// <summary>
+        /// Action for getting the form layout
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="app">Application identifier which is unique within an organisation.</param>
+        /// <param name="formLayoutName">Name of layout page</param>
+        /// <returns>Request form layout as byte array</returns>
+        [HttpGet]
+        [Route("api/resource/{formLayoutName}")]
+        public async Task<ActionResult<Dictionary<string, JsonNode>>> GetFormLayouts(string org, string app, string formLayoutName)
+        {
+            string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
             AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
-            string jsonSchemaContent = await altinnAppGitRepository.GetJsonSchema(modelname);
-            return Ok(jsonSchemaContent);
+            Dictionary<string, JsonNode> formLayouts = await altinnAppGitRepository.GetFormLayouts(null);
+            // return as byte array to imitate app backend
+            byte[] formLayoutsContent = JsonSerializer.SerializeToUtf8Bytes(formLayouts);
+            return new FileContentResult(formLayoutsContent, MimeTypeMap.GetMimeType(Path.GetExtension(formLayoutName).ToLower()));
+        }
+
+        /// <summary>
+        /// Action for getting the ruleHandler
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="app">Application identifier which is unique within an organisation.</param>
+        /// <returns>Rule handler as string or no content if not found</returns>
+        [HttpGet]
+        [Route("api/resource/RuleHandler.js")]
+        public async Task<ActionResult<string>> GetRuleHandler(string org, string app)
+        {
+            try
+            {
+                string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
+                AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
+                string ruleHandler = await altinnAppGitRepository.GetRuleHandler(null);
+                return Ok(ruleHandler);
+            }
+            catch (NotFoundException)
+            {
+                return NoContent();
+            }
+        }
+
+        /// <summary>
+        /// Action for getting the ruleConfiguration
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="app">Application identifier which is unique within an organisation.</param>
+        /// <returns>Rule configuration as string or no content if not found</returns>
+        [HttpGet]
+        [Route("api/resource/RuleConfiguration.json")]
+        public async Task<ActionResult<string>> GetRuleConfiguration(string org, string app)
+        {
+            try
+            {
+                string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
+                AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
+                string ruleConfig = await altinnAppGitRepository.GetRuleConfiguration(null);
+                return Ok(ruleConfig);
+            }
+            catch (NotFoundException)
+            {
+                return NoContent();
+            }
+
         }
     }
 }

--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -270,18 +270,6 @@ namespace Altinn.Studio.Designer.Controllers
         }
 
         /// <summary>
-        /// Action for getting the mocked instance object
-        /// </summary>
-        /// <returns>Mocked instance object</returns>
-        [HttpGet]
-        [Route("instances/undefined")]
-        public ActionResult GetInstance(string org, string app)
-        {
-            // consider to use an actual generated instanceID instead of undefined
-            return Ok(MockInstance);
-        }
-
-        /// <summary>
         /// Action for creating the mocked instance object
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
@@ -381,18 +369,17 @@ namespace Altinn.Studio.Designer.Controllers
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
-        /// <param name="formLayoutName">Name of layout page</param>
         /// <returns>Request form layout as byte array</returns>
         [HttpGet]
-        [Route("api/resource/{formLayoutName}")]
-        public async Task<ActionResult<Dictionary<string, JsonNode>>> GetFormLayouts(string org, string app, string formLayoutName)
+        [Route("api/resource/FormLayout.json")]
+        public async Task<ActionResult<Dictionary<string, JsonNode>>> GetFormLayouts(string org, string app)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
             AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
             Dictionary<string, JsonNode> formLayouts = await altinnAppGitRepository.GetFormLayouts(null);
             // return as byte array to imitate app backend
             byte[] formLayoutsContent = JsonSerializer.SerializeToUtf8Bytes(formLayouts);
-            return new FileContentResult(formLayoutsContent, MimeTypeMap.GetMimeType(Path.GetExtension(formLayoutName).ToLower()));
+            return new FileContentResult(formLayoutsContent, MimeTypeMap.GetMimeType(".json"));
         }
 
         /// <summary>
@@ -412,7 +399,7 @@ namespace Altinn.Studio.Designer.Controllers
                 string ruleHandler = await altinnAppGitRepository.GetRuleHandler(null);
                 return Ok(ruleHandler);
             }
-            catch (NotFoundException)
+            catch (FileNotFoundException)
             {
                 return NoContent();
             }

--- a/backend/src/Designer/Designer.csproj
+++ b/backend/src/Designer/Designer.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Altinn.Common.AccessToken" />
     <PackageReference Include="Altinn.Common.AccessTokenClient" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" />
+    <PackageReference Include="Altinn.Platform.Models" />
     <PackageReference Include="CompilerAttributes" />
     <PackageReference Include="ini-parser-netstandard" />
     <PackageReference Include="JWTCookieAuthentication" />

--- a/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -34,6 +34,8 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         private const string LAYOUT_SETTINGS_FILENAME = "Settings.json";
         private const string APP_METADATA_FILENAME = "applicationmetadata.json";
         private const string LAYOUT_SETS_FILENAME = "layout-sets.json";
+        private const string RULE_HANDLER_FILENAME = "ruleHandler.js";
+        private const string RULE_CONFIGURATION_FILENAME = "RuleConfiguration.json";
 
         private const string _layoutSettingsSchemaUrl = "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json";
 
@@ -482,11 +484,72 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
 
         public async Task<LayoutSets> GetLayoutSetsFile()
         {
-            string layoutSetsFilePath = GetPathToLayoutSetsFile();
-            string fileContent = await ReadTextByRelativePathAsync(layoutSetsFilePath);
-            LayoutSets layoutSetsFile = JsonSerializer.Deserialize<LayoutSets>(fileContent, _jsonOptions);
+            if (AppUsesLayoutSets())
+            {
+                string layoutSetsFilePath = GetPathToLayoutSetsFile();
+                string fileContent = await ReadTextByRelativePathAsync(layoutSetsFilePath);
+                LayoutSets layoutSetsFile = JsonSerializer.Deserialize<LayoutSets>(fileContent, _jsonOptions);
+                return layoutSetsFile;
+            }
 
-            return layoutSetsFile;
+            throw new NotFoundException("No layoutset was found for this app");
+        }
+
+        /// <summary>
+        /// Saves the RuleHandler.js for a specific layoutset
+        /// </summary>
+        /// <param name="layoutSetName">The name of the layoutset where the layout belong</param>
+        /// <param name="ruleHandler">The layoutsettings to be saved</param>
+        /// <returns>The content of Settings.json</returns>
+        public async Task SaveRuleHandler(string layoutSetName, string ruleHandler)
+        {
+            string ruleHandlerPath = GetPathToRuleHandler(layoutSetName);
+            await WriteTextByRelativePathAsync(ruleHandlerPath, ruleHandler);
+        }
+
+        /// <summary>
+        /// Gets the RuleHandler.js for a specific layoutset
+        /// </summary>
+        /// <param name="layoutSetName">The name of the layoutset where the layout belong</param>
+        /// <returns>The content of Settings.json</returns>
+        public async Task<string> GetRuleHandler(string layoutSetName)
+        {
+            string ruleHandlerPath = GetPathToRuleHandler(layoutSetName);
+            if (FileExistsByRelativePath(ruleHandlerPath))
+            {
+                string ruleHandler = await ReadTextByRelativePathAsync(ruleHandlerPath);
+                return ruleHandler;
+            }
+
+            throw new FileNotFoundException("Rule handler not found.");
+        }
+
+        /// <summary>
+        /// Saves the RuleConfiguration.json for a specific layoutset
+        /// </summary>
+        /// <param name="layoutSetName">The name of the layoutset where the layout belong</param>
+        /// <param name="ruleConfiguration">The layoutsettings to be saved</param>
+        /// <returns>The content of Settings.json</returns>
+        public async Task SaveRuleConfiguration(string layoutSetName, string ruleConfiguration)
+        {
+            string ruleConfigurationPath = GetPathToRuleConfiguration(layoutSetName);
+            await WriteTextByRelativePathAsync(ruleConfigurationPath, ruleConfiguration);
+        }
+
+        /// <summary>
+        /// Gets the RuleConfiguration.json for a specific layoutset
+        /// </summary>
+        /// <param name="layoutSetName">The name of the layoutset where the layout belong</param>
+        /// <returns>The content of Settings.json</returns>
+        public async Task<string> GetRuleConfiguration(string layoutSetName)
+        {
+            string ruleConfigurationPath = GetPathToRuleConfiguration(layoutSetName);
+            if (FileExistsByRelativePath(ruleConfigurationPath))
+            {
+                string ruleConfiguration = await ReadTextByRelativePathAsync(ruleConfigurationPath);
+                return ruleConfiguration;
+            }
+            throw new NotFoundException("Rule configuration not found.");
         }
 
         /// <summary>
@@ -538,6 +601,20 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         private static string GetPathToLayoutSetsFile()
         {
             return Path.Combine(LAYOUTS_FOLDER_NAME, LAYOUT_SETS_FILENAME);
+        }
+
+        private static string GetPathToRuleHandler(string layoutSetName)
+        {
+            return layoutSetName.IsNullOrEmpty() ?
+                Path.Combine(LAYOUTS_FOLDER_NAME, RULE_HANDLER_FILENAME) :
+                Path.Combine(LAYOUTS_FOLDER_NAME, layoutSetName, RULE_HANDLER_FILENAME);
+        }
+
+        private static string GetPathToRuleConfiguration(string layoutSetName)
+        {
+            return layoutSetName.IsNullOrEmpty() ?
+                Path.Combine(LAYOUTS_FOLDER_NAME, RULE_CONFIGURATION_FILENAME) :
+                Path.Combine(LAYOUTS_FOLDER_NAME, layoutSetName, RULE_CONFIGURATION_FILENAME);
         }
 
         /// <summary>

--- a/backend/src/Designer/Infrastructure/ServiceRegistration.cs
+++ b/backend/src/Designer/Infrastructure/ServiceRegistration.cs
@@ -50,6 +50,7 @@ namespace Altinn.Studio.Designer.Infrastructure
             services.AddTransient<ITextsService, TextsService>();
             services.AddTransient<IEnvironmentsService, EnvironmentsService>();
             services.AddTransient<IAppDevelopmentService, AppDevelopmentService>();
+            services.AddTransient<IPreviewService, PreviewService>();
             services.RegisterDatamodeling(configuration);
 
             return services;

--- a/backend/src/Designer/Models/ApplicationSettings.cs
+++ b/backend/src/Designer/Models/ApplicationSettings.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Altinn.Studio.Designer.Models;
+
+public class ApplicationSettings
+{
+    /// <summary>
+    /// Gets or sets the unique id of the application, e.g. test/app-34
+    /// </summary>
+    [JsonProperty(PropertyName = "id")]
+    public string Id { get; set; }
+
+    /// <summary>Gets or sets the application version id.</summary>
+    [JsonProperty(PropertyName = "versionId")]
+    public string VersionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the short code representing the owner of the service. E.g. nav
+    /// </summary>
+    [JsonProperty(PropertyName = "org")]
+    public string Org { get; set; }
+
+    /// <summary>
+    /// Gets or sets the title of the application with language codes.
+    /// </summary>
+    [JsonProperty(PropertyName = "title")]
+    public Dictionary<string, string> Title { get; set; }
+}

--- a/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
+++ b/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
-using NuGet.Protocol;
 
 namespace Altinn.Studio.Designer.Services.Implementation
 {
@@ -107,6 +106,34 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 return;
             }
             await altinnAppGitRepository.SaveLayoutSettings(null, layoutSettings);
+        }
+
+        /// <inheritdoc />
+        public async Task<string> GetRuleHandler(string org, string app, string developer, string layoutSetName)
+        {
+            AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
+            bool appUsesLayoutSets = altinnAppGitRepository.AppUsesLayoutSets();
+            if (appUsesLayoutSets)
+            {
+                string ruleHandlerForLayoutSet = await altinnAppGitRepository.GetRuleHandler(layoutSetName);
+                return ruleHandlerForLayoutSet;
+            }
+
+            string ruleHandler = await altinnAppGitRepository.GetRuleHandler(null);
+            return ruleHandler;
+        }
+
+        /// <inheritdoc />
+        public async Task SaveRuleHandler(string org, string app, string developer, string ruleHandler, string layoutSetName)
+        {
+            AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
+            bool appUsesLayoutSets = altinnAppGitRepository.AppUsesLayoutSets();
+            if (appUsesLayoutSets)
+            {
+                await altinnAppGitRepository.SaveRuleHandler(layoutSetName, ruleHandler);
+                return;
+            }
+            await altinnAppGitRepository.SaveRuleHandler(null, ruleHandler);
         }
     }
 }

--- a/backend/src/Designer/Services/Implementation/PreviewService.cs
+++ b/backend/src/Designer/Services/Implementation/PreviewService.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Studio.Designer.Infrastructure.GitRepository;
+using Altinn.Studio.Designer.Services.Interfaces;
+
+namespace Altinn.Studio.Designer.Services.Implementation;
+
+/// <summary>
+/// Interface for dealing with texts in new format in an app repository.
+/// </summary>
+public class PreviewService : IPreviewService
+{
+    private readonly IAltinnGitRepositoryFactory _altinnGitRepositoryFactory;
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="altinnGitRepositoryFactory">IAltinnGitRepository</param>
+    public PreviewService(IAltinnGitRepositoryFactory altinnGitRepositoryFactory)
+    {
+        _altinnGitRepositoryFactory = altinnGitRepositoryFactory;
+    }
+
+    public async Task<Application> GetApplication(string org, string app, string developer)
+    {
+        AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
+        Application mockApplicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
+        return mockApplicationMetadata;
+    }
+
+    public Instance CreateMockInstance(string org, string app, string developer, int? instanceOwnerPartyId)
+    {
+        Instance instance = new()
+        {
+            InstanceOwner = new InstanceOwner { PartyId = instanceOwnerPartyId.Value.ToString() },
+            Id = $"{instanceOwnerPartyId}/test-id",
+            Data = new()
+                { new ()
+                {
+                    DataType = "Task_1",
+                    Id = "test-datatask-id"
+                } },
+            Process = new()
+            {
+                CurrentTask = new()
+                {
+                    ElementId = "Task_1"
+                }
+            }
+        };
+        return instance;
+    }
+}

--- a/backend/src/Designer/Services/Interfaces/IPreviewService.cs
+++ b/backend/src/Designer/Services/Interfaces/IPreviewService.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using Altinn.Platform.Storage.Interface.Models;
+
+namespace Altinn.Studio.Designer.Services.Interfaces;
+
+/// <summary>
+/// Interface for handling texts in new format.
+/// </summary>
+public interface IPreviewService
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="org">Organisation</param>
+    /// <param name="app">Repository</param>
+    /// <param name="developer">Username of developer</param>
+    public Task<Application> GetApplication(string org, string app, string developer);
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="org">Organisation</param>
+    /// <param name="app">Repository</param>
+    /// <param name="developer">Username of developer</param>
+    /// <param name="instanceOwnerPartyId"></param>
+    public Instance CreateMockInstance(string org, string app, string developer, int? instanceOwnerPartyId);
+}

--- a/backend/src/Designer/Services/Interfaces/IPreviewService.cs
+++ b/backend/src/Designer/Services/Interfaces/IPreviewService.cs
@@ -4,12 +4,12 @@ using Altinn.Platform.Storage.Interface.Models;
 namespace Altinn.Studio.Designer.Services.Interfaces;
 
 /// <summary>
-/// Interface for handling texts in new format.
+/// Interface for handling a mocked instance object for preview mode
 /// </summary>
 public interface IPreviewService
 {
     /// <summary>
-    ///
+    /// Gets the application metadata as application object from platform models
     /// </summary>
     /// <param name="org">Organisation</param>
     /// <param name="app">Repository</param>
@@ -17,11 +17,21 @@ public interface IPreviewService
     public Task<Application> GetApplication(string org, string app, string developer);
 
     /// <summary>
-    ///
+    /// Creates a mocked instance object with limited data needed to serve app-frontend
     /// </summary>
     /// <param name="org">Organisation</param>
     /// <param name="app">Repository</param>
     /// <param name="developer">Username of developer</param>
     /// <param name="instanceOwnerPartyId"></param>
-    public Instance CreateMockInstance(string org, string app, string developer, int? instanceOwnerPartyId);
+    public Task<Instance> CreateMockInstance(string org, string app, string developer, int? instanceOwnerPartyId);
+
+    /// <summary>
+    /// Gets the datatype from application metadata that corresponds to the process Task_1
+    /// which is default task id for apps without layoutset
+    /// </summary>
+    /// <param name="org"></param>
+    /// <param name="app"></param>
+    /// <param name="developer"></param>
+    /// <returns></returns>
+    public Task<DataType> GetDataTypeForTask1(string org, string app, string developer);
 }

--- a/backend/src/Designer/Views/Preview/index.cshtml
+++ b/backend/src/Designer/Views/Preview/index.cshtml
@@ -1,18 +1,27 @@
 @{ViewBag.Title = "Altinn Studio";}
+
 <html lang="no">
     <head>
       <title>@ViewBag.Title</title>
-      <link rel="shortcut icon" href="/designer/img/favicon.ico"/>
-      <style>
-        html,body,#root {
-          height: 100%;
-          width: 100%;
-          margin: 0;
-        }
-      </style>
+        <link rel="shortcut icon" href="/designer/img/favicon.ico"/>
+        <style>
+      html, body {
+      margin: 0;
+      padding: 0;
+      }
+      body {
+      height: 100vh;
+      width: 100vw;
+      }
+      div {
+      height: 100%;
+      width: 100%;
+      }
+    </style>
     </head>
     <body>
-        <div id="root" class="media-body flex-column d-flex"></div>
+    <div id="root" class="media-body flex-column d-flex"></div>
+    <link href="https://altinncdn.no/fonts/altinn-din/altinn-din.css" rel="stylesheet">
         <link  href="/designer/frontend/app-preview/app-preview.css" asp-append-version="true" rel="stylesheet">
         <script src="/designer/frontend/app-preview/app-preview.js" asp-append-version="true" type="text/javascript"></script>
     </body>

--- a/backend/src/Designer/wwwroot/designer/html/preview.html
+++ b/backend/src/Designer/wwwroot/designer/html/preview.html
@@ -10,23 +10,19 @@
     <link rel="stylesheet" href="https://altinncdn.no/toolkits/fortawesome/altinn-no-regular/0.1/css/embedded-woff.css">
     <link rel="stylesheet" href="https://altinncdn.no/toolkits/fortawesome/altinn-studio/0.1/css/embedded-woff.css">
     <link href="https://altinncdn.no/fonts/altinn-din/altinn-din.css" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="http://localhost:8080/altinn-app-frontend.css">
-    <style>
-        html, body {
-            height: 100%;
-        }
-    </style>
+    <link rel="stylesheet" type="text/css" href="https://altinncdn.no/toolkits/altinn-app-frontend/3/altinn-app-frontend.css">
     <script>
         window.isPreview = true;
         const urlParams = new URLSearchParams(window.location.search);
         window.org = urlParams.get('org');
         window.app = urlParams.get('app');
+        window.instanceId = urlParams.get('instanceId')
     </script>
 </head>
 <body>
 <div class="flex-column d-flex media-body">
     <div id="root" class="media-body flex-column d-flex"></div>
 </div>
-<script src="http://localhost:8080/altinn-app-frontend.js"></script>
+<script src="https://altinncdn.no/toolkits/altinn-app-frontend/3/altinn-app-frontend.js"></script>
 </body>
 </html>

--- a/backend/src/Designer/wwwroot/designer/html/preview.html
+++ b/backend/src/Designer/wwwroot/designer/html/preview.html
@@ -16,7 +16,6 @@
         const urlParams = new URLSearchParams(window.location.search);
         window.org = urlParams.get('org');
         window.app = urlParams.get('app');
-        window.instanceId = urlParams.get('instanceId')
     </script>
 </head>
 <body>

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerBase.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerBase.cs
@@ -1,0 +1,38 @@
+using System;
+using Altinn.Studio.Designer.Configuration;
+using Altinn.Studio.Designer.Services.Interfaces;
+using Designer.Tests.Controllers.ApiTests;
+using Designer.Tests.Mocks;
+using Designer.Tests.Utils;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Designer.Tests.Controllers.PreviewController
+{
+    public class PreviewControllerTestsBase<TControllerTestType> : ApiTestsBase<Altinn.Studio.Designer.Controllers.PreviewController, TControllerTestType>, IDisposable
+        where TControllerTestType : class
+    {
+        protected static string VersionPrefix(string org, string repository) => $"/designer/api/{org}/{repository}";
+        protected string CreatedFolderPath { get; set; }
+
+        public void Dispose()
+        {
+            if (!string.IsNullOrWhiteSpace(CreatedFolderPath))
+            {
+                TestDataHelper.DeleteDirectory(CreatedFolderPath);
+            }
+        }
+
+        public PreviewControllerTestsBase(WebApplicationFactory<Altinn.Studio.Designer.Controllers.PreviewController> factory) : base(factory)
+        {
+        }
+
+        protected override void ConfigureTestServices(IServiceCollection services)
+        {
+            services.Configure<ServiceRepositorySettings>(c =>
+                c.RepositoryLocation = TestRepositoriesLocation);
+            services.AddSingleton<IGitea, IGiteaMock>();
+        }
+
+    }
+}

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTests.cs
@@ -1,6 +1,321 @@
-namespace Designer.Tests.Controllers;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Altinn.Platform.Profile.Models;
+using Altinn.Platform.Register.Models;
+using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Studio.Designer.Configuration;
+using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Services.Interfaces;
+using Designer.Tests.Controllers.PreviewController;
+using Designer.Tests.Mocks;
+using Designer.Tests.Utils;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using SharedResources.Tests;
+using Xunit;
+using TextResource = Altinn.Studio.Designer.Models.TextResource;
 
-public class PreviewControllerTests
+namespace Designer.Tests.Controllers
 {
+    public class PreviewControllerTests : PreviewControllerTestsBase<PreviewControllerTests>
+    {
+        private const string Org = "ttd";
+        private const string App = "preview-app";
+        private const string Developer = "testUser";
 
+        public PreviewControllerTests(WebApplicationFactory<Altinn.Studio.Designer.Controllers.PreviewController> factory) : base(factory)
+        {
+        }
+
+        protected override void ConfigureTestServices(IServiceCollection services)
+        {
+            services.Configure<ServiceRepositorySettings>(c =>
+                c.RepositoryLocation = TestRepositoriesLocation);
+            services.AddSingleton<IGitea, IGiteaMock>();
+        }
+
+        [Fact]
+        public async Task GetPreviewStatus_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/preview-status";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetApplicationMetadata_Ok()
+        {
+            string expectedApplicationMetadata = TestDataHelper.GetFileFromRepo(Org, App, Developer, "App/config/applicationmetadata.json");
+
+            string dataPathWithData = $"{Org}/{App}/api/v1/applicationmetadata";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonUtils.DeepEquals(expectedApplicationMetadata, responseBody).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetApplicationSettings_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/api/v1/applicationsettings";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonDocument responseDocument = JsonDocument.Parse(responseBody);
+            ApplicationSettings applicationSettings = JsonConvert.DeserializeObject<ApplicationSettings>(responseDocument.RootElement.ToString());
+            Assert.Equal("ttd/preview-app", applicationSettings.Id);
+            Assert.Equal("ttd", applicationSettings.Org);
+            Assert.Equal("preview-app", applicationSettings.Title["nb"]);
+        }
+
+        [Fact]
+        public async Task GetLayoutSets_NotFound()
+        {
+            string dataPathWithData = $"{Org}/{App}/api/layoutsets";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetLayoutSettings_Ok()
+        {
+            string expectedLayoutSettings = TestDataHelper.GetFileFromRepo(Org, App, Developer, "App/ui/Settings.json");
+
+            string dataPathWithData = $"{Org}/{App}/api/layoutsettings";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonUtils.DeepEquals(expectedLayoutSettings, responseBody).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetAnonymous_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/api/v1/data/anonymous";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonUtils.DeepEquals("{}", responseBody).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetKeepAlive_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/api/authentication/keepAlive";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetCurrentUser_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/api/v1/profile/user";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonDocument responseDocument = JsonDocument.Parse(responseBody);
+            UserProfile currentUser = JsonConvert.DeserializeObject<UserProfile>(responseDocument.RootElement.ToString());
+            Assert.Equal("previewUser", currentUser.UserName);
+        }
+
+        [Fact]
+        public async Task GetCurrentParty_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/api/authorization/parties/current";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonDocument responseDocument = JsonDocument.Parse(responseBody);
+            Party currentParty = JsonConvert.DeserializeObject<Party>(responseDocument.RootElement.ToString());
+            Assert.Equal(1, currentParty.PartyId);
+        }
+
+        [Fact]
+        public async Task PostValidateInstantiation_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/api/v1/parties/validateInstantiation";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonUtils.DeepEquals(@"{""valid"": true}", responseBody).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetText_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/api/v1/texts/nb";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonDocument responseDocument = JsonDocument.Parse(responseBody);
+            TextResource text = JsonConvert.DeserializeObject<TextResource>(responseDocument.RootElement.ToString());
+            Assert.Equal("nb", text.Language);
+        }
+
+        [Fact]
+        public async Task PostInstance_Ok()
+        {
+            string targetRepository = TestDataHelper.GenerateTestRepoName();
+            CreatedFolderPath = await TestDataHelper.CopyRepositoryForTest(Org, App, Developer, targetRepository);
+
+            string dataPathWithData = $"{Org}/{targetRepository}/instances";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonDocument responseDocument = JsonDocument.Parse(responseBody);
+            Instance instance = JsonConvert.DeserializeObject<Instance>(responseDocument.RootElement.ToString());
+            Assert.Equal("test-datatask-id", instance.Data[0].Id);
+            Assert.Equal("Task_1", instance.Process.CurrentTask.ElementId);
+        }
+
+        [Fact]
+        public async Task GetFormData_Ok()
+        {
+            string expectedFormData = TestDataHelper.GetFileFromRepo(Org, App, Developer, "App/models/custom-dm-name.schema.json");
+
+            string dataPathWithData = $"{Org}/{App}/instances/1/test-id/data/test-datatask-id";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonUtils.DeepEquals(expectedFormData, responseBody).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetProcess_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/instances/undefined/process";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonDocument responseDocument = JsonDocument.Parse(responseBody);
+            ProcessState processState = JsonConvert.DeserializeObject<ProcessState>(responseDocument.RootElement.ToString());
+            Assert.Equal("data", processState.CurrentTask.AltinnTaskType);
+            Assert.Equal("Task_1", processState.CurrentTask.ElementId);
+        }
+
+        [Fact]
+        public async Task GetProcessNext_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/instances/undefined/process/next";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonDocument responseDocument = JsonDocument.Parse(responseBody);
+            ProcessState processState = JsonConvert.DeserializeObject<ProcessState>(responseDocument.RootElement.ToString());
+            Assert.Equal("data", processState.CurrentTask.AltinnTaskType);
+            Assert.Equal("Task_1", processState.CurrentTask.ElementId);
+        }
+
+        [Fact]
+        public async Task GetTextResources_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/api/v1/textresources";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonDocument responseDocument = JsonDocument.Parse(responseBody);
+            TextResource text = JsonConvert.DeserializeObject<TextResource>(responseDocument.RootElement.ToString());
+            Assert.Equal("nb", text.Language);
+        }
+
+        [Fact]
+        public async Task GetDatamodel_Ok()
+        {
+            string expectedDatamodel = TestDataHelper.GetFileFromRepo(Org, App, Developer, "App/models/custom-dm-name.schema.json");
+
+            string dataPathWithData = $"{Org}/{App}/api/jsonschema/custom-dm-name";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonUtils.DeepEquals(expectedDatamodel, responseBody).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetFormLayouts_Ok()
+        {
+            string expectedFormLayout = TestDataHelper.GetFileFromRepo(Org, App, Developer, "App/ui/layouts/layout.json");
+            string expectedFormLayouts = @"{""layout"": " + expectedFormLayout + "}";
+
+            string dataPathWithData = $"{Org}/{App}/api/resource/FormLayout.json";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonUtils.DeepEquals(expectedFormLayouts, responseBody).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetRuleHandler_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/api/resource/RuleHandler.js";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status204NoContent, (int)response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetRuleConfiguration_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/api/resource/RuleConfiguration.json";
+            HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status204NoContent, (int)response.StatusCode);
+        }
+    }
 }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTests.cs
@@ -1,0 +1,6 @@
+namespace Designer.Tests.Controllers;
+
+public class PreviewControllerTests
+{
+
+}

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/hvem-er-hvem/App/ui/Settings.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/hvem-er-hvem/App/ui/Settings.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
+    "pages": {
+        "order": [
+            "layout"
+        ],
+        "showLanguageSelector": true
+    }
+}

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/hvem-er-hvem/App/ui/layouts/layout.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/hvem-er-hvem/App/ui/layouts/layout.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+    "data": {
+        "layout": [
+            {
+                "id": "Input-6wAfAW",
+                "type": "Input",
+                "textResourceBindings": {},
+                "dataModelBindings": {},
+                "required": true,
+                "readOnly": false
+            }
+        ],
+        "hidden": false
+    }
+}

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/preview-app/App/config/applicationmetadata.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/preview-app/App/config/applicationmetadata.json
@@ -1,0 +1,49 @@
+{
+    "id": "ttd/preview-app",
+    "org": "ttd",
+    "title": {
+        "nb": "preview-app"
+    },
+    "dataTypes": [
+        {
+            "id": "ref-data-as-pdf",
+            "allowedContentTypes": [
+                "application/pdf"
+            ],
+            "maxCount": 0,
+            "minCount": 0,
+            "enablePdfCreation": true,
+            "enableFileScan": false,
+            "validationErrorOnPendingFileScan": false
+        },
+        {
+            "id": "custom-dm-name",
+            "allowedContentTypes": [
+                "application/xml"
+            ],
+            "appLogic": {
+                "autoCreate": true,
+                "classRef": "Altinn.App.Models.Skjema",
+                "allowAnonymousOnStateless": false,
+                "autoDeleteOnProcessEnd": false
+            },
+            "taskId": "Task_1",
+            "maxCount": 1,
+            "minCount": 1,
+            "enablePdfCreation": true,
+            "enableFileScan": false,
+            "validationErrorOnPendingFileScan": false
+        }
+    ],
+    "partyTypesAllowed": {
+        "bankruptcyEstate": false,
+        "organisation": false,
+        "person": false,
+        "subUnit": false
+    },
+    "autoDeleteOnProcessEnd": false,
+    "created": "2023-03-30T10:37:28.703135Z",
+    "createdBy": "localgiteaadmin",
+    "lastChanged": "2023-03-30T10:37:28.703236Z",
+    "lastChangedBy": "localgiteaadmin"
+}

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/preview-app/App/config/texts/resource.en.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/preview-app/App/config/texts/resource.en.json
@@ -1,0 +1,17 @@
+﻿{
+    "language": "en",
+    "resources": [
+        {
+            "id": "appName",
+            "value": "preview-app"
+        },
+        {
+            "id": "side1-ledetekst",
+            "value": "test lead text"
+        },
+        {
+            "id": "Side2.Input-vl2X7X.title",
+            "value": "new text"
+        }
+    ]
+}

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/preview-app/App/config/texts/resource.nb.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/preview-app/App/config/texts/resource.nb.json
@@ -1,0 +1,17 @@
+﻿{
+    "language": "nb",
+    "resources": [
+        {
+            "id": "appName",
+            "value": "preview-app"
+        },
+        {
+            "id": "side1-ledetekst",
+            "value": "test ledetekst"
+        },
+        {
+            "id": "Side2.Input-vl2X7X.title",
+            "value": "ny tekst"
+        }
+    ]
+}

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/preview-app/App/models/custom-dm-name.schema.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/preview-app/App/models/custom-dm-name.schema.json
@@ -1,0 +1,184 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "schema.json",
+    "type": "object",
+    "@xsdNamespaces": {
+        "xsd": "http://www.w3.org/2001/XMLSchema"
+    },
+    "@xsdSchemaAttributes": {
+        "AttributeFormDefault": "Unqualified",
+        "ElementFormDefault": "Qualified",
+        "BlockDefault": "None",
+        "FinalDefault": "None"
+    },
+    "@xsdRootElement": "InnflytterSkjema",
+    "oneOf": [
+        {
+            "$ref": "#/$defs/Skjema"
+        }
+    ],
+    "$defs": {
+        "Skjema": {
+            "properties": {
+                "Innflytter": {
+                    "$ref": "#/$defs/Innflytter",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                }
+            },
+            "required": [
+                "Innflytter"
+            ]
+        },
+        "Innflytter": {
+            "properties": {
+                "Fornavn": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Etternavn": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Mellomnavn": {
+                    "@xsdType": "string",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "@xsdMinOccurs": 0,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Alder": {
+                    "@xsdType": "integer",
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "@xsdMinOccurs": 0,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Arbeidsinformasjon": {
+                    "$ref": "#/$defs/Arbeidsinformasjon",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "KanBrukeSkjema": {
+                    "@xsdType": "boolean",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "TidligereBosteder": {
+                    "minItems": 1,
+                    "maxItems": 10,
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Adresse"
+                    },
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "10"
+                },
+                "Adresse": {
+                    "$ref": "#/$defs/Adresse",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Kontaktinformasjon": {
+                    "$ref": "#/$defs/Kontaktinformasjon",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                }
+            },
+            "required": [
+                "Fornavn",
+                "Etternavn",
+                "Arbeidsinformasjon",
+                "KanBrukeSkjema",
+                "TidligereBosteder",
+                "Adresse",
+                "Kontaktinformasjon"
+            ]
+        },
+        "Adresse": {
+            "properties": {
+                "Gateadresse": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Postnr": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Poststed": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                }
+            },
+            "required": [
+                "Gateadresse",
+                "Postnr",
+                "Poststed"
+            ]
+        },
+        "Kontaktinformasjon": {
+            "properties": {
+                "Telefonnummer": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Epost": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                }
+            },
+            "required": [
+                "Telefonnummer",
+                "Epost"
+            ]
+        },
+        "Arbeidsinformasjon": {
+            "properties": {
+                "Sektor": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Bransje": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 0,
+                    "@xsdMaxOccurs": "1"
+                },
+                "AarIArbeidslivet": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                }
+            },
+            "required": [
+                "Sektor",
+                "AarIArbeidslivet"
+            ]
+        }
+    }
+}

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/preview-app/App/ui/Settings.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/preview-app/App/ui/Settings.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
+    "pages": {
+        "order": [
+            "layout"
+        ],
+        "showLanguageSelector": true
+    }
+}

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/preview-app/App/ui/layouts/layout.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/preview-app/App/ui/layouts/layout.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+    "data": {
+        "layout": [
+            {
+                "id": "Input-6wAfAW",
+                "type": "Input",
+                "textResourceBindings": {},
+                "dataModelBindings": {},
+                "required": true,
+                "readOnly": false
+            }
+        ],
+        "hidden": false
+    }
+}

--- a/frontend/app-preview/index.tsx
+++ b/frontend/app-preview/index.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { PreviewApp } from './src/PreviewApp';
 import { BrowserRouter } from 'react-router-dom';
+//import { PREVIEW_BASENAME } from 'app-shared/constants';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
 
 root.render(
   <BrowserRouter>
-    <PreviewApp />
+      <PreviewApp />
   </BrowserRouter>
 );

--- a/frontend/app-preview/index.tsx
+++ b/frontend/app-preview/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { PreviewApp } from './src/PreviewApp';
 import { BrowserRouter } from 'react-router-dom';
-//import { PREVIEW_BASENAME } from 'app-shared/constants';
 
 const container = document.getElementById('root');
 const root = createRoot(container);

--- a/frontend/app-preview/src/PreviewApp.tsx
+++ b/frontend/app-preview/src/PreviewApp.tsx
@@ -8,7 +8,7 @@ export const PreviewApp = () => {
   return (
     <div className={classes.previewContainer}>
       <Routes>
-        <Route path='/preview/:org/:app' element={<LandingPage />} />
+        <Route path='/:org/:app/preview' element={<LandingPage />} />
         <Route path='*' element={<NoMatch />} />
       </Routes>
     </div>

--- a/frontend/app-preview/src/PreviewContext.tsx
+++ b/frontend/app-preview/src/PreviewContext.tsx
@@ -15,7 +15,7 @@ export const PreviewContext = (props: any) => {
   const [data, setData] = useState<undefined>();
   useEffect(() => {
     axios
-      .get(`/designer/api/${org}/${app}/preview-status`)
+      .get(`/${org}/${app}/preview/preview-status`)
       .then((result) => setData(result.data))
       .finally(() => setIsReady(true));
   }, [app, org]);

--- a/frontend/app-preview/src/views/LandingPage.module.css
+++ b/frontend/app-preview/src/views/LandingPage.module.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css?family=Inter');
+
 .landingPage {
   background-color: #0a572e;
 }
@@ -10,7 +12,10 @@
 }
 
 .header {
+  font-family: Inter, 'San Fransisco', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  color: white;
   padding: 10px;
+  height: auto;
   border-bottom: 1px solid gray;
   background-color: #15a859;
 }

--- a/frontend/app-preview/src/views/LandingPage.tsx
+++ b/frontend/app-preview/src/views/LandingPage.tsx
@@ -1,41 +1,16 @@
 import React from 'react';
 import classes from './LandingPage.module.css';
 import { PreviewContext } from '../PreviewContext';
-import { Button, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
 import { useParams } from 'react-router-dom';
 import { stringify } from 'qs';
 
 export const LandingPage = () => {
   const { org, app } = useParams();
-  let componentCounter = 0;
-  const simulateAddingNewComponent = () => {
-    // @ts-ignore
-    document.getElementById('app-frontend-react-iframe').contentWindow.postMessage({
-      type: 'add-new-component',
-      component: {
-        id: `my-component${componentCounter}`,
-        type: 'Input',
-        textResourceBinding: {
-          title: `Demokomponent ${componentCounter}`,
-        },
-        dataModelBindings: {},
-        required: true,
-        readOnly: false,
-      },
-    });
-    componentCounter++;
-  };
+
   return (
     <PreviewContext>
       <div className={classes.header}>
-        <h1>Preview from Hackaton</h1>
-        <Button
-          onClick={simulateAddingNewComponent}
-          variant={ButtonVariant.Outline}
-          color={ButtonColor.Secondary}
-        >
-          Simulate adding a new component
-        </Button>
+        <h1>Altinn Studio - App Preview</h1>
       </div>
       <iframe
         title='App in preview'

--- a/frontend/app-preview/src/views/NoMatch.tsx
+++ b/frontend/app-preview/src/views/NoMatch.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
 export const NoMatch = () => {
-  debugger;
   return <div>Congratulation, you have reached `app-preview`, but there is no route match.</div>;
 };

--- a/frontend/app-preview/src/views/NoMatch.tsx
+++ b/frontend/app-preview/src/views/NoMatch.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
 export const NoMatch = () => {
-  return <div>Congratulation, you have reach `app-preview`, but there is no route match.</div>;
+  debugger;
+  return <div>Congratulation, you have reached `app-preview`, but there is no route match.</div>;
 };

--- a/frontend/packages/shared/src/constants.js
+++ b/frontend/packages/shared/src/constants.js
@@ -1,3 +1,4 @@
 export const APP_DEVELOPMENT_BASENAME = '/editor';
 export const DASHBOARD_BASENAME = '/dashboard';
+//export const PREVIEW_BASENAME = '/preview';
 export const DEFAULT_LANGUAGE = 'nb';

--- a/frontend/packages/shared/src/constants.js
+++ b/frontend/packages/shared/src/constants.js
@@ -1,4 +1,3 @@
 export const APP_DEVELOPMENT_BASENAME = '/editor';
 export const DASHBOARD_BASENAME = '/dashboard';
-//export const PREVIEW_BASENAME = '/preview';
 export const DEFAULT_LANGUAGE = 'nb';


### PR DESCRIPTION
## Description
- Add mock endpoints in PreviewController of all requests sent from app-frontend to the app-api
- Mock responses that is reliant on data Studio dont possess, such as instance data
- Send actual data of layouts, layoutsettings and texts
- Make small adjustments to frontend

_Needs discussion regarding route_ 

## Testing
_Tests will be implemented!_
However, we might not need tests for all endpoints since some are hardcoded and static, while others are covered by other controllertests since they basically do the same.
Some endpoints that might be worht to cover with tests:
- `GET api/v1/applicationmetadata` since it is using a new previewService
- `GET api/layoutsettings` since it converts the layoutSettings to a byte array before returning
- `POST instances` since it is using a new previewService
- `GET instances/{instanceId}/data/{datatask-id}` since it is using a new previewService
- `GET api/resource/{formLayoutName}` since it converts the formlayout to a byte array before returning

## Related issue
- #10122 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
