### PR TITLE
map over all selected translations and add overflow css

### DIFF
--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -100,6 +100,7 @@ export const TextEditor = ({
             searchQuery={searchQuery}
             updateEntryId={updateEntryId}
             upsertTextResource={upsertTextResource}
+            selectedLanguages={selectedLangCodes}
           />
         </div>
       </div>

--- a/frontend/packages/text-editor/src/TextList.test.tsx
+++ b/frontend/packages/text-editor/src/TextList.test.tsx
@@ -51,6 +51,7 @@ const renderTextList = (props: Partial<TextListProps> = {}) => {
     updateEntryId: (_arg) => undefined,
     removeEntry: (_arg) => undefined,
     upsertTextResource: (_entry) => undefined,
+    selectedLanguages: ['nb', 'en', 'nn'],
     ...props,
   };
   const user = userEvent.setup();

--- a/frontend/packages/text-editor/src/TextList.tsx
+++ b/frontend/packages/text-editor/src/TextList.tsx
@@ -12,11 +12,17 @@ import { Table, TableBody, TableCell, TableHeader, TableRow } from '@digdir/desi
 export type TextListProps = {
   resourceRows: TextTableRow[];
   searchQuery: string;
+  selectedLanguages: string[];
   upsertTextResource: (entry: UpsertTextResourcesMutation) => void;
   removeEntry: ({ textId }: TextResourceEntryDeletion) => void;
   updateEntryId: ({ oldId, newId }: TextResourceIdMutation) => void;
 };
-export const TextList = ({ resourceRows, searchQuery, ...rest }: TextListProps) => {
+export const TextList = ({
+  resourceRows,
+  searchQuery,
+  selectedLanguages,
+  ...rest
+}: TextListProps) => {
   const textIds = useMemo(() => resourceRows.map((row) => row.textKey), [resourceRows]);
   const idExists = (textId: string): boolean => textIds.includes(textId);
 
@@ -24,10 +30,8 @@ export const TextList = ({ resourceRows, searchQuery, ...rest }: TextListProps) 
     <Table>
       <TableHeader>
         <TableRow>
-          {resourceRows[0].translations.map((translation) => (
-            <TableCell key={'header-lang' + translation.lang}>
-              {getLangName({ code: translation.lang })}
-            </TableCell>
+          {selectedLanguages.map((language) => (
+            <TableCell key={'header-lang' + language}>{getLangName({ code: language })}</TableCell>
           ))}
           <TableCell>Tekstnøkkel</TableCell>
           <TableCell>Variabler</TableCell>
@@ -44,6 +48,7 @@ export const TextList = ({ resourceRows, searchQuery, ...rest }: TextListProps) 
               idExists={idExists}
               textRowEntries={row.translations}
               variables={row.variables || []}
+              selectedLanguages={selectedLanguages}
               {...rest}
             />
           ))}

--- a/frontend/packages/text-editor/src/TextRow.module.css
+++ b/frontend/packages/text-editor/src/TextRow.module.css
@@ -34,3 +34,8 @@
   height: 16px;
   width: 16px;
 }
+
+.textId {
+  overflow: scroll;
+  overflow-wrap: break-word;
+}

--- a/frontend/packages/text-editor/src/TextRow.test.tsx
+++ b/frontend/packages/text-editor/src/TextRow.test.tsx
@@ -24,6 +24,7 @@ describe('TextRow', () => {
       variables: [],
       updateEntryId: (_args) => undefined,
       upsertTextResource: (_args) => undefined,
+      selectedLanguages: ['nb', 'en', 'nn'],
       ...props,
     };
     const user = userEvent.setup();

--- a/frontend/packages/text-editor/src/TextRow.test.tsx
+++ b/frontend/packages/text-editor/src/TextRow.test.tsx
@@ -112,4 +112,21 @@ describe('TextRow', () => {
     await act(() => user.keyboard(' '));
     expect(screen.getByText(illegalCharMsg)).toBeInTheDocument();
   });
+
+  test('that the full row of languages is shown even if a translation is missing', async () => {
+    renderTextRow({
+      textRowEntries: [
+        {
+          lang: 'nb',
+          translation: 'Dette er en tekst',
+        },
+        {
+          lang: 'nn',
+          translation: 'Dette er en tekst',
+        },
+      ],
+    });
+    const textFields = await screen.findAllByTestId('InputWrapper');
+    expect(textFields.length).toBe(3);
+  });
 });

--- a/frontend/packages/text-editor/src/TextRow.tsx
+++ b/frontend/packages/text-editor/src/TextRow.tsx
@@ -29,6 +29,7 @@ export interface TextRowProps {
   updateEntryId: (data: TextResourceIdMutation) => void;
   upsertTextResource: (data: UpsertTextResourcesMutation) => void;
   variables: TextResourceVariable[];
+  selectedLanguages: string[];
 }
 
 export const TextRow = ({
@@ -39,6 +40,7 @@ export const TextRow = ({
   updateEntryId,
   idExists,
   variables,
+  selectedLanguages,
 }: TextRowProps) => {
   const [textIdValue, setTextIdValue] = useState(textId);
   const [textIdEditOpen, setTextIdEditOpen] = useState(false);
@@ -71,11 +73,20 @@ export const TextRow = ({
 
   return (
     <TableRow data-testid={'lang-row'}>
-      {textRowEntries.map((translation) => (
-        <TableCell key={translation.lang + '-' + textId}>
-          <TextEntry {...translation} upsertTextResource={upsertTextResource} textId={textId} />
-        </TableCell>
-      ))}
+      {selectedLanguages.map((lang) => {
+        let translation = textRowEntries.find((e) => e.lang === lang);
+        if (!translation) {
+          translation = {
+            lang,
+            translation: '',
+          };
+        }
+        return (
+          <TableCell key={translation.lang + '-' + textId}>
+            <TextEntry {...translation} upsertTextResource={upsertTextResource} textId={textId} />
+          </TableCell>
+        );
+      })}
       <TableCell>
         <ButtonContainer>
           {textIdEditOpen ? (
@@ -91,8 +102,8 @@ export const TextRow = ({
               {keyError ? <ErrorMessage>{keyError}</ErrorMessage> : null}
             </div>
           ) : (
-            <div role='text' aria-readonly>
-              {textIdValue}
+            <div role='text' aria-readonly className={classes.textId}>
+              <span>{textIdValue}</span>
             </div>
           )}
           <Button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Map over selected languages rather than actual translations when generating table for text editor, as translations might be missing for some text keys, and this causes the table cells to shift.

Also added overflow CSS for the textkey so that it does not overflow into the variables column (or beyond). 
This is just a quick fix, we probably need a new review with design on how this should behave.

## Related Issue(s)
- #10153 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
