### PR TITLE
Added auto-deploy-app-v3 in local json and data.sql

### DIFF
--- a/development/db/data.sql
+++ b/development/db/data.sql
@@ -1,5 +1,5 @@
 insert into designer.deployments (sequenceno, buildid, tagname, org, app, buildresult, created, entity)
-values  (1, '1239', '2403', 'ttd', 'autodeploy-v3', 'succeeded', '2022-01-09 17:19:28.845000 +00:00', '{
+values  (1, '1239', '2403', 'ttd', 'auto-deploy-app-v3', 'succeeded', '2022-01-09 17:19:28.845000 +00:00', '{
   "tagName": "2403",
   "envName": "tt02",
   "createdBy" : "localgiteaadmin",
@@ -12,7 +12,7 @@ values  (1, '1239', '2403', 'ttd', 'autodeploy-v3', 'succeeded', '2022-01-09 17:
     "finished": "2022-11-21T13:19:03.641397Z"
   }
 }'),
-  (2, '1240', '2404', 'ttd', 'autodeploy-v3', 'failed', '2022-01-10 17:19:28.845000 +00:00', '{
+  (2, '1240', '2404', 'ttd', 'auto-deploy-app-v3', 'failed', '2022-01-10 17:19:28.845000 +00:00', '{
   "tagName": "2404",
   "envName": "at21",
   "createdBy" : "localgiteaadmin",
@@ -25,7 +25,7 @@ values  (1, '1239', '2403', 'ttd', 'autodeploy-v3', 'succeeded', '2022-01-09 17:
     "finished": "2022-11-21T13:20:03.641397Z"
   }
 }'),
-  (3, '1241', '2405', 'ttd', 'autodeploy-v3', 'succeeded', '2022-01-11 17:19:28.845000 +00:00', '{
+  (3, '1241', '2405', 'ttd', 'auto-deploy-app-v3', 'succeeded', '2022-01-11 17:19:28.845000 +00:00', '{
   "tagName": "2405",
   "envName": "at22",
   "createdBy" : "localgiteaadmin",

--- a/frontend/testing/cypress/config/local.json
+++ b/frontend/testing/cypress/config/local.json
@@ -3,7 +3,7 @@
   "baseUrl": "http://studio.localhost",
   "env": {
     "testEmail": "test1@test.com",
-    "deployApp": "ttd/autodeploy-v3",
+    "deployApp": "ttd/auto-deploy-app-v3",
     "designerApp": "ttd/designer",
     "withoutDataModelApp": "ttd/appwithout-dm",
     "appOwner": "ttd"


### PR DESCRIPTION
Changed the names of the deployApp in local.json and changed the name from autodeploy-v3 in data to auto-deploy-app-v3 to match the new app name

## Description
Simply changed the names of the applications in local.json and data.sql to match that of the new app.

## Related Issue(s)
- 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
