### PR TITLE
Make Sonarcloud check run asynchronously

### DIFF
--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -34,11 +34,6 @@ jobs:
         with:
           languages: javascript
           queries: +security-and-quality
-          query-filters:
-            - exclude:
-                id: js/ml-powered/xss
-            - exclude:
-                id: js/ml-powered/sql-injection
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
@@ -84,6 +79,18 @@ jobs:
 
       - name: Fix code coverage paths
         run: sed -i 's@'frontend/'@/github/workspace/frontend/@g' frontend/coverage/lcov.info
+
+  sonarcloud:
+    name: Sonarcloud scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checking out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Installing dependencies
+        uses: ./.github/actions/yarn-install
 
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master


### PR DESCRIPTION
The Sonarcloud scan was set up to run after the unit tests. By running the checks simultaneously, the total time for the them to finish is reduced by nearly a half.