### PR TITLE
Make sure error is returned from controller when Post to language throws argument exception

### DIFF
--- a/backend/src/Designer/Controllers/TextController.cs
+++ b/backend/src/Designer/Controllers/TextController.cs
@@ -133,6 +133,10 @@ namespace Altinn.Studio.Designer.Controllers
                 await _textsService.SaveTextV1(org, app, developer, jsonData, languageCode);
                 return Ok($"Text resource, resource.{languageCode}.json, was successfully saved.");
             }
+            catch (ArgumentException e)
+            {
+                return BadRequest(e.Message);
+            }
             catch (NotFoundException)
             {
                 return NotFound($"Text resource, resource.{languageCode}.json, could not be found.");


### PR DESCRIPTION
## Description
Make sure error is returned from controller when Post to language throws argument exception


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
