### PR TITLE
Added color property to the right-submenu buttons

### DIFF
--- a/frontend/app-preview/src/components/AppBarConfig/AppPreviewBarConfig.tsx
+++ b/frontend/app-preview/src/components/AppBarConfig/AppPreviewBarConfig.tsx
@@ -100,13 +100,13 @@ export const SubPreviewMenuRightContent = () => {
   const { t } = useTranslation();
   return (
     <div className={classes.rightSubHeaderButtons}>
-      <Button icon={<ArrowCirclepathIcon />} variant='quiet' size='small'>
+      <Button icon={<ArrowCirclepathIcon />} variant='quiet' size='small' color="inverted">
         {t('preview.subheader.restart')}
       </Button>
-      <Button icon={<EyeIcon />} variant='quiet' size='small'>
+      <Button icon={<EyeIcon />} variant='quiet' size='small' color="inverted">
         {t('preview.subheader.showas')}
       </Button>
-      <Button icon={<LinkIcon />} variant='quiet' size='small'>
+      <Button icon={<LinkIcon />} variant='quiet' size='small' color="inverted">
         {t('preview.subheader.sharelink')}
       </Button>
     </div>

--- a/frontend/app-preview/src/components/AppPreviewSubMenu.module.css
+++ b/frontend/app-preview/src/components/AppPreviewSubMenu.module.css
@@ -62,10 +62,6 @@
   gap: 16px;
   justify-content: flex-end;
   flex: 3;
-  --component-button-quiet-primary-color-background-default: none;
-  --component-button-quiet-primary-color-border-default: none;
-  --component-button-quiet-primary-color-border-hover: #004e95;
-  --component-button-quiet-primary-color-text-default: #ffffff;
 }
 
 /* Overriding this style because it is hardcoded in the design system */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added color property to the right-submenu header (in app-preview )to get the white color. 
- Removed unused css 

## Related Issue(s)
- #11015 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
