### PR TITLE
Exclude group components from group table headers list

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/EditFormContainer.tsx
+++ b/frontend/packages/ux-editor/src/components/config/EditFormContainer.tsx
@@ -204,12 +204,14 @@ export const EditFormContainer = ({
           {items.length > 0 && (
             <CheckboxGroup
               error={tableHeadersError}
-              items={items.map((id) => ({
-                label: getTextResource(components[id].textResourceBindings?.title, textResources),
-                name: id,
-                checked:
-                  container.tableHeaders === undefined || container.tableHeaders.includes(id),
-              }))}
+              items={items
+                .filter((id) => !!components[id])
+                .map((id) => ({
+                  label: getTextResource(components[id].textResourceBindings?.title, textResources),
+                  name: id,
+                  checked:
+                    container.tableHeaders === undefined || container.tableHeaders.includes(id),
+                }))}
               legend={t('ux_editor.modal_properties_group_table_headers')}
               onChange={handleTableHeadersChange}
             />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Group component config fails for repeating groups which contain other groups.
The issue was that we try to get all the group's child _components_ to present in a checklist for which headings should be part of the repeating groups table.
However, any _Group_ components are not part of the `components` list. Also, group components should probably not be part of the table heading anyways.
Fix for now is to filter child components so that we only include components that are not a "Group" type.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
