### PR TITLE
10389 policy editor

### DIFF
--- a/frontend/resourceadm/app/App.tsx
+++ b/frontend/resourceadm/app/App.tsx
@@ -8,6 +8,8 @@ import { ResourceDashboard } from '../pages/ResourceDashboard';
 import { RessurstilgangSide1 } from '../pages/RessurstilgangSide1';
 import { OlsenbandenPage } from '../pages/OlsenbandenPage';
 import { TestPage } from '../pages/TestPage';
+import { PolicyEditorStartPage } from 'resourceadm/pages/PolicyEditorStartPage';
+import { PolicyEditor } from 'resourceadm/pages/PolicyEditor';
 
 import { Route, Routes } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -17,9 +19,7 @@ import { useOrganizationsQuery } from '../hooks/queries';
 
 import { ErrorMessage } from 'resourceadm/components/ErrorMessage';
 
-
 export const App = (): JSX.Element => {
-
   const { t } = useTranslation();
 
   const { data: user, isError: isUserError } = useUserQuery();
@@ -58,19 +58,26 @@ export const App = (): JSX.Element => {
     return (
       <div className={classes.root}>
         <Routes>
-
-        <Route element={ <TestPage /> } >
-            <Route path='/' element={ <ResourceDashboard user = {user} organizations={organizations} /> } />
+          <Route element={<TestPage />}>
+            <Route
+              path='/'
+              element={<ResourceDashboard user={user} organizations={organizations} />}
+            />
           </Route>
 
           <Route element={<PageLayout />}>
-            <Route path='/skatt/repo1'  element={ <ResourceDashboard user = {user} organizations={organizations} /> } />
+            <Route
+              path='/skatt/repo1'
+              element={<ResourceDashboard user={user} organizations={organizations} />}
+            />
           </Route>
 
-          <Route path='/skatt/dummy1' element={ <RessurstilgangSide1 /> } />
+          <Route path='/skatt/dummy1' element={<RessurstilgangSide1 />} />
 
-          <Route path='/olsenbanden' element={ <OlsenbandenPage /> } />
+          <Route path='/olsenbanden' element={<OlsenbandenPage />} />
 
+          <Route path='/PolicyEditorStartPage' element={<PolicyEditorStartPage />} />
+          <Route path='/policyEditor' element={<PolicyEditor />} />
         </Routes>
       </div>
     );

--- a/frontend/resourceadm/components/CardButton/CardButton.module.css
+++ b/frontend/resourceadm/components/CardButton/CardButton.module.css
@@ -1,0 +1,17 @@
+.button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+  margin: 0;
+  background-color: #FFFFFF;
+  border-radius: 12px;
+  border: solid 1px #D9D9D9;
+  cursor: pointer;
+}
+
+.buttonText {
+  font-size: 16px;
+  font-weight: 500;
+}

--- a/frontend/resourceadm/components/CardButton/CardButton.tsx
+++ b/frontend/resourceadm/components/CardButton/CardButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import classes from './CardButton.module.css';
+import { PlusIcon } from '@navikt/aksel-icons';
+
+interface Props {
+  buttonText: string;
+  onClick: () => void;
+}
+
+/**
+ * Button component that displays a text and a plus icon.
+ *
+ * @param props.buttonText text to display on the button
+ * @param props.onClick function for handling the button click
+ *
+ * TODO - Translate
+ */
+export const CardButton = ({ buttonText, onClick }: Props) => {
+  return (
+    <button className={classes.button} type='button' onClick={onClick}>
+      <p className={classes.buttonText}>{buttonText}</p>
+      <PlusIcon title='Add rule' fontSize='1.4rem' />
+    </button>
+  );
+};

--- a/frontend/resourceadm/components/CardButton/index.ts
+++ b/frontend/resourceadm/components/CardButton/index.ts
@@ -1,0 +1,1 @@
+export { CardButton } from './CardButton'

--- a/frontend/resourceadm/components/Chip/Chip.module.css
+++ b/frontend/resourceadm/components/Chip/Chip.module.css
@@ -1,0 +1,46 @@
+.chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #FFFFFF;
+  border-radius: 50px;
+  border: 1px solid #000000;
+  padding-inline: 12px;
+  padding-block: 5px;
+  width: fit-content;
+  cursor: pointer;
+  margin-right: 8px;
+  margin-bottom: 8px;
+}
+
+.chipSelected {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #E3F7FF;
+  border-radius: 50px;
+  border: 1px solid #1EAEF7;
+  padding-inline: 12px;
+  padding-block: 5px;
+  width: fit-content;
+  cursor: pointer;
+  margin-right: 8px;
+  margin-bottom: 8px;
+}
+
+.chip:hover, .chipSelected:hover {
+  background-color: #00315D;
+  color: #FFFFFF;
+  border: 1px solid #00315D;
+}
+
+.chip:focus, .chipSelected:focus {
+  border: 1px solid #FFDA06;
+  /* TODO - handle when clicked and accessed with keyboard */
+}
+
+.text {
+  font-size: 12px;
+  font-weight: 400;
+  margin: 0;
+}

--- a/frontend/resourceadm/components/Chip/Chip.tsx
+++ b/frontend/resourceadm/components/Chip/Chip.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import classes from './Chip.module.css';
+
+interface Props {
+  text: string;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+/**
+ * Component that displays a button that looks like a chip.
+ *
+ * @param props.text the text to display on the chip
+ * @param props.isSelected boolean to decide the colour of the chip
+ * @param props.onClick function to handle the click on the chip
+ */
+export const Chip = ({ text, isSelected, onClick }: Props) => {
+  return (
+    <button
+      className={isSelected ? classes.chipSelected : classes.chip}
+      type='button'
+      onClick={onClick}
+    >
+      <p className={classes.text}>{text}</p>
+    </button>
+  );
+};

--- a/frontend/resourceadm/components/Chip/index.ts
+++ b/frontend/resourceadm/components/Chip/index.ts
@@ -1,0 +1,1 @@
+export { Chip } from './Chip'

--- a/frontend/resourceadm/components/ExpandablePolicyCard/ExpandablePolicyCard.module.css
+++ b/frontend/resourceadm/components/ExpandablePolicyCard/ExpandablePolicyCard.module.css
@@ -1,0 +1,50 @@
+.wrapper {
+  display: flex;
+  width: 100%;
+}
+
+.cardWrapper {
+  width: 595px;
+  min-width: 595px;
+}
+
+.ruleWarning {
+  padding: 20px;
+  color: #E02E49;
+}
+
+.subHeader {
+  font-weight: 500;
+  font-size: 16px;
+  margin-bottom: 5px;
+  margin-top: 10px;
+}
+
+.text {
+  font-weight: 400;
+  font-size: 16px;
+}
+
+.smallText {
+  font-weight: 400;
+  font-size: 12px;
+  margin: 0;
+  padding: 0;
+}
+
+.chipWrapper {
+  display: flex;
+  margin-top: 10px;
+}
+
+.textAreaWrapper {
+  margin-top: 10px;
+}
+
+.addResourceButton {
+  margin-top: 10px;
+}
+
+.warningCardWrapper {
+  margin-top: 10px;
+}

--- a/frontend/resourceadm/components/ExpandablePolicyCard/ExpandablePolicyCard.tsx
+++ b/frontend/resourceadm/components/ExpandablePolicyCard/ExpandablePolicyCard.tsx
@@ -11,7 +11,6 @@ import {
 import { PolicyRuleSubjectListItem } from '../PolicyRuleSubjectListItem';
 import { PolicySubjectSelectButton } from '../PolicySubjectSelectButton';
 import { ResourceNarrowingList } from '../ResourceNarrowingList';
-import { VerificationModal } from '../VerificationModal';
 import { WarningCard } from '../WarningCard';
 import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
 import { ExpandablePolicyElement } from '../ExpandablePolicyElement';
@@ -60,7 +59,6 @@ export const ExpandablePolicyCard = ({
   const [selectedActions, setSelectedActions] = useState(policyRule.Actions);
   const [ruleDescription, setRuleDescription] = useState(policyRule.Description);
   const [selectedSubjectTitles, setSelectedSubjectTitles] = useState(policyRule.Subject);
-  const [verificationModalOpen, setVerificationModalOpen] = useState(false);
 
   const [hasResourceError, setHasResourceError] = useState(policyRule.Resources.length === 0);
   const [hasRightsError, setHasRightsErrors] = useState(policyRule.Actions.length === 0);
@@ -344,15 +342,6 @@ export const ExpandablePolicyCard = ({
     return hasResourceError || hasRightsError || hasSubjectsError;
   };
 
-  /**
-   * Removes the rule and closes the modal
-   */
-  const handleRemoveRule = () => {
-    console.log('inside');
-    handleDeleteRule();
-    setVerificationModalOpen(false);
-  };
-
   return (
     <div className={classes.wrapper}>
       <div className={classes.cardWrapper}>
@@ -360,7 +349,7 @@ export const ExpandablePolicyCard = ({
           title={`Regel ${getPolicyRuleId()}`}
           isCard
           handleDuplicateElement={handleDuplicateRule}
-          handleRemoveElement={() => setVerificationModalOpen(true)}
+          handleRemoveElement={handleDeleteRule}
         >
           <p className={classes.subHeader}>Hvilken ressurser skal regelen gjelde for?</p>
           {displayResources}
@@ -394,14 +383,6 @@ export const ExpandablePolicyCard = ({
               rows={5}
             />
           </div>
-          <VerificationModal
-            isOpen={verificationModalOpen}
-            onClose={() => setVerificationModalOpen(false)}
-            text='Er du sikker på at du vil slette denne regelen?'
-            closeButtonText='Nei, gå tilbake'
-            actionButtonText='Ja, slett regel'
-            onPerformAction={handleRemoveRule}
-          />
         </ExpandablePolicyElement>
       </div>
       {getHasRuleError() && (

--- a/frontend/resourceadm/components/ExpandablePolicyCard/ExpandablePolicyCard.tsx
+++ b/frontend/resourceadm/components/ExpandablePolicyCard/ExpandablePolicyCard.tsx
@@ -1,0 +1,414 @@
+import React, { useState } from 'react';
+import { Button, TextArea } from '@digdir/design-system-react';
+import { Chip } from '../Chip';
+
+import classes from './ExpandablePolicyCard.module.css';
+import {
+  PolicyRuleCardType,
+  PolicyRuleResourceType,
+  PolicySubjectType,
+} from 'resourceadm/types/global';
+import { PolicyRuleSubjectListItem } from '../PolicyRuleSubjectListItem';
+import { PolicySubjectSelectButton } from '../PolicySubjectSelectButton';
+import { ResourceNarrowingList } from '../ResourceNarrowingList';
+import { VerificationModal } from '../VerificationModal';
+import { WarningCard } from '../WarningCard';
+import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
+import { ExpandablePolicyElement } from '../ExpandablePolicyElement';
+
+interface Props {
+  policyRule: PolicyRuleCardType;
+  actions: string[];
+  subjects: PolicySubjectType[];
+  rules: PolicyRuleCardType[];
+  setPolicyRules: React.Dispatch<React.SetStateAction<PolicyRuleCardType[]>>;
+  rulePosition: number;
+  resourceId: string;
+  resourceType: string;
+  handleDuplicateRule: () => void;
+  handleDeleteRule: () => void;
+}
+
+/**
+ * Component that displays a card where a user can view and update a policy rule
+ * for a resource.
+ *
+ * @param props.policyRule the rule to display in the card
+ * @param props.actions the possible actions to select from
+ * @param props.subjects the possible subjects to select from
+ * @param props.rules the list of all the rules
+ * @param props.setPolicyRules useState function to update the list of rules
+ * @param props.rulePosition the position of the rule in the rule array
+ * @param props.resourceId the ID of the resource
+ * @param props.resourceType the type of the resource
+ * @param props.handleDuplicateRule function to be executed when clicking duplicate rule
+ * @param props.handleDeleteRule function to be executed when clicking delete rule
+ */
+export const ExpandablePolicyCard = ({
+  policyRule,
+  actions,
+  subjects,
+  rules,
+  setPolicyRules,
+  rulePosition,
+  resourceId,
+  resourceType,
+  handleDuplicateRule,
+  handleDeleteRule,
+}: Props) => {
+  const [resources, setResources] = useState<PolicyRuleResourceType[][]>(policyRule.Resources);
+  const [selectedActions, setSelectedActions] = useState(policyRule.Actions);
+  const [ruleDescription, setRuleDescription] = useState(policyRule.Description);
+  const [selectedSubjectTitles, setSelectedSubjectTitles] = useState(policyRule.Subject);
+  const [verificationModalOpen, setVerificationModalOpen] = useState(false);
+
+  const [hasResourceError, setHasResourceError] = useState(policyRule.Resources.length === 0);
+  const [hasRightsError, setHasRightsErrors] = useState(policyRule.Actions.length === 0);
+  const [hasSubjectsError, setHasSubjectsError] = useState(policyRule.Subject.length === 0);
+
+  /**
+   * Function to update the fields inside the rule object in the rule array.
+   * This function has to be called every time an element inside the card is
+   * changing so that the parent component knows that the child element is changed.
+   *
+   * @param d the description
+   * @param s the selected subjectTitle array
+   * @param a the selected actions array
+   * @param r the selected resources array
+   */
+  const updateRules = (d: string, s: string[], a: string[], r: PolicyRuleResourceType[][]) => {
+    const updatedRules = [...rules];
+    updatedRules[rulePosition] = {
+      ...updatedRules[rulePosition],
+      Description: d,
+      Subject: s,
+      Actions: a,
+      Resources: r,
+    };
+    setPolicyRules(updatedRules);
+  };
+
+  /**
+   * Maps the subject objects to option objects for display in the select component
+   */
+  const getSubjectOptions = () => {
+    return subjects
+      .filter((s) => !selectedSubjectTitles.includes(s.SubjectTitle))
+      .map((s) => ({ value: s.SubjectTitle, label: s.SubjectTitle }));
+  };
+  const [subjectOptions, setSubjectOptions] = useState(getSubjectOptions());
+
+  /**
+   * Gets the id of the policy
+   */
+  const getPolicyRuleId = () => {
+    return policyRule.RuleId.toString();
+  };
+
+  /**
+   * Handles the changes in the input fields inside the resource blocks
+   *
+   * @param index the index of the element in the resource block
+   * @param field the type of textfield to update
+   * @param value the value types in the textfield
+   * @param resourceIndex the index of the resource block
+   */
+  const handleInputChange = (
+    index: number,
+    field: 'id' | 'type',
+    value: string,
+    resourceIndex: number
+  ) => {
+    const updatedResources = [...resources];
+    updatedResources[resourceIndex][index] = {
+      ...updatedResources[resourceIndex][index],
+      [field]: value,
+    };
+
+    setResources(updatedResources);
+    updateRules(ruleDescription, selectedSubjectTitles, selectedActions, updatedResources);
+  };
+
+  /**
+   * Adds a resource block to the list of resources. The first element in the
+   * resource block is set to the resource's ID and type.
+   */
+  const handleClickAddResource = () => {
+    const newResource: PolicyRuleResourceType[] = [
+      {
+        type: resourceType,
+        id: resourceId,
+      },
+    ];
+
+    const updatedResources = [...resources, newResource];
+    setResources(updatedResources);
+    updateRules(ruleDescription, selectedSubjectTitles, selectedActions, updatedResources);
+
+    // TODO - Display Error when fields are empty???
+    setHasResourceError(false);
+  };
+
+  /**
+   * Displays a list of resource blocks, which each contains a list of the resources
+   * and the list narrowing down the elements.
+   */
+  const displayResources = resources.map((r, i) => {
+    return (
+      <ResourceNarrowingList
+        key={i}
+        resources={r}
+        handleInputChange={(narrowResourceIndex, field, s) =>
+          handleInputChange(narrowResourceIndex, field, s, i)
+        }
+        handleRemoveResource={(narrowResourceIndex) =>
+          handleRemoveNarrowingResource(narrowResourceIndex, i)
+        }
+        handleClickAddResource={() => handleClickAddResourceNarrowing(i)}
+        handleDuplicateElement={() => handleDuplicateResourceGroup(i)}
+        handleRemoveElement={() => handleDeleteResourceGroup(i)}
+      />
+    );
+  });
+
+  /**
+   * Handles the addition of more resources
+   */
+  const handleClickAddResourceNarrowing = (resourceIndex: number) => {
+    const newResource: PolicyRuleResourceType = {
+      type: '',
+      id: '',
+    };
+
+    setResources(() => {
+      const newElem = [...resources];
+      newElem[resourceIndex].push(newResource);
+      return newElem;
+    });
+  };
+
+  /**
+   * Handles the removal of the narrowed resources
+   */
+  const handleRemoveNarrowingResource = (index: number, resourceIndex: number) => {
+    const updatedResources = [...resources];
+    updatedResources[resourceIndex].splice(index, 1);
+    setResources(updatedResources);
+    updateRules(ruleDescription, selectedSubjectTitles, selectedActions, updatedResources);
+  };
+
+  /**
+   * Displays the actions
+   */
+  const displayActions = actions.map((a, i) => {
+    return (
+      <Chip
+        key={i}
+        text={a}
+        isSelected={selectedActions.includes(a)}
+        onClick={() => handleClickAction(i, a)}
+      />
+    );
+  });
+
+  /**
+   * Removes or adds an action
+   */
+  const handleClickAction = (index: number, action: string) => {
+    // If already present, remove it
+    if (selectedActions.includes(actions[index])) {
+      const updatedSelectedActions = [...selectedActions];
+      const selectedActionIndex = selectedActions.findIndex((a) => a === action);
+      updatedSelectedActions.splice(selectedActionIndex, 1);
+      setSelectedActions(updatedSelectedActions);
+      updateRules(ruleDescription, selectedSubjectTitles, updatedSelectedActions, resources);
+
+      setHasRightsErrors(updatedSelectedActions.length === 0);
+    }
+    // else add it
+    else {
+      const updatedSelectedActions = [...selectedActions];
+      updatedSelectedActions.push(action);
+      setSelectedActions(updatedSelectedActions);
+      updateRules(ruleDescription, selectedSubjectTitles, updatedSelectedActions, resources);
+
+      setHasRightsErrors(false);
+    }
+  };
+
+  /**
+   * Displays the selected subjects
+   */
+  const displaySubjects = selectedSubjectTitles.map((s, i) => {
+    return (
+      <PolicyRuleSubjectListItem
+        key={i}
+        subjectTitle={s}
+        onRemove={() => handleRemoveSubject(i, s)}
+      />
+    );
+  });
+
+  /**
+   * Handles the removal of resources
+   */
+  const handleRemoveSubject = (index: number, subjectTitle: string) => {
+    // Remove from selected list
+    const updatedSubjects = [...selectedSubjectTitles];
+    updatedSubjects.splice(index, 1);
+    setSelectedSubjectTitles(updatedSubjects);
+
+    // Add to options list
+    setSubjectOptions([...subjectOptions, { value: subjectTitle, label: subjectTitle }]);
+    updateRules(ruleDescription, updatedSubjects, selectedActions, resources);
+
+    setHasSubjectsError(updatedSubjects.length === 0);
+  };
+
+  /**
+   * Handles the click on a subject in the select list. It removes the clicked element
+   * from the options list, and adds it to the selected subject title list.
+   */
+  const handleClickSubjectInList = (option: string) => {
+    // As the input field is multiple, the onchance function uses string[], but
+    // we are removing the element from the options list before it is displayed, so
+    // it will only ever be a first value in the array.
+    const clickedOption = option; //[0];
+
+    // Remove from options list
+    const index = subjectOptions.findIndex((o) => o.value === clickedOption);
+    const updatedOptions = [...subjectOptions];
+    updatedOptions.splice(index, 1);
+    setSubjectOptions(updatedOptions);
+
+    const updatedSubjectTitles = [...selectedSubjectTitles, clickedOption];
+    // Add to selected list
+    setSelectedSubjectTitles(updatedSubjectTitles);
+
+    updateRules(ruleDescription, updatedSubjectTitles, selectedActions, resources);
+
+    setHasSubjectsError(false);
+  };
+
+  /**
+   * Updates the description of the rule
+   */
+  const handleChangeDescription = (description: string) => {
+    setRuleDescription(description);
+    updateRules(description, selectedSubjectTitles, selectedActions, resources);
+  };
+
+  /**
+   * Duplicates a resource group and all the content in it.
+   *
+   * @param resourceIndex the index of the resource group to duplicate
+   */
+  const handleDuplicateResourceGroup = (resourceIndex: number) => {
+    const resourceGroupToDuplicate: PolicyRuleResourceType[] = resources[resourceIndex];
+    const updatedResources = [...resources, resourceGroupToDuplicate];
+    setResources(updatedResources);
+    updateRules(ruleDescription, selectedSubjectTitles, selectedActions, updatedResources);
+  };
+
+  /**
+   * Removes a resource group and all the content in it.
+   *
+   * @param resourceIndex the index of the resource group to remove
+   */
+  const handleDeleteResourceGroup = (resourceIndex: number) => {
+    const updatedResources = [...resources];
+    updatedResources.splice(resourceIndex, 1);
+    setResources(updatedResources);
+    updateRules(ruleDescription, selectedSubjectTitles, selectedActions, updatedResources);
+
+    setHasResourceError(updatedResources.length === 0);
+  };
+
+  /**
+   * Displays the given text in a warning card
+   *
+   * @param text the text to display
+   */
+  const displayWarningCard = (text: string) => {
+    return (
+      <div className={classes.warningCardWrapper}>
+        <WarningCard text={text} />
+      </div>
+    );
+  };
+
+  /**
+   * Gets if there is an error in the rule card
+   */
+  const getHasRuleError = () => {
+    return hasResourceError || hasRightsError || hasSubjectsError;
+  };
+
+  /**
+   * Removes the rule and closes the modal
+   */
+  const handleRemoveRule = () => {
+    console.log('inside');
+    handleDeleteRule();
+    setVerificationModalOpen(false);
+  };
+
+  return (
+    <div className={classes.wrapper}>
+      <div className={classes.cardWrapper}>
+        <ExpandablePolicyElement
+          title={`Regel ${getPolicyRuleId()}`}
+          isCard
+          handleDuplicateElement={handleDuplicateRule}
+          handleRemoveElement={() => setVerificationModalOpen(true)}
+        >
+          <p className={classes.subHeader}>Hvilken ressurser skal regelen gjelde for?</p>
+          {displayResources}
+          <div className={classes.addResourceButton}>
+            <Button type='button' onClick={handleClickAddResource}>
+              Legg til en ressurs
+            </Button>
+          </div>
+          {hasResourceError && displayWarningCard('Du må legge til en ressurs')}
+          <p className={classes.subHeader}>Hvilke rettigheter skal gis?</p>
+          <p className={classes.smallText}>Velg minimum ett alternativ fra listen under</p>
+          <div className={classes.chipWrapper}>{displayActions}</div>
+          {hasRightsError && displayWarningCard('Du må legge til hvilken rettigheter som skal gis')}
+          <p className={classes.subHeader}>Hvem skal ha disse rettighetene?</p>
+          {displaySubjects}
+          {subjectOptions.length > 0 && (
+            <PolicySubjectSelectButton
+              options={subjectOptions}
+              onChange={handleClickSubjectInList}
+            />
+          )}
+          {hasSubjectsError &&
+            displayWarningCard('Du må legge til hvem rettighetene skal gjelde for')}
+          <p className={classes.subHeader}>Legg til en beskrivelse av regelen</p>
+          <div className={classes.textAreaWrapper}>
+            <TextArea
+              resize='vertical'
+              placeholder='Beskrivelse beskrevet her i tekst av tjenesteeier'
+              value={ruleDescription}
+              onChange={(e) => handleChangeDescription(e.currentTarget.value)}
+              rows={5}
+            />
+          </div>
+          <VerificationModal
+            isOpen={verificationModalOpen}
+            onClose={() => setVerificationModalOpen(false)}
+            text='Er du sikker på at du vil slette denne regelen?'
+            closeButtonText='Nei, gå tilbake'
+            actionButtonText='Ja, slett regel'
+            onPerformAction={handleRemoveRule}
+          />
+        </ExpandablePolicyElement>
+      </div>
+      {getHasRuleError() && (
+        <div className={classes.ruleWarning}>
+          <ExclamationmarkTriangleFillIcon title='The rule has a warning' fontSize='2rem' />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/resourceadm/components/ExpandablePolicyCard/index.ts
+++ b/frontend/resourceadm/components/ExpandablePolicyCard/index.ts
@@ -1,0 +1,1 @@
+export { ExpandablePolicyCard } from './ExpandablePolicyCard'

--- a/frontend/resourceadm/components/ExpandablePolicyElement/DropdownMenu.module.css
+++ b/frontend/resourceadm/components/ExpandablePolicyElement/DropdownMenu.module.css
@@ -1,0 +1,51 @@
+
+.dropdownContainer {
+  position: relative;
+  display: inline-block;
+}
+
+.dropdownMenu {
+  position: absolute;
+  z-index: 4;
+  top: 100%;
+  right: 0;
+  width: 150px;
+  background-color: #FFFFFF;
+  border-radius: 5px;
+  filter: drop-shadow(0px 0px 4px rgba(0, 0, 0, 0.25));
+}
+
+.dropdownDuplicateButton {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 8px;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.dropdownDeleteButton {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 8px;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+  border-top: 1px solid #000000;
+  color: #E23B53;
+}
+
+.dropdownDuplicateButton:hover, .dropdownDeleteButton:hover {
+  background-color: #E9EAEC;
+}
+
+.dropdownDuplicateButton:focus, .dropdownDeleteButton:focus {
+  background-color: #D9D9D9;
+}
+
+.dropdownItemText {
+  font-size: 14px;
+  margin-left: 10px;
+}

--- a/frontend/resourceadm/components/ExpandablePolicyElement/DropdownMenu.tsx
+++ b/frontend/resourceadm/components/ExpandablePolicyElement/DropdownMenu.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useRef } from 'react';
+import classes from './DropdownMenu.module.css';
+import { Button } from '@digdir/design-system-react';
+import { MenuElipsisVerticalIcon, TabsIcon, TrashIcon } from '@navikt/aksel-icons';
+
+interface Props {
+  isOpen: boolean;
+  handleClickMoreIcon: () => void;
+  handleCloseMenu: () => void;
+  handleDuplicate: () => void;
+  handleDelete: () => void;
+}
+
+/**
+ * Dropdown menu component that displays a duplicate and a delete button
+ *
+ * @param props.isOpen boolean for if the menu is open or not
+ * @param props.handleClickMoreIcon function to be executed when the menu icon is clicked
+ * @param props.handleCloseMenu function to be executed when closing the menu
+ * @param props.handleDuplicate function to handle the click of the duplicate button
+ * @param props.handleDelete function to handle the click of the delete button
+ */
+export const DropdownMenu = ({
+  isOpen,
+  handleClickMoreIcon,
+  handleCloseMenu,
+  handleDuplicate,
+  handleDelete,
+}: Props) => {
+  const dropdownRef = useRef(null);
+  const firstMenuItemRef = useRef<HTMLButtonElement>(null);
+  const lastMenuItemRef = useRef<HTMLButtonElement>(null);
+
+  /**
+   * Closes the menu when clicking outside the menu
+   */
+  const handleClickOutside = (e: MouseEvent) => {
+    if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
+      handleCloseMenu();
+    }
+  };
+
+  /**
+   * Closes the menu when clicking the ESCAPE key
+   */
+  const handleEscapeKey = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      handleCloseMenu();
+    }
+  };
+
+  /**
+   * Closes the menu when the menu is open and the user is navigating backwards
+   * out of the menu using SHIFT + TAB.
+   */
+  const handleFirstMenuItemShiftTabKey = (e: KeyboardEvent) => {
+    if (e.key === 'Tab' && e.shiftKey && e.target === firstMenuItemRef.current) {
+      handleCloseMenu();
+    }
+  };
+
+  /**
+   * Closes the menu when the menu is open and the user is navigating
+   * out of the menu using TAB.
+   */
+  const handleLastMenuItemTabKey = (e: KeyboardEvent) => {
+    if (e.key === 'Tab' && !e.shiftKey) {
+      handleCloseMenu();
+    }
+  };
+
+  /**
+   * Listens to the events of clicking outside or using the keys on the menu
+   */
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => handleClickOutside(e);
+    const handleKeydown = (e: KeyboardEvent) => handleEscapeKey(e);
+    const handleFirstTabKey = (e: KeyboardEvent) => handleFirstMenuItemShiftTabKey(e);
+    const handleLastTabKey = (e: KeyboardEvent) => handleLastMenuItemTabKey(e);
+
+    document.addEventListener('click', handleClick);
+    document.addEventListener('keydown', handleKeydown);
+
+    if (isOpen && firstMenuItemRef.current && lastMenuItemRef.current) {
+      const firstMenuItem = firstMenuItemRef.current;
+      const lastMenuItem = lastMenuItemRef.current;
+
+      firstMenuItem.addEventListener('keydown', handleFirstTabKey);
+      lastMenuItem.addEventListener('keydown', handleLastTabKey);
+
+      return () => {
+        firstMenuItem.removeEventListener('keydown', handleFirstTabKey);
+        lastMenuItem.removeEventListener('keydown', handleLastTabKey);
+      };
+    }
+
+    return () => {
+      document.removeEventListener('click', handleClick);
+      document.removeEventListener('keydown', handleKeydown);
+    };
+  });
+
+  return (
+    <div className={classes.dropdownContainer} ref={dropdownRef}>
+      <Button
+        icon={<MenuElipsisVerticalIcon title='More' fontSize='1.8rem' />}
+        onClick={handleClickMoreIcon}
+        onKeyDown={(e) => {}}
+        variant='quiet'
+        color='secondary'
+      />
+      {isOpen && (
+        <div className={classes.dropdownMenu}>
+          <button
+            className={classes.dropdownDuplicateButton}
+            type='button'
+            onClick={handleDuplicate}
+            ref={firstMenuItemRef}
+          >
+            <TabsIcon title='Dupliser' fontSize='1.3rem' />
+            <p className={classes.dropdownItemText}>Lag kopi</p>
+          </button>
+          <button
+            className={classes.dropdownDeleteButton}
+            type='button'
+            onClick={handleDelete}
+            ref={lastMenuItemRef}
+          >
+            <TrashIcon title='Slett' fontSize='1.3rem' />
+            <p className={classes.dropdownItemText}>Slett</p>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/resourceadm/components/ExpandablePolicyElement/ExpandablePolicyElement.module.css
+++ b/frontend/resourceadm/components/ExpandablePolicyElement/ExpandablePolicyElement.module.css
@@ -1,0 +1,60 @@
+.cardWrapper {
+  border-radius: 12px;
+  border: solid 1px #D9D9D9;
+  width: 100%;
+}
+
+.elementWrapper {
+  border: solid 1px #D9D9D9;
+  border-radius: 5px;
+  background-color: #F4F4F4;
+}
+
+.title {
+  font-weight: 500;
+  font-size: 16px;
+}
+
+.topWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-right: 15px;
+}
+
+.cardExpandButton{
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 20px;
+  padding-right: 5px;
+  margin: 0;
+}
+
+.elementExpandButton{
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding-block: 10px;
+  padding-left: 20px;
+  padding-right: 5px;
+  margin: 0;
+}
+
+.cardBottomWrapper {
+  padding-inline: 20px;
+  padding-bottom: 20px;
+}
+
+.elementBottomWrapper {
+  padding-inline: 20px;
+  padding-bottom: 10px;
+}

--- a/frontend/resourceadm/components/ExpandablePolicyElement/ExpandablePolicyElement.tsx
+++ b/frontend/resourceadm/components/ExpandablePolicyElement/ExpandablePolicyElement.tsx
@@ -1,0 +1,70 @@
+import React, { ReactNode, useState } from 'react';
+import classes from './ExpandablePolicyElement.module.css';
+import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons';
+import { DropdownMenu } from './DropdownMenu';
+
+interface Props {
+  title: string;
+  children: ReactNode;
+  isCard?: boolean;
+  handleRemoveElement: () => void;
+  handleDuplicateElement: () => void;
+}
+
+/**
+ * Displays a wrapper component that can be expanded and collapsed. The wrapper
+ * component is wrapped around the content that can be collapsed.
+ *
+ * @param props.title the title to display on the element.
+ * @param props.children the React childrens to display inside it.
+ * @param props.isCard optional for if the component is a card or an element
+ * @param props.handleRemoveElement function to be executed when the element is to be removed
+ * @param props.handleDuplicateElement function to be executed when the element is duplicated
+ */
+export const ExpandablePolicyElement = ({
+  title: cardTitle,
+  children,
+  isCard = true,
+  handleRemoveElement,
+  handleDuplicateElement,
+}: Props) => {
+  const [isOpen, setIsOpen] = useState(true);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const handleClickMoreButton = () => {
+    setIsDropdownOpen((prev) => !prev);
+  };
+
+  return (
+    <div className={isCard ? classes.cardWrapper : classes.elementWrapper}>
+      <div className={classes.topWrapper}>
+        <button
+          className={isCard ? classes.cardExpandButton : classes.elementExpandButton}
+          onClick={() => setIsOpen((prev) => !prev)}
+        >
+          <p className={classes.title}>{cardTitle}</p>
+          {isOpen ? (
+            <ChevronUpIcon title='Close the card' fontSize='1.8rem' />
+          ) : (
+            <ChevronDownIcon title='Open the card' fontSize='1.8rem' />
+          )}
+        </button>
+        <DropdownMenu
+          isOpen={isDropdownOpen}
+          handleClickMoreIcon={handleClickMoreButton}
+          handleCloseMenu={() => setIsDropdownOpen(false)}
+          handleDuplicate={handleDuplicateElement}
+          handleDelete={() => {
+            handleRemoveElement();
+            setIsDropdownOpen(false);
+          }}
+        />
+      </div>
+      {isOpen && (
+        <div className={isCard ? classes.cardBottomWrapper : classes.elementBottomWrapper}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/resourceadm/components/ExpandablePolicyElement/index.ts
+++ b/frontend/resourceadm/components/ExpandablePolicyElement/index.ts
@@ -1,0 +1,1 @@
+export { ExpandablePolicyElement } from './ExpandablePolicyElement'

--- a/frontend/resourceadm/components/PolicyResourceFields/PolicyResourceFields.module.css
+++ b/frontend/resourceadm/components/PolicyResourceFields/PolicyResourceFields.module.css
@@ -1,0 +1,16 @@
+.wrapper {
+  display: flex;
+  justify-content: space-between;
+  margin-block: 5px;
+}
+
+.inputWrapper {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin-right: 5px;
+}
+
+.textfieldWrapper {
+  width: 48%;
+}

--- a/frontend/resourceadm/components/PolicyResourceFields/PolicyResourceFields.tsx
+++ b/frontend/resourceadm/components/PolicyResourceFields/PolicyResourceFields.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import classes from './PolicyResourceFields.module.css';
+import { Button, TextField } from '@digdir/design-system-react';
+import { MultiplyIcon } from '@navikt/aksel-icons';
+
+interface Props {
+  isEditable: boolean;
+  onRemove: () => void;
+  valueId: string;
+  onChangeId: (s: string) => void;
+  valueType: string;
+  onChangeType: (s: string) => void;
+}
+
+/**
+ * Component that displays two input fields next to each other, and a button
+ * to remove the component from the list it belongs to. It is used to display
+ * resources for a policy rules in the policy editor.
+ *
+ * @param props.isEditable boolean to decide if the two textfields are editable or not.
+ * @param props.onRemove function to be executed when the remove button is clicked
+ * @param props.valueId the value of the id field
+ * @param props.onChangeId function to be executed when the id value changes
+ * @param props.valueType the value of the type field
+ * @param props.onChangeType function to be executed when the type value changes
+ */
+export const PolicyResourceFields = ({
+  isEditable,
+  onRemove,
+  valueId,
+  valueType,
+  onChangeId,
+  onChangeType,
+}: Props) => {
+  return (
+    <div className={classes.wrapper}>
+      <div className={classes.inputWrapper}>
+        <div className={classes.textfieldWrapper}>
+          <TextField
+            placeholder='Type'
+            value={valueType}
+            onChange={(e) => onChangeType(e.target.value)}
+            disabled={!isEditable}
+          />
+        </div>
+        <div className={classes.textfieldWrapper}>
+          <TextField
+            placeholder='Id'
+            value={valueId}
+            onChange={(e) => onChangeId(e.target.value)}
+            disabled={!isEditable}
+          />
+        </div>
+      </div>
+      <div>
+        <Button
+          variant='quiet'
+          icon={<MultiplyIcon title='Fjern ressursen' />}
+          disabled={!isEditable}
+          onClick={onRemove}
+          color='danger'
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/resourceadm/components/PolicyResourceFields/index.ts
+++ b/frontend/resourceadm/components/PolicyResourceFields/index.ts
@@ -1,0 +1,1 @@
+export { PolicyResourceFields } from './PolicyResourceFields';

--- a/frontend/resourceadm/components/PolicyRuleSubjectListItem/PolicyRuleSubjectListItem.module.css
+++ b/frontend/resourceadm/components/PolicyRuleSubjectListItem/PolicyRuleSubjectListItem.module.css
@@ -1,0 +1,56 @@
+.wrapper {
+  display: flex;
+  align-items: center;
+  background-color: #F4F4F4;
+  width: fit-content;
+  border-radius: 4px;
+  margin-block: 5px;
+}
+
+.titleWrapper {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding-block: 8px;
+  padding-left: 8px;
+}
+
+.subjectTitle {
+  font-weight: 400;
+  font-size: 16px;
+  margin: 0;
+  padding: 0;
+}
+
+.button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  background-color: transparent;
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  padding: 9px;
+  margin-left: 15px;
+  cursor: pointer;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.button:hover {
+  background-color: #E02E49;
+  color: #FFFFFF;
+}
+
+.button:focus {
+  background-color: #E02E49;
+  color: #FFFFFF;
+  outline-offset: 2px;
+  outline-color: #98177E;
+}
+
+.button:active {
+  background-color: #861C2C;
+  color: #FFFFFF;
+}

--- a/frontend/resourceadm/components/PolicyRuleSubjectListItem/PolicyRuleSubjectListItem.tsx
+++ b/frontend/resourceadm/components/PolicyRuleSubjectListItem/PolicyRuleSubjectListItem.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import classes from './PolicyRuleSubjectListItem.module.css';
+import { MultiplyIcon } from '@navikt/aksel-icons';
+
+interface Props {
+  subjectTitle: string;
+  onRemove: () => void;
+}
+
+/**
+ * Component to display the list of subjects that belongs to a rule in a card in
+ * the policy editor. The elements in the list are removable by clicking the
+ * 'X' button.
+ *
+ * @param props.subjectTitle the title to display on the list item
+ * @param props.onRemove function to be executed when the remove button is clicked
+ */
+export const PolicyRuleSubjectListItem = ({ subjectTitle, onRemove }: Props) => {
+  return (
+    <div className={classes.wrapper}>
+      <div className={classes.titleWrapper}>
+        <p className={classes.subjectTitle}>{subjectTitle}</p>
+      </div>
+      <button className={classes.button} onClick={onRemove} type='button'>
+        <MultiplyIcon title='Fjern rettigheter for valgt rolle' color='inherit' fontSize='1.3rem' />
+      </button>
+    </div>
+  );
+};

--- a/frontend/resourceadm/components/PolicyRuleSubjectListItem/index.ts
+++ b/frontend/resourceadm/components/PolicyRuleSubjectListItem/index.ts
@@ -1,0 +1,1 @@
+export { PolicyRuleSubjectListItem } from './PolicyRuleSubjectListItem'

--- a/frontend/resourceadm/components/PolicySubjectSelectButton/PolicySubjectSelectButton.module.css
+++ b/frontend/resourceadm/components/PolicySubjectSelectButton/PolicySubjectSelectButton.module.css
@@ -1,0 +1,6 @@
+.customDropdownIndicator {
+  padding-inline: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/frontend/resourceadm/components/PolicySubjectSelectButton/PolicySubjectSelectButton.tsx
+++ b/frontend/resourceadm/components/PolicySubjectSelectButton/PolicySubjectSelectButton.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import Select, { StylesConfig } from 'react-select';
+import { PlusIcon } from '@navikt/aksel-icons';
+import classes from './PolicySubjectSelectButton.module.css';
+
+const OPTION_ELEMENT_HEIGHT = 36;
+const NUMBER_OF_OPTIONS_TO_DISPLAY = 7;
+
+/**
+ * Re-styling the react-select component to match the correct styles
+ */
+const customStyles: StylesConfig = {
+  control: (provided, state) => ({
+    ...provided,
+    cursor: 'pointer',
+    outline: state.isFocused ? '2px solid #98177e' : 'none',
+    outlineOffset: state.isFocused ? '3px' : 'none',
+    boxShadow: state.isFocused ? 'none' : provided.boxShadow,
+    border: '2px solid #1e2b3c',
+
+    ':hover': {
+      border: '2px solid #0062ba',
+    },
+  }),
+
+  menuList: (provided) => ({
+    ...provided,
+    padding: 0,
+    border: '1px solid #68707c',
+    borderRadius: '2px',
+    boxShadow: '1px 1px 3px #00000040',
+    maxHeight: `${OPTION_ELEMENT_HEIGHT * NUMBER_OF_OPTIONS_TO_DISPLAY}px`,
+  }),
+
+  menu: (provided) => ({
+    ...provided,
+    margin: 0,
+  }),
+
+  indicatorSeparator: (provided) => ({
+    ...provided,
+    display: 'none',
+  }),
+
+  option: (provided, state) => ({
+    ...provided,
+    borderColor: '#022f5180',
+    borderWidth: '1px 0 0 0',
+    borderStyle: 'solid',
+    cursor: 'pointer',
+    fontSize: '16px',
+    fontWeight: '300',
+    minHeight: `${OPTION_ELEMENT_HEIGHT}px`,
+    backgroundColor: state.isFocused ? '#b3d0ea' : 'transparent',
+
+    ':first-of-type': {
+      border: 'none',
+    },
+
+    ':hover': {
+      backgroundColor: '#e6eff8',
+    },
+  }),
+};
+
+/**
+ * Displays a custom made dropdown indicator displaying the
+ * plus icon instead of the arrow down
+ */
+const CustomDropdownIndicator = () => (
+  <div className={classes.customDropdownIndicator}>
+    <PlusIcon title='Legg til en rolle' fontSize='1.5rem' />
+  </div>
+);
+
+interface Props {
+  options: { value: string; label: string }[];
+  onChange: (options: string) => void;
+}
+
+/**
+ * Component that displays a select element used to select subjects one-by-one
+ * for a rule in the policy editor.
+ *
+ * @param props.options the options to select from
+ * @param props.onChange function to be executed when an element in the list is clicked
+ */
+export const PolicySubjectSelectButton = ({ options, onChange }: Props) => {
+  return (
+    <div>
+      <Select
+        options={options}
+        isSearchable
+        onChange={(selectedOption: { value: string; label: string }) =>
+          selectedOption !== null && onChange(selectedOption.value)
+        }
+        placeholder='Legg til'
+        value={{ value: 'Legg til rolle', label: 'Legg til rolle' }}
+        aria-label='Legg til rolle som skal ha rettighetene'
+        styles={customStyles}
+        components={{ DropdownIndicator: CustomDropdownIndicator }}
+      />
+    </div>
+  );
+};

--- a/frontend/resourceadm/components/PolicySubjectSelectButton/index.ts
+++ b/frontend/resourceadm/components/PolicySubjectSelectButton/index.ts
@@ -1,0 +1,1 @@
+export { PolicySubjectSelectButton } from './PolicySubjectSelectButton'

--- a/frontend/resourceadm/components/ResourceNarrowingList/ResourceNarrowingList.module.css
+++ b/frontend/resourceadm/components/ResourceNarrowingList/ResourceNarrowingList.module.css
@@ -1,0 +1,3 @@
+.wrapper {
+  margin-top: 10px;
+}

--- a/frontend/resourceadm/components/ResourceNarrowingList/ResourceNarrowingList.tsx
+++ b/frontend/resourceadm/components/ResourceNarrowingList/ResourceNarrowingList.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import classes from './ResourceNarrowingList.module.css';
+import { PolicyResourceFields } from '../PolicyResourceFields';
+import { PolicyRuleResourceType } from 'resourceadm/types/global';
+import { ExpandablePolicyElement } from '../ExpandablePolicyElement';
+import { Button } from '@digdir/design-system-react';
+
+interface Props {
+  resources: PolicyRuleResourceType[];
+  handleInputChange: (i: number, field: 'id' | 'type', s: string) => void;
+  handleRemoveResource: (index: number) => void;
+  handleClickAddResource: () => void;
+  handleRemoveElement: () => void;
+  handleDuplicateElement: () => void;
+}
+
+/**
+ * Displays the narrowing list of the resources. The component is expandable, and
+ * has a button to add elements to the list.
+ *
+ * @param props.resources the list of policy resources to display
+ * @param props.handleInputChange function to update the values when the text fields changes value
+ * @param props.handleRemoveResource function that removes a resource from the list
+ * @param props.handleClickAddResource function that adds a resource to the list
+ * @param props.handleRemoveElement function to be executed when the element is to be removed
+ * @param props.handleDuplicateElement function to be executed when the element is duplicated
+ */
+export const ResourceNarrowingList = ({
+  resources,
+  handleInputChange,
+  handleRemoveResource,
+  handleClickAddResource,
+  handleRemoveElement,
+  handleDuplicateElement,
+}: Props) => {
+  /**
+   * Displays the list of resources
+   */
+  const displayResources = resources.map((r, i) => {
+    return (
+      <PolicyResourceFields
+        key={i}
+        isEditable={i > 0}
+        onRemove={() => handleRemoveResource(i)}
+        valueId={r.id}
+        valueType={r.type}
+        onChangeId={(s: string) => handleInputChange(i, 'id', s)}
+        onChangeType={(s: string) => handleInputChange(i, 'type', s)}
+      />
+    );
+  });
+
+  /**
+   * Creates a name for the resourcegroup based on the id of the resource
+   */
+  const getResourceName = (): string => {
+    return resources.map((r) => r.id).join(' - ');
+  };
+
+  return (
+    <div className={classes.wrapper}>
+      <ExpandablePolicyElement
+        title={getResourceName()}
+        isCard={false}
+        handleDuplicateElement={handleDuplicateElement}
+        handleRemoveElement={handleRemoveElement}
+      >
+        {displayResources}
+        <Button type='button' onClick={handleClickAddResource}>
+          Legg til en innsnevring av ressursen {/* TODO - Komme med bedre navn*/}
+        </Button>
+      </ExpandablePolicyElement>
+    </div>
+  );
+};

--- a/frontend/resourceadm/components/ResourceNarrowingList/index.ts
+++ b/frontend/resourceadm/components/ResourceNarrowingList/index.ts
@@ -1,0 +1,1 @@
+export { ResourceNarrowingList } from './ResourceNarrowingList'

--- a/frontend/resourceadm/components/VerificationModal/VerificationModal.module.css
+++ b/frontend/resourceadm/components/VerificationModal/VerificationModal.module.css
@@ -1,0 +1,11 @@
+.modalText {
+  margin: 0;
+  font-weight: 500;
+  font-size: 20px;
+}
+
+.buttonWrapper {
+  display: flex;
+  justify-content: space-around;
+  margin-top: 20px;
+}

--- a/frontend/resourceadm/components/VerificationModal/VerificationModal.tsx
+++ b/frontend/resourceadm/components/VerificationModal/VerificationModal.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import classes from './VerificationModal.module.css';
+import Modal from 'react-modal';
+import { Button } from '@digdir/design-system-react';
+
+const modalStyles = {
+  content: {
+    width: 'fit-content',
+    height: 'fit-content',
+    margin: 'auto',
+    paddingBlock: '40px',
+    paddingInline: '70px',
+  },
+  overlay: {
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+  },
+};
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  text: string;
+  closeButtonText: string;
+  actionButtonText: string;
+  onPerformAction: () => void;
+}
+
+/**
+ * Displays a verification modal. To be used when the user needs one extra level
+ * of chekcing if they really want to perform an action.
+ *
+ * @param props.isOpen boolean for if the modal is open or not
+ * @param props.onClose function to be executed when closing the modal
+ * @param props.closeButtonText the text to display on the close button
+ * @param props.actionButtonText the text to display on the action button
+ * @param props.onPerformAction function to be executed when the action button is clicked
+ */
+export const VerificationModal = ({
+  isOpen,
+  onClose,
+  text,
+  closeButtonText,
+  actionButtonText,
+  onPerformAction,
+}: Props) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onRequestClose={onClose}
+      contentLabel='Verification Modal'
+      style={modalStyles}
+      ariaHideApp={false}
+    >
+      <p className={classes.modalText}>{text}</p>
+      <div className={classes.buttonWrapper}>
+        <Button type='button' onClick={onClose}>
+          {closeButtonText}
+        </Button>
+        <Button type='button' onClick={onPerformAction} color='danger'>
+          {actionButtonText}
+        </Button>
+      </div>
+    </Modal>
+  );
+};

--- a/frontend/resourceadm/components/VerificationModal/index.ts
+++ b/frontend/resourceadm/components/VerificationModal/index.ts
@@ -1,0 +1,1 @@
+export { VerificationModal } from './VerificationModal'

--- a/frontend/resourceadm/components/WarningCard/WarningCard.module.css
+++ b/frontend/resourceadm/components/WarningCard/WarningCard.module.css
@@ -1,0 +1,10 @@
+.wrapper {
+  display: flex;
+  background-color: #F9CAD3;
+  box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.25);
+  padding: 12px;
+}
+
+.iconWrapper {
+  margin-right: 10px;
+}

--- a/frontend/resourceadm/components/WarningCard/WarningCard.tsx
+++ b/frontend/resourceadm/components/WarningCard/WarningCard.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import classes from './WarningCard.module.css';
+import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
+
+interface Props {
+  text: string;
+}
+
+/**
+ * Displays a pink warning card with some warning text
+ *
+ * @param props.text the text to display
+ */
+export const WarningCard = ({ text }: Props) => {
+  return (
+    <div className={classes.wrapper}>
+      <div className={classes.iconWrapper}>
+        <ExclamationmarkTriangleFillIcon title='Warning Icon' fontSize='1.5rem' />
+      </div>
+      <p>{text}</p>
+    </div>
+  );
+};

--- a/frontend/resourceadm/components/WarningCard/index.ts
+++ b/frontend/resourceadm/components/WarningCard/index.ts
@@ -1,0 +1,1 @@
+export { WarningCard } from './WarningCard'

--- a/frontend/resourceadm/data-mocks/policies/index.ts
+++ b/frontend/resourceadm/data-mocks/policies/index.ts
@@ -1,0 +1,136 @@
+import { PolicyEditorSendType, PolicyRuleBackendType, PolicyRuleResourceType, PolicySubjectType } from "resourceadm/types/global";
+
+// RESOURCE ID
+export const resourceIdMock1: string = "test_id_1"
+export const resourceIdMock2: string = "test_id_2"
+export const resourceIdMock3: string = "test_id_3"
+
+// RESOURCE TYPE
+export const resourceTypeMock1: string = "urn:altinn:resource1"
+export const resourceTypeMock2: string = "urn:altinn:resource2"
+export const resourceTypeMock3: string = "urn:altinn:resource3"
+
+// RESOURCES
+const resourceMock1: PolicyRuleResourceType = {
+  type: resourceTypeMock1,
+  id: resourceIdMock1
+}
+const resourceMock2: PolicyRuleResourceType = {
+  type: resourceTypeMock2,
+  id: resourceIdMock2
+}
+
+// SUBJECT STRINGS FROM BACKEND
+export const subjectStringBackendMock1: string = 'urn:altinn:rolecode:dagl'
+export const subjectStringBackendMock3: string = 'urn:altinn:rolecode:dagl3'
+
+// RULES
+const ruleMock1: PolicyRuleBackendType = {
+  RuleId: `${resourceTypeMock1}:${resourceIdMock1}:ruleid:1`,
+  Resources: [[`${resourceMock1.type}:${resourceMock1.id}`, `${resourceMock2.type}:${resourceMock2.id}`]],
+  Actions: ['read', 'write'],
+  Subject: [subjectStringBackendMock1, subjectStringBackendMock3],
+  Description: 'Dette er en forklaring på hva regelen er.'
+}
+
+// POLICIES
+export const policyMock1: PolicyEditorSendType = {
+  Rules: [ruleMock1]
+};
+
+export const policyMock2: PolicyEditorSendType = {
+  Rules: []
+};
+
+// ACTIONS
+export const actionsListMock: string[] = [
+  "read",
+  "write",
+  "confirm",
+  "sign",
+  "delete"
+]
+
+// SUBJECTS
+export const subjectMock1: PolicySubjectType = {
+  SubjectId: "dagl",
+  SubjectSource: "altinn:role",
+  SubjectTitle: "Daglig leder",
+  SubjectDescription: "Daglig leder fra enhetsregisteret"
+}
+
+const subjectMock2: PolicySubjectType = {
+  SubjectId: "dagl2",
+  SubjectSource: "altinn:role",
+  SubjectTitle: "Daglig leder 2",
+  SubjectDescription: "Daglig leder fra enhetsregisteret"
+}
+
+const subjectMock3: PolicySubjectType = {
+  SubjectId: "dagl3",
+  SubjectSource: "altinn:role",
+  SubjectTitle: "Daglig leder 3",
+  SubjectDescription: "Daglig leder fra enhetsregisteret"
+}
+
+const subjectMock4: PolicySubjectType = {
+  SubjectId: "dagl4",
+  SubjectSource: "altinn:role",
+  SubjectTitle: "Daglig leder 4",
+  SubjectDescription: "Daglig leder fra enhetsregisteret"
+}
+
+const subjectMock5: PolicySubjectType = {
+  SubjectId: "dagl5",
+  SubjectSource: "altinn:role",
+  SubjectTitle: "Daglig leder 5",
+  SubjectDescription: "Daglig leder fra enhetsregisteret"
+}
+
+const subjectMock6: PolicySubjectType = {
+  SubjectId: "dagl 6",
+  SubjectSource: "altinn:role",
+  SubjectTitle: "Daglig leder 6",
+  SubjectDescription: "Daglig leder fra enhetsregisteret"
+}
+
+const subjectMock7: PolicySubjectType = {
+  SubjectId: "dagl7",
+  SubjectSource: "altinn:role",
+  SubjectTitle: "Daglig leder 7",
+  SubjectDescription: "Daglig leder fra enhetsregisteret"
+}
+
+const subjectMock8: PolicySubjectType = {
+  SubjectId: "dagl8",
+  SubjectSource: "altinn:role",
+  SubjectTitle: "Daglig leder 8",
+  SubjectDescription: "Daglig leder fra enhetsregisteret"
+}
+
+const subjectMock9: PolicySubjectType = {
+  SubjectId: "dagl9",
+  SubjectSource: "altinn:role",
+  SubjectTitle: "Daglig leder 9",
+  SubjectDescription: "Daglig leder fra enhetsregisteret"
+}
+
+const subjectMock10: PolicySubjectType = {
+  SubjectId: "dagl10",
+  SubjectSource: "altinn:role",
+  SubjectTitle: "Daglig leder 10",
+  SubjectDescription: "Daglig leder fra enhetsregisteret"
+}
+
+export const subjectsListMock: PolicySubjectType[] = [
+  subjectMock1,
+  subjectMock2,
+  subjectMock3,
+  subjectMock4,
+  subjectMock5,
+  subjectMock6,
+  subjectMock7,
+  subjectMock8,
+  subjectMock9,
+  subjectMock10
+]

--- a/frontend/resourceadm/pages/PolicyEditor/PolicyEditor.module.css
+++ b/frontend/resourceadm/pages/PolicyEditor/PolicyEditor.module.css
@@ -1,0 +1,92 @@
+/* TODO - font families */
+.policyEditorWrapper {
+  /* This goes outside the screen to the right atm - TODO - fix*/
+  width: 80%;
+  margin: 0;
+  padding-inline: 10%;
+  padding-top: 20px;
+  padding-bottom: 50px;
+}
+
+.policyEditorTop {
+  width: 450px;
+  margin-bottom: 50px;
+}
+
+.addCardButtonWrapper {
+  margin-block: 20px;
+  width: 595px;
+  min-width: 595px;
+}
+
+.space {
+  margin-block: 20px;
+}
+
+.policyEditorHeader {
+  margin-bottom: 40px;
+  font-weight: 400;
+}
+
+.subHeader {
+  font-weight: 500;
+  margin-bottom: 5px;
+  margin-top: 20px;
+}
+
+/* TODO - Fix hover, tab-focus, active, visisted. */
+.externalLink {
+  color: #000000;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  text-decoration-color: #1EAEF7;
+  text-decoration-thickness: 1.5px;
+}
+
+.componentWrapper {
+  margin-top: 10px;
+}
+
+.textFieldIdWrapper {
+  display: flex;
+  align-items: center;
+  margin-top: 5px;
+}
+
+.idBox {
+  background-color: #E9EAEC;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 1px;
+  padding: 2px;
+  margin-right: 8px;
+}
+
+.idBoxText {
+  font-size: 10px;
+  font-weight: 600;
+  margin: 0;
+  padding: 0;
+}
+
+.idText {
+  font-size: 14px;
+  font-weight: 400;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.emptyPolicyName {
+  height: 36px;
+  margin-top: 5px;
+}
+
+p {
+  margin: 0;
+  line-height: 24px;
+}

--- a/frontend/resourceadm/pages/PolicyEditor/PolicyEditor.tsx
+++ b/frontend/resourceadm/pages/PolicyEditor/PolicyEditor.tsx
@@ -21,6 +21,7 @@ import {
   emptyPolicyRule,
   mapPolicyRuleToPolicyRuleBackendObject,
 } from 'resourceadm/utils/policyEditorUtils';
+import { VerificationModal } from 'resourceadm/components/VerificationModal';
 
 /**
  * Displays the content where a user can add and edit a policy
@@ -38,9 +39,13 @@ export const PolicyEditor = () => {
   const [actions, setActions] = useState<string[]>([]);
   const [subjects, setSubjects] = useState<PolicySubjectType[]>([]);
   const [policyRules, setPolicyRules] = useState<PolicyRuleCardType[]>([]);
+  const [verificationModalOpen, setVerificationModalOpen] = useState(false);
 
   // Handle the new updated IDs of the rules when a rule is deleted / duplicated
   const [lastRuleId, setLastRuleId] = useState(0);
+
+  // To keep track of which rule to delete
+  const [ruleIdToDelete, setRuleIdToDelete] = useState('0');
 
   // TODO - implement useOnce hook to get the policy
   useEffect(() => {
@@ -79,7 +84,10 @@ export const PolicyEditor = () => {
         resourceId={resourceId}
         resourceType={resourceType}
         handleDuplicateRule={() => handleDuplicateRule(i)}
-        handleDeleteRule={() => handleDeleteRule(i)}
+        handleDeleteRule={() => {
+          setVerificationModalOpen(true);
+          setRuleIdToDelete(pr.RuleId);
+        }}
       />
     </div>
   ));
@@ -128,11 +136,15 @@ export const PolicyEditor = () => {
    *
    * @param index the index of the rule to delete
    */
-  const handleDeleteRule = (index: number) => {
-    console.log('clicked');
+  const handleDeleteRule = (ruleId: string) => {
     const updatedRules = [...policyRules];
-    updatedRules.splice(index, 1);
+    const indexToRemove = updatedRules.findIndex((a) => a.RuleId === ruleId);
+    updatedRules.splice(indexToRemove, 1);
     setPolicyRules(updatedRules);
+
+    // Reset
+    setVerificationModalOpen(false);
+    setRuleIdToDelete('0');
   };
 
   /**
@@ -166,14 +178,17 @@ export const PolicyEditor = () => {
         <div className={classes.addCardButtonWrapper}>
           <CardButton buttonText='Legg til ekstra regelsett' onClick={handleAddCardClick} />
         </div>
-        <Button
-          type='button'
-          onClick={() => {
-            handleSavePolicy();
-          }}
-        >
+        <Button type='button' onClick={handleSavePolicy}>
           Lagre policyen
         </Button>
+        <VerificationModal
+          isOpen={verificationModalOpen}
+          onClose={() => setVerificationModalOpen(false)}
+          text='Er du sikker på at du vil slette denne regelen?'
+          closeButtonText='Nei, gå tilbake'
+          actionButtonText='Ja, slett regel'
+          onPerformAction={() => handleDeleteRule(ruleIdToDelete)}
+        />
       </div>
     </div>
   );

--- a/frontend/resourceadm/pages/PolicyEditor/PolicyEditor.tsx
+++ b/frontend/resourceadm/pages/PolicyEditor/PolicyEditor.tsx
@@ -1,0 +1,180 @@
+import React, { useEffect, useState } from 'react';
+import classes from './PolicyEditor.module.css';
+import { ExpandablePolicyCard } from 'resourceadm/components/ExpandablePolicyCard';
+import { CardButton } from 'resourceadm/components/CardButton';
+import { Button } from '@digdir/design-system-react';
+import {
+  PolicyEditorSendType,
+  PolicyRuleCardType,
+  PolicyRuleBackendType,
+  PolicySubjectType,
+} from 'resourceadm/types/global';
+import { useLocation } from 'react-router-dom';
+import {
+  actionsListMock,
+  policyMock1,
+  policyMock2,
+  subjectsListMock,
+} from 'resourceadm/data-mocks/policies';
+import {
+  mapPolicyRulesBackendObjectToPolicyRuleCardType,
+  emptyPolicyRule,
+  mapPolicyRuleToPolicyRuleBackendObject,
+} from 'resourceadm/utils/policyEditorUtils';
+
+/**
+ * Displays the content where a user can add and edit a policy
+ */
+export const PolicyEditor = () => {
+  // TODO - translation
+
+  const { state } = useLocation();
+
+  // Set the resurceId sent in params or set it to null. If null, display error (TODO)
+  const resourceId = state === null ? null : state.resourceId;
+  const resourceType = state === null ? null : state.resourceType;
+
+  // TODO - replace with list from backend
+  const [actions, setActions] = useState<string[]>([]);
+  const [subjects, setSubjects] = useState<PolicySubjectType[]>([]);
+  const [policyRules, setPolicyRules] = useState<PolicyRuleCardType[]>([]);
+
+  // Handle the new updated IDs of the rules when a rule is deleted / duplicated
+  const [lastRuleId, setLastRuleId] = useState(0);
+
+  // TODO - implement useOnce hook to get the policy
+  useEffect(() => {
+    // TODO - API Call to get the correct actions, AND TRANSLATE THEM
+    setActions(actionsListMock);
+    // TODO - API Call to get the correct subjects
+    setSubjects(subjectsListMock);
+
+    // TODO - API Call to get policy by the resource ID
+    // TODO - Find out what the object sent from backend looks like
+    setPolicyRules(
+      mapPolicyRulesBackendObjectToPolicyRuleCardType(
+        subjectsListMock,
+        resourceId === 'test_id_1' ? policyMock1.Rules : policyMock2.Rules
+      )
+    );
+
+    // TODO - replace when found out how to handle the IDs
+    setLastRuleId(
+      resourceId === 'test_id_1' ? policyMock1.Rules.length + 1 : policyMock2.Rules.length + 1
+    );
+  }, [resourceId]);
+
+  /**
+   * Displays all the rule cards
+   */
+  const displayRules = policyRules.map((pr, i) => (
+    <div className={classes.space} key={i}>
+      <ExpandablePolicyCard
+        policyRule={pr}
+        actions={actions}
+        subjects={subjects}
+        rules={policyRules}
+        setPolicyRules={setPolicyRules}
+        rulePosition={i}
+        resourceId={resourceId}
+        resourceType={resourceType}
+        handleDuplicateRule={() => handleDuplicateRule(i)}
+        handleDeleteRule={() => handleDeleteRule(i)}
+      />
+    </div>
+  ));
+
+  /**
+   * Returns the rule ID to be used on the new element, and
+   * updates the store of the next rule id
+   */
+  const getRuleId = () => {
+    const currentRuleId = lastRuleId;
+    setLastRuleId(currentRuleId + 1);
+    return currentRuleId;
+  };
+
+  /**
+   * Handles adding of more cards
+   */
+  const handleAddCardClick = () => {
+    setPolicyRules((prevRules) => [
+      ...prevRules,
+      ...[
+        {
+          ...emptyPolicyRule,
+          RuleId: getRuleId().toString(),
+          Resources: [[{ type: resourceType, id: resourceId }]],
+        },
+      ],
+    ]);
+  };
+
+  /**
+   * Duplicates a rule with all the content in it
+   *
+   * @param index the index of the rule to duplicate
+   */
+  const handleDuplicateRule = (index: number) => {
+    const ruleToDuplicate: PolicyRuleCardType = {
+      ...policyRules[index],
+      RuleId: getRuleId().toString(),
+    };
+    setPolicyRules([...policyRules, ruleToDuplicate]);
+  };
+
+  /**
+   * Deletes a rule from the list
+   *
+   * @param index the index of the rule to delete
+   */
+  const handleDeleteRule = (index: number) => {
+    console.log('clicked');
+    const updatedRules = [...policyRules];
+    updatedRules.splice(index, 1);
+    setPolicyRules(updatedRules);
+  };
+
+  /**
+   * Handle the saving of the updated policy
+   */
+  const handleSavePolicy = () => {
+    const policyEditorRules: PolicyRuleBackendType[] = policyRules.map((pr) =>
+      mapPolicyRuleToPolicyRuleBackendObject(subjects, pr, resourceType, resourceId)
+    );
+
+    const resourceWithRules: PolicyEditorSendType = {
+      Rules: policyEditorRules,
+    };
+
+    // TODO - Error handling
+    console.log('Object to be sent as JSON object: \n', JSON.stringify(resourceWithRules, null, 2));
+  };
+
+  return (
+    // TODO - display spinner when loading
+    // TODO - display error if resourceId === null
+    <div className={classes.policyEditorWrapper}>
+      <div>
+        <div className={classes.policyEditorTop}>
+          <h2 className={classes.policyEditorHeader}>Policy editor</h2>
+          <p>
+            Policy gjelder for ressursen: <strong>{resourceId}</strong>
+          </p>
+        </div>
+        {displayRules}
+        <div className={classes.addCardButtonWrapper}>
+          <CardButton buttonText='Legg til ekstra regelsett' onClick={handleAddCardClick} />
+        </div>
+        <Button
+          type='button'
+          onClick={() => {
+            handleSavePolicy();
+          }}
+        >
+          Lagre policyen
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/resourceadm/pages/PolicyEditor/index.ts
+++ b/frontend/resourceadm/pages/PolicyEditor/index.ts
@@ -1,0 +1,1 @@
+export { PolicyEditor } from './PolicyEditor';

--- a/frontend/resourceadm/pages/PolicyEditorStartPage/PolicyEditorStartPage.module.css
+++ b/frontend/resourceadm/pages/PolicyEditorStartPage/PolicyEditorStartPage.module.css
@@ -1,0 +1,23 @@
+.wrapper {
+  padding: 100px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.contentWrapper {
+  background: #DEDEDE;
+  padding-block: 20px;
+  padding-inline: 40px;
+  border-radius: 15px;
+}
+
+.buttonWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.buttonWrapper > button {
+  margin-top: 20px;
+}

--- a/frontend/resourceadm/pages/PolicyEditorStartPage/PolicyEditorStartPage.tsx
+++ b/frontend/resourceadm/pages/PolicyEditorStartPage/PolicyEditorStartPage.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import classes from './PolicyEditorStartPage.module.css';
+import { Button } from '@digdir/design-system-react';
+import { useNavigate } from 'react-router-dom';
+import {
+  resourceIdMock1,
+  resourceIdMock3,
+  resourceTypeMock1,
+  resourceTypeMock3,
+} from 'resourceadm/data-mocks/policies';
+
+/**
+ * Dummy component to display buttons where the user can click to view either
+ * the create new policy or edit policy functionality
+ */
+export const PolicyEditorStartPage = () => {
+  const navigate = useNavigate();
+  return (
+    <div className={classes.wrapper}>
+      <div className={classes.contentWrapper}>
+        <h2>Hva vil du gjøre?</h2>
+        <div className={classes.buttonWrapper}>
+          <Button
+            type='button'
+            onClick={() => {
+              navigate('/policyEditor', {
+                state: {
+                  resourceId: resourceIdMock3,
+                  resourceType: resourceTypeMock3,
+                },
+              });
+            }}
+          >
+            Lag ny policy
+          </Button>
+          <Button
+            type='button'
+            onClick={() => {
+              navigate('/policyEditor', {
+                state: {
+                  resourceId: resourceIdMock1,
+                  resourceType: resourceTypeMock1,
+                },
+              });
+            }}
+          >
+            Endre policy
+          </Button>
+          <p>
+            Valgt policy: <strong>policy1</strong>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/resourceadm/pages/PolicyEditorStartPage/index.ts
+++ b/frontend/resourceadm/pages/PolicyEditorStartPage/index.ts
@@ -1,0 +1,1 @@
+export { PolicyEditorStartPage } from './PolicyEditorStartPage'

--- a/frontend/resourceadm/types/global.ts
+++ b/frontend/resourceadm/types/global.ts
@@ -1,0 +1,35 @@
+export interface PolicyType {
+  Rules: PolicyRuleCardType[]
+}
+
+export interface PolicyRuleCardType {
+  RuleId: string;
+  Description: string;
+  Subject: string[];
+  Actions: string[];
+  Resources: PolicyRuleResourceType[][];
+}
+
+export interface PolicyRuleResourceType {
+  type: string;
+  id: string;
+}
+
+export interface PolicySubjectType {
+  SubjectId: string;
+  SubjectSource: string;
+  SubjectTitle: string;
+  SubjectDescription: string;
+}
+
+export interface PolicyRuleBackendType {
+  RuleId: string,
+  Description: string,
+  Subject: string[],
+  Actions: string[],
+  Resources: string[][]
+}
+
+export interface PolicyEditorSendType {
+  Rules: PolicyRuleBackendType[]
+}

--- a/frontend/resourceadm/utils/policyEditorUtils/index.ts
+++ b/frontend/resourceadm/utils/policyEditorUtils/index.ts
@@ -1,0 +1,8 @@
+export {
+  emptyPolicyRule,
+  mapPolicySubjectToSubjectTitle,
+  mapPolicyRulesBackendObjectToPolicyRuleCardType,
+  mapResourceFromBackendToResourceType,
+  mapPolicyRuleToPolicyRuleBackendObject,
+  mapSubjectTitleToSubjectString
+} from './policyEditorUtils'

--- a/frontend/resourceadm/utils/policyEditorUtils/policyEditorUtils.test.ts
+++ b/frontend/resourceadm/utils/policyEditorUtils/policyEditorUtils.test.ts
@@ -1,0 +1,15 @@
+import { subjectStringBackendMock1, subjectStringBackendMock3, subjectsListMock } from "resourceadm/data-mocks/policies"
+import { mapPolicySubjectToSubjectTitle } from "./policyEditorUtils"
+
+// TODO - add more
+describe('mapPolicySubjectToSubjectTitle', () => {
+  it('should ', () => {
+
+    const subjects = [subjectStringBackendMock1, subjectStringBackendMock3]
+    const result = mapPolicySubjectToSubjectTitle(subjectsListMock, subjects)
+
+    const resultIncludes = result.includes("Daglig leder")
+
+    expect(resultIncludes).toBe(true)
+  })
+})

--- a/frontend/resourceadm/utils/policyEditorUtils/policyEditorUtils.ts
+++ b/frontend/resourceadm/utils/policyEditorUtils/policyEditorUtils.ts
@@ -1,0 +1,139 @@
+import {
+  PolicyRuleBackendType,
+  PolicyRuleCardType,
+  PolicyRuleResourceType,
+  PolicySubjectType
+} from "resourceadm/types/global";
+
+/**
+ * Empty rule when new card added
+ */
+export const emptyPolicyRule: PolicyRuleCardType = {
+  RuleId: '0',
+  Resources: [],
+  Actions: [],
+  Subject: [],
+  Description: '',
+};
+
+/**
+ * Maps the list of policy subject strings from backend of the format
+ * "subjectID:subjectResource" to the title of the subject.
+ *
+ * @param subjectOptions the possible subjects to select from
+ * @param policySubjects the already selected sujects
+ *
+ * @returns a mapped string[] with subject titles
+ */
+export const mapPolicySubjectToSubjectTitle = (
+  subjectOptions: PolicySubjectType[],
+  policySubjects: string[]
+): string[] => {
+  const subjectIds = policySubjects.map((s) => {
+    const splitted = s.split(':');
+    return splitted[splitted.length - 1];
+  });
+
+  return subjectIds.map((subjectId) => {
+    if (subjectOptions.map((s) => s.SubjectId).includes(subjectId)) {
+      return subjectOptions.find((s) => s.SubjectId === subjectId).SubjectTitle;
+    }
+  });
+};
+
+/**
+ * Maps the resource string from backend to a resource object with type and id.
+ *
+ * @param resource the resoruce string to map
+ *
+ * @returns a mapped resource object
+ */
+export const mapResourceFromBackendToResourceType = (
+  resource: string
+): PolicyRuleResourceType => {
+  const resourceArr = resource.split(':');
+  const id: string = resourceArr.pop();
+  const type: string = resourceArr.join(':');
+
+  return {
+    type: type,
+    id: id,
+  };
+};
+
+/**
+ * Maps the policy rules object from backend to an object of the type used to
+ * display data on the policy cards on the policy editor.
+ *
+ * @param subjectOptions the possible subjects to select from
+ * @param rules an array of rule objects where all elements are strings from backend.
+ *
+ * @returns a list of mapped objects of the policy rule card type
+ */
+export const mapPolicyRulesBackendObjectToPolicyRuleCardType = (
+  subjectOptions: PolicySubjectType[],
+  rules: PolicyRuleBackendType[]
+): PolicyRuleCardType[] => {
+  const newRules = rules.map((r) => {
+    const idArr = r.RuleId.split(':');
+    const id = idArr[idArr.length - 1];
+
+    const mappedResources = r.Resources.map((resource) =>
+      resource.map(r => mapResourceFromBackendToResourceType(r))
+    );
+
+    return {
+      RuleId: id,
+      Actions: r.Actions,
+      Description: r.Description,
+      Subject: mapPolicySubjectToSubjectTitle(subjectOptions, r.Subject),
+      Resources: mappedResources,
+    };
+  });
+  return newRules;
+};
+
+/**
+ * Maps a Subject title to the string format to send to backend: "urn:subjectsource:subjectid"
+ *
+ * @param subjectOptions the possible subjects to select from
+ * @param subjectTitle the title of the subject
+ *
+ * @returns a string of the correct format to send
+ */
+export const mapSubjectTitleToSubjectString = (
+  subjectOptions: PolicySubjectType[],
+  subjectTitle: string
+): string => {
+  const subject: PolicySubjectType = subjectOptions.find((s) => s.SubjectTitle === subjectTitle);
+  return `urn:${subject.SubjectSource}:${subject.SubjectId}`;
+};
+
+/**
+ * Maps a policy rule object used on the policy cards to a policy rule object
+ * to be sent to backend where all fields are strings.
+ *
+ * @param subjectOptions the possible subjects to select from
+ * @param policyRule the policy rule to map
+ * @param resourceType the type of the parent resource
+ * @param resourceId the id of the parent resource
+ *
+ * @returns a mapped object ready to be sent to backend
+ */
+export const mapPolicyRuleToPolicyRuleBackendObject = (
+  subjectOptions: PolicySubjectType[],
+  policyRule: PolicyRuleCardType,
+  resourceType: string,
+  resourceId: string
+): PolicyRuleBackendType => {
+  const resources: string[][] = policyRule.Resources.map((resource) => resource.map(r => `${r.type}:${r.id}`));
+  const subject: string[] = policyRule.Subject.map((s) => mapSubjectTitleToSubjectString(subjectOptions, s));
+
+  return {
+    RuleId: `${resourceType}:${resourceId}:ruleid:${policyRule.RuleId}`,
+    Description: policyRule.Description,
+    Subject: subject,
+    Actions: policyRule.Actions,
+    Resources: resources,
+  };
+};


### PR DESCRIPTION
# Implementing frontend of edit resource policy
## Related Issue(s)
- #10389

## Description
Created the page for where a user can edit a policy of a resource. The user can add new rules, or view/update/delete existing ones. 
<img width="573" alt="Screenshot 2023-06-01 at 11 24 56" src="https://github.com/Altinn/altinn-studio/assets/133344438/5c86ba5f-bdac-4dae-812d-a7fbfd589069">

### Components added
#### CardButton
Button that looks like the rule card when it is collapsed. 
<img width="593" alt="Screenshot 2023-06-01 at 11 24 30" src="https://github.com/Altinn/altinn-studio/assets/133344438/f89ad932-ca02-4e60-a0bf-8c34a8334f21">

#### Chip 
Chip to select which rights to add on a rule
<img width="286" alt="Screenshot 2023-06-01 at 11 25 24" src="https://github.com/Altinn/altinn-studio/assets/133344438/3272983e-13b2-4973-b717-6d5ba1ffafc3">

#### ExpandablePolicyCard
The card that can be collapsed / expanded with the rules in it. 

#### ExpandablePolicyElement / ExpandablePolicyElement
The collapse / expand component. This is both used for the Expandable cards, and the expandable resourcegroups inside a rule card. 

#### ExpandablePolicyElement / DropdownMenu
The dropdown menu displayed in the 3 dots on the ExpandablePolicyElement. The menu has the option to duplicate the element or delete it. 
<img width="176" alt="Screenshot 2023-06-01 at 11 32 41" src="https://github.com/Altinn/altinn-studio/assets/133344438/35bb83a5-fd51-4391-82c4-dce275c8163b">

#### PolicyResourceFields
The "textfield-pair" where the user can add the type and id of a resource to narrow down what the rule is for. 
<img width="433" alt="Screenshot 2023-06-01 at 11 33 38" src="https://github.com/Altinn/altinn-studio/assets/133344438/6179fbda-be77-4d5e-a90d-8a1bc827f1eb">

#### PolicyRuleSubjectListitem
The element displayed in the list of subjects the rule is for.
<img width="160" alt="Screenshot 2023-06-01 at 11 34 12" src="https://github.com/Altinn/altinn-studio/assets/133344438/fd625157-781f-4412-a680-a8c80fb51dfe">

#### PolicySubjectSelectButton
```react-select``` component that is edited to let the user select a subject that is to be displayed in the list of subjects. 
<img width="480" alt="Screenshot 2023-06-01 at 11 35 24" src="https://github.com/Altinn/altinn-studio/assets/133344438/7a3845c7-6fac-4711-9859-c1aab409d6df">

#### ResourceNarrowingList
Holds the list of a resource group and the button to add more narrowing. 

#### VerificationModal
A verification modal to double check that the user wants to perform an action. It is developed using ```react-modal```. 
<img width="524" alt="Screenshot 2023-06-01 at 11 37 08" src="https://github.com/Altinn/altinn-studio/assets/133344438/79e93395-6d99-4d34-8f27-f7fb4dbdc019">

#### WarningCard
A red card to display a warning / error to the user. 
<img width="506" alt="Screenshot 2023-06-01 at 11 37 43" src="https://github.com/Altinn/altinn-studio/assets/133344438/8b821ca3-1da6-4d4c-8bf5-8dafbefadd7c">
