### PR TITLE
Add variables back if they were present before when editing text directly

### DIFF
--- a/backend/src/Designer/Services/Implementation/TextsService.cs
+++ b/backend/src/Designer/Services/Implementation/TextsService.cs
@@ -10,6 +10,7 @@ using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Microsoft.IdentityModel.Tokens;
+using NuGet.Protocol;
 
 namespace Altinn.Studio.Designer.Services.Implementation
 {
@@ -212,7 +213,15 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 else
                 {
                     int indexTextResourceElementUpdateKey = textResourceObject.Resources.IndexOf(textResourceContainsKey);
-                    textResourceObject.Resources[indexTextResourceElementUpdateKey] = new TextResourceElement { Id = kvp.Key, Value = kvp.Value };
+                    if (textResourceContainsKey.Variables == null)
+                    {
+                        textResourceObject.Resources[indexTextResourceElementUpdateKey] = new TextResourceElement { Id = kvp.Key, Value = kvp.Value };
+                    }
+                    else
+                    {
+                        List<TextResourceVariable> variables = textResourceContainsKey.Variables;
+                        textResourceObject.Resources[indexTextResourceElementUpdateKey] = new TextResourceElement { Id = kvp.Key, Value = kvp.Value, Variables = variables };
+                    }
                 }
             }
 

--- a/backend/tests/Designer.Tests/Controllers/TextController/UpdateTextsForKeys.cs
+++ b/backend/tests/Designer.Tests/Controllers/TextController/UpdateTextsForKeys.cs
@@ -38,9 +38,9 @@ namespace Designer.Tests.Controllers.TextController
             CreatedFolderPath = await TestDataHelper.CopyRepositoryForTest(org, app, developer, targetRepository);
 
             string file = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, $"App/config/texts/resource.{lang}.json");
-            var expectedResource = JsonSerializer.Deserialize<Altinn.Studio.Designer.Models.TextResource>(file, _jsonOptions);
+            TextResource expectedResource = JsonSerializer.Deserialize<TextResource>(file, _jsonOptions);
 
-            PrepareExpectedResource(expectedResource, updateDictionary);
+            PrepareExpectedResourceWithoutVariables(expectedResource, updateDictionary);
 
             string url = $"{VersionPrefix(org, targetRepository)}/language/{lang}";
 
@@ -53,9 +53,30 @@ namespace Designer.Tests.Controllers.TextController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string actualContent = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, $"App/config/texts/resource.{lang}.json");
             JsonUtils.DeepEquals(JsonSerializer.Serialize(expectedResource, _jsonOptions), actualContent).Should().BeTrue();
-
         }
-        private static void PrepareExpectedResource(TextResource resource, Dictionary<string, string> updateDictionary)
+
+        [Theory]
+        [MemberData(nameof(DataForTextWithVariables))]
+        public async Task UpdateTextsForKeys_ForTextsThatHaveVariables_MaintainsVariablesAndReturnsOk(string org, string app, string developer, string lang, Dictionary<string, string> updateDictionary)
+        {
+            string targetRepository = TestDataHelper.GenerateTestRepoName();
+            CreatedFolderPath = await TestDataHelper.CopyRepositoryForTest(org, app, developer, targetRepository);
+
+            string url = $"{VersionPrefix(org, targetRepository)}/language/{lang}";
+
+            using var httpContent = new StringContent(JsonSerializer.Serialize(updateDictionary), Encoding.UTF8, MediaTypeNames.Application.Json);
+
+            // Act
+            using HttpResponseMessage response = await HttpClient.Value.PutAsync(url, httpContent);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            string actualContent = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, $"App/config/texts/resource.{lang}.json");
+            TextResource actualResource = JsonSerializer.Deserialize<TextResource>(actualContent, _jsonOptions);
+            actualResource.Resources.Find(el => el.Id == "TextUsingVariables").Variables.Should().NotBeNull();
+        }
+
+        private static void PrepareExpectedResourceWithoutVariables(TextResource resource, Dictionary<string, string> updateDictionary)
         {
             foreach ((string key, string value) in updateDictionary)
             {
@@ -79,6 +100,15 @@ namespace Designer.Tests.Controllers.TextController
                 {
                     {"Epost", "new"},
                     {"nonExistingKey", "new value"}
+                }}
+            };
+
+        public static IEnumerable<object[]> DataForTextWithVariables =>
+            new List<object[]>
+            {
+                new object[] { "ttd", "hvem-er-hvem", "testUser", "nb", new Dictionary<string,string>()
+                {
+                    {"TextUsingVariables", "Dette er den nye teksten og variablene {0} og {1} har ikke blitt borte eller endret"},
                 }}
             };
     }

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/hvem-er-hvem/App/config/texts/resource.nb.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/hvem-er-hvem/App/config/texts/resource.nb.json
@@ -55,11 +55,11 @@
         "variables": [
         {
           "key": "aFieldInTheModel",
-          "datasource": "dataModel.testModel"
+          "dataSource": "dataModel.testModel"
         },
         {
           "key": "appId",
-          "datasource": "instanceContext"
+          "dataSource": "instanceContext"
         }
       ]
     }

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/hvem-er-hvem/App/config/texts/resource.nb.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/hvem-er-hvem/App/config/texts/resource.nb.json
@@ -48,6 +48,20 @@
     {
       "id": "ServiceName",
       "value": "Hvem er hvem?"
+    },
+    {
+      "id": "TextUsingVariables",
+      "value": "Dette er en tekst som skal oppdateres, men som har variablene {0} og {1} tilknyttet seg, som IKKE skal bli borte eller endret",
+        "variables": [
+        {
+          "key": "aFieldInTheModel",
+          "datasource": "dataModel.testModel"
+        },
+        {
+          "key": "appId",
+          "datasource": "instanceContext"
+        }
+      ]
     }
   ]
 }

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/hvem-er-hvem/App/models/testModel.metadata.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/hvem-er-hvem/App/models/testModel.metadata.json
@@ -1,1 +1,31 @@
-{"Org":"ttd","ServiceName":"hvem-er-hvem","RepositoryName":null,"ServiceId":null,"elements":{"root":{"id":"root","parentElement":null,"typeName":"/definitions/rootType","name":"root","dataBindingName":null,"xPath":"/root","restrictions":{},"choices":null,"type":"Group","xsdValueType":null,"texts":{},"customProperties":{},"maxOccurs":1,"minOccurs":0,"xName":"root","isTagContent":false,"fixedValue":null,"isReadOnly":false,"xmlSchemaXPath":null,"jsonSchemaPointer":"#/properties/root","displayString":"root : [0..1] /definitions/rootType"}}}
+{
+    "Org": "ttd",
+    "ServiceName": "hvem-er-hvem",
+    "RepositoryName": null,
+    "ServiceId": null,
+    "elements": {
+        "root": {
+            "id": "root",
+            "parentElement": null,
+            "typeName": "/definitions/rootType",
+            "name": "root",
+            "dataBindingName": null,
+            "xPath": "/root",
+            "restrictions": {},
+            "choices": null,
+            "type": "Group",
+            "xsdValueType": null,
+            "texts": {},
+            "customProperties": {},
+            "maxOccurs": 1,
+            "minOccurs": 0,
+            "xName": "root",
+            "isTagContent": false,
+            "fixedValue": null,
+            "isReadOnly": false,
+            "xmlSchemaXPath": null,
+            "jsonSchemaPointer": "#/properties/root",
+            "displayString": "root : [0..1] /definitions/rootType"
+        }
+    }
+}

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
@@ -70,7 +70,7 @@ const TextBox = ({ language, t, textResource, textResourceId }: TextBoxProps) =>
   const { mutate } = useUpsertTextResourcesMutation(org, app);
 
   const updateTextResource = (text: string) =>
-    mutate({ language, textResources: [{ id: textResourceId, value: text }] });
+    mutate({ language, textResources: [{ id: textResourceId, value: text, variables: textResource.variables }] });
 
   const [value, setValue] = useState<string>(textResource?.value || '');
 


### PR DESCRIPTION
## Description
- Add variables back if they were present before when editing text directly
- Add variables in frontend text state when doing upsert
- Add test in backend

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

