### PR TITLE
Call addXsdFromRepo when fetching XSD datamodels

### DIFF
--- a/frontend/app-development/hooks/queries/useSchemaQuery.test.ts
+++ b/frontend/app-development/hooks/queries/useSchemaQuery.test.ts
@@ -1,0 +1,45 @@
+import { renderHookWithProviders } from '../../../packages/schema-editor/test/renderHookWithProviders';
+import { waitFor } from '@testing-library/react';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { useSchemaQuery } from './useSchemaQuery';
+
+// Test data:
+const jsonModelPathWithSlash = '/App/models/model.schema.json';
+const xsdModelPath = 'App/models/model.xsd';
+const xsdModelPathWithSlash = '/' + xsdModelPath;
+const getDatamodel = jest.fn().mockImplementation(() => Promise.resolve({}));
+const addXsdFromRepo = jest.fn().mockImplementation(() => Promise.resolve({}));
+const org = 'org';
+const app = 'app';
+
+describe('useDatamodelsMetadataQuery', () => {
+  afterEach(jest.clearAllMocks);
+
+  it('Calls getDatamodel with correct arguments when Json Schema', async () => {
+    const { result } = renderHookWithProviders({
+      queryClient: createQueryClientMock(),
+      servicesContextProps: {
+        getDatamodel,
+        addXsdFromRepo,
+      },
+    })(() => useSchemaQuery(jsonModelPathWithSlash));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getDatamodel).toHaveBeenCalledTimes(1);
+    expect(getDatamodel).toHaveBeenCalledWith(org, app, jsonModelPathWithSlash);
+    expect(addXsdFromRepo).not.toHaveBeenCalled();
+  });
+
+  it('Calls addXsdFromRepo with correct arguments when XSD', async () => {
+    const { result } = renderHookWithProviders({
+      queryClient: createQueryClientMock(),
+      servicesContextProps: {
+        getDatamodel,
+        addXsdFromRepo,
+      },
+    })(() => useSchemaQuery(xsdModelPathWithSlash));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(addXsdFromRepo).toHaveBeenCalledTimes(1);
+    expect(addXsdFromRepo).toHaveBeenCalledWith(org, app, xsdModelPath);
+    expect(getDatamodel).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app-development/hooks/queries/useSchemaQuery.ts
+++ b/frontend/app-development/hooks/queries/useSchemaQuery.ts
@@ -4,12 +4,18 @@ import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { useParams } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import { JsonSchema } from 'app-shared/types/JsonSchema';
+import { isXsdFile } from 'app-shared/utils/filenameUtils';
+import { removeStart } from 'app-shared/utils/stringUtils';
 
 export const useSchemaQuery = (modelPath: string): UseQueryResult<JsonSchema | null, AxiosError> => {
   const { org, app } = useParams<{ org: string; app: string }>();
-  const { getDatamodel } = useServicesContext();
+  const { getDatamodel, addXsdFromRepo } = useServicesContext();
   return useQuery<JsonSchema | null, AxiosError>(
     [QueryKey.JsonSchema, org, app, modelPath],
-    async () => getDatamodel(org, app, modelPath),
+    async () => (
+      isXsdFile(modelPath)
+        ? addXsdFromRepo(org, app, removeStart(modelPath, '/'))
+        : getDatamodel(org, app, modelPath)
+    ),
   );
 }

--- a/frontend/packages/shared/src/utils/filenameUtils.test.ts
+++ b/frontend/packages/shared/src/utils/filenameUtils.test.ts
@@ -1,4 +1,4 @@
-import { removeExtension, removeSchemaExtension } from 'app-shared/utils/filenameUtils';
+import { isXsdFile, removeExtension, removeSchemaExtension } from 'app-shared/utils/filenameUtils';
 
 describe('filenameUtils', () => {
   describe('removeExtension', () => {
@@ -27,6 +27,18 @@ describe('filenameUtils', () => {
 
     it('Returns entire input string if there is no .schema.json or .xsd extension', () => {
       expect(removeSchemaExtension('filename.xml')).toEqual('filename.xml');
+    });
+  });
+
+  describe('isXsdFile', () => {
+    it('Returns true if filename has an XSD extension', () => {
+      expect(isXsdFile('filename.xsd')).toBe(true);
+      expect(isXsdFile('filename.XSD')).toBe(true);
+    });
+
+    it('Returns false if filename does not have an XSD extension', () => {
+      expect(isXsdFile('filename.schema.json')).toBe(false);
+      expect(isXsdFile('filename')).toBe(false);
     });
   });
 });

--- a/frontend/packages/shared/src/utils/filenameUtils.ts
+++ b/frontend/packages/shared/src/utils/filenameUtils.ts
@@ -17,3 +17,10 @@ export const removeExtension = (filename: string): string => {
  */
 export const removeSchemaExtension = (filename: string): string =>
   removeEnd(filename, '.schema.json', '.xsd');
+
+/**
+ * Check if filename has an XSD extension.
+ * @param filename
+ * @returns true if filename has an XSD extension, otherwise false.
+ */
+export const isXsdFile = (filename: string): boolean => filename.toLowerCase().endsWith('.xsd');

--- a/frontend/packages/shared/src/utils/stringUtils.test.ts
+++ b/frontend/packages/shared/src/utils/stringUtils.test.ts
@@ -1,4 +1,10 @@
-import { removeEnd, replaceEnd, substringAfterLast, substringBeforeLast } from 'app-shared/utils/stringUtils';
+import {
+  removeEnd,
+  removeStart,
+  replaceEnd,
+  substringAfterLast,
+  substringBeforeLast
+} from 'app-shared/utils/stringUtils';
 
 describe('stringUtils', () => {
   describe('substringAfterLast', () => {
@@ -38,6 +44,26 @@ describe('stringUtils', () => {
       expect(replaceEnd('abcdefghi', 'abc', 'xyz')).toBe('abcdefghi');
       expect(replaceEnd('abcdefghi', 'def', 'xyz')).toBe('abcdefghi');
       expect(replaceEnd('abcdefghidef', 'def', 'xyz')).toBe('abcdefghixyz');
+    });
+  });
+
+  describe('removeStart', () => {
+    it('Removes any of the given substrings from the start of the string', () => {
+      expect(removeStart('abc/def/ghi', 'abc')).toBe('/def/ghi');
+      expect(removeStart('abc/def/ghi', 'abc', 'def')).toBe('/def/ghi');
+      expect(removeStart('abc/def/ghi', 'def', 'abc')).toBe('/def/ghi');
+    });
+
+    it('Does not change the string if none of the substrings appear at the start', () => {
+      expect(removeStart('abc/def/ghi', 'ghi')).toBe('abc/def/ghi');
+      expect(removeStart('abc/def/ghi', 'def')).toBe('abc/def/ghi');
+      expect(removeStart('abc/def/ghi', 'def', 'ghi')).toBe('abc/def/ghi');
+    });
+
+    it('Is not case sensitive', () => {
+      expect(removeStart('abc/def/ghi', 'ABC')).toBe('/def/ghi');
+      expect(removeStart('ABC/DEF/GHI', 'abc')).toBe('/DEF/GHI');
+      expect(removeStart('aBc/DeF/gHi', 'AbC')).toBe('/DeF/gHi');
     });
   });
 

--- a/frontend/packages/shared/src/utils/stringUtils.ts
+++ b/frontend/packages/shared/src/utils/stringUtils.ts
@@ -29,6 +29,22 @@ export const replaceEnd = (str: string, substring: string, replacement: string):
   str.replace(new RegExp(substring + '$'), replacement);
 
 /**
+ * Removes any of the given substrings from the start of the string.
+ * @param str The string to search in.
+ * @param substrings The substrings to search for.
+ * @returns The string with the substrings removed from the start.
+ */
+export const removeStart = (str: string, ...substrings: string[]): string => {
+  const lowerCaseStr = str.toLowerCase();
+  for (const substring of substrings) {
+    if (lowerCaseStr.startsWith(substring.toLowerCase())) {
+      return str.slice(substring.length);
+    }
+  }
+  return str;
+}
+
+/**
  * Removes any of the given substrings from the end of the string.
  * If none of the substrings appear at the end of the string, the string is returned unchanged.
  * Not case sensitive.


### PR DESCRIPTION
## Description
Added the `addXsdFromRepo` call, which was omitted when refactoring to React Query.

## Related Issue(s)
- #10978

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
