### PR TITLE
replace setInterval with react query refetchInterval

### DIFF
--- a/frontend/app-development/features/appPublish/containers/deployContainer.tsx
+++ b/frontend/app-development/features/appPublish/containers/deployContainer.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import classes from './deployContainer.module.css';
 import { AltinnContentLoader } from 'app-shared/components/molecules/AltinnContentLoader';
 import { AppDeploymentComponent, ImageOption } from '../components/appDeploymentComponent';
-import { BuildResult, BuildStatus } from '../../../sharedResources/appRelease/types';
+import { BuildResult } from '../../../sharedResources/appRelease/types';
 import { useAppSelector } from '../../../hooks';
 import { useParams } from 'react-router-dom';
 import {
@@ -12,11 +12,11 @@ import {
   useEnvironments,
   useOrgList,
 } from '../hooks/query-hooks';
-import { ICreateAppDeploymentEnvObject, IDeployment } from '../../../sharedResources/appDeployment/types';
+import {
+  ICreateAppDeploymentEnvObject,
+  IDeployment,
+} from '../../../sharedResources/appDeployment/types';
 import { formatDateTime } from 'app-shared/pure/date-format';
-import { useQueryClient } from '@tanstack/react-query';
-import { QueryKey } from '../../../types/QueryKey';
-
 
 export interface IDeployEnvironment {
   appsUrl: string;
@@ -40,19 +40,6 @@ export const DeployContainerComponent = () => {
   const { data: orgs = { orgs: {} }, isLoading: orgsIsLoading } = useOrgList();
   const { data: permissions, isLoading: permissionsIsLoading } = useDeployPermissions(org, app);
 
-  const queryClient = useQueryClient();
-  useEffect(() => {
-    const interval = setInterval(async () => {
-      const index = appDeployments.findIndex(
-        (deployment) => deployment.build.status !== BuildStatus.completed
-      );
-      if (index > -1) {
-        await queryClient.invalidateQueries([QueryKey.AppDeployments, org, app]);
-      }
-    }, 6666);
-    return () => clearInterval(interval);
-  }, [appDeployments, queryClient, org, app]);
-
   const isLoading = () =>
     releasesIsLoading || orgsIsLoading || permissionsIsLoading || envIsLoading || deploysAreLoading;
 
@@ -67,7 +54,9 @@ export const DeployContainerComponent = () => {
   const deployEnvironments: ICreateAppDeploymentEnvObject[] = useMemo(
     () =>
       orgs?.orgs[org]?.environments
-        .map((envName: string) => environmentList.find((env: IDeployEnvironment) => env.name === envName))
+        .map((envName: string) =>
+          environmentList.find((env: IDeployEnvironment) => env.name === envName)
+        )
         .filter((element: any) => element != null),
     [orgs, org, environmentList]
   );
@@ -98,7 +87,9 @@ export const DeployContainerComponent = () => {
   return (
     <div className={classes.deployContainer}>
       {deployEnvironments.map((env: IDeployEnvironment, index: number) => {
-        const deploymentsInEnv: IDeployment[] = appDeployments.filter((x) => x.envName === env.name);
+        const deploymentsInEnv: IDeployment[] = appDeployments.filter(
+          (x) => x.envName === env.name
+        );
         return (
           <AppDeploymentComponent
             key={index}
@@ -112,7 +103,11 @@ export const DeployContainerComponent = () => {
               permissions.findIndex((e) => e.toLowerCase() === env.name.toLowerCase()) > -1
             }
             orgName={orgName}
-            showLinkToApp={deploymentsInEnv.length > 0 && deploymentsInEnv[0].deployedInEnv && deploymentsInEnv[0].build.result === BuildResult.succeeded}
+            showLinkToApp={
+              deploymentsInEnv.length > 0 &&
+              deploymentsInEnv[0].deployedInEnv &&
+              deploymentsInEnv[0].build.result === BuildResult.succeeded
+            }
           />
         );
       })}

--- a/frontend/app-development/features/appPublish/hooks/query-hooks.ts
+++ b/frontend/app-development/features/appPublish/hooks/query-hooks.ts
@@ -4,7 +4,8 @@ import { IRelease } from '../../../sharedResources/appRelease/types';
 import { useQuery } from '@tanstack/react-query';
 import { QueryKey } from '../../../types/QueryKey';
 import { useServicesContext } from '../../../common/ServiceContext';
-import { IDeployEnvironment } from "../containers/deployContainer";
+import { IDeployEnvironment } from '../containers/deployContainer';
+import { DEPLOYMENTS_REFETCH_INTERVAL } from 'app-shared/constants';
 
 interface IOrgsState {
   orgs: any;
@@ -49,9 +50,13 @@ export const useAppReleases = (owner, app): UseQueryResult<IRelease[]> => {
 
 export const useAppDeployments = (owner, app): UseQueryResult<IDeployment[]> => {
   const { getDeployments } = useServicesContext();
-  return useQuery<IDeployment[]>([QueryKey.AppDeployments, owner, app], async () => {
-    const res = await getDeployments(owner, app);
-    return res.results;
+  return useQuery<IDeployment[]>({
+    queryKey: [QueryKey.AppDeployments, owner, app],
+    queryFn: async () => {
+      const res = await getDeployments(owner, app);
+      return res.results;
+    },
+    refetchInterval: DEPLOYMENTS_REFETCH_INTERVAL,
   });
 };
 export interface BranchStatus {

--- a/frontend/packages/shared/src/constants.js
+++ b/frontend/packages/shared/src/constants.js
@@ -3,3 +3,4 @@ export const DASHBOARD_BASENAME = '/dashboard';
 export const PREVIEW_BASENAME = '/preview';
 export const DEFAULT_LANGUAGE = 'nb';
 export const BASE_CONTAINER_ID = '__base__';
+export const DEPLOYMENTS_REFETCH_INTERVAL = 15000;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
While working with another issue where the deployments endpoint returns 500 server error, we noticed that the implementation for refetching deployments could be improved by using React Query built in refetch functionality. This PR implements that.

The current refetch functionality (with `setInterval`) did not actually work, and would not refetch on an actual interval, but did re-fetch on focus if the user has moved focus out of the window.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
