### PR TITLE
Remove node selection callback

### DIFF
--- a/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab.tsx
@@ -1,7 +1,7 @@
 import type { BaseSyntheticEvent } from 'react';
 import React, { useEffect } from 'react';
 import { PropertyItem } from './PropertyItem';
-import { removeSelection, setSelectedNode } from '../../features/editor/schemaEditorSlice';
+import { removeSelection } from '../../features/editor/schemaEditorSlice';
 import { useDispatch } from 'react-redux';
 import type { UiSchemaNode, FieldType } from '@altinn/schema-model';
 import {
@@ -51,7 +51,6 @@ export const ItemFieldsTab = ({ selectedItem }: ItemFieldsTabProps) => {
       setPropertyName(data, {
         path,
         name: value,
-        callback: (newPointer) => dispatch(setSelectedNode(newPointer)),
       })
     );
 

--- a/frontend/packages/schema-model/src/lib/mutations/ui-schema-reducers.ts
+++ b/frontend/packages/schema-model/src/lib/mutations/ui-schema-reducers.ts
@@ -253,7 +253,7 @@ export const addCombinationItem: UiSchemaReducer<AddCombinationItemArgs> =
 export type SetPropertyNameArgs = {
   path: string;
   name: string;
-  callback: (pointer: string) => void;
+  callback?: (pointer: string) => void;
 };
 export const setPropertyName: UiSchemaReducer<SetPropertyNameArgs> =
   (uiSchema, { path, name, callback }) => {
@@ -264,7 +264,7 @@ export const setPropertyName: UiSchemaReducer<SetPropertyNameArgs> =
     const nodeToRename = getNodeByPointer(newSchema, path);
     const oldPointer = nodeToRename.pointer;
     const newPointer = replaceLastPointerSegment(oldPointer, name);
-    callback(newPointer);
+    callback?.(newPointer);
     return renameNodePointer(newSchema, nodeToRename.pointer, newPointer);
   };
 


### PR DESCRIPTION
## Description
Removed the callback that update the selected node after editing field names

## Related Issue(s)
- #10648 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
