### PR TITLE
Create query client mock

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -716,7 +716,7 @@
   "sync_header.changes_made_samme_place_submessage": "Du må beskrive de endringer du gjort før du kan hente ned den siste versjonen.",
   "sync_header.changes_made_samme_place_subsubmessage": "Gode beskrivelser av hva som er endret gjør det enklere å finne tilbake til tidligere versjoner.",
   "sync_header.changes_to_share": "Last opp dine endringer",
-  "sync_header.clone": "Clone",
+  "sync_header.clone": "Klone",
   "sync_header.clone_https": "Klone med HTTPS",
   "sync_header.clone_https_button": "Kopier Lenke",
   "sync_header.controlling_service_status": "Sjekker status på appen din",

--- a/frontend/packages/shared/src/contexts/ServicesContext.tsx
+++ b/frontend/packages/shared/src/contexts/ServicesContext.tsx
@@ -11,7 +11,7 @@ export type ServicesContextProviderProps = ServicesContextProps & {
 };
 
 const ServicesContext = createContext<ServicesContextProps>(null);
-export const queryClient = new QueryClient({
+const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: Infinity,

--- a/frontend/packages/shared/src/hooks/mutations/useUpsertTextResourcesMutation.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useUpsertTextResourcesMutation.ts
@@ -1,6 +1,6 @@
 import { ITextResource, ITextResources } from 'app-shared/types/global';
-import { useMutation } from '@tanstack/react-query';
-import { queryClient, useServicesContext } from 'app-shared/contexts/ServicesContext';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { convertTextResourcesArrayToObject, modifyTextResources } from 'app-shared/utils/textResourceUtils';
 import { usePreviewConnection } from "app-shared/providers/PreviewConnectionContext";
@@ -13,6 +13,7 @@ export interface UpsertTextResourcesMutationArgs {
 export const useUpsertTextResourcesMutation = (org: string, app: string) => {
   const previewConnection = usePreviewConnection();
   const { upsertTextResources } = useServicesContext();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ language, textResources }: UpsertTextResourcesMutationArgs) =>
       upsertTextResources(

--- a/frontend/packages/ux-editor/src/components/TextResource.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResource.test.tsx
@@ -3,13 +3,13 @@ import userEvent from '@testing-library/user-event';
 import type { ITextResource, ITextResourcesWithLanguage } from 'app-shared/types/global';
 import { TextResource, TextResourceProps } from './TextResource';
 import {
+  queryClientMock,
   renderHookWithMockStore,
   renderWithMockStore,
 } from '../testing/mocks';
 import { act, screen, waitFor } from '@testing-library/react';
 import { mockUseTranslation } from '../../../../testing/mocks/i18nMock';
 import { useTextResourcesQuery } from 'app-shared/hooks/queries/useTextResourcesQuery';
-import { queryClient } from 'app-shared/contexts/ServicesContext';
 import { DEFAULT_LANGUAGE } from 'app-shared/constants';
 
 const user = userEvent.setup();
@@ -48,7 +48,7 @@ jest.mock(
 describe('TextResource', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    queryClient.clear();
+    queryClientMock.clear();
   });
 
   it('Renders add button when no resource id is given', async () => {

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
@@ -5,7 +5,9 @@ import type { ITextResources, ITextResourcesWithLanguage } from 'app-shared/type
 import userEvent from '@testing-library/user-event';
 import { TextResourceEdit } from './TextResourceEdit';
 import {
-  appDataMock, queriesMock,
+  appDataMock,
+  queriesMock,
+  queryClientMock,
   renderHookWithMockStore,
   renderWithMockStore,
   textResourcesMock
@@ -13,7 +15,6 @@ import {
 import { act, screen, waitFor } from '@testing-library/react';
 import { mockUseTranslation } from '../../../../testing/mocks/i18nMock';
 import { useTextResourcesQuery } from 'app-shared/hooks/queries/useTextResourcesQuery';
-import { queryClient } from 'app-shared/contexts/ServicesContext';
 
 const user = userEvent.setup();
 
@@ -45,7 +46,7 @@ describe('TextResourceEdit', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    queryClient.clear();
+    queryClientMock.clear();
   });
 
   it('Does not render anything if edit id is undefined', async () => {

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.ts
@@ -20,7 +20,7 @@ export const useAddItemToLayoutMutation = (org: string, app: string, layoutSetNa
   const { layout, layoutName } = useFormLayoutsSelector(selectedLayoutWithNameSelector);
   const formLayoutsMutation = useFormLayoutMutation(org, app, layoutName, layoutSetName);
   const appAttachmentMetadataMutation = useAddAppAttachmentMetadataMutation(org, app);
-  const { data: getLayoutSets } = useLayoutSetsQuery(org, app);
+  const { data: layoutSets } = useLayoutSetsQuery(org, app);
 
   return useMutation({
     mutationFn: ({ componentType, newId, parentId, index }: AddFormItemMutationArgs) => {
@@ -31,7 +31,6 @@ export const useAddItemToLayoutMutation = (org: string, app: string, layoutSetNa
 
       return formLayoutsMutation.mutateAsync(updatedLayout).then(() => {
         if (componentType === ComponentType.FileUpload || componentType === ComponentType.FileUploadWithTag) {
-          const layoutSets = getLayoutSets;
           const taskId = layoutSets ? layoutSets?.sets.find(set => set.id === layoutSetName)?.tasks[0] : TASKID_FOR_STATELESS_APPS;
           const fileUploadComponent = updatedLayout.components[newId];
           // Todo: Consider to handle this in the backend. It should not be necessary to make two calls.

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddLayoutMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddLayoutMutation.ts
@@ -1,15 +1,12 @@
 import { useFormLayoutsQuery } from '../queries/useFormLayoutsQuery';
 import { useDispatch } from 'react-redux';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FormLayoutActions } from '../../features/formDesigner/formLayout/formLayoutSlice';
 import { deepCopy } from 'app-shared/pure';
 import { convertInternalToLayoutFormat, createEmptyLayout } from '../../utils/formLayoutUtils';
 import { IInternalLayout } from '../../types/global';
 import { ExternalFormLayout } from 'app-shared/types/api/FormLayoutsResponse';
-import {
-  queryClient,
-  useServicesContext,
-} from 'app-shared/contexts/ServicesContext';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { useFormLayoutSettingsMutation } from './useFormLayoutSettingsMutation';
 import { useFormLayoutSettingsQuery } from '../queries/useFormLayoutSettingsQuery';
@@ -27,6 +24,7 @@ export const useAddLayoutMutation = (org: string, app: string, layoutSetName: st
   const formLayoutSettingsQuery = useFormLayoutSettingsQuery(org, app, layoutSetName);
   const formLayoutSettingsMutation = useFormLayoutSettingsMutation(org, app, layoutSetName);
   const dispatch = useDispatch();
+  const queryClient = useQueryClient();
 
   const save = async (updatedLayoutName: string, updatedLayout: IInternalLayout) => {
     const convertedLayout: ExternalFormLayout = convertInternalToLayoutFormat(updatedLayout);

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddWidgetMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddWidgetMutation.ts
@@ -1,12 +1,11 @@
 import { IFormDesignerComponents, IFormLayouts, IInternalLayout, IWidget } from '../../types/global';
 import { convertFromLayoutToInternalFormat } from '../../utils/formLayoutUtils';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { selectedLayoutWithNameSelector } from '../../selectors/formLayoutSelectors';
 import { useFormLayoutsSelector } from '../useFormLayoutsSelector';
 import { deepCopy } from 'app-shared/pure';
 import { v4 as uuidv4 } from 'uuid';
 import { useFormLayoutMutation } from './useFormLayoutMutation';
-import { queryClient } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { BASE_CONTAINER_ID } from 'app-shared/constants';
 import { useUpsertTextResourcesMutation } from 'app-shared/hooks/mutations';
@@ -22,6 +21,7 @@ export const useAddWidgetMutation = (org: string, app: string, layoutSetName: st
   const { layout, layoutName } = useFormLayoutsSelector(selectedLayoutWithNameSelector);
   const { mutateAsync: updateLayout } = useFormLayoutMutation(org, app, layoutName, layoutSetName);
   const { mutateAsync: updateText } = useUpsertTextResourcesMutation(org, app);
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({ widget, position, containerId }: AddWidgetMutationArgs) => {
       const internalComponents = convertFromLayoutToInternalFormat({

--- a/frontend/packages/ux-editor/src/hooks/mutations/useConfigureLayoutSetMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useConfigureLayoutSetMutation.ts
@@ -1,6 +1,6 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useDispatch } from 'react-redux';
-import { queryClient, useServicesContext } from 'app-shared/contexts/ServicesContext';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { FormLayoutActions } from "../../features/formDesigner/formLayout/formLayoutSlice";
 
@@ -11,6 +11,7 @@ export interface ConfigureLayoutSetMutationArgs {
 export const useConfigureLayoutSetMutation = (org: string, app: string) => {
   const { configureLayoutSet } = useServicesContext();
   const dispatch = useDispatch();
+  const queryClient = useQueryClient();
 
   return useMutation({
 

--- a/frontend/packages/ux-editor/src/hooks/mutations/useDeleteLayoutMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useDeleteLayoutMutation.ts
@@ -1,5 +1,5 @@
-import { useMutation } from '@tanstack/react-query';
-import { queryClient, useServicesContext } from 'app-shared/contexts/ServicesContext';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { useDispatch, useSelector } from 'react-redux';
 import { FormLayoutActions } from '../../features/formDesigner/formLayout/formLayoutSlice';
 import { QueryKey } from 'app-shared/types/QueryKey';
@@ -25,6 +25,7 @@ export const useDeleteLayoutMutation = (org: string, app: string, layoutSetName:
   const selectedLayout = useSelector(selectedLayoutNameSelector);
   const dispatch = useDispatch();
   const t = useText();
+  const queryClient = useQueryClient();
 
   const saveLayout = async (updatedLayoutName: string, updatedLayout: IInternalLayout) => {
     const convertedLayout: ExternalFormLayout = convertInternalToLayoutFormat(updatedLayout);

--- a/frontend/packages/ux-editor/src/hooks/mutations/useFormLayoutMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useFormLayoutMutation.ts
@@ -1,8 +1,8 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { IFormLayouts, IInternalLayout } from '../../types/global';
 import { convertInternalToLayoutFormat } from '../../utils/formLayoutUtils';
 import { QueryKey } from 'app-shared/types/QueryKey';
-import { queryClient, useServicesContext } from 'app-shared/contexts/ServicesContext';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { usePreviewConnection } from 'app-shared/providers/PreviewConnectionContext';
 import { ExternalFormLayout } from 'app-shared/types/api/FormLayoutsResponse';
 
@@ -10,6 +10,7 @@ export const useFormLayoutMutation = (org: string, app: string, layoutName: stri
 
   const previewConnection = usePreviewConnection();
   const { saveFormLayout } = useServicesContext();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (layout: IInternalLayout) => {

--- a/frontend/packages/ux-editor/src/hooks/mutations/useFormLayoutSettingsMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useFormLayoutSettingsMutation.ts
@@ -1,12 +1,13 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ILayoutSettings } from 'app-shared/types/global';
-import { queryClient, useServicesContext } from 'app-shared/contexts/ServicesContext';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { usePreviewConnection } from 'app-shared/providers/PreviewConnectionContext';
 
 export const useFormLayoutSettingsMutation = (org: string, app: string, layoutSetName: string) => {
   const previewConnection = usePreviewConnection();
   const { saveFormLayoutSettings } = useServicesContext();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (settings: ILayoutSettings) => saveFormLayoutSettings(org, app, layoutSetName, settings).then(() => settings),
     onSuccess: async (savedSettings) => {

--- a/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormComponentMutation.test.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormComponentMutation.test.ts
@@ -1,11 +1,11 @@
-import { queriesMock, renderHookWithMockStore } from '../../testing/mocks';
-import { useFormLayoutsQuery } from '../queries/useFormLayoutsQuery';
-import { waitFor } from '@testing-library/react';
+import { queriesMock, queryClientMock, renderHookWithMockStore } from '../../testing/mocks';
 import { ComponentType } from 'app-shared/types/ComponentType';
 import { UpdateFormComponentArgs, useUpdateFormComponentMutation } from './useUpdateFormComponentMutation';
-import { component1IdMock, layout1NameMock } from '../../testing/layoutMock';
+import { component1IdMock, externalLayoutsMock, layout1NameMock } from '../../testing/layoutMock';
 import type { FormComponent, FormFileUploaderComponent } from '../../types/FormComponent';
 import { IDataModelBindings } from '../../types/global';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import { convertExternalLayoutsToInternalFormat } from '../../utils/formLayoutsUtils';
 
 // Test data:
 const org = 'org';
@@ -26,7 +26,7 @@ describe('useUpdateFormComponentMutation', () => {
   afterEach(jest.clearAllMocks);
 
   it('Saves layout with updated component', async () => {
-    await renderAndWaitForData();
+    renderAndWaitForData();
 
     const updateFormComponentResult = renderHookWithMockStore()(() => useUpdateFormComponentMutation(org, app, selectedLayoutSet))
       .renderHookResult
@@ -55,7 +55,7 @@ describe('useUpdateFormComponentMutation', () => {
   });
 
   it('Does not run attachment metadata queries if the component type is not fileupload', async () => {
-    await renderAndWaitForData();
+    renderAndWaitForData();
     const updateFormComponentResult = renderHookWithMockStore()(() => useUpdateFormComponentMutation(org, app, selectedLayoutSet))
       .renderHookResult
       .result;
@@ -66,7 +66,7 @@ describe('useUpdateFormComponentMutation', () => {
   });
 
   it('Updates attachment metadata queries if the component type is fileupload', async () => {
-    await renderAndWaitForData();
+    renderAndWaitForData();
     const updateFormComponentResult = renderHookWithMockStore()(() => useUpdateFormComponentMutation(org, app, selectedLayoutSet))
       .renderHookResult
       .result;
@@ -89,7 +89,7 @@ describe('useUpdateFormComponentMutation', () => {
   });
 });
 
-const renderAndWaitForData = async () => {
-  const formLayoutsResult = renderHookWithMockStore()(() => useFormLayoutsQuery(org, app, selectedLayoutSet)).renderHookResult.result;
-  await waitFor(() => expect(formLayoutsResult.current.isSuccess).toBe(true));
-}
+const renderAndWaitForData = () => queryClientMock.setQueryData(
+  [QueryKey.FormLayouts, org, app, selectedLayoutSet],
+  convertExternalLayoutsToInternalFormat(externalLayoutsMock).convertedLayouts
+);

--- a/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormComponentMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormComponentMutation.ts
@@ -23,7 +23,7 @@ export const useUpdateFormComponentMutation = (org: string, app: string, layoutS
   const addAppAttachmentMetadataMutation = useAddAppAttachmentMetadataMutation(org, app);
   const deleteAppAttachmentMetadataMutation = useDeleteAppAttachmentMetadataMutation(org, app);
   const updateAppAttachmentMetadata = useUpdateAppAttachmentMetadataMutation(org, app);
-  const { data: getLayoutSets } = useLayoutSetsQuery(org, app);
+  const { data: layoutSets } = useLayoutSetsQuery(org, app);
 
   return useMutation({
     mutationFn: ({ updatedComponent, id }: UpdateFormComponentArgs) => {
@@ -56,7 +56,6 @@ export const useUpdateFormComponentMutation = (org: string, app: string, layoutS
       return formLayoutMutation.mutateAsync(updatedLayout).then(async (data) => {
         if (updatedComponent.type === ComponentType.FileUpload || updatedComponent.type === ComponentType.FileUploadWithTag) {
           // Todo: Consider handling this in the backend
-          const layoutSets = getLayoutSets;
           const taskId = layoutSets ? layoutSets?.sets.find(set => set.id === layoutSetName)?.tasks[0] : TASKID_FOR_STATELESS_APPS;
           const { maxNumberOfAttachments, minNumberOfAttachments, maxFileSizeInMB, validFileEndings } =
             updatedComponent as FormFileUploaderComponent;

--- a/frontend/packages/ux-editor/src/hooks/mutations/useUpdateLayoutNameMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useUpdateLayoutNameMutation.ts
@@ -1,5 +1,5 @@
-import { queryClient, useServicesContext } from 'app-shared/contexts/ServicesContext';
-import { useMutation } from '@tanstack/react-query';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useDispatch } from 'react-redux';
 import { FormLayoutActions } from '../../features/formDesigner/formLayout/formLayoutSlice';
 import { QueryKey } from 'app-shared/types/QueryKey';
@@ -19,6 +19,7 @@ export const useUpdateLayoutNameMutation = (org: string, app: string, layoutSetN
   const formLayoutSettingsQuery = useFormLayoutSettingsQuery(org, app, layoutSetName);
   const formLayoutSettingsMutation = useFormLayoutSettingsMutation(org, app, layoutSetName);
   const dispatch = useDispatch();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ oldName, newName }: UpdateLayoutNameMutationArgs) =>
       updateFormLayoutName(org, app, oldName, newName, layoutSetName).then(() => ({ oldName, newName })),

--- a/frontend/packages/ux-editor/src/testing/layoutMock.ts
+++ b/frontend/packages/ux-editor/src/testing/layoutMock.ts
@@ -92,13 +92,14 @@ export const externalLayoutsMock: FormLayoutsResponse = {
 export const layoutSetsMock: LayoutSets = {
   sets: [
     {
-    id: 'test-layout-set',
-    dataTypes: 'datamodel',
-    tasks: ['Task_1']
+      id: 'test-layout-set',
+      dataTypes: 'datamodel',
+      tasks: ['Task_1']
     },
     {
       id: 'test-layout-set-2',
       dataTypes: 'datamodel-2',
       tasks: ['Task_2']
-    }]
+    }
+  ]
 };

--- a/frontend/packages/ux-editor/src/testing/mocks.tsx
+++ b/frontend/packages/ux-editor/src/testing/mocks.tsx
@@ -20,6 +20,7 @@ import {
   layoutSetsMock,
 } from './layoutMock';
 import { queriesMock as allQueriesMock } from 'app-shared/mocks/queriesMock';
+import { QueryClient } from '@tanstack/react-query';
 
 export const textResourcesMock: ITextResourcesState = {
   currentEditId: undefined,
@@ -80,12 +81,23 @@ export const queriesMock: ServicesContextProps = {
   upsertTextResources: jest.fn().mockImplementation(() => Promise.resolve()),
 };
 
+export const queryClientMock = new QueryClient({
+  logger: {
+    log: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+  defaultOptions: {
+    queries: { staleTime: Infinity },
+  },
+});
+
 export const renderWithMockStore =
   (state: Partial<IAppState> = {}, queries: Partial<ServicesContextProps> = {}) =>
   (component: ReactNode) => {
     const store = configureStore()({ ...appStateMock, ...state });
     const renderResult = render(
-      <ServicesContextProvider {...queriesMock} {...queries}>
+      <ServicesContextProvider {...queriesMock} {...queries} client={queryClientMock}>
         <PreviewConnectionContextProvider>
           <Provider store={store}>
             <BrowserRouter>{component}</BrowserRouter>
@@ -95,14 +107,13 @@ export const renderWithMockStore =
     );
     return { renderResult, store };
   };
-
 export const renderHookWithMockStore =
   (state: Partial<IAppState> = {}, queries: Partial<ServicesContextProps> = {}) =>
   (hook: () => any) => {
     const store = configureStore()({ ...appStateMock, ...state });
     const renderHookResult = renderHook(hook, {
       wrapper: ({ children }) => (
-        <ServicesContextProvider {...queriesMock} {...queries}>
+        <ServicesContextProvider {...queriesMock} {...queries} client={queryClientMock}>
           <PreviewConnectionContextProvider>
             <Provider store={store}>{children}</Provider>
           </PreviewConnectionContextProvider>


### PR DESCRIPTION
## Description
- Created a query client mock for testing and made sure it is used within the unit tests
- Improved `useAddItemToLayoutMutation` tests by by setting the query cache data directly using the new mock

## Related Issue(s)
- #10465

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
