### PR TITLE
Fix broken components documentation link

### DIFF
--- a/frontend/packages/ux-editor/src/components/toolbar/InformationPanelComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/toolbar/InformationPanelComponent.tsx
@@ -51,7 +51,7 @@ export const InformationPanelComponent = ({
       </div>
       <div className={classNames(classes.informationPanelLink)}>
         <a
-          href='https://docs.altinn.studio/technology/solutions/altinn-studio/designer/functional/build-app/ui-designer/components/'
+          href='https://docs.altinn.studio/app/development/ux/components/'
           target='_blank'
           rel='noopener noreferrer'
         >


### PR DESCRIPTION
Info-lenke til komponenter i design studio gir not found:

![CleanShot 2023-08-15 at 12 14 49](https://github.com/Altinn/altinn-studio/assets/5313373/c52e5521-a2b7-411a-a172-6d426ba615a0)

Gammel lenke: 
https://docs.altinn.studio/technology/solutions/altinn-studio/designer/functional/build-app/ui-designer/components/

Bytta til 
https://docs.altinn.studio/app/development/ux/components/
