### PR TITLE
Add Gitea language selection to Cypress

### DIFF
--- a/frontend/testing/cypress/src/selectors/login.js
+++ b/frontend/testing/cypress/src/selectors/login.js
@@ -1,5 +1,7 @@
 export const login = {
   getCreateUserLink: () => cy.findByRole('link', { name: 'Opprett ny bruker' }),
+  getLanguageMenu: () => cy.findByRole('menu'),
+  getLanguageMenuItem: (language) => cy.findByRole('menuitem', { name: language }),
   getLoginButton: () => cy.findByRole('button', { name: 'Logg inn' }),
   getLoginErrorMessage: () => cy.findByText('Ugyldig brukernavn eller passord.'),
   getPasswordField: () => cy.findByLabelText('Passord'),

--- a/frontend/testing/cypress/src/support/studio.js
+++ b/frontend/testing/cypress/src/support/studio.js
@@ -15,6 +15,8 @@ Cypress.Commands.add('studiologin', (userName, userPwd) => {
   cy.session([userName, userPwd], () => {
     cy.visit('/');
     login.getLoginButton().should('be.visible').click();
+    login.getLanguageMenu().should('be.visible').click();
+    login.getLanguageMenuItem('Norsk').should('be.visible').click();
     login.getUsernameField().should('be.visible').type(userName);
     login.getPasswordField().should('be.visible').type(userPwd, { log: false });
     login.getLoginButton().should('be.visible').click();


### PR DESCRIPTION
## Description
Cypress tests fail in some environments because of different language settings in Gitea. This change makes them always choose Norwegian, which we use in the selectors.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
