### PR TITLE
Add validation of identifier to be used in filename

### DIFF
--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -834,9 +834,9 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 if (!CheckIfResourceFileAlreadyExists(newResource.Identifier, org, repository))
                 {
                     string repopath = _settings.GetServicePath(org, repository, AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext));
-                    string fullPathOfNewResource = Path.Combine(repopath, newResource.Identifier, string.Format("{0}_resource.json", newResource.Identifier));
+                    string fullPathOfNewResource = Path.Combine(repopath, newResource.Identifier.AsFileName(), string.Format("{0}_resource.json", newResource.Identifier));
                     string newResourceJson = JsonConvert.SerializeObject(newResource);
-                    Directory.CreateDirectory(Path.Combine(repopath, newResource.Identifier));
+                    Directory.CreateDirectory(Path.Combine(repopath, newResource.Identifier.AsFileName()));
                     File.WriteAllText(fullPathOfNewResource, newResourceJson);
 
                     return new StatusCodeResult(201);


### PR DESCRIPTION
## Description
Add call to StringExtensions.AsFileName when using newResource.Identifier in creation of paths in the AddResource-method.

## Related Issue(s)
- #10564 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
