### PR TITLE
10373 allow preview of apps with layoutsets

### DIFF
--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -349,7 +349,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <summary>
         /// Endpoint to get instance in receipt step
         /// </summary>
-        /// <returns>The processState object on the global mockInstance object</returns>
+        /// <returns>A mocked instance object</returns>
         [HttpGet]
         [Route("instances/{partyId}/{instanceGuId}")]
         public async Task<ActionResult<Instance>> InstancesForReceipt(string org, string app, [FromRoute] int partyId)
@@ -357,6 +357,20 @@ namespace Altinn.Studio.Designer.Controllers
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
             Instance mockInstance = await _previewService.GetMockInstance(org, app, developer, partyId);
             return Ok(mockInstance);
+        }
+
+        /// <summary>
+        /// Endpoint to get active instances
+        /// </summary>
+        /// <returns>A list of a single mocked instance</returns>
+        [HttpGet]
+        [Route("instances/{partyId}/active")]
+        public async Task<ActionResult<List<Instance>>> InstancesForAppsWithLayoutSets(string org, string app, [FromRoute] int partyId)
+        {
+            string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
+            Instance mockInstance = await _previewService.GetMockInstance(org, app, developer, partyId);
+            List<Instance> activeInstances = new () { mockInstance };
+            return Ok(activeInstances);
         }
 
         /// <summary>

--- a/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -36,7 +36,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         private const string LAYOUT_SETTINGS_FILENAME = "Settings.json";
         private const string APP_METADATA_FILENAME = "applicationmetadata.json";
         private const string LAYOUT_SETS_FILENAME = "layout-sets.json";
-        private const string RULE_HANDLER_FILENAME = "ruleHandler.js";
+        private const string RULE_HANDLER_FILENAME = "RuleHandler.js";
         private const string RULE_CONFIGURATION_FILENAME = "RuleConfiguration.json";
 
         private const string _layoutSettingsSchemaUrl = "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json";

--- a/backend/src/Designer/Models/LayoutSets.cs
+++ b/backend/src/Designer/Models/LayoutSets.cs
@@ -10,6 +10,6 @@ public class LayoutSets
 public class LayoutSetConfig
 {
     public string Id { get; set; }
-    public string DataTypes { get; set; }
+    public string DataType { get; set; }
     public List<string> Tasks { get; set; }
 }

--- a/backend/src/Designer/Services/Implementation/PreviewService.cs
+++ b/backend/src/Designer/Services/Implementation/PreviewService.cs
@@ -1,7 +1,10 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
+using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
+using LibGit2Sharp;
 
 namespace Altinn.Studio.Designer.Services.Implementation;
 
@@ -22,52 +25,74 @@ public class PreviewService : IPreviewService
     }
 
     /// <inherit />
-    public async Task<Application> GetApplication(string org, string app, string developer)
-    {
-        AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
-        Application mockApplicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
-        return mockApplicationMetadata;
-    }
-
-    /// <inherit />
     public async Task<Instance> GetMockInstance(string org, string app, string developer, int? instanceOwnerPartyId)
     {
         AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
         Application applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
-        DataType dataType = await GetDataTypeForTask1(org, app, developer);
+        try
+        {
+            LayoutSets layoutSets = await altinnAppGitRepository.GetLayoutSetsFile();
+            if (layoutSets.Sets is { Count: > 0 } && instanceOwnerPartyId == 51001)
+            {
+                // Convert partyId into task counter if app uses layout sets
+                instanceOwnerPartyId = 1;
+            }
+        }
+        catch (NotFoundException)
+        {
+        }
+
+        string currentTask = instanceOwnerPartyId == 51001 ? "Task_1" : ConvertTaskNumberToString(instanceOwnerPartyId);
+        DataType dataType = await GetDataTypeForTask(org, app, developer, currentTask);
         // RegEx for instance guid in app-frontend: [\da-f]{8}-[\da-f]{4}-[1-5][\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}
         string instanceGuid = "f1e23d45-6789-1bcd-8c34-56789abcdef0";
         Instance instance = new()
         {
             InstanceOwner = new InstanceOwner { PartyId = instanceOwnerPartyId == null ? "undefined" : instanceOwnerPartyId.Value.ToString() },
             Id = $"{instanceOwnerPartyId}/{instanceGuid}",
-            Data = new()
-                { new ()
-                {
-                    DataType = dataType?.Id,
-                    Id = "test-datatask-id"
-                } },
+            AppId = applicationMetadata.Id,
+            Data = new List<DataElement>
+            { new ()
+                // All data types attached to the current task in the process model should be added here
+                    {
+                        DataType = dataType?.Id,
+                        Id = "test-datatask-id"
+                    }
+                },
             Org = applicationMetadata.Org == developer ? "ttd" : applicationMetadata.Org,
             Process = new()
             {
                 CurrentTask = new()
                 {
-                    ElementId = "Task_1"
+                    AltinnTaskType = "data",
+                    ElementId = currentTask
                 }
             }
         };
         return instance;
     }
 
-    /// <inherit />
-    public async Task<DataType> GetDataTypeForTask1(string org, string app, string developer)
+    /// <summary>
+    /// Gets the datatype from application metadata that corresponds to the current data task in the process
+    /// </summary>
+    /// <param name="org">Organisation</param>
+    /// <param name="app">Repository</param>
+    /// <param name="developer">Username of developer</param>
+    /// <param name="task">Current task in process</param>
+    public async Task<DataType> GetDataTypeForTask(string org, string app, string developer, string task)
     {
-        Application mockApplicationMetadata = await GetApplication(org, app, developer);
-        if (mockApplicationMetadata.DataTypes != null && mockApplicationMetadata.DataTypes?.Count > 0)
+        AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
+        Application applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
+        if (applicationMetadata.DataTypes is { Count: > 0 })
         {
-            DataType dataType = mockApplicationMetadata.DataTypes.Find(element => !string.IsNullOrEmpty(element.AppLogic?.ClassRef) && element.TaskId == "Task_1");
+            DataType dataType = applicationMetadata.DataTypes.Find(element => !string.IsNullOrEmpty(element.AppLogic?.ClassRef) && element.TaskId == task);
             return dataType;
         }
         return null;
+    }
+
+    public string ConvertTaskNumberToString(int? currentTask)
+    {
+        return $"Task_{currentTask.ToString()}";
     }
 }

--- a/backend/src/Designer/Services/Implementation/PreviewService.cs
+++ b/backend/src/Designer/Services/Implementation/PreviewService.cs
@@ -4,7 +4,6 @@ using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
-using LibGit2Sharp;
 
 namespace Altinn.Studio.Designer.Services.Implementation;
 
@@ -42,7 +41,7 @@ public class PreviewService : IPreviewService
             { new ()
                 // All data types attached to the current task in the process model should be added here
                     {
-                        DataType = dataType.Id,
+                        DataType = dataType?.Id,
                         Id = "test-datatask-id"
                     }
                 },

--- a/backend/src/Designer/Services/Interfaces/IPreviewService.cs
+++ b/backend/src/Designer/Services/Interfaces/IPreviewService.cs
@@ -8,18 +8,23 @@ namespace Altinn.Studio.Designer.Services.Interfaces;
 /// </summary>
 public interface IPreviewService
 {
-
     /// <summary>
     /// Creates a mocked instance object with limited data needed to serve app-frontend
     /// </summary>
     /// <param name="org">Organisation</param>
     /// <param name="app">Repository</param>
     /// <param name="developer">Username of developer</param>
-    /// <param name="instanceOwnerPartyId"></param>
-    public Task<Instance> GetMockInstance(string org, string app, string developer, int? instanceOwnerPartyId);
+    /// <param name="instanceOwnerPartyId">Id for instance owner party</param>
+    /// <param name="layoutSetName">Name of current layout set to view</param>
+    public Task<Instance> GetMockInstance(string org, string app, string developer, int? instanceOwnerPartyId, string layoutSetName);
 
-    public Task<DataType> GetDataTypeForTask(string org, string app, string developer, string task);
-
-    public string ConvertTaskNumberToString(int? currentTask);
+    /// <summary>
+    /// Gets the datatype object with the datamodel name and datatype id based on the current layout set name
+    /// </summary>
+    /// <param name="org">Organisation</param>
+    /// <param name="app">Repository</param>
+    /// <param name="developer">Username of developer</param>
+    /// <param name="layoutSetName">Name of current layout set to view</param>
+    public Task<DataType> GetDataTypeForLayoutSetName(string org, string app, string developer, string layoutSetName);
 
 }

--- a/backend/src/Designer/Services/Interfaces/IPreviewService.cs
+++ b/backend/src/Designer/Services/Interfaces/IPreviewService.cs
@@ -8,13 +8,6 @@ namespace Altinn.Studio.Designer.Services.Interfaces;
 /// </summary>
 public interface IPreviewService
 {
-    /// <summary>
-    /// Gets the application metadata as application object from platform models
-    /// </summary>
-    /// <param name="org">Organisation</param>
-    /// <param name="app">Repository</param>
-    /// <param name="developer">Username of developer</param>
-    public Task<Application> GetApplication(string org, string app, string developer);
 
     /// <summary>
     /// Creates a mocked instance object with limited data needed to serve app-frontend
@@ -25,13 +18,8 @@ public interface IPreviewService
     /// <param name="instanceOwnerPartyId"></param>
     public Task<Instance> GetMockInstance(string org, string app, string developer, int? instanceOwnerPartyId);
 
-    /// <summary>
-    /// Gets the datatype from application metadata that corresponds to the process Task_1
-    /// which is default task id for apps without layoutset
-    /// </summary>
-    /// <param name="org"></param>
-    /// <param name="app"></param>
-    /// <param name="developer"></param>
-    /// <returns></returns>
-    public Task<DataType> GetDataTypeForTask1(string org, string app, string developer);
+    public Task<DataType> GetDataTypeForTask(string org, string app, string developer, string task);
+
+    public string ConvertTaskNumberToString(int? currentTask);
+
 }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerBase.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerBase.cs
@@ -4,6 +4,7 @@ using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Mocks;
 using Designer.Tests.Utils;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -12,7 +13,6 @@ namespace Designer.Tests.Controllers.PreviewController
     public class PreviewControllerTestsBase<TControllerTestType> : ApiTestsBase<Altinn.Studio.Designer.Controllers.PreviewController, TControllerTestType>, IDisposable
         where TControllerTestType : class
     {
-        protected static string VersionPrefix(string org, string repository) => $"/designer/api/{org}/{repository}";
         protected string CreatedFolderPath { get; set; }
 
         public void Dispose()

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTests.cs
@@ -11,14 +11,12 @@ using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.Models;
 using Designer.Tests.Utils;
-using Fare;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Newtonsoft.Json;
 using SharedResources.Tests;
 using Xunit;
-using YamlDotNet.Core;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 using TextResource = Altinn.Studio.Designer.Models.TextResource;
 
@@ -31,8 +29,8 @@ namespace Designer.Tests.Controllers.PreviewController
         private const string StatefulApp = "app-with-layoutsets";
         private const string Developer = "testUser";
         private const string LayoutSetName = "layoutSet1";
+        private const string LayoutSetName2 = "layoutSet2";
         private const string PartyId = "51001";
-        private const string PartyIdAsTaskCounter = "1";
         private const string InstanceGuId = "f1e23d45-6789-1bcd-8c34-56789abcdef0";
         private readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions()
         {
@@ -216,6 +214,7 @@ namespace Designer.Tests.Controllers.PreviewController
 
             string dataPathWithData = $"{Org}/{targetRepository}/instances?instanceOwnerPartyId=51001";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={App}&selectedLayoutSetInEditor=");
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
@@ -235,6 +234,7 @@ namespace Designer.Tests.Controllers.PreviewController
 
             string dataPathWithData = $"{Org}/{targetRepository}/instances?instanceOwnerPartyId=51001";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={StatefulApp}&selectedLayoutSetInEditor={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
@@ -253,6 +253,8 @@ namespace Designer.Tests.Controllers.PreviewController
 
             string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={App}&selectedLayoutSetInEditor=");
+
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
 
@@ -265,6 +267,8 @@ namespace Designer.Tests.Controllers.PreviewController
         {
             string dataPathWithData = $"{Org}/empty-app/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={App}&selectedLayoutSetInEditor=");
+
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
 
@@ -277,8 +281,10 @@ namespace Designer.Tests.Controllers.PreviewController
         {
             string expectedFormData = TestDataHelper.GetFileFromRepo(Org, StatefulApp, Developer, "App/models/datamodel.schema.json");
 
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyIdAsTaskCounter}/{InstanceGuId}/data/test-datatask-id";
+            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={StatefulApp}&selectedLayoutSetInEditor={LayoutSetName}");
+
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
 
@@ -289,14 +295,15 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_FormDataForStatefulAppForTaskWithoutDatamodel_Ok()
         {
-            string newTaskCounter = (Int32.Parse(PartyIdAsTaskCounter) + 1).ToString();
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{newTaskCounter}/{InstanceGuId}/data/test-datatask-id";
+            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={StatefulApp}&selectedLayoutSetInEditor={LayoutSetName2}");
+
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            responseBody.Should().Be($"{newTaskCounter}/{InstanceGuId}");
+            responseBody.Should().Be($"{PartyId}/{InstanceGuId}");
         }
 
         [Fact]
@@ -304,6 +311,7 @@ namespace Designer.Tests.Controllers.PreviewController
         {
             string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Put, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={App}&selectedLayoutSetInEditor=");
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
@@ -314,6 +322,7 @@ namespace Designer.Tests.Controllers.PreviewController
         {
             string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/process";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={App}&selectedLayoutSetInEditor=");
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
@@ -328,8 +337,9 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_ProcessForStatefulApp_Ok()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyIdAsTaskCounter}/{InstanceGuId}/process";
+            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/process";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={StatefulApp}&selectedLayoutSetInEditor={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
@@ -342,10 +352,11 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
-        public async Task Get_InstanceForReceipt_Ok()
+        public async Task Get_InstanceForNextProcess_Ok()
         {
             string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={App}&selectedLayoutSetInEditor=");
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
@@ -360,9 +371,9 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_InstanceForNextTaskForStatefulApp_Ok_TaskIsIncreased()
         {
-            string newTaskCounter = (Int32.Parse(PartyIdAsTaskCounter) + 1).ToString();
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyIdAsTaskCounter}/{InstanceGuId}";
+            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={StatefulApp}&selectedLayoutSetInEditor={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
@@ -370,9 +381,9 @@ namespace Designer.Tests.Controllers.PreviewController
             string responseBody = await response.Content.ReadAsStringAsync();
             JsonDocument responseDocument = JsonDocument.Parse(responseBody);
             Instance instance = JsonConvert.DeserializeObject<Instance>(responseDocument.RootElement.ToString());
-            Assert.Equal($"{newTaskCounter}/{InstanceGuId}", instance.Id);
+            Assert.Equal($"{PartyId}/{InstanceGuId}", instance.Id);
             Assert.Equal("ttd", instance.Org);
-            Assert.Equal("Task_2", instance.Process.CurrentTask.ElementId);
+            Assert.Equal("Task_1", instance.Process.CurrentTask.ElementId);
         }
 
         [Fact]
@@ -380,6 +391,7 @@ namespace Designer.Tests.Controllers.PreviewController
         {
             string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/process/next";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={App}&selectedLayoutSetInEditor=");
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
@@ -394,8 +406,9 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_ProcessNextForStatefulApp_Ok()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyIdAsTaskCounter}/{InstanceGuId}/process/next";
+            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/process/next";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={StatefulApp}&selectedLayoutSetInEditor={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
@@ -404,7 +417,7 @@ namespace Designer.Tests.Controllers.PreviewController
             JsonDocument responseDocument = JsonDocument.Parse(responseBody);
             ProcessState processState = JsonConvert.DeserializeObject<ProcessState>(responseDocument.RootElement.ToString());
             Assert.Equal("data", processState.CurrentTask.AltinnTaskType);
-            Assert.Equal("Task_2", processState.CurrentTask.ElementId);
+            Assert.Equal("Task_1", processState.CurrentTask.ElementId);
         }
 
         [Fact]
@@ -412,6 +425,7 @@ namespace Designer.Tests.Controllers.PreviewController
         {
             string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/process/next";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Put, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={App}&selectedLayoutSetInEditor=");
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
@@ -423,15 +437,18 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Put_ProcessNextForStatefulAppForNonExistingTask_Ok()
         {
-            string newTaskCounter = (Int32.Parse(PartyIdAsTaskCounter) + 2).ToString();
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{newTaskCounter}/{InstanceGuId}/process/next";
+            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/process/next";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Put, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"http://studio.localhost/designer/html/preview.html?org={Org}&app={StatefulApp}&selectedLayoutSetInEditor={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            Assert.Equal(@"{""ended"": ""ended""}", responseBody);
+            JsonDocument responseDocument = JsonDocument.Parse(responseBody);
+            ProcessState processState = JsonConvert.DeserializeObject<ProcessState>(responseDocument.RootElement.ToString());
+            Assert.Equal("data", processState.CurrentTask.AltinnTaskType);
+            Assert.Equal("Task_1", processState.CurrentTask.ElementId);
         }
 
         [Fact]
@@ -520,13 +537,27 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_RuleHandlerForStatefulAppWithRuleHandler_Ok()
         {
-            string layoutSetName2 = "layoutSet2";
-
-            string dataPathWithData = $"{Org}/{StatefulApp}/api/rulehandler/{layoutSetName2}";
+            string dataPathWithData = $"{Org}/{StatefulApp}/api/rulehandler/{LayoutSetName2}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Get_RuleConfiguration_Ok()
+        {
+            string appwithRuleConfig = "app-without-layoutsets";
+            string expectedRuleConfig = TestDataHelper.GetFileFromRepo(Org, appwithRuleConfig, Developer, "App/ui/RuleConfiguration.json");
+
+            string dataPathWithData = $"{Org}/{appwithRuleConfig}/api/resource/RuleConfiguration.json";
+            using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
+            Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonUtils.DeepEquals(expectedRuleConfig, responseBody).Should().BeTrue();
         }
 
         [Fact]
@@ -552,14 +583,16 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_RuleConfigurationForStatefulAppWithRuleConfig_Ok()
         {
-            string layoutSetName2 = "layoutSet2";
-            string expectedRuleConfig = TestDataHelper.GetFileFromRepo(Org, StatefulApp, Developer, $"App/ui/{layoutSetName2}layouts/RuleConfiguration.json");
+            string expectedRuleConfig = TestDataHelper.GetFileFromRepo(Org, StatefulApp, Developer, $"App/ui/{LayoutSetName2}/RuleConfiguration.json");
 
-            string dataPathWithData = $"{Org}/{StatefulApp}/api/ruleconfiguration/{layoutSetName2}";
+            string dataPathWithData = $"{Org}/{StatefulApp}/api/ruleconfiguration/{LayoutSetName2}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.Value.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonUtils.DeepEquals(expectedRuleConfig, responseBody).Should().BeTrue();
         }
 
         [Fact]

--- a/backend/tests/Designer.Tests/Infrastructure/GitRepository/AltinnAppGitRepositoryTests.cs
+++ b/backend/tests/Designer.Tests/Infrastructure/GitRepository/AltinnAppGitRepositoryTests.cs
@@ -282,7 +282,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
         public Task GetOptionListIds_WithAppThatHasNoOptionLists_ShouldThrowNotFoundException()
         {
             string org = "ttd";
-            string repository = "app-with-layoutsets";
+            string repository = "empty-app";
             string developer = "testUser";
             AltinnAppGitRepository altinnAppGitRepository = PrepareRepositoryForTest(org, repository, developer);
             Assert.Throws<LibGit2Sharp.NotFoundException>(altinnAppGitRepository.GetOptionListIds);

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/config/applicationmetadata.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/config/applicationmetadata.json
@@ -1,0 +1,50 @@
+{
+    "id": "ttd/app-with-layoutsets",
+    "org": "ttd",
+    "title": {
+        "nb": "app-with-layoutsets"
+    },
+    "dataTypes": [
+        {
+            "id": "datamodel",
+            "allowedContentTypes": [
+                "application/xml"
+            ],
+            "appLogic": {
+                "autoCreate": true,
+                "classRef": "Altinn.App.Models.datamodel"
+            },
+            "taskId": "Task_1",
+            "maxCount": 1,
+            "minCount": 1
+        },
+        {
+            "id": "fileUpload-message",
+            "taskId": "Task_1",
+            "maxSize": 5,
+            "maxCount": 3,
+            "minCount": 0
+        },
+        {
+            "id": "fileUploadWithTags-changename",
+            "taskId": "Task_2",
+            "maxSize": 5,
+            "maxCount": 3,
+            "minCount": 0
+        }
+    ],
+    "partyTypesAllowed": {
+        "bankruptcyEstate": false,
+        "organisation": false,
+        "person": false,
+        "subUnit": false
+    },
+    "autoDeleteOnProcessEnd": false,
+    "onEntry": {
+        "show": "select-instance"
+    },
+    "created": "2021-02-06T15:18:12.2060944Z",
+    "createdBy": "jeeva",
+    "lastChanged": "2021-02-06T15:18:12.2062288Z",
+    "lastChangedBy": "jeeva"
+}

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/models/datamodel.schema.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/models/datamodel.schema.json
@@ -1,0 +1,184 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "schema.json",
+    "type": "object",
+    "@xsdNamespaces": {
+        "xsd": "http://www.w3.org/2001/XMLSchema"
+    },
+    "@xsdSchemaAttributes": {
+        "AttributeFormDefault": "Unqualified",
+        "ElementFormDefault": "Qualified",
+        "BlockDefault": "None",
+        "FinalDefault": "None"
+    },
+    "@xsdRootElement": "InnflytterSkjema",
+    "oneOf": [
+        {
+            "$ref": "#/$defs/Skjema"
+        }
+    ],
+    "$defs": {
+        "Skjema": {
+            "properties": {
+                "Innflytter": {
+                    "$ref": "#/$defs/Innflytter",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                }
+            },
+            "required": [
+                "Innflytter"
+            ]
+        },
+        "Innflytter": {
+            "properties": {
+                "Fornavn": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Etternavn": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Mellomnavn": {
+                    "@xsdType": "string",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "@xsdMinOccurs": 0,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Alder": {
+                    "@xsdType": "integer",
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "@xsdMinOccurs": 0,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Arbeidsinformasjon": {
+                    "$ref": "#/$defs/Arbeidsinformasjon",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "KanBrukeSkjema": {
+                    "@xsdType": "boolean",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "TidligereBosteder": {
+                    "minItems": 1,
+                    "maxItems": 10,
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Adresse"
+                    },
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "10"
+                },
+                "Adresse": {
+                    "$ref": "#/$defs/Adresse",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Kontaktinformasjon": {
+                    "$ref": "#/$defs/Kontaktinformasjon",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                }
+            },
+            "required": [
+                "Fornavn",
+                "Etternavn",
+                "Arbeidsinformasjon",
+                "KanBrukeSkjema",
+                "TidligereBosteder",
+                "Adresse",
+                "Kontaktinformasjon"
+            ]
+        },
+        "Adresse": {
+            "properties": {
+                "Gateadresse": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Postnr": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Poststed": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                }
+            },
+            "required": [
+                "Gateadresse",
+                "Postnr",
+                "Poststed"
+            ]
+        },
+        "Kontaktinformasjon": {
+            "properties": {
+                "Telefonnummer": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Epost": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                }
+            },
+            "required": [
+                "Telefonnummer",
+                "Epost"
+            ]
+        },
+        "Arbeidsinformasjon": {
+            "properties": {
+                "Sektor": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                },
+                "Bransje": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 0,
+                    "@xsdMaxOccurs": "1"
+                },
+                "AarIArbeidslivet": {
+                    "@xsdType": "string",
+                    "type": "string",
+                    "@xsdMinOccurs": 1,
+                    "@xsdMaxOccurs": "1"
+                }
+            },
+            "required": [
+                "Sektor",
+                "AarIArbeidslivet"
+            ]
+        }
+    }
+}

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/options/test-options.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/options/test-options.json
@@ -1,0 +1,10 @@
+[
+    {
+        "label": "label1",
+        "value": "value1"
+    },
+    {
+        "label": "label2",
+        "value": "value2"
+    }
+]

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layout-sets.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layout-sets.json
@@ -9,7 +9,7 @@
         },
         {
             "id": "layoutSet2",
-            "dataType": "data-model-2",
+            "dataType": null,
             "tasks": [
                 "Task_2"
             ]

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layout-sets.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layout-sets.json
@@ -2,7 +2,7 @@
     "sets": [
         {
             "id": "layoutSet1",
-            "dataType": "data-model-1",
+            "dataType": "datamodel",
             "tasks": [
                 "Task_1"
             ]

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layoutSet2/RuleConfiguration.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layoutSet2/RuleConfiguration.json
@@ -1,0 +1,56 @@
+{
+    "data": {
+        "ruleConnection": {},
+        "conditionalRendering": {
+            "22c73880-5c97-11ea-a95f-056c5a78cd14": {
+                "selectedFunction": "biggerThan10",
+                "inputParams": {
+                    "number": "Endringsmelding-grp-9786.OversiktOverEndringene-grp-9788[0].SkattemeldingEndringEtterFristNyttBelop-datadef-37132.value"
+                },
+                "selectedAction": "Hide",
+                "selectedFields": {
+                    "22c67530-5c97-11ea-a95f-056c5a78cd14": "summary-1",
+                    "22c67530-5c97-11ea-a95f-056c5a78cd15": "summary-2"
+                }
+            },
+            "hide-repeating-group": {
+                "selectedFunction": "showGroup",
+                "inputParams": {
+                    "value": "Endringsmelding-grp-9786.Avgiver-grp-9787.KontaktpersonEPost-datadef-27688.value"
+                },
+                "selectedAction": "Show",
+                "selectedFields": {
+                    "22c67530-5c97-11ea-a95f-056c5a78cd14": "mainGroup"
+                }
+            },
+            "hide-extra-options": {
+                "selectedFunction": "showExtraOptions",
+                "inputParams": {
+                    "value": "Endringsmelding-grp-9786.OversiktOverEndringene-grp-9788{0}.nested-grp-1234{1}.extraOptionsToggle"
+                },
+                "selectedAction": "Show",
+                "selectedFields": {
+                    "abc123": "nestedOptions{0}{1}"
+                },
+                "repeatingGroup": {
+                    "groupId": "mainGroup",
+                    "childGroupId": "subGroup"
+                }
+            },
+            "hide-comment-field": {
+                "selectedFunction": "hideCommentField",
+                "inputParams": {
+                    "value": "Endringsmelding-grp-9786.OversiktOverEndringene-grp-9788{0}.nested-grp-1234{1}.hideComment"
+                },
+                "selectedAction": "Hide",
+                "selectedFields": {
+                    "abc123": "comments{0}{1}"
+                },
+                "repeatingGroup": {
+                    "groupId": "mainGroup",
+                    "childGroupId": "subGroup"
+                }
+            }
+        }
+    }
+}

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layoutSet2/RuleHandler.js
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layoutSet2/RuleHandler.js
@@ -1,0 +1,63 @@
+var ruleHandlerObject = {
+    sum: (obj) => {
+        obj.a = obj.a ? +obj.a : 0;
+        obj.b = obj.b ? +obj.b : 0;
+        return obj.a + obj.b;
+    },
+
+    fullName: (obj) => {
+        return obj.first + ' ' + obj.last;
+    }
+}
+var ruleHandlerHelper = {
+    fullName: () => {
+        return {
+            first: "first name",
+            last: "last name"
+        };
+    },
+
+    sum: () => {
+        return {
+            a: "a",
+            b: "b",
+        }
+    }
+}
+
+var conditionalRuleHandlerObject = {
+    biggerThan10: (obj) => {
+        obj.number = +obj.number;
+        return obj.number > 10;
+    },
+
+    smallerThan10: (obj) => {
+        obj.number = +obj.number;
+        return obj.number > 10;
+    },
+
+    lengthBiggerThan4: (obj) => {
+        if (obj.value == null) return false;
+        return obj.value.length >= 4;
+    }
+}
+var conditionalRuleHandlerHelper = {
+    biggerThan10: () => {
+        return {
+            number: "number"
+        };
+    },
+
+    smallerThan10: () => {
+        return {
+            number: "number"
+        }
+    },
+
+    lengthBiggerThan4: () => {
+        return {
+            value: "value"
+        }
+    }
+
+}

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-without-layoutsets/App/ui/RuleConfiguration.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-without-layoutsets/App/ui/RuleConfiguration.json
@@ -1,0 +1,56 @@
+{
+    "data": {
+        "ruleConnection": {},
+        "conditionalRendering": {
+            "22c73880-5c97-11ea-a95f-056c5a78cd14": {
+                "selectedFunction": "biggerThan10",
+                "inputParams": {
+                    "number": "Endringsmelding-grp-9786.OversiktOverEndringene-grp-9788[0].SkattemeldingEndringEtterFristNyttBelop-datadef-37132.value"
+                },
+                "selectedAction": "Hide",
+                "selectedFields": {
+                    "22c67530-5c97-11ea-a95f-056c5a78cd14": "summary-1",
+                    "22c67530-5c97-11ea-a95f-056c5a78cd15": "summary-2"
+                }
+            },
+            "hide-repeating-group": {
+                "selectedFunction": "showGroup",
+                "inputParams": {
+                    "value": "Endringsmelding-grp-9786.Avgiver-grp-9787.KontaktpersonEPost-datadef-27688.value"
+                },
+                "selectedAction": "Show",
+                "selectedFields": {
+                    "22c67530-5c97-11ea-a95f-056c5a78cd14": "mainGroup"
+                }
+            },
+            "hide-extra-options": {
+                "selectedFunction": "showExtraOptions",
+                "inputParams": {
+                    "value": "Endringsmelding-grp-9786.OversiktOverEndringene-grp-9788{0}.nested-grp-1234{1}.extraOptionsToggle"
+                },
+                "selectedAction": "Show",
+                "selectedFields": {
+                    "abc123": "nestedOptions{0}{1}"
+                },
+                "repeatingGroup": {
+                    "groupId": "mainGroup",
+                    "childGroupId": "subGroup"
+                }
+            },
+            "hide-comment-field": {
+                "selectedFunction": "hideCommentField",
+                "inputParams": {
+                    "value": "Endringsmelding-grp-9786.OversiktOverEndringene-grp-9788{0}.nested-grp-1234{1}.hideComment"
+                },
+                "selectedAction": "Hide",
+                "selectedFields": {
+                    "abc123": "comments{0}{1}"
+                },
+                "repeatingGroup": {
+                    "groupId": "mainGroup",
+                    "childGroupId": "subGroup"
+                }
+            }
+        }
+    }
+}

--- a/frontend/app-preview/src/views/LandingPage.tsx
+++ b/frontend/app-preview/src/views/LandingPage.tsx
@@ -17,6 +17,8 @@ export const LandingPage = () => {
   const selectedLayoutInEditor = localStorage.getItem(instanceId);
   const localSelectedViewSize = localStorage.getItem('viewSize');
   const [viewSize, setViewSize] = useState<string>(localSelectedViewSize ?? 'desktop');
+  const selectedLayoutSetInEditor = localStorage.getItem('layoutSetName');
+
 
   const isIFrame = (input: HTMLElement | null): input is HTMLIFrameElement =>
     input !== null && input.tagName === 'IFRAME';
@@ -70,7 +72,7 @@ export const LandingPage = () => {
           <iframe
             title={t('preview.iframe_title')}
             id='app-frontend-react-iframe'
-            src={`/designer/html/preview.html?${stringify({ org, app })}`}
+            src={`/designer/html/preview.html?${stringify({ org, app, selectedLayoutSetInEditor })}`}
             className={viewSize === 'desktop' ? classes.iframeDesktop : classes.iframeMobile}
           ></iframe>
           {viewSize === 'mobile' && <div className={classes.iframeMobileViewOverlay}></div>}

--- a/frontend/packages/ux-editor/src/App.tsx
+++ b/frontend/packages/ux-editor/src/App.tsx
@@ -101,6 +101,7 @@ export function App() {
 
   useEffect(() => {
     localStorage.setItem(instanceId, selectedLayout);
+    localStorage.setItem('layoutSetName', '');
   }, [selectedLayout, instanceId]);
 
   if (componentHasError) {

--- a/frontend/packages/ux-editor/src/App.tsx
+++ b/frontend/packages/ux-editor/src/App.tsx
@@ -101,6 +101,7 @@ export function App() {
 
   useEffect(() => {
     localStorage.setItem(instanceId, selectedLayout);
+    // get default based on app being stateless or not: stateless --> '', stateful --> first layoutset in layoutsets.json
     localStorage.setItem('layoutSetName', '');
   }, [selectedLayout, instanceId]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add mocked endpoints to handle process changes in stateful apps (aka apps with layoutsets)
- Add `selectedlayoutsetineditor` to localstorage in editor in order to fetch this value in preview and add it to the url in order to fetch this in the mocked backend through the referer header in the requests from app-frontend

## Related Issue(s)
- #2058 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
