### PR TITLE
Added missing folder support in resourcerepository

### DIFF
--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -17,7 +17,6 @@ using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.RepositoryClient.Model;
 using Altinn.Studio.Designer.Services.Interfaces;
-using IdentityModel.OidcClient;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -878,6 +877,21 @@ namespace Altinn.Studio.Designer.Services.Implementation
             {
                 foreach (FileSystemObject resourceFile in contents)
                 {
+                    if (resourceFile.Type.Equals("Dir") && !resourceFile.Name.StartsWith("."))
+                    {
+                        List<FileSystemObject> contentsInFolder = GetContents(org, repository, resourceFile.Name);
+
+                        if (contentsInFolder != null)
+                        {
+                            foreach (FileSystemObject content in contentsInFolder)
+                            {
+                                if (content.Name.EndsWith("_resource.json"))
+                                {
+                                    resourceFiles.Add(content);
+                                }
+                            }
+                        }
+                    }
                     if (resourceFile.Name.EndsWith("_resource.json"))
                     {
                         resourceFiles.Add(resourceFile);


### PR DESCRIPTION
## Description
Added logic in RepositorySI.GetResourceFiles() to make it able to locate resourcefiles located in subfolders within the repositoryfolder.

## Related Issue(s)
- #10451 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
