### PR TITLE
Display component type when text resource is empty

### DIFF
--- a/frontend/packages/ux-editor/src/components/FormComponent.test.tsx
+++ b/frontend/packages/ux-editor/src/components/FormComponent.test.tsx
@@ -1,17 +1,27 @@
 import React from 'react';
-import { act, screen } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { DndProvider } from 'react-dnd';
 import type { IFormComponentProps } from './FormComponent';
 import { FormComponent } from './FormComponent';
-import { queriesMock, renderWithMockStore } from '../testing/mocks';
+import { queriesMock, renderHookWithMockStore, renderWithMockStore } from '../testing/mocks';
 import { component1IdMock, component1Mock } from '../testing/layoutMock';
 import { textMock } from '../../../../testing/mocks/i18nMock';
+import { useTextResourcesQuery } from 'app-shared/hooks/queries/useTextResourcesQuery';
+import { ITextResource } from 'app-shared/types/global';
 
 const user = userEvent.setup();
 
 // Test data:
+const org = 'org';
+const app = 'app';
+const testTextResourceKey = 'test-key';
+const testTextResourceValue = 'test-value';
+const emptyTextResourceKey = 'empty-key';
+const testTextResource: ITextResource = { id: testTextResourceKey, value: testTextResourceValue };
+const emptyTextResource: ITextResource = { id: emptyTextResourceKey, value: '' };
+const nbTextResources: ITextResource[] = [testTextResource, emptyTextResource];
 const handleEditMock = jest.fn();
 const handleSaveMock = jest.fn().mockImplementation(() => Promise.resolve());
 const handleDiscardMock = jest.fn();
@@ -33,7 +43,67 @@ describe('FormComponent', () => {
 
     expect(queriesMock.saveFormLayout).toHaveBeenCalledTimes(1);
   });
+
+  describe('title', () => {
+    it('should display the title', async () => {
+      await render({
+        component: {
+          ...component1Mock,
+          textResourceBindings: {
+            title: testTextResourceKey
+          },
+        }
+      });
+
+      expect(screen.getByText(testTextResourceValue)).toBeInTheDocument();
+    });
+
+    it('should display the component type when the title is empty', async () => {
+      await render({
+        component: {
+          ...component1Mock,
+          textResourceBindings: {
+            title: emptyTextResourceKey,
+          },
+        },
+      });
+
+      expect(screen.getByText(textMock('ux_editor.component_input'))).toBeInTheDocument();
+    });
+
+    it('should display the component type when the title is undefined', async () => {
+      await render({
+        component: {
+          ...component1Mock,
+          textResourceBindings: {
+            title: undefined,
+          },
+        }
+      });
+
+      expect(screen.getByText(textMock('ux_editor.component_input'))).toBeInTheDocument();
+    });
+
+    it('should display "Unknown component" when both the title and the component type are undefined', async () => {
+      await render({
+        component: {
+          ...component1Mock,
+          textResourceBindings: undefined,
+          type: undefined,
+        }
+      });
+
+      expect(screen.getByText(textMock('ux_editor.component_unknown'))).toBeInTheDocument();
+    });
+  })
 });
+
+const waitForData = async () => {
+  const { result: texts } = renderHookWithMockStore({}, {
+    getTextResources: () => Promise.resolve({ language: 'nb', resources: nbTextResources })
+  })(() => useTextResourcesQuery(org, app)).renderHookResult;
+  await waitFor(() => expect(texts.current.isSuccess).toBe(true));
+};
 
 const render = async (props: Partial<IFormComponentProps> = {}) => {
   const allProps: IFormComponentProps = {
@@ -45,6 +115,8 @@ const render = async (props: Partial<IFormComponentProps> = {}) => {
     handleDiscard: handleDiscardMock,
     ...props
   };
+
+  await waitForData();
 
   return renderWithMockStore()(
     <DndProvider backend={HTML5Backend}>

--- a/frontend/packages/ux-editor/src/components/FormComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/FormComponent.tsx
@@ -70,6 +70,8 @@ export const FormComponent = memo(function FormComponent({
     setIsPreviewMode(previous => !previous);
   };
 
+  const textResource = !isPreviewMode ? getTextResource(component.textResourceBindings?.title, textResources) : null;
+
   return (
     <div
       className={cn(classes.wrapper, isEditMode && classes.editMode, isPreviewMode && classes.previewMode)}
@@ -96,11 +98,8 @@ export const FormComponent = memo(function FormComponent({
           ) : (
             <div className={classes.formComponentTitle}>
               <i className={formItemConfigs?.[component.type]?.icon || 'fa fa-help-circle'} />
-              {component.textResourceBindings?.title
-                ? truncate(
-                    getTextResource(component.textResourceBindings.title, textResources),
-                    80
-                  )
+              {textResource
+                ? truncate(textResource, 80)
                 : getComponentTitleByComponentType(component.type, t) ||
                   t('ux_editor.component_unknown')}
             </div>

--- a/frontend/packages/ux-editor/src/containers/ComponentPreview/ButtonPreview/ButtonPreview.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/ComponentPreview/ButtonPreview/ButtonPreview.test.tsx
@@ -14,7 +14,13 @@ const app = 'app';
 const sendInnKey = 'sendinn';
 const sendInnText = 'Send inn';
 const sendInnTextResource: ITextResource = { id: sendInnKey, value: sendInnText };
-const nbTextResources: ITextResource[] = [sendInnTextResource];
+const backKey = 'back';
+const backText = 'Back';
+const backTextResource: ITextResource = { id: backKey, value: backText };
+const nextKey = 'next';
+const nextText = 'Next';
+const nextTextResource: ITextResource = { id: nextKey, value: nextText };
+const nbTextResources: ITextResource[] = [sendInnTextResource, backTextResource, nextTextResource];
 
 describe('ButtonPreview', () => {
   describe('Submit button', () => {
@@ -49,8 +55,8 @@ describe('ButtonPreview', () => {
     const navigationButtons: FormButtonComponent = {
       id: 'PreviewNavigationButton',
       textResourceBindings: {
-        next: 'next',
-        back: 'back',
+        next: nextKey,
+        back: backKey,
       },
       showBackButton: true,
       type: ComponentType.NavigationButtons,
@@ -64,18 +70,18 @@ describe('ButtonPreview', () => {
         ...navigationButtons,
         showBackButton: false,
       });
-      expect(screen.getByRole('button', { name: 'next' }));
+      expect(screen.getByRole('button', { name: nextText }));
     });
 
     test('should render back navigation button', async () => {
       await renderWithMock(navigationButtons);
-      expect(screen.getByRole('button', { name: 'back' }));
+      expect(screen.getByRole('button', { name: backText }));
     });
 
     test('Should render back and next buttons', async () => {
       await renderWithMock(navigationButtons);
-      expect(screen.getByRole('button', { name: 'back' }));
-      expect(screen.getByRole('button', { name: 'next' }));
+      expect(screen.getByRole('button', { name: nextText }));
+      expect(screen.getByRole('button', { name: backText }));
     });
 
     test('Should render back and next buttons with a default value when the text resource is empty', async () => {

--- a/frontend/packages/ux-editor/src/utils/language.test.ts
+++ b/frontend/packages/ux-editor/src/utils/language.test.ts
@@ -1,4 +1,4 @@
-import { getComponentHelperTextByComponentType } from './language';
+import { getComponentHelperTextByComponentType, getTextResource } from './language';
 import { ComponentType } from 'app-shared/types/ComponentType';
 
 const language = {
@@ -50,4 +50,22 @@ describe('Designer > utils/language', () => {
       );
     });
   });
+
+  describe('getTextResource', () => {
+    const textResources = [{ id: 'test', value: 'test' }];
+    const textResource = textResources[0];
+
+    it('should return the text resource', () => {
+      expect(getTextResource(textResource.id, textResources)).toBe(textResource.value);
+    });
+    it('should return undefined when resourceKey is empty', () => {
+      expect(getTextResource('', textResources)).toBeUndefined();
+    });
+    it('should return undefined when resources are empty', () => {
+      expect(getTextResource(textResource.id, [])).toBeUndefined();
+    });
+    it('should return undefined when the text resource doesn\'t exist', () => {
+      expect(getTextResource('wrong-id', textResources)).toBeUndefined();
+    });
+  })
 });

--- a/frontend/packages/ux-editor/src/utils/language.ts
+++ b/frontend/packages/ux-editor/src/utils/language.ts
@@ -132,6 +132,7 @@ export function truncate(s: string, size: number) {
 }
 
 export function getTextResource(resourceKey: string, textResources: ITextResource[]): string {
-  const textResource = textResources?.find((resource) => resource.id === resourceKey);
-  return textResource ? textResource.value : resourceKey;
+  if (!resourceKey || !textResources?.length) return;
+  const textResource = textResources.find((resource) => resource.id === resourceKey);
+  return textResource?.value;
 }


### PR DESCRIPTION
## Related Issue(s)
#10656 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
