### PR TITLE
use commit-and-push endpoint

### DIFF
--- a/frontend/app-development/hooks/mutations/useRepoCommitAndPushMutation.test.ts
+++ b/frontend/app-development/hooks/mutations/useRepoCommitAndPushMutation.test.ts
@@ -1,0 +1,24 @@
+import { CreateRepoCommitPayload } from 'app-shared/types/api';
+import { queriesMock, renderHookWithMockStore } from '../../test/mocks';
+import { useRepoCommitAndPushMutation } from './useRepoCommitAndPushMutation';
+
+// Test data:
+const org = 'org';
+const app = 'app';
+
+describe('useRepoCommitAndPushMutation', () => {
+  it('Calls commitAndPushChanges with correct arguments and payload', async () => {
+    const result = renderHookWithMockStore()(() => useRepoCommitAndPushMutation(org, app))
+      .renderHookResult.result;
+
+    const commitMessage = 'test commit message';
+    await result.current.mutateAsync({ commitMessage });
+
+    expect(queriesMock.commitAndPushChanges).toHaveBeenCalledTimes(1);
+    expect(queriesMock.commitAndPushChanges).toHaveBeenCalledWith(org, app, {
+      message: commitMessage,
+      org,
+      repository: app,
+    } as CreateRepoCommitPayload);
+  });
+});

--- a/frontend/app-development/hooks/mutations/useRepoCommitAndPushMutation.ts
+++ b/frontend/app-development/hooks/mutations/useRepoCommitAndPushMutation.ts
@@ -16,5 +16,9 @@ export const useRepoCommitAndPushMutation = (owner, app) => {
       q.invalidateQueries({ queryKey: [QueryKey.RepoStatus, owner, app] }).then();
       q.invalidateQueries({ queryKey: [QueryKey.BranchStatus, owner, app, 'master'] }).then();
     },
+    onError: (error) => {
+      q.invalidateQueries({ queryKey: [QueryKey.RepoStatus, owner, app] }).then();
+      q.invalidateQueries({ queryKey: [QueryKey.BranchStatus, owner, app, 'master'] }).then();
+    },
   });
 };

--- a/frontend/app-development/hooks/mutations/useRepoCommitAndPushMutation.ts
+++ b/frontend/app-development/hooks/mutations/useRepoCommitAndPushMutation.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
+import { QueryKey } from 'app-shared/types/QueryKey';
+
+export const useRepoCommitAndPushMutation = (owner, app) => {
+  const q = useQueryClient();
+  const { commitAndPushChanges } = useServicesContext();
+  return useMutation({
+    mutationFn: ({ commitMessage }: { commitMessage: string }) =>
+      commitAndPushChanges(owner, app, {
+        message: commitMessage,
+        org: owner,
+        repository: app,
+      }),
+    onSuccess: () => {
+      q.invalidateQueries({ queryKey: [QueryKey.RepoStatus, owner, app] }).then();
+      q.invalidateQueries({ queryKey: [QueryKey.BranchStatus, owner, app, 'master'] }).then();
+    },
+  });
+};

--- a/frontend/app-development/hooks/mutations/useRepoCommitAndPushMutation.ts
+++ b/frontend/app-development/hooks/mutations/useRepoCommitAndPushMutation.ts
@@ -16,9 +16,5 @@ export const useRepoCommitAndPushMutation = (owner, app) => {
       q.invalidateQueries({ queryKey: [QueryKey.RepoStatus, owner, app] }).then();
       q.invalidateQueries({ queryKey: [QueryKey.BranchStatus, owner, app, 'master'] }).then();
     },
-    onError: (error) => {
-      q.invalidateQueries({ queryKey: [QueryKey.RepoStatus, owner, app] }).then();
-      q.invalidateQueries({ queryKey: [QueryKey.BranchStatus, owner, app, 'master'] }).then();
-    },
   });
 };

--- a/frontend/app-development/layout/version-control/VersionControlHeader.test.tsx
+++ b/frontend/app-development/layout/version-control/VersionControlHeader.test.tsx
@@ -29,20 +29,42 @@ const okRepoStatus: RepoStatus = {
   behindBy: 0,
   contentStatus: [],
   hasMergeConflict: false,
-  repositoryStatus: 'Ok'
+  repositoryStatus: 'Ok',
 };
+
+const aheadRepoStatus: RepoStatus = {
+  aheadBy: 1,
+  behindBy: 0,
+  contentStatus: [],
+  hasMergeConflict: false,
+  repositoryStatus: 'Ok',
+};
+
+const mergeConflictRepoStatus: RepoStatus = {
+  aheadBy: 1,
+  behindBy: 1,
+  contentStatus: [],
+  hasMergeConflict: true,
+  repositoryStatus: 'Ok',
+};
+
 const getRepoMetadata = jest.fn().mockImplementation(() => Promise.resolve({}));
 const getRepoStatus = jest.fn().mockImplementation(() => Promise.resolve(okRepoStatus));
 const getRepoPull = jest.fn().mockImplementation(() => Promise.resolve(okRepoStatus));
+const commitAndPushChanges = jest.fn().mockImplementation(() => Promise.resolve(okRepoStatus));
 
 const queries: ServicesContextProps = {
   ...queriesMock,
   getRepoMetadata,
   getRepoStatus,
   getRepoPull,
+  commitAndPushChanges,
 };
 
 describe('Shared > Version Control > VersionControlHeader', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   it('should render header when type is not defined', async () => {
     render(
       <ServicesContextProvider {...queries}>
@@ -55,32 +77,105 @@ describe('Shared > Version Control > VersionControlHeader', () => {
     expect(screen.queryByTestId('version-control-share-button')).toBeNull();
   });
 
-  it('should render header when type is header', async () => {
-    render(
-      <ServicesContextProvider {...queries}>
-        <VersionControlHeader hasPushRight={true} />
-      </ServicesContextProvider>
-    );
-    await waitFor(() => expect(getRepoMetadata).toHaveBeenCalledTimes(1));
-    // eslint-disable-next-line testing-library/prefer-presence-queries
-    expect(screen.queryByTestId('version-control-header')).not.toBeNull();
-    expect(screen.queryByTestId('version-control-fetch-button')).toBeNull();
-    expect(screen.queryByTestId('version-control-share-button')).toBeNull();
-  });
-
   it('Refetches queries when clicking the fetch button', async () => {
     render(
       <ServicesContextProvider {...queries}>
         <VersionControlHeader hasPushRight={true} />
       </ServicesContextProvider>
     );
-    await waitFor(() => expect(getRepoMetadata).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(getRepoStatus).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(getRepoPull).toHaveBeenCalledTimes(1));
     const fetchButton = screen.getByRole('button', { name: textMock('sync_header.fetch_changes') });
     await act(() => user.click(fetchButton));
-    await waitFor(() => expect(getRepoMetadata).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(getRepoStatus).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(getRepoPull).toHaveBeenCalledTimes(3)); // This is called twice because it is also refetched to check the repository status. See "todo" comment in the component file.
+    await waitFor(() => expect(getRepoMetadata).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getRepoStatus).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getRepoPull).toHaveBeenCalledTimes(2)); // This is called twice because it is also refetched to check the repository status. See "todo" comment in the component file.
+  });
+
+  it('should render commit message modal when clicking the share button with changes', async () => {
+    const mockGetRepoStatus = jest.fn().mockImplementation(() => Promise.resolve(aheadRepoStatus));
+    const mockQueries: ServicesContextProps = {
+      ...queries,
+      getRepoStatus: mockGetRepoStatus,
+    };
+    render(
+      <ServicesContextProvider {...mockQueries}>
+        <VersionControlHeader hasPushRight={true} />
+      </ServicesContextProvider>
+    );
+
+    // await waitFor(() => expect(getRepoPull).toHaveBeenCalledTimes(1));
+    const shareButton = screen.getByRole('button', {
+      name: textMock('sync_header.no_changes_to_share'),
+    });
+    await act(() => user.click(shareButton));
+    await waitFor(() => expect(mockGetRepoStatus).toHaveBeenCalledTimes(1));
+    expect(
+      await screen.findByText(textMock('sync_header.describe_and_validate'))
+    ).toBeInTheDocument();
+  });
+
+  it('should render no changes message when clicking the share button with no changes', async () => {
+    render(
+      <ServicesContextProvider {...queries}>
+        <VersionControlHeader hasPushRight={true} />
+      </ServicesContextProvider>
+    );
+
+    // await waitFor(() => expect(getRepoPull).toHaveBeenCalledTimes(1));
+    const shareButton = screen.getByRole('button', {
+      name: textMock('sync_header.no_changes_to_share'),
+    });
+    await act(() => user.click(shareButton));
+    await waitFor(() => expect(getRepoStatus).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(textMock('sync_header.nothing_to_push'))).toBeInTheDocument();
+  });
+
+  it('should render commit message modal when clicking the share button with merge conflicts', async () => {
+    const mockGetRepoStatus = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(mergeConflictRepoStatus));
+    const mockQueries: ServicesContextProps = {
+      ...queries,
+      getRepoStatus: mockGetRepoStatus,
+    };
+    render(
+      <ServicesContextProvider {...mockQueries}>
+        <VersionControlHeader hasPushRight={true} />
+      </ServicesContextProvider>
+    );
+
+    const shareButton = screen.getByRole('button', {
+      name: textMock('sync_header.no_changes_to_share'),
+    });
+    await act(() => user.click(shareButton));
+    await waitFor(() => expect(mockGetRepoStatus).toHaveBeenCalledTimes(1));
+    expect(
+      await screen.findByText(textMock('sync_header.describe_and_validate'))
+    ).toBeInTheDocument();
+  });
+
+  it('should call commitAndPush endpoint clicking the share button with changes', async () => {
+    const mockGetRepoStatus = jest.fn().mockImplementation(() => Promise.resolve(aheadRepoStatus));
+    const mockQueries: ServicesContextProps = {
+      ...queries,
+      getRepoStatus: mockGetRepoStatus,
+    };
+    render(
+      <ServicesContextProvider {...mockQueries}>
+        <VersionControlHeader hasPushRight={true} />
+      </ServicesContextProvider>
+    );
+
+    const shareButton = screen.getByRole('button', {
+      name: textMock('sync_header.no_changes_to_share'),
+    });
+    await act(() => user.click(shareButton));
+
+    await waitFor(() => expect(mockGetRepoStatus).toHaveBeenCalledTimes(1));
+    await act(() =>
+      user.click(
+        screen.getByRole('button', { name: textMock('sync_header.describe_and_validate_btnText') })
+      )
+    );
+    await waitFor(() => expect(commitAndPushChanges).toHaveBeenCalledTimes(1));
   });
 });

--- a/frontend/language/src/en.json
+++ b/frontend/language/src/en.json
@@ -708,7 +708,7 @@
   "sync_header.merge_conflict": "Mergeconflict",
   "sync_header.merge_conflict_btn": "Solve conflict",
   "sync_header.merge_conflict_occured": "Someone else has made changes in the same place as you in the app.",
-  "sync_header.merge_conflict_occured_submessage": "Open the codeeditor to decide which changes you wish to keep",
+  "sync_header.merge_conflict_occured_submessage": "These are in conflict with your changes. Click the button to resolve the conflict.",
   "sync_header.no_changes_to_share": "Push",
   "sync_header.nothing_to_push": "You have pushed your latest changes",
   "sync_header.repo_is_offline": "Repo is offline",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -749,7 +749,7 @@
   "sync_header.merge_conflict": "Mergekonflikt",
   "sync_header.merge_conflict_btn": "Løs konflikt",
   "sync_header.merge_conflict_occured": "En annen har gjort endringer på appen på samme sted som deg.",
-  "sync_header.merge_conflict_occured_submessage": "Åpne kodeeditoren for å bestemme hvilke endringer du ønsker å beholde",
+  "sync_header.merge_conflict_occured_submessage": "Disse er i konflikt med dine endringer. Trykk på knappen under for å løse konflikten.",
   "sync_header.no_changes_to_share": "Last opp dine endringer",
   "sync_header.nothing_to_push": "Du har delt dine siste endringer",
   "sync_header.repo_is_offline": "Repo er utilgjengelig",

--- a/frontend/packages/shared/src/api/mutations.ts
+++ b/frontend/packages/shared/src/api/mutations.ts
@@ -1,5 +1,5 @@
 import { del, get, post, put } from 'app-shared/utils/networking';
-import { appMetadataAttachmentPath, copyAppPath, createRepoPath, deploymentsPath, formLayoutNamePath, formLayoutPath, layoutSetsPath, layoutSetPath, layoutSettingsPath, releasesPath, repoCommitPath, repoPushPath, repoResetPath, ruleConfigPath, textResourceIdsPath, textResourcesPath, userLogoutPath, userStarredRepoPath } from 'app-shared/api/paths';
+import { appMetadataAttachmentPath, copyAppPath, createRepoPath, deploymentsPath, formLayoutNamePath, formLayoutPath, layoutSetsPath, layoutSetPath, layoutSettingsPath, releasesPath, repoCommitPath, repoPushPath, repoResetPath, ruleConfigPath, textResourceIdsPath, textResourcesPath, userLogoutPath, userStarredRepoPath, repoCommitPushPath } from 'app-shared/api/paths';
 import { AddLanguagePayload } from 'app-shared/types/api/AddLanguagePayload';
 import { AddRepoParams } from 'app-shared/types/api';
 import { ApplicationAttachmentMetadata } from 'app-shared/types/ApplicationAttachmentMetadata';
@@ -25,6 +25,7 @@ export const addLayoutSet = (org: string, app: string, payload: LayoutSetConfig)
 export const addRepo = (repoToAdd: AddRepoParams) => post<IRepository>(`${createRepoPath()}${buildQueryParams(repoToAdd)}`);
 export const copyApp = (org: string, app: string, repoName: string) => post(copyAppPath(org, app, repoName));
 export const createDeployment = (org: string, app: string, payload: CreateDeploymentPayload) => post<void, CreateDeploymentPayload>(deploymentsPath(org, app), payload);
+export const commitAndPushChanges = (org: string, app: string, payload: CreateRepoCommitPayload) => post<CreateRepoCommitPayload>(repoCommitPushPath(org, app), payload, { headers });
 export const configureLayoutSet = (org: string, app: string, layoutSetName: string) => post<LayoutSets>(layoutSetPath(org, app, layoutSetName));
 export const createRelease = (org: string, app: string, payload: CreateReleasePayload) => post<void, CreateReleasePayload>(releasesPath(org, app), payload);
 export const createRepoCommit = (org: string, app: string, payload: CreateRepoCommitPayload) => post<CreateRepoCommitPayload>(repoCommitPath(org, app), payload, { headers });

--- a/frontend/packages/shared/src/mocks/queriesMock.ts
+++ b/frontend/packages/shared/src/mocks/queriesMock.ts
@@ -5,6 +5,7 @@ export const queriesMock: ServicesContextProps = {
   addLanguageCode: jest.fn(),
   addRepo: jest.fn(),
   addLayoutSet: jest.fn(),
+  commitAndPushChanges: jest.fn(),
   configureLayoutSet: jest.fn(),
   copyApp: jest.fn(),
   createDeployment: jest.fn(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed from using the endpoints `commit` followed by `push`, to the `commit-and-push` endpoint which does the "save" operation in a single operation, making it easier for the user to work with.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
