### PR TITLE
Cypress improvements 3

### DIFF
--- a/frontend/app-development/features/administration/components/MainContent.tsx
+++ b/frontend/app-development/features/administration/components/MainContent.tsx
@@ -21,6 +21,10 @@ interface IMainContentProps {
   appNameAnchorEl: any;
 }
 
+const nameLabelId = 'administrationInputAppNameHeader';
+const descriptionLabelId = 'administrationInputAppDescriptionHeader';
+const appIdLabelId = 'administrationInputAppIdHeader';
+
 export const MainContent = (props: IMainContentProps): JSX.Element => {
   const [searchParams] = useSearchParams();
   const copiedApp = Boolean(searchParams.get('copiedApp'));
@@ -39,11 +43,11 @@ export const MainContent = (props: IMainContentProps): JSX.Element => {
           </p>
         </>
       )}
-      <h2>{t('general.service_name')}</h2>
+      <h2 id={nameLabelId}>{t('general.service_name')}</h2>
       <p>{t('administration.service_name_administration_description')}</p>
       <div className={classes.sideBySide}>
         <TextField
-          id='administrationInputAppName_textField'
+          aria-labelledby={nameLabelId}
           onChange={props.onAppNameChange}
           value={props.appName}
           onBlur={props.onAppNameBlur}
@@ -63,10 +67,10 @@ export const MainContent = (props: IMainContentProps): JSX.Element => {
         anchorEl={props.appNameAnchorEl}
         message={t('administration.service_name_empty_message')}
       />
-      <h2>{t('administration.service_id')}</h2>
+      <h2 id={appIdLabelId}>{t('administration.service_id')}</h2>
       <p>{t('administration.service_id_description')}</p>
       <TextField
-        id='administrationInputAppId_textField'
+        aria-labelledby={appIdLabelId}
         onChange={props.onAppIdChange}
         value={props.appId}
         onBlur={props.onAppIdBlur}
@@ -74,10 +78,10 @@ export const MainContent = (props: IMainContentProps): JSX.Element => {
       <h2>{t('general.service_saved_name')}</h2>
       <p>{t('administration.service_saved_name_administration_description')}</p>
       <TextField id='administrationInputReponame' value={props.repositoryName} disabled={true} />
-      <h2>{t('administration.service_comment')}</h2>
+      <h2 id={descriptionLabelId}>{t('administration.service_comment')}</h2>
       <p>{t('administration.service_comment_description')}</p>
       <TextArea
-        id='administrationInputDescription_textField'
+        aria-labelledby={descriptionLabelId}
         onChange={props.onAppDescriptionChange}
         rows={7}
         value={props.appDescription}

--- a/frontend/app-development/features/administration/components/ServiceAdministration.test.tsx
+++ b/frontend/app-development/features/administration/components/ServiceAdministration.test.tsx
@@ -120,9 +120,7 @@ describe('Administration', () => {
     const editButton = screen.getByRole('button', { name: textMock('general.edit') });
     await act(() => user.click(editButton));
 
-    const inputElement = screen
-      .getByTestId('service-administration-container')
-      .querySelector('#administrationInputAppName_textField'); // eslint-disable-line testing-library/no-node-access
+    const inputElement = screen.getByRole('textbox', { name: textMock('general.service_name') });
     expect((inputElement as HTMLInputElement).value).toEqual(mockServiceName);
 
     fireEvent.change(inputElement, mockEvent);
@@ -153,9 +151,7 @@ describe('Administration', () => {
     const mockEvent = { target: { value: 'New description' } };
     const dispatchSpy = jest.spyOn(utils.store, 'dispatch');
 
-    const inputElement = screen
-      .getByTestId('service-administration-container')
-      .querySelector('#administrationInputDescription_textField'); // eslint-disable-line testing-library/no-node-access
+    const inputElement = screen.getByRole('textbox', { name: textMock('administration.service_comment') });
     expect((inputElement as HTMLInputElement).value).toEqual(mockServiceDescription);
 
     fireEvent.change(inputElement, mockEvent);
@@ -186,9 +182,7 @@ describe('Administration', () => {
     const dispatchSpy = jest.spyOn(utils.store, 'dispatch');
     const mockEvent = { target: { value: 'New id' } };
 
-    const inputElement = screen
-      .getByTestId('service-administration-container')
-      .querySelector('#administrationInputAppId_textField'); // eslint-disable-line testing-library/no-node-access
+    const inputElement = screen.getByRole('textbox', { name: textMock('administration.service_id') });
     expect((inputElement as HTMLInputElement).value).toEqual(mockServiceId);
 
     fireEvent.change(inputElement, mockEvent);

--- a/frontend/packages/ux-editor/src/components/dragAndDrop/DraggableToolbarItem.tsx
+++ b/frontend/packages/ux-editor/src/components/dragAndDrop/DraggableToolbarItem.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 import { useDrag } from 'react-dnd';
 import type { NewDndItem } from '../../types/dndTypes';
 import { DraggableEditorItemType } from '../../types/dndTypes';
+import * as testids from '../../../../../testing/testids';
 
 export interface DraggableToolbarItemProps {
   notDraggable?: boolean;
@@ -15,5 +16,5 @@ export const DraggableToolbarItem = ({ children, notDraggable, item }: Draggable
     type: DraggableEditorItemType.ToolbarItem,
     canDrag: () => !notDraggable,
   });
-  return <div ref={drag}>{children}</div>;
+  return <div ref={drag} data-testid={testids.draggableToolbarItem}>{children}</div>;
 };

--- a/frontend/testing/cypress/src/integration/studio/designer.js
+++ b/frontend/testing/cypress/src/integration/studio/designer.js
@@ -1,25 +1,18 @@
 /// <reference types="cypress" />
 /// <reference types="../../support" />
 
-import { designer } from '../../pageobjects/designer';
+import * as texts from '../../../../../language/src/nb.json';
+import { administration } from "../../selectors/administration";
+import { designer } from "../../selectors/designer";
+import { header } from "../../selectors/header";
 
 context('Designer', () => {
   before(() => {
     cy.visit('/');
     cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.getrepo(Cypress.env('designerApp'), Cypress.env('accessToken')).then((response) => {
-      if (response.status === 404) {
-        const [_, appName] = Cypress.env('designerApp').split('/');
-        cy.createapp(Cypress.env('autoTestUser'), appName);
-      }
-    });
-    cy.visit('/');
-    cy.getrepo(Cypress.env('withoutDataModelApp'), Cypress.env('accessToken')).then((response) => {
-      if (response.status !== 200) {
-        const [_, appName] = Cypress.env('withoutDataModelApp').split('/');
-        cy.createapp(Cypress.env('autoTestUser'), appName);
-      }
-    });
+    cy.deleteallapps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.createapp(Cypress.env('autoTestUser'), 'designer');
+    cy.createapp(Cypress.env('autoTestUser'), 'appwithout-dm');
     cy.clearCookies();
     cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
   });
@@ -30,29 +23,26 @@ context('Designer', () => {
   it('is possible to edit information about the app', () => {
     const designerApp = Cypress.env('designerApp');
     cy.searchAndOpenApp(designerApp);
-    cy.contains(designer.aboutApp.appHeader, 'Om appen').should('be.visible');
-    cy.contains("[data-testid='administrationInputAppName_ChangeButton']", 'Endre').click();
-    cy.get(designer.aboutApp.appName).clear().type('New app name');
-    cy.get(designer.aboutApp.appDescription).click().clear().type('App description');
-    cy.get(designer.aboutApp.appName).invoke('val').should('contain', 'New app name');
-    cy.get(designer.aboutApp.appDescription).invoke('val').should('contain', 'App description');
-    cy.visit(`/editor/${designerApp}/text-editor`);
-    cy.contains('textarea', 'New app name');
+    cy.findByRole('heading', { name: texts['administration.administration'] }).should('be.visible');
+    cy.findByRole('button', { name: texts['general.edit'] }).click();
+    administration.getAppNameField().clear().type('New app name');
+    administration.getDescriptionField().clear().type('App description');
+    administration.getAppNameField().invoke('val').should('contain', 'New app name');
+    administration.getDescriptionField().invoke('val').should('contain', 'App description');
   });
 
   it('is possible to add and delete form components', () => {
     cy.searchAndOpenApp(Cypress.env('designerApp'));
-    cy.findByRole('link', { name: designer.appMenu.editText }).click();
-    cy.get("button[aria-label='Legg til ny side']").click();
-    cy.findByText('Navigasjonsknapper').should('be.visible');
-    cy.get(designer.formComponents.shortAnswer).parents(designer.draggable).trigger('dragstart');
-    cy.get(designer.dragToArea).trigger('drop');
+    header.getCreateLink().click();
+    designer.getAddPageButton().click();
+    designer.getAddPageButton().click();
+    cy.findByText(texts['ux_editor.component_navigation_buttons']).should('be.visible');
+    designer.getToolbarItemByText(texts['ux_editor.component_input']).trigger('dragstart');
+    designer.getDroppableList().trigger('drop');
     cy.wait(500);
-    cy.get(designer.dragToArea)
-      .find("[role='listitem']")
-      .then(($elements) => {
-        expect($elements.length).eq(2);
-      });
+    designer.getDroppableList()
+      .findAllByRole('listitem')
+      .then(($elements) => expect($elements.length).eq(2));
     cy.deletecomponents();
   });
 

--- a/frontend/testing/cypress/src/selectors/administration.js
+++ b/frontend/testing/cypress/src/selectors/administration.js
@@ -1,0 +1,6 @@
+import * as texts from "@altinn-studio/language/src/nb.json";
+
+export const administration = {
+  getAppNameField: () => cy.findByRole('textbox', { name: texts['general.service_name'] }),
+  getDescriptionField: () => cy.findByRole('textbox', { name: texts['administration.service_comment'] }),
+};

--- a/frontend/testing/cypress/src/selectors/designer.js
+++ b/frontend/testing/cypress/src/selectors/designer.js
@@ -1,0 +1,11 @@
+import * as texts from "@altinn-studio/language/src/nb.json";
+import * as testids from "../../../testids";
+
+const getToolbarItems = () => cy.findAllByTestId(testids.draggableToolbarItem);
+
+export const designer = {
+  getAddPageButton: () => cy.findByRole('button', { name: texts['left_menu.pages_add'] }),
+  getDroppableList: () => cy.findByTestId(testids.droppableList),
+  getToolbarItemByText: (text) => getToolbarItems().findByText(text),
+  getToolbarItems,
+};

--- a/frontend/testing/cypress/src/selectors/header.js
+++ b/frontend/testing/cypress/src/selectors/header.js
@@ -5,6 +5,7 @@ const getMenuItem = (name) => cy.findByRole('menuitem', { name });
 
 export const header = {
   getAvatar: () => cy.findByAltText(texts['shared.header_button_alt']),
+  getCreateLink: () => cy.findByRole('link', { name: texts['top_menu.create'] }),
   getDatamodelLink: () => cy.findByRole('link', { name: texts['top_menu.datamodel'] }),
   getMenuItem,
   getMenuItemAll: () => getMenuItem(texts['shared.header_all']),

--- a/frontend/testing/cypress/src/support/studio.js
+++ b/frontend/testing/cypress/src/support/studio.js
@@ -1,12 +1,11 @@
 /// <reference types="cypress" />
 import '@testing-library/cypress/add-commands';
-import { login } from '../selectors/login';
-import { designer } from '../pageobjects/designer';
-import { dashboard } from '../selectors/dashboard';
-import { header } from '../selectors/header';
-import * as texts from '../../../../language/src/nb.json';
-
 import '@testing-library/cypress/add-commands';
+import * as texts from '../../../../language/src/nb.json';
+import { dashboard } from '../selectors/dashboard';
+import { designer } from '../selectors/designer';
+import { header } from '../selectors/header';
+import { login } from '../selectors/login';
 
 /**
  * Login to studio with user name and password
@@ -60,58 +59,20 @@ Cypress.Commands.add('createapp', (orgName, appName) => {
  * Delete all the added components in ux-editor
  */
 Cypress.Commands.add('deletecomponents', () => {
-  cy.get(designer.dragToArea)
-    .find("[role='listitem']")
+  designer
+    .getDroppableList()
+    .findAllByRole('listitem')
     .then(($elements) => {
-      if ($elements.length > 0 && $elements.text().indexOf('Tomt, dra noe inn her...') === -1) {
+      if ($elements.length > 0 && $elements.text().indexOf(texts['ux_editor.container_empty']) === -1) {
         cy.get($elements).each(($element) => {
           cy.wrap($element).trigger('mouseover');
+          cy.wrap($element).findByTitle(texts['general.delete']).click({ force: true });
+          cy.wrap($element)
+            .findByRole('button', { name: texts['ux_editor.component_deletion_confirm'] })
+            .click();
         });
-        cy.get("[data-testid='component-delete-button']").click({ multiple: true, force: true });
       }
     });
-});
-
-/**
- * Delete all the added components with specified test in ux-editor
- */
-Cypress.Commands.add('deletecomponentsWithText', (text) => {
-  cy.get(designer.dragToArea)
-    .find("[role='listitem']")
-    .then(($elements) => {
-      if ($elements.length > 0 && $elements.text().indexOf('Tomt, dra noe inn her...') === -1) {
-        cy.get($elements).each(($element) => {
-          if ($element.get(text)) {
-            cy.wrap($element).trigger('mouseover');
-          }
-        });
-        cy.get("[data-testid='component-delete-button']").click({ multiple: true, force: true });
-      }
-    });
-});
-
-/**
- * Delete local changes of an app for a logged in user
- */
-Cypress.Commands.add('deleteLocalChanges', (appId) => {
-  cy.getCookie('AltinnStudioDesigner').should('exist');
-  cy.visit(`editor/${appId}#/`);
-  cy.get(designer.aboutApp.repoName).should('be.visible');
-  cy.get(designer.sideMenu)
-    .find(designer.deleteChanges.reset)
-    .should(($button) => {
-      expect(Cypress.dom.isDetached($button), 'button should not be detached').to.eq(false);
-    })
-    .should('be.visible')
-    .click();
-  cy.get(designer.deleteChanges.name)
-    .should('be.visible')
-    .type(`${appId.split('/')[1]}`)
-    .blur();
-  cy.intercept('GET', '**/reset').as('resetRepo');
-  cy.get(designer.deleteChanges.confirm).should('be.visible').click();
-  cy.wait('@resetRepo');
-  cy.get(designer.deleteChanges.name).should('not.exist');
 });
 
 /**

--- a/frontend/testing/cypress/src/support/studio.js
+++ b/frontend/testing/cypress/src/support/studio.js
@@ -1,6 +1,5 @@
 /// <reference types="cypress" />
 import '@testing-library/cypress/add-commands';
-import '@testing-library/cypress/add-commands';
 import * as texts from '../../../../language/src/nb.json';
 import { dashboard } from '../selectors/dashboard';
 import { designer } from '../selectors/designer';

--- a/frontend/testing/testids.js
+++ b/frontend/testing/testids.js
@@ -1,3 +1,4 @@
+export const draggableToolbarItem = 'draggableToolbarItem';
 export const droppableList = 'droppableList';
 export const orgMenuItem = (orgUserName) => (orgUserName ? `menu-org-${orgUserName}` : 'menu-org-no-org-user-name');
 export const searchReposField = 'repos-search-field';


### PR DESCRIPTION
## Description
- The check for existing apps in the `designer` tests didn't work. Used the `deleteAllApps` function instead. This way, we also ensure that the tested use case is always the same (starting from scratch).
- Replaced some more selecctors.
- Deleted some unused functions.
- Fixed some labels.

## Related Issue(s)
- #10792
