### PR TITLE
Check if layout is receipt and avoid adding/removing nav-button if so

### DIFF
--- a/frontend/packages/ux-editor/src/utils/formLayoutsUtils.test.ts
+++ b/frontend/packages/ux-editor/src/utils/formLayoutsUtils.test.ts
@@ -143,6 +143,42 @@ describe('formLayoutsUtils', () => {
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith(layoutId, updatedLayouts[layoutId]);
     });
+
+    it('Does not add navigation buttons to layout if additional layout is receipt', async () => {
+      const layoutId = 'layout1';
+      const layoutReceiptId = 'receipt';
+      const callback = jest.fn();
+      const navButtonsId = 'navButtons';
+      const navButtonsComponent: FormButtonComponent = {
+        id: navButtonsId,
+        itemType: 'COMPONENT',
+        onClickAction: jest.fn(),
+        type: ComponentType.NavigationButtons,
+        dataModelBindings: {},
+      };
+      const layouts: IFormLayouts = {
+        [layoutId]: {
+          components: { [navButtonsId]: navButtonsComponent },
+          containers: { [BASE_CONTAINER_ID]: { itemType: 'CONTAINER' } },
+          order: { [BASE_CONTAINER_ID]: [navButtonsId] },
+          customRootProperties: {},
+          customDataProperties: {},
+        },
+        [layoutReceiptId]: createEmptyLayout(),
+      };
+      const updatedLayouts = await addOrRemoveNavigationButtons(
+        layouts,
+        callback,
+        null,
+        layoutReceiptId
+      );
+      const layout1Components = Object.values(updatedLayouts[layoutId].components);
+      const layoutReceiptComponents = Object.values(updatedLayouts[layoutReceiptId].components);
+      expect(layout1Components.length).toBe(0);
+      expect(layoutReceiptComponents.length).toBe(0);
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(layoutId, updatedLayouts[layoutId]);
+    });
   });
 
   describe('convertExternalLayoutsToInternalFormat', () => {

--- a/frontend/packages/ux-editor/src/utils/formLayoutsUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/formLayoutsUtils.ts
@@ -54,7 +54,7 @@ export const addOrRemoveNavigationButtons = async (
     if (currentLayoutName) {
       // Add navigation buttons to the current layout if they are not present, and run callback
       let currentLayout = layouts[currentLayoutName];
-      if (!hasNavigationButtons(currentLayout)) {
+      if (!hasNavigationButtons(currentLayout) && currentLayoutName !== receiptLayoutName){
         const navButtonsId = generateComponentId(ComponentType.NavigationButtons, layouts);
         currentLayout = addNavigationButtons(currentLayout, navButtonsId);
         updatedLayouts[currentLayoutName] = currentLayout;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add a check if layout is receipt page, when going through all layouts, and avoid adding/removing nav-button if check is true.

## Related Issue(s)
- #10401 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
