### PR TITLE
10226 mock endpoints when pressing send inn in preview

### DIFF
--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -348,6 +348,18 @@ namespace Altinn.Studio.Designer.Controllers
         }
 
         /// <summary>
+        /// Action for mocking a end to the process in order to get receipt after "send inn" is pressed
+        /// </summary>
+        /// <returns>Process object where ended is set</returns>
+        [HttpPut]
+        [Route("instances/undefined/process/next")]
+        public ActionResult ProcessNext([FromQuery] string lang)
+        {
+            string process = @"{""ended"": ""ended""}";
+            return Ok(process);
+        }
+
+        /// <summary>
         /// Action for mocking a response to getting all text resources
         /// </summary>
         /// <remarks>Hardcoded to only serve norwegian bokmal resource file</remarks>

--- a/backend/src/Designer/Services/Implementation/PreviewService.cs
+++ b/backend/src/Designer/Services/Implementation/PreviewService.cs
@@ -30,8 +30,10 @@ public class PreviewService : IPreviewService
     }
 
     /// <inherit />
-    public async Task<Instance> CreateMockInstance(string org, string app, string developer, int? instanceOwnerPartyId)
+    public async Task<Instance> GetMockInstance(string org, string app, string developer, int? instanceOwnerPartyId)
     {
+        AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
+        Application applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
         DataType dataType = await GetDataTypeForTask1(org, app, developer);
         Instance instance = new()
         {
@@ -43,6 +45,7 @@ public class PreviewService : IPreviewService
                     DataType = dataType?.Id,
                     Id = "test-datatask-id"
                 } },
+            Org = applicationMetadata.Org,
             Process = new()
             {
                 CurrentTask = new()

--- a/backend/src/Designer/Services/Implementation/PreviewService.cs
+++ b/backend/src/Designer/Services/Implementation/PreviewService.cs
@@ -35,17 +35,19 @@ public class PreviewService : IPreviewService
         AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
         Application applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
         DataType dataType = await GetDataTypeForTask1(org, app, developer);
+        // RegEx for instance guid in app-frontend: [\da-f]{8}-[\da-f]{4}-[1-5][\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}
+        string instanceGuid = "f1e23d45-6789-1bcd-8c34-56789abcdef0";
         Instance instance = new()
         {
             InstanceOwner = new InstanceOwner { PartyId = instanceOwnerPartyId == null ? "undefined" : instanceOwnerPartyId.Value.ToString() },
-            Id = $"{instanceOwnerPartyId}/test-id",
+            Id = $"{instanceOwnerPartyId}/{instanceGuid}",
             Data = new()
                 { new ()
                 {
                     DataType = dataType?.Id,
                     Id = "test-datatask-id"
                 } },
-            Org = applicationMetadata.Org,
+            Org = applicationMetadata.Org == developer ? "ttd" : applicationMetadata.Org,
             Process = new()
             {
                 CurrentTask = new()

--- a/backend/src/Designer/Services/Interfaces/IPreviewService.cs
+++ b/backend/src/Designer/Services/Interfaces/IPreviewService.cs
@@ -23,7 +23,7 @@ public interface IPreviewService
     /// <param name="app">Repository</param>
     /// <param name="developer">Username of developer</param>
     /// <param name="instanceOwnerPartyId"></param>
-    public Task<Instance> CreateMockInstance(string org, string app, string developer, int? instanceOwnerPartyId);
+    public Task<Instance> GetMockInstance(string org, string app, string developer, int? instanceOwnerPartyId);
 
     /// <summary>
     /// Gets the datatype from application metadata that corresponds to the process Task_1

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTests.cs
@@ -26,6 +26,8 @@ namespace Designer.Tests.Controllers.PreviewController
         private const string Org = "ttd";
         private const string App = "preview-app";
         private const string Developer = "testUser";
+        private const string PartyId = "51001";
+        private const string InstanceGuId = "f1e23d45-6789-1bcd-8c34-56789abcdef0";
         private readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -155,7 +157,7 @@ namespace Designer.Tests.Controllers.PreviewController
             string responseBody = await response.Content.ReadAsStringAsync();
             JsonDocument responseDocument = JsonDocument.Parse(responseBody);
             Party currentParty = JsonConvert.DeserializeObject<Party>(responseDocument.RootElement.ToString());
-            Assert.Equal(1, currentParty.PartyId);
+            Assert.Equal(51001, currentParty.PartyId);
         }
 
         [Fact]
@@ -209,9 +211,8 @@ namespace Designer.Tests.Controllers.PreviewController
         {
             string expectedFormData = TestDataHelper.GetFileFromRepo(Org, App, Developer, "App/models/custom-dm-name.schema.json");
 
-            string dataPathWithData = $"{Org}/{App}/instances/1/test-id/data/test-datatask-id";
+            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
-
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
 
@@ -222,7 +223,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task UpdateFormData_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/instances/undefined/data/test-datatask-id";
+            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Put, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
@@ -232,7 +233,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task GetProcess_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/instances/undefined/process";
+            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/process";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
@@ -246,9 +247,25 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
+        public async Task GetInstancesReceiptStep_Ok_OrgIsTTD()
+        {
+            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}";
+            using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonDocument responseDocument = JsonDocument.Parse(responseBody);
+            Instance instanceReceiptStep = JsonConvert.DeserializeObject<Instance>(responseDocument.RootElement.ToString());
+            Assert.Equal($"{PartyId}/{InstanceGuId}", instanceReceiptStep.Id);
+            Assert.Equal("ttd", instanceReceiptStep.Org);
+        }
+
+        [Fact]
         public async Task GetProcessNext_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/instances/undefined/process/next";
+            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/process/next";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
@@ -259,6 +276,19 @@ namespace Designer.Tests.Controllers.PreviewController
             ProcessState processState = JsonConvert.DeserializeObject<ProcessState>(responseDocument.RootElement.ToString());
             Assert.Equal("data", processState.CurrentTask.AltinnTaskType);
             Assert.Equal("Task_1", processState.CurrentTask.ElementId);
+        }
+
+        [Fact]
+        public async Task PutProcessNext_Ok()
+        {
+            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/process/next";
+            using HttpRequestMessage httpRequestMessage = new(HttpMethod.Put, dataPathWithData);
+
+            using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            Assert.Equal(@"{""ended"": ""ended""}", responseBody);
         }
 
         [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Changed id instance id to be a hardcoded guid that matches app frontends regex
- Add endpoints to respond to api calls made when app frontend finishes the process and shows receipt

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
