### PR TITLE
fix(BPMN): converted BPMN ext to JS instead of TS

### DIFF
--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedContextPadProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedContextPadProvider.js
@@ -3,7 +3,7 @@ class SupportedContextPadProvider {
     contextPad.registerProvider(this);
   }
 
-  public getContextPadEntries() {
+  getContextPadEntries() {
     return function (entries) {
       // Should not be able to replace the entry
       delete entries['replace'];
@@ -12,7 +12,9 @@ class SupportedContextPadProvider {
   }
 }
 
+SupportedContextPadProvider.$inject = ['contextPad'];
+
 export default {
-  init: ['supportedContextPadProvider'],
+  __init__: ['supportedContextPadProvider'],
   supportedContextPadProvider: ['type', SupportedContextPadProvider],
 };

--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
@@ -1,4 +1,4 @@
-const supportedEntries: string[] = [
+const supportedEntries = [
   'create.exclusive-gateway',
   'create.start-event',
   'create.end-event',
@@ -10,30 +10,32 @@ class SupportedPaletteProvider {
     palette.registerProvider(this);
   }
 
-  public getPaletteEntries() {
+  getPaletteEntries() {
     return (entries) => {
-      this.deleteUnsupportedEntries(entries);
+      this._deleteUnsupportedEntries(entries);
       return entries;
     };
   }
 
-  private deleteUnsupportedEntries(entries): void {
-    const entriesToDelete = this.getUnsupportedEntries(entries);
+  _deleteUnsupportedEntries(entries) {
+    const entriesToDelete = this._getUnsupportedEntries(entries);
     entriesToDelete.forEach((entry) => {
       delete entries[entry];
     });
   }
 
-  private getUnsupportedEntries(entries): string[] {
-    return Object.keys(entries).filter(this.isUnsupportedEntry);
+  _getUnsupportedEntries(entries) {
+    return Object.keys(entries).filter(this._isUnsupportedEntry);
   }
 
-  private isUnsupportedEntry(entry: string): boolean {
+  _isUnsupportedEntry(entry) {
     return !supportedEntries.includes(entry);
   }
 }
 
+SupportedPaletteProvider.$inject = ['palette'];
+
 export default {
-  init: ['supportedPaletteProvider'],
+  __init__: ['supportedPaletteProvider'],
   supportedPaletteProvider: ['type', SupportedPaletteProvider],
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The BPMN package is built using JS and not TS. They also depend on a _$inject_ (dependency-injection) on the class that TypeScript complains about. Can read more about it [here](https://forum.bpmn.io/t/can-someone-explain-the-inject-call/8307).

I have done some research and other TS-projects are also writing their BPMN-js ext using JS instead of TS, even if the rest of the app is written with TS. I think we should do the same thing to avoid other conflicts with the configurations within the BPMN-js package now and in the future.

## Related Issue(s)
- PR itself

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
