### PR TITLE
wrap deployments update in try/catch block

### DIFF
--- a/backend/src/Designer/Services/Implementation/DeploymentService.cs
+++ b/backend/src/Designer/Services/Implementation/DeploymentService.cs
@@ -8,6 +8,7 @@ using Altinn.Studio.Designer.Repository.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Altinn.Studio.Designer.Services.Models;
 using Altinn.Studio.Designer.TypedHttpClients.AzureDevOps;
+using Altinn.Studio.Designer.TypedHttpClients.AzureDevOps.Enums;
 using Altinn.Studio.Designer.TypedHttpClients.AzureDevOps.Models;
 using Altinn.Studio.Designer.TypedHttpClients.KubernetesWrapper;
 using Altinn.Studio.Designer.ViewModels.Request;
@@ -120,15 +121,26 @@ namespace Altinn.Studio.Designer.Services.Implementation
         {
             DeploymentEntity deploymentEntity = await _deploymentRepository.Get(appOwner, buildNumber);
 
-            BuildEntity buildEntity = await _azureDevOpsBuildClient.Get(buildNumber);
-            DeploymentEntity deployment = new() { Build = buildEntity };
+            try
+            {
+                BuildEntity buildEntity = await _azureDevOpsBuildClient.Get(buildNumber);
+                DeploymentEntity deployment = new() { Build = buildEntity };
 
-            deploymentEntity.Build.Status = deployment.Build.Status;
-            deploymentEntity.Build.Result = deployment.Build.Result;
-            deploymentEntity.Build.Started = deployment.Build.Started;
-            deploymentEntity.Build.Finished = deployment.Build.Finished;
+                deploymentEntity.Build.Status = deployment.Build.Status;
+                deploymentEntity.Build.Result = deployment.Build.Result;
+                deploymentEntity.Build.Started = deployment.Build.Started;
+                deploymentEntity.Build.Finished = deployment.Build.Finished;
 
-            await _deploymentRepository.Update(deploymentEntity);
+                await _deploymentRepository.Update(deploymentEntity);
+            }
+            catch (Exception)
+            {
+                _logger.LogInformation("The requested build number {buildNumber} does not exist, updating it as failed in the database", buildNumber);
+                deploymentEntity.Build.Status = BuildStatus.None;
+                deploymentEntity.Build.Result = BuildResult.Failed;
+                await _deploymentRepository.Update(deploymentEntity);
+            }
+
         }
 
         private async Task<Build> QueueDeploymentBuild(

--- a/backend/src/Designer/Services/Implementation/DeploymentService.cs
+++ b/backend/src/Designer/Services/Implementation/DeploymentService.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Infrastructure.Models;
 using Altinn.Studio.Designer.Repository;
@@ -133,14 +133,13 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
                 await _deploymentRepository.Update(deploymentEntity);
             }
-            catch (Exception)
+            catch (HttpRequestException)
             {
                 _logger.LogInformation("The requested build number {buildNumber} does not exist, updating it as failed in the database", buildNumber);
-                deploymentEntity.Build.Status = BuildStatus.None;
+                deploymentEntity.Build.Status = BuildStatus.Completed;
                 deploymentEntity.Build.Result = BuildResult.Failed;
                 await _deploymentRepository.Update(deploymentEntity);
             }
-
         }
 
         private async Task<Build> QueueDeploymentBuild(

--- a/backend/src/Designer/TypedHttpClients/AzureDevOps/AzureDevOpsBuildClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AzureDevOps/AzureDevOpsBuildClient.cs
@@ -58,6 +58,7 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AzureDevOps
             string requestUri = $"{buildId}?api-version=5.1";
             _logger.LogInformation("Doing a request toward: {HttpClientBaseAddress}{RequestUri}", _httpClient.BaseAddress, requestUri);
             HttpResponseMessage response = await _httpClient.GetAsync(requestUri);
+            response.EnsureSuccessStatusCode();
             Build build = await response.Content.ReadAsAsync<Build>();
             return ToBuildEntity(build);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When fetching status on deployments that are "In progress" in our DB, we can end up in the situation where the actual deployment in AzureDevOps is so old that is has been deleted and no longer exists. This results in a 404 response from AzureDevOps, which our code did not handle, resulting in a 500 server error from our endpoint.

This is a perfectly valid situation that our code should handle. Added error handling, and updating the database entry in the cases where this happens so that it is clear that the build has failed.


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
