### PR TITLE
Only delete key and not assign return value to updatedTextResourceBinding

### DIFF
--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -864,7 +864,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             List<FileSystemObject> resourceFiles = new List<FileSystemObject>();
 
             if (contents != null)
-            { 
+            {
                 foreach (FileSystemObject resourceFile in contents)
                 {
                     if (resourceFile.Name.EndsWith("resource.json"))

--- a/backend/src/Designer/Services/Implementation/TextsService.cs
+++ b/backend/src/Designer/Services/Implementation/TextsService.cs
@@ -344,7 +344,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 }
                 else
                 {
-                    updatedTextResourceBindings = (updatedTextResourceBindings as JsonObject)!.Remove(key);
+                    (updatedTextResourceBindings as JsonObject)!.Remove(key);
                 }
             }
             return updatedTextResourceBindings;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove assigning return value to `updatedTextResourceBindings` when calling remove method
