### PR TITLE
Fix failing Cypress test

### DIFF
--- a/frontend/testing/cypress/src/integration/usecase/usecase.js
+++ b/frontend/testing/cypress/src/integration/usecase/usecase.js
@@ -24,10 +24,8 @@ context(
     });
     beforeEach(() => {
       cy.studiologin(Cypress.env('useCaseUser'), Cypress.env('useCaseUserPwd'));
-      cy.intercept('GET', '**/datamodels/all-json').as('getDatamodels');
       cy.visit('/');
       cy.searchAndOpenApp(Cypress.env('deployApp'));
-      cy.wait('@getDatamodels');
       cy.get(designer.layOutContainer).should('be.visible');
     });
 


### PR DESCRIPTION
## Description
Tests fail because they wait for the `all-json` endpoint to be called while on the overview page. This endpoint is not called here, and there is no reason it should be (maybe except for prefilling the cache for performance reasons, but there's not a huge amount of data).

## Verification
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
