### PR TITLE
Removing the GET Capabilities test from use case tests

### DIFF
--- a/src/test/K6/src/tests/platform/eFormidling/eFormidling.js
+++ b/src/test/K6/src/tests/platform/eFormidling/eFormidling.js
@@ -44,12 +44,6 @@ export default function () {
   });
   addErrorCount(success);
 
-  var res = eFormidling.getCapabilities(orgNo);
-  var success = check(res, {
-    'Get Capabilities for orgNo Status is 200': (r) => r.status === 200,
-  });
-  addErrorCount(success);
-
   var res = eFormidling.checkHealth();
   var success = check(res, {
     'Check Health Status is 200': (r) => r.status === 200,


### PR DESCRIPTION
## Description
Removing the GET Capabilities test as it is too unstable. There are other tests that cover eFormidling availability. Testing the capabilities endpoint is less important. It isn't a part of our use of eFormidling, but it's available for custom implementations in an app should they feel the need.
