### PR TITLE
Add information of preview being beta and enable in prod

### DIFF
--- a/frontend/app-development/layout/AppBar/AppBar.module.css
+++ b/frontend/app-development/layout/AppBar/AppBar.module.css
@@ -116,3 +116,15 @@
   align-items: center;
   gap: 1rem;
 }
+
+.infoPreviewIsBetaMessage {
+  padding: 20px;
+  display: inline-block;
+}
+
+.infoIcon {
+  border: white 1px solid;
+  border-radius: 50%;
+  font-size: larger;
+  margin-top: 3px
+}

--- a/frontend/app-development/layout/AppBar/AppBar.tsx
+++ b/frontend/app-development/layout/AppBar/AppBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, MouseEvent } from 'react';
 import classNames from 'classnames';
 import { Link, useParams } from 'react-router-dom';
 import { getTopBarMenu, TopBarMenu } from './appBarConfig';
@@ -11,8 +11,9 @@ import AltinnStudioLogo from 'app-shared/navigation/main-header/AltinnStudioLogo
 import { ThreeDotsMenu } from './ThreeDotsMenu';
 import { BranchingIcon } from '@navikt/aksel-icons';
 import { Button, ButtonVariant } from '@digdir/design-system-react';
+import { Popover } from '@mui/material';
+import { InformationIcon } from '@navikt/aksel-icons';
 import { previewPath, publiserPath } from 'app-shared/api-paths';
-import { _useIsProdHack } from 'app-shared/utils/_useIsProdHack';
 import { useUserQuery } from 'app-development/hooks/queries/useUserQuery';
 import { useAppSelector } from '../../hooks';
 
@@ -32,9 +33,18 @@ export const AppBar = ({ activeSubHeaderSelection, showSubMenu }: IAppBarProps) 
     window.location.href = publiserPath(org, app);
   };
   const { data: user } = useUserQuery();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   const handlePreviewClick = () => {
     window.open(previewPath(org, app), '_blank');
+  };
+
+  const handlePopoverOpen = (event: MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handlePopoverClose = () => {
+    setAnchorEl(null);
   };
 
   return (
@@ -64,17 +74,36 @@ export const AppBar = ({ activeSubHeaderSelection, showSubMenu }: IAppBarProps) 
         </ul>
         <div className={classes.rightContent}>
           <div className={classes.rightContentButtons}>
-            {/* TODO: Enable cypress usecase test when below button is enabled in prod/dev (testing/cypress/src/integration/usecase/usecase.js:57) */}
-            {!_useIsProdHack() && (
-              <Button
-                className={classes.previewButton}
-                onClick={handlePreviewClick}
-                variant={ButtonVariant.Outline}
-                data-testid={TopBarMenu.Preview}
+            <Button
+              className={classes.previewButton}
+              onClick={handlePreviewClick}
+              variant={ButtonVariant.Outline}
+              data-testid={TopBarMenu.Preview}
+            >
+              {t('top_menu.preview')}
+              <span
+                aria-haspopup="true"
+                onMouseEnter={handlePopoverOpen}
+                onMouseLeave={handlePopoverClose}
               >
-                {t('top_menu.preview')}
-              </Button>
-            )}
+                <InformationIcon
+                className={classes.infoIcon}
+                />
+              </span>
+              <Popover
+                open={!!anchorEl}
+                onClose={handlePopoverClose}
+                anchorEl={anchorEl}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                disableRestoreFocus
+                sx={{ pointerEvents: 'none', }}
+              >
+                <span className={classes.infoPreviewIsBetaMessage}>
+                  {t('top_menu.preview_is_beta_message')}
+                </span>
+              </Popover>
+            </Button>
             <Button
               onClick={handlePubliserClick}
               variant={ButtonVariant.Outline}

--- a/frontend/app-preview/src/views/LandingPage.module.css
+++ b/frontend/app-preview/src/views/LandingPage.module.css
@@ -14,8 +14,20 @@
 .header {
   font-family: Inter, 'San Fransisco', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   color: white;
-  padding: 10px;
-  height: auto;
   border-bottom: 1px solid gray;
   background-color: #15a859;
+  display: flex;
+  align-items: center;
+  height: 80px;
+  padding: 0 2rem;
+}
+
+.betaTag {
+  border: 2px solid white;
+  border-radius: 4px;
+  width: fit-content;
+  height: fit-content;
+  margin-left: 30px;
+  padding: 0 5px;
+  font-weight: bold;
 }

--- a/frontend/app-preview/src/views/LandingPage.tsx
+++ b/frontend/app-preview/src/views/LandingPage.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 import { stringify } from 'qs';
 import { useTranslation } from 'react-i18next';
 import { usePreviewConnection } from "app-shared/providers/PreviewConnectionContext";
+import AltinnStudioLogo from "app-shared/navigation/main-header/AltinnStudioLogo";
 
 export const LandingPage = () => {
   const { org, app } = useParams();
@@ -30,7 +31,12 @@ export const LandingPage = () => {
   return (
     <PreviewContext>
       <div className={classes.header}>
-        <h1>Altinn Studio - App Preview</h1>
+        <a href='/'>
+          <AltinnStudioLogo />
+        </a>
+        <div className={classes.betaTag}>
+          {'BETA'}
+        </div>
       </div>
       <iframe
         title={t('preview.iframe_title')}

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -754,6 +754,7 @@
   "top_menu.datamodel": "Datamodell",
   "top_menu.deploy": "Publiser",
   "top_menu.preview": "Forhåndsvis",
+  "top_menu.preview_is_beta_message": "Denne funksjonaliteten er i beta. Vi jobber med å forbedre den.",
   "top_menu.texts": "Tekst",
   "top_menu.texts_old": "Tekst *",
   "ux_editor.add_map_layer": "Legg til kartlag",

--- a/frontend/testing/cypress/src/integration/usecase/usecase.js
+++ b/frontend/testing/cypress/src/integration/usecase/usecase.js
@@ -54,8 +54,7 @@ context(
     it('App builds and deploys', () => {
       cy.intercept('**/deployments*').as('deploys');
       cy.get(designer.appMenu.deploy).should('be.visible').click();
-      // TODO: Add below line again after preview is enabled in prod/dev (app-development/layout/AppBar/AppBar.tsx:65)
-      // cy.get(designer.appMenu.preview).should('be.visible').click();
+      cy.get(designer.appMenu.preview).should('be.visible').click();
       cy.wait('@deploys').its('response.statusCode').should('eq', 200);
       const checkDeployOf = Cypress.env('environment') === 'prod' ? 'prod' : 'at22';
       cy.get(designer.deployHistory[checkDeployOf]).then((table) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add beta tag in preview
- Add Altinn Studio logo in header and redirect
- Add info button in preview button and message of functionality being beta

![Screenshot 2023-05-15 at 15 16 23](https://github.com/Altinn/altinn-studio/assets/71079896/d434282f-e069-49a2-aa48-32a76f113939)

![Screenshot 2023-05-16 at 09 05 07](https://github.com/Altinn/altinn-studio/assets/71079896/988f087a-e6bf-414e-b65c-c6cedae62706)



## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

