### PR TITLE
explicitly pass org to component

### DIFF
--- a/frontend/app-development/features/administration/components/ResetRepoModal.test.tsx
+++ b/frontend/app-development/features/administration/components/ResetRepoModal.test.tsx
@@ -49,6 +49,7 @@ describe('ResetRepoModal', () => {
       onClose: mockFunc,
       open: true,
       repositoryName: mockRepoName,
+      org: 'testOrg',
     };
     return renderWithMockStore({}, queries)(<ResetRepoModal {...defaultProps} {...props} />);
   };

--- a/frontend/app-development/features/administration/components/ResetRepoModal.tsx
+++ b/frontend/app-development/features/administration/components/ResetRepoModal.tsx
@@ -4,7 +4,6 @@ import { AltinnSpinner } from 'app-shared/components';
 import { Button, ButtonColor, ButtonVariant, TextField } from '@digdir/design-system-react';
 import { Popover } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
 import { useResetRepositoryMutation } from 'app-development/hooks/mutations/useResetRepositoryMutation';
 
 export interface IResetRepoModalProps {
@@ -12,12 +11,12 @@ export interface IResetRepoModalProps {
   onClose: any;
   open: boolean;
   repositoryName: string;
+  org: string;
 }
 
 export function ResetRepoModal(props: IResetRepoModalProps) {
   const [canDelete, setCanDelete] = useState<boolean>(false);
   const [deleteRepoName, setDeleteRepoName] = useState<string>('');
-  const { org, app } = useParams<{ org: string; app: string }>();
 
   useEffect(() => {
     if (deleteRepoName === props.repositoryName) {
@@ -29,7 +28,7 @@ export function ResetRepoModal(props: IResetRepoModalProps) {
 
   const onDeleteRepoNameChange = (event: any) => setDeleteRepoName(event.target.value);
 
-  const repoResetMutation = useResetRepositoryMutation(org, app);
+  const repoResetMutation = useResetRepositoryMutation(props.org, props.repositoryName);
   const onResetWrapper = () => {
     setCanDelete(false);
     repoResetMutation.mutate();

--- a/frontend/app-development/features/administration/components/SideMenuContent.tsx
+++ b/frontend/app-development/features/administration/components/SideMenuContent.tsx
@@ -85,6 +85,7 @@ export const SideMenuContent = (props: ISideMenuContent): JSX.Element => {
         onClose={onCloseModal}
         open={resetRepoModalOpen}
         repositoryName={props.service.name}
+        org={org}
       />
       {/* Download local repository */}
       <h3>{t('administration.download_repo')}</h3>

--- a/frontend/app-development/features/simpleMerge/MergeConflictWarning.tsx
+++ b/frontend/app-development/features/simpleMerge/MergeConflictWarning.tsx
@@ -50,6 +50,7 @@ export const MergeConflictWarning = ({ org, app }: MergeConflictWarningProps) =>
           onClose={toggleResetModal}
           open={resetRepoModalOpen}
           repositoryName={app}
+          org={org}
         />
       </ButtonContainer>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Explicitly pass org/app to the ResetRepoModal component so it works in context where route params are not available.

## Related Issue(s)
- #10596 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
