### PR TITLE
wrap debounceSave in setTimeout

### DIFF
--- a/frontend/packages/ux-editor/src/components/rightMenu/Content.tsx
+++ b/frontend/packages/ux-editor/src/components/rightMenu/Content.tsx
@@ -25,8 +25,10 @@ export const Content = () => {
           editFormId={formId}
           container={form}
           handleContainerUpdate={async (updatedContainer) => {
-            handleUpdate(updatedContainer);
-            debounceSave();
+            handleUpdate((updatedContainer));
+            // Workaround to make sure the container is updated before the form is saved
+            // TODO: https://github.com/Altinn/altinn-studio/issues/10923
+            setTimeout(() => debounceSave());
           }}
         />
       ) : (
@@ -35,7 +37,9 @@ export const Content = () => {
           component={form}
           handleComponentUpdate={async (updatedComponent) => {
             handleUpdate(updatedComponent);
-            debounceSave();
+            // Workaround to make sure the component is updated before the form is saved
+            // TODO: https://github.com/Altinn/altinn-studio/issues/10923
+            setTimeout(() => debounceSave());
           }}
         />
       )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Wrap the `debounceSave()` call in a setTimeout to give the form state enough time to update before triggering save of data.

## Related Issue(s)
- #10923

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
