### PR TITLE
Add GetOptions endpoint & service methods

### DIFF
--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -474,5 +474,30 @@ namespace Altinn.Studio.Designer.Controllers
             }
 
         }
+
+        /// <summary>
+        /// Action for getting options list for a given options list id
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="app">Application identifier which is unique within an organisation.</param>
+        /// <param name="optionListId">The id of the options list</param>
+        /// <returns>The options list if it exists, otherwise nothing</returns>
+        [HttpGet]
+        [Route("api/options/{optionListId}")]
+        public async Task<ActionResult<string>> GetOptions(string org, string app, string optionListId)
+        {
+            try
+            {
+                string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
+                AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
+                string options = await altinnAppGitRepository.GetOptions(optionListId);
+                return Ok(options);
+            }
+            catch (NotFoundException)
+            {
+                return NoContent();
+            }
+
+        }
     }
 }

--- a/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -25,6 +25,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
     {
         private const string MODEL_FOLDER_PATH = "App/models/";
         private const string CONFIG_FOLDER_PATH = "App/config/";
+        private const string OPTIONS_FOLDER_PATH = "App/options/";
         private const string LAYOUTS_FOLDER_NAME = "App/ui/";
         private const string LAYOUTS_IN_SET_FOLDER_NAME = "layouts/";
         private const string LANGUAGE_RESOURCE_FOLDER_NAME = "texts/";
@@ -577,6 +578,45 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
                 return ruleConfiguration;
             }
             throw new NotFoundException("Rule configuration not found.");
+        }
+
+        /// <summary>
+        /// Gets the options list with the provided id.
+        /// <param name="optionsListId">The id of the options list to fetch.</param>
+        /// <returns>The options list as a string.</returns>
+        /// </summary>
+        public async Task<string> GetOptions(string optionsListId)
+        {
+            string optionsFilePath = Path.Combine(OPTIONS_FOLDER_PATH, $"{optionsListId}.json");
+            if (!FileExistsByRelativePath(optionsFilePath))
+            {
+                throw new NotFoundException("Options file not found.");
+            }
+            string fileContent = await ReadTextByRelativePathAsync(optionsFilePath);
+
+            return fileContent;
+        }
+
+        /// <summary>
+        /// Gets a list of file names from the Options folder representing the available options lists.
+        /// <returns>A list of option list names.</returns>
+        /// </summary>
+        public string GetOptionListIds()
+        {
+            string optionsFolder = Path.Combine(OPTIONS_FOLDER_PATH);
+            if (!DirectoryExistsByRelativePath(optionsFolder))
+            {
+                throw new NotFoundException("Options folder not found.");
+            }
+            string[] fileNames = GetFilesByRelativeDirectory(optionsFolder);
+            List<string> optionListIds = new();
+            foreach (string fileName in fileNames)
+            {
+                string optionListId = Path.GetFileNameWithoutExtension(fileName);
+                optionListIds.Add(optionListId);
+            }
+
+            return JsonSerializer.Serialize(optionListIds);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added GetOptions endpoint for preview mock. Also added corresponding service method to fetch any available options from the app repo (only works for static options list files, not dynamic options).
Finally, added a service method for fetching all option list id's, for future use in Studio.

## Related Issue(s)
- #10329

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
