### PR TITLE
replace sonarcloud with codecov

### DIFF
--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -78,16 +78,13 @@ jobs:
       - name: 'Running Unit Tests'
         run: yarn test:ci
 
-      - name: Fix code coverage paths
-        run: sed -i 's@'frontend/'@/github/workspace/frontend/@g' frontend/coverage/lcov.info
-
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        with:
-          projectBaseDir: frontend
+      - name: 'Upload coverage reports to Codecov'
+        uses: codecov/codecov-action@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          directory: frontend/coverage
+          fail_ci_if_error: true
 
   build:
     name: 'Building'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaced sonarcloud setup with codecov for a faster PR run.
If we need sonarcloud for static code analysis we can trigger it to run in parallel with testing.
