### PR TITLE
Use groups concept in previewHub to only send to clients with same developer name

### DIFF
--- a/backend/src/Designer/Hubs/PreviewHub.cs
+++ b/backend/src/Designer/Hubs/PreviewHub.cs
@@ -1,6 +1,7 @@
-using System;
 using System.Threading.Tasks;
+using Altinn.Studio.Designer.Helpers;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 
@@ -10,15 +11,26 @@ namespace Altinn.Studio.Designer.Hubs;
 public class PreviewHub : Hub
 {
     private readonly ILogger _logger;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
-    public PreviewHub(ILogger<PreviewHub> logger)
+    public PreviewHub(ILogger<PreviewHub> logger, IHttpContextAccessor httpContextAccessor)
     {
         _logger = logger;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public override Task OnConnectedAsync()
+    {
+        string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
+        string connectionId = Context.ConnectionId;
+        Groups.AddToGroupAsync(connectionId, developer);
+        return base.OnConnectedAsync();
     }
 
     public async Task SendMessage(string message)
     {
+        string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
         _logger.LogInformation("Message received from client: {MessageFromClient}", message);
-        await Clients.Others.SendAsync("ReceiveMessage", message);
+        await Clients.Group(developer).SendAsync("ReceiveMessage", message);
     }
 }

--- a/backend/tests/Designer.Tests/Hubs/PreviewHubTests.cs
+++ b/backend/tests/Designer.Tests/Hubs/PreviewHubTests.cs
@@ -1,6 +1,9 @@
-using System.Threading;
+using System.Collections.Generic;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Hubs;
+using AltinnCore.Authentication.Constants;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -11,10 +14,14 @@ namespace Designer.Tests.Hubs;
 public class PreviewHubTests
 {
     private readonly Mock<ILogger<PreviewHub>> _logger;
+    private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
+    private const string TestUser = "testUser";
 
     public PreviewHubTests()
     {
         _logger = new Mock<ILogger<PreviewHub>>();
+        _httpContextAccessor = new Mock<IHttpContextAccessor>();
+        _httpContextAccessor.Setup(req => req.HttpContext).Returns(GetHttpContextForTestUser(TestUser));
     }
 
     [Fact]
@@ -24,14 +31,50 @@ public class PreviewHubTests
         Mock<IHubCallerClients> mockClients = new();
         Mock<IClientProxy> mockClientProxy = new();
 
-        mockClients.Setup(clients => clients.Others).Returns(mockClientProxy.Object);
+        mockClients.Setup(clients => clients.Group(TestUser)).Returns(mockClientProxy.Object);
 
-        PreviewHub previewHubMock = new(_logger.Object) { Clients = mockClients.Object };
+        PreviewHub previewHubMock = new(_logger.Object, _httpContextAccessor.Object) { Clients = mockClients.Object };
 
         // act
         await previewHubMock.SendMessage("testMessage");
 
         // assert
-        mockClients.Verify(clients => clients.Others, Times.Once);
+        mockClients.Verify(clients => clients.Group(TestUser), Times.Once);
+    }
+
+    [Fact]
+    public async Task SignalR_ClientWithDifferentDeveloperName_ShouldNotReceiveMessage()
+    {
+        // arrange
+        Mock<IHubCallerClients> mockClients = new();
+        Mock<IClientProxy> mockClientProxy = new();
+
+        mockClients.Setup(clients => clients.Group(TestUser)).Returns(mockClientProxy.Object);
+
+        PreviewHub previewHubMock = new(_logger.Object, _httpContextAccessor.Object) { Clients = mockClients.Object };
+
+        // act
+        await previewHubMock.SendMessage("testMessage");
+
+        // assert
+        mockClients.Verify(clients => clients.Group("AnotherDeveloperName"), Times.Never);
+    }
+
+    private static HttpContext GetHttpContextForTestUser(string userName)
+    {
+        List<Claim> claims = new()
+        {
+            new Claim(AltinnCoreClaimTypes.Developer, userName, ClaimValueTypes.String, "altinn.no")
+        };
+        ClaimsIdentity identity = new("TestUserLogin");
+        identity.AddClaims(claims);
+
+        ClaimsPrincipal principal = new(identity);
+        HttpContext c = new DefaultHttpContext();
+        c.Request.HttpContext.User = principal;
+        c.Request.RouteValues.Add("org", "ttd");
+        c.Request.RouteValues.Add("app", "apps-test-tba");
+
+        return c;
     }
 }


### PR DESCRIPTION
## Description
- Use developer as identifier for the group that should receive the message (that trigger reload) from the signal r preview hub

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
