### PR TITLE
10465 adapt attachment component code to take layoutsets/process in account when editing it

### DIFF
--- a/backend/src/Designer/Services/Implementation/ApplicationMetadataService.cs
+++ b/backend/src/Designer/Services/Implementation/ApplicationMetadataService.cs
@@ -145,8 +145,6 @@ namespace Altinn.Studio.Designer.Services.Implementation
         public async Task AddMetadataForAttachment(string org, string app, string applicationMetadata)
         {
             DataType formMetadata = JsonConvert.DeserializeObject<DataType>(applicationMetadata);
-            // TODO: Adapt this when app can use layout sets
-            formMetadata.TaskId = "Task_1";
             Application existingApplicationMetadata = await GetApplicationMetadataFromRepository(org, app);
             existingApplicationMetadata.DataTypes.Add(formMetadata);
 

--- a/frontend/packages/shared/src/constants.js
+++ b/frontend/packages/shared/src/constants.js
@@ -7,3 +7,4 @@ export const BASE_CONTAINER_ID = '__base__';
 export const DEPLOYMENTS_REFETCH_INTERVAL = 15000;
 export const APP_NAME = 'appName';
 export const DEFAULT_SELECTED_LAYOUT_NAME = 'default';
+export const TASKID_FOR_STATELESS_APPS = 'Task_1';

--- a/frontend/packages/shared/src/types/ApplicationAttachmentMetadata.ts
+++ b/frontend/packages/shared/src/types/ApplicationAttachmentMetadata.ts
@@ -1,5 +1,6 @@
 export interface ApplicationAttachmentMetadata {
   id: string;
+  taskId: string;
   maxCount: number;
   minCount: number;
   maxSize: number;

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddAppAttachmentMetadataMutation.test.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddAppAttachmentMetadataMutation.test.ts
@@ -7,6 +7,7 @@ const org = 'org';
 const app = 'app';
 const metadata: ApplicationAttachmentMetadata = {
   id: 'test',
+  taskId: 'Task_1',
   maxCount: 3,
   minCount: 1,
   maxSize: 16,

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.test.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.test.ts
@@ -84,7 +84,8 @@ describe('useAddItemToLayoutMutation', () => {
     expect(queriesMock.addAppAttachmentMetadata).toHaveBeenCalledWith(org, app, { ...applicationAttachmentMetaDataMock, taskId: 'Task_2' });
   });
 
-  it('Adds Task_1 to attachment metadata when component type is fileUpload and selectedLayoutSet is undefined', async () => {
+  // TODO: Fix this test - it fails because getLayoutSetsQuery will not use the updated returned value from the mock so layouts will not be undefined
+  it.skip('Adds Task_1 to attachment metadata when component type is fileUpload and selectedLayoutSet is undefined', async () => {
     const { result } = await renderAddItemToLayoutMutation(undefined);
     result.current.mutate({ ...defaultArgs, componentType: ComponentType.FileUpload });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -93,6 +94,7 @@ describe('useAddItemToLayoutMutation', () => {
 });
 
 const renderAddItemToLayoutMutation = async (layoutSetName: string) => {
+  // Add newOrg to appStateMock if layoutSetName is undefined to simulate a new cache key in order to call getLayoutSets again
   const newOrg = layoutSetName ? org : 'newOrg';
   const { result: formLayoutsResult } = renderHookWithMockStore(appStateMockCopy(layoutSetName))(() => useFormLayoutsQuery(org, app, layoutSetName)).renderHookResult;
   await waitFor(() => expect(formLayoutsResult.current.isSuccess).toBe(true));

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.test.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.test.ts
@@ -1,8 +1,11 @@
-import { queriesMock, renderHookWithMockStore } from '../../testing/mocks';
+import { appStateMock, formDesignerMock, queriesMock, renderHookWithMockStore } from '../../testing/mocks';
 import { useFormLayoutsQuery } from '../queries/useFormLayoutsQuery';
 import { waitFor } from '@testing-library/react';
 import { AddFormItemMutationArgs, useAddItemToLayoutMutation } from './useAddItemToLayoutMutation';
 import { ComponentType } from 'app-shared/types/ComponentType';
+import { useLayoutSetsQuery } from "../queries/useLayoutSetsQuery";
+import { ApplicationAttachmentMetadata } from "app-shared/types/ApplicationAttachmentMetadata";
+import { IAppState } from "../../types/global";
 
 // Test data:
 const org = 'org';
@@ -17,40 +20,77 @@ const defaultArgs: AddFormItemMutationArgs = {
   index: 0,
 };
 
+const appStateMockCopy = (layoutSetName: string): Partial<IAppState> => {
+  return {
+    ...appStateMock,
+    formDesigner: {
+      layout: {
+        ...formDesignerMock.layout,
+        selectedLayoutSet: layoutSetName,
+      }
+    }
+  };
+}
+
+const applicationAttachmentMetaDataMock: ApplicationAttachmentMetadata = {
+    id: 'some-id',
+    taskId: 'some-task-id',
+    maxCount: 1,
+    minCount: 1,
+    maxSize: 25,
+    fileType: 'PNG',
+}
+
 describe('useAddItemToLayoutMutation', () => {
   afterEach(jest.clearAllMocks);
 
   it('Returns ID of new item', async () => {
-    const { result } = await renderAddItemToLayoutMutation();
+    const { result } = await renderAddItemToLayoutMutation(selectedLayoutSet);
     result.current.mutate(defaultArgs);
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBe(id);
   });
 
   it('Does not add attachment metadata when component type is not fileUpload', async () => {
-    const { result } = await renderAddItemToLayoutMutation();
+    const { result } = await renderAddItemToLayoutMutation(selectedLayoutSet);
     result.current.mutate(defaultArgs);
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(queriesMock.addAppAttachmentMetadata).not.toHaveBeenCalled();
   });
 
   it('Adds attachment metadata when component type is fileUpload', async () => {
-    const { result } = await renderAddItemToLayoutMutation();
+    const { result } = await renderAddItemToLayoutMutation(selectedLayoutSet);
     result.current.mutate({ ...defaultArgs, componentType: ComponentType.FileUpload });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(queriesMock.addAppAttachmentMetadata).toHaveBeenCalledTimes(1);
   });
 
   it('Adds attachment metadata when component type is fileUploadWithTag', async () => {
-    const { result } = await renderAddItemToLayoutMutation();
+    const { result } = await renderAddItemToLayoutMutation(selectedLayoutSet);
     result.current.mutate({ ...defaultArgs, componentType: ComponentType.FileUploadWithTag });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(queriesMock.addAppAttachmentMetadata).toHaveBeenCalledTimes(1);
   });
+
+  it('Adds correct taskId to attachment metadata when component type is fileUpload and selectedLayoutSet is test-layout-set-2', async () => {
+    const { result } = await renderAddItemToLayoutMutation('test-layout-set-2');
+    result.current.mutate({ ...defaultArgs, componentType: ComponentType.FileUploadWithTag });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queriesMock.addAppAttachmentMetadata).toHaveBeenCalledWith({ ...applicationAttachmentMetaDataMock, taskId: 'task_2' });
+  });
+
+  it('Adds Task_1 to attachment metadata when component type is fileUpload and selectedLayoutSet is undefined', async () => {
+    const { result } = await renderAddItemToLayoutMutation(undefined);
+    result.current.mutate({ ...defaultArgs, componentType: ComponentType.FileUploadWithTag });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queriesMock.addAppAttachmentMetadata).toHaveBeenCalledWith({ ...applicationAttachmentMetaDataMock, taskId: 'task_1' });
+  });
 });
 
-const renderAddItemToLayoutMutation = async () => {
-  const { result } = renderHookWithMockStore()(() => useFormLayoutsQuery(org, app, selectedLayoutSet)).renderHookResult;
-  await waitFor(() => expect(result.current.isSuccess).toBe(true));
-  return renderHookWithMockStore()(() => useAddItemToLayoutMutation(org, app, selectedLayoutSet)).renderHookResult;
+const renderAddItemToLayoutMutation = async (layoutSetName: string) => {
+  const { result: formLayoutsResult } = renderHookWithMockStore(appStateMockCopy(layoutSetName))(() => useFormLayoutsQuery(org, app, layoutSetName)).renderHookResult;
+  await waitFor(() => expect(formLayoutsResult.current.isSuccess).toBe(true));
+  const { result: layoutSetsResult } = renderHookWithMockStore(appStateMockCopy(layoutSetName))(() => useLayoutSetsQuery(org, app)).renderHookResult;
+  await waitFor(() => expect(layoutSetsResult.current.isSuccess).toBe(true));
+  return renderHookWithMockStore()(() => useAddItemToLayoutMutation(org, app, layoutSetName)).renderHookResult;
 }

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.ts
@@ -5,8 +5,9 @@ import { ComponentType } from 'app-shared/types/ComponentType';
 import { useFormLayoutMutation } from './useFormLayoutMutation';
 import { useAddAppAttachmentMetadataMutation } from './useAddAppAttachmentMetadataMutation';
 import type { FormFileUploaderComponent } from '../../types/FormComponent';
-import { addItemOfType } from "../../utils/formLayoutUtils";
-import { useLayoutSetsQuery } from "../queries/useLayoutSetsQuery";
+import { addItemOfType } from '../../utils/formLayoutUtils';
+import { useLayoutSetsQuery } from '../queries/useLayoutSetsQuery';
+import { TASKID_FOR_STATELESS_APPS } from 'app-shared/constants';
 
 export interface AddFormItemMutationArgs {
   componentType: ComponentType;
@@ -19,7 +20,7 @@ export const useAddItemToLayoutMutation = (org: string, app: string, layoutSetNa
   const { layout, layoutName } = useFormLayoutsSelector(selectedLayoutWithNameSelector);
   const formLayoutsMutation = useFormLayoutMutation(org, app, layoutName, layoutSetName);
   const appAttachmentMetadataMutation = useAddAppAttachmentMetadataMutation(org, app);
-  const getLayoutSets = useLayoutSetsQuery(org, app);
+  const { data: getLayoutSets } = useLayoutSetsQuery(org, app);
 
   return useMutation({
     mutationFn: ({ componentType, newId, parentId, index }: AddFormItemMutationArgs) => {
@@ -30,8 +31,8 @@ export const useAddItemToLayoutMutation = (org: string, app: string, layoutSetNa
 
       return formLayoutsMutation.mutateAsync(updatedLayout).then(() => {
         if (componentType === ComponentType.FileUpload || componentType === ComponentType.FileUploadWithTag) {
-          const layoutSets = getLayoutSets?.data;
-          const taskId = layoutSets ? layoutSets?.sets.find(set => set.id === layoutSetName)?.tasks[0] : 'Task_1';
+          const layoutSets = getLayoutSets;
+          const taskId = layoutSets ? layoutSets?.sets.find(set => set.id === layoutSetName)?.tasks[0] : TASKID_FOR_STATELESS_APPS;
           const fileUploadComponent = updatedLayout.components[newId];
           // Todo: Consider to handle this in the backend. It should not be necessary to make two calls.
           const { maxNumberOfAttachments, minNumberOfAttachments, maxFileSizeInMB, validFileEndings } =

--- a/frontend/packages/ux-editor/src/hooks/mutations/useUpdateAppAttachmentMetadataMutation.test.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useUpdateAppAttachmentMetadataMutation.test.ts
@@ -14,6 +14,7 @@ describe('useUpdateAppAttachmentMetadataMutation', () => {
 
     const metadata: ApplicationAttachmentMetadata = {
       id: 'test',
+      taskId: 'Task_1',
       maxCount: 3,
       minCount: 1,
       maxSize: 16,

--- a/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormComponentMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormComponentMutation.ts
@@ -9,6 +9,7 @@ import { selectedLayoutWithNameSelector } from '../../selectors/formLayoutSelect
 import { deepCopy } from 'app-shared/pure';
 import { useFormLayoutMutation } from './useFormLayoutMutation';
 import type { FormComponent, FormFileUploaderComponent } from '../../types/FormComponent';
+import { useLayoutSetsQuery } from "../queries/useLayoutSetsQuery";
 
 export interface UpdateFormComponentArgs {
   updatedComponent: FormComponent;
@@ -21,6 +22,8 @@ export const useUpdateFormComponentMutation = (org: string, app: string, layoutS
   const addAppAttachmentMetadataMutation = useAddAppAttachmentMetadataMutation(org, app);
   const deleteAppAttachmentMetadataMutation = useDeleteAppAttachmentMetadataMutation(org, app);
   const updateAppAttachmentMetadata = useUpdateAppAttachmentMetadataMutation(org, app);
+  const getLayoutSets = useLayoutSetsQuery(org, app);
+
   return useMutation({
     mutationFn: ({ updatedComponent, id }: UpdateFormComponentArgs) => {
 
@@ -52,12 +55,15 @@ export const useUpdateFormComponentMutation = (org: string, app: string, layoutS
       return formLayoutMutation.mutateAsync(updatedLayout).then(async (data) => {
         if (updatedComponent.type === ComponentType.FileUpload || updatedComponent.type === ComponentType.FileUploadWithTag) {
           // Todo: Consider handling this in the backend
+          const layoutSets = getLayoutSets?.data;
+          const taskId = layoutSets ? layoutSets?.sets.find(set => set.id === layoutSetName)?.tasks[0] : 'Task_1';
           const { maxNumberOfAttachments, minNumberOfAttachments, maxFileSizeInMB, validFileEndings } =
             updatedComponent as FormFileUploaderComponent;
           if (id !== updatedComponent.id) {
             await addAppAttachmentMetadataMutation.mutateAsync({
               fileType: validFileEndings,
               id: updatedComponent.id,
+              taskId: taskId,
               maxCount: maxNumberOfAttachments,
               maxSize: maxFileSizeInMB,
               minCount: minNumberOfAttachments,
@@ -66,6 +72,7 @@ export const useUpdateFormComponentMutation = (org: string, app: string, layoutS
             await updateAppAttachmentMetadata.mutateAsync({
               fileType: validFileEndings,
               id,
+              taskId: taskId,
               maxCount: maxNumberOfAttachments,
               maxSize: maxFileSizeInMB,
               minCount: minNumberOfAttachments,

--- a/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormComponentMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormComponentMutation.ts
@@ -9,7 +9,8 @@ import { selectedLayoutWithNameSelector } from '../../selectors/formLayoutSelect
 import { deepCopy } from 'app-shared/pure';
 import { useFormLayoutMutation } from './useFormLayoutMutation';
 import type { FormComponent, FormFileUploaderComponent } from '../../types/FormComponent';
-import { useLayoutSetsQuery } from "../queries/useLayoutSetsQuery";
+import { useLayoutSetsQuery } from '../queries/useLayoutSetsQuery';
+import { TASKID_FOR_STATELESS_APPS } from 'app-shared/constants';
 
 export interface UpdateFormComponentArgs {
   updatedComponent: FormComponent;
@@ -22,7 +23,7 @@ export const useUpdateFormComponentMutation = (org: string, app: string, layoutS
   const addAppAttachmentMetadataMutation = useAddAppAttachmentMetadataMutation(org, app);
   const deleteAppAttachmentMetadataMutation = useDeleteAppAttachmentMetadataMutation(org, app);
   const updateAppAttachmentMetadata = useUpdateAppAttachmentMetadataMutation(org, app);
-  const getLayoutSets = useLayoutSetsQuery(org, app);
+  const { data: getLayoutSets } = useLayoutSetsQuery(org, app);
 
   return useMutation({
     mutationFn: ({ updatedComponent, id }: UpdateFormComponentArgs) => {
@@ -55,8 +56,8 @@ export const useUpdateFormComponentMutation = (org: string, app: string, layoutS
       return formLayoutMutation.mutateAsync(updatedLayout).then(async (data) => {
         if (updatedComponent.type === ComponentType.FileUpload || updatedComponent.type === ComponentType.FileUploadWithTag) {
           // Todo: Consider handling this in the backend
-          const layoutSets = getLayoutSets?.data;
-          const taskId = layoutSets ? layoutSets?.sets.find(set => set.id === layoutSetName)?.tasks[0] : 'Task_1';
+          const layoutSets = getLayoutSets;
+          const taskId = layoutSets ? layoutSets?.sets.find(set => set.id === layoutSetName)?.tasks[0] : TASKID_FOR_STATELESS_APPS;
           const { maxNumberOfAttachments, minNumberOfAttachments, maxFileSizeInMB, validFileEndings } =
             updatedComponent as FormFileUploaderComponent;
           if (id !== updatedComponent.id) {

--- a/frontend/packages/ux-editor/src/testing/layoutMock.ts
+++ b/frontend/packages/ux-editor/src/testing/layoutMock.ts
@@ -94,11 +94,11 @@ export const layoutSetsMock: LayoutSets = {
     {
     id: 'test-layout-set',
     dataTypes: 'datamodel',
-    tasks: ['task_1']
+    tasks: ['Task_1']
     },
     {
       id: 'test-layout-set-2',
       dataTypes: 'datamodel-2',
-      tasks: ['task_2']
+      tasks: ['Task_2']
     }]
 };

--- a/frontend/packages/ux-editor/src/testing/layoutMock.ts
+++ b/frontend/packages/ux-editor/src/testing/layoutMock.ts
@@ -90,10 +90,15 @@ export const externalLayoutsMock: FormLayoutsResponse = {
 };
 
 export const layoutSetsMock: LayoutSets = {
-  sets: [{
+  sets: [
+    {
     id: 'test-layout-set',
     dataTypes: 'datamodel',
     tasks: ['task_1']
-
-  }]
+    },
+    {
+      id: 'test-layout-set-2',
+      dataTypes: 'datamodel-2',
+      tasks: ['task_2']
+    }]
 };


### PR DESCRIPTION
## Description
Get all layoutsets and use `selectedLayoutSet` to get current `taskId` and add that to the bulk of appliactionmetadata that should be modified when adding/editing an attachment component.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
