### PR TITLE
Fix Cypress select option selector

### DIFF
--- a/frontend/testing/cypress/src/pageobjects/dashboard.js
+++ b/frontend/testing/cypress/src/pageobjects/dashboard.js
@@ -5,7 +5,7 @@ export const dashboard = {
   appName: '#service-saved-name',
   button: 'button',
   createApp: 'Opprett applikasjon',
-  appOwnersList: "[data-testid='select-root'] [role='option']",
+  appOwnersList: "[role='option']",
   searchApp: '#search-repos',
   apps: {
     name: "div[data-field='name']",


### PR DESCRIPTION
In the latest version of the design system, the option list is applied to the root of the document and not inside the DOM element, so this selector must be changed. Also, we should avoid using test ids from external libraries in general.
