### PR TITLE
Remove unnecessary checks in Cypress

### DIFF
--- a/frontend/testing/cypress/src/integration/usecase/usecase.js
+++ b/frontend/testing/cypress/src/integration/usecase/usecase.js
@@ -6,6 +6,7 @@ import * as texts from "@altinn-studio/language/src/nb.json";
 import { administration } from "../../selectors/administration";
 import { deploy } from "../../selectors/deploy";
 import { designer } from "../../selectors/designer";
+import { gitea } from "../../selectors/gitea";
 import { header } from '../../selectors/header';
 import { preview } from "../../selectors/preview";
 import { textEditor } from "../../selectors/textEditor";
@@ -56,15 +57,8 @@ context(
 
       // Repos
       header.getProfileIcon().should('be.visible').click();
-      header.getOpenRepoLink()
-        .should('be.visible')
-        .invoke('attr', 'href')
-        .then((href) => {
-          cy.visit(href);
-          cy.get('.repo-header').should('be.visible');
-          cy.get('a[href="/repos/"]').should('be.visible').click();
-          cy.get('img[alt="Altinn logo"]').should('be.visible');
-        });
+      header.getOpenRepoLink().should('be.visible').click();
+      gitea.getRepositoryHeader().should('be.visible');
     });
 
     // it('Gitea connection - Pull changes', () => {


### PR DESCRIPTION
## Description
The Gitea interface has changed after the last update, making the usecase test fail. I made the test only check that the repo header exists, just to confirm that the interface loads. Further tests on the Gitea interface should not be necessary since it is an external app.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
