### PR TITLE
prevented showing popover when adding language

### DIFF
--- a/frontend/packages/text-editor/src/RightMenu.test.tsx
+++ b/frontend/packages/text-editor/src/RightMenu.test.tsx
@@ -34,8 +34,6 @@ describe('RightMenu', () => {
     const confirmButton = screen.getByText(/schema_editor.language_conferm_deletion/);
     fireEvent.click(confirmButton);
     expect(defaultProps.deleteLanguage).toHaveBeenCalledWith('en');
-    const cancelButton = screen.getByText(/schema_editor.textRow-cancel-popover/);
-    fireEvent.click(cancelButton);
   });
 
   test('calls deleteLanguage with the correct language code when confirm deletion button is clicked', async () => {

--- a/frontend/packages/text-editor/src/RightMenu.tsx
+++ b/frontend/packages/text-editor/src/RightMenu.tsx
@@ -34,7 +34,7 @@ export const RightMenu = ({
   const addLangOptions = langOptions.filter((x) => !availableLanguages.includes(x.value));
   const canDeleteLang = (code) => availableLanguages.length > 1 && code !== defaultLangCode;
   const { t } = useTranslation();
-  const [confirmDeleteState, setConfirmDeleteState] = useState<{ [key: string]: boolean }>({});
+  const [langCodeToDelete, setLangCodeToDelete] = useState<LangCode>();
 
   const handleSelectChange = async ({ target }: React.ChangeEvent<HTMLInputElement>) =>
     target.checked
@@ -42,21 +42,14 @@ export const RightMenu = ({
       : setSelectedLanguages(removeItemByValue(selectedLanguages, target.name));
 
   const handleDeleteLanguage = (langCode: LangCode) => {
-    if (confirmDeleteState[langCode]) {
+    if (langCodeToDelete === langCode) {
       setSelectedLanguages(removeItemByValue(selectedLanguages, langCode));
       deleteLanguage(langCode);
     }
-    setConfirmDeleteState((prevState) => {
-      const newState = { ...prevState };
-      delete newState[langCode];
-      return newState;
-    });
+    setLangCodeToDelete(null);
   };
   const toggleConfirmDeletePopover = (langCode: LangCode) => {
-    setConfirmDeleteState((prevState) => ({
-      ...prevState,
-      [langCode]: !prevState[langCode],
-    }));
+    setLangCodeToDelete((prevState) => (prevState === langCode ? null : langCode));
   };
 
   return (
@@ -82,7 +75,7 @@ export const RightMenu = ({
                   title={'delete'}
                   variant={PopoverVariant.Warning}
                   placement={'left'}
-                  open={confirmDeleteState[langCode] || false}
+                  open={langCodeToDelete === langCode || false}
                   trigger={
                     <Button
                       variant={
@@ -98,7 +91,7 @@ export const RightMenu = ({
                     </Button>
                   }
                 >
-                  {confirmDeleteState[langCode] && (
+                  {langCodeToDelete === langCode && (
                     <div>
                       {t('schema_editor.language_display_confirm_delete')}
                       <div className={classes.popoverButtons}>

--- a/frontend/packages/text-editor/src/RightMenu.tsx
+++ b/frontend/packages/text-editor/src/RightMenu.tsx
@@ -46,6 +46,11 @@ export const RightMenu = ({
       setSelectedLanguages(removeItemByValue(selectedLanguages, langCode));
       deleteLanguage(langCode);
     }
+    setConfirmDeleteState((prevState) => {
+      const newState = { ...prevState };
+      delete newState[langCode];
+      return newState;
+    });
   };
   const toggleConfirmDeletePopover = (langCode: LangCode) => {
     setConfirmDeleteState((prevState) => ({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated handleDelete Language function to prevent showing popover when adding a language which is deleted previously

## Related Issue(s)
- #10672 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
