### PR TITLE
Added state to prevent error message in text field

### DIFF
--- a/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/ItemDataComponent.tsx
@@ -69,6 +69,7 @@ export function ItemDataComponent(props: IItemDataComponentProps) {
 
   const [itemTitle, setItemItemTitle] = useState<string>(title || '');
   const [nodeName, setNodeName] = useState(getNameFromPointer({ pointer }));
+  const [isTextModified, setIsTextModified] = useState(false);
 
   const [nameError, setNameError] = useState(NameError.NoError);
   const [itemDescription, setItemItemDescription] = useState<string>(description || '');
@@ -98,6 +99,7 @@ export function ItemDataComponent(props: IItemDataComponentProps) {
   }, [nodeName]);
 
   const onNameChange = ({ target }: ChangeEvent) => {
+   setIsTextModified(true); 
     const { value } = target as HTMLInputElement;
     setNodeName(value);
   };
@@ -144,6 +146,9 @@ export function ItemDataComponent(props: IItemDataComponentProps) {
   const handleArrayPropertyToggle = () => mutate(toggleArrayField(data, pointer));
 
   const handleChangeNodeName = () => {
+     if (!isTextModified) {
+      return;
+    } 
     const error = hardValidateName();
     if (error !== NameError.NoError) {
       return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added a state to prevent display of an error message when the user simply click inside the text field, and then outside without making any modifications. 

## Related Issue(s)
- #10625 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
