### PR TITLE
More Resourceadm Cypress tests

### DIFF
--- a/frontend/testing/cypress/src/integration/studio/resourceadm.js
+++ b/frontend/testing/cypress/src/integration/studio/resourceadm.js
@@ -3,7 +3,7 @@
 
 import * as texts from '@altinn-studio/language/src/nb.json';
 
-// First Cypress tests of sub-repo Resourceadm: this is a work in progress
+// Cypress tests of sub-repo Resourceadm: this is a work in progress
 
 context('Resourceadm', () => {
   before(() => {
@@ -41,4 +41,226 @@ context('Resourceadm', () => {
     cy.visit('/resourceadm/ttd/');
     cy.url().should('include', '/ttd/ttd-resources');
   });
+
+  it('is possible to create a new Resource', () => {
+    cy.findByRole('button', {
+      name: texts['resourceadm.dashboard_create_resource'],
+    }).click();
+
+    cy.findByRole('heading', {
+      name: texts['resourceadm.dashboard_create_resource'],
+    });
+
+    cy.get('#resourceNameInputId').type('cy-ny-ressurs1');
+
+    cy.findByRole('button', {
+      name: texts['resourceadm.dashboard_create_modal_create_button'],
+    }).click();
+
+    cy.url().should('include', '/about');
+
+    cy.findByRole('heading', {
+      name: texts['resourceadm.about_resource_title'],
+    });
+  });
+
+  it('is possible to visit Resource page via table edit button', () => {
+    // cy.switchSelectedContext('oneSingleRepoOrg'); // IN DEV: has SINGLE resource (unfortunately, also policy now)
+    // cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_edit']).click();
+
+    // At this point, after creating a resource in ttd,
+    // the resource should not have a policy
+    // cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_has_policy']); // IN DEV
+    // not necessary now that Docker Desktop kan delete resources in Volumes GUI
+
+    cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_missing_policy']);
+
+    cy.findByRole('table')
+      .findByRole('button', {
+        name: texts['resourceadm.dashboard_table_row_edit'],
+      })
+      .click(); // findByRole("button") will fail if there are multiple identical buttons present
+
+    cy.url().should('include', '/about');
+  });
+
+  it('is possible to return from Resource page via left nav button', () => {
+    // cy.switchSelectedContext('oneSingleRepoOrg'); // has SINGLE resource (unfortunately, also policy now)
+
+    cy.findByRole('table')
+      .findByRole('button', {
+        name: texts['resourceadm.dashboard_table_row_edit'],
+      })
+      .click(); // findByRole("button") will fail if there are multiple identical buttons present
+
+    cy.findByRole('button', {
+      name: texts['resourceadm.left_nav_bar_back'],
+    }).click();
+
+    cy.url().should('include', '/ttd/ttd-resources');
+  });
+
+  it('is possible to switch order of resources and check policy status', () => {
+    // We should by this point have a single resource, without policy:
+    // cy.switchSelectedContext('oneSingleRepoOrg'); // IN DEV: has SINGLE resource (unfortunately, also policy now)
+
+    cy.findByRole('button', {
+      name: texts['resourceadm.dashboard_table_header_last_changed'],
+    }).click();
+
+    cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_missing_policy']);
+    // cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_has_policy']); // IN DEV
+  });
+
+  it('is possible to visit Resource page and add a policy', () => {
+    // cy.switchSelectedContext('oneSingleRepoOrg'); // IN DEV: has SINGLE resource (unfortunately, also policy now)
+
+    cy.findByRole('table')
+      .findByRole('button', {
+        name: texts['resourceadm.dashboard_table_row_edit'],
+      })
+      .click(); // findByRole("button") will fail if there are multiple identical buttons in table
+
+    cy.findByRole('button', {
+      name: texts['resourceadm.left_nav_bar_policy'],
+    }).click();
+
+    cy.findByRole('heading', {
+      name: texts['resourceadm.resource_navigation_modal_title_resource'],
+    });
+
+    cy.findByRole('button', {
+      name: texts['resourceadm.resource_navigation_modal_button_move_on'],
+    }).click();
+
+    cy.url().should('include', '/policy');
+
+    cy.findByRole('heading', {
+      name: texts['resourceadm.policy_editor_title'],
+    });
+
+    cy.findByRole('button', {
+      name: texts['policy_editor.card_button_text'],
+    }).click();
+
+    cy.findByRole('button', {
+      name: texts['resourceadm.left_nav_bar_back'],
+    }).click();
+
+    cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_has_policy']);
+
+    cy.url().should('include', '/ttd/ttd-resources'); // IN PROD
+  });
+
+  it('is possible to visit Policy page and return to Resource page', () => {
+    // cy.switchSelectedContext('oneSingleRepoOrg'); // IN DEV: has SINGLE resource (unfortunately, also policy now)
+
+    cy.findByRole('table')
+      .findByRole('button', {
+        name: texts['resourceadm.dashboard_table_row_edit'],
+      })
+      .click(); // findByRole("button") will fail if there are multiple identical buttons in table
+
+    cy.findByRole('button', {
+      name: texts['resourceadm.left_nav_bar_policy'],
+    }).click();
+
+    cy.findByRole('heading', {
+      name: texts['resourceadm.resource_navigation_modal_title_resource'],
+    });
+
+    cy.findByRole('button', {
+      name: texts['resourceadm.resource_navigation_modal_button_move_on'],
+    }).click();
+
+    cy.url().should('include', '/policy');
+
+    cy.findByRole('button', {
+      name: texts['resourceadm.left_nav_bar_about'],
+    }).click();
+
+    cy.findByRole('heading', {
+      name: texts['resourceadm.resource_navigation_modal_title_policy'],
+    });
+
+    cy.findByRole('button', {
+      name: texts['resourceadm.resource_navigation_modal_button_move_on'],
+    }).click();
+
+    cy.url().should('include', '/about');
+  });
+
+  /*
+  it('is possible to visit Deploy page and return to Resource page', () => {
+    cy.switchSelectedContext('oneSingleRepoOrg'); // IN DEV: has SINGLE resource (unfortunately, also policy now)
+
+    // cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_edit']).click();
+
+    cy.findByRole('table')
+      .findByRole('button', {
+        name: texts['resourceadm.dashboard_table_row_edit'],
+      })
+      .click(); // findByRole("button") will fail if there are multiple identical buttons in table
+
+    cy.findByRole('button', {
+      name: texts['resourceadm.left_nav_bar_deploy'],
+    }).click();
+
+    cy.findByRole('heading', {
+      name: texts['resourceadm.resource_navigation_modal_title_resource'],
+    });
+
+    cy.findByRole('button', {
+      name: texts['resourceadm.resource_navigation_modal_button_move_on'],
+    }).click();
+
+    cy.url().should('include', '/deploy');
+
+    cy.findByRole('heading', {
+      name: texts['resourceadm.deploy_title'],
+    });
+
+    // RETURN to Resource Page
+    
+    cy.findByRole('button', { 
+      name: texts['resourceadm.left_nav_bar_about'],
+    }).click(); // interessant: her på Deploy page så virker dette ikke,
+    // fordi William har brukt button inni Alert-module varsel om feil på sidene
+    // med identisk språk-nøkkel (linker jo til samme side...) 
+
+    // Er vel flere måter å fikse dette på: Tomas vil ikke like data-cy tagger,
+    // men jeg kan kanskje gå inn i resourceadm språknøkler og lage
+    // egne språknøkler for Alert-module...
+    
+
+    cy.findByRole('button', { 
+      name: texts['resourceadm.left_nav_bar_policy'],
+    }).click(); // vil Policy knapp finnes? Nei, ikke den heller
+    
+
+    // OK RødBoksMedFiksFeil er en Alert-module,
+    // som inni der bruker <button class="Link-module"...> griseri
+    cy.findByRole('link', {
+      name: texts['resourceadm.left_nav_bar_about'],
+    }); //.click();
+
+    cy.findByRole('link', {
+      name: texts['resourceadm.left_nav_bar_policy'],
+    }); //.click();
+
+    // hva med Dashboard i VenstreNavMeny?
+    cy.findByRole('button', {
+      name: texts['resourceadm.left_nav_bar_back'],
+    }).click(); // den fungerer
+    // ---> da er det nok at det er lenker, med tekst
+    // <a>Om ressursen</a> og <a>Tilgangsregler</>
+    // som forstyrrer cy.findByRole... selv om den røde error-boksen
+    // kanskje ikke er "button"
+
+    // denne kode-blokken, selv om den finner knappen fra Policy-siden...
+    cy.get('button').contains('Om ressursen').click(); // trenger ikke Modal-skip her
+
+    cy.url().should('include', '/about');
+  });
+  */
 });

--- a/frontend/testing/cypress/src/integration/studio/resourceadm.js
+++ b/frontend/testing/cypress/src/integration/studio/resourceadm.js
@@ -46,221 +46,127 @@ context('Resourceadm', () => {
     cy.findByRole('button', {
       name: texts['resourceadm.dashboard_create_resource'],
     }).click();
-
     cy.findByRole('heading', {
       name: texts['resourceadm.dashboard_create_resource'],
     });
-
     cy.get('#resourceNameInputId').type('cy-ny-ressurs1');
-
     cy.findByRole('button', {
       name: texts['resourceadm.dashboard_create_modal_create_button'],
     }).click();
-
     cy.url().should('include', '/about');
-
     cy.findByRole('heading', {
       name: texts['resourceadm.about_resource_title'],
     });
   });
 
   it('is possible to visit Resource page via table edit button', () => {
-    // cy.switchSelectedContext('oneSingleRepoOrg'); // IN DEV: has SINGLE resource (unfortunately, also policy now)
-    // cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_edit']).click();
-
-    // At this point, after creating a resource in ttd,
-    // the resource should not have a policy
-    // cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_has_policy']); // IN DEV
-    // not necessary now that Docker Desktop kan delete resources in Volumes GUI
-
     cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_missing_policy']);
-
     cy.findByRole('table')
       .findByRole('button', {
         name: texts['resourceadm.dashboard_table_row_edit'],
       })
-      .click(); // findByRole("button") will fail if there are multiple identical buttons present
-
+      .click();
     cy.url().should('include', '/about');
   });
 
   it('is possible to return from Resource page via left nav button', () => {
-    // cy.switchSelectedContext('oneSingleRepoOrg'); // has SINGLE resource (unfortunately, also policy now)
-
     cy.findByRole('table')
       .findByRole('button', {
         name: texts['resourceadm.dashboard_table_row_edit'],
       })
-      .click(); // findByRole("button") will fail if there are multiple identical buttons present
-
+      .click();
     cy.findByRole('button', {
       name: texts['resourceadm.left_nav_bar_back'],
     }).click();
-
     cy.url().should('include', '/ttd/ttd-resources');
   });
 
   it('is possible to switch order of resources and check policy status', () => {
-    // We should by this point have a single resource, without policy:
-    // cy.switchSelectedContext('oneSingleRepoOrg'); // IN DEV: has SINGLE resource (unfortunately, also policy now)
-
     cy.findByRole('button', {
       name: texts['resourceadm.dashboard_table_header_last_changed'],
     }).click();
-
     cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_missing_policy']);
-    // cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_has_policy']); // IN DEV
   });
 
   it('is possible to visit Resource page and add a policy', () => {
-    // cy.switchSelectedContext('oneSingleRepoOrg'); // IN DEV: has SINGLE resource (unfortunately, also policy now)
-
     cy.findByRole('table')
       .findByRole('button', {
         name: texts['resourceadm.dashboard_table_row_edit'],
       })
-      .click(); // findByRole("button") will fail if there are multiple identical buttons in table
-
+      .click();
     cy.findByRole('button', {
       name: texts['resourceadm.left_nav_bar_policy'],
     }).click();
-
     cy.findByRole('heading', {
       name: texts['resourceadm.resource_navigation_modal_title_resource'],
     });
-
     cy.findByRole('button', {
       name: texts['resourceadm.resource_navigation_modal_button_move_on'],
     }).click();
-
     cy.url().should('include', '/policy');
-
     cy.findByRole('heading', {
       name: texts['resourceadm.policy_editor_title'],
     });
-
     cy.findByRole('button', {
       name: texts['policy_editor.card_button_text'],
     }).click();
-
     cy.findByRole('button', {
       name: texts['resourceadm.left_nav_bar_back'],
     }).click();
-
     cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_has_policy']);
-
-    cy.url().should('include', '/ttd/ttd-resources'); // IN PROD
+    cy.url().should('include', '/ttd/ttd-resources');
   });
 
   it('is possible to visit Policy page and return to Resource page', () => {
-    // cy.switchSelectedContext('oneSingleRepoOrg'); // IN DEV: has SINGLE resource (unfortunately, also policy now)
-
     cy.findByRole('table')
       .findByRole('button', {
         name: texts['resourceadm.dashboard_table_row_edit'],
       })
-      .click(); // findByRole("button") will fail if there are multiple identical buttons in table
-
+      .click();
     cy.findByRole('button', {
       name: texts['resourceadm.left_nav_bar_policy'],
     }).click();
-
     cy.findByRole('heading', {
       name: texts['resourceadm.resource_navigation_modal_title_resource'],
     });
-
     cy.findByRole('button', {
       name: texts['resourceadm.resource_navigation_modal_button_move_on'],
     }).click();
-
     cy.url().should('include', '/policy');
-
     cy.findByRole('button', {
       name: texts['resourceadm.left_nav_bar_about'],
     }).click();
-
     cy.findByRole('heading', {
       name: texts['resourceadm.resource_navigation_modal_title_policy'],
     });
-
     cy.findByRole('button', {
       name: texts['resourceadm.resource_navigation_modal_button_move_on'],
     }).click();
-
     cy.url().should('include', '/about');
   });
 
-  /*
   it('is possible to visit Deploy page and return to Resource page', () => {
-    cy.switchSelectedContext('oneSingleRepoOrg'); // IN DEV: has SINGLE resource (unfortunately, also policy now)
-
-    // cy.findByRole('table').contains(texts['resourceadm.dashboard_table_row_edit']).click();
-
     cy.findByRole('table')
       .findByRole('button', {
         name: texts['resourceadm.dashboard_table_row_edit'],
       })
-      .click(); // findByRole("button") will fail if there are multiple identical buttons in table
-
+      .click();
     cy.findByRole('button', {
       name: texts['resourceadm.left_nav_bar_deploy'],
     }).click();
-
     cy.findByRole('heading', {
       name: texts['resourceadm.resource_navigation_modal_title_resource'],
     });
-
     cy.findByRole('button', {
       name: texts['resourceadm.resource_navigation_modal_button_move_on'],
     }).click();
-
     cy.url().should('include', '/deploy');
-
     cy.findByRole('heading', {
       name: texts['resourceadm.deploy_title'],
     });
 
-    // RETURN to Resource Page
-    
-    cy.findByRole('button', { 
-      name: texts['resourceadm.left_nav_bar_about'],
-    }).click(); // interessant: her på Deploy page så virker dette ikke,
-    // fordi William har brukt button inni Alert-module varsel om feil på sidene
-    // med identisk språk-nøkkel (linker jo til samme side...) 
-
-    // Er vel flere måter å fikse dette på: Tomas vil ikke like data-cy tagger,
-    // men jeg kan kanskje gå inn i resourceadm språknøkler og lage
-    // egne språknøkler for Alert-module...
-    
-
-    cy.findByRole('button', { 
-      name: texts['resourceadm.left_nav_bar_policy'],
-    }).click(); // vil Policy knapp finnes? Nei, ikke den heller
-    
-
-    // OK RødBoksMedFiksFeil er en Alert-module,
-    // som inni der bruker <button class="Link-module"...> griseri
-    cy.findByRole('link', {
-      name: texts['resourceadm.left_nav_bar_about'],
-    }); //.click();
-
-    cy.findByRole('link', {
-      name: texts['resourceadm.left_nav_bar_policy'],
-    }); //.click();
-
-    // hva med Dashboard i VenstreNavMeny?
-    cy.findByRole('button', {
-      name: texts['resourceadm.left_nav_bar_back'],
-    }).click(); // den fungerer
-    // ---> da er det nok at det er lenker, med tekst
-    // <a>Om ressursen</a> og <a>Tilgangsregler</>
-    // som forstyrrer cy.findByRole... selv om den røde error-boksen
-    // kanskje ikke er "button"
-
-    // denne kode-blokken, selv om den finner knappen fra Policy-siden...
-    cy.get('button').contains('Om ressursen').click(); // trenger ikke Modal-skip her
-
+    // Note: cy.findByRole('button') will not work while Error-module is visible
+    cy.get('button').contains('Om ressursen').click();
     cy.url().should('include', '/about');
   });
-  */
 });


### PR DESCRIPTION
## Description
Another seven Cypress tests have been added to increase coverage of resourceadm sub-repo.

Note that the resourceadm app is not complete yet, thus the coverage by necessity is incomplete.

For example, the Migration page cannot be tested because there is yet a bug in the Resource page
validation etc.

This is a work in progress.


## Related Issue(s)
- #10912

## Verification
- [X ] **Your** code builds clean without any errors or warnings
- [X ] Manual testing done (required)
- [X ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

