### PR TITLE
Fix broken link in dashboard and add Cypress coverage of anchor links in Dashboard

### DIFF
--- a/frontend/dashboard/components/Resources/Resources.tsx
+++ b/frontend/dashboard/components/Resources/Resources.tsx
@@ -154,7 +154,7 @@ const resources: Resource[] = [
   {
     label: 'dashboard.resource_roadmap_label',
     description: 'dashboard.resource_roadmap_description',
-    url: 'https://docs.altinn.studio/community/roadmap/studio/',
+    url: 'https://docs.altinn.studio/nb/community/roadmap/',
     icon: (
       <svg
         width='60'

--- a/frontend/testing/cypress/src/integration/studio/dashboard.js
+++ b/frontend/testing/cypress/src/integration/studio/dashboard.js
@@ -23,6 +23,17 @@ context('Dashboard', () => {
     cy.wait('@fetchApps').its('response.statusCode').should('eq', 200);
   });
 
+  it('is possible to check for broken anchor links, including in Footer', () => {
+    cy.get("a").each(link => {
+      if (link.prop('href')) 
+        cy.request({
+          url: link.prop('href'),    
+          failOnStatusCode: true
+        })
+      cy.log( link.prop('href')); 
+    }); 
+  });
+
   it('is possible to view apps, add and remove favourites', () => {
     const createdBy = Cypress.env('autoTestUser');
     cy.intercept('PUT', '**/designer/api/user/starred/**').as('addFavourite');

--- a/frontend/testing/cypress/src/integration/studio/dashboard.js
+++ b/frontend/testing/cypress/src/integration/studio/dashboard.js
@@ -24,7 +24,7 @@ context('Dashboard', () => {
   });
 
   it('is possible to check for broken anchor links, including in Footer', () => {
-    cy.get("a").each(link => {
+    cy.findAllByRole('link').each(link => {
       if (link.prop('href')) 
         cy.request({
           url: link.prop('href'),    


### PR DESCRIPTION

## Description
The Footer link to Roadmap Docs in Dashboard Footer have (probably) been broken for several months. 

The link has been repaired and a Cypress test to cover all anchor links in Dashboard has been added.

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
