### PR TITLE
Added error message if deleting a text fails

### DIFF
--- a/frontend/app-development/hooks/mutations/useTextIdMutation.ts
+++ b/frontend/app-development/hooks/mutations/useTextIdMutation.ts
@@ -2,12 +2,22 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { UpdateTextIdPayload } from 'app-shared/types/api/UpdateTextIdPayload';
+import { useTranslation } from 'react-i18next';
 
 export const useTextIdMutation = (owner, app) => {
   const queryClient = useQueryClient();
   const { updateTextId } = useServicesContext();
+  const { t } = useTranslation();
+
   return useMutation({
-    mutationFn: (payload: UpdateTextIdPayload) => updateTextId(owner, app, payload),
+    mutationFn: async (payload: UpdateTextIdPayload) => {
+      try {
+        await updateTextId(owner, app, payload);
+      } catch (error) {
+        console.error(t('schema_editor.delete_text_id_error'));
+        alert(t('schema_editor.delete_text_id_error'));
+      }
+    },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: [QueryKey.TextResources, owner, app] });
       await queryClient.invalidateQueries({ queryKey: [QueryKey.FormLayouts, owner, app] });

--- a/frontend/app-development/hooks/mutations/useTextIdMutation.ts
+++ b/frontend/app-development/hooks/mutations/useTextIdMutation.ts
@@ -14,7 +14,6 @@ export const useTextIdMutation = (owner, app) => {
       try {
         await updateTextId(owner, app, payload);
       } catch (error) {
-        console.error(t('schema_editor.delete_text_id_error'));
         alert(t('schema_editor.delete_text_id_error'));
       }
     },

--- a/frontend/language/src/en.json
+++ b/frontend/language/src/en.json
@@ -584,6 +584,7 @@
   "schema_editor.definitions": "Definitions",
   "schema_editor.delete": "Delete",
   "schema_editor.delete_field": "Delete field",
+  "schema_editor.delete_text_id_error": "An error occurred while deleting the text.",
   "schema_editor.depth_error": "It is not possible to put the group here because it will make the form exceed the maximum allowed depth.",
   "schema_editor.description": "Description",
   "schema_editor.descriptive_fields": "Descriptive fields",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -617,6 +617,7 @@
   "schema_editor.definitions": "Definisjoner",
   "schema_editor.delete": "Slett",
   "schema_editor.delete_field": "Slett felt",
+  "schema_editor.delete_text_id_error": "Det oppsto en feil under sletting av teksten.",
   "schema_editor.depth_error": "Det er ikke mulig å plassere gruppen her fordi det vil føre til at skjemaet får for mange nivåer.",
   "schema_editor.description": "Tekst",
   "schema_editor.descriptive_fields": "Beskrivende felter",

--- a/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -174,7 +174,8 @@ describe('TextEditor', () => {
     it('reverts to the previous IDs if an entry could not be deleted', async () => {
       const { error, onTextIdChange } = setupError();
       await deleteSomething(onTextIdChange);
-      expect(error).toHaveBeenCalledWith('Deleting text failed:\n', 'some error');
+      const errorMessage = textMock('schema_editor.delete_text_id_error');
+      expect(error).toHaveBeenCalledWith(errorMessage);
       const resultAfter = screen.getAllByRole('button', {
         name: textMock('schema_editor.delete'),
       });

--- a/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -174,8 +174,7 @@ describe('TextEditor', () => {
     it('reverts to the previous IDs if an entry could not be deleted', async () => {
       const { error, onTextIdChange } = setupError();
       await deleteSomething(onTextIdChange);
-      const errorMessage = textMock('schema_editor.delete_text_id_error');
-      expect(error).toHaveBeenCalledWith(errorMessage);
+      expect(error).toHaveBeenCalledWith('Deleting text failed:\n', 'some error');
       const resultAfter = screen.getAllByRole('button', {
         name: textMock('schema_editor.delete'),
       });

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import classes from './TextEditor.module.css';
 import type {
   LangCode,
@@ -14,7 +14,6 @@ import { defaultLangCode } from './constants';
 import { TextList } from './TextList';
 import ISO6391 from 'iso-639-1';
 import { ITextResources } from 'app-shared/types/global';
-import { useTranslation } from 'react-i18next';
 
 export interface TextEditorProps {
   addLanguage: (language: LangCode) => void;
@@ -42,9 +41,6 @@ export const TextEditor = ({
   upsertTextResource,
 }: TextEditorProps) => {
   const resourceRows = mapResourceFilesToTableRows(textResourceFiles);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
-  const { t } = useTranslation();
-
   const availableLangCodesFiltered = useMemo(
     () => availableLanguages?.filter((code) => ISO6391.validate(code)),
     [availableLanguages]
@@ -58,16 +54,11 @@ export const TextEditor = ({
     setSearchQuery('');
   };
 
-  const removeEntry = async ({ textId }: TextResourceEntryDeletion) => {
+  const removeEntry = ({ textId }: TextResourceEntryDeletion) => {
     try {
       updateTextId({ oldId: textId });
     } catch (e: unknown) {
-      let errorMessage = t('schema_editor.delete_text_id_error');
-      console.error(errorMessage);
-      if (e instanceof Error) {
-        errorMessage = (t('schema_editor.delete_text_id_error:'), `${e.toString()}`);
-      }
-      setDeleteError(errorMessage);
+      console.error('Deleting text failed:\n', e);
     }
   };
 
@@ -101,7 +92,6 @@ export const TextEditor = ({
           </div>
         </div>
         <div className={classes.TextEditor__body}>
-          {deleteError && <p>{deleteError}</p>}
           <TextList
             removeEntry={removeEntry}
             resourceRows={resourceRows}

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import classes from './TextEditor.module.css';
 import type {
   LangCode,
@@ -14,6 +14,7 @@ import { defaultLangCode } from './constants';
 import { TextList } from './TextList';
 import ISO6391 from 'iso-639-1';
 import { ITextResources } from 'app-shared/types/global';
+import { useTranslation } from 'react-i18next';
 
 export interface TextEditorProps {
   addLanguage: (language: LangCode) => void;
@@ -41,6 +42,8 @@ export const TextEditor = ({
   upsertTextResource,
 }: TextEditorProps) => {
   const resourceRows = mapResourceFilesToTableRows(textResourceFiles);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const { t } = useTranslation();
 
   const availableLangCodesFiltered = useMemo(
     () => availableLanguages?.filter((code) => ISO6391.validate(code)),
@@ -55,11 +58,16 @@ export const TextEditor = ({
     setSearchQuery('');
   };
 
-  const removeEntry = ({ textId }: TextResourceEntryDeletion) => {
+  const removeEntry = async ({ textId }: TextResourceEntryDeletion) => {
     try {
       updateTextId({ oldId: textId });
     } catch (e: unknown) {
-      console.error('Deleting text failed:\n', e);
+      let errorMessage = t('schema_editor.delete_text_id_error');
+      console.error(errorMessage);
+      if (e instanceof Error) {
+        errorMessage = (t('schema_editor.delete_text_id_typr_error:'), `${e.toString()}`);
+      }
+      setDeleteError(errorMessage);
     }
   };
 
@@ -93,6 +101,7 @@ export const TextEditor = ({
           </div>
         </div>
         <div className={classes.TextEditor__body}>
+          {deleteError && <p>{deleteError}</p>}
           <TextList
             removeEntry={removeEntry}
             resourceRows={resourceRows}

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -65,7 +65,7 @@ export const TextEditor = ({
       let errorMessage = t('schema_editor.delete_text_id_error');
       console.error(errorMessage);
       if (e instanceof Error) {
-        errorMessage = (t('schema_editor.delete_text_id_typr_error:'), `${e.toString()}`);
+        errorMessage = (t('schema_editor.delete_text_id_error:'), `${e.toString()}`);
       }
       setDeleteError(errorMessage);
     }

--- a/frontend/packages/text-editor/src/TextRow.tsx
+++ b/frontend/packages/text-editor/src/TextRow.tsx
@@ -70,6 +70,7 @@ export const TextRow = ({
 
   const handleDeleteClick = () => {
     removeEntry({ textId });
+    setIsConfirmDeleteOpen(false);
   };
 
   const toggleConfirmDeletePopover = () => setIsConfirmDeleteOpen((prev) => !prev);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated delete text in text editor to give an error message if somthing wrong happens when deleting a text. 

## Related Issue(s)
- #10420 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
