### PR TITLE
Bug/10562 fix runtime error in text field of component

### DIFF
--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
@@ -137,7 +137,7 @@ const render = async (resources: ITextResources = {}, editId?: string) => {
     textResources
   };
 
-  const { result } = renderHookWithMockStore({ appData },{
+  const { result } = renderHookWithMockStore({ appData }, {
     getTextLanguages: () => Promise.resolve(['nb', 'nn', 'en']),
     getTextResources: (_o, _a, lang) => Promise.resolve<ITextResourcesWithLanguage>({
       language: lang,
@@ -146,5 +146,5 @@ const render = async (resources: ITextResources = {}, editId?: string) => {
   })(() => useTextResourcesQuery(org, app)).renderHookResult;
   await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-  return renderWithMockStore({ appData })(<TextResourceEdit />);
+  return renderWithMockStore({ appData })(<TextResourceEdit/>);
 };

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
@@ -10,7 +10,7 @@ import {
   queryClientMock,
   renderHookWithMockStore,
   renderWithMockStore,
-  textResourcesMock,
+  textResourcesMock
 } from '../testing/mocks';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { mockUseTranslation } from '../../../../testing/mocks/i18nMock';
@@ -37,9 +37,13 @@ const texts = {
 };
 
 // Mocks:
-jest.mock('react-i18next', () => ({ useTranslation: () => mockUseTranslation(texts) }));
+jest.mock(
+  'react-i18next', 
+  () => ({ useTranslation: () => mockUseTranslation(texts) }),
+);
 
 describe('TextResourceEdit', () => {
+
   afterEach(() => {
     jest.clearAllMocks();
     queryClientMock.clear();
@@ -58,7 +62,7 @@ describe('TextResourceEdit', () => {
     const resources: ITextResources = {
       nb: [{ id, value: valueNb }],
       nn: [{ id, value: valueNn }],
-      en: [{ id, value: valueEn }],
+      en: [{ id, value: valueEn }]
     };
     await render(resources, id);
     expect(screen.getByText(legendText)).toBeInTheDocument();
@@ -123,27 +127,24 @@ describe('TextResourceEdit', () => {
 });
 
 const render = async (resources: ITextResources = {}, editId?: string) => {
+
   const textResources: ITextResourcesState = {
     ...textResourcesMock,
-    currentEditId: editId,
+    currentEditId: editId
   };
 
   const appData: IAppDataState = {
     ...appDataMock,
-    textResources,
+    textResources
   };
 
-  const { result } = renderHookWithMockStore(
-    { appData },
-    {
-      getTextLanguages: () => Promise.resolve(['nb', 'nn', 'en']),
-      getTextResources: (_o, _a, lang) =>
-        Promise.resolve<ITextResourcesWithLanguage>({
-          language: lang,
-          resources: resources[lang] || [],
-        }),
-    }
-  )(() => useTextResourcesQuery(org, app)).renderHookResult;
+  const { result } = renderHookWithMockStore({ appData },{
+    getTextLanguages: () => Promise.resolve(['nb', 'nn', 'en']),
+    getTextResources: (_o, _a, lang) => Promise.resolve<ITextResourcesWithLanguage>({
+      language: lang,
+      resources: resources[lang] || []
+    }),
+  })(() => useTextResourcesQuery(org, app)).renderHookResult;
   await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
   return renderWithMockStore({ appData })(<TextResourceEdit />);

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
@@ -38,7 +38,7 @@ const texts = {
 
 // Mocks:
 jest.mock(
-  'react-i18next', 
+  'react-i18next',
   () => ({ useTranslation: () => mockUseTranslation(texts) }),
 );
 
@@ -83,9 +83,8 @@ describe('TextResourceEdit', () => {
     await act(() => user.type(textBox, additionalValue));
     await act(() => user.tab());
     expect(queriesMock.upsertTextResources).toHaveBeenCalledTimes(1);
-    expect(queriesMock.upsertTextResources).toHaveBeenCalledWith(org, app, 'nb', {
-      [id]: value + additionalValue,
-    });
+    expect(queriesMock.upsertTextResources).toHaveBeenCalledWith(org, app, 'nb', { [id]: value + 
+additionalValue });
   });
 
   it('Calls upsertTextResources with correct parameters when a text is NOT changed', async () => {

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
@@ -87,7 +87,7 @@ describe('TextResourceEdit', () => {
 additionalValue });
   });
 
-  it('Calls upsertTextResources with correct parameters when a text is NOT changed', async () => {
+  it('upsertTextResources should not be called when the text is NOT changed', async () => {
     const id = 'some-id';
     const oldValue = 'Lorem';
     const newValue = `${oldValue} ipsum`;

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
@@ -10,7 +10,7 @@ import {
   queryClientMock,
   renderHookWithMockStore,
   renderWithMockStore,
-  textResourcesMock,
+  textResourcesMock
 } from '../testing/mocks';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { mockUseTranslation } from '../../../../testing/mocks/i18nMock';
@@ -37,9 +37,13 @@ const texts = {
 };
 
 // Mocks:
-jest.mock('react-i18next', () => ({ useTranslation: () => mockUseTranslation(texts) }));
+jest.mock(
+  'react-i18next',
+  () => ({ useTranslation: () => mockUseTranslation(texts) }),
+  );
 
 describe('TextResourceEdit', () => {
+  
   afterEach(() => {
     jest.clearAllMocks();
     queryClientMock.clear();
@@ -58,7 +62,7 @@ describe('TextResourceEdit', () => {
     const resources: ITextResources = {
       nb: [{ id, value: valueNb }],
       nn: [{ id, value: valueNn }],
-      en: [{ id, value: valueEn }],
+      en: [{ id, value: valueEn }]
     };
     await render(resources, id);
     expect(screen.getByText(legendText)).toBeInTheDocument();
@@ -79,9 +83,8 @@ describe('TextResourceEdit', () => {
     await act(() => user.type(textBox, additionalValue));
     await act(() => user.tab());
     expect(queriesMock.upsertTextResources).toHaveBeenCalledTimes(1);
-    expect(queriesMock.upsertTextResources).toHaveBeenCalledWith(org, app, 'nb', {
-      [id]: value + additionalValue,
-    });
+    expect(queriesMock.upsertTextResources).toHaveBeenCalledWith(org, app, 'nb', { [id]: value +
+       additionalValue });
   });
 
   it('Calls upsertTextResources with correct parameters when a text is NOT changed', async () => {
@@ -125,26 +128,22 @@ describe('TextResourceEdit', () => {
 const render = async (resources: ITextResources = {}, editId?: string) => {
   const textResources: ITextResourcesState = {
     ...textResourcesMock,
-    currentEditId: editId,
+    currentEditId: editId
   };
 
   const appData: IAppDataState = {
     ...appDataMock,
-    textResources,
+    textResources
   };
 
-  const { result } = renderHookWithMockStore(
-    { appData },
-    {
+  const { result } = renderHookWithMockStore({ appData }, {
       getTextLanguages: () => Promise.resolve(['nb', 'nn', 'en']),
-      getTextResources: (_o, _a, lang) =>
-        Promise.resolve<ITextResourcesWithLanguage>({
+      getTextResources: (_o, _a, lang) => Promise.resolve<ITextResourcesWithLanguage>({
           language: lang,
-          resources: resources[lang] || [],
+          resources: resources[lang] || []
         }),
-    }
-  )(() => useTextResourcesQuery(org, app)).renderHookResult;
+    })(() => useTextResourcesQuery(org, app)).renderHookResult;
   await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-  return renderWithMockStore({ appData })(<TextResourceEdit />);
+  return renderWithMockStore({ appData })(<TextResourceEdit/>);
 };

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
@@ -10,7 +10,7 @@ import {
   queryClientMock,
   renderHookWithMockStore,
   renderWithMockStore,
-  textResourcesMock
+  textResourcesMock,
 } from '../testing/mocks';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { mockUseTranslation } from '../../../../testing/mocks/i18nMock';
@@ -37,13 +37,9 @@ const texts = {
 };
 
 // Mocks:
-jest.mock(
-  'react-i18next',
-  () => ({ useTranslation: () => mockUseTranslation(texts) }),
-  );
+jest.mock('react-i18next', () => ({ useTranslation: () => mockUseTranslation(texts) }));
 
 describe('TextResourceEdit', () => {
-  
   afterEach(() => {
     jest.clearAllMocks();
     queryClientMock.clear();
@@ -62,7 +58,7 @@ describe('TextResourceEdit', () => {
     const resources: ITextResources = {
       nb: [{ id, value: valueNb }],
       nn: [{ id, value: valueNn }],
-      en: [{ id, value: valueEn }]
+      en: [{ id, value: valueEn }],
     };
     await render(resources, id);
     expect(screen.getByText(legendText)).toBeInTheDocument();
@@ -83,8 +79,9 @@ describe('TextResourceEdit', () => {
     await act(() => user.type(textBox, additionalValue));
     await act(() => user.tab());
     expect(queriesMock.upsertTextResources).toHaveBeenCalledTimes(1);
-    expect(queriesMock.upsertTextResources).toHaveBeenCalledWith(org, app, 'nb', { [id]: value +
-       additionalValue });
+    expect(queriesMock.upsertTextResources).toHaveBeenCalledWith(org, app, 'nb', {
+      [id]: value + additionalValue,
+    });
   });
 
   it('Calls upsertTextResources with correct parameters when a text is NOT changed', async () => {
@@ -128,22 +125,26 @@ describe('TextResourceEdit', () => {
 const render = async (resources: ITextResources = {}, editId?: string) => {
   const textResources: ITextResourcesState = {
     ...textResourcesMock,
-    currentEditId: editId
+    currentEditId: editId,
   };
 
   const appData: IAppDataState = {
     ...appDataMock,
-    textResources
+    textResources,
   };
 
-  const { result } = renderHookWithMockStore({ appData }, {
+  const { result } = renderHookWithMockStore(
+    { appData },
+    {
       getTextLanguages: () => Promise.resolve(['nb', 'nn', 'en']),
-      getTextResources: (_o, _a, lang) => Promise.resolve<ITextResourcesWithLanguage>({
+      getTextResources: (_o, _a, lang) =>
+        Promise.resolve<ITextResourcesWithLanguage>({
           language: lang,
-          resources: resources[lang] || []
+          resources: resources[lang] || [],
         }),
-    })(() => useTextResourcesQuery(org, app)).renderHookResult;
+    }
+  )(() => useTextResourcesQuery(org, app)).renderHookResult;
   await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-  return renderWithMockStore({ appData })(<TextResourceEdit/>);
+  return renderWithMockStore({ appData })(<TextResourceEdit />);
 };

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
@@ -70,12 +70,10 @@ const TextBox = ({ language, t, textResource, textResourceId }: TextBoxProps) =>
   const { mutate } = useUpsertTextResourcesMutation(org, app);
 
   const updateTextResource = (text: string) => {
-    if (textResource) {
       mutate({
         language,
         textResources: [{ id: textResourceId, value: text, variables:textResource?.variables }],
       });
-    }
   };
 
   const [value, setValue] = useState<string>(textResource?.value || '');

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
@@ -58,7 +58,7 @@ export const TextResourceEdit = () => {
   );
 };
 
-interface TextBoxProps {
+export interface TextBoxProps {
   language: string;
   t: (key: string) => string;
   textResource?: ITextResource;
@@ -69,14 +69,21 @@ const TextBox = ({ language, t, textResource, textResourceId }: TextBoxProps) =>
   const { org, app } = useParams();
   const { mutate } = useUpsertTextResourcesMutation(org, app);
 
-  const updateTextResource = (text: string) =>
-    mutate({ language, textResources: [{ id: textResourceId, value: text, variables: textResource.variables }] });
+  const updateTextResource = (text: string) => {
+    if (textResource) {
+      const variables = textResource.variables || [];
+      mutate({
+        language,
+        textResources: [{ id: textResourceId, value: text, variables }],
+      });
+    }
+  };
 
   const [value, setValue] = useState<string>(textResource?.value || '');
 
   useEffect(() => {
     setValue(textResource?.value || '');
-  }, [textResource?.value]);
+  }, [textResource?.value, textResource?.variables]);
 
   return (
     <div>

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
@@ -71,10 +71,9 @@ const TextBox = ({ language, t, textResource, textResourceId }: TextBoxProps) =>
 
   const updateTextResource = (text: string) => {
     if (textResource) {
-      const variables = textResource.variables || [];
       mutate({
         language,
-        textResources: [{ id: textResourceId, value: text, variables }],
+        textResources: [{ id: textResourceId, value: text, variables:textResource?.variables }],
       });
     }
   };
@@ -82,8 +81,8 @@ const TextBox = ({ language, t, textResource, textResourceId }: TextBoxProps) =>
   const [value, setValue] = useState<string>(textResource?.value || '');
 
   useEffect(() => {
-    setValue(textResource?.value || '');
-  }, [textResource?.value, textResource?.variables]);
+    setValue(textResource?.value || '')
+  }, [textResource?.value]);
 
   return (
     <div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes:
- Updated textResouceEdit to fix runtime error when the user click inside and outside the text field without changing the text. 
- Added test 

## Related Issue(s)
- #10562 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
