### PR TITLE
Fix inifinite re-rendering of checkbox and radio components

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions.tsx
@@ -69,7 +69,7 @@ export function EditOptions({
 
   useEffect(() => {
     resetPrevOptionsType();
-  }, [resetPrevOptionsType, selectedOptionsType]);
+  }, [selectedOptionsType]);
 
   const handleOptionsTypeChange = (value) => {
     setSelectedOptionsType(value);


### PR DESCRIPTION
## Description
I think I discovered a bug while I was working with the editor.
There is an infinite re-rendering of checkbox and radio components when adding a new option.

https://github.com/Altinn/altinn-studio/assets/24462611/ed65864c-baa6-4cde-bb71-c7dc695e6a61