### PR TITLE
10277 cach is not invalidated when keystexts are deleted in text editor

### DIFF
--- a/frontend/app-development/hooks/mutations/useTextIdMutation.ts
+++ b/frontend/app-development/hooks/mutations/useTextIdMutation.ts
@@ -5,13 +5,13 @@ import { QueryKey } from '../../types/QueryKey';
 import { QueryKey as UxEditorQueryKey } from '../../../packages/ux-editor/src/types/QueryKey';
 
 export const useTextIdMutation = (owner, app) => {
-  const { invalidateQueries } = useQueryClient();
+  const query = useQueryClient();
   const { updateTextId } = useServicesContext();
   return useMutation({
     mutationFn: (payload: TextResourceIdMutation[]) => updateTextId(owner, app, payload),
     onSuccess: async () => {
-      await invalidateQueries({ queryKey: [QueryKey.TextResources, owner, app] });
-      await invalidateQueries({ queryKey: [UxEditorQueryKey.FormLayouts, owner, app] });
+      await query.invalidateQueries({ queryKey: [QueryKey.TextResources, owner, app] });
+      await query.invalidateQueries({ queryKey: [UxEditorQueryKey.FormLayouts, owner, app] });
     },
   });
 };

--- a/frontend/app-development/hooks/mutations/useTextIdMutation.ts
+++ b/frontend/app-development/hooks/mutations/useTextIdMutation.ts
@@ -5,13 +5,13 @@ import { QueryKey } from '../../types/QueryKey';
 import { QueryKey as UxEditorQueryKey } from '../../../packages/ux-editor/src/types/QueryKey';
 
 export const useTextIdMutation = (owner, app) => {
-  const query = useQueryClient();
+  const queryClient = useQueryClient();
   const { updateTextId } = useServicesContext();
   return useMutation({
     mutationFn: (payload: TextResourceIdMutation[]) => updateTextId(owner, app, payload),
     onSuccess: async () => {
-      await query.invalidateQueries({ queryKey: [QueryKey.TextResources, owner, app] });
-      await query.invalidateQueries({ queryKey: [UxEditorQueryKey.FormLayouts, owner, app] });
+      await queryClient.invalidateQueries({ queryKey: [QueryKey.TextResources, owner, app] });
+      await queryClient.invalidateQueries({ queryKey: [UxEditorQueryKey.FormLayouts, owner, app] });
     },
   });
 };

--- a/frontend/packages/text-editor/src/TextList.test.tsx
+++ b/frontend/packages/text-editor/src/TextList.test.tsx
@@ -91,10 +91,10 @@ describe('TextList', () => {
     await act(() => user.keyboard('2'));
     expect(screen.queryByText(errorMsg)).toBeNull();
     await act(() => user.keyboard('{BACKSPACE}'));
-    expect(screen.queryByText(errorMsg)).toBeNull();
+    expect(screen.getByText(errorMsg)).toBeInTheDocument();
     await act(() => user.keyboard('{TAB}'));
     expect(updateEntryId).not.toHaveBeenCalled();
     await act(() => user.keyboard('{SHIFT>}{TAB}{/SHIFT}{END}2{TAB}'));
-    expect(updateEntryId).toHaveBeenCalledWith({ oldId: 'a', newId: 'a2' });
+    expect(updateEntryId).toHaveBeenCalledWith({ oldId: 'a', newId: 'b2' });
   });
 });

--- a/frontend/packages/text-editor/src/TextList.test.tsx
+++ b/frontend/packages/text-editor/src/TextList.test.tsx
@@ -91,10 +91,10 @@ describe('TextList', () => {
     await act(() => user.keyboard('2'));
     expect(screen.queryByText(errorMsg)).toBeNull();
     await act(() => user.keyboard('{BACKSPACE}'));
-    expect(screen.getByText(errorMsg)).toBeInTheDocument();
+    expect(screen.queryByText(errorMsg)).toBeNull();
     await act(() => user.keyboard('{TAB}'));
     expect(updateEntryId).not.toHaveBeenCalled();
     await act(() => user.keyboard('{SHIFT>}{TAB}{/SHIFT}{END}2{TAB}'));
-    expect(updateEntryId).toHaveBeenCalledWith({ oldId: 'a', newId: 'b2' });
+    expect(updateEntryId).toHaveBeenCalledWith({ oldId: 'a', newId: 'a2' });
   });
 });

--- a/frontend/packages/text-editor/src/TextRow.tsx
+++ b/frontend/packages/text-editor/src/TextRow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import classes from './TextRow.module.css';
 import type { UpsertTextResourceMutation } from './types';
 import { TrashIcon, PencilIcon } from '@navikt/aksel-icons';

--- a/frontend/packages/text-editor/src/TextRow.tsx
+++ b/frontend/packages/text-editor/src/TextRow.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import classes from './TextRow.module.css';
 import type { UpsertTextResourceMutation } from './types';
 import { TrashIcon, PencilIcon } from '@navikt/aksel-icons';
@@ -50,6 +50,12 @@ export const TextRow = ({
   const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
   const { t } = useTranslation();
 
+  useEffect(() => {
+    if (textId !== textIdValue) {
+      setTextIdValue(textId);
+    }
+  }, [textId, textIdValue]);
+
   const handleTextIdChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const newTextId = event.currentTarget.value;
     if (newTextId !== textId) {
@@ -68,7 +74,12 @@ export const TextRow = ({
     }
   };
 
-  const handleDeleteClick = () => removeEntry({ textId });
+  const handleDeleteClick = () => {
+    localStorage.removeItem(textId);
+    removeEntry({ textId });
+    setIsConfirmDeleteOpen(false);
+  };
+
   const toggleConfirmDeletePopover = () => setIsConfirmDeleteOpen((prev) => !prev);
 
   return (

--- a/frontend/packages/text-editor/src/TextRow.tsx
+++ b/frontend/packages/text-editor/src/TextRow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import classes from './TextRow.module.css';
 import type { UpsertTextResourceMutation } from './types';
 import { TrashIcon, PencilIcon } from '@navikt/aksel-icons';
@@ -50,12 +50,6 @@ export const TextRow = ({
   const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
   const { t } = useTranslation();
 
-  useEffect(() => {
-    if (textId !== textIdValue) {
-      setTextIdValue(textId);
-    }
-  }, [textId, textIdValue]);
-
   const handleTextIdChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const newTextId = event.currentTarget.value;
     if (newTextId !== textId) {
@@ -75,9 +69,7 @@ export const TextRow = ({
   };
 
   const handleDeleteClick = () => {
-    localStorage.removeItem(textId);
     removeEntry({ textId });
-    setIsConfirmDeleteOpen(false);
   };
 
   const toggleConfirmDeletePopover = () => setIsConfirmDeleteOpen((prev) => !prev);

--- a/frontend/packages/text-editor/src/TextRow.tsx
+++ b/frontend/packages/text-editor/src/TextRow.tsx
@@ -50,12 +50,6 @@ export const TextRow = ({
   const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
   const { t } = useTranslation();
 
-  useEffect(() => {
-    if (textId !== textIdValue) {
-      setTextIdValue(textId);
-    }
-  }, [textId, textIdValue]);
-
   const handleTextIdChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const newTextId = event.currentTarget.value;
     if (newTextId !== textId) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Deletion a text in text-Editor works now, 

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
