### PR TITLE
Change post to del on delete attachment comp endpoint

### DIFF
--- a/backend/src/Designer/Controllers/ApplicationMetadataController.cs
+++ b/backend/src/Designer/Controllers/ApplicationMetadataController.cs
@@ -139,7 +139,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns></returns>
         [HttpDelete]
         [Route("attachment-component")]
-        public async Task<ActionResult> DeleteMetadataForAttachment(string org, string app, string id)
+        public async Task<ActionResult> DeleteMetadataForAttachment(string org, string app, [FromBody] string id)
         {
             try
             {

--- a/frontend/app-development/queries/mutations.ts
+++ b/frontend/app-development/queries/mutations.ts
@@ -48,7 +48,7 @@ export const addAppAttachmentMetadata = (org, app, payload) =>
   post(appMetadataAttachmentPath(org, app), payload);
 
 export const deleteAppAttachmentMetadata = (org, app, id) =>
-  post(appMetadataAttachmentPath(org, app) + id, { id });
+  del(appMetadataAttachmentPath(org, app), { headers, data: id });
 
 export const updateAppAttachmentMetadata = (org, app, payload) =>
   post(appMetadataAttachmentPath(org, app), payload);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix so delete attachment comp is called with HTTP DELETE and not POST when deleting it

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
