### PR TITLE
remove accidentally added click on preview button

### DIFF
--- a/frontend/testing/cypress/src/integration/usecase/usecase.js
+++ b/frontend/testing/cypress/src/integration/usecase/usecase.js
@@ -48,7 +48,7 @@ context(
       cy.get(designer.texts.new).should('be.visible');
 
       // Preview
-      cy.findByRole('button', { name: designer.appMenu.previewText }).should('be.visible').click();
+      cy.findByRole('button', { name: designer.appMenu.previewText }).should('be.visible');
       cy.visit('/preview/' + Cypress.env('deployApp'));
       cy.get(`a[href^="/editor/${Cypress.env('deployApp')}"]`)
         .should('be.visible')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This was fixed previously, but accidentally added it back with recent cypress test updates.
Preview button should not be clicked as it opens a new window which occasionally causes cypress to freak out. The test visits the preview page without clicking to make sure that it is available.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
