### PR TITLE
10481 hidealways field in appmetadata is overridden to false by studio

### DIFF
--- a/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -48,7 +48,8 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
             WriteIndented = true,
             Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true
         };
 
         /// <summary>

--- a/backend/src/Designer/Services/Implementation/ApplicationMetadataService.cs
+++ b/backend/src/Designer/Services/Implementation/ApplicationMetadataService.cs
@@ -244,8 +244,14 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
             // It's used to avoid sensibility to BOM
             using var fileStream = new MemoryStream(Convert.FromBase64String(file.Content));
-            using StreamReader utf8Reader = new StreamReader(fileStream, Encoding.UTF8);
-            return JsonSerializer.Deserialize<Application>(await utf8Reader.ReadToEndAsync(), new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+            using StreamReader utf8Reader = new(fileStream, Encoding.UTF8);
+            return JsonSerializer.Deserialize<Application>(await utf8Reader.ReadToEndAsync(),
+                new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+                });
         }
 
         public bool ApplicationMetadataExistsInRepository(string org, string app)

--- a/backend/src/Designer/TypedHttpClients/AltinnStorage/AltinnStorageAppMetadataClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnStorage/AltinnStorageAppMetadataClient.cs
@@ -100,8 +100,6 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
             {
                 Content = new StringContent(stringContent, Encoding.UTF8, "application/json"),
             };
-            string content = await request.Content.ReadAsStringAsync();
-            _logger.LogInformation($"Application metadata sent to storage uri, {uri}, with content: {content}");
             await _httpClient.SendAsync(request);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Skatt had an issue with a prop in `messageBoxConfig`; `hideAlways`, turning false even though they set it to true. This was because they had written `messageboxConfig` with a small `B`. To avoid that the deserialization totally avoids this property due to the minor case-typo and sets all its underlying props to default values, we should be case insensitive.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
