### PR TITLE
enabling "deleteLocalChanges"

### DIFF
--- a/frontend/testing/cypress/src/integration/usecase/usecase.js
+++ b/frontend/testing/cypress/src/integration/usecase/usecase.js
@@ -43,8 +43,7 @@ context(
     });
 
     it('Gitea connection - Pull changes', () => {
-      // Disable this for now, due to https://github.com/Altinn/altinn-studio/issues/10201  - we do not actually make any changes in our tests, so should be ok
-      //cy.deleteLocalChanges(Cypress.env('deployApp'));
+      cy.deleteLocalChanges(Cypress.env('deployApp'));
       cy.wait(5000);
       cy.intercept(/(P|p)ull/).as('pullChanges');
       cy.get(designer.syncApp.pull).should('be.visible').click();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add back the "delete local changes" step in usecase tests, to ensure that there are no local changes interfering with the tests.
Since we are now hard deleting the local changes, this should no longer be problematic.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
