### PR TITLE
Updated binding of link to datamodell in lage page

### DIFF
--- a/frontend/dashboard/index.tsx
+++ b/frontend/dashboard/index.tsx
@@ -30,7 +30,6 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: false,
-      staleTime: 10 * 60 * 1000,
       refetchOnWindowFocus: false,
     },
   },

--- a/frontend/packages/shared/src/contexts/ServicesContext.tsx
+++ b/frontend/packages/shared/src/contexts/ServicesContext.tsx
@@ -11,13 +11,7 @@ export type ServicesContextProviderProps = ServicesContextProps & {
 };
 
 const ServicesContext = createContext<ServicesContextProps>(null);
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: Infinity,
-    },
-  },
-});
+const queryClient = new QueryClient();
 export const ServicesContextProvider = ({
   children,
   client,

--- a/frontend/packages/ux-editor/src/hooks/queries/useDatamodelMetadataQuery.ts
+++ b/frontend/packages/ux-editor/src/hooks/queries/useDatamodelMetadataQuery.ts
@@ -17,6 +17,7 @@ export const useDatamodelMetadataQuery =
           }
         });
         return dataModelFields;
-      })
+      }),
+      { staleTime: 1000 }
     );
   };

--- a/frontend/packages/ux-editor/src/hooks/queries/useDatamodelMetadataQuery.ts
+++ b/frontend/packages/ux-editor/src/hooks/queries/useDatamodelMetadataQuery.ts
@@ -17,7 +17,6 @@ export const useDatamodelMetadataQuery =
           }
         });
         return dataModelFields;
-      }),
-      { staleTime: 1000 }
+      })
     );
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Updated query with staleTime in one second to remain in cache  and response with updated data.

## Related Issue(s)
- #10632 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
