### PR TITLE
reduce from 10 to 2 minutes

### DIFF
--- a/backend/src/Designer/Controllers/ReleasesController.cs
+++ b/backend/src/Designer/Controllers/ReleasesController.cs
@@ -47,7 +47,7 @@ namespace Altinn.Studio.Designer.Controllers
         {
             SearchResults<ReleaseEntity> releases = await _releaseService.GetAsync(org, app, query);
 
-            List<ReleaseEntity> laggingReleases = releases.Results.Where(d => d.Build.Status.Equals(BuildStatus.InProgress) && d.Build.Started.Value.AddMinutes(10) < DateTime.UtcNow).ToList();
+            List<ReleaseEntity> laggingReleases = releases.Results.Where(d => d.Build.Status.Equals(BuildStatus.InProgress) && d.Build.Started.Value.AddMinutes(2) < DateTime.UtcNow).ToList();
 
             foreach (ReleaseEntity release in laggingReleases)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since build times rarely go above 2 minutes, and even more rarely above 3 minutes, waiting for 10 minutes before updating "lagging builds" seems excessive. Suggest we change it to 2 minutes so that user doesn't have to wait a long time for build result to be updated.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
