### PR TITLE
fix: endret rettskriving: beskrivselse -> beskrivelse

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -962,7 +962,7 @@
   "ux_editor.modal_properties_textResourceBindings_body": "Tekstinnhold",
   "ux_editor.modal_properties_textResourceBindings_body_add": "Legg til tekstinnhold",
   "ux_editor.modal_properties_textResourceBindings_description": "Beskrivelse",
-  "ux_editor.modal_properties_textResourceBindings_description_add": "Legg til beskrivselse",
+  "ux_editor.modal_properties_textResourceBindings_description_add": "Legg til beskrivelse",
   "ux_editor.modal_properties_textResourceBindings_help": "Hjelpetekst",
   "ux_editor.modal_properties_textResourceBindings_help_add": "Legg til hjelpetekst",
   "ux_editor.modal_properties_textResourceBindings_next": "Tekst på neste-knapp",


### PR DESCRIPTION
Endret en skrivefeil i Studio

## Description
Feltet "beskrivelse" i Studio hadde en feilstavvet ledetekst

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [N/A] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
