### PR TITLE
support different states of add/remove layouts

### DIFF
--- a/frontend/packages/shared/src/constants.js
+++ b/frontend/packages/shared/src/constants.js
@@ -4,4 +4,5 @@ export const PREVIEW_BASENAME = '/preview';
 export const DEFAULT_LANGUAGE = 'nb';
 export const BASE_CONTAINER_ID = '__base__';
 export const DEPLOYMENTS_REFETCH_INTERVAL = 15000;
-export const APP_NAME = "appName";
+export const APP_NAME = 'appName';
+export const DEFAULT_SELECTED_LAYOUT_NAME = 'default';

--- a/frontend/packages/ux-editor/src/App.tsx
+++ b/frontend/packages/ux-editor/src/App.tsx
@@ -19,6 +19,7 @@ import { useFormLayoutSettingsQuery } from './hooks/queries/useFormLayoutSetting
 import { useTextResourcesQuery } from '../../../app-development/hooks/queries/useTextResourcesQuery';
 import { useRuleModelQuery } from './hooks/queries/useRuleModelQuery';
 import { firstAvailableLayout } from './utils/formLayoutsUtils';
+import { DEFAULT_SELECTED_LAYOUT_NAME } from 'app-shared/constants';
 
 /**
  * This is the main React component responsible for controlling
@@ -74,12 +75,19 @@ export function App() {
     return createErrorMessage(t('general.unknown_error'));
   };
 
-  // Set Layout to first layout in the page set if none is selected.
+  /**
+   * Set the correct selected layout based on url parameters
+   */
   useEffect(() => {
     if (searchParams.has('deletedLayout')) {
-      const useLayout = firstAvailableLayout(searchParams.get('deletedLayout'), layoutPagesOrder);
-      dispatch(FormLayoutActions.updateSelectedLayout(useLayout));
-      setSearchParams(useLayout !== 'default' ? { layout: useLayout } : {});
+      const layoutToSelect = firstAvailableLayout(
+        searchParams.get('deletedLayout'),
+        layoutPagesOrder
+      );
+      dispatch(FormLayoutActions.updateSelectedLayout(layoutToSelect));
+      setSearchParams(
+        layoutToSelect !== DEFAULT_SELECTED_LAYOUT_NAME ? { layout: layoutToSelect } : {}
+      );
     } else if (!searchParams.has('layout') && layoutPagesOrder?.[0]) {
       setSearchParams({ ...deepCopy(searchParams), layout: layoutPagesOrder[0] });
       dispatch(FormLayoutActions.updateSelectedLayout(layoutPagesOrder[0]));

--- a/frontend/packages/ux-editor/src/App.tsx
+++ b/frontend/packages/ux-editor/src/App.tsx
@@ -15,10 +15,10 @@ import { ErrorPage } from './components/ErrorPage';
 import { useDatamodelQuery } from './hooks/queries/useDatamodelQuery';
 import { useFormLayoutsQuery } from './hooks/queries/useFormLayoutsQuery';
 import { selectedLayoutNameSelector } from './selectors/formLayoutSelectors';
-import { useAddLayoutMutation } from './hooks/mutations/useAddLayoutMutation';
 import { useFormLayoutSettingsQuery } from './hooks/queries/useFormLayoutSettingsQuery';
 import { useTextResourcesQuery } from '../../../app-development/hooks/queries/useTextResourcesQuery';
 import { useRuleModelQuery } from './hooks/queries/useRuleModelQuery';
+import { firstAvailableLayout } from './utils/formLayoutsUtils';
 
 /**
  * This is the main React component responsible for controlling
@@ -33,12 +33,10 @@ export function App() {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const { data: datamodel, isError: dataModelFetchedError } = useDatamodelQuery(org, app);
-  const { data: formLayouts, isError: layoutFetchedError  } = useFormLayoutsQuery(org, app);
+  const { data: formLayouts, isError: layoutFetchedError } = useFormLayoutsQuery(org, app);
   const { data: formLayoutSettings } = useFormLayoutSettingsQuery(org, app);
   const { data: textResources } = useTextResourcesQuery(org, app);
   const { data: ruleModel } = useRuleModelQuery(org, app);
-  const addLayoutMutation = useAddLayoutMutation(org, app);
-
   const selectedLayout = useSelector(selectedLayoutNameSelector);
 
   const layoutPagesOrder = formLayoutSettings?.pages.order;
@@ -50,15 +48,9 @@ export function App() {
   const widgetFetchedError = useSelector((state: IAppState) => state.widgets.error);
 
   const componentIsReady =
-    formLayouts &&
-    isWidgetFetched &&
-    formLayoutSettings &&
-    datamodel &&
-    textResources &&
-    ruleModel;
+    formLayouts && isWidgetFetched && formLayoutSettings && datamodel && textResources && ruleModel;
 
-  const componentHasError =
-    dataModelFetchedError || layoutFetchedError || widgetFetchedError;
+  const componentHasError = dataModelFetchedError || layoutFetchedError || widgetFetchedError;
 
   const mapErrorToDisplayError = (): { title: string; message: string } => {
     const defaultTitle = t('general.fetch_error_title');
@@ -66,7 +58,7 @@ export function App() {
 
     const createErrorMessage = (resource: string): { title: string; message: string } => ({
       title: `${defaultTitle} ${resource}`,
-      message: defaultMessage
+      message: defaultMessage,
     });
 
     if (dataModelFetchedError) {
@@ -84,13 +76,18 @@ export function App() {
 
   // Set Layout to first layout in the page set if none is selected.
   useEffect(() => {
-    if (!searchParams.has('layout') && layoutPagesOrder?.[0]) {
+    if (searchParams.has('deletedLayout')) {
+      const useLayout = firstAvailableLayout(searchParams.get('deletedLayout'), layoutPagesOrder);
+      dispatch(FormLayoutActions.updateSelectedLayout(useLayout));
+      setSearchParams(useLayout !== 'default' ? { layout: useLayout } : {});
+    } else if (!searchParams.has('layout') && layoutPagesOrder?.[0]) {
       setSearchParams({ ...deepCopy(searchParams), layout: layoutPagesOrder[0] });
-    }
-    if (selectedLayout === 'default' && searchParams.has('layout')) {
+      dispatch(FormLayoutActions.updateSelectedLayout(layoutPagesOrder[0]));
+    } else if (searchParams.has('layout')) {
       dispatch(FormLayoutActions.updateSelectedLayout(searchParams.get('layout')));
     }
-  }, [dispatch, layoutPagesOrder, searchParams, setSearchParams, selectedLayout, org, app]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, layoutPagesOrder, selectedLayout, org, app]);
 
   useEffect(() => {
     const fetchFiles = () => {
@@ -111,14 +108,6 @@ export function App() {
       window.removeEventListener('message', shouldRefetchFiles);
     };
   }, [dispatch, org, app]);
-
-  // Make sure to create a new page when the last one is deleted!
-  useEffect(() => {
-    if (!selectedLayout && layoutPagesOrder.length === 0) {
-      const layoutName = t('general.page') + (layoutPagesOrder.length + 1);
-      addLayoutMutation.mutate({ layoutName, isReceiptPage: false });
-    }
-  }, [app, dispatch, layoutOrder?.length, layoutPagesOrder?.length, org, selectedLayout, t, addLayoutMutation]);
 
   if (componentHasError) {
     const mappedError = mapErrorToDisplayError();

--- a/frontend/packages/ux-editor/src/components/leftMenu/LeftMenu.tsx
+++ b/frontend/packages/ux-editor/src/components/leftMenu/LeftMenu.tsx
@@ -14,9 +14,12 @@ import { useText } from '../../hooks';
 import { selectedLayoutNameSelector } from '../../selectors/formLayoutSelectors';
 import { useAddLayoutMutation } from '../../hooks/mutations/useAddLayoutMutation';
 import { useFormLayoutSettingsQuery } from '../../hooks/queries/useFormLayoutSettingsQuery';
+import { useDispatch } from 'react-redux';
+import { FormLayoutActions } from '../../features/formDesigner/formLayout/formLayoutSlice';
 
 export const LeftMenu = () => {
   const { org, app } = useParams();
+  const dispatch = useDispatch();
   const addLayoutMutation = useAddLayoutMutation(org, app);
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedLayout: string = useSelector(selectedLayoutNameSelector);
@@ -35,6 +38,7 @@ export const LeftMenu = () => {
     }
     addLayoutMutation.mutate({ layoutName: name, isReceiptPage: false });
     setSearchParams({ ...deepCopy(searchParams), layout: name });
+    dispatch(FormLayoutActions.updateSelectedLayout(name));
   }
 
   return (

--- a/frontend/packages/ux-editor/src/components/leftMenu/PageElement.tsx
+++ b/frontend/packages/ux-editor/src/components/leftMenu/PageElement.tsx
@@ -120,7 +120,11 @@ export function PageElement({ name, invalid }: IPageElementProps) {
   const handleConfirmDelete = () => {
     setDeleteAnchorEl(null);
     deleteLayout(name);
-    setSearchParams(removeKey(searchParams, 'layout'));
+    setSearchParams({
+      ...removeKey(searchParams, 'layout'),
+      deletedLayout: name,
+    });
+    dispatch(FormLayoutActions.updateSelectedLayout('default'));
   };
 
   return (
@@ -186,7 +190,7 @@ export function PageElement({ name, invalid }: IPageElementProps) {
           id='edit-page-button'
           disabled={invalid}
         />
-        <Divider marginless/>
+        <Divider marginless />
         <AltinnMenuItem
           onClick={(event) => onMenuItemClick(event, 'delete')}
           text={t('left_menu.page_menu_delete')}

--- a/frontend/packages/ux-editor/src/components/leftMenu/PagesContainer.tsx
+++ b/frontend/packages/ux-editor/src/components/leftMenu/PagesContainer.tsx
@@ -1,17 +1,33 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { deepCopy } from 'app-shared/pure';
 import { PageElement } from './PageElement';
 import type { IAppState } from '../../types/global';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { useFormLayoutSettingsQuery } from '../../hooks/queries/useFormLayoutSettingsQuery';
+import { useAddLayoutMutation } from '../../hooks/mutations/useAddLayoutMutation';
+import { useText } from '../../hooks';
 
 export function PagesContainer() {
   const { org, app } = useParams();
+  const t = useText();
+  const [searchParams, setSearchParams] = useSearchParams();
   const formLayoutSettingsQuery = useFormLayoutSettingsQuery(org, app);
+  const addLayoutMutation = useAddLayoutMutation(org, app);
   const layoutOrder = formLayoutSettingsQuery.data.pages.order;
   const invalidLayouts: string[] = useSelector(
     (state: IAppState) => state.formDesigner.layout.invalidLayouts
   );
+
+  useEffect((): void => {
+    if (!layoutOrder?.length) {
+      const layoutName = `${t('general.page')}1`;
+      if (!addLayoutMutation.isLoading) {
+        addLayoutMutation.mutate({ layoutName, isReceiptPage: false });
+        setSearchParams({ ...deepCopy(searchParams), layout: layoutName });
+      }
+    }
+  }, [layoutOrder, addLayoutMutation, t, searchParams, setSearchParams]);
 
   return (
     <>

--- a/frontend/packages/ux-editor/src/containers/FormDesigner.tsx
+++ b/frontend/packages/ux-editor/src/containers/FormDesigner.tsx
@@ -1,18 +1,14 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import { useDispatch } from 'react-redux';
 import { RightMenu } from '../components/rightMenu/RightMenu';
 import { DesignView } from './DesignView';
 import type { IFormLayoutOrder } from '../types/global';
 import { deepCopy } from 'app-shared/pure';
 import classes from './FormDesigner.module.css';
 import { LeftMenu } from '../components/leftMenu/LeftMenu';
-import { useText } from '../hooks';
-import { useParams } from 'react-router-dom';
 import { useFormLayoutsSelector } from '../hooks/useFormLayoutsSelector';
 import { selectedLayoutSelector } from '../selectors/formLayoutSelectors';
-import { useAddLayoutMutation } from '../hooks/mutations/useAddLayoutMutation';
 
 type FormDesignerProps = {
   selectedLayout: string;
@@ -24,26 +20,8 @@ export const FormDesigner = ({
   layoutOrder,
   selectedLayout,
 }: FormDesignerProps): JSX.Element => {
-  const dispatch = useDispatch();
-  const { org, app } = useParams();
   const { order } = useFormLayoutsSelector(selectedLayoutSelector);
-  const addLayoutMutation = useAddLayoutMutation(org, app);
   const layoutOrderCopy = deepCopy(layoutOrder || {});
-  const t = useText();
-
-  useEffect((): void => {
-    const addInitialPage = (): void => {
-      const layoutName = `${t('general.page')}1`;
-      addLayoutMutation.mutate({ layoutName, isReceiptPage: false });
-    };
-
-    const layoutsExist = layoutOrder && !Object.keys(layoutOrder).length;
-    // Old apps might have selectedLayout='default' even when there exist a single layout.
-    // Should only add initial page if no layouts exist.
-    if (selectedLayout === 'default' && !layoutsExist) {
-      addInitialPage();
-    }
-  }, [app, dispatch, org, selectedLayout, t, layoutOrder, addLayoutMutation]);
 
   return (
     <DndProvider backend={HTML5Backend}>

--- a/frontend/packages/ux-editor/src/features/formDesigner/formDesignerTypes.ts
+++ b/frontend/packages/ux-editor/src/features/formDesigner/formDesignerTypes.ts
@@ -1,8 +1,9 @@
-import type {
-  IFormComponent,
-  IWidget,
-  IFormLayoutOrder,
-} from '../../types/global';
+import type { IFormComponent, IWidget, IFormLayoutOrder } from '../../types/global';
+
+export interface IAddLayoutFulfilledAction {
+  layoutOrder: string[];
+  receiptLayoutName?: string;
+}
 
 export interface IFormDesignerActionRejected {
   error: Error;
@@ -27,7 +28,7 @@ export interface IAddApplicationMetadataAction {
   minFiles: number;
   maxSize: number;
   fileType: string;
-  org :string;
+  org: string;
   app: string;
 }
 

--- a/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSlice.ts
+++ b/frontend/packages/ux-editor/src/features/formDesigner/formLayout/formLayoutSlice.ts
@@ -4,6 +4,7 @@ import { actions, moduleName } from './formLayoutActions';
 import { sortArray } from '../../../utils/arrayHelpers/arrayLogic';
 import type {
   IAddActiveFormContainerAction,
+  IAddLayoutFulfilledAction,
   IDeleteLayoutAction,
   IFormDesignerActionRejected,
   IUpdateActiveListActionFulfilled,
@@ -16,7 +17,7 @@ export interface IFormLayoutState {
   unSavedChanges: boolean;
   activeContainer: string;
   activeList: any;
-  selectedLayout: string
+  selectedLayout: string;
   invalidLayouts: string[];
 }
 
@@ -44,9 +45,9 @@ const formLayoutSlice = createSlice({
       }
       state.activeContainer = containerId;
     },
-    addLayoutFulfilled: (state, action: PayloadAction<string[]>) => {
-      const layoutOrder = action.payload;
-      state.selectedLayout = layoutOrder[layoutOrder.length - 1];
+    addLayoutFulfilled: (state, action: PayloadAction<IAddLayoutFulfilledAction>) => {
+      const { layoutOrder, receiptLayoutName } = action.payload;
+      state.selectedLayout = receiptLayoutName || layoutOrder[layoutOrder.length - 1];
     },
     addLayoutRejected: (state, action: PayloadAction<IFormDesignerActionRejected>) => {
       const { error } = action.payload;

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddLayoutMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddLayoutMutation.ts
@@ -3,12 +3,12 @@ import { useDispatch } from 'react-redux';
 import { useMutation } from '@tanstack/react-query';
 import { FormLayoutActions } from '../../features/formDesigner/formLayout/formLayoutSlice';
 import { deepCopy } from 'app-shared/pure';
-import {
-  convertInternalToLayoutFormat,
-  createEmptyLayout
-} from '../../utils/formLayoutUtils';
+import { convertInternalToLayoutFormat, createEmptyLayout } from '../../utils/formLayoutUtils';
 import { IExternalFormLayout, IInternalLayout } from '../../types/global';
-import { queryClient, useServicesContext } from '../../../../../app-development/common/ServiceContext';
+import {
+  queryClient,
+  useServicesContext,
+} from '../../../../../app-development/common/ServiceContext';
 import { QueryKey } from '../../types/QueryKey';
 import { useFormLayoutSettingsMutation } from './useFormLayoutSettingsMutation';
 import { useFormLayoutSettingsQuery } from '../queries/useFormLayoutSettingsQuery';
@@ -33,33 +33,39 @@ export const useAddLayoutMutation = (org: string, app: string) => {
   };
 
   return useMutation({
-
     mutationFn: async ({ layoutName, isReceiptPage }: AddLayoutMutationArgs) => {
+      const layoutSettings: ILayoutSettings = formLayoutSettingsQuery.data;
       const layouts = formLayoutsQuery.data;
 
       if (Object.keys(layouts).indexOf(layoutName) !== -1) throw Error('Layout already exists');
       let newLayouts = deepCopy(layouts);
 
       newLayouts[layoutName] = createEmptyLayout();
-      newLayouts = await addOrRemoveNavigationButtons(newLayouts, save, layoutName);
+      newLayouts = await addOrRemoveNavigationButtons(
+        newLayouts,
+        save,
+        layoutName,
+        isReceiptPage ? layoutName : layoutSettings.receiptLayoutName
+      );
       return { newLayouts, layoutName, isReceiptPage };
     },
 
     onSuccess: async ({ newLayouts, layoutName, isReceiptPage }) => {
-
       const layoutSettings: ILayoutSettings = deepCopy(formLayoutSettingsQuery.data);
       const { order } = layoutSettings?.pages;
 
       if (isReceiptPage) layoutSettings.receiptLayoutName = layoutName;
-      order.push(layoutName);
+      else order.push(layoutName);
 
       await formLayoutSettingsMutation.mutateAsync(layoutSettings);
-      dispatch(FormLayoutActions.addLayoutFulfilled(order));
-
-      queryClient.setQueryData(
-        [QueryKey.FormLayouts, org, app],
-        () => newLayouts
+      dispatch(
+        FormLayoutActions.addLayoutFulfilled({
+          layoutOrder: order,
+          receiptLayoutName: layoutSettings.receiptLayoutName,
+        })
       );
-    }
+
+      queryClient.setQueryData([QueryKey.FormLayouts, org, app], () => newLayouts);
+    },
   });
-}
+};

--- a/frontend/packages/ux-editor/src/hooks/mutations/useDeleteLayoutMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useDeleteLayoutMutation.ts
@@ -1,5 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
-import { queryClient, useServicesContext } from '../../../../../app-development/common/ServiceContext';
+import {
+  queryClient,
+  useServicesContext,
+} from '../../../../../app-development/common/ServiceContext';
 import { useDispatch } from 'react-redux';
 import { FormLayoutActions } from '../../features/formDesigner/formLayout/formLayoutSlice';
 import { QueryKey } from '../../types/QueryKey';
@@ -28,7 +31,12 @@ export const useDeleteLayoutMutation = (org: string, app: string) => {
     mutationFn: async (layoutName: string) => {
       let layouts = deepCopy(formLayouts);
       delete layouts[layoutName];
-      layouts = await addOrRemoveNavigationButtons(layouts, saveLayout);
+      layouts = await addOrRemoveNavigationButtons(
+        layouts,
+        saveLayout,
+        undefined,
+        formLayoutSettings.receiptLayoutName
+      );
       await deleteFormLayout(org, app, layoutName);
       return { layoutName, layouts };
     },
@@ -45,11 +53,8 @@ export const useDeleteLayoutMutation = (org: string, app: string) => {
       }
       formLayoutSettingsMutation.mutate(layoutSettings);
 
-      queryClient.setQueryData(
-        [QueryKey.FormLayouts, org, app],
-        () => layouts
-      );
+      queryClient.setQueryData([QueryKey.FormLayouts, org, app], () => layouts);
       dispatch(FormLayoutActions.deleteLayoutFulfilled({ layout: layoutName, pageOrder: order }));
-    }
+    },
   });
 };

--- a/frontend/packages/ux-editor/src/utils/formLayoutsUtils.test.ts
+++ b/frontend/packages/ux-editor/src/utils/formLayoutsUtils.test.ts
@@ -1,8 +1,12 @@
 import { IFormButtonComponent, IFormLayouts } from '../types/global';
-import { addOrRemoveNavigationButtons, convertExternalLayoutsToInternalFormat } from './formLayoutsUtils';
+import {
+  addOrRemoveNavigationButtons,
+  convertExternalLayoutsToInternalFormat,
+  firstAvailableLayout,
+} from './formLayoutsUtils';
 import { ComponentType } from '../components';
 import { createEmptyLayout } from './formLayoutUtils';
-import { BASE_CONTAINER_ID } from 'app-shared/constants';
+import { BASE_CONTAINER_ID, DEFAULT_SELECTED_LAYOUT_NAME } from 'app-shared/constants';
 import { externalLayoutsMock, layout1NameMock, layout2NameMock } from '../testing/mocks';
 
 describe('formLayoutsUtils', () => {
@@ -13,7 +17,7 @@ describe('formLayoutsUtils', () => {
       const callback = jest.fn();
       const layouts: IFormLayouts = {
         [layout1id]: createEmptyLayout(),
-        [layout2id]: createEmptyLayout()
+        [layout2id]: createEmptyLayout(),
       };
       const updatedLayouts = await addOrRemoveNavigationButtons(layouts, callback, layout1id);
       const layout1Components = Object.values(updatedLayouts[layout1id].components);
@@ -22,6 +26,57 @@ describe('formLayoutsUtils', () => {
       expect(layout1Components[0].type).toBe(ComponentType.NavigationButtons);
       expect(layout2Components.length).toBe(1);
       expect(layout2Components[0].type).toBe(ComponentType.NavigationButtons);
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenCalledWith(layout1id, updatedLayouts[layout1id]);
+      expect(callback).toHaveBeenCalledWith(layout2id, updatedLayouts[layout2id]);
+    });
+
+    it('Does not add navigation buttons to all layouts if there are two layouts when one of them is the receipt layout', async () => {
+      const layout1id = 'layout1';
+      const layoutReceiptId = 'receipt';
+      const callback = jest.fn();
+      const layouts: IFormLayouts = {
+        [layout1id]: createEmptyLayout(),
+        [layoutReceiptId]: createEmptyLayout(),
+      };
+      const updatedLayouts = await addOrRemoveNavigationButtons(
+        layouts,
+        callback,
+        null,
+        layoutReceiptId
+      );
+
+      const layout1Components = Object.values(updatedLayouts[layout1id].components);
+      const layoutReceiptComponents = Object.values(updatedLayouts[layoutReceiptId].components);
+      expect(layout1Components.length).toBe(0);
+      expect(layoutReceiptComponents.length).toBe(0);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('Ignores receipt layout when adding navigation buttons to all layouts if there are multiple layouts', async () => {
+      const layout1id = 'layout1';
+      const layout2id = 'layout2';
+      const layoutReceiptId = 'receipt';
+      const callback = jest.fn();
+      const layouts: IFormLayouts = {
+        [layout1id]: createEmptyLayout(),
+        [layout2id]: createEmptyLayout(),
+        [layoutReceiptId]: createEmptyLayout(),
+      };
+      const updatedLayouts = await addOrRemoveNavigationButtons(
+        layouts,
+        callback,
+        layout1id,
+        layoutReceiptId
+      );
+      const layout1Components = Object.values(updatedLayouts[layout1id].components);
+      const layout2Components = Object.values(updatedLayouts[layout2id].components);
+      const layoutReceiptComponents = Object.values(updatedLayouts[layoutReceiptId].components);
+      expect(layout1Components.length).toBe(1);
+      expect(layout1Components[0].type).toBe(ComponentType.NavigationButtons);
+      expect(layout2Components.length).toBe(1);
+      expect(layout2Components[0].type).toBe(ComponentType.NavigationButtons);
+      expect(layoutReceiptComponents.length).toBe(0);
       expect(callback).toHaveBeenCalledTimes(2);
       expect(callback).toHaveBeenCalledWith(layout1id, updatedLayouts[layout1id]);
       expect(callback).toHaveBeenCalledWith(layout2id, updatedLayouts[layout2id]);
@@ -52,16 +107,75 @@ describe('formLayoutsUtils', () => {
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith(layoutId, updatedLayouts[layoutId]);
     });
+
+    it('Removes navigation buttons from layout if there is only one layout AND a receipt layout', async () => {
+      const layoutId = 'layout1';
+      const layoutReceiptId = 'receipt';
+      const callback = jest.fn();
+      const navButtonsId = 'navButtons';
+      const navButtonsComponent: IFormButtonComponent = {
+        id: navButtonsId,
+        itemType: 'COMPONENT',
+        onClickAction: jest.fn(),
+        type: ComponentType.NavigationButtons,
+      };
+      const layouts: IFormLayouts = {
+        [layoutId]: {
+          components: { [navButtonsId]: navButtonsComponent },
+          containers: { [BASE_CONTAINER_ID]: { itemType: 'CONTAINER' } },
+          order: { [BASE_CONTAINER_ID]: [navButtonsId] },
+          customRootProperties: {},
+          customDataProperties: {},
+        },
+        [layoutReceiptId]: createEmptyLayout(),
+      };
+      const updatedLayouts = await addOrRemoveNavigationButtons(
+        layouts,
+        callback,
+        null,
+        layoutReceiptId
+      );
+      const layout1Components = Object.values(updatedLayouts[layoutId].components);
+      expect(layout1Components.length).toBe(0);
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(layoutId, updatedLayouts[layoutId]);
+    });
   });
 
   describe('convertExternalLayoutsToInternalFormat', () => {
     it('Converts external layouts to internal format', () => {
-      const { convertedLayouts, invalidLayouts } = convertExternalLayoutsToInternalFormat(externalLayoutsMock);
+      const { convertedLayouts, invalidLayouts } =
+        convertExternalLayoutsToInternalFormat(externalLayoutsMock);
       expect(convertedLayouts).toEqual({
         [layout1NameMock]: expect.any(Object),
         [layout2NameMock]: expect.any(Object),
       });
       expect(invalidLayouts).toEqual([]);
+    });
+  });
+
+  describe('firstAvailableLayout', () => {
+    it('Chooses next layout in list when one exists', () => {
+      const layout1Id = 'layout1';
+      const layout2Id = 'layout2';
+      const layoutOrder = [layout1Id, layout2Id];
+      const layout = firstAvailableLayout(layout1Id, layoutOrder);
+      expect(layout).toBe(layout2Id);
+    });
+
+    it('Chooses previous layout in list when one exists and next layout does not exist', () => {
+      const layout1Id = 'layout1';
+      const layout2Id = 'layout2';
+      const layoutOrder = [layout1Id, layout2Id];
+      const layout = firstAvailableLayout(layout2Id, layoutOrder);
+      expect(layout).toBe(layout1Id);
+    });
+
+    it('Returns default layout name when no other layouts exist', () => {
+      const layout1Id = 'layout1';
+      const layoutOrder = [layout1Id];
+      const layout = firstAvailableLayout(layout1Id, layoutOrder);
+      expect(layout).toBe(DEFAULT_SELECTED_LAYOUT_NAME);
     });
   });
 });

--- a/frontend/packages/ux-editor/src/utils/formLayoutsUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/formLayoutsUtils.ts
@@ -4,7 +4,7 @@ import {
   convertFromLayoutToInternalFormat,
   createEmptyLayout,
   hasNavigationButtons,
-  removeComponentsByType
+  removeComponentsByType,
 } from './formLayoutUtils';
 import { ComponentType } from '../components';
 import { removeItemByValue } from 'app-shared/utils/arrayUtils';
@@ -22,6 +22,7 @@ export const addOrRemoveNavigationButtons = async (
   layouts: IFormLayouts,
   callback: (layoutName: string, layout: IInternalLayout) => Promise<void>,
   currentLayoutName?: string,
+  receiptLayoutName?: string
 ): Promise<IFormLayouts> => {
   if (currentLayoutName && !layouts[currentLayoutName]) {
     throw new Error(`Layout with name ${currentLayoutName} does not exist.`);
@@ -30,7 +31,7 @@ export const addOrRemoveNavigationButtons = async (
   const updatedLayouts = deepCopy(layouts);
 
   // Update layouts to have navigation buttons if there are multiple layouts, or remove them if there is the only one.
-  const allLayoutNames = Object.keys(layouts);
+  const allLayoutNames = Object.keys(layouts).filter((name) => name !== receiptLayoutName);
   if (allLayoutNames.length === 1) {
     // There is only one layout
     const name = allLayoutNames[0];
@@ -60,7 +61,7 @@ export const addOrRemoveNavigationButtons = async (
     }
   }
   return updatedLayouts;
-}
+};
 
 interface AllLayouts {
   convertedLayouts: IFormLayouts;
@@ -72,7 +73,9 @@ interface AllLayouts {
  * @param layouts List of layouts in external format.
  * @returns A list of layouts in internal format and a list of layouts with an invalid format.
  */
-export const convertExternalLayoutsToInternalFormat = (layouts: IExternalFormLayouts): AllLayouts => {
+export const convertExternalLayoutsToInternalFormat = (
+  layouts: IExternalFormLayouts
+): AllLayouts => {
   const convertedLayouts: IFormLayouts = {};
   const invalidLayouts: string[] = [];
   Object.entries(layouts).forEach(([name, layout]) => {
@@ -87,4 +90,23 @@ export const convertExternalLayoutsToInternalFormat = (layouts: IExternalFormLay
     }
   });
   return { convertedLayouts, invalidLayouts };
+};
+
+/**
+ * Finds the first available layout to select when a layout is deleted
+ * @param deletedLayoutName The name of the deleted layout
+ * @param layoutPagesOrder  The current layout order
+ * @returns The name of the layout to select, or 'default' if there are no available layouts
+ */
+export const firstAvailableLayout = (deletedLayoutName: string, layoutPagesOrder: string[]) => {
+  const deletedLayoutIndex = layoutPagesOrder.indexOf(deletedLayoutName);
+  if (deletedLayoutIndex > 0) {
+    return layoutPagesOrder[deletedLayoutIndex - 1];
+  }
+
+  if (deletedLayoutIndex < layoutPagesOrder.length - 1) {
+    return layoutPagesOrder[deletedLayoutIndex + 1];
+  }
+
+  return 'default';
 };

--- a/frontend/packages/ux-editor/src/utils/formLayoutsUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/formLayoutsUtils.ts
@@ -10,6 +10,7 @@ import { ComponentType } from '../components';
 import { removeItemByValue } from 'app-shared/utils/arrayUtils';
 import { generateComponentId } from './generateId';
 import { deepCopy } from 'app-shared/pure';
+import { DEFAULT_SELECTED_LAYOUT_NAME } from 'app-shared/constants';
 
 /**
  * Update layouts to have navigation buttons if there are multiple layouts, or remove them if this is the only one.
@@ -17,6 +18,7 @@ import { deepCopy } from 'app-shared/pure';
  * @param layouts All layouts.
  * @param callback Callback to be called for each layout if there are changes or if the layout is the one specified by the currentLayoutName parameter.
  * @param currentLayoutName The name of the current layout. Callback will always be called for this layout if set.
+ * @param receiptLayoutName The name of the receipt layout. Ensures that receipt layout is ignored when adding/deleting navigation buttons.
  */
 export const addOrRemoveNavigationButtons = async (
   layouts: IFormLayouts,
@@ -108,5 +110,5 @@ export const firstAvailableLayout = (deletedLayoutName: string, layoutPagesOrder
     return layoutPagesOrder[deletedLayoutIndex + 1];
   }
 
-  return 'default';
+  return DEFAULT_SELECTED_LAYOUT_NAME;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Support for adding a first page if there are no layouts
- Support for selecting/displaying correct layout when a layout is deleted
- Make sure receipt layout is not shown together with the ordinary layouts
- Update logic for setting selected layout based on urlparams

## Related Issue(s)
- #10190 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
