### PR TITLE
Fix deselection of components

### DIFF
--- a/frontend/packages/ux-editor/src/containers/DesignView.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView.test.tsx
@@ -4,16 +4,13 @@ import { DesignView } from './DesignView';
 import { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
 import { externalLayoutsMock, layout1NameMock, layout2NameMock } from '../testing/layoutMock';
 import { FormLayoutsResponse } from 'app-shared/types/api/FormLayoutsResponse';
-import { act, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { textMock } from '../../../../testing/mocks/i18nMock';
 import { useFormLayoutsQuery } from '../hooks/queries/useFormLayoutsQuery';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { ComponentType } from 'app-shared/types/ComponentType';
-import userEvent from '@testing-library/user-event';
 import { FormContext } from './FormContext';
-
-const user = userEvent.setup();
 
 // Test data:
 const org = 'org';
@@ -41,15 +38,6 @@ describe('DesignView', () => {
     };
     await render(queries);
     expect(screen.getByText(layout1NameMock)).toBeInTheDocument();
-  });
-
-  it('Calls handleEdit when the parent element is clicked', async () => {
-    const queries: Partial<ServicesContextProps> = {
-      getFormLayouts: () => Promise.resolve({})
-    };
-    await render(queries);
-    await act(() => user.click(screen.getByTestId('designViewContainer')));
-    expect(mockHandleEdit).toHaveBeenCalled();
   });
 
   it('Does not render container if no container id', async () => {

--- a/frontend/packages/ux-editor/src/containers/DesignView.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView.tsx
@@ -119,11 +119,6 @@ export const DesignView = ({ className }: DesignViewProps) => {
   return (
     <div
       className={className}
-      onClick={(event: React.MouseEvent<HTMLDivElement>) => {
-        event.stopPropagation();
-        if (formId) handleEdit(null)
-      }}
-      data-testid="designViewContainer"
     >
       <h1 className={classes.pageHeader}>{layoutName}</h1>
       {layout && renderContainer(BASE_CONTAINER_ID, true)}

--- a/frontend/packages/ux-editor/src/containers/FormContainer.tsx
+++ b/frontend/packages/ux-editor/src/containers/FormContainer.tsx
@@ -61,7 +61,8 @@ export const FormContainer = ({
         event.stopPropagation();
         if (isEditMode) return;
         await handleSave();
-        handleEdit(isBaseContainer ? null : { ...container, id });
+        if (isBaseContainer) return;
+        handleEdit({ ...container, id });
       }}
     >
       {!isBaseContainer && (

--- a/frontend/packages/ux-editor/src/containers/FormContext.tsx
+++ b/frontend/packages/ux-editor/src/containers/FormContext.tsx
@@ -39,6 +39,7 @@ export const FormContextProvider = ({ children }: FormContextProviderProps): JSX
   const { org, app } = useParams();
   const selectedLayoutSetName = useSelector(selectedLayoutSetSelector);
   const selectedLayoutName = useSelector(selectedLayoutNameSelector);
+  const prevSelectedLayoutSetNameRef = useRef(selectedLayoutSetName);
   const prevSelectedLayoutNameRef = useRef(selectedLayoutName);
 
   const autoSaveTimeoutRef = useRef(undefined);
@@ -88,11 +89,9 @@ export const FormContextProvider = ({ children }: FormContextProviderProps): JSX
   }, [handleComponentSave, handleContainerSave]);
 
   const handleEdit = useCallback((updatedForm: FormContainer | FormComponent): void => {
-    if (updatedForm) {
-      dispatch(setCurrentEditId(undefined));
-      setFormId(updatedForm?.id);
-      setForm(updatedForm);
-    }  
+    dispatch(setCurrentEditId(undefined));
+    setFormId(updatedForm?.id);
+    setForm(updatedForm);
   }, [dispatch]);
 
   const handleDiscard = useCallback((): void => {
@@ -109,14 +108,16 @@ export const FormContextProvider = ({ children }: FormContextProviderProps): JSX
 
   useEffect(() => {
     const autoSaveOnLayoutChange = async () => {
-      if (prevSelectedLayoutNameRef.current === selectedLayoutName) return;
+      if (prevSelectedLayoutSetNameRef.current === selectedLayoutSetName &&
+        prevSelectedLayoutNameRef.current === selectedLayoutName) return;
       await handleSave();
       handleDiscard();
+      prevSelectedLayoutSetNameRef.current = selectedLayoutName;
       prevSelectedLayoutNameRef.current = selectedLayoutName;
     };
 
     autoSaveOnLayoutChange();
-  }, [handleDiscard, handleSave, selectedLayoutName]);
+  }, [handleDiscard, handleSave, selectedLayoutSetName, selectedLayoutName]);
 
   const value = useMemo(() => ({
     formId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A selected component should be unselected after deleting it or switching between layoutsets and layouts

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
