### PR TITLE
10664 remove the code that adds empty text resources in norwegian

### DIFF
--- a/frontend/packages/ux-editor/src/components/TextResource.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResource.tsx
@@ -21,10 +21,8 @@ import { generateTextResourceId } from '../utils/generateId';
 import { useText } from '../hooks';
 import { prepend } from 'app-shared/utils/arrayUtils';
 import cn from 'classnames';
-import { useParams } from 'react-router-dom';
 import type { ITextResource } from 'app-shared/types/global';
 import { useTextResourcesSelector } from '../hooks';
-import { useUpsertTextResourcesMutation } from 'app-shared/hooks/mutations';
 import { FormField } from './FormField';
 
 export interface TextResourceProps {
@@ -67,10 +65,6 @@ export const TextResource = ({
   const textResources: ITextResource[] = useTextResourcesSelector<ITextResource[]>(allTextResourceIdsWithTextSelector(DEFAULT_LANGUAGE));
   const t = useText();
   const [isSearchMode, setIsSearchMode] = useState(false);
-  const { org, app } = useParams();
-  const { mutate } = useUpsertTextResourcesMutation(org, app);
-  const addTextResource =
-    (id: string) => mutate({ language: DEFAULT_LANGUAGE, textResources: [{ id, value: '' }] });
 
   const editId = useSelector(getCurrentEditId);
   const setEditId = (id: string) => dispatch(setCurrentEditId(id));
@@ -82,7 +76,6 @@ export const TextResource = ({
       setEditId(textResourceId);
     } else {
       const id = generateId(generateIdOptions);
-      addTextResource(id);
       handleIdChange(id);
       setEditId(id);
     }

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.test.tsx
@@ -89,12 +89,22 @@ additionalValue });
 
   it('upsertTextResources should not be called when the text is NOT changed', async () => {
     const id = 'some-id';
-    const oldValue = 'Lorem';
-    const newValue = `${oldValue} ipsum`;
-    const resources: ITextResources = { nb: [{ id, value: oldValue }] };
+    const value = 'Lorem';
+    const resources: ITextResources = { nb: [{ id, value }] };
     await render(resources, id);
     const textBox = screen.getByLabelText(nbText);
-    fireEvent.change(textBox, { target: { value: newValue } });
+    await act(() => user.clear(textBox));
+    await act(() => user.type(textBox, value));
+    await act(() => user.tab());
+    expect(queriesMock.upsertTextResources).not.toHaveBeenCalled();
+  });
+
+  it('upsertTextResources should not be called when the text resource does not exist and the text is empty', async () => {
+    const id = 'some-id';
+    const resources: ITextResources = { nb: [] };
+    await render(resources, id);
+    const textBox = screen.getByLabelText(nbText);
+    await act(() => user.clear(textBox));
     await act(() => user.tab());
     expect(queriesMock.upsertTextResources).not.toHaveBeenCalled();
   });

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
@@ -69,8 +69,10 @@ const TextBox = ({ language, t, textResource, textResourceId }: TextBoxProps) =>
   const { org, app } = useParams();
   const { mutate } = useUpsertTextResourcesMutation(org, app);
 
+  const textResourceValue = textResource?.value || '';
+
   const updateTextResource = (text: string) => {
-    if (!textResource && !text) return;
+    if (text === textResourceValue) return;
 
     mutate({
       language,
@@ -78,11 +80,11 @@ const TextBox = ({ language, t, textResource, textResourceId }: TextBoxProps) =>
     });
   };
 
-  const [value, setValue] = useState<string>(textResource?.value || '');
+  const [value, setValue] = useState<string>(textResourceValue);
 
   useEffect(() => {
-    setValue(textResource?.value || '')
-  }, [textResource?.value]);
+    setValue(textResourceValue)
+  }, [textResourceValue]);
 
   return (
     <div>

--- a/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResourceEdit.tsx
@@ -70,10 +70,12 @@ const TextBox = ({ language, t, textResource, textResourceId }: TextBoxProps) =>
   const { mutate } = useUpsertTextResourcesMutation(org, app);
 
   const updateTextResource = (text: string) => {
-      mutate({
-        language,
-        textResources: [{ id: textResourceId, value: text, variables:textResource?.variables }],
-      });
+    if (!textResource && !text) return;
+
+    mutate({
+      language,
+      textResources: [{ id: textResourceId, value: text, variables:textResource?.variables }],
+    });
   };
 
   const [value, setValue] = useState<string>(textResource?.value || '');


### PR DESCRIPTION
## Description
- removed the code that adds an empty text resource in Norwegian when editing a text resource that does not exist
- checked if the value has been changed before updating the text resources, to avoid adding an empty text resource and to avoid unnecessary updates

## Related Issue(s)
- #10664 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
