### PR TITLE
10643 update react redux to latest version & fix safety checks

### DIFF
--- a/frontend/app-development/package.json
+++ b/frontend/app-development/package.json
@@ -19,7 +19,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-i18next": "12.3.1",
-    "react-redux": "8.0.7",
+    "react-redux": "8.1.1",
     "react-router-dom": "6.14.1",
     "redux": "4.2.1",
     "redux-saga": "1.2.3",

--- a/frontend/app-development/sharedResources/applicationMetadata/selectors/applicationMetadata.test.ts
+++ b/frontend/app-development/sharedResources/applicationMetadata/selectors/applicationMetadata.test.ts
@@ -1,4 +1,4 @@
-import { makeGetApplicationMetadata } from './applicationMetadataSelector';
+import { applicationMetadataSelector } from './applicationMetadataSelector';
 
 describe('ApplicationMetadata', () => {
   let mockApplicationMetadata: any;
@@ -18,8 +18,7 @@ describe('ApplicationMetadata', () => {
   });
 
   it('applicationMetadataSelector should return correct state', () => {
-    const getApplicationMetadata = makeGetApplicationMetadata();
-    const applicationMetadata = getApplicationMetadata(mockState);
+    const applicationMetadata = applicationMetadataSelector(mockState);
     expect(applicationMetadata).toBe(mockApplicationMetadata);
   });
 });

--- a/frontend/app-development/sharedResources/applicationMetadata/selectors/applicationMetadata.test.ts
+++ b/frontend/app-development/sharedResources/applicationMetadata/selectors/applicationMetadata.test.ts
@@ -1,4 +1,4 @@
-import { applicationMetadataSelector } from './applicationMetadataSelector';
+import { makeGetApplicationMetadata } from './applicationMetadataSelector';
 
 describe('ApplicationMetadata', () => {
   let mockApplicationMetadata: any;
@@ -18,7 +18,7 @@ describe('ApplicationMetadata', () => {
   });
 
   it('applicationMetadataSelector should return correct state', () => {
-    const applicationMetadata = applicationMetadataSelector(mockState);
+    const applicationMetadata = makeGetApplicationMetadata(mockState);
     expect(applicationMetadata).toBe(mockApplicationMetadata);
   });
 });

--- a/frontend/app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector.ts
+++ b/frontend/app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector.ts
@@ -1,14 +1,5 @@
-import { createSelector } from 'reselect';
 import type { RootState } from '../../../store';
 
-const applicationMetadataSelector = (state: RootState) => {
-  return state.applicationMetadataState.applicationMetadata;
+export const applicationMetadataSelector = (state: RootState) => {
+  return state.applicationMetadataState?.applicationMetadata;
 };
-
-const getApplicationMetadata = () => {
-  return createSelector([applicationMetadataSelector], (applicationMetadata) => {
-    return applicationMetadata;
-  });
-};
-
-export const makeGetApplicationMetadata = getApplicationMetadata;

--- a/frontend/app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector.ts
+++ b/frontend/app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector.ts
@@ -1,5 +1,12 @@
+import { createSelector } from 'reselect';
 import type { RootState } from '../../../store';
 
-export const applicationMetadataSelector = (state: RootState) => {
+const applicationMetadataSelector = (state: RootState) => {
   return state.applicationMetadataState?.applicationMetadata;
 };
+
+const getApplicationMetadata = createSelector([applicationMetadataSelector], (applicationMetadata) => {
+  return applicationMetadata;
+});
+
+export const makeGetApplicationMetadata = getApplicationMetadata;

--- a/frontend/app-preview/package.json
+++ b/frontend/app-preview/package.json
@@ -14,7 +14,7 @@
     "qs": "6.11.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-redux": "8.0.7",
+    "react-redux": "8.1.1",
     "react-router-dom": "6.14.1"
   },
   "devDependencies": {

--- a/frontend/packages/schema-editor/package.json
+++ b/frontend/packages/schema-editor/package.json
@@ -18,7 +18,7 @@
     "react-dnd": "16.0.1",
     "react-dnd-html5-backend": "16.0.1",
     "react-dom": "18.2.0",
-    "react-redux": "8.0.7",
+    "react-redux": "8.1.1",
     "redux": "4.2.1"
   },
   "private": true,

--- a/frontend/packages/schema-editor/src/components/SchemaEditor.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaEditor.tsx
@@ -24,13 +24,13 @@ import { useTranslation } from 'react-i18next';
 import { TypesInspector } from './TypesInspector';
 import classNames from 'classnames';
 import {
-  rootChildrenSelector,
-  rootNodesSelector,
-  selectedDefinitionParentSelector,
-  selectedItemSelector,
-  selectedPropertyParentSelector
+  selectedPropertyNodeIdSelector,
+  selectedDefinitionNodeIdSelector,
+  selectedIdSelector,
+  getRootChildren,
+  getRootNodes
 } from '@altinn/schema-editor/selectors/schemaStateSelectors';
-import { useSchemaSelector } from '@altinn/schema-editor/hooks/useSchemaSelector';
+import { useSchemaSelector, useParentSchemaSelector } from '@altinn/schema-editor/hooks/useSchemaSelector';
 import { useDatamodelQuery } from '@altinn/schema-editor/hooks/queries';
 import { Toolbar, ToolbarProps } from 'app-shared/features/dataModelling/components/Toolbar';
 import { JsonSchema } from 'app-shared/types/JsonSchema';
@@ -84,8 +84,8 @@ export const SchemaEditor = ({
   const translation = useTranslation();
   const t = (key: string, options: KeyValuePairs) => translation.t('schema_editor.' + key, options);
 
-  const rootNodeMap = useSchemaSelector(rootNodesSelector);
-  const rootChildren = useSchemaSelector(rootChildrenSelector);
+  const rootNodeMap = getRootNodes(data);
+  const rootChildren = getRootChildren(data);
   const properties: UiSchemaNodes = [];
   const definitions: UiSchemaNodes = [];
   rootChildren?.forEach(
@@ -94,8 +94,8 @@ export const SchemaEditor = ({
       : properties.push(rootNodeMap.get(childPointer))
   );
 
-  const selectedPropertyParent = useSchemaSelector(selectedPropertyParentSelector);
-  const selectedItem = useSchemaSelector(selectedItemSelector);
+  const selectedPropertyParent = useParentSchemaSelector(selectedPropertyNodeIdSelector);
+  const selectedItem = useSchemaSelector(selectedIdSelector);
 
   useEffect(() => {
     if (selectedType) {
@@ -115,7 +115,7 @@ export const SchemaEditor = ({
     }
   }, [selectedPropertyParent, expandedPropNodes]);
 
-  const selectedDefinitionParent = useSchemaSelector(selectedDefinitionParentSelector);
+  const selectedDefinitionParent = useParentSchemaSelector(selectedDefinitionNodeIdSelector);
   useEffect(() => {
     if (selectedDefinitionParent && !expandedDefNodes.includes(selectedDefinitionParent.pointer)) {
       setExpandedDefNodes((prevState) => [...prevState, selectedDefinitionParent.pointer]);

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/CustomProperties.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/CustomProperties.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Button, Checkbox, FieldSet, HelpText, TextField } from '@digdir/design-system-react';
-import { selectedItemSelector } from '@altinn/schema-editor/selectors/schemaStateSelectors';
 import { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
 import {
   CustomPropertyType,
@@ -15,6 +14,7 @@ import classes from './CustomProperties.module.css';
 import { useDatamodelQuery } from '@altinn/schema-editor/hooks/queries';
 import { useDatamodelMutation } from '@altinn/schema-editor/hooks/mutations';
 import { useSchemaSelector } from '@altinn/schema-editor/hooks/useSchemaSelector';
+import { selectedIdSelector } from '@altinn/schema-editor/selectors/schemaStateSelectors';
 
 export interface CustomPropertiesProps {
   path: string;
@@ -26,7 +26,7 @@ export const CustomProperties = ({ path }: CustomPropertiesProps) => {
   const { data } = useDatamodelQuery();
   const { mutate } = useDatamodelMutation();
   const { t } = useTranslation();
-  const { custom } = useSchemaSelector(selectedItemSelector);
+  const { custom } = useSchemaSelector(selectedIdSelector);
 
   function changeProperties(properties: KeyValuePairs) {
     mutate(setCustomProperties(data, { path, properties }));

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
@@ -18,7 +18,6 @@ import { PlusIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 import { useDatamodelMutation } from '@altinn/schema-editor/hooks/mutations';
 import { useDatamodelQuery } from '@altinn/schema-editor/hooks/queries';
-import { useSchemaSelector } from '@altinn/schema-editor/hooks/useSchemaSelector';
 import { getFieldNodesSelector } from '@altinn/schema-editor/selectors/schemaStateSelectors';
 
 export interface ItemFieldsTabProps {
@@ -31,7 +30,7 @@ export const ItemFieldsTab = ({ selectedItem }: ItemFieldsTabProps) => {
   const { data } = useDatamodelQuery();
   const { mutate } = useDatamodelMutation();
 
-  const fieldNodes = useSchemaSelector(getFieldNodesSelector(selectedItem));
+  const fieldNodes = getFieldNodesSelector(selectedItem)(data);
 
   const numberOfChildNodes = fieldNodes.length;
   const prevNumberOfChildNodes = usePrevious<number>(numberOfChildNodes) ?? 0;

--- a/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
+++ b/frontend/packages/schema-editor/src/components/TreeView/SchemaItem.tsx
@@ -19,7 +19,6 @@ import type { DragItem } from './dnd-helpers';
 import { useDatamodelQuery } from '@altinn/schema-editor/hooks/queries';
 import { useDatamodelMutation } from '@altinn/schema-editor/hooks/mutations';
 import { getRefNodeSelector, selectedIdSelector } from '@altinn/schema-editor/selectors/schemaStateSelectors';
-import { useSchemaSelector } from '@altinn/schema-editor/hooks/useSchemaSelector';
 
 type SchemaItemProps = {
   selectedNode: UiSchemaNode;
@@ -47,7 +46,7 @@ export function SchemaItem({
 
   const keyPrefix = isPropertiesView ? 'properties' : 'definitions';
 
-  const refNode = useSchemaSelector(getRefNodeSelector(selectedNode));
+  const refNode = getRefNodeSelector(selectedNode)(data);
   const childNodes = getChildNodesByPointer(data, (refNode || selectedNode).pointer);
   const referredNodes = getReferredNodes(data, selectedNode.pointer);
   const focusedNode = refNode ?? selectedNode;

--- a/frontend/packages/schema-editor/src/hooks/useSchemaSelector.test.ts
+++ b/frontend/packages/schema-editor/src/hooks/useSchemaSelector.test.ts
@@ -1,0 +1,41 @@
+import { useSchemaSelector, useParentSchemaSelector } from './useSchemaSelector';
+import { renderHook } from '@testing-library/react';
+import { dataMock } from '@altinn/schema-editor/mockData';
+import { selectedIdSelector } from '../selectors/schemaStateSelectors';
+import { useDatamodelQuery } from '@altinn/schema-editor/hooks/queries';
+import { useSelector } from 'react-redux';
+import { buildUiSchema } from '@altinn/schema-model';
+
+jest.mock('@altinn/schema-editor/hooks/queries');
+jest.mock('react-redux');
+
+describe('useFormLayoutsSelector', () => {
+  beforeEach(() => {
+    (useDatamodelQuery as jest.Mock).mockClear();
+    (useSelector as jest.Mock).mockClear();
+  });
+
+  it('should return selected node', async () => {
+    const uiSchema = buildUiSchema(dataMock);
+    (useDatamodelQuery as jest.Mock).mockReturnValue({ data: uiSchema });
+
+    const selectedId = '#/properties/melding';
+    (useSelector as jest.Mock).mockReturnValue(selectedId);
+
+    const { result } = renderHook(() => useSchemaSelector(selectedIdSelector));
+
+    expect(result.current).toEqual(uiSchema.find(item => item.pointer === selectedId));
+  });
+
+  it('should return selected parent node', async () => {
+    const uiSchema = buildUiSchema(dataMock);
+    (useDatamodelQuery as jest.Mock).mockReturnValue({ data: uiSchema });
+
+    const selectedId = '#/$defs/AntallRestriksjon';
+    (useSelector as jest.Mock).mockReturnValue(selectedId);
+
+    const { result } = renderHook(() => useParentSchemaSelector(selectedIdSelector));
+
+    expect(result.current).toEqual(uiSchema.find(item => item.pointer === '#'));
+  });
+});

--- a/frontend/packages/schema-editor/src/hooks/useSchemaSelector.ts
+++ b/frontend/packages/schema-editor/src/hooks/useSchemaSelector.ts
@@ -1,10 +1,20 @@
 import { useDatamodelQuery } from '@altinn/schema-editor/hooks/queries';
 import { SchemaStateSelector } from '@altinn/schema-editor/selectors/schemaStateSelectors';
 import { useSelector } from 'react-redux';
-import { SchemaState } from '@altinn/schema-editor/types';
+import {
+  getParentNodeByPointer,
+  getNodeByPointer,
+  UiSchemaNode,
+} from '@altinn/schema-model'
 
-export const useSchemaSelector = <T>(selector: SchemaStateSelector<T>): T | null => {
+export const useSchemaSelector = (selector: SchemaStateSelector<string>): UiSchemaNode | null => {
   const { data } = useDatamodelQuery();
-  const state = useSelector((state: SchemaState) => state);
-  return data ? selector(state, data) : null;
+  const state = useSelector(selector);
+  return data && state ? getNodeByPointer(data, state) : null;
+};
+
+export const useParentSchemaSelector = (selector: SchemaStateSelector<string>): UiSchemaNode | null => {
+  const { data } = useDatamodelQuery();
+  const state = useSelector(selector);
+  return data && state ? getParentNodeByPointer(data, state) : null;
 };

--- a/frontend/packages/schema-editor/src/selectors/schemaStateSelectors.ts
+++ b/frontend/packages/schema-editor/src/selectors/schemaStateSelectors.ts
@@ -39,7 +39,7 @@ export const getFieldNodesSelector =
 
 export const getRootNodes: SchemaSelector<Map<string, UiSchemaNode>> = (schema: UiSchemaNodes) => {
   const nodesmap = new Map();
-  if (schema.length) {
+  if (schema?.length) {
     getChildNodesByPointer(schema, ROOT_POINTER).forEach((node) => {
       nodesmap.set(node.pointer, node);
     });
@@ -49,4 +49,4 @@ export const getRootNodes: SchemaSelector<Map<string, UiSchemaNode>> = (schema: 
 
 export const getRootChildren: SchemaSelector<string[] | undefined> =
   (schema: UiSchemaNodes) =>
-    schema.length ? getNodeByPointer(schema, ROOT_POINTER).children : undefined;
+    schema?.length ? getNodeByPointer(schema, ROOT_POINTER).children : undefined;

--- a/frontend/packages/schema-editor/src/selectors/schemaStateSelectors.ts
+++ b/frontend/packages/schema-editor/src/selectors/schemaStateSelectors.ts
@@ -2,47 +2,42 @@ import { SchemaState } from '@altinn/schema-editor/types';
 import {
   getChildNodesByPointer,
   getNodeByPointer,
-  getParentNodeByPointer,
   ObjectKind, ROOT_POINTER,
   UiSchemaNode,
   UiSchemaNodes
 } from '@altinn/schema-model'
 import { getDomFriendlyID } from '@altinn/schema-editor/utils/ui-schema-utils';
 
-export type SchemaStateSelector<T> = (state: SchemaState, schema?: UiSchemaNodes) => T;
+export type SchemaStateSelector<T> = (state: SchemaState) => T;
+export type SchemaSelector<T> = (schema?: UiSchemaNodes) => T;
 
-export const selectedPropertyParentSelector: SchemaStateSelector<UiSchemaNode> =
-  (state, schema: UiSchemaNodes) => getParentNodeByPointer(schema, state.selectedPropertyNodeId);
+export const selectedPropertyNodeIdSelector: SchemaStateSelector<string> =
+  (state: SchemaState) => state.selectedPropertyNodeId;
+
+export const selectedDefinitionNodeIdSelector: SchemaStateSelector<string> =
+  (state: SchemaState) => state.selectedDefinitionNodeId;
 
 export const selectedIdSelector: SchemaStateSelector<string> =
   (state) => state.selectedEditorTab === 'properties'
     ? state.selectedPropertyNodeId
     : state.selectedDefinitionNodeId;
 
-export const selectedItemSelector: SchemaStateSelector<UiSchemaNode> = (state: SchemaState, schema: UiSchemaNodes) => {
-  const selectedId = selectedIdSelector(state);
-  return selectedId ? getNodeByPointer(schema, selectedId) : undefined;
-};
-
-export const selectedDefinitionParentSelector: SchemaStateSelector<UiSchemaNode> =
-  (state, schema) => getParentNodeByPointer(schema, state.selectedDefinitionNodeId);
-
 export const getRefNodeSelector =
-  (currentNode: UiSchemaNode): SchemaStateSelector<UiSchemaNode> =>
-    (state: SchemaState, schema: UiSchemaNodes) =>
+  (currentNode: UiSchemaNode): SchemaSelector<UiSchemaNode> =>
+    (schema: UiSchemaNodes) =>
       currentNode.objectKind === ObjectKind.Reference && currentNode.reference
         ? getNodeByPointer(schema, currentNode.reference)
         : undefined;
 
 export const getFieldNodesSelector =
-  (currentNode: UiSchemaNode): SchemaStateSelector<(UiSchemaNode & { domId: string })[]> =>
-    (state: SchemaState, schema: UiSchemaNodes) =>
+  (currentNode: UiSchemaNode): SchemaSelector<(UiSchemaNode & { domId: string })[]> =>
+    (schema: UiSchemaNodes) =>
       getChildNodesByPointer(schema, currentNode.pointer).map((node) => ({
         ...node,
         domId: getDomFriendlyID(node.pointer),
       }));
 
-export const rootNodesSelector: SchemaStateSelector<Map<string, UiSchemaNode>> = (state: SchemaState, schema: UiSchemaNodes) => {
+export const getRootNodes: SchemaSelector<Map<string, UiSchemaNode>> = (schema: UiSchemaNodes) => {
   const nodesmap = new Map();
   if (schema.length) {
     getChildNodesByPointer(schema, ROOT_POINTER).forEach((node) => {
@@ -52,6 +47,6 @@ export const rootNodesSelector: SchemaStateSelector<Map<string, UiSchemaNode>> =
   return nodesmap;
 }
 
-export const rootChildrenSelector: SchemaStateSelector<string[] | undefined> =
-  (state: SchemaState, schema: UiSchemaNodes) =>
+export const getRootChildren: SchemaSelector<string[] | undefined> =
+  (schema: UiSchemaNodes) =>
     schema.length ? getNodeByPointer(schema, ROOT_POINTER).children : undefined;

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -13,7 +13,7 @@
     "react-dnd": "16.0.1",
     "react-dnd-html5-backend": "16.0.1",
     "react-dom": "18.2.0",
-    "react-redux": "8.0.7",
+    "react-redux": "8.1.1",
     "react-router-dom": "6.14.1",
     "react-select": "5.7.3",
     "redux-saga": "1.2.3"

--- a/frontend/packages/shared/src/features/dataModelling/DataModelling.tsx
+++ b/frontend/packages/shared/src/features/dataModelling/DataModelling.tsx
@@ -3,7 +3,7 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Panel } from '@altinn/altinn-design-system';
 import { Button, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
 import { SchemaEditorApp } from '@altinn/schema-editor/index';
-import { createDataModel, deleteDataModel, fetchDataModel, saveDataModel } from './sagas';
+import { IDataModellingState, createDataModel, deleteDataModel, fetchDataModel, saveDataModel } from './sagas';
 import { createDataModelMetadataOptions } from './functions/createDataModelMetadataOptions';
 import { findPreferredMetadataOption } from './functions/findPreferredMetadataOption';
 import { schemaPathIsSame } from './functions/schemaPathIsSame';
@@ -15,6 +15,8 @@ import { getLocalStorageItem, setLocalStorageItem } from './functions/localStora
 import classes from './DataModelling.module.css';
 import { useTranslation } from 'react-i18next';
 import { JsonSchema } from 'app-shared/types/JsonSchema';
+import { createSelector } from '@reduxjs/toolkit';
+import { RootState } from 'app-development/store';
 
 interface IDataModellingContainerProps extends React.PropsWithChildren<any> {
   org: string;
@@ -40,6 +42,12 @@ export const shouldSelectFirstEntry = ({
   );
 };
 
+export const jsonSchemaStateSelector = createSelector
+(
+  (state: RootState) => state.dataModelling,
+  (dataModelling: IDataModellingState) => ({ error: dataModelling.error, saving: dataModelling.saving })
+);
+
 export function DataModelling({
   org,
   repo,
@@ -47,10 +55,7 @@ export function DataModelling({
 }: IDataModellingContainerProps): ReactNode {
   const dispatch = useDispatch();
   const { t } = useTranslation();
-  const jsonSchemaState = useSelector((state: any) => {
-    const { error, saving } = state.dataModelling;
-    return { error, saving };
-  });
+  const jsonSchemaState = useSelector(jsonSchemaStateSelector);
   const metadataOptions = useSelector(createDataModelMetadataOptions, shallowEqual);
   const metadataLoadingState = useSelector((state: any) => state.dataModelsMetadataState.loadState);
   const [selectedOption, setSelectedOption] = useState(undefined);

--- a/frontend/packages/shared/src/features/dataModelling/functions/createDataModelMetadataOptions.test.ts
+++ b/frontend/packages/shared/src/features/dataModelling/functions/createDataModelMetadataOptions.test.ts
@@ -1,26 +1,16 @@
 import { createDataModelMetadataOptions } from './createDataModelMetadataOptions';
-import type { IDataModelsMetadataState } from '../sagas/metadata';
 import { LoadingState } from '../sagas/metadata';
 
 describe('createDataModelMetadataOptions', () => {
-  const dataModelsMetadataState: IDataModelsMetadataState = {
-    dataModelsMetadata: [],
-    loadState: LoadingState.Idle,
-  };
   const state = {
-    dataModelsMetadataState,
+    dataModelsMetadataState: {
+      dataModelsMetadata: [],
+      loadState: LoadingState.Idle,
+    }
   };
-
-  it('should return empty if no metadata is set', () => {
-    const result = createDataModelMetadataOptions(state);
-    expect(result).toHaveLength(2);
-    expect(result[0].options).toHaveLength(0);
-    expect(result[1].options).toHaveLength(0);
-  });
-
-  describe('with data', () => {
-    beforeEach(() => {
-      state.dataModelsMetadataState.dataModelsMetadata = [
+  const stateWithData = {
+    dataModelsMetadataState: {
+      dataModelsMetadata: [
         {
           fileName: `first-schema.schema.json`,
           fileType: '.json',
@@ -51,11 +41,21 @@ describe('createDataModelMetadataOptions', () => {
           fileType: '.xsd',
           repositoryRelativeUrl: '',
         },
-      ];
-    });
+      ],
+      loadState: LoadingState.Idle,
+    }
+  };
 
+  it('should return empty if no metadata is set', () => {
+    const result = createDataModelMetadataOptions(state);
+    expect(result).toHaveLength(2);
+    expect(result[0].options).toHaveLength(0);
+    expect(result[1].options).toHaveLength(0);
+  });
+
+  describe('with data', () => {
     it('creates expected options out of the provided metadata', () => {
-      const options = createDataModelMetadataOptions(state);
+      const options = createDataModelMetadataOptions(stateWithData);
       expect(options).toHaveLength(2);
       const [jsonOptions, xsdOptions] = options;
 

--- a/frontend/packages/shared/src/features/dataModelling/functions/createDataModelMetadataOptions.test.ts
+++ b/frontend/packages/shared/src/features/dataModelling/functions/createDataModelMetadataOptions.test.ts
@@ -1,14 +1,14 @@
 import { createDataModelMetadataOptions } from './createDataModelMetadataOptions';
 import { LoadingState } from '../sagas/metadata';
+import { RootState } from 'app-development/store';
+import { rootStateMock } from 'app-development/test/rootStateMock';
 
 describe('createDataModelMetadataOptions', () => {
-  const state = {
-    dataModelsMetadataState: {
-      dataModelsMetadata: [],
-      loadState: LoadingState.Idle,
-    }
+  const state: RootState = {
+    ...rootStateMock,
   };
-  const stateWithData = {
+  const stateWithData: RootState = {
+    ...rootStateMock,
     dataModelsMetadataState: {
       dataModelsMetadata: [
         {

--- a/frontend/packages/shared/src/features/dataModelling/functions/createDataModelMetadataOptions.ts
+++ b/frontend/packages/shared/src/features/dataModelling/functions/createDataModelMetadataOptions.ts
@@ -1,14 +1,13 @@
-import type { IDataModelMetadataItem, IDataModelsMetadataState } from '../sagas/metadata';
+import type { IDataModelMetadataItem } from '../sagas/metadata';
 import type { GroupedOption } from '../components/SchemaSelect';
 import type { IMetadataOption } from './types';
+import { createSelector } from '@reduxjs/toolkit';
+import { RootState } from 'app-development/store';
 
-export function createDataModelMetadataOptions({
-  dataModelsMetadataState,
-}: {
-  dataModelsMetadataState: IDataModelsMetadataState;
-}): GroupedOption[] {
-  const { dataModelsMetadata } = dataModelsMetadataState;
-
+export const createDataModelMetadataOptions = createSelector
+(
+  (state: RootState) => state.dataModelsMetadataState.dataModelsMetadata,
+  (dataModelsMetadata: IDataModelMetadataItem[]): GroupedOption[] => {
   if (!dataModelsMetadata?.length) {
     return makeGroupedOptions({ jsonOptions: [], xsdOptions: [] });
   }
@@ -20,7 +19,7 @@ export function createDataModelMetadataOptions({
     dataModelsMetadata.filter((option) => option.fileType === '.xsd')
   );
   return makeGroupedOptions({ jsonOptions, xsdOptions });
-}
+});
 
 const mapModelsMetadataToOptions = (metadata: IDataModelMetadataItem[]): IMetadataOption[] => {
   if (!metadata?.length) {

--- a/frontend/packages/ux-editor/package.json
+++ b/frontend/packages/ux-editor/package.json
@@ -13,7 +13,7 @@
     "react-dnd-html5-backend": "16.0.1",
     "react-dom": "18.2.0",
     "react-modal": "3.16.1",
-    "react-redux": "8.0.7",
+    "react-redux": "8.1.1",
     "react-select": "5.7.3",
     "redux": "4.2.1",
     "reselect": "4.1.8",

--- a/frontend/packages/ux-editor/src/components/FormComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/FormComponent.tsx
@@ -16,9 +16,10 @@ import { getComponentTitleByComponentType, getTextResource, truncate } from '../
 import { selectedLayoutNameSelector, selectedLayoutSetSelector } from '../selectors/formLayoutSelectors';
 import { textResourcesByLanguageSelector } from '../selectors/textResourceSelectors';
 import { useDeleteFormComponentMutation } from '../hooks/mutations/useDeleteFormComponentMutation';
-import { useFormLayoutsSelector, useTextResourcesSelector } from '../hooks';
+import { useTextResourcesSelector } from '../hooks';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
 export interface IFormComponentProps {
   component: IFormComponent;
@@ -43,8 +44,8 @@ export const FormComponent = memo(function FormComponent({
   const { org, app } = useParams();
 
   const textResources: ITextResource[] = useTextResourcesSelector<ITextResource[]>(textResourcesByLanguageSelector(DEFAULT_LANGUAGE));
-  const selectedLayout = useFormLayoutsSelector(selectedLayoutNameSelector);
-  const selectedLayoutSetName = useFormLayoutsSelector(selectedLayoutSetSelector);
+  const selectedLayout = useSelector(selectedLayoutNameSelector);
+  const selectedLayoutSetName = useSelector(selectedLayoutSetSelector);
 
   const { mutate: deleteFormComponent } = useDeleteFormComponentMutation(org, app, selectedLayoutSetName);
 

--- a/frontend/packages/ux-editor/src/components/config/EditFormComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/EditFormComponent.tsx
@@ -6,8 +6,8 @@ import { ComponentSpecificContent } from './componentSpecificContent';
 import { FieldSet } from '@digdir/design-system-react';
 import classes from './EditFormComponent.module.css';
 import type { FormComponent } from '../../types/FormComponent';
-import { useFormLayoutsSelector } from '../../hooks';
 import { selectedLayoutNameSelector } from '../../selectors/formLayoutSelectors';
+import { useSelector } from 'react-redux';
 
 export interface IEditFormComponentProps {
   editFormId: string;
@@ -20,7 +20,7 @@ export const EditFormComponent = ({
   component,
   handleComponentUpdate,
 }: IEditFormComponentProps) => {
-  const selectedLayout = useFormLayoutsSelector(selectedLayoutNameSelector);
+  const selectedLayout = useSelector(selectedLayoutNameSelector);
   const renderFromComponentSpecificDefinition = (configDef: EditSettings[]) => {
     if (!configDef) return null;
 

--- a/frontend/packages/ux-editor/src/components/config/EditFormContainer.tsx
+++ b/frontend/packages/ux-editor/src/components/config/EditFormContainer.tsx
@@ -11,8 +11,7 @@ import { TextResource } from '../TextResource';
 import { useDatamodelMetadataQuery } from '../../hooks/queries/useDatamodelMetadataQuery';
 import { useText } from '../../hooks';
 import { useParams } from 'react-router-dom';
-import { useFormLayoutsSelector, useTextResourcesSelector } from '../../hooks';
-import { selectedLayoutSelector } from '../../selectors/formLayoutSelectors';
+import { useSelectedFormLayout, useTextResourcesSelector } from '../../hooks';
 import { textResourcesByLanguageSelector } from '../../selectors/textResourceSelectors';
 import { DEFAULT_LANGUAGE } from 'app-shared/constants';
 import { ITextResource } from 'app-shared/types/global';
@@ -42,7 +41,7 @@ export const EditFormContainer = ({
   const selectedLayoutSetName = useSelector(selectedLayoutSetSelector);
   const { data: formLayouts } = useFormLayoutsQuery(org, app, selectedLayoutSetName);
   const { data: dataModel } = useDatamodelMetadataQuery(org, app);
-  const { components, containers } = useFormLayoutsSelector(selectedLayoutSelector);
+  const { components, containers } = useSelectedFormLayout();
   const textResources: ITextResource[] = useTextResourcesSelector<ITextResource[]>(
     textResourcesByLanguageSelector(DEFAULT_LANGUAGE)
   );

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditComponentId.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditComponentId.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { idExists } from '../../../utils/formLayoutUtils';
 import { useTranslation } from 'react-i18next';
-import { useFormLayoutsSelector } from '../../../hooks';
-import { selectedLayoutSelector } from '../../../selectors/formLayoutSelectors';
+import { useSelectedFormLayout } from '../../../hooks';
 import type { FormComponent } from '../../../types/FormComponent';
 import { FormField } from '../../FormField';
 import { TextField } from '@digdir/design-system-react';
@@ -12,7 +11,7 @@ export interface IEditComponentId {
   component: FormComponent;
 }
 export const EditComponentId = ({ component, handleComponentUpdate }: IEditComponentId) => {
-  const { components, containers } = useFormLayoutsSelector(selectedLayoutSelector);
+  const { components, containers } = useSelectedFormLayout();
   const { t } = useTranslation();
 
   const handleIdChange = (id: string) => {

--- a/frontend/packages/ux-editor/src/components/toolbar/ConditionalRenderingModal.tsx
+++ b/frontend/packages/ux-editor/src/components/toolbar/ConditionalRenderingModal.tsx
@@ -7,11 +7,11 @@ import type { IRuleModelFieldElement } from '../../types/global';
 import { useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { useFormLayoutsSelector } from '../../hooks';
+import { useFormLayouts } from '../../hooks';
 import {
-  allLayoutComponentsSelector,
-  allLayoutContainersSelector,
-  fullLayoutOrderSelector,
+  getAllLayoutContainers,
+  getAllLayoutComponents,
+  getFullLayoutOrder,
   selectedLayoutSetSelector,
 } from '../../selectors/formLayoutSelectors';
 import { useRuleModelQuery } from '../../hooks/queries/useRuleModelQuery';
@@ -33,9 +33,10 @@ export function ConditionalRenderingModal(props: IConditionalRenderingModalProps
   const { data: ruleModel } = useRuleModelQuery(org, app, selectedLayoutSet);
   const { data: ruleConfig } = useRuleConfigQuery(org, app, selectedLayoutSet);
   const { mutate: saveRuleConfig } = useRuleConfigMutation(org, app, selectedLayoutSet);
-  const layoutContainers = useFormLayoutsSelector(allLayoutContainersSelector);
-  const layoutComponents = useFormLayoutsSelector(allLayoutComponentsSelector);
-  const layoutOrder = useFormLayoutsSelector(fullLayoutOrderSelector);
+  const formLayouts = useFormLayouts();
+  const layoutContainers = getAllLayoutContainers(formLayouts);
+  const layoutComponents = getAllLayoutComponents(formLayouts);
+  const layoutOrder = getFullLayoutOrder(formLayouts);
   const { t } = useTranslation();
 
   const conditionRules = ruleModel?.filter(({ type }: IRuleModelFieldElement) => type === 'condition');

--- a/frontend/packages/ux-editor/src/containers/DesignView.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView.tsx
@@ -5,7 +5,6 @@ import type { FormContainer as IFormContainer } from '../types/FormContainer';
 import type { FormComponent as IFormComponent } from '../types/FormComponent';
 import type { ExistingDndItem, HandleDrop, ItemPosition, NewDndItem } from '../types/dndTypes';
 import { DraggableEditorItemType } from '../types/dndTypes';
-import { useFormLayoutsSelector } from '../hooks';
 import { selectedLayoutNameSelector, selectedLayoutSetSelector } from '../selectors/formLayoutSelectors';
 import { FormComponent } from '../components/FormComponent';
 import { useFormLayoutsQuery } from '../hooks/queries/useFormLayoutsQuery';
@@ -30,7 +29,7 @@ export const DesignView = ({ className }: DesignViewProps) => {
   const { org, app } = useParams();
   const selectedLayoutSet: string = useSelector(selectedLayoutSetSelector);
   const { data: layouts } = useFormLayoutsQuery(org, app, selectedLayoutSet);
-  const layoutName = useFormLayoutsSelector(selectedLayoutNameSelector);
+  const layoutName = useSelector(selectedLayoutNameSelector);
   const { mutate: updateFormLayout } = useFormLayoutMutation(org, app, layoutName, selectedLayoutSet);
   const { mutate: addItemToLayout } = useAddItemToLayoutMutation(org, app, selectedLayoutSet);
   const { formId, form, handleDiscard, handleEdit, handleComponentSave } = useContext(FormContext);

--- a/frontend/packages/ux-editor/src/containers/FormContainer.tsx
+++ b/frontend/packages/ux-editor/src/containers/FormContainer.tsx
@@ -7,8 +7,8 @@ import { useDeleteFormContainerMutation } from '../hooks/mutations/useDeleteForm
 import type { FormContainer as IFormContainer } from '../types/FormContainer';
 import { FormContainerHeader } from './FormContainerHeader';
 import { ConnectDragSource } from 'react-dnd';
-import { useFormLayoutsSelector } from "../hooks/useFormLayoutsSelector";
 import { selectedLayoutSetSelector } from "../selectors/formLayoutSelectors";
+import { useSelector } from 'react-redux';
 
 export interface IFormContainerProps {
   children: ReactNode;
@@ -32,7 +32,7 @@ export const FormContainer = ({
   isEditMode,
 } : IFormContainerProps) => {
   const { org, app } = useParams();
-  const selectedLayoutSetName = useFormLayoutsSelector(selectedLayoutSetSelector);
+  const selectedLayoutSetName = useSelector(selectedLayoutSetSelector);
 
   const { mutate: deleteFormContainer } = useDeleteFormContainerMutation(org, app, selectedLayoutSetName);
 

--- a/frontend/packages/ux-editor/src/containers/FormContext.tsx
+++ b/frontend/packages/ux-editor/src/containers/FormContext.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useMemo, useCallback, createContext, useRef } from 'react';
 import { useParams } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import type { FormContainer } from '../types/FormContainer';
 import type { FormComponent } from '../types/FormComponent';
 import { setCurrentEditId } from '../features/appData/textResources/textResourcesSlice';
 import { useUpdateFormContainerMutation } from '../hooks/mutations/useUpdateFormContainerMutation';
 import { useUpdateFormComponentMutation } from '../hooks/mutations/useUpdateFormComponentMutation';
-import { useFormLayoutsSelector } from '../hooks';
-import { selectedLayoutSelector, selectedLayoutSetSelector } from '../selectors/formLayoutSelectors';
+import { useSelectedFormLayout } from '../hooks';
+import { selectedLayoutSetSelector } from '../selectors/formLayoutSelectors';
 import { AUTOSAVE_DEBOUNCE_INTERVAL } from 'app-shared/constants';
 
 export type FormContext = {
@@ -37,7 +37,7 @@ type FormContextProviderProps = {
 export const FormContextProvider = ({ children }: FormContextProviderProps): JSX.Element => {
   const dispatch = useDispatch();
   const { org, app } = useParams();
-  const selectedLayoutSetName = useFormLayoutsSelector(selectedLayoutSetSelector);
+  const selectedLayoutSetName = useSelector(selectedLayoutSetSelector);
 
   const containerTimeoutRef = useRef(null);
   const componentTimeoutRef = useRef(null);
@@ -47,7 +47,7 @@ export const FormContextProvider = ({ children }: FormContextProviderProps): JSX
 
   const { mutateAsync: updateFormContainer } = useUpdateFormContainerMutation(org, app, selectedLayoutSetName);
   const { mutateAsync: updateFormComponent } = useUpdateFormComponentMutation(org, app, selectedLayoutSetName);
-  const { components } = useFormLayoutsSelector(selectedLayoutSelector);
+  const { components } = useSelectedFormLayout();
 
   const handleUpdateFormContainer = useCallback(
     updateFormContainer,

--- a/frontend/packages/ux-editor/src/hooks/index.ts
+++ b/frontend/packages/ux-editor/src/hooks/index.ts
@@ -1,6 +1,6 @@
 export type { UseText } from './useText';
 export { useComponentErrorMessage } from './useComponentErrorMessage';
-export { useFormLayoutsSelector } from './useFormLayoutsSelector';
+export { useFormLayouts, useSelectedFormLayout, useSelectedFormLayoutWithName } from './useFormLayoutsSelector';
 export { useText } from './useText';
 export { useTextResourcesSelector } from './useTextResourcesSelector';
 export type { ComponentValidationResult, ErrorCode } from './useValidateComponent';

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddAppAttachmentMetadataMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddAppAttachmentMetadataMutation.ts
@@ -3,12 +3,12 @@ import { ApplicationAttachmentMetadata } from 'app-shared/types/ApplicationAttac
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { useDispatch, useSelector } from 'react-redux';
 import { ApplicationMetadataActions } from '../../../../../app-development/sharedResources/applicationMetadata/applicationMetadataSlice';
-import { makeGetApplicationMetadata } from '../../../../../app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector';
+import { applicationMetadataSelector } from '../../../../../app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector';
 
 export const useAddAppAttachmentMetadataMutation = (org: string, app: string) => {
   const { addAppAttachmentMetadata } = useServicesContext();
   const dispatch = useDispatch();
-  const applicationMetadata = useSelector(makeGetApplicationMetadata);
+  const applicationMetadata = useSelector(applicationMetadataSelector);
   return useMutation({
     mutationFn: async (metadata: ApplicationAttachmentMetadata) => {
       await addAppAttachmentMetadata(org, app, metadata);

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddAppAttachmentMetadataMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddAppAttachmentMetadataMutation.ts
@@ -3,12 +3,12 @@ import { ApplicationAttachmentMetadata } from 'app-shared/types/ApplicationAttac
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { useDispatch, useSelector } from 'react-redux';
 import { ApplicationMetadataActions } from '../../../../../app-development/sharedResources/applicationMetadata/applicationMetadataSlice';
-import { applicationMetadataSelector } from '../../../../../app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector';
+import { makeGetApplicationMetadata } from '../../../../../app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector';
 
 export const useAddAppAttachmentMetadataMutation = (org: string, app: string) => {
   const { addAppAttachmentMetadata } = useServicesContext();
   const dispatch = useDispatch();
-  const applicationMetadata = useSelector(applicationMetadataSelector);
+  const applicationMetadata = useSelector(makeGetApplicationMetadata);
   return useMutation({
     mutationFn: async (metadata: ApplicationAttachmentMetadata) => {
       await addAppAttachmentMetadata(org, app, metadata);

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddFormContainerMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddFormContainerMutation.ts
@@ -2,8 +2,7 @@ import { generateComponentId } from '../../utils/generateId';
 import { IInternalLayout } from '../../types/global';
 import { ComponentType } from 'app-shared/types/ComponentType';
 import { useFormLayoutsQuery } from '../queries/useFormLayoutsQuery';
-import { useFormLayoutsSelector } from '../useFormLayoutsSelector';
-import { selectedLayoutWithNameSelector } from '../../selectors/formLayoutSelectors';
+import { useSelectedFormLayoutWithName } from '../useFormLayoutsSelector';
 import { useMutation } from '@tanstack/react-query';
 import { useFormLayoutMutation } from './useFormLayoutMutation';
 import { FormContainer } from '../../types/FormContainer';
@@ -18,7 +17,7 @@ export interface AddFormContainerMutationArgs {
 
 export const useAddFormContainerMutation = (org: string, app: string, layoutSetName: string) => {
   const formLayoutsQuery = useFormLayoutsQuery(org, app, layoutSetName);
-  const { layout, layoutName } = useFormLayoutsSelector(selectedLayoutWithNameSelector);
+  const { layout, layoutName } = useSelectedFormLayoutWithName();
   const formLayoutsMutation = useFormLayoutMutation(org, app, layoutName, layoutSetName);
 
   return useMutation({

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.ts
@@ -1,5 +1,4 @@
-import { selectedLayoutWithNameSelector } from '../../selectors/formLayoutSelectors';
-import { useFormLayoutsSelector } from '../useFormLayoutsSelector';
+import { useSelectedFormLayoutWithName } from '../useFormLayoutsSelector';
 import { useMutation } from '@tanstack/react-query';
 import { ComponentType } from 'app-shared/types/ComponentType';
 import { useFormLayoutMutation } from './useFormLayoutMutation';
@@ -17,7 +16,7 @@ export interface AddFormItemMutationArgs {
 }
 
 export const useAddItemToLayoutMutation = (org: string, app: string, layoutSetName: string) => {
-  const { layout, layoutName } = useFormLayoutsSelector(selectedLayoutWithNameSelector);
+  const { layout, layoutName } = useSelectedFormLayoutWithName();
   const formLayoutsMutation = useFormLayoutMutation(org, app, layoutName, layoutSetName);
   const appAttachmentMetadataMutation = useAddAppAttachmentMetadataMutation(org, app);
   const { data: layoutSets } = useLayoutSetsQuery(org, app);

--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddWidgetMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddWidgetMutation.ts
@@ -1,8 +1,7 @@
 import { IFormDesignerComponents, IFormLayouts, IInternalLayout, IWidget } from '../../types/global';
 import { convertFromLayoutToInternalFormat } from '../../utils/formLayoutUtils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { selectedLayoutWithNameSelector } from '../../selectors/formLayoutSelectors';
-import { useFormLayoutsSelector } from '../useFormLayoutsSelector';
+import { useSelectedFormLayoutWithName } from '../useFormLayoutsSelector';
 import { deepCopy } from 'app-shared/pure';
 import { v4 as uuidv4 } from 'uuid';
 import { useFormLayoutMutation } from './useFormLayoutMutation';
@@ -18,7 +17,7 @@ export interface AddWidgetMutationArgs {
 }
 
 export const useAddWidgetMutation = (org: string, app: string, layoutSetName: string) => {
-  const { layout, layoutName } = useFormLayoutsSelector(selectedLayoutWithNameSelector);
+  const { layout, layoutName } = useSelectedFormLayoutWithName();
   const { mutateAsync: updateLayout } = useFormLayoutMutation(org, app, layoutName, layoutSetName);
   const { mutateAsync: updateText } = useUpsertTextResourcesMutation(org, app);
   const queryClient = useQueryClient();

--- a/frontend/packages/ux-editor/src/hooks/mutations/useDeleteAppAttachmentMetadataMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useDeleteAppAttachmentMetadataMutation.ts
@@ -2,12 +2,12 @@ import { useMutation } from '@tanstack/react-query';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { useDispatch, useSelector } from 'react-redux';
 import { ApplicationMetadataActions } from '../../../../../app-development/sharedResources/applicationMetadata/applicationMetadataSlice';
-import { makeGetApplicationMetadata } from '../../../../../app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector';
+import { applicationMetadataSelector } from '../../../../../app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector';
 
 export const useDeleteAppAttachmentMetadataMutation = (org: string, app: string) => {
   const { deleteAppAttachmentMetadata } = useServicesContext();
   const dispatch = useDispatch();
-  const applicationMetadata = useSelector(makeGetApplicationMetadata) ?? {};
+  const applicationMetadata = useSelector(applicationMetadataSelector) ?? {};
   return useMutation({
     mutationFn: async (id: string) => {
       await deleteAppAttachmentMetadata(org, app, id);

--- a/frontend/packages/ux-editor/src/hooks/mutations/useDeleteAppAttachmentMetadataMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useDeleteAppAttachmentMetadataMutation.ts
@@ -2,12 +2,12 @@ import { useMutation } from '@tanstack/react-query';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { useDispatch, useSelector } from 'react-redux';
 import { ApplicationMetadataActions } from '../../../../../app-development/sharedResources/applicationMetadata/applicationMetadataSlice';
-import { applicationMetadataSelector } from '../../../../../app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector';
+import { makeGetApplicationMetadata } from '../../../../../app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector';
 
 export const useDeleteAppAttachmentMetadataMutation = (org: string, app: string) => {
   const { deleteAppAttachmentMetadata } = useServicesContext();
   const dispatch = useDispatch();
-  const applicationMetadata = useSelector(applicationMetadataSelector) ?? {};
+  const applicationMetadata = useSelector(makeGetApplicationMetadata) ?? {};
   return useMutation({
     mutationFn: async (id: string) => {
       await deleteAppAttachmentMetadata(org, app, id);

--- a/frontend/packages/ux-editor/src/hooks/mutations/useDeleteFormComponentMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useDeleteFormComponentMutation.ts
@@ -1,5 +1,4 @@
-import { useFormLayoutsSelector } from '../useFormLayoutsSelector';
-import { selectedLayoutWithNameSelector } from '../../selectors/formLayoutSelectors';
+import { useSelectedFormLayoutWithName } from '../useFormLayoutsSelector';
 import { useMutation } from '@tanstack/react-query';
 import { ComponentType } from 'app-shared/types/ComponentType';
 import { useFormLayoutMutation } from './useFormLayoutMutation';
@@ -7,7 +6,7 @@ import { useDeleteAppAttachmentMetadataMutation } from './useDeleteAppAttachment
 import { removeComponent } from '../../utils/formLayoutUtils';
 
 export const useDeleteFormComponentMutation = (org: string, app: string, layoutSetName: string) =>  {
-  const { layout, layoutName } = useFormLayoutsSelector(selectedLayoutWithNameSelector);
+  const { layout, layoutName } = useSelectedFormLayoutWithName();
   const formLayoutsMutation = useFormLayoutMutation(org, app, layoutName, layoutSetName);
   const deleteAppAttachmentMetadataMutation = useDeleteAppAttachmentMetadataMutation(org, app);
   return useMutation({

--- a/frontend/packages/ux-editor/src/hooks/mutations/useDeleteFormContainerMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useDeleteFormContainerMutation.ts
@@ -1,12 +1,11 @@
 import { IInternalLayout } from '../../types/global';
-import { useFormLayoutsSelector } from '../useFormLayoutsSelector';
-import { selectedLayoutWithNameSelector } from '../../selectors/formLayoutSelectors';
+import { useSelectedFormLayoutWithName } from '../useFormLayoutsSelector';
 import { useMutation } from '@tanstack/react-query';
 import { useFormLayoutMutation } from './useFormLayoutMutation';
 import { deepCopy } from 'app-shared/pure';
 
 export const useDeleteFormContainerMutation = (org: string, app: string, layoutSetName: string) =>  {
-  const { layout, layoutName } = useFormLayoutsSelector(selectedLayoutWithNameSelector);
+  const { layout, layoutName } = useSelectedFormLayoutWithName();
   const formLayoutsMutation = useFormLayoutMutation(org, app, layoutName, layoutSetName);
   return useMutation({
     mutationFn: (id: string) => {

--- a/frontend/packages/ux-editor/src/hooks/mutations/useUpdateAppAttachmentMetadataMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useUpdateAppAttachmentMetadataMutation.ts
@@ -2,13 +2,13 @@ import { useMutation } from '@tanstack/react-query';
 import { ApplicationAttachmentMetadata } from 'app-shared/types/ApplicationAttachmentMetadata';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { ApplicationMetadataActions } from '../../../../../app-development/sharedResources/applicationMetadata/applicationMetadataSlice';
-import { applicationMetadataSelector } from '../../../../../app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector';
+import { makeGetApplicationMetadata } from '../../../../../app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector';
 import { useDispatch, useSelector } from 'react-redux';
 
 export const useUpdateAppAttachmentMetadataMutation = (org: string, app: string) => {
   const { updateAppAttachmentMetadata } = useServicesContext();
   const dispatch = useDispatch();
-  const applicationMetadata = useSelector(applicationMetadataSelector);
+  const applicationMetadata = useSelector(makeGetApplicationMetadata);
   return useMutation({
     mutationFn: async (metadata: ApplicationAttachmentMetadata) => {
       await updateAppAttachmentMetadata(org, app, metadata);

--- a/frontend/packages/ux-editor/src/hooks/mutations/useUpdateAppAttachmentMetadataMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useUpdateAppAttachmentMetadataMutation.ts
@@ -2,13 +2,13 @@ import { useMutation } from '@tanstack/react-query';
 import { ApplicationAttachmentMetadata } from 'app-shared/types/ApplicationAttachmentMetadata';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { ApplicationMetadataActions } from '../../../../../app-development/sharedResources/applicationMetadata/applicationMetadataSlice';
-import { makeGetApplicationMetadata } from '../../../../../app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector';
+import { applicationMetadataSelector } from '../../../../../app-development/sharedResources/applicationMetadata/selectors/applicationMetadataSelector';
 import { useDispatch, useSelector } from 'react-redux';
 
 export const useUpdateAppAttachmentMetadataMutation = (org: string, app: string) => {
   const { updateAppAttachmentMetadata } = useServicesContext();
   const dispatch = useDispatch();
-  const applicationMetadata = useSelector(makeGetApplicationMetadata);
+  const applicationMetadata = useSelector(applicationMetadataSelector);
   return useMutation({
     mutationFn: async (metadata: ApplicationAttachmentMetadata) => {
       await updateAppAttachmentMetadata(org, app, metadata);

--- a/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormComponentMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormComponentMutation.ts
@@ -7,8 +7,7 @@ import { useUpdateAppAttachmentMetadataMutation } from './useUpdateAppAttachment
 import { switchSelectedFieldId } from '../../utils/ruleConfigUtils';
 import { useRuleConfigQuery } from '../queries/useRuleConfigQuery';
 import { useRuleConfigMutation } from './useRuleConfigMutation';
-import { useFormLayoutsSelector } from '../useFormLayoutsSelector';
-import { selectedLayoutWithNameSelector } from '../../selectors/formLayoutSelectors';
+import { useSelectedFormLayoutWithName } from '../useFormLayoutsSelector';
 import { deepCopy } from 'app-shared/pure';
 import { useFormLayoutMutation } from './useFormLayoutMutation';
 import type { FormComponent, FormFileUploaderComponent } from '../../types/FormComponent';
@@ -21,7 +20,7 @@ export interface UpdateFormComponentArgs {
 }
 
 export const useUpdateFormComponentMutation = (org: string, app: string, layoutSetName: string) => {
-  const { layout, layoutName } = useFormLayoutsSelector(selectedLayoutWithNameSelector);
+  const { layout, layoutName } = useSelectedFormLayoutWithName();
   const { mutateAsync: saveLayout } = useFormLayoutMutation(org, app, layoutName, layoutSetName);
   const { data: ruleConfig } = useRuleConfigQuery(org, app, layoutSetName);
   const addAppAttachmentMetadataMutation = useAddAppAttachmentMetadataMutation(org, app);

--- a/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormComponentOrderMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormComponentOrderMutation.ts
@@ -1,12 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 import { IFormLayoutOrder } from '../../types/global';
-import { selectedLayoutWithNameSelector } from '../../selectors/formLayoutSelectors';
-import { useFormLayoutsSelector } from '../useFormLayoutsSelector';
+import { useSelectedFormLayoutWithName } from '../useFormLayoutsSelector';
 import { deepCopy } from 'app-shared/pure';
 import { useFormLayoutMutation } from './useFormLayoutMutation';
 
 export const useUpdateFormComponentOrderMutation = (org: string, app: string, layoutSetName: string) => {
-  const { layout, layoutName } = useFormLayoutsSelector(selectedLayoutWithNameSelector);
+  const { layout, layoutName } = useSelectedFormLayoutWithName();
   const formLayoutMutation = useFormLayoutMutation(org, app, layoutName, layoutSetName);
   return useMutation({
     mutationFn: (order: IFormLayoutOrder) => {

--- a/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormContainerMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useUpdateFormContainerMutation.ts
@@ -1,6 +1,5 @@
 import { IInternalLayout } from '../../types/global';
-import { useFormLayoutsSelector } from '../useFormLayoutsSelector';
-import { selectedLayoutWithNameSelector } from '../../selectors/formLayoutSelectors';
+import { useSelectedFormLayoutWithName } from '../useFormLayoutsSelector';
 import { useMutation } from '@tanstack/react-query';
 import { useFormLayoutMutation } from './useFormLayoutMutation';
 import { switchSelectedFieldId } from '../../utils/ruleConfigUtils';
@@ -15,7 +14,7 @@ export interface UpdateFormContainerMutationArgs {
 }
 
 export const useUpdateFormContainerMutation = (org: string, app: string, layoutSetName: string) => {
-  const { layout, layoutName } = useFormLayoutsSelector(selectedLayoutWithNameSelector);
+  const { layout, layoutName } = useSelectedFormLayoutWithName();
   const { data: ruleConfig } = useRuleConfigQuery(org, app, layoutSetName);
   const { mutateAsync: saveLayout } = useFormLayoutMutation(org, app, layoutName, layoutSetName);
   const { mutateAsync: saveRuleConfig } = useRuleConfigMutation(org, app, layoutSetName);

--- a/frontend/packages/ux-editor/src/hooks/useFormLayoutsSelector.test.ts
+++ b/frontend/packages/ux-editor/src/hooks/useFormLayoutsSelector.test.ts
@@ -4,36 +4,35 @@ import { useFormLayoutsQuery } from '../hooks/queries/useFormLayoutsQuery';
 import { externalLayoutsMock, layoutMock, layout1NameMock } from '../testing/layoutMock';
 import { waitFor } from '@testing-library/react';
 import { convertExternalLayoutsToInternalFormat } from '../utils/formLayoutsUtils';
+import { IFormLayouts, IInternalLayout, IInternalLayoutWithName } from '../types/global';
 
 // Test data:
 const org = 'org';
 const app = 'app';
 const selectedLayoutSet = 'test-layout-set';
 
+const render = async (callback: () => IFormLayouts | IInternalLayout | IInternalLayoutWithName) => {
+  const formLayoutsResult = renderHookWithMockStore()(() => useFormLayoutsQuery(org, app, selectedLayoutSet)).renderHookResult.result;
+  await waitFor(() => expect(formLayoutsResult.current.isSuccess).toBe(true));
+
+  return renderHookWithMockStore()(() => callback()).renderHookResult;
+}
+
 describe('useFormLayoutsSelector', () => {
   it('should return all layouts', async () => {
-    const formLayoutsResult = renderHookWithMockStore()(() => useFormLayoutsQuery(org, app, selectedLayoutSet)).renderHookResult.result;
-    await waitFor(() => expect(formLayoutsResult.current.isSuccess).toBe(true));
-
-    const { result } = renderHookWithMockStore()(() => useFormLayouts()).renderHookResult;
+    const { result } = await render(useFormLayouts);
     const { convertedLayouts } = convertExternalLayoutsToInternalFormat(externalLayoutsMock);
 
     expect(result.current).toEqual(convertedLayouts);
   });
 
   it('should return the selected layout', async () => {
-    const formLayoutsResult = renderHookWithMockStore()(() => useFormLayoutsQuery(org, app, selectedLayoutSet)).renderHookResult.result;
-    await waitFor(() => expect(formLayoutsResult.current.isSuccess).toBe(true));
-
-    const { result } = renderHookWithMockStore()(() => useSelectedFormLayout()).renderHookResult;
+    const { result } = await render(useSelectedFormLayout);
     expect(result.current).toEqual(layoutMock);
   });
 
   it('should return the selected layout and the selected layout name', async () => {
-    const formLayoutsResult = renderHookWithMockStore()(() => useFormLayoutsQuery(org, app, selectedLayoutSet)).renderHookResult.result;
-    await waitFor(() => expect(formLayoutsResult.current.isSuccess).toBe(true));
-
-    const { result } = renderHookWithMockStore()(() => useSelectedFormLayoutWithName()).renderHookResult;
+    const { result } = await render(useSelectedFormLayoutWithName);
     expect(result.current).toEqual({
       layout: layoutMock,
       layoutName: layout1NameMock,

--- a/frontend/packages/ux-editor/src/hooks/useFormLayoutsSelector.test.ts
+++ b/frontend/packages/ux-editor/src/hooks/useFormLayoutsSelector.test.ts
@@ -1,0 +1,42 @@
+import { useFormLayouts, useSelectedFormLayout, useSelectedFormLayoutWithName } from './useFormLayoutsSelector';
+import { renderHookWithMockStore } from '../testing/mocks';
+import { useFormLayoutsQuery } from '../hooks/queries/useFormLayoutsQuery';
+import { externalLayoutsMock, layoutMock, layout1NameMock } from '../testing/layoutMock';
+import { waitFor } from '@testing-library/react';
+import { convertExternalLayoutsToInternalFormat } from '../utils/formLayoutsUtils';
+
+// Test data:
+const org = 'org';
+const app = 'app';
+const selectedLayoutSet = 'test-layout-set';
+
+describe('useFormLayoutsSelector', () => {
+  it('should return all layouts', async () => {
+    const formLayoutsResult = renderHookWithMockStore()(() => useFormLayoutsQuery(org, app, selectedLayoutSet)).renderHookResult.result;
+    await waitFor(() => expect(formLayoutsResult.current.isSuccess).toBe(true));
+
+    const { result } = renderHookWithMockStore()(() => useFormLayouts()).renderHookResult;
+    const { convertedLayouts } = convertExternalLayoutsToInternalFormat(externalLayoutsMock);
+
+    expect(result.current).toEqual(convertedLayouts);
+  });
+
+  it('should return the selected layout', async () => {
+    const formLayoutsResult = renderHookWithMockStore()(() => useFormLayoutsQuery(org, app, selectedLayoutSet)).renderHookResult.result;
+    await waitFor(() => expect(formLayoutsResult.current.isSuccess).toBe(true));
+
+    const { result } = renderHookWithMockStore()(() => useSelectedFormLayout()).renderHookResult;
+    expect(result.current).toEqual(layoutMock);
+  });
+
+  it('should return the selected layout and the selected layout name', async () => {
+    const formLayoutsResult = renderHookWithMockStore()(() => useFormLayoutsQuery(org, app, selectedLayoutSet)).renderHookResult.result;
+    await waitFor(() => expect(formLayoutsResult.current.isSuccess).toBe(true));
+
+    const { result } = renderHookWithMockStore()(() => useSelectedFormLayoutWithName()).renderHookResult;
+    expect(result.current).toEqual({
+      layout: layoutMock,
+      layoutName: layout1NameMock,
+    });
+  });
+});

--- a/frontend/packages/ux-editor/src/hooks/useFormLayoutsSelector.ts
+++ b/frontend/packages/ux-editor/src/hooks/useFormLayoutsSelector.ts
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom';
 import { useFormLayoutsQuery } from './queries/useFormLayoutsQuery';
 import { useSelector } from 'react-redux';
-import { IFormLayouts, IInternalLayout } from '../types/global';
+import { IFormLayouts, IInternalLayout, IInternalLayoutWithName } from '../types/global';
 import { selectedLayoutNameSelector, selectedLayoutSetSelector } from "../selectors/formLayoutSelectors";
 import { createEmptyLayout } from '../utils/formLayoutUtils';
 
@@ -20,12 +20,7 @@ export const useSelectedFormLayout = (): IInternalLayout => {
   return data?.[layoutName] || createEmptyLayout();
 }
 
-interface SelectedLayoutWithName {
-  layout: IInternalLayout;
-  layoutName: string;
-}
-
-export const useSelectedFormLayoutWithName = (): SelectedLayoutWithName => {
+export const useSelectedFormLayoutWithName = (): IInternalLayoutWithName => {
   const layout = useSelectedFormLayout();
   const layoutName = useSelector(selectedLayoutNameSelector);
   return {

--- a/frontend/packages/ux-editor/src/hooks/useFormLayoutsSelector.ts
+++ b/frontend/packages/ux-editor/src/hooks/useFormLayoutsSelector.ts
@@ -1,13 +1,35 @@
 import { useParams } from 'react-router-dom';
 import { useFormLayoutsQuery } from './queries/useFormLayoutsQuery';
 import { useSelector } from 'react-redux';
-import { FormLayoutsSelector, IAppState } from '../types/global';
-import { selectedLayoutSetSelector } from "../selectors/formLayoutSelectors";
+import { IFormLayouts, IInternalLayout } from '../types/global';
+import { selectedLayoutNameSelector, selectedLayoutSetSelector } from "../selectors/formLayoutSelectors";
+import { createEmptyLayout } from '../utils/formLayoutUtils';
 
-export const useFormLayoutsSelector = <T>(selector: FormLayoutsSelector<T>): T => {
+export const useFormLayouts = (): IFormLayouts => {
   const { org, app } = useParams();
   const selectedLayoutSet = useSelector(selectedLayoutSetSelector);
   const formLayoutsQuery = useFormLayoutsQuery(org, app, selectedLayoutSet);
   const { data } = formLayoutsQuery;
-  return useSelector((state: IAppState) => selector(state, data));
+  return data;
+}
+
+export const useSelectedFormLayout = (): IInternalLayout => {
+  const data = useFormLayouts();
+
+  const layoutName = useSelector(selectedLayoutNameSelector);
+  return data?.[layoutName] || createEmptyLayout();
+}
+
+interface SelectedLayoutWithName {
+  layout: IInternalLayout;
+  layoutName: string;
+}
+
+export const useSelectedFormLayoutWithName = (): SelectedLayoutWithName => {
+  const layout = useSelectedFormLayout();
+  const layoutName = useSelector(selectedLayoutNameSelector);
+  return {
+    layout,
+    layoutName,
+  };
 }

--- a/frontend/packages/ux-editor/src/selectors/formLayoutSelectors.test.ts
+++ b/frontend/packages/ux-editor/src/selectors/formLayoutSelectors.test.ts
@@ -1,11 +1,11 @@
 import { IAppState, IFormLayouts } from '../types/global';
 import { appStateMock, formDesignerMock } from '../testing/mocks';
 import {
-  allLayoutComponentsSelector,
-  allLayoutContainersSelector,
-  fullLayoutOrderSelector,
+  getAllLayoutComponents,
+  getAllLayoutContainers,
+  getFullLayoutOrder,
   selectedLayoutNameSelector,
-  selectedLayoutSelector
+  selectedLayoutSetSelector
 } from './formLayoutSelectors';
 import { ComponentType } from 'app-shared/types/ComponentType';
 
@@ -13,6 +13,7 @@ import { ComponentType } from 'app-shared/types/ComponentType';
 const layout1Name = 'Side1';
 const layout2Name = 'Side2';
 const selectedLayout = layout1Name;
+const selectedLayoutSet = 'test-layout-set';
 const appState: IAppState = {
   ...appStateMock,
   formDesigner: {
@@ -82,20 +83,20 @@ describe('formLayoutSelectors', () => {
     expect(selectedLayoutNameSelector(appState)).toEqual(selectedLayout);
   });
 
-  test('selectedLayoutSelector', () => {
-    expect(selectedLayoutSelector(appState, formLayoutsData)).toEqual(formLayoutsData[selectedLayout]);
+  test('selectedLayoutSetSelector', () => {
+    expect(selectedLayoutSetSelector(appState)).toEqual(selectedLayoutSet);
   });
 
-  test('allLayoutContainersSelector', () => {
-    expect(allLayoutContainersSelector(appState, formLayoutsData)).toEqual({
+  test('getAllLayoutContainers', () => {
+    expect(getAllLayoutContainers(formLayoutsData)).toEqual({
       [container0Id]: formLayoutsData[layout1Name].containers[container0Id],
       [container1Id]: formLayoutsData[layout1Name].containers[container1Id],
       [container2Id]: formLayoutsData[layout2Name].containers[container2Id],
     });
   });
 
-  test('allLayoutComponentsSelector', () => {
-    expect(allLayoutComponentsSelector(appState, formLayoutsData)).toEqual({
+  test('getAllLayoutComponents', () => {
+    expect(getAllLayoutComponents(formLayoutsData)).toEqual({
       [component0AId]: formLayoutsData[layout1Name].components[component0AId],
       [component0BId]: formLayoutsData[layout1Name].components[component0BId],
       [component1AId]: formLayoutsData[layout1Name].components[component1AId],
@@ -105,8 +106,8 @@ describe('formLayoutSelectors', () => {
     });
   });
 
-  test('fullLayoutOrderSelector', () => {
-    expect(fullLayoutOrderSelector(appState, formLayoutsData)).toEqual({
+  test('getFullLayoutOrder', () => {
+    expect(getFullLayoutOrder(formLayoutsData)).toEqual({
       [container0Id]: container0Order,
       [container1Id]: container1Order,
       [container2Id]: container2Order,

--- a/frontend/packages/ux-editor/src/selectors/formLayoutSelectors.ts
+++ b/frontend/packages/ux-editor/src/selectors/formLayoutSelectors.ts
@@ -2,9 +2,7 @@ import {
   AppStateSelector,
   FormLayoutsSelector, IFormDesignerComponents,
   IFormDesignerContainers, IFormLayoutOrder,
-  IInternalLayout
 } from '../types/global';
-import { createEmptyLayout } from '../utils/formLayoutUtils';
 
 export const selectedLayoutNameSelector: AppStateSelector<string> =
   (state) => state.formDesigner.layout.selectedLayout;
@@ -12,31 +10,17 @@ export const selectedLayoutNameSelector: AppStateSelector<string> =
 export const selectedLayoutSetSelector: AppStateSelector<string> =
   (state) => state.formDesigner.layout.selectedLayoutSet;
 
-export const selectedLayoutSelector: FormLayoutsSelector<IInternalLayout> =
-  (state, formLayoutsData) =>
-    formLayoutsData?.[selectedLayoutNameSelector(state)] || createEmptyLayout();
-
-interface SelectedLayoutWithName {
-  layout: IInternalLayout;
-  layoutName: string;
-}
-export const selectedLayoutWithNameSelector: FormLayoutsSelector<SelectedLayoutWithName> =
-  (state, formLayoutsData) => ({
-    layout: selectedLayoutSelector(state, formLayoutsData),
-    layoutName: selectedLayoutNameSelector(state),
-  });
-
-export const allLayoutContainersSelector: FormLayoutsSelector<IFormDesignerContainers> =
-  (state, formLayoutsData) => Object
+export const getAllLayoutContainers: FormLayoutsSelector<IFormDesignerContainers> =
+  (formLayoutsData) => Object
     .values(formLayoutsData)
     .reduce((acc, layout) => ({ ...acc, ...layout.containers }), {});
 
-export const allLayoutComponentsSelector: FormLayoutsSelector<IFormDesignerComponents> =
-  (state, formLayoutsData) => Object
+export const getAllLayoutComponents: FormLayoutsSelector<IFormDesignerComponents> =
+  (formLayoutsData) => Object
     .values(formLayoutsData)
     .reduce((acc, layout) => ({ ...acc, ...layout.components }), {});
 
-export const fullLayoutOrderSelector: FormLayoutsSelector<IFormLayoutOrder> =
-  (state, formLayoutsData) => Object
+export const getFullLayoutOrder: FormLayoutsSelector<IFormLayoutOrder> =
+  (formLayoutsData) => Object
     .values(formLayoutsData)
     .reduce((acc, layout) => ({ ...acc, ...layout.order }), {});

--- a/frontend/packages/ux-editor/src/testing/layoutMock.ts
+++ b/frontend/packages/ux-editor/src/testing/layoutMock.ts
@@ -16,7 +16,7 @@ export const component1Mock: FormComponent = {
   id: component1IdMock,
   type: component1TypeMock,
   itemType: 'COMPONENT',
-  dataModelBindings: {},
+  propertyPath: 'definitions/inputComponent',
 };
 export const component2IdMock = 'Component-2';
 export const component2TypeMock = ComponentType.Paragraph;
@@ -24,7 +24,7 @@ export const component2Mock: FormComponent = {
   id: component2IdMock,
   type: component2TypeMock,
   itemType: 'COMPONENT',
-  dataModelBindings: {},
+  propertyPath: undefined,
 };
 export const container1IdMock = 'Container-1';
 export const customRootPropertiesMock: KeyValuePairs = {
@@ -43,9 +43,11 @@ export const layoutMock: IInternalLayout = {
   containers: {
     [baseContainerIdMock]: {
       itemType: 'CONTAINER',
+      index: 0,
     },
     [container1IdMock]: {
       itemType: 'CONTAINER',
+      propertyPath: 'definitions/groupComponent',
     },
   },
   order: {

--- a/frontend/packages/ux-editor/src/types/global.ts
+++ b/frontend/packages/ux-editor/src/types/global.ts
@@ -39,6 +39,11 @@ export interface IInternalLayout {
   customDataProperties: KeyValuePairs;
 }
 
+export interface IInternalLayoutWithName {
+  layout: IInternalLayout;
+  layoutName: string;
+}
+
 export type IFormLayoutOrder = KeyValuePairs<string[]>;
 
 export interface IRuleModelFieldElement {

--- a/frontend/packages/ux-editor/src/types/global.ts
+++ b/frontend/packages/ux-editor/src/types/global.ts
@@ -78,6 +78,6 @@ export enum LayoutItemType {
 
 export type AppStateSelector<T> = (state: IAppState) => T;
 
-export type FormLayoutsSelector<T> = (state: IAppState, formLayoutsData: IFormLayouts) => T;
+export type FormLayoutsSelector<T> = (formLayoutsData: IFormLayouts) => T;
 
 export type TextResourcesSelector<T> = (textResources: ITextResources) => T;

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,7 +74,7 @@ __metadata:
     react-dnd: 16.0.1
     react-dnd-html5-backend: 16.0.1
     react-dom: 18.2.0
-    react-redux: 8.0.7
+    react-redux: 8.1.1
     redux: 4.2.1
   languageName: unknown
   linkType: soft
@@ -5267,7 +5267,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-i18next: 12.3.1
-    react-redux: 8.0.7
+    react-redux: 8.1.1
     react-router-dom: 6.14.1
     redux: 4.2.1
     redux-saga: 1.2.3
@@ -5289,7 +5289,7 @@ __metadata:
     qs: 6.11.2
     react: 18.2.0
     react-dom: 18.2.0
-    react-redux: 8.0.7
+    react-redux: 8.1.1
     react-router-dom: 6.14.1
     typescript: 5.1.6
     webpack: 5.88.1
@@ -5313,7 +5313,7 @@ __metadata:
     react-dnd: 16.0.1
     react-dnd-html5-backend: 16.0.1
     react-dom: 18.2.0
-    react-redux: 8.0.7
+    react-redux: 8.1.1
     react-router-dom: 6.14.1
     react-select: 5.7.3
     redux-saga: 1.2.3
@@ -12742,9 +12742,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-redux@npm:8.0.7":
-  version: 8.0.7
-  resolution: "react-redux@npm:8.0.7"
+"react-redux@npm:8.1.1":
+  version: 8.1.1
+  resolution: "react-redux@npm:8.1.1"
   dependencies:
     "@babel/runtime": ^7.12.1
     "@types/hoist-non-react-statics": ^3.3.1
@@ -12753,7 +12753,6 @@ __metadata:
     react-is: ^18.0.0
     use-sync-external-store: ^1.0.0
   peerDependencies:
-    "@reduxjs/toolkit": ^1 || ^2.0.0-beta.0
     "@types/react": ^16.8 || ^17.0 || ^18.0
     "@types/react-dom": ^16.8 || ^17.0 || ^18.0
     react: ^16.8 || ^17.0 || ^18.0
@@ -12761,8 +12760,6 @@ __metadata:
     react-native: ">=0.59"
     redux: ^4 || ^5.0.0-beta.0
   peerDependenciesMeta:
-    "@reduxjs/toolkit":
-      optional: true
     "@types/react":
       optional: true
     "@types/react-dom":
@@ -12773,7 +12770,7 @@ __metadata:
       optional: true
     redux:
       optional: true
-  checksum: d903aa79b12154258fd76b8e61fcf56f72123f69c31033b262805646371e23822cd0cd11d24194cda1e03569a7b1bf86e935cd57a9bab4523186804ed2742fac
+  checksum: 370676330727764d78f35e9c5a0ed0591d79482fe9b70fffcab4aa6bcccc6194e4f1ebd818b4b390351dea5557e70d3bd4d95d7a0ac9baa1f45d6bf2230ee713
   languageName: node
   linkType: hard
 
@@ -15080,7 +15077,7 @@ __metadata:
     react-dnd-html5-backend: 16.0.1
     react-dom: 18.2.0
     react-modal: 3.16.1
-    react-redux: 8.0.7
+    react-redux: 8.1.1
     react-select: 5.7.3
     redux: 4.2.1
     redux-devtools-extension: 2.13.9


### PR DESCRIPTION
## Description
Refactoring of formLayoutSelectors and schemaStateSelectors to fix new safety checks :
- removed from useState, selectors that didn't use the state (getAllLayoutContainers, getAllLayoutComponents, getFullLayoutOrder, getRootNodes, getRootChildren) as we did for example with getAllTextResourceIds
- removed react-query calls to selectors that didn't use data from react-query (selectedLayoutNameSelector, selectedLayoutSetSelector) and called them directly using useSelector
- created specific hooks (useSelectedFormLayout, useSelectedFormLayoutWithName, useParentSchemaSelector) for selectors that use both state and data (selectedLayoutSelector, selectedLayoutWithNameSelector, selectedPropertyParentSelector, selectedItemSelector, selectedDefinitionParentSelector)
- memoized functions that make transformations of data returned by the state (createDataModelMetadataOptions)

## Related Issue(s)
- #10643

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
