### PR TITLE
add list to avilable dataModelBindingKeys

### DIFF
--- a/frontend/packages/ux-editor/src/testing/schemas/json/component/FileUpload.schema.v1.json
+++ b/frontend/packages/ux-editor/src/testing/schemas/json/component/FileUpload.schema.v1.json
@@ -15,7 +15,22 @@
       "const": "FileUpload"
     },
     "dataModelBindings": {
-      "$ref": "https://altinncdn.no/schemas/json/component/common-defs.schema.v1.json#/definitions/basicDataModelBindings"
+      "title": "Data model bindings",
+      "description": "Data model bindings for component",
+      "type": "object",
+      "properties": {
+        "simpleBinding": {
+          "type": "string",
+          "title": "Simple binding",
+          "description": "Data model binding for file uploader with a single file"
+        },
+        "list": {
+          "type": "string",
+          "title": "List",
+          "description": "Data model binding for file uploader with multiple files"
+        }
+      },
+      "additionalProperties": false
     },
     "textResourceBindings": {
       "type": "object",

--- a/frontend/packages/ux-editor/src/testing/schemas/json/component/FileUploadWithTag.schema.v1.json
+++ b/frontend/packages/ux-editor/src/testing/schemas/json/component/FileUploadWithTag.schema.v1.json
@@ -15,7 +15,22 @@
       "const": "FileUploadWithTag"
     },
     "dataModelBindings": {
-      "$ref": "https://altinncdn.no/schemas/json/component/common-defs.schema.v1.json#/definitions/basicDataModelBindings"
+      "title": "Data model bindings",
+      "description": "Data model bindings for component",
+      "type": "object",
+      "properties": {
+        "simpleBinding": {
+          "type": "string",
+          "title": "Simple binding",
+          "description": "Data model binding for file uploader with a single file"
+        },
+        "list": {
+          "type": "string",
+          "title": "List",
+          "description": "Data model binding for file uploader with multiple files"
+        }
+      },
+      "additionalProperties": false
     },
     "textResourceBindings": {
       "type": "object",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed dataModelBindings schema for FileUpload and FileUploadWithTags components, as these were missing the `list` property.

## Related Issue(s)
- #8664

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
