### PR TITLE
feat(TextEntry): created hooks to auto-resize the TextEntry while typing

### DIFF
--- a/frontend/packages/text-editor/src/TextEntry.tsx
+++ b/frontend/packages/text-editor/src/TextEntry.tsx
@@ -18,10 +18,7 @@ export const TextEntry = ({
   className,
 }: TextEntryProps) => {
   const [textEntryValue, setTextEntryValue] = useState(translation);
-
-  // Use useState instead of useRef to ensure that the textarea is resized on initial render when ref is set
-  const [textAreaRef, setTextAreaRef] = useState<HTMLTextAreaElement>(null);
-  useAutoSizeTextArea(textAreaRef, textEntryValue);
+  const textareaRef = useAutoSizeTextArea(textEntryValue);
 
   const variables = [];
 
@@ -38,7 +35,7 @@ export const TextEntry = ({
         value={textEntryValue}
         onBlur={handleTextEntryBlur}
         onChange={handleTextEntryChange}
-        ref={(ref) => setTextAreaRef(ref)}
+        ref={textareaRef}
         resize={'vertical'}
       />
       <Variables variables={variables} />

--- a/frontend/packages/text-editor/src/TextEntry.tsx
+++ b/frontend/packages/text-editor/src/TextEntry.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { TextTableRowEntry, UpsertTextResourceMutation } from './types';
 import { TextArea } from '@digdir/design-system-react';
 import { Variables } from './Variables';
-import { autosize } from './utils';
+import { useAutoSizeTextArea } from './hooks/useAutoSizeTextArea';
 
 export interface TextEntryProps extends TextTableRowEntry {
   textId: string;
@@ -10,8 +10,18 @@ export interface TextEntryProps extends TextTableRowEntry {
   className?: string;
 }
 
-export const TextEntry = ({ textId, lang, translation, upsertTextResource, className }: TextEntryProps) => {
+export const TextEntry = ({
+  textId,
+  lang,
+  translation,
+  upsertTextResource,
+  className,
+}: TextEntryProps) => {
   const [textEntryValue, setTextEntryValue] = useState(translation);
+
+  // Use useState instead of useRef to ensure that the textarea is resized on initial render when ref is set
+  const [textAreaRef, setTextAreaRef] = useState<HTMLTextAreaElement>(null);
+  useAutoSizeTextArea(textAreaRef, textEntryValue);
 
   const variables = [];
 
@@ -28,7 +38,7 @@ export const TextEntry = ({ textId, lang, translation, upsertTextResource, class
         value={textEntryValue}
         onBlur={handleTextEntryBlur}
         onChange={handleTextEntryChange}
-        ref={autosize}
+        ref={(ref) => setTextAreaRef(ref)}
         resize={'vertical'}
       />
       <Variables variables={variables} />

--- a/frontend/packages/text-editor/src/hooks/useAutoSizeTextArea.ts
+++ b/frontend/packages/text-editor/src/hooks/useAutoSizeTextArea.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { useOnWindowSizeChange } from './useOnWindowSizeChange';
+
+export const useAutoSizeTextArea = (
+  textAreaRef: HTMLTextAreaElement | null,
+  value: string
+): void => {
+  const { windowSize } = useOnWindowSizeChange();
+
+  useEffect(() => {
+    if (textAreaRef) {
+      // We need to reset the height momentarily to get the correct scrollHeight for the textarea
+      textAreaRef.style.height = '0px';
+      const scrollHeight = textAreaRef.scrollHeight;
+      textAreaRef.style.height = scrollHeight + 'px';
+    }
+  }, [textAreaRef, value, windowSize]);
+};

--- a/frontend/packages/text-editor/src/hooks/useAutoSizeTextArea.ts
+++ b/frontend/packages/text-editor/src/hooks/useAutoSizeTextArea.ts
@@ -1,10 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useOnWindowSizeChange } from './useOnWindowSizeChange';
 
-export const useAutoSizeTextArea = (
-  textAreaRef: HTMLTextAreaElement | null,
-  value: string
-): void => {
+export const useAutoSizeTextArea = (value: string) => {
+  const [textAreaRef, setTextAreaRef] = useState<HTMLTextAreaElement>(null);
   const { windowSize } = useOnWindowSizeChange();
 
   useEffect(() => {
@@ -16,4 +14,6 @@ export const useAutoSizeTextArea = (
     }
     // Added windowSize to the dependency array to recalculate the height of the textarea when the window size changes
   }, [textAreaRef, value, windowSize]);
+
+  return setTextAreaRef;
 };

--- a/frontend/packages/text-editor/src/hooks/useAutoSizeTextArea.ts
+++ b/frontend/packages/text-editor/src/hooks/useAutoSizeTextArea.ts
@@ -14,5 +14,6 @@ export const useAutoSizeTextArea = (
       const scrollHeight = textAreaRef.scrollHeight;
       textAreaRef.style.height = scrollHeight + 'px';
     }
+    // Added windowSize to the dependency array to recalculate the height of the textarea when the window size changes
   }, [textAreaRef, value, windowSize]);
 };

--- a/frontend/packages/text-editor/src/hooks/useOnWindowSizeChange.ts
+++ b/frontend/packages/text-editor/src/hooks/useOnWindowSizeChange.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+type UseOnWindowSizeChangeResult = {
+  windowSize: {
+    width: number;
+    height: number;
+  };
+};
+export const useOnWindowSizeChange = (): UseOnWindowSizeChangeResult => {
+  const [windowSize, setWindowSize] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  const onWindowSizeChange = (): void => {
+    setWindowSize({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', onWindowSizeChange);
+    return () => window.removeEventListener('resize', onWindowSizeChange);
+  });
+
+  return { windowSize };
+};

--- a/frontend/packages/text-editor/src/utils.ts
+++ b/frontend/packages/text-editor/src/utils.ts
@@ -92,23 +92,3 @@ export const validateTextId = (textIdToValidate: string): string => {
 
   return '';
 };
-
-export const autosize = (element) => {
-  if (!element || !element.nodeName || element.nodeName !== 'TEXTAREA') return;
-
-  const computed = window.getComputedStyle(element);
-
-  let newHeight;
-
-  if (computed.boxSizing === 'content-box') {
-    newHeight = element.scrollHeight - (parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom));
-  } else {
-    newHeight = element.scrollHeight + parseFloat(computed.borderTopWidth) + parseFloat(computed.borderBottomWidth);
-  }
-
-  if (computed.maxHeight !== 'none' && newHeight > parseFloat(computed.maxHeight)) {
-    newHeight = parseFloat(computed.maxHeight);
-  }
-
-  element.style.height = newHeight + 'px';
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I've developed two hooks that enable the TextEntry component to automatically adjust its size while users type:

- The TextArea now dynamically expands in height as new lines are added to the textarea.
- When users remove lines, the TextArea resizes accordingly, becoming smaller to fit the content.
- Upon the initial loading of the component, the textarea size adjusts to match its text content.
- The textarea now dynamically adjusts its size in response to changes in window sizes.

## Related Issue(s)
- #10697 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
