### PR TITLE
Bug/10562 fix text resource bindings

### DIFF
--- a/frontend/language/src/en.json
+++ b/frontend/language/src/en.json
@@ -850,6 +850,8 @@
   "ux_editor.modal_properties_button_type_helper": "Button type",
   "ux_editor.modal_properties_button_type_navigation": "Navigation",
   "ux_editor.modal_properties_button_type_submit": "Submit",
+  "ux_editor.modal_properties_button_type_back": "Back",
+  "ux_editor.modal_properties_button_type_next": "Next",
   "ux_editor.modal_properties_code_list_id": "Code list ID",
   "ux_editor.modal_properties_custom_code_list_id": "Custom code list ID",
   "ux_editor.modal_properties_code_list_read_more": "\"<0 href=\\\"{{optionsDocs}}\\\" >Read more about code lists</0>\",",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -907,6 +907,8 @@
   "ux_editor.modal_properties_button_type_helper": "Type knapp",
   "ux_editor.modal_properties_button_type_navigation": "Navigasjon",
   "ux_editor.modal_properties_button_type_submit": "Send inn",
+  "ux_editor.modal_properties_button_type_back": "Forrige",
+  "ux_editor.modal_properties_button_type_next": "Neste",
   "ux_editor.modal_properties_code_list_id": "Kodeliste-ID",
   "ux_editor.modal_properties_custom_code_list_id": "ID til egendefinert kodeliste",
   "ux_editor.modal_properties_code_list_read_more": "<0 href=\"{{optionsDocs}}\" >Les mer om kodelister</0>",

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Button/ButtonComponent.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Button/ButtonComponent.test.tsx
@@ -6,7 +6,6 @@ import { renderWithMockStore, renderHookWithMockStore } from '../../../../testin
 import { useLayoutSchemaQuery } from '../../../../hooks/queries/useLayoutSchemaQuery';
 import { ButtonComponent } from './ButtonComponent';
 import { ComponentType } from 'app-shared/types/ComponentType';
-import { textMock } from '../../../../../../../testing/mocks/i18nMock';
 import type { FormButtonComponent } from '../../../../types/FormComponent';
 
 // Test data:
@@ -35,8 +34,8 @@ describe('ButtonComponent', () => {
       type: ComponentType.NavigationButtons,
       showBackButton: true,
       textResourceBindings: {
-        next: 'next',
-        back: 'back',
+        next: undefined,
+        back: undefined,
       },
     });
   });
@@ -56,9 +55,7 @@ describe('ButtonComponent', () => {
     expect(mockHandleComponentChange).toHaveBeenCalledWith({
       ...component,
       type: ComponentType.Button,
-      textResourceBindings: {
-        title: textMock('ux_editor.modal_properties_button_type_submit'),
-      },
+      textResourceBindings: {},
     });
   });
 });

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Button/ButtonComponent.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Button/ButtonComponent.test.tsx
@@ -55,7 +55,9 @@ describe('ButtonComponent', () => {
     expect(mockHandleComponentChange).toHaveBeenCalledWith({
       ...component,
       type: ComponentType.Button,
-      textResourceBindings: {},
+      textResourceBindings: {
+        title: undefined,
+      },
     });
   });
 });

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Button/ButtonComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Button/ButtonComponent.tsx
@@ -17,16 +17,11 @@ export const ButtonComponent = ({ component, handleComponentChange }: IGenericEd
     }
     if (selected === ComponentType.NavigationButtons) {
       componentCopy.type = ComponentType.NavigationButtons;
-      componentCopy.textResourceBindings = {
-        next: undefined,
-        back: undefined,
-      };
       componentCopy.showBackButton = true;
     } else if (selected === ComponentType.Button) {
       componentCopy.type = ComponentType.Button;
       delete componentCopy.showPrev;
       delete componentCopy.showBackButton;
-      componentCopy.textResourceBindings = {};
     }
     handleComponentChange(componentCopy);
   };

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Button/ButtonComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Button/ButtonComponent.tsx
@@ -18,17 +18,15 @@ export const ButtonComponent = ({ component, handleComponentChange }: IGenericEd
     if (selected === ComponentType.NavigationButtons) {
       componentCopy.type = ComponentType.NavigationButtons;
       componentCopy.textResourceBindings = {
-        next: 'next',
-        back: 'back',
+        next: undefined,
+        back: undefined,
       };
       componentCopy.showBackButton = true;
     } else if (selected === ComponentType.Button) {
       componentCopy.type = ComponentType.Button;
       delete componentCopy.showPrev;
       delete componentCopy.showBackButton;
-      componentCopy.textResourceBindings = {
-        title: t('ux_editor.modal_properties_button_type_submit'),
-      };
+      componentCopy.textResourceBindings = {};
     }
     handleComponentChange(componentCopy);
   };

--- a/frontend/packages/ux-editor/src/containers/ComponentPreview/ButtonPreview/ButtonPreview.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/ComponentPreview/ButtonPreview/ButtonPreview.test.tsx
@@ -6,6 +6,7 @@ import { renderHookWithMockStore, renderWithMockStore } from '../../../testing/m
 import { useTextResourcesQuery } from 'app-shared/hooks/queries/useTextResourcesQuery';
 import { ITextResource } from 'app-shared/types/global';
 import type { FormButtonComponent } from '../../../types/FormComponent';
+import { textMock } from '../../../../../../testing/mocks/i18nMock';
 
 // Test data:
 const org = 'org';
@@ -16,8 +17,8 @@ const sendInnTextResource: ITextResource = { id: sendInnKey, value: sendInnText 
 const nbTextResources: ITextResource[] = [sendInnTextResource];
 
 describe('ButtonPreview', () => {
-  test('should render "Send inn" button', async () => {
-    await renderWithMock({
+  describe('Submit button', () => {
+    const submitButton: FormButtonComponent = {
       id: 'PreviewButtonSubmit',
       textResourceBindings: {
         title: sendInnKey,
@@ -26,44 +27,26 @@ describe('ButtonPreview', () => {
       onClickAction: () => {},
       itemType: 'COMPONENT',
       dataModelBindings: {},
+    };
+
+    test('should render "Send inn" button', async () => {
+      await renderWithMock(submitButton);
+      expect(screen.getByRole('button', { name: sendInnText }));
     });
-    expect(screen.getByRole('button', { name: sendInnText }));
+
+    test('Should render "Send inn" button with a default value when the text resource is empty', async () => {
+      await renderWithMock({
+        ...submitButton,
+        textResourceBindings: {
+          title: undefined,
+        },
+      });
+      expect(screen.getByRole('button', { name: textMock('ux_editor.modal_properties_button_type_submit') }));
+    });
   });
 
-  test('should render next navigation button', async () => {
-    await renderWithMock({
-      id: 'PreviewNavigationButton',
-      textResourceBindings: {
-        next: 'next',
-        back: 'back',
-      },
-      showBackButton: false,
-      type: ComponentType.NavigationButtons,
-      onClickAction: () => {},
-      itemType: 'COMPONENT',
-      dataModelBindings: {},
-    });
-    expect(screen.getByRole('button', { name: 'next' }));
-  });
-
-  test('should render back navigation button', async () => {
-    await renderWithMock({
-      id: 'PreviewNavigationButton',
-      textResourceBindings: {
-        next: 'next',
-        back: 'back',
-      },
-      showBackButton: true,
-      type: ComponentType.NavigationButtons,
-      onClickAction: () => {},
-      itemType: 'COMPONENT',
-      dataModelBindings: {},
-    });
-    expect(screen.getByRole('button', { name: 'back' }));
-  });
-
-  test('Should render back and next buttons', async () => {
-    await renderWithMock({
+  describe('Navigation buttons', () => {
+    const navigationButtons: FormButtonComponent = {
       id: 'PreviewNavigationButton',
       textResourceBindings: {
         next: 'next',
@@ -74,9 +57,38 @@ describe('ButtonPreview', () => {
       onClickAction: () => {},
       itemType: 'COMPONENT',
       dataModelBindings: {},
+    };
+
+    test('should render next navigation button', async () => {
+      await renderWithMock({
+        ...navigationButtons,
+        showBackButton: false,
+      });
+      expect(screen.getByRole('button', { name: 'next' }));
     });
-    expect(screen.getByRole('button', { name: 'back' }));
-    expect(screen.getByRole('button', { name: 'next' }));
+
+    test('should render back navigation button', async () => {
+      await renderWithMock(navigationButtons);
+      expect(screen.getByRole('button', { name: 'back' }));
+    });
+
+    test('Should render back and next buttons', async () => {
+      await renderWithMock(navigationButtons);
+      expect(screen.getByRole('button', { name: 'back' }));
+      expect(screen.getByRole('button', { name: 'next' }));
+    });
+
+    test('Should render back and next buttons with a default value when the text resource is empty', async () => {
+      await renderWithMock({
+        ...navigationButtons,
+        textResourceBindings: {
+          next: undefined,
+          back: undefined,
+        },
+      });
+      expect(screen.getByRole('button', { name: textMock('ux_editor.modal_properties_button_type_back') }));
+      expect(screen.getByRole('button', { name: textMock('ux_editor.modal_properties_button_type_next') }));
+    });
   });
 });
 

--- a/frontend/packages/ux-editor/src/containers/ComponentPreview/ButtonPreview/ButtonPreview.tsx
+++ b/frontend/packages/ux-editor/src/containers/ComponentPreview/ButtonPreview/ButtonPreview.tsx
@@ -4,7 +4,7 @@ import { getTextResource } from '../../../utils/language';
 import { ComponentType } from 'app-shared/types/ComponentType';
 import classes from './ButtonPreview.module.css';
 import { ITextResource } from 'app-shared/types/global';
-import { useTextResourcesSelector } from '../../../hooks';
+import { useText, useTextResourcesSelector } from '../../../hooks';
 import { textResourcesByLanguageSelector } from '../../../selectors/textResourceSelectors';
 import { DEFAULT_LANGUAGE } from 'app-shared/constants';
 import type { FormButtonComponent } from '../../../types/FormComponent';
@@ -14,6 +14,7 @@ export interface ButtonPreviewProps {
 }
 
 export const ButtonPreview = ({ component }: ButtonPreviewProps): JSX.Element => {
+  const t = useText();
   const texts: ITextResource[] = useTextResourcesSelector<ITextResource[]>(textResourcesByLanguageSelector(DEFAULT_LANGUAGE));
 
   const isNavigationButton = component.type === ComponentType.NavigationButtons;
@@ -29,19 +30,19 @@ export const ButtonPreview = ({ component }: ButtonPreviewProps): JSX.Element =>
         {
           variant: ButtonVariant.Filled,
           color: buttonColor,
-          text: getTextResource(component.textResourceBindings?.back, texts),
+          text: getTextResource(component.textResourceBindings?.back, texts) || t('ux_editor.modal_properties_button_type_back'),
         },
         {
           variant: ButtonVariant.Filled,
           color: buttonColor,
-          text: getTextResource(component.textResourceBindings?.next, texts),
+          text: getTextResource(component.textResourceBindings?.next, texts) || t('ux_editor.modal_properties_button_type_next'),
         },
       ]
     : [
         {
           variant: ButtonVariant.Filled,
           color: buttonColor,
-          text: getTextResource(buttonText, texts),
+          text: getTextResource(buttonText, texts) || t('ux_editor.modal_properties_button_type_submit'),
         },
       ];
 

--- a/frontend/packages/ux-editor/src/utils/formLayoutUtils.test.tsx
+++ b/frontend/packages/ux-editor/src/utils/formLayoutUtils.test.tsx
@@ -555,7 +555,7 @@ describe('formLayoutUtils', () => {
       const layout = addNavigationButtons(mockInternal, id);
       expect(layout.components[id]).toBeDefined();
       expect(layout.components[id].type).toEqual(ComponentType.NavigationButtons);
-      expect(layout.components[id].textResourceBindings).toEqual({ next: 'next', back: 'back' });
+      expect(layout.components[id].textResourceBindings).toEqual({ next: undefined, back: undefined });
       expect(layout.order[BASE_CONTAINER_ID].slice(-1)[0]).toEqual(id);
       expect(layout.order[BASE_CONTAINER_ID].length).toEqual(mockInternal.order[BASE_CONTAINER_ID].length + 1);
     });

--- a/frontend/packages/ux-editor/src/utils/formLayoutUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/formLayoutUtils.ts
@@ -396,7 +396,7 @@ export const addNavigationButtons = (layout: IInternalLayout, id: string): IInte
     itemType: 'COMPONENT',
     onClickAction: () => {},
     showBackButton: true,
-    textResourceBindings: { next: 'next', back: 'back', },
+    textResourceBindings: { next: undefined, back: undefined, },
     type: ComponentType.NavigationButtons,
   };
   return addComponent(layout, navigationButtons);


### PR DESCRIPTION
## Description
Fix default values of text resource bindings for button component

## Related Issue(s)
- #10562 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
