### PR TITLE
feat(FeatureFlag): support feature-flag toggling

### DIFF
--- a/frontend/app-development/utils/featureToggleUtils.test.ts
+++ b/frontend/app-development/utils/featureToggleUtils.test.ts
@@ -1,0 +1,44 @@
+import { shouldDisplayFeature } from './featureToggleUtils';
+
+describe('featureToggle localStorage', () => {
+  it('should return true if feature is enabled in the localStorage', () => {
+    window?.localStorage.setItem('featureFlags', 'process');
+    expect(shouldDisplayFeature('process')).toBe(true);
+  });
+
+  it('should return true if featureFlag includes in feature params', () => {
+    window?.localStorage.setItem('featureFlags', 'demo,process');
+    expect(shouldDisplayFeature('process')).toBe(true);
+  });
+
+  it('should return false if feature is not enabled in the localStorage', () => {
+    window?.localStorage.setItem('featureFlags', 'demo');
+    expect(shouldDisplayFeature('process')).toBe(false);
+  });
+
+  it('should return false if feature is not enabled in the localStorage', () => {
+    expect(shouldDisplayFeature('process')).toBe(false);
+  });
+});
+
+describe('featureToggle url', () => {
+  it('should return true if feature is enabled in the url', () => {
+    window.history.pushState({}, 'PageUrl', '/?featureFlags=process');
+    expect(shouldDisplayFeature('process')).toBe(true);
+  });
+
+  it('should return true if featureFlag includes in feature params', () => {
+    window.history.pushState({}, 'PageUrl', '/?featureFlags=demo,process');
+    expect(shouldDisplayFeature('process')).toBe(true);
+  });
+
+  it('should return false if feature is not included in the url', () => {
+    window.history.pushState({}, 'PageUrl', '/?featureFlags=demo');
+    expect(shouldDisplayFeature('process')).toBe(false);
+  });
+
+  it('should return false if feature is not included in the url', () => {
+    window.history.pushState({}, 'PageUrl', '/');
+    expect(shouldDisplayFeature('process')).toBe(false);
+  });
+});

--- a/frontend/app-development/utils/featureToggleUtils.test.ts
+++ b/frontend/app-development/utils/featureToggleUtils.test.ts
@@ -1,18 +1,19 @@
+import { typedLocalStorage } from 'app-shared/utils/webStorage';
 import { shouldDisplayFeature } from './featureToggleUtils';
 
 describe('featureToggle localStorage', () => {
   it('should return true if feature is enabled in the localStorage', () => {
-    window?.localStorage.setItem('featureFlags', 'process');
+    typedLocalStorage.setItem<string[]>('featureFlags', ['process']);
     expect(shouldDisplayFeature('process')).toBe(true);
   });
 
   it('should return true if featureFlag includes in feature params', () => {
-    window?.localStorage.setItem('featureFlags', 'demo,process');
+    typedLocalStorage.setItem<string[]>('featureFlags', ['demo', 'process']);
     expect(shouldDisplayFeature('process')).toBe(true);
   });
 
   it('should return false if feature is not enabled in the localStorage', () => {
-    window?.localStorage.setItem('featureFlags', 'demo');
+    typedLocalStorage.setItem<string[]>('featureFlags', ['demo']);
     expect(shouldDisplayFeature('process')).toBe(false);
   });
 

--- a/frontend/app-development/utils/featureToggleUtils.ts
+++ b/frontend/app-development/utils/featureToggleUtils.ts
@@ -1,3 +1,5 @@
+import { typedLocalStorage } from 'app-shared/utils/webStorage';
+
 const featureFlagKey = 'featureFlags';
 
 // All the features that you want to be toggle on/off should be added here. To ensure that we type check the feature name.
@@ -42,11 +44,6 @@ const isFeatureActivatedByUrl = (featureFlag: SupportedFeatureFlags): boolean =>
 
 // Check if feature includes in local storage, feature=[featureName]
 const isFeatureActivatedByLocalStorage = (featureFlag: SupportedFeatureFlags): boolean => {
-  // TODO wait for PR #10816 to be merged to use the new TypedLocalStorage and then use it here
-  const featureParam = localStorage.getItem(featureFlagKey);
-  if (featureParam) {
-    const features = featureParam.split(',');
-    return features.includes(featureFlag);
-  }
-  return false;
+  const featureFlagsFromStorage = typedLocalStorage.getItem<string[]>(featureFlagKey) || [];
+  return featureFlagsFromStorage.includes(featureFlag);
 };

--- a/frontend/app-development/utils/featureToggleUtils.ts
+++ b/frontend/app-development/utils/featureToggleUtils.ts
@@ -31,7 +31,7 @@ const isDefaultActivatedFeature = (featureFlag: SupportedFeatureFlags): boolean 
   return defaultActiveFeatures.includes(featureFlag);
 };
 
-// Check if feature includes in the url query, (url)?feature=[featureName]
+// Check if feature includes in the url query, (url)?featureFlags=[featureName]
 const isFeatureActivatedByUrl = (featureFlag: SupportedFeatureFlags): boolean => {
   const urlParams = new URLSearchParams(window.location.search);
   const featureParam = urlParams.get(featureFlagKey);
@@ -42,7 +42,7 @@ const isFeatureActivatedByUrl = (featureFlag: SupportedFeatureFlags): boolean =>
   return false;
 };
 
-// Check if feature includes in local storage, feature=[featureName]
+// Check if feature includes in local storage, featureFlags: ["featureName"]
 const isFeatureActivatedByLocalStorage = (featureFlag: SupportedFeatureFlags): boolean => {
   const featureFlagsFromStorage = typedLocalStorage.getItem<string[]>(featureFlagKey) || [];
   return featureFlagsFromStorage.includes(featureFlag);

--- a/frontend/app-development/utils/featureToggleUtils.ts
+++ b/frontend/app-development/utils/featureToggleUtils.ts
@@ -1,0 +1,52 @@
+const featureFlagKey = 'featureFlags';
+
+// All the features that you want to be toggle on/off should be added here. To ensure that we type check the feature name.
+export type SupportedFeatureFlags = 'process';
+
+/*
+ * Please add all the features that you want to be toggle on by default here.
+ * Remember that all the features that are listed here will be available to the users in production,
+ * since this is the default active features.
+ */
+const defaultActiveFeatures: SupportedFeatureFlags[] = [];
+
+/**
+ * @param featureFlag
+ * @returns boolean
+ * @description This function will check if the feature should be displayed or not. The feature can be toggled on by the url query, by local storage or set as default active feature.
+ * @example shouldDisplayFeature('myFeatureName')
+ */
+export const shouldDisplayFeature = (featureFlag: SupportedFeatureFlags): boolean => {
+  return (
+    isDefaultActivatedFeature(featureFlag) ||
+    isFeatureActivatedByUrl(featureFlag) ||
+    isFeatureActivatedByLocalStorage(featureFlag)
+  );
+};
+
+// Check if the feature is one of the default active features
+const isDefaultActivatedFeature = (featureFlag: SupportedFeatureFlags): boolean => {
+  return defaultActiveFeatures.includes(featureFlag);
+};
+
+// Check if feature includes in the url query, (url)?feature=[featureName]
+const isFeatureActivatedByUrl = (featureFlag: SupportedFeatureFlags): boolean => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const featureParam = urlParams.get(featureFlagKey);
+  if (featureParam) {
+    const features = featureParam.split(',');
+    return features.includes(featureFlag);
+  }
+  return false;
+};
+
+// Check if feature includes in local storage, feature=[featureName]
+const isFeatureActivatedByLocalStorage = (featureFlag: SupportedFeatureFlags): boolean => {
+  // TODO wait for PR #10816 to be merged to use the new TypedLocalStorage and then use it here
+  const featureParam = localStorage.getItem(featureFlagKey);
+  if (featureParam) {
+    const features = featureParam.split(',');
+    return features.includes(featureFlag);
+  }
+  return false;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To make it easier to develop new features step by step, we should be able to toggle features. Meaning we can partially develop new features without displaying them to the end user. The benefits of this are smaller pull requests and easier-to-do great reviews.

Within this PR I have created utilities to check if the feature should be displayed or not. There are three ways to activate the features. 

1. Add the feature flag to the `defaultActiveFeatures` array within `featureToggleUtils.ts` line 11. _(Makes it easy to deploy a feature to production and rollback if needed)_
2. Activate the feature with search params within the URL, `?featureFlags=process,anotherNewFeature`.  _(Makes it easy to share preview of new features with non-technical persons)_
3. Activate the feature with local storage to persist the feature between sessions. This can be done by adding the key-value-pair to the local storage, `featureFlags: [process, anotherNewFeature]`.  _(Makes it easy for developers to have the feature persisted between sessions and refreshes)_

## Related Issue(s)
- #10819 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
