### PR TITLE
Exclude experimental Codeql rules

### DIFF
--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           languages: javascript
           queries: +security-and-quality
+          query-filters:
+            - exclude:
+                id: js/ml-powered/xss
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -37,6 +37,8 @@ jobs:
           query-filters:
             - exclude:
                 id: js/ml-powered/xss
+            - exclude:
+                id: js/ml-powered/sql-injection
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
## Description
Exclude the experimental "Client-side cross-site scripting" rule, which gives a lot of irrelevant warnings.
