### PR TITLE
Fix reference error

### DIFF
--- a/frontend/packages/schema-model/src/lib/mappers/field-type.ts
+++ b/frontend/packages/schema-model/src/lib/mappers/field-type.ts
@@ -19,7 +19,7 @@ export const findUiFieldType = (schemaNode: KeyValuePairs) => {
   const keys = Object.keys(schemaNode);
   if (typeof schemaNode.properties === 'object') {
     return FieldType.Object;
-  } else if (typeof schemaNode.type === 'string' && objectKind === ObjectKind.Field) {
+  } else if (typeof schemaNode.type === 'string' && [ObjectKind.Field, ObjectKind.Reference].includes(objectKind)) {
     return schemaNode.type;
   } else if (objectKind === ObjectKind.Combination) {
     const kind = getCombinationKind(schemaNode);

--- a/frontend/packages/schema-model/src/lib/utils.ts
+++ b/frontend/packages/schema-model/src/lib/utils.ts
@@ -32,7 +32,7 @@ export const getCombinationKind = (schemaNode: KeyValuePairs): CombinationKind =
 };
 
 export const getObjectKind = (schemaNode: KeyValuePairs): ObjectKind => {
-  if (schemaNode.$ref) {
+  if (schemaNode.$ref !== undefined) {
     return ObjectKind.Reference;
   } else if (getCombinationKind(schemaNode)) {
     return ObjectKind.Combination;


### PR DESCRIPTION
## Description
Schema nodes that are supposed to be references are not recognized as such before an actual reference is added. This is caused by the `$ref` property in the Json Schema being an empty string. I solved this by making the check in `getObjectKind` stricter.

## Related Issue(s)
- #10804

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
  _We should add tests for the whole file, I'll create a separate task._
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
