### PR TITLE
Adapt preview after app frontend update

### DIFF
--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -131,7 +131,7 @@ namespace Altinn.Studio.Designer.Controllers
             }
             catch (NotFoundException)
             {
-                return NotFound();
+                return Ok();
             }
 
         }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTests.cs
@@ -76,7 +76,7 @@ namespace Designer.Tests.Controllers.PreviewController
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
-            Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
         }
 
         [Fact]

--- a/frontend/app-development/layout/AppBar/AppBar.tsx
+++ b/frontend/app-development/layout/AppBar/AppBar.tsx
@@ -34,7 +34,7 @@ export const AppBar = ({ activeSubHeaderSelection, showSubMenu }: IAppBarProps) 
   const { data: user } = useUserQuery();
 
   const handlePreviewClick = () => {
-    window.location.href = previewPath(org, app);
+    window.open(previewPath(org, app), '_blank');
   };
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adapt the mocked app-backend to return `200 OK` if no layoutsets exists in application
- Change window location to be a new separate window when clicking preview-button

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

