### PR TITLE
fix weird-looking styling on datamodels toolbar

### DIFF
--- a/frontend/packages/schema-editor/src/components/TopToolbar.module.css
+++ b/frontend/packages/schema-editor/src/components/TopToolbar.module.css
@@ -43,7 +43,7 @@
 }
 
 .toggleButtonGroupWrapper {
-  flex: 1;
+  flex: 0.5;
 }
 
 .wrapper {

--- a/frontend/packages/schema-editor/src/components/TopToolbar.module.css
+++ b/frontend/packages/schema-editor/src/components/TopToolbar.module.css
@@ -20,7 +20,7 @@
 }
 
 .spinnerWrapper {
-  width: 200px;
+  flex: 1;
 }
 
 @keyframes fadeOut {
@@ -40,4 +40,15 @@
 
 .statusPopover.success {
   animation: fadeOut 1.5s;
+}
+
+.toggleButtonGroupWrapper {
+  flex: 1;
+}
+
+.wrapper {
+  display: flex;
+  flex: 3;
+  gap: 1rem;
+  justify-content: flex-end;
 }

--- a/frontend/packages/schema-editor/src/components/TopToolbar.tsx
+++ b/frontend/packages/schema-editor/src/components/TopToolbar.tsx
@@ -60,54 +60,58 @@ export function TopToolbar({
   return (
     <section className={classes.toolbar} role={'toolbar'}>
       {Toolbar}
-      <div className={classes.spinnerWrapper}>
-        {saving ? (
-          <Spinner title={t('general.saving')} />
-        ) : (
-          <Popover
-            className={cn(classes.statusPopover, generatedSchemaSuccessfully && classes.success)}
-            open={showGenerationState}
-            trigger={
-              <Button
-                id='save-model-button'
-                data-testid='save-model-button'
-                onClick={handleGenerateButtonClick}
-                disabled={!editMode || !saveAction}
-                icon={<CogIcon />}
-                variant={ButtonVariant.Quiet}
-              >
-                {t('schema_editor.generate_model_files')}
-              </Button>
-            }
-          >
-            {error?.message ? (
-              <>
-                <ErrorMessage role='alertdialog'>{error.message}</ErrorMessage>
+      <div className={classes.wrapper}>
+        <div className={classes.spinnerWrapper}>
+          {saving ? (
+            <Spinner title={t('general.saving')} />
+          ) : (
+            <Popover
+              className={cn(classes.statusPopover, generatedSchemaSuccessfully && classes.success)}
+              open={showGenerationState}
+              trigger={
                 <Button
-                  onClick={() => setShowGenerationState(false)}
-                  variant={ButtonVariant.Outline}
+                  id='save-model-button'
+                  data-testid='save-model-button'
+                  onClick={handleGenerateButtonClick}
+                  disabled={!editMode || !saveAction}
+                  icon={<CogIcon />}
+                  variant={ButtonVariant.Quiet}
                 >
-                  {t('general.close')}
+                  {t('schema_editor.generate_model_files')}
                 </Button>
-              </>
-            ) : (
-              <Panel variant={PanelVariant.Success} forceMobileLayout={true}>
-                {t('general.saved')}
-              </Panel>
-            )}
-          </Popover>
+              }
+            >
+              {error?.message ? (
+                <>
+                  <ErrorMessage role='alertdialog'>{error.message}</ErrorMessage>
+                  <Button
+                    onClick={() => setShowGenerationState(false)}
+                    variant={ButtonVariant.Outline}
+                  >
+                    {t('general.close')}
+                  </Button>
+                </>
+              ) : (
+                <Panel variant={PanelVariant.Success} forceMobileLayout={true}>
+                  {t('general.saved')}
+                </Panel>
+              )}
+            </Popover>
+          )}
+        </div>
+        {toggleEditMode && (
+          <div className={classes.toggleButtonGroupWrapper}>
+            <ToggleButtonGroup
+              selectedValue={editMode ? 'edit' : 'view'}
+              onChange={toggleEditMode}
+              items={[
+                { value: 'view', label: t('schema_editor.view_mode') },
+                { value: 'edit', label: t('schema_editor.edit_mode') },
+              ]}
+            />
+          </div>
         )}
       </div>
-      {toggleEditMode && (
-        <ToggleButtonGroup
-          selectedValue={editMode ? 'edit' : 'view'}
-          onChange={toggleEditMode}
-          items={[
-            { value: 'view', label: t('schema_editor.view_mode') },
-            { value: 'edit', label: t('schema_editor.edit_mode') },
-          ]}
-        />
-      )}
     </section>
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Edit/readonly toggle button was suddenly very large, squishing all the other components up to the left side of the toolbar.

![Screenshot 2023-06-14 at 14 33 48](https://github.com/Altinn/altinn-studio/assets/1636323/387abf1d-6545-4005-b349-437c5b589b11)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
