### PR TITLE
Fix info dialog

### DIFF
--- a/frontend/app-development/features/textEditor/TextEditor.module.css
+++ b/frontend/app-development/features/textEditor/TextEditor.module.css
@@ -1,5 +1,5 @@
 .infoDialog {
-  position: absolute;
+  position: fixed;
   z-index: 1;
 }
 

--- a/frontend/app-development/features/textEditor/TextEditor.module.css
+++ b/frontend/app-development/features/textEditor/TextEditor.module.css
@@ -1,3 +1,8 @@
+.infoDialog {
+  position: absolute;
+  z-index: 1;
+}
+
 .buttons {
   display: flex;
   gap: 13px;

--- a/frontend/app-development/features/textEditor/TextEditor.tsx
+++ b/frontend/app-development/features/textEditor/TextEditor.tsx
@@ -83,38 +83,44 @@ useEffect(() => {
 
   return (
     <>
-      <PopoverPanel
-        forceMobileLayout={true}
-        variant={PanelVariant.Info}
-        open={!hideIntroPage}
-        side={'bottom'}
-        title={t('text_editor.info_dialog_title')}
-        trigger={<span className={'sr-only'} />}
-        onOpenChange={() => setHideIntroPage(!hideIntroPage)}
-      >
-        <p>{t('text_editor.info_dialog_1')}</p>
-        <p>
-          <Link target={'_blank'} to={`/../designer/${org}/${app}/Text`} relative={'path'}>
-            {t('text_editor.info_dialog_nav_to_old')}
-          </Link>
-        </p>
-        <span className={classes.buttons}>
-          <Button
-            color={ButtonColor.Primary}
-            onClick={() => setHideIntroPage(true)}
-            variant={ButtonVariant.Outline}
-          >
-            {t('general.close')}
-          </Button>
-          <Button
-            color={ButtonColor.Secondary}
-            onClick={handleHideIntroPageButtonClick}
-            variant={ButtonVariant.Outline}
-          >
-            {t('general.do_not_show_anymore')}
-          </Button>
-        </span>
-      </PopoverPanel>
+      {
+        !hideIntroPage && (
+          <div className={classes.infoDialog}>
+            <PopoverPanel
+              forceMobileLayout={true}
+              variant={PanelVariant.Info}
+              open={!hideIntroPage}
+              side={'bottom'}
+              title={t('text_editor.info_dialog_title')}
+              trigger={<span className={'sr-only'} />}
+              onOpenChange={() => setHideIntroPage(!hideIntroPage)}
+            >
+              <p>{t('text_editor.info_dialog_1')}</p>
+              <p>
+                <Link target={'_blank'} to={`/../designer/${org}/${app}/Text`} relative={'path'}>
+                  {t('text_editor.info_dialog_nav_to_old')}
+                </Link>
+              </p>
+              <span className={classes.buttons}>
+                <Button
+                  color={ButtonColor.Primary}
+                  onClick={() => setHideIntroPage(true)}
+                  variant={ButtonVariant.Outline}
+                >
+                  {t('general.close')}
+                </Button>
+                <Button
+                  color={ButtonColor.Secondary}
+                  onClick={handleHideIntroPageButtonClick}
+                  variant={ButtonVariant.Outline}
+                >
+                  {t('general.do_not_show_anymore')}
+                </Button>
+              </span>
+            </PopoverPanel>
+          </div>
+        )
+      }
       <TextEditorImpl
         addLanguage={handleAddLanguage}
         availableLanguages={appLangCodes}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix visual issues with info dialog after updating design system to latest version

<img width="514" alt="259423335-89ae1ec8-de33-4c2c-b97f-e75fa2d0b112" src="https://github.com/Altinn/altinn-studio/assets/24462611/5f96cbf2-303c-4d0b-a252-6c54a00e95ef">

I fixed it by adding a wrapper with a `z-index`-property as it did not seem possible to directly pass a `className` to the `PopoverPanel` component.

This should also fix this issue : https://github.com/Altinn/altinn-studio/issues/10706.

Ideally, we should replace both this `PopoverPanel` component and the `Dialog` component from the datamodel page with a component from design system like `Popover` to make them consistent: https://github.com/Altinn/altinn-studio/issues/10756

## Related Issue(s)
- #10775 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
