### PR TITLE
Range attribute fix

### DIFF
--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -321,9 +321,10 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
 
         private static string GetRangeValueAsString(ElementMetadata element, Restriction restriction)
         {
-            string value = restriction?.Value;
+            string value = restriction?.Value ?? string.Empty;
+            bool isAlreadyDecimal = value.Contains('.') || value.Contains(',');
             // Use decimal range value for all types except int and long
-            if (element.XsdValueType.HasValue && !new[]
+            if (!isAlreadyDecimal && element.XsdValueType.HasValue && !new[]
                 {
                     BaseValueType.Int, BaseValueType.Long
                 }.Contains(element.XsdValueType.Value))
@@ -346,7 +347,6 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
                 case BaseValueType.NonPositiveInteger:
                 case BaseValueType.NonNegativeInteger:
                 case BaseValueType.PositiveInteger:
-                case BaseValueType.Decimal:
                     classBuilder.AppendLine(Indent(2) + $"[Range({LeftRangeLimit(type)},{RightRangeLimit(type)}" + errorMessage + ")]");
                     break;
                 case BaseValueType.GYear:

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -298,21 +298,38 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             bool hasMin = element.Restrictions.TryGetValue(leftRestrictionName, out var minRestriction);
             bool hasMax = element.Restrictions.TryGetValue(rightRestrictionName, out var maxRestriction);
 
+            string minVal = GetStringRangeValue(element, minRestriction);
+            string maxVal = GetStringRangeValue(element, maxRestriction);
+
             if ( hasMin && hasMax)
             {
-                classBuilder.AppendLine(Indent(2) + "[Range(" + minRestriction.Value + ", " + maxRestriction.Value + errorMessage + ")]");
+                classBuilder.AppendLine($"{Indent(2)}[Range({minVal}, {maxVal}{errorMessage})]");
                 hasRange = true;
             }
             else if (hasMin)
             {
-                classBuilder.AppendLine(Indent(2) + "[Range(" + minRestriction.Value + ", " + RightRangeLimit(element.XsdValueType ?? BaseValueType.Double) + errorMessage + ")]");
+                classBuilder.AppendLine($"{Indent(2)}[Range({minVal}, {RightRangeLimit(element.XsdValueType ?? BaseValueType.Double)}{errorMessage})]");
                 hasRange = true;
             }
             else if (hasMax)
             {
-                classBuilder.AppendLine(Indent(2) + "[Range(" +  LeftRangeLimit(element.XsdValueType ?? BaseValueType.Double) + ", " + maxRestriction.Value + errorMessage + ")]");
+                classBuilder.AppendLine($"{Indent(2)}[Range({LeftRangeLimit(element.XsdValueType ?? BaseValueType.Double)}, {maxVal}{errorMessage})]");
                 hasRange = true;
             }
+        }
+
+        private string GetStringRangeValue(ElementMetadata element, Restriction restriction)
+        {
+            string value = restriction?.Value;
+            // Use decimal range value for all types except int and long
+            if (element.XsdValueType.HasValue && !new[]
+                {
+                    BaseValueType.Int, BaseValueType.Long
+                }.Contains(element.XsdValueType.Value))
+            {
+                value = $"{value}d";
+            }
+            return value;
         }
 
 

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -270,10 +270,10 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
                 classBuilder.AppendLine(Indent(2) + "[MaxLength(" + maxLengthRestriction.Value + errorMessage + ")]");
             }
 
-            SetRangeRestriction(classBuilder, element, errorMessage, "minInclusive", "maxInclusive", out hasRange);
+            WriteRangeRestriction(classBuilder, element, errorMessage, "minInclusive", "maxInclusive", out hasRange);
             if (!hasRange)
             {
-                SetRangeRestriction(classBuilder, element, errorMessage, "minimum", "maximum", out hasRange);
+                WriteRangeRestriction(classBuilder, element, errorMessage, "minimum", "maximum", out hasRange);
             }
 
 
@@ -293,7 +293,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             }
         }
 
-        private void SetRangeRestriction(StringBuilder classBuilder, ElementMetadata element, string errorMessage, string leftRestrictionName, string rightRestrictionName, out bool hasRange)
+        private void WriteRangeRestriction(StringBuilder classBuilder, ElementMetadata element, string errorMessage, string leftRestrictionName, string rightRestrictionName, out bool hasRange)
         {
             hasRange = false;
             bool hasMinimum = element.Restrictions.TryGetValue(leftRestrictionName, out var minRestriction);

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -299,22 +299,19 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             bool hasMinimum = element.Restrictions.TryGetValue(leftRestrictionName, out var minRestriction);
             bool hasMaximum = element.Restrictions.TryGetValue(rightRestrictionName, out var maxRestriction);
 
-            string minValue = GetRangeValueAsString(element, minRestriction);
-            string maxValue = GetRangeValueAsString(element, maxRestriction);
-
             if (hasMinimum && hasMaximum)
             {
-                classBuilder.AppendLine($"{Indent(2)}[Range({minValue}, {maxValue}{errorMessage})]");
+                classBuilder.AppendLine($"{Indent(2)}[Range({GetRangeValueAsString(element, minRestriction)}, {GetRangeValueAsString(element, maxRestriction)}{errorMessage})]");
                 hasRange = true;
             }
             else if (hasMinimum)
             {
-                classBuilder.AppendLine($"{Indent(2)}[Range({minValue}, {RightRangeLimit(element.XsdValueType ?? BaseValueType.Double)}{errorMessage})]");
+                classBuilder.AppendLine($"{Indent(2)}[Range({GetRangeValueAsString(element, minRestriction)}, {RightRangeLimit(element.XsdValueType ?? BaseValueType.Double)}{errorMessage})]");
                 hasRange = true;
             }
             else if (hasMaximum)
             {
-                classBuilder.AppendLine($"{Indent(2)}[Range({LeftRangeLimit(element.XsdValueType ?? BaseValueType.Double)}, {maxValue}{errorMessage})]");
+                classBuilder.AppendLine($"{Indent(2)}[Range({LeftRangeLimit(element.XsdValueType ?? BaseValueType.Double)}, {GetRangeValueAsString(element, maxRestriction)}{errorMessage})]");
                 hasRange = true;
             }
         }

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -296,25 +296,25 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
         private void SetRangeRestriction(StringBuilder classBuilder, ElementMetadata element, string errorMessage, string leftRestrictionName, string rightRestrictionName, out bool hasRange)
         {
             hasRange = false;
-            bool hasMin = element.Restrictions.TryGetValue(leftRestrictionName, out var minRestriction);
-            bool hasMax = element.Restrictions.TryGetValue(rightRestrictionName, out var maxRestriction);
+            bool hasMinimum = element.Restrictions.TryGetValue(leftRestrictionName, out var minRestriction);
+            bool hasMaximum = element.Restrictions.TryGetValue(rightRestrictionName, out var maxRestriction);
 
-            string minVal = GetStringRangeValue(element, minRestriction);
-            string maxVal = GetStringRangeValue(element, maxRestriction);
+            string minValue = GetStringRangeValue(element, minRestriction);
+            string maxValue = GetStringRangeValue(element, maxRestriction);
 
-            if (hasMin && hasMax)
+            if (hasMinimum && hasMaximum)
             {
-                classBuilder.AppendLine($"{Indent(2)}[Range({minVal}, {maxVal}{errorMessage})]");
+                classBuilder.AppendLine($"{Indent(2)}[Range({minValue}, {maxValue}{errorMessage})]");
                 hasRange = true;
             }
-            else if (hasMin)
+            else if (hasMinimum)
             {
-                classBuilder.AppendLine($"{Indent(2)}[Range({minVal}, {RightRangeLimit(element.XsdValueType ?? BaseValueType.Double)}{errorMessage})]");
+                classBuilder.AppendLine($"{Indent(2)}[Range({minValue}, {RightRangeLimit(element.XsdValueType ?? BaseValueType.Double)}{errorMessage})]");
                 hasRange = true;
             }
-            else if (hasMax)
+            else if (hasMaximum)
             {
-                classBuilder.AppendLine($"{Indent(2)}[Range({LeftRangeLimit(element.XsdValueType ?? BaseValueType.Double)}, {maxVal}{errorMessage})]");
+                classBuilder.AppendLine($"{Indent(2)}[Range({LeftRangeLimit(element.XsdValueType ?? BaseValueType.Double)}, {maxValue}{errorMessage})]");
                 hasRange = true;
             }
         }

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -356,7 +356,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             }
         }
 
-        private string LeftRangeLimit(BaseValueType type) => type switch
+        private static string LeftRangeLimit(BaseValueType type) => type switch
         {
             BaseValueType.Int => "Int32.MinValue",
             BaseValueType.Integer => "Double.MinValue",
@@ -369,7 +369,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             BaseValueType.Long => "Int64.MinValue",
             _ => throw new CsharpGenerationException("Unsupported range for type: " + type)
         };
-        private string RightRangeLimit(BaseValueType? type) => type switch
+        private static string RightRangeLimit(BaseValueType? type) => type switch
         {
             BaseValueType.Int => "Int32.MaxValue",
             BaseValueType.Integer => "Double.MaxValue",

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -299,8 +299,8 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             bool hasMinimum = element.Restrictions.TryGetValue(leftRestrictionName, out var minRestriction);
             bool hasMaximum = element.Restrictions.TryGetValue(rightRestrictionName, out var maxRestriction);
 
-            string minValue = GetStringRangeValue(element, minRestriction);
-            string maxValue = GetStringRangeValue(element, maxRestriction);
+            string minValue = GetRangeValueAsString(element, minRestriction);
+            string maxValue = GetRangeValueAsString(element, maxRestriction);
 
             if (hasMinimum && hasMaximum)
             {
@@ -319,7 +319,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             }
         }
 
-        private static string GetStringRangeValue(ElementMetadata element, Restriction restriction)
+        private static string GetRangeValueAsString(ElementMetadata element, Restriction restriction)
         {
             string value = restriction?.Value;
             // Use decimal range value for all types except int and long

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -329,6 +329,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
                 case BaseValueType.NonPositiveInteger:
                 case BaseValueType.NonNegativeInteger:
                 case BaseValueType.PositiveInteger:
+                case BaseValueType.Decimal:
                     classBuilder.AppendLine(Indent(2) + $"[Range({LeftRangeLimit(type)},{RightRangeLimit(type)}" + errorMessage + ")]");
                     break;
                 case BaseValueType.GYear:

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -251,6 +251,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
 
             WriteTypeRestrictions(classBuilder, element.XsdValueType.Value, errorMessage);
         }
+
         private void WriteRestrictions(StringBuilder classBuilder, ElementMetadata element, string errorMessage, out bool hasRange)
         {
             hasRange = false;
@@ -301,7 +302,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             string minVal = GetStringRangeValue(element, minRestriction);
             string maxVal = GetStringRangeValue(element, maxRestriction);
 
-            if ( hasMin && hasMax)
+            if (hasMin && hasMax)
             {
                 classBuilder.AppendLine($"{Indent(2)}[Range({minVal}, {maxVal}{errorMessage})]");
                 hasRange = true;
@@ -318,7 +319,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             }
         }
 
-        private string GetStringRangeValue(ElementMetadata element, Restriction restriction)
+        private static string GetStringRangeValue(ElementMetadata element, Restriction restriction)
         {
             string value = restriction?.Value;
             // Use decimal range value for all types except int and long
@@ -331,7 +332,6 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             }
             return value;
         }
-
 
         private void WriteTypeRestrictions(StringBuilder classBuilder, BaseValueType type, string errorMessage)
         {
@@ -386,6 +386,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             BaseValueType.Long => "Int64.MinValue",
             _ => throw new CsharpGenerationException("Unsupported range for type: " + type)
         };
+
         private static string RightRangeLimit(BaseValueType? type) => type switch
         {
             BaseValueType.Int => "Int32.MaxValue",

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -322,25 +322,14 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             switch (type)
             {
                 case BaseValueType.Double:
-                    classBuilder.AppendLine(Indent(2) + $"[Range({LeftRangeLimit(type)},{RightRangeLimit(type)}" + errorMessage + ")]");
-                    break;
                 case BaseValueType.Int:
-                    classBuilder.AppendLine(Indent(2) + $"[Range({LeftRangeLimit(type)},{RightRangeLimit(type)}" + errorMessage + ")]");
-                    break;
                 case BaseValueType.Integer:
-                    classBuilder.AppendLine(Indent(2) + $"[Range({LeftRangeLimit(type)},{RightRangeLimit(type)}" + errorMessage + ")]");
-                    break;
+                case BaseValueType.Long:
                 case BaseValueType.NegativeInteger:
-                    classBuilder.AppendLine(Indent(2) + $"[Range({LeftRangeLimit(type)},-1" + errorMessage + ")]");
-                    break;
                 case BaseValueType.NonPositiveInteger:
-                    classBuilder.AppendLine(Indent(2) + $"[Range({LeftRangeLimit(type)},0" + errorMessage + ")]");
-                    break;
                 case BaseValueType.NonNegativeInteger:
-                    classBuilder.AppendLine(Indent(2) + $"[Range(0,{RightRangeLimit(type)}" + errorMessage + ")]");
-                    break;
                 case BaseValueType.PositiveInteger:
-                    classBuilder.AppendLine(Indent(2) + $"[Range(1,{RightRangeLimit(type)}" + errorMessage + ")]");
+                    classBuilder.AppendLine(Indent(2) + $"[Range({LeftRangeLimit(type)},{RightRangeLimit(type)}" + errorMessage + ")]");
                     break;
                 case BaseValueType.GYear:
                     classBuilder.AppendLine(Indent(2) + "[RegularExpression(@\"^[0-9]{4}$\"" + errorMessage + ")]");
@@ -376,6 +365,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             BaseValueType.PositiveInteger => "1",
             BaseValueType.Decimal => "Double.MinValue",
             BaseValueType.Double => "Double.MinValue",
+            BaseValueType.Long => "Int64.MinValue",
             _ => throw new CsharpGenerationException("Unsupported range for type: " + type)
         };
         private string RightRangeLimit(BaseValueType? type) => type switch
@@ -388,6 +378,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             BaseValueType.PositiveInteger => "Double.MaxValue",
             BaseValueType.Decimal => "Double.MaxValue",
             BaseValueType.Double => "Double.MaxValue",
+            BaseValueType.Long => "Int64.MaxValue",
             _ => throw new CsharpGenerationException("Unsupported range for type: " + type)
         };
 

--- a/backend/src/DataModeling/Converter/Metadata/JsonSchemaToMetamodelConverter.cs
+++ b/backend/src/DataModeling/Converter/Metadata/JsonSchemaToMetamodelConverter.cs
@@ -598,20 +598,7 @@ namespace Altinn.Studio.DataModeling.Converter.Metadata
         {
             var baseValueType = BaseValueType.Integer;
 
-            if (subSchema.TryGetKeyword(out MinimumKeyword minimumKeyword))
-            {
-                decimal? minimum = minimumKeyword.Value;
-
-                if (minimum > 0.0m)
-                {
-                    baseValueType = BaseValueType.PositiveInteger;
-                }
-                else if (minimum == 0.0m)
-                {
-                    baseValueType = BaseValueType.NonNegativeInteger;
-                }
-            }
-            else if (TryParseXsdTypeKeyword(subSchema, out var parsedBaseValueType))
+            if (TryParseXsdTypeKeyword(subSchema, out var parsedBaseValueType))
             {
                 baseValueType = parsedBaseValueType;
             }

--- a/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
+++ b/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
@@ -33,6 +33,9 @@ public class CSharpE2ERestrictionsTestData : IEnumerable<object[]>
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeLimits", "long?", "[Range(Int64.MinValue, Int64.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeLeftLimit", "long?", "[Range(-100, Int64.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeRightLimit", "long?", "[Range(Int64.MinValue, 100)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeLimits", "decimal?", "[Range(Double.MinValue, Double.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeLeftLimit", "decimal?", "[Range(-100.0, Double.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100.0)]" };
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
+++ b/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
@@ -30,6 +30,9 @@ public class CSharpE2ERestrictionsTestData : IEnumerable<object[]>
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeLimits", "decimal?", "[Range(Double.MinValue, Double.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeLeftLimit", "decimal?", "[Range(-100, Double.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeLimits", "long?", "[Range(Int64.MinValue, Int64.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeLeftLimit", "long?", "[Range(-100, Int64.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeRightLimit", "long?", "[Range(Int64.MinValue, 100)]" };
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
+++ b/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
@@ -24,6 +24,12 @@ public class CSharpE2ERestrictionsTestData : IEnumerable<object[]>
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "nonPrimitive", "string", @"[RegularExpression(@""[0-9]+"")]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "nonPrimitive", "string", "[MinLength(5)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "nonPrimitive", "string", "[MaxLength(20)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeLimits", "int?", "[Range(Int32.MinValue, Int32.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeLeftLimit", "int?", "[Range(-100, Int32.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeRightLimit", "int?", "[Range(Int32.MinValue, 100)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeLimits", "decimal?", "[Range(Double.MinValue, Double.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeLeftLimit", "decimal?", "[Range(-100, Double.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100)]" };
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
+++ b/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
@@ -15,7 +15,7 @@ public class CSharpE2ERestrictionsTestData : IEnumerable<object[]>
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t2", "string", "[MaxLength(10)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t4", "string", @"[RegularExpression(@""^\d\.\d\.\d$"")]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "n1", "decimal?", @"[RegularExpression(@""^-?(([0-9]){1}(\.)?){0,10}$"")]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "n1", "decimal?", @"[Range(-100, 100)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "n1", "decimal?", "[Range(-100d, 100d)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "n1", "decimal?", "[Required]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "i1", "int?", @"[RegularExpression(@""^-?[0-9]{0,10}$"")]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "i1", "int?", "[Required]" };
@@ -29,17 +29,17 @@ public class CSharpE2ERestrictionsTestData : IEnumerable<object[]>
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeLeftLimit", "int?", "[Range(-100, Int32.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeRightLimit", "int?", "[Range(Int32.MinValue, 100)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeWithoutLimits", "decimal?", "[Range(Double.MinValue, Double.MaxValue)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeWithLimits", "decimal?", "[Range(-100, 100)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeLeftLimit", "decimal?", "[Range(-100, Double.MaxValue)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeWithLimits", "decimal?", "[Range(-100d, 100d)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeLeftLimit", "decimal?", "[Range(-100d, Double.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100d)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeWithoutLimits", "long?", "[Range(Int64.MinValue, Int64.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeWithLimits", "long?", "[Range(-100, 100)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeLeftLimit", "long?", "[Range(-100, Int64.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeRightLimit", "long?", "[Range(Int64.MinValue, 100)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeWithoutLimits", "decimal?", "[Range(Double.MinValue, Double.MaxValue)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeWithLimits", "decimal?", "[Range(-100, 100.0)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeLeftLimit", "decimal?", "[Range(-100.0, Double.MaxValue)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100.0)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeWithLimits", "decimal?", "[Range(-100.0d, 100.0d)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeLeftLimit", "decimal?", "[Range(-100.0d, Double.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100.0d)]" };
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
+++ b/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
@@ -36,9 +36,8 @@ public class CSharpE2ERestrictionsTestData : IEnumerable<object[]>
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeWithLimits", "long?", "[Range(-100, 100)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeLeftLimit", "long?", "[Range(-100, Int64.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeRightLimit", "long?", "[Range(Int64.MinValue, 100)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeWithoutLimits", "decimal?", "[Range(Double.MinValue, Double.MaxValue)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeWithLimits", "decimal?", "[Range(-100.0d, 100.0d)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeLeftLimit", "decimal?", "[Range(-100.0d, Double.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeWithLimits", "decimal?", "[Range(-100.0, 100.0)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeLeftLimit", "decimal?", "[Range(-100.0, Double.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100.0d)]" };
     }
 

--- a/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
+++ b/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
@@ -24,16 +24,20 @@ public class CSharpE2ERestrictionsTestData : IEnumerable<object[]>
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "nonPrimitive", "string", @"[RegularExpression(@""[0-9]+"")]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "nonPrimitive", "string", "[MinLength(5)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "nonPrimitive", "string", "[MaxLength(20)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeLimits", "int?", "[Range(Int32.MinValue, Int32.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeWithoutLimits", "int?", "[Range(Int32.MinValue, Int32.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeWithLimits", "int?", "[Range(-100, 100)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeLeftLimit", "int?", "[Range(-100, Int32.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeRightLimit", "int?", "[Range(Int32.MinValue, 100)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeLimits", "decimal?", "[Range(Double.MinValue, Double.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeWithoutLimits", "decimal?", "[Range(Double.MinValue, Double.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeWithLimits", "decimal?", "[Range(-100, 100)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeLeftLimit", "decimal?", "[Range(-100, Double.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeLimits", "long?", "[Range(Int64.MinValue, Int64.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeWithoutLimits", "long?", "[Range(Int64.MinValue, Int64.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeWithLimits", "long?", "[Range(-100, 100)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeLeftLimit", "long?", "[Range(-100, Int64.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeRightLimit", "long?", "[Range(Int64.MinValue, 100)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeLimits", "decimal?", "[Range(Double.MinValue, Double.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeWithoutLimits", "decimal?", "[Range(Double.MinValue, Double.MaxValue)]" };
+        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeWithLimits", "decimal?", "[Range(-100, 100.0)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeLeftLimit", "decimal?", "[Range(-100.0, Double.MaxValue)]" };
         yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100.0)]" };
     }

--- a/testdata/Model/CSharp/Gitea/skjema.cs
+++ b/testdata/Model/CSharp/Gitea/skjema.cs
@@ -251,7 +251,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("MobilBoenhet")]
     public bool? MobilBoenhet { get; set; }
 
-    [Range(1, 999)]
+    [Range(1d, 999d)]
     [XmlElement("AntallEnerom", Order = 4)]
     [JsonProperty("AntallEnerom")]
     [JsonPropertyName("AntallEnerom")]
@@ -267,7 +267,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("TvEllerInternett")]
     public bool? TvEllerInternett { get; set; }
 
-    [Range(0, 999)]
+    [Range(0d, 999d)]
     [XmlElement("AntallRomMedKjokken", Order = 7)]
     [JsonProperty("AntallRomMedKjokken")]
     [JsonPropertyName("AntallRomMedKjokken")]

--- a/testdata/Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd
+++ b/testdata/Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd
@@ -184,7 +184,7 @@
   </xsd:simpleType>
   <xsd:simpleType name="decimalRangeWithLimits">
     <xsd:restriction base="xsd:decimal">
-      <xsd:minInclusive value="-100" />
+      <xsd:minInclusive value="-100.0" />
       <xsd:maxInclusive value="100.0" />
     </xsd:restriction>
   </xsd:simpleType>

--- a/testdata/Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd
+++ b/testdata/Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd
@@ -27,6 +27,9 @@
         <xsd:element name="longRangeLimits" type="longRangeLimits" />
         <xsd:element name="longRangeLeftLimit" type="longRangeLeftLimit" />
         <xsd:element name="longRangeRightLimit" type="longRangeRightLimit" />
+        <xsd:element name="decimalRangeLimits" type="decimalRangeLimits" />
+        <xsd:element name="decimalRangeLeftLimit" type="decimalRangeLeftLimit" />
+        <xsd:element name="decimalRangeRightLimit" type="decimalRangeRightLimit" />
       </xsd:sequence>
     </xsd:complexType>
   </xsd:element>
@@ -151,6 +154,20 @@
   <xsd:simpleType name="longRangeRightLimit">
     <xsd:restriction base="xsd:long">
       <xsd:maxInclusive value="100" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="decimalRangeLimits">
+    <xsd:restriction base="xsd:decimal">
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="decimalRangeLeftLimit">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="-100.0" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="decimalRangeRightLimit">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:maxInclusive value="100.0" />
     </xsd:restriction>
   </xsd:simpleType>
 

--- a/testdata/Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd
+++ b/testdata/Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd
@@ -24,6 +24,9 @@
         <xsd:element name="integerRangeLimits" type="integerRangeLimits" />
         <xsd:element name="integerRangeLeftLimit" type="integerRangeLeftLimit" />
         <xsd:element name="integerRangeRightLimit" type="integerRangeRightLimit" />
+        <xsd:element name="longRangeLimits" type="longRangeLimits" />
+        <xsd:element name="longRangeLeftLimit" type="longRangeLeftLimit" />
+        <xsd:element name="longRangeRightLimit" type="longRangeRightLimit" />
       </xsd:sequence>
     </xsd:complexType>
   </xsd:element>
@@ -108,13 +111,8 @@
       <xsd:pattern value="[0-9]+"/>
     </xsd:restriction>
   </xsd:simpleType>
-
   <xsd:simpleType name="intRangeLimits">
     <xsd:restriction base="xsd:int">
-    </xsd:restriction>
-  </xsd:simpleType>
-  <xsd:simpleType name="integerRangeLimits">
-    <xsd:restriction base="xsd:integer">
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:simpleType name="intRangeLeftLimit">
@@ -127,6 +125,10 @@
       <xsd:maxInclusive value="100" />
     </xsd:restriction>
   </xsd:simpleType>
+  <xsd:simpleType name="integerRangeLimits">
+    <xsd:restriction base="xsd:integer">
+    </xsd:restriction>
+  </xsd:simpleType>
   <xsd:simpleType name="integerRangeLeftLimit">
     <xsd:restriction base="xsd:integer">
       <xsd:minInclusive value="-100" />
@@ -137,4 +139,19 @@
       <xsd:maxInclusive value="100" />
     </xsd:restriction>
   </xsd:simpleType>
+  <xsd:simpleType name="longRangeLimits">
+    <xsd:restriction base="xsd:long">
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="longRangeLeftLimit">
+    <xsd:restriction base="xsd:long">
+      <xsd:minInclusive value="-100" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="longRangeRightLimit">
+    <xsd:restriction base="xsd:long">
+      <xsd:maxInclusive value="100" />
+    </xsd:restriction>
+  </xsd:simpleType>
+
 </xsd:schema>

--- a/testdata/Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd
+++ b/testdata/Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd
@@ -18,6 +18,12 @@
         <xsd:element name="f5" type="numberRestrictionsFractional4" />
         <xsd:element name="f6" type="numberRestrictionsFractional5" />
         <xsd:element name="nonPrimitive" type="nestedStringRestrictions" />
+        <xsd:element name="intRangeLimits" type="intRangeLimits" />
+        <xsd:element name="intRangeLeftLimit" type="intRangeLeftLimit" />
+        <xsd:element name="intRangeRightLimit" type="intRangeRightLimit" />
+        <xsd:element name="integerRangeLimits" type="integerRangeLimits" />
+        <xsd:element name="integerRangeLeftLimit" type="integerRangeLeftLimit" />
+        <xsd:element name="integerRangeRightLimit" type="integerRangeRightLimit" />
       </xsd:sequence>
     </xsd:complexType>
   </xsd:element>
@@ -100,6 +106,35 @@
   <xsd:simpleType name="nestedStringRestrictions">
     <xsd:restriction base="stringMinMaxLengthRestrictions">
       <xsd:pattern value="[0-9]+"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="intRangeLimits">
+    <xsd:restriction base="xsd:int">
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="integerRangeLimits">
+    <xsd:restriction base="xsd:integer">
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="intRangeLeftLimit">
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="-100" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="intRangeRightLimit">
+    <xsd:restriction base="xsd:int">
+      <xsd:maxInclusive value="100" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="integerRangeLeftLimit">
+    <xsd:restriction base="xsd:integer">
+      <xsd:minInclusive value="-100" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="integerRangeRightLimit">
+    <xsd:restriction base="xsd:integer">
+      <xsd:maxInclusive value="100" />
     </xsd:restriction>
   </xsd:simpleType>
 </xsd:schema>

--- a/testdata/Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd
+++ b/testdata/Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd
@@ -18,16 +18,20 @@
         <xsd:element name="f5" type="numberRestrictionsFractional4" />
         <xsd:element name="f6" type="numberRestrictionsFractional5" />
         <xsd:element name="nonPrimitive" type="nestedStringRestrictions" />
-        <xsd:element name="intRangeLimits" type="intRangeLimits" />
+        <xsd:element name="intRangeWithoutLimits" type="intRangeWithoutLimits" />
+        <xsd:element name="intRangeWithLimits" type="intRangeWithLimits" />
         <xsd:element name="intRangeLeftLimit" type="intRangeLeftLimit" />
         <xsd:element name="intRangeRightLimit" type="intRangeRightLimit" />
-        <xsd:element name="integerRangeLimits" type="integerRangeLimits" />
+        <xsd:element name="integerRangeWithoutLimits" type="integerRangeWithoutLimits" />
+        <xsd:element name="integerRangeWithLimits" type="integerRangeWithLimits" />
         <xsd:element name="integerRangeLeftLimit" type="integerRangeLeftLimit" />
         <xsd:element name="integerRangeRightLimit" type="integerRangeRightLimit" />
-        <xsd:element name="longRangeLimits" type="longRangeLimits" />
+        <xsd:element name="longRangeWithoutLimits" type="longRangeWithoutLimits" />
+        <xsd:element name="longRangeWithLimits" type="longRangeWithLimits" />
         <xsd:element name="longRangeLeftLimit" type="longRangeLeftLimit" />
         <xsd:element name="longRangeRightLimit" type="longRangeRightLimit" />
-        <xsd:element name="decimalRangeLimits" type="decimalRangeLimits" />
+        <xsd:element name="decimalRangeWithoutLimits" type="decimalRangeWithoutLimits" />
+        <xsd:element name="decimalRangeWithLimits" type="decimalRangeWithLimits" />
         <xsd:element name="decimalRangeLeftLimit" type="decimalRangeLeftLimit" />
         <xsd:element name="decimalRangeRightLimit" type="decimalRangeRightLimit" />
       </xsd:sequence>
@@ -114,8 +118,14 @@
       <xsd:pattern value="[0-9]+"/>
     </xsd:restriction>
   </xsd:simpleType>
-  <xsd:simpleType name="intRangeLimits">
+  <xsd:simpleType name="intRangeWithoutLimits">
     <xsd:restriction base="xsd:int">
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="intRangeWithLimits">
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="-100" />
+      <xsd:maxInclusive value="100" />
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:simpleType name="intRangeLeftLimit">
@@ -128,8 +138,14 @@
       <xsd:maxInclusive value="100" />
     </xsd:restriction>
   </xsd:simpleType>
-  <xsd:simpleType name="integerRangeLimits">
+  <xsd:simpleType name="integerRangeWithoutLimits">
     <xsd:restriction base="xsd:integer">
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="integerRangeWithLimits">
+    <xsd:restriction base="xsd:integer">
+      <xsd:minInclusive value="-100" />
+      <xsd:maxInclusive value="100" />
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:simpleType name="integerRangeLeftLimit">
@@ -142,8 +158,14 @@
       <xsd:maxInclusive value="100" />
     </xsd:restriction>
   </xsd:simpleType>
-  <xsd:simpleType name="longRangeLimits">
+  <xsd:simpleType name="longRangeWithoutLimits">
     <xsd:restriction base="xsd:long">
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="longRangeWithLimits">
+    <xsd:restriction base="xsd:long">
+      <xsd:minInclusive value="-100" />
+      <xsd:maxInclusive value="100" />
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:simpleType name="longRangeLeftLimit">
@@ -156,8 +178,14 @@
       <xsd:maxInclusive value="100" />
     </xsd:restriction>
   </xsd:simpleType>
-  <xsd:simpleType name="decimalRangeLimits">
+  <xsd:simpleType name="decimalRangeWithoutLimits">
     <xsd:restriction base="xsd:decimal">
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="decimalRangeWithLimits">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="-100" />
+      <xsd:maxInclusive value="100.0" />
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:simpleType name="decimalRangeLeftLimit">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fixed Range attribute when only minimum or maximum is defined
- Enforce Double type for Range attribute for decimal types

## Related Issue(s)
- #10851

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
