### PR TITLE
Removed edit icone for appname to prevent change textkay for appName

### DIFF
--- a/frontend/packages/shared/src/constants.js
+++ b/frontend/packages/shared/src/constants.js
@@ -4,3 +4,4 @@ export const PREVIEW_BASENAME = '/preview';
 export const DEFAULT_LANGUAGE = 'nb';
 export const BASE_CONTAINER_ID = '__base__';
 export const DEPLOYMENTS_REFETCH_INTERVAL = 15000;
+export const APP_NAME = "appName";

--- a/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -150,7 +150,7 @@ describe('TextEditor', () => {
       await act(() => user.keyboard('new-key{TAB}')); // type new text and blur
 
       await expect(onTextIdChange).toHaveBeenCalledWith({
-        oldId: nb[1].id,
+        oldId: nb[0].id,
         newId: 'new-key',
       });
       return textIdInputs;
@@ -165,7 +165,7 @@ describe('TextEditor', () => {
 
     it('signals that a textId has changed', async () => {
       await makeChangesToTextIds();
-      const textIdRefsAfter1 = screen.getAllByText('textId1');
+      const textIdRefsAfter1 = screen.getAllByText('textId2');
       expect(textIdRefsAfter1).toHaveLength(1); // The id is also on the delete button
     });
 
@@ -175,7 +175,7 @@ describe('TextEditor', () => {
       const { error, onTextIdChange } = setupError();
       const original = await makeChangesToTextIds(onTextIdChange);
       expect(error).toHaveBeenCalledWith('Renaming text-id failed:\n', 'some error');
-      const textIdRefsAfter1 = screen.getAllByText('textId1');
+      const textIdRefsAfter1 = screen.getAllByText('textId2');
       expect(textIdRefsAfter1).toHaveLength(1);
 
       const textIdRefsAfter2 = screen.queryAllByText(/new-key/i);

--- a/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -150,7 +150,7 @@ describe('TextEditor', () => {
       await act(() => user.keyboard('new-key{TAB}')); // type new text and blur
 
       await expect(onTextIdChange).toHaveBeenCalledWith({
-        oldId: nb[0].id,
+        oldId: nb[1].id,
         newId: 'new-key',
       });
       return textIdInputs;
@@ -165,7 +165,7 @@ describe('TextEditor', () => {
 
     it('signals that a textId has changed', async () => {
       await makeChangesToTextIds();
-      const textIdRefsAfter1 = screen.getAllByText('textId2');
+      const textIdRefsAfter1 = screen.getAllByText('textId1');
       expect(textIdRefsAfter1).toHaveLength(1); // The id is also on the delete button
     });
 
@@ -175,7 +175,7 @@ describe('TextEditor', () => {
       const { error, onTextIdChange } = setupError();
       const original = await makeChangesToTextIds(onTextIdChange);
       expect(error).toHaveBeenCalledWith('Renaming text-id failed:\n', 'some error');
-      const textIdRefsAfter1 = screen.getAllByText('textId2');
+      const textIdRefsAfter1 = screen.getAllByText('textId1');
       expect(textIdRefsAfter1).toHaveLength(1);
 
       const textIdRefsAfter2 = screen.queryAllByText(/new-key/i);

--- a/frontend/packages/text-editor/src/TextList.tsx
+++ b/frontend/packages/text-editor/src/TextList.tsx
@@ -41,7 +41,7 @@ export const TextList = ({
       <TableBody>
         {resourceRows
           .filter((row) => filterFunction(row.textKey, row.translations, searchQuery))
-          .map((row) => (
+          .map((row, index) => (
             <TextRow
               key={`${row.translations[0].lang}.${row.textKey}`}
               textId={row.textKey}
@@ -49,6 +49,7 @@ export const TextList = ({
               textRowEntries={row.translations}
               variables={row.variables || []}
               selectedLanguages={selectedLanguages}
+              showButton={index !== 0}
               {...rest}
             />
           ))}

--- a/frontend/packages/text-editor/src/TextList.tsx
+++ b/frontend/packages/text-editor/src/TextList.tsx
@@ -41,7 +41,7 @@ export const TextList = ({
       <TableBody>
         {resourceRows
           .filter((row) => filterFunction(row.textKey, row.translations, searchQuery))
-          .map((row, index) => (
+          .map((row) => (
             <TextRow
               key={`${row.translations[0].lang}.${row.textKey}`}
               textId={row.textKey}
@@ -49,7 +49,7 @@ export const TextList = ({
               textRowEntries={row.translations}
               variables={row.variables || []}
               selectedLanguages={selectedLanguages}
-              showButton={index !== 0}
+              showButton={row.textKey !== 'appName'}
               {...rest}
             />
           ))}

--- a/frontend/packages/text-editor/src/TextList.tsx
+++ b/frontend/packages/text-editor/src/TextList.tsx
@@ -8,6 +8,7 @@ import type {
 import { filterFunction, getLangName } from './utils';
 import { TextTableRow } from './types';
 import { Table, TableBody, TableCell, TableHeader, TableRow } from '@digdir/design-system-react';
+import { APP_NAME } from '../../shared/src/constants';
 
 export type TextListProps = {
   resourceRows: TextTableRow[];
@@ -49,7 +50,7 @@ export const TextList = ({
               textRowEntries={row.translations}
               variables={row.variables || []}
               selectedLanguages={selectedLanguages}
-              showButton={row.textKey !== 'appName'}
+              showButton={row.textKey !== APP_NAME}
               {...rest}
             />
           ))}

--- a/frontend/packages/text-editor/src/TextRow.test.tsx
+++ b/frontend/packages/text-editor/src/TextRow.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { TextRowProps } from './TextRow';
 import userEvent from '@testing-library/user-event';
 import { TextRow } from './TextRow';
-import { screen, render as rtlRender, waitFor, act, render } from '@testing-library/react';
+import { screen, render as rtlRender, waitFor, act } from '@testing-library/react';
 import { textMock } from '../../../testing/mocks/i18nMock';
 import { TextTableRowEntry } from './types';
 import { Table, TableBody } from '@digdir/design-system-react';

--- a/frontend/packages/text-editor/src/TextRow.test.tsx
+++ b/frontend/packages/text-editor/src/TextRow.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { TextRowProps } from './TextRow';
 import userEvent from '@testing-library/user-event';
 import { TextRow } from './TextRow';
-import { screen, render as rtlRender, waitFor, act } from '@testing-library/react';
+import { screen, render as rtlRender, waitFor, act, render } from '@testing-library/react';
 import { textMock } from '../../../testing/mocks/i18nMock';
 import { TextTableRowEntry } from './types';
 import { Table, TableBody } from '@digdir/design-system-react';
@@ -87,6 +87,18 @@ describe('TextRow', () => {
     });
     await act(() => user.click(confirmDeleteButton));
     expect(removeEntry).toBeCalledWith({ textId: 'key1' });
+  });
+
+  test('renders a Button component with a PencilIcon when showButton is true', () => {
+    renderTextRow({ showButton: true });
+    const button = screen.getByRole('button', { name: 'toggle-textkey-edit' });
+    expect(button).toBeInTheDocument();
+  });
+
+  test('Hide a Button component with a PencilIcon when showButton is false', () => {
+    renderTextRow({ showButton: false });
+    const button = screen.queryByRole('button', { name: 'toggle-textkey-edit' });
+    expect(button).not.toBeInTheDocument();
   });
 
   test('that the user is warned if an illegal character is used', async () => {

--- a/frontend/packages/text-editor/src/TextRow.tsx
+++ b/frontend/packages/text-editor/src/TextRow.tsx
@@ -30,6 +30,7 @@ export interface TextRowProps {
   upsertTextResource: (data: UpsertTextResourceMutation) => void;
   variables: TextResourceVariable[];
   selectedLanguages: string[];
+  showButton?: boolean;
 }
 
 export const TextRow = ({
@@ -41,12 +42,12 @@ export const TextRow = ({
   idExists,
   variables,
   selectedLanguages,
+  showButton = true,
 }: TextRowProps) => {
   const [textIdValue, setTextIdValue] = useState(textId);
   const [textIdEditOpen, setTextIdEditOpen] = useState(false);
   const [keyError, setKeyError] = useState('');
   const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
-
   const { t } = useTranslation();
 
   const handleTextIdChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -68,7 +69,6 @@ export const TextRow = ({
   };
 
   const handleDeleteClick = () => removeEntry({ textId });
-
   const toggleConfirmDeletePopover = () => setIsConfirmDeleteOpen((prev) => !prev);
 
   return (
@@ -106,13 +106,15 @@ export const TextRow = ({
               <span>{textIdValue}</span>
             </div>
           )}
-          <Button
-            aria-label={'toggle-textkey-edit'}
-            icon={<PencilIcon className={classes.smallIcon} />}
-            variant={ButtonVariant.Quiet}
-            size={ButtonSize.Small}
-            onClick={() => setTextIdEditOpen(!textIdEditOpen)}
-          />
+          {showButton && (
+            <Button
+              aria-label={'toggle-textkey-edit'}
+              icon={<PencilIcon className={classes.smallIcon} />}
+              variant={ButtonVariant.Quiet}
+              size={ButtonSize.Small}
+              onClick={() => setTextIdEditOpen(!textIdEditOpen)}
+            />
+          )}
         </ButtonContainer>
       </TableCell>
       <TableCell>


### PR DESCRIPTION


Prevent changing appname in textEditor, by removing edit icon from the first row of the texts table. 

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
