### PR TITLE
set values directly instead of using object.assign to get correct value

### DIFF
--- a/frontend/packages/schema-model/src/lib/build-ui-schema.ts
+++ b/frontend/packages/schema-model/src/lib/build-ui-schema.ts
@@ -41,8 +41,8 @@ const createUiNode = (schemaNode: KeyValuePairs, uiNode: UiSchemaNode): UiSchema
     uiNode.fieldType = findUiFieldType(schemaNode);
     uiNode.implicitType = schemaNode[Keyword.Type] === undefined;
     uiNode.reference = findReference(schemaNode[Keyword.Reference]);
-    Object.assign(uiNode.custom, findCustomAttributes(schemaNode));
-    Object.assign(uiNode.restrictions, findRestrictionsOnNode(schemaNode));
+    uiNode.custom = findCustomAttributes(schemaNode);
+    uiNode.restrictions = findRestrictionsOnNode(schemaNode);
     Object.assign(uiNode, findGenericKeywordsOnNode(schemaNode));
     const uiSchemaNodes: UiSchemaNode[] = [uiNode];
 
@@ -92,6 +92,5 @@ export const buildUiSchema = (jsonSchema: JsonSchema): UiSchemaNodes => {
       item.fieldType = lookup.get(item.reference);
     }
   });
-
   return uiNodeMap;
 };

--- a/frontend/packages/schema-model/src/lib/build-ui-schema.ts
+++ b/frontend/packages/schema-model/src/lib/build-ui-schema.ts
@@ -41,8 +41,8 @@ const createUiNode = (schemaNode: KeyValuePairs, uiNode: UiSchemaNode): UiSchema
     uiNode.fieldType = findUiFieldType(schemaNode);
     uiNode.implicitType = schemaNode[Keyword.Type] === undefined;
     uiNode.reference = findReference(schemaNode[Keyword.Reference]);
-    uiNode.custom = findCustomAttributes(schemaNode);
-    uiNode.restrictions = findRestrictionsOnNode(schemaNode);
+    Object.assign(uiNode.restrictions, findRestrictionsOnNode(schemaNode));
+    Object.assign(uiNode.custom, findCustomAttributes(schemaNode));
     Object.assign(uiNode, findGenericKeywordsOnNode(schemaNode));
     const uiSchemaNodes: UiSchemaNode[] = [uiNode];
 

--- a/frontend/packages/schema-model/src/lib/utils.ts
+++ b/frontend/packages/schema-model/src/lib/utils.ts
@@ -14,7 +14,7 @@ export const createNodeBase = (...args: string[]): UiSchemaNode => ({
   isArray: false,
   children: [],
   custom: {},
-  restrictions: [],
+  restrictions: {},
   implicitType: true,
   default: undefined,
   enum: [],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
UPDATED
The initial value of the uiSchemaNode `restriction` property, as created in `createNodeBase` was set to `[]`, which is the wrong data type. `restrictions` should be an `object` (key value pair), not an `array`. 
Setting the initial value to `{}` solves the issue.

## Related Issue(s)
- #10613 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
