### PR TITLE
Ensure error message when deploy mutation fails

### DIFF
--- a/frontend/app-development/features/appPublish/components/appDeploymentComponent.test.tsx
+++ b/frontend/app-development/features/appPublish/components/appDeploymentComponent.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { AppDeploymentComponent, AppDeploymentComponentProps } from './appDeploymentComponent';
+import { screen } from '@testing-library/react';
+import { renderWithMockStore } from 'app-development/test/mocks';
+import { textMock } from '../../../../testing/mocks/i18nMock';
+import { IDeployment } from 'app-development/sharedResources/appDeployment/types';
+
+const render = (props?: Partial<AppDeploymentComponentProps>) => {
+  const defaultProps: AppDeploymentComponentProps = {
+    deployHistory: [],
+    deployPermission: true,
+    envName: 'test',
+    imageOptions: [],
+    orgName: 'test',
+    showLinkToApp: true,
+  };
+  const merged = { ...defaultProps, ...props };
+
+  return renderWithMockStore({}, {})(<AppDeploymentComponent {...merged} />);
+};
+describe('AppDeploymentComponent', () => {
+  it('should render', () => {
+    render();
+    expect(screen.getByText(`${textMock('app_deploy.environment')}`)).toBeInTheDocument();
+  });
+
+  it('should render with no deploy history', () => {
+    render();
+    expect(screen.getByText(textMock('app_deploy.no_app_deployed'))).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('app_deploy_table.deployed_version_history_empty'))
+    ).toBeInTheDocument();
+  });
+
+  it('should render missing rights message if deployPermission is false', () => {
+    render({ deployPermission: false });
+    expect(screen.getByText(textMock('app_publish.missing_rights'))).toBeInTheDocument();
+  });
+
+  it('should render with deploy history', () => {
+    const deployHistory: IDeployment[] = [
+      {
+        app: 'test-app',
+        created: new Date().toDateString(),
+        createdBy: 'test-user',
+        envName: 'test',
+        id: 'test-id',
+        org: 'test-org',
+        tagName: 'test',
+        build: {
+          id: 'test-id',
+          finished: new Date().toDateString(),
+          result: 'succeeded',
+          status: 'Completed',
+          started: new Date().toDateString(),
+        },
+        deployedInEnv: true,
+      },
+    ];
+    render({ deployHistory });
+    expect(screen.getByText(textMock('app_deploy.deployed_version'))).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('app_deploy_table.deployed_version_history'))
+    ).toBeInTheDocument();
+    expect(screen.getByText('test')).toBeInTheDocument();
+  });
+
+  it('should render error message if latest deploy failed', () => {
+    const deployHistory: IDeployment[] = [
+      {
+        app: 'test-app',
+        created: new Date().toDateString(),
+        createdBy: 'test-user',
+        envName: 'test',
+        id: 'test-id',
+        org: 'test-org',
+        tagName: 'test',
+        build: {
+          id: 'test-id',
+          finished: new Date().toDateString(),
+          result: 'failed',
+          status: 'failed',
+          started: new Date().toDateString(),
+        },
+        deployedInEnv: false,
+      },
+    ];
+    render({ deployHistory });
+    expect(screen.getByText(textMock('app_deploy_messages.technical_error_1'))).toBeInTheDocument();
+  });
+});

--- a/frontend/app-development/features/appPublish/components/appDeploymentComponent.test.tsx
+++ b/frontend/app-development/features/appPublish/components/appDeploymentComponent.test.tsx
@@ -139,4 +139,30 @@ describe('AppDeploymentComponent', () => {
     await act(() => user.click(dropdown));
     expect(screen.getAllByRole('option')).toHaveLength(2);
   });
+
+  it('should render spinner when deployment is in progress', () => {
+    const deployHistory: IDeployment[] = [
+      {
+        app: 'test-app',
+        created: new Date().toDateString(),
+        createdBy: 'test-user',
+        envName: 'test',
+        id: 'test-id',
+        org: 'test-org',
+        tagName: 'test',
+        build: {
+          id: 'test-id',
+          finished: null,
+          result: 'inProgress',
+          status: 'inProgress',
+          started: new Date().toDateString(),
+        },
+        deployedInEnv: true,
+      },
+    ];
+    render({ deployHistory });
+    expect(
+      screen.getByText(`${textMock('app_publish.deployment_in_progress')}...`)
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/app-development/features/appPublish/components/appDeploymentComponent.tsx
+++ b/frontend/app-development/features/appPublish/components/appDeploymentComponent.tsx
@@ -19,7 +19,7 @@ export type ImageOption = {
   label: string;
 };
 
-interface IAppDeploymentComponentProps {
+export interface AppDeploymentComponentProps {
   envName: string;
   urlToApp?: string;
   urlToAppLinkTxt?: string;
@@ -49,7 +49,7 @@ export const AppDeploymentComponent = ({
   urlToAppLinkTxt,
   orgName,
   showLinkToApp,
-}: IAppDeploymentComponentProps) => {
+}: AppDeploymentComponentProps) => {
   const [selectedImageTag, setSelectedImageTag] = useState(null);
   const { t } = useTranslation();
 
@@ -71,7 +71,7 @@ export const AppDeploymentComponent = ({
     [deployHistory]
   );
   const latestDeploy = deployHistory ? deployHistory[0] : null;
-  const deploymentInEnv = deployHistory ? deployHistory.find(d => d.deployedInEnv) : false;
+  const deploymentInEnv = deployHistory ? deployHistory.find((d) => d.deployedInEnv) : false;
   const { deployInProgress, deploymentStatus } = useMemo(() => {
     if (latestDeploy && latestDeploy.build.finished === null) {
       return { deployInProgress: true, deploymentStatus: DeploymentStatus.inProgress };
@@ -84,7 +84,8 @@ export const AppDeploymentComponent = ({
 
   const appDeployedAndReachable = !!deploymentInEnv;
   const deployFailed = latestDeploy && deploymentStatus === DeploymentStatus.failed;
-  const deployedVersionNotReachable = latestDeploy && !appDeployedAndReachable && deploymentStatus === DeploymentStatus.succeeded;
+  const deployedVersionNotReachable =
+    latestDeploy && !appDeployedAndReachable && deploymentStatus === DeploymentStatus.succeeded;
   const noAppDeployed = !latestDeploy || deployInProgress;
 
   return (
@@ -92,12 +93,12 @@ export const AppDeploymentComponent = ({
       <div className={classes.headingContainer}>
         <div className={classes.envTitle}>{t('app_deploy.environment', { envName })}</div>
         <div className={classes.gridItem}>
-          {appDeployedAndReachable && !deployInProgress &&
+          {appDeployedAndReachable &&
+            !deployInProgress &&
             t('app_deploy.deployed_version', { appDeployedVersion: deploymentInEnv.tagName })}
           {(noAppDeployed || (deployFailed && !appDeployedAndReachable)) &&
             t('app_deploy.no_app_deployed')}
-          {deployedVersionNotReachable &&
-            t('app_deploy.deployed_version_unavailable')}
+          {deployedVersionNotReachable && t('app_deploy.deployed_version_unavailable')}
         </div>
         <div className={classes.gridItem}>
           {showLinkToApp && (
@@ -120,8 +121,7 @@ export const AppDeploymentComponent = ({
               <div>{t('app_publish.missing_rights', { envName, orgName })}</div>
             </div>
           )}
-          {deployPermission && imageOptions.length > 0 &&
-            !deployInProgress && (
+          {deployPermission && imageOptions.length > 0 && !deployInProgress && (
             <DeployDropdown
               appDeployedVersion={latestDeploy ? latestDeploy.tagName : undefined}
               envName={envName}
@@ -134,7 +134,9 @@ export const AppDeploymentComponent = ({
               startDeploy={startDeploy}
             />
           )}
-          {deployInProgress && <AltinnSpinner spinnerText={t('app_publish.deployment_in_progress') + '...'} />}
+          {deployInProgress && (
+            <AltinnSpinner spinnerText={t('app_publish.deployment_in_progress') + '...'} />
+          )}
           {deployPermission && latestDeploy && deployedVersionNotReachable && (
             <Panel variant={PanelVariant.Error}>
               <Trans i18nKey={'app_deploy_messages.unable_to_list_deploys'}>
@@ -142,7 +144,7 @@ export const AppDeploymentComponent = ({
               </Trans>
             </Panel>
           )}
-          {deployPermission && deployFailed && (
+          {deployPermission && (deployFailed || mutation.isError) && (
             <Panel variant={PanelVariant.Error}>
               <Trans i18nKey={'app_deploy_messages.technical_error_1'}>
                 <a href='mailto:tjenesteeier@altinn.no' />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There are some automatic formatting changes, sorry about that. The actual change is on line 147, added a check on the mutation-function as well, so that error messages is shown if the actual deploy-call fails for some reason.

## Related Issue(s)
- #10390 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
