### PR TITLE
Make generated CSS class names readable

### DIFF
--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -35,7 +35,11 @@ module.exports = {
           'style-loader',
           {
             loader: 'css-loader',
-            options: { modules: true },
+            options: {
+              modules: {
+                localIdentName: '[name]__[local]--[hash:base64:5]',
+              },
+            },
           },
         ],
       },


### PR DESCRIPTION
## Description
Added file name and original class name to the generated CSS classes to make debugging easier.

## Related Issue(s)
- #10796

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
