### PR TITLE
Updated css in TextResourceEdit

### DIFF
--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.module.css
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.module.css
@@ -3,3 +3,7 @@
   flex-direction: column;
   gap: 2rem;
 }
+
+#textArea {
+  height: 100px;
+}

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
@@ -69,8 +69,8 @@ const TextBox = ({ language, t, textResource, textResourceId }: TextBoxProps) =>
   const { org, app } = useParams();
   const { mutate } = useUpsertTextResourcesMutation(org, app);
 
-  const updateTextResource =
-    (text: string) => mutate({ language, textResources: [{ id: textResourceId, value: text }] });
+  const updateTextResource = (text: string) =>
+    mutate({ language, textResources: [{ id: textResourceId, value: text }] });
 
   const [value, setValue] = useState<string>(textResource?.value || '');
 
@@ -81,6 +81,7 @@ const TextBox = ({ language, t, textResource, textResourceId }: TextBoxProps) =>
   return (
     <div>
       <TextArea
+        id={classes.textArea}
         label={t(`language.${language}`)}
         onBlur={(e) => updateTextResource((e.target as HTMLTextAreaElement).value)}
         onChange={(e) => setValue((e.target as HTMLTextAreaElement).value)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the size of the textBox in TextResourceEdit to be twice as large as the previous size.

## Related Issue(s)
- #10124 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
