### PR TITLE
Updated TextEditor to keep language box checked

### DIFF
--- a/frontend/app-development/features/textEditor/TextEditor.test.tsx
+++ b/frontend/app-development/features/textEditor/TextEditor.test.tsx
@@ -5,11 +5,37 @@ import React from 'react';
 import { TextEditor } from './TextEditor';
 import { textMock } from '../../../testing/mocks/i18nMock';
 
+const mockLocalStorage = (() => {
+  let store = jest.fn();
+  return {
+    getItem: (key) => store[key] || null,
+    setItem: (key, value) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = jest.fn();
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: mockLocalStorage });
+
 describe('TextEditor', () => {
   it('should render the spinner', () => {
     renderWithProviders(<TextEditor />, {
       startUrl: `${APP_DEVELOPMENT_BASENAME}/test-org/test-app`,
     });
     expect(screen.getByText(textMock('general.loading'))).toBeInTheDocument();
+  }); 
+ 
+  it('should store selected language in local storage', () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error');
+    consoleErrorSpy.mockImplementation(jest.fn());
+    mockLocalStorage.setItem('selectedLanguages', JSON.stringify(['nb']));
+    expect(console.error).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/frontend/app-development/features/textEditor/TextEditor.tsx
+++ b/frontend/app-development/features/textEditor/TextEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import type { LangCode } from '@altinn/text-editor';
-import { TextEditor as TextEditorImpl } from '@altinn/text-editor';
+import { TextEditor as TextEditorImpl, defaultLangCode } from '@altinn/text-editor';
 import { PanelVariant, PopoverPanel } from '@altinn/altinn-design-system';
 import { Button, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
 import { PageSpinner } from 'app-shared/components';
@@ -23,10 +23,13 @@ export const TextEditor = () => {
   const [searchParams, setSearchParams] = useSearchParams({ lang: '', search: '' });
   const [selectedLangCodes, setSelectedLangCodes] = useState<LangCode[]>([]);
 
-useEffect(() => {
-  const initialSelectedLangCodes = JSON.parse(localStorage.getItem('selectedLanguages')) || [];
-  setSelectedLangCodes(initialSelectedLangCodes);
-}, []);
+  const handleSelectedLangCodes = (value: LangCode[]) => {
+    setSelectedLangCodes(value?.length > 0 ? value : [defaultLangCode]);
+  };
+  useEffect(() => {
+    const initialSelectedLangCodes = JSON.parse(localStorage.getItem('selectedLanguages'));
+    handleSelectedLangCodes(initialSelectedLangCodes);
+  }, []);
 
 useEffect(() => {
   localStorage.setItem('selectedLanguages', JSON.stringify(selectedLangCodes));
@@ -119,7 +122,7 @@ useEffect(() => {
         searchQuery={getSearchQuery()}
         selectedLangCodes={selectedLangCodes}
         setSearchQuery={setSearchQuery}
-        setSelectedLangCodes={setSelectedLangCodes}
+        setSelectedLangCodes={handleSelectedLangCodes}
         textResourceFiles={textResources || {}}
         updateTextId={(data: TextResourceIdMutation) => textIdMutation([data])}
         upsertTextResource={upsertTextResource}

--- a/frontend/app-development/features/textEditor/TextEditor.tsx
+++ b/frontend/app-development/features/textEditor/TextEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import type { LangCode } from '@altinn/text-editor';
-import { TextEditor as TextEditorImpl, defaultLangCode } from '@altinn/text-editor';
+import { TextEditor as TextEditorImpl } from '@altinn/text-editor';
 import { PanelVariant, PopoverPanel } from '@altinn/altinn-design-system';
 import { Button, ButtonColor, ButtonVariant } from '@digdir/design-system-react';
 import { PageSpinner } from 'app-shared/components';
@@ -21,7 +21,17 @@ const storageGroupName = 'textEditorStorage';
 
 export const TextEditor = () => {
   const [searchParams, setSearchParams] = useSearchParams({ lang: '', search: '' });
-  const selectedLangCodes = searchParams.get('lang').split('-');
+  const [selectedLangCodes, setSelectedLangCodes] = useState<LangCode[]>([]);
+
+useEffect(() => {
+  const initialSelectedLangCodes = JSON.parse(localStorage.getItem('selectedLanguages')) || [];
+  setSelectedLangCodes(initialSelectedLangCodes);
+}, []);
+
+useEffect(() => {
+  localStorage.setItem('selectedLanguages', JSON.stringify(selectedLangCodes));
+}, [selectedLangCodes]);
+
   const getSearchQuery = () => searchParams.get('search') || '';
   const { org, app } = useParams();
 
@@ -31,13 +41,6 @@ export const TextEditor = () => {
     isLoading: isInitialLoadingLang,
     isFetching: isFetchingTranslations
   } = useTextResourcesQuery(org, app);
-  const setSelectedLangCodes = async (langs: string[]) => {
-    const params: any = { lang: langs.join('-') };
-    if (getSearchQuery().length > 0) {
-      params.search = searchParams.get('search');
-    }
-    await setSearchParams(params);
-  };
 
   const setSearchQuery = (search: string) => {
     const params: any = { lang: searchParams.get('lang') };
@@ -46,12 +49,7 @@ export const TextEditor = () => {
     }
     setSearchParams(params);
   };
-  useEffect(() => {
-    if (appLangCodes && !appLangCodes.includes(selectedLangCodes[0])) {
-      setSelectedLangCodes([defaultLangCode]).then();
-    }
-  }, [appLangCodes, selectedLangCodes]); // eslint-disable-line react-hooks/exhaustive-deps
-
+  
   const { t } = useTranslation();
 
   const [hideIntroPage, setHideIntroPage] = useState(

--- a/frontend/packages/text-editor/src/RightMenu.tsx
+++ b/frontend/packages/text-editor/src/RightMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import classes from './RightMenu.module.css';
 import type { LangCode } from './types';
 import { LangSelector } from './LangSelector';
@@ -53,10 +53,6 @@ export const RightMenu = ({
   const toggleConfirmDeletePopover = (langCode: LangCode) => {
     setLangCodeToDelete((prevState) => (prevState === langCode ? null : langCode));
   };
-
-  useEffect(() => {
-    localStorage.setItem('selectedLanguages', JSON.stringify(selectedLanguages));
-  }, [selectedLanguages]);
 
   return (
     <aside className={classes.RightMenu__sidebar}>

--- a/frontend/packages/text-editor/src/RightMenu.tsx
+++ b/frontend/packages/text-editor/src/RightMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import classes from './RightMenu.module.css';
 import type { LangCode } from './types';
 import { LangSelector } from './LangSelector';
@@ -36,10 +36,12 @@ export const RightMenu = ({
   const { t } = useTranslation();
   const [langCodeToDelete, setLangCodeToDelete] = useState<LangCode>();
 
-  const handleSelectChange = async ({ target }: React.ChangeEvent<HTMLInputElement>) =>
+  const handleSelectChange = async ({ target }: React.ChangeEvent<HTMLInputElement>) =>{
     target.checked
-      ? setSelectedLanguages([...selectedLanguages, target.name])
-      : setSelectedLanguages(removeItemByValue(selectedLanguages, target.name));
+    ? setSelectedLanguages([...selectedLanguages, target.name])
+    : setSelectedLanguages(removeItemByValue(selectedLanguages, target.name));
+  }
+   
 
   const handleDeleteLanguage = (langCode: LangCode) => {
     if (langCodeToDelete === langCode) {
@@ -51,6 +53,10 @@ export const RightMenu = ({
   const toggleConfirmDeletePopover = (langCode: LangCode) => {
     setLangCodeToDelete((prevState) => (prevState === langCode ? null : langCode));
   };
+
+  useEffect(() => {
+    localStorage.setItem('selectedLanguages', JSON.stringify(selectedLanguages));
+  }, [selectedLanguages]);
 
   return (
     <aside className={classes.RightMenu__sidebar}>

--- a/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -132,8 +132,8 @@ describe('TextEditor', () => {
     expect(translationsToChange).toHaveLength(2);
     const changedTranslations = nb;
     changedTranslations[0].value = 'new translation';
-    await act(() => user.tripleClick(translationsToChange[0])); // select all text
-    await act(() => user.keyboard(`${changedTranslations[0].value}{TAB}`)); // type new text and blur
+    await act(() => user.tripleClick(translationsToChange[0])); 
+    await act(() => user.keyboard(`${changedTranslations[0].value}{TAB}`)); 
     expect(upsertTextResource).toHaveBeenCalledWith({
       language: 'nb',
       textId: 'textId1',

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo} from 'react';
+import React, { useMemo } from 'react';
 import classes from './TextEditor.module.css';
 import type {
   LangCode,

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useState } from 'react';
+import React, { useMemo} from 'react';
 import classes from './TextEditor.module.css';
 import type {
   LangCode,
@@ -70,12 +70,6 @@ export const TextEditor = ({
     }
   };
   const handleSearchChange = (event: any) => setSearchQuery(event.target.value);
-  const initialSelectedLangCodes = JSON.parse(localStorage.getItem('selectedLanguages')) || [];
-  [selectedLangCodes, setSelectedLangCodes] = useState<LangCode[]>(initialSelectedLangCodes);
-  
-  useEffect(() => {
-   localStorage.setItem('selectedLanguages', JSON.stringify(selectedLangCodes));
- }, [selectedLangCodes]);
 
   return (
     <div className={classes.TextEditor}>

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect, useState } from 'react';
 import classes from './TextEditor.module.css';
 import type {
   LangCode,
@@ -70,6 +70,12 @@ export const TextEditor = ({
     }
   };
   const handleSearchChange = (event: any) => setSearchQuery(event.target.value);
+  const initialSelectedLangCodes = JSON.parse(localStorage.getItem('selectedLanguages')) || [];
+  [selectedLangCodes, setSelectedLangCodes] = useState<LangCode[]>(initialSelectedLangCodes);
+  
+  useEffect(() => {
+   localStorage.setItem('selectedLanguages', JSON.stringify(selectedLangCodes));
+ }, [selectedLangCodes]);
 
   return (
     <div className={classes.TextEditor}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Kept language box checked when we navigate to other components. in editor / tekst page

## Related Issue(s)
- #10671 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
