### PR TITLE
Persist context and page size in the url using the useSearchParams hook

### DIFF
--- a/frontend/dashboard/contexts/appContext.tsx
+++ b/frontend/dashboard/contexts/appContext.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { createStrictContext } from '../utils/createStrictContext';
 import { SelectedContextType } from 'app-shared/navigation/main-header/Header';
+import { useSearchParamsState } from 'dashboard/hooks/useSearchParamsState';
 
 type AppContext = {
   selectedContext: SelectedContextType | number;
@@ -13,11 +14,15 @@ type ServicesContextProviderProps = {
   children: React.ReactNode;
 };
 export const AppContextProvider = ({ children }: ServicesContextProviderProps) => {
-  const [selectedContext, setSelectedContext] = useState<SelectedContextType | number>(
-    SelectedContextType.Self
+  const [selectedContext, setSelectedContext] = useSearchParamsState<SelectedContextType | number>(
+    'context',
+    SelectedContextType.Self,
+    (value: string) => {
+      return Object.values(SelectedContextType).some(item => item === value) ? value as SelectedContextType : Number(value);
+    }
   );
 
-  const providerValue = useMemo(() => ({ selectedContext, setSelectedContext }), [selectedContext]);
+  const providerValue = useMemo(() => ({ selectedContext, setSelectedContext }), [selectedContext, setSelectedContext]);
   return <AppProvider value={providerValue}>{children}</AppProvider>;
 };
 

--- a/frontend/dashboard/hooks/useReposSearch/useRepoSearch.ts
+++ b/frontend/dashboard/hooks/useReposSearch/useRepoSearch.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { GridSortModel } from '@mui/x-data-grid';
 import { useSearchReposQuery } from 'dashboard/hooks/useRepoQueries';
 import { SearchRepository } from '../../services/repoService';
+import { useSearchParamsState } from '../useSearchParamsState';
 
 type UseRepoSearchResult = {
   searchResults: SearchRepository | undefined;
@@ -24,7 +25,7 @@ export const useReposSearch = ({
   defaultPageSize,
 }: UseReposSearchProps): UseRepoSearchResult => {
   const [pageNumber, setPageNumber] = useState(0);
-  const [pageSize, setPageSize] = useState<number>(defaultPageSize || 5);
+  const [pageSize, setPageSize] = useSearchParamsState<number>('pageSize', defaultPageSize || 5, Number);
   const [sortModel, setSortModel] = useState<GridSortModel>([{ field: 'alpha', sort: 'asc' }]);
 
   const { data: searchResults, isLoading: isLoadingSearchResults } = useSearchReposQuery({

--- a/frontend/dashboard/hooks/useSearchParamsState/index.ts
+++ b/frontend/dashboard/hooks/useSearchParamsState/index.ts
@@ -1,0 +1,1 @@
+export * from './useSearchParamsState';

--- a/frontend/dashboard/hooks/useSearchParamsState/useSearchParamsState.test.ts
+++ b/frontend/dashboard/hooks/useSearchParamsState/useSearchParamsState.test.ts
@@ -1,0 +1,27 @@
+import { renderHook, act } from '@testing-library/react';
+import { useSearchParamsState } from './useSearchParamsState';
+import { useSearchParams } from 'react-router-dom';
+
+jest.mock('react-router-dom', () => ({
+  useSearchParams: jest.fn(),
+}));
+
+describe('useSearchParamsState', () => {
+  it('should return the default value when the parameter is missing from the url', () => {
+    const searchParams = new URLSearchParams();
+    (useSearchParams as jest.Mock).mockReturnValue([searchParams, jest.fn()]);
+
+    const { result } = renderHook(() => useSearchParamsState('test', 10));
+
+    expect(result.current[0]).toEqual(10);
+  });
+
+  it('should return the value of the parameter', () => {
+    const searchParams = new URLSearchParams('test=20');
+    (useSearchParams as jest.Mock).mockReturnValue([searchParams, jest.fn()]);
+
+    const { result } = renderHook(() => useSearchParamsState('test', 10, Number));
+
+    expect(result.current[0]).toEqual(20);
+  });
+});

--- a/frontend/dashboard/hooks/useSearchParamsState/useSearchParamsState.test.ts
+++ b/frontend/dashboard/hooks/useSearchParamsState/useSearchParamsState.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { useSearchParamsState } from './useSearchParamsState';
 import { useSearchParams } from 'react-router-dom';
 

--- a/frontend/dashboard/hooks/useSearchParamsState/useSearchParamsState.ts
+++ b/frontend/dashboard/hooks/useSearchParamsState/useSearchParamsState.ts
@@ -1,0 +1,34 @@
+import { useSearchParams } from "react-router-dom";
+
+// Inspired by https://blog.logrocket.com/use-state-url-persist-state-usesearchparams/
+export function useSearchParamsState<T>(
+    searchParamName: string,
+    defaultValue: T,
+    cast: (_: string) => T = (_: string) => _ as T
+): [
+    searchParamsState: T,
+    setSearchParamsState: (newState: T) => void
+] {
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const searchParam = searchParams.get(searchParamName);
+    const searchParamsState = searchParam ? cast(searchParam) : defaultValue;
+
+    const setSearchParamsState = (newState: T) => {
+        setSearchParams(prev => {
+          const { [searchParamName]: _, ...existingSearchParams } = Object.fromEntries(prev.entries())
+
+          const newSearchParams = new URLSearchParams({
+            ...existingSearchParams,
+            ...(newState && { [searchParamName]: newState.toString() })
+          });
+
+          // Sort the search params to ensure that the URL is consistent (e.g. for bookmarking)
+          newSearchParams.sort();
+
+          return newSearchParams;
+      });
+    };
+
+    return [searchParamsState, setSearchParamsState];
+}


### PR DESCRIPTION
## Description
Created a new hook called useSearchParamsState based on the useSearchParams hook.
This hook aims to simplify the management of query parameters.

## Related Issue(s)
- #10098

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green