### PR TITLE
Fixed overlapping between /legg til/ button and schema

### DIFF
--- a/frontend/packages/schema-editor/src/components/SchemaEditor.module.css
+++ b/frontend/packages/schema-editor/src/components/SchemaEditor.module.css
@@ -1,4 +1,6 @@
 .root {
+  display: flex;
+  flex-direction: column;
   height: 100%;
   width: 100%;
 }
@@ -14,8 +16,6 @@
 .editor {
   background-color: white;
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
   flex: 1;
   height: 100%;
   min-height: 200px;

--- a/frontend/packages/schema-editor/src/components/SchemaEditor.module.css
+++ b/frontend/packages/schema-editor/src/components/SchemaEditor.module.css
@@ -1,6 +1,4 @@
 .root {
-  display: flex;
-  flex-direction: column;
   height: 100%;
   width: 100%;
 }

--- a/frontend/packages/schema-editor/src/components/common/ActionMenu.module.css
+++ b/frontend/packages/schema-editor/src/components/common/ActionMenu.module.css
@@ -1,7 +1,6 @@
 .root {
   position: relative;
   height: 4rem;
-  margin-bottom: 45px;
 }
 
 .menu {
@@ -10,7 +9,6 @@
   border-radius: 3px;
   box-sizing: border-box;
   left: 0;
-  position: absolute;
   top: 0;
   width: 150px;
   z-index: 1;
@@ -33,7 +31,7 @@
   height: 2.5rem;
   padding: 4px 0;
   text-transform: none;
-  width: 100%;
+  width: 150px;
   font-size: 16px;
   align-items: center;
 }

--- a/frontend/packages/schema-editor/src/components/common/ActionMenu.module.css
+++ b/frontend/packages/schema-editor/src/components/common/ActionMenu.module.css
@@ -1,6 +1,7 @@
 .root {
   position: relative;
   height: 4rem;
+  margin-bottom: 45px;
 }
 
 .menu {
@@ -66,6 +67,7 @@
   border-top: 1px solid #c9c9c9;
   padding-top: 4px;
   padding-left: 0;
+  margin-top: 444px;
 }
 
 .list:not(:last-child) {

--- a/frontend/packages/schema-editor/src/components/common/ActionMenu.module.css
+++ b/frontend/packages/schema-editor/src/components/common/ActionMenu.module.css
@@ -9,6 +9,7 @@
   border-radius: 3px;
   box-sizing: border-box;
   left: 0;
+  position: absolute;
   top: 0;
   width: 150px;
   z-index: 1;
@@ -31,7 +32,7 @@
   height: 2.5rem;
   padding: 4px 0;
   text-transform: none;
-  width: 150px;
+  width: 100%;
   font-size: 16px;
   align-items: center;
 }
@@ -65,7 +66,6 @@
   border-top: 1px solid #c9c9c9;
   padding-top: 4px;
   padding-left: 0;
-  margin-top: 444px;
 }
 
 .list:not(:last-child) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed overlapping between /legg til/ button and schema.
When the schema items becomes long , then the name (scheme) -which is the first object in schema- goes under (Leggg til ) button.

## Related Issue(s)
- #10135 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
