### PR TITLE
Add owners-team to permitted envs

### DIFF
--- a/backend/src/Designer/Controllers/DeploymentsController.cs
+++ b/backend/src/Designer/Controllers/DeploymentsController.cs
@@ -69,11 +69,13 @@ namespace Altinn.Studio.Designer.Controllers
         [Route("permissions")]
         public async Task<ActionResult<List<string>>> Permissions([FromRoute] string org)
         {
+            // Add Owners to permitted environments so that users in Owners team can see deploy page with
+            // all environments even though they are not in Deploy-<env> team and cannot deploy to the environment.
             List<Team> teams = await _giteaService.GetTeams();
             List<string> permittedEnvironments = teams.Where(t =>
                         t.Organization.Username.Equals(org, StringComparison.OrdinalIgnoreCase)
-                        && t.Name.StartsWith("Deploy-", StringComparison.OrdinalIgnoreCase))
-                    .Select(t => t.Name.Split('-')[1])
+                        && (t.Name.StartsWith("Deploy-", StringComparison.OrdinalIgnoreCase) || t.Name.Equals("Owners")))
+                    .Select(t => t.Name.Equals("Owners") ? t.Name : t.Name.Split('-')[1])
                     .ToList();
 
             return Ok(permittedEnvironments);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For users that are in the owners team of an org to be able to see the deploy page (even though they cannot deploy to any env) the owners-team is added to the permitted envs list. By doing this frontend will not show the error-infopage that will show if permitted-envs list is an empty list.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)