### PR TITLE
Hide delete icon from appName i text editor

### DIFF
--- a/frontend/packages/text-editor/src/TextRow.tsx
+++ b/frontend/packages/text-editor/src/TextRow.tsx
@@ -78,41 +78,43 @@ export const TextRow = ({
   return (
     <TableRow data-testid={'lang-row'}>
       <TableCell>
-        <Popover
-          title={'Slett_rad'}
-          variant={PopoverVariant.Warning}
-          placement={'left'}
-          open={isConfirmDeleteOpen}
-          trigger={
-            <Button
-              className={classes.deleteButton}
-              icon={<TrashIcon title={`Slett ${textId}`} />}
-              variant={ButtonVariant.Quiet}
-              onClick={toggleConfirmDeletePopover}
-              aria-label={t('schema_editor.delete')}
-            >
-              {t('schema_editor.delete')}
-            </Button>
-          }
-        >
-          {isConfirmDeleteOpen && (
-            <div>
-              <p>{t('schema_editor.textRow-title-confirmCancel-popover')}</p>
-              <div className={classes.popoverButtons}>
-                <Button onClick={handleDeleteClick} color={ButtonColor.Danger}>
-                  <p>{t('schema_editor.textRow-confirm-cancel-popover')}</p>
-                </Button>
-                <Button
-                  variant={ButtonVariant.Quiet}
-                  onClick={toggleConfirmDeletePopover}
-                  color={ButtonColor.Secondary}
-                >
-                  <p>{t('schema_editor.textRow-cancel-popover')}</p>
-                </Button>
+        {showButton && (
+          <Popover
+            title={'Slett_rad'}
+            variant={PopoverVariant.Warning}
+            placement={'left'}
+            open={isConfirmDeleteOpen}
+            trigger={
+              <Button
+                className={classes.deleteButton}
+                icon={<TrashIcon title={`Slett ${textId}`} />}
+                variant={ButtonVariant.Quiet}
+                onClick={toggleConfirmDeletePopover}
+                aria-label={t('schema_editor.delete')}
+              >
+                {t('schema_editor.delete')}
+              </Button>
+            }
+          >
+            {isConfirmDeleteOpen && (
+              <div>
+                <p>{t('schema_editor.textRow-title-confirmCancel-popover')}</p>
+                <div className={classes.popoverButtons}>
+                  <Button onClick={handleDeleteClick} color={ButtonColor.Danger}>
+                    <p>{t('schema_editor.textRow-confirm-cancel-popover')}</p>
+                  </Button>
+                  <Button
+                    variant={ButtonVariant.Quiet}
+                    onClick={toggleConfirmDeletePopover}
+                    color={ButtonColor.Secondary}
+                  >
+                    <p>{t('schema_editor.textRow-cancel-popover')}</p>
+                  </Button>
+                </div>
               </div>
-            </div>
-          )}
-        </Popover>
+            )}
+          </Popover>
+        )}
       </TableCell>
       {selectedLanguages.map((lang) => {
         let translation = textRowEntries.find((e) => e.lang === lang);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hide /delete icon / from appName in text editor, because it is not allowed to change or delete appName. 

## Related Issue(s)
- #10681 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
