### PR TITLE
Call layout name update service when updating layout name

### DIFF
--- a/frontend/language/src/en.json
+++ b/frontend/language/src/en.json
@@ -251,6 +251,7 @@
   "general.loading": "Loading content",
   "general.no_options": "No options available",
   "general.optional": "Optional",
+  "general.options": "Options",
   "general.page": "Page",
   "general.preview": "Preview",
   "general.required": "Required",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -276,6 +276,7 @@
   "general.loading": "Laster innhold",
   "general.no_options": "Ingen alternativer tilgjengelige",
   "general.optional": "Valgfri",
+  "general.options": "Alternativer",
   "general.page": "Side",
   "general.preview": "Forhåndsvisning",
   "general.required": "Obligatorisk",

--- a/frontend/packages/ux-editor/src/components/leftMenu/PageElement.test.tsx
+++ b/frontend/packages/ux-editor/src/components/leftMenu/PageElement.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { IPageElementProps, PageElement } from './PageElement';
+import { formDesignerMock, queriesMock, renderHookWithMockStore, renderWithMockStore } from '../../testing/mocks';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useFormLayoutsQuery } from '../../hooks/queries/useFormLayoutsQuery';
+import { useFormLayoutSettingsQuery } from '../../hooks/queries/useFormLayoutSettingsQuery';
+import { textMock } from '../../../../../testing/mocks/i18nMock';
+
+const user = userEvent.setup();
+
+// Test data:
+const org = 'org';
+const app = 'app';
+const name = formDesignerMock.layout.selectedLayout;
+const defaultProps: IPageElementProps = { name };
+
+describe('PageElement', () => {
+  it('Calls updateFormLayoutName with new name when name is changed by the user', async () => {
+    const newName = 'new-name';
+    await waitForData();
+    render();
+    await act(() => user.click(screen.getByTitle(textMock('general.options'))));
+    await act(() => user.click(screen.getByText(textMock('left_menu.page_menu_edit'))));
+    const textbox = screen.getByRole('textbox');
+    expect(textbox).toHaveValue(name);
+    await act(() => user.clear(textbox));
+    await act(() => user.type(textbox, newName));
+    await act(() => user.tab());
+    expect(queriesMock.updateFormLayoutName).toHaveBeenCalledTimes(1);
+    expect(queriesMock.updateFormLayoutName).toHaveBeenCalledWith(org, app, name, newName);
+  });
+});
+
+const render = (props: Partial<IPageElementProps> = {}) =>
+  renderWithMockStore()(<PageElement {...defaultProps} {...props} />);
+
+const waitForData = async () => {
+  const formLayoutsResult = renderHookWithMockStore()(() => useFormLayoutsQuery(org, app)).renderHookResult.result;
+  const settingsResult = renderHookWithMockStore()(() => useFormLayoutSettingsQuery(org, app)).renderHookResult.result;
+  await waitFor(() => expect(formLayoutsResult.current.isSuccess).toBe(true));
+  await waitFor(() => expect(settingsResult.current.isSuccess).toBe(true));
+};

--- a/frontend/packages/ux-editor/src/components/leftMenu/PageElement.tsx
+++ b/frontend/packages/ux-editor/src/components/leftMenu/PageElement.tsx
@@ -28,11 +28,11 @@ export function PageElement({ name, invalid }: IPageElementProps) {
   const selectedLayout = searchParams.get('layout');
   const { t } = useTranslation();
   const { org, app } = useParams();
-  const formLayoutSettingsQuery = useFormLayoutSettingsQuery(org, app);
-  const updateLayoutOrderMutation = useUpdateLayoutOrderMutation(org, app);
-  const deleteLayoutMutation = useDeleteLayoutMutation(org, app);
-  const updateLayoutNameMutation = useUpdateLayoutNameMutation(org, app);
-  const layoutOrder = formLayoutSettingsQuery.data?.pages.order;
+  const { data: formLayoutSettings } = useFormLayoutSettingsQuery(org, app);
+  const { mutate: updateLayoutOrder } = useUpdateLayoutOrderMutation(org, app);
+  const { mutate: deleteLayout } = useDeleteLayoutMutation(org, app);
+  const { mutate: updateLayoutName } = useUpdateLayoutNameMutation(org, app);
+  const layoutOrder = formLayoutSettings?.pages.order;
   const [editMode, setEditMode] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [newName, setNewName] = useState<string>('');
@@ -68,15 +68,15 @@ export function PageElement({ name, invalid }: IPageElementProps) {
       setEditMode(true);
       setNewName(name);
     } else if (action === 'up' || action === 'down') {
-      updateLayoutOrderMutation.mutate({ layoutName: name, direction: action });
+      updateLayoutOrder({ layoutName: name, direction: action });
     }
     setMenuAnchorEl(null);
   };
 
-  const handleOnBlur = async (_event: any) => {
+  const handleOnBlur = (_event: any) => {
     setEditMode(false);
     if (!errorMessage && name !== newName) {
-      await dispatch(FormLayoutActions.updateLayoutName({ oldName: name, newName }));
+      updateLayoutName({ oldName: name, newName });
       setSearchParams({ ...deepCopy(searchParams), layout: newName });
     } else {
       setNewName('');
@@ -106,7 +106,7 @@ export function PageElement({ name, invalid }: IPageElementProps) {
 
   const handleKeyPress = async (event: any) => {
     if (event.key === 'Enter' && !errorMessage && name !== newName) {
-      updateLayoutNameMutation.mutate({ oldName: name, newName });
+      updateLayoutName({ oldName: name, newName });
       setSearchParams({ ...deepCopy(searchParams), layout: newName });
       setEditMode(false);
     } else if (event.key === 'Escape') {
@@ -119,7 +119,7 @@ export function PageElement({ name, invalid }: IPageElementProps) {
 
   const handleConfirmDelete = () => {
     setDeleteAnchorEl(null);
-    deleteLayoutMutation.mutate({ layoutName: name });
+    deleteLayout({ layoutName: name });
     setSearchParams(removeKey(searchParams, 'layout'));
   };
 
@@ -157,6 +157,7 @@ export function PageElement({ name, invalid }: IPageElementProps) {
           onClick={onPageSettingsClick}
           style={menuAnchorEl ? { visibility: 'visible' } : {}}
           variant={ButtonVariant.Quiet}
+          title={t('general.options')}
         />
       </div>
       <AltinnMenu anchorEl={menuAnchorEl} open={Boolean(menuAnchorEl)} onClose={onMenuClose}>

--- a/frontend/packages/ux-editor/src/testing/mocks.tsx
+++ b/frontend/packages/ux-editor/src/testing/mocks.tsx
@@ -21,6 +21,7 @@ import { IFormDesignerState } from '../features/formDesigner/formDesignerReducer
 import { ComponentType } from '../components';
 import { ILayoutSettings } from 'app-shared/types/global';
 import { BASE_CONTAINER_ID } from 'app-shared/constants';
+import { BrowserRouter } from 'react-router-dom';
 
 export const textResourcesMock: ITextResourcesState = {
   currentEditId: undefined,
@@ -180,7 +181,11 @@ export const renderWithMockStore =
       const store = configureStore()({ ...appStateMock, ...state });
       const renderResult = render(
         <ServicesContextProvider {...queriesMock} {...queries}>
-          <Provider store={store}>{component}</Provider>
+          <Provider store={store}>
+            <BrowserRouter>
+              {component}
+            </BrowserRouter>
+          </Provider>
         </ServicesContextProvider>
       );
       return { renderResult, store };


### PR DESCRIPTION
## Description
- Added missing call to `updateLayoutNameMutation`
- Added title to layout options button
- Added test that ensures the mutation it is called when name is changed by the user
- Added `BrowserRouter` to `renderWithMockStore` because `PageElement` depends on it

## Related Issue(s)
- #10158

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
