### PR TITLE
Add selectedLayout to localstorage with mock instanceid as cachekey

### DIFF
--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -33,6 +33,8 @@ namespace Altinn.Studio.Designer.Controllers
         private readonly IPreviewService _previewService;
         private readonly ITextsService _textsService;
 
+        private const int PartyId = 51001;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PreviewController"/> class.
         /// </summary>
@@ -202,7 +204,7 @@ namespace Altinn.Studio.Designer.Controllers
                 UserName = "previewUser",
                 PhoneNumber = "12345678",
                 Email = "test@test.com",
-                PartyId = 51001,
+                PartyId = PartyId,
                 Party = new(),
                 UserType = 0,
                 ProfileSettingPreference = new() { Language = "nb" }
@@ -224,7 +226,7 @@ namespace Altinn.Studio.Designer.Controllers
             // TODO: return actual current party when tenor testusers are available
             Party party = new()
             {
-                PartyId = 51001,
+                PartyId = PartyId,
                 PartyTypeName = PartyType.Person,
                 OrgNumber = "1",
                 SSN = null,
@@ -281,6 +283,21 @@ namespace Altinn.Studio.Designer.Controllers
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
             Instance mockInstance = await _previewService.GetMockInstance(org, app, developer, instanceOwnerPartyId);
             return Ok(mockInstance);
+        }
+
+        /// <summary>
+        /// Action for getting the mocked instance id
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="app">Application identifier which is unique within an organisation.</param>
+        /// <returns>The mocked instance object</returns>
+        [HttpGet]
+        [Route("/designer/api/{org}/{app}/mock-instance-id")]
+        public async Task<ActionResult<string>> GetInstanceId(string org, string app)
+        {
+            string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
+            Instance mockInstance = await _previewService.GetMockInstance(org, app, developer, PartyId);
+            return Ok(mockInstance.Id);
         }
 
         /// <summary>

--- a/frontend/app-development/queries/queries.ts
+++ b/frontend/app-development/queries/queries.ts
@@ -7,6 +7,7 @@ import {
   deploymentsPath,
   envConfigPath,
   formLayoutsPath,
+  instanceIdForPreviewPath,
   layoutSettingsPath,
   releasesPath,
   repoMetaPath,
@@ -32,6 +33,7 @@ export const getDeployments = (owner: string, app: string) => get(deploymentsPat
 export const getEnvironments = () => get(envConfigPath());
 export const getFormLayoutSettings = (owner: string, app: string) => get(layoutSettingsPath(owner, app));
 export const getFormLayouts = (owner: string, app: string) => get(formLayoutsPath(owner, app));
+export const getInstanceIdForPreview = (owner: string, app: string) => get(instanceIdForPreviewPath(owner, app));
 export const getOrgList = () => get(orgsListUrl());
 export const getRepoMetadata = (owner: string, app: string) => get(repoMetaPath(owner, app));
 export const getRepoPull = (owner: string, app: string) => get(repoPullPath(owner, app));

--- a/frontend/packages/shared/src/api-paths/index.js
+++ b/frontend/packages/shared/src/api-paths/index.js
@@ -55,6 +55,7 @@ export const orgsListPath = () => '/designer/api/orgs'; // Get
 
 // Preview
 export const previewPath = (org, app) => `/preview/${org}/${app}`;
+export const instanceIdForPreviewPath = (org, app) => `/designer/api/${org}/${app}/mock-instance-id`; // Get
 
 // Preview - SignalR Hub
 export const previewSignalRHubSubPath = () => '/previewHub';

--- a/frontend/packages/ux-editor/src/App.tsx
+++ b/frontend/packages/ux-editor/src/App.tsx
@@ -18,6 +18,7 @@ import { firstAvailableLayout } from './utils/formLayoutsUtils';
 import { DEFAULT_SELECTED_LAYOUT_NAME } from 'app-shared/constants';
 import { useRuleConfigQuery } from './hooks/queries/useRuleConfigQuery';
 import { useWidgetsQuery } from './hooks/queries/useWidgetsQuery';
+import { useInstanceIdQuery } from './hooks/queries/useInstanceIdQuery';
 
 /**
  * This is the main React component responsible for controlling
@@ -38,6 +39,7 @@ export function App() {
   const { isSuccess: isRuleModelFetched } = useRuleModelQuery(org, app);
   const { isSuccess: isRuleConfigFetched } = useRuleConfigQuery(org, app);
   const { isSuccess: areWidgetsFetched, isError: widgetFetchedError } = useWidgetsQuery(org, app);
+  const { data: instanceId } = useInstanceIdQuery(org, app);
   const selectedLayout = useSelector(selectedLayoutNameSelector);
 
   const layoutPagesOrder = formLayoutSettings?.pages.order;
@@ -97,6 +99,10 @@ export function App() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, layoutPagesOrder, selectedLayout, org, app]);
+
+  useEffect(() => {
+    localStorage.setItem(instanceId, selectedLayout);
+  }, [selectedLayout, instanceId]);
 
   if (componentHasError) {
     const mappedError = mapErrorToDisplayError();

--- a/frontend/packages/ux-editor/src/hooks/queries/useInstanceIdQuery.ts
+++ b/frontend/packages/ux-editor/src/hooks/queries/useInstanceIdQuery.ts
@@ -1,0 +1,11 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { QueryKey } from '../../types/QueryKey';
+import { useServicesContext } from '../../../../../app-development/common/ServiceContext';
+
+export const useInstanceIdQuery = (org: string, app: string): UseQueryResult<string> => {
+  const { getInstanceIdForPreview } = useServicesContext();
+  return useQuery(
+    [QueryKey.InstanceId, org, app],
+    () => getInstanceIdForPreview(org, app)
+  );
+};

--- a/frontend/packages/ux-editor/src/testing/mocks.tsx
+++ b/frontend/packages/ux-editor/src/testing/mocks.tsx
@@ -68,6 +68,7 @@ export const queriesMock: ServicesContextProps = {
   getEnvironments: jest.fn(),
   getFormLayoutSettings: jest.fn().mockImplementation(() => Promise.resolve(formLayoutSettingsMock)),
   getFormLayouts: jest.fn().mockImplementation(() => Promise.resolve(externalLayoutsMock)),
+  getInstanceIdForPreview: jest.fn(),
   getOrgList: jest.fn(),
   getRepoMetadata: jest.fn(),
   getRepoPull: jest.fn(),

--- a/frontend/packages/ux-editor/src/types/QueryKey.ts
+++ b/frontend/packages/ux-editor/src/types/QueryKey.ts
@@ -2,6 +2,7 @@ export enum QueryKey {
   Datamodel = 'Datamodel',
   FormLayoutSettings = 'FormLayoutSettings',
   FormLayouts = 'FormLayouts',
+  InstanceId = 'InstanceId',
   RuleConfig = 'RuleConfig',
   RuleHandler = 'RuleHandler',
   Widgets = 'Widgets',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add instanceId cache key in localstorage that holds selectedlayout from the editor so app-preview uses this to show correct page

## Related Issue(s)
- #10272 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
