### PR TITLE
Fix failing Cypress test

### DIFF
--- a/frontend/packages/ux-editor/src/components/dragAndDrop/DroppableList.tsx
+++ b/frontend/packages/ux-editor/src/components/dragAndDrop/DroppableList.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useCallback } from 'react';
 import { DropTargetMonitor, useDrop } from 'react-dnd';
 import { DraggableEditorItemType, DndItem, HandleDrop } from '../../types/dndTypes';
 import classes from './DroppableList.module.css';
+import { cypressTestid } from '../../../../../testing/cypress/cypressTestid';
 
 export interface DroppableListProps {
   children: ReactNode;
@@ -36,5 +37,14 @@ export const DroppableList = ({
     }),
   });
   const backgroundColor = canBeDropped ? 'var(--list-empty-space-hover-color)' : 'transparent';
-  return <div ref={drop} style={{ backgroundColor }} className={classes.root}>{children}</div>;
+  return (
+    <div
+      className={classes.root}
+      data-testid={cypressTestid.droppableList}
+      ref={drop}
+      style={{ backgroundColor }}
+    >
+      {children}
+    </div>
+  );
 }

--- a/frontend/testing/cypress/cypressTestid.js
+++ b/frontend/testing/cypress/cypressTestid.js
@@ -1,0 +1,3 @@
+export const cypressTestid = {
+  droppableList: 'droppableList',
+}

--- a/frontend/testing/cypress/package.json
+++ b/frontend/testing/cypress/package.json
@@ -6,7 +6,7 @@
     "@faker-js/faker": "7.6.0",
     "@testing-library/cypress": "9.0.0",
     "axe-core": "4.7.1",
-    "cypress": "12.12.0",
+    "cypress": "12.13.0",
     "cypress-axe": "1.4.0",
     "cypress-plugin-tab": "1.0.5",
     "eslint": "8.41.0",

--- a/frontend/testing/cypress/src/pageobjects/designer.js
+++ b/frontend/testing/cypress/src/pageobjects/designer.js
@@ -1,4 +1,6 @@
 //Selectors in designer
+import {cypressTestid} from "../../cypressTestid";
+
 export const designer = {
   appMenu: {
     about: "[data-testid='top_menu.about']",
@@ -56,7 +58,7 @@ export const designer = {
     uiEditor: "[data-testid='leftMenu_ui-editor']",
     accessControl: "a[data-testid='leftMenu_accesscontrol']",
   },
-  dragToArea: "[data-testid='droppable-draggable-container']",
+  dragToArea: `[data-testid='${cypressTestid.droppableList}']`,
   draggable: "div[draggable='true']",
   formComponents: {
     shortAnswer: "i[class^='fa fa-short-answer']",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6736,7 +6736,7 @@ __metadata:
     "@faker-js/faker": 7.6.0
     "@testing-library/cypress": 9.0.0
     axe-core: 4.7.1
-    cypress: 12.12.0
+    cypress: 12.13.0
     cypress-axe: 1.4.0
     cypress-plugin-tab: 1.0.5
     eslint: 8.41.0
@@ -6744,9 +6744,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"cypress@npm:12.12.0":
-  version: 12.12.0
-  resolution: "cypress@npm:12.12.0"
+"cypress@npm:12.13.0":
+  version: 12.13.0
+  resolution: "cypress@npm:12.13.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -6792,7 +6792,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: 5ab0a8bc58c8af90cdb5fea93692422e6e74436ffdaeb41853e91a3fcfcdb7a39ad6ae512537bf0edf25cc3bc3732248a32e8ad3bec3440d5f527f3a3b4650b7
+  checksum: 8e73c7033dadc15caf17b106cd88665107c8bbf3ba66fc266de1f14a2c1401edfa99c222f2ae6070e1ffb8123eb255fb559dc3e5e24460fadf8e05ce74afa41b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Fixed test that was failing after the refactoring of the drag and drop functionality.

I added a new `cypressTestid` variable in which we can store test ids to get better control over them. I suggest we start adding test ids used by Cypress in this file from now on. This will also make it clear what the test id is meant for within the component.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
