### PR TITLE
Add debounced auto-save on data model

### DIFF
--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SchemaEditorWithToolbar.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SchemaEditorWithToolbar.tsx
@@ -33,13 +33,15 @@ export const SchemaEditorWithToolbar = ({
         setSelectedOption={setSelectedOption}
       />
       <main className={classes.main}>
-        {!datamodels.length && (
-          <LandingPagePanel
-            openCreateNew={() => setCreateNewOpen(true)}
+        {!datamodels.length && <LandingPagePanel openCreateNew={() => setCreateNewOpen(true)} />}
+        {modelPath && (
+          <SelectedSchemaEditor
+            datamodels={datamodels}
+            modelName={modelName}
+            modelPath={modelPath}
           />
         )}
-        {modelPath && <SelectedSchemaEditor modelName={modelName} modelPath={modelPath}/>}
       </main>
     </div>
   );
-}
+};

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.test.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.test.tsx
@@ -5,19 +5,21 @@ import { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
 import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import { textMock } from '../../../../testing/mocks/i18nMock';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { jsonMetadataMock } from 'app-shared/mocks/datamodelMetadataMocks';
 
 // Test data:
 const modelPath = 'testModelPath';
 const modelName = 'testModelName';
 const defaultProps: SelectedSchemaEditorProps = {
+  datamodels: [jsonMetadataMock],
   modelPath,
   modelName,
 };
 
 // Mocks:
 const schemaEditorTestId = 'schema-editor';
-jest.mock('@altinn/schema-editor/SchemaEditorApp', () => ({
-  SchemaEditorApp: () => <div data-testid={schemaEditorTestId} />,
+jest.mock('@altinn/schema-editor/components/SchemaEditor', () => ({
+  SchemaEditor: () => <div data-testid={schemaEditorTestId} />,
 }));
 
 describe('SelectedSchemaEditor', () => {
@@ -46,5 +48,10 @@ describe('SelectedSchemaEditor', () => {
 const render = (
   queries: Partial<ServicesContextProps> = {},
   queryClient = createQueryClientMock(),
-  props: Partial<SelectedSchemaEditorProps> = {},
-) => renderWithMockStore({}, queries, queryClient)(<SelectedSchemaEditor {...defaultProps} {...props} />);
+  props: Partial<SelectedSchemaEditorProps> = {}
+) =>
+  renderWithMockStore(
+    {},
+    queries,
+    queryClient
+  )(<SelectedSchemaEditor {...defaultProps} {...props} />);

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
@@ -14,7 +14,7 @@ export interface SelectedSchemaEditorProps {
 
 export const SelectedSchemaEditor = ({ modelPath, modelName }: SelectedSchemaEditorProps) => {
   const { data, status, error } = useSchemaQuery(modelPath);
-  const { mutate } = useSchemaMutation(modelPath);
+  const { mutate } = useSchemaMutation();
   const { t } = useTranslation();
 
   switch (status) {
@@ -33,6 +33,13 @@ export const SelectedSchemaEditor = ({ modelPath, modelName }: SelectedSchemaEdi
       );
 
     case 'success':
-      return <SchemaEditorApp jsonSchema={data} save={mutate} modelName={modelName} />;
+      return (
+        <SchemaEditorApp
+          jsonSchema={data}
+          save={mutate}
+          modelName={modelName}
+          modelPath={modelPath}
+        />
+      );
   }
-}
+};

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
@@ -7,6 +7,7 @@ import { Alert, ErrorMessage, Paragraph } from '@digdir/design-system-react';
 import { SchemaEditorApp } from '@altinn/schema-editor/SchemaEditorApp';
 import { useTranslation } from 'react-i18next';
 import { DatamodelMetadata } from 'app-shared/types/DatamodelMetadata';
+import { SchemaEditor } from '@altinn/schema-editor/components/SchemaEditor';
 
 export interface SelectedSchemaEditorProps {
   datamodels: DatamodelMetadata[];
@@ -23,30 +24,30 @@ export const SelectedSchemaEditor = ({
   const { mutate } = useSchemaMutation();
   const { t } = useTranslation();
 
-  switch (status) {
-    case 'loading':
-      return <PageSpinner />;
+  const render = () => {
+    switch (status) {
+      case 'loading':
+        return <PageSpinner />;
 
-    case 'error':
-      return (
-        <Center>
-          <Alert severity='danger'>
-            <Paragraph>{t('general.fetch_error_message')}</Paragraph>
-            <Paragraph>{t('general.error_message_with_colon')}</Paragraph>
-            <ErrorMessage>{error.message}</ErrorMessage>
-          </Alert>
-        </Center>
-      );
+      case 'error':
+        return (
+          <Center>
+            <Alert severity='danger'>
+              <Paragraph>{t('general.fetch_error_message')}</Paragraph>
+              <Paragraph>{t('general.error_message_with_colon')}</Paragraph>
+              <ErrorMessage>{error.message}</ErrorMessage>
+            </Alert>
+          </Center>
+        );
 
-    case 'success':
-      return (
-        <SchemaEditorApp
-          datamodels={datamodels}
-          jsonSchema={data}
-          save={mutate}
-          modelName={modelName}
-          modelPath={modelPath}
-        />
-      );
-  }
+      case 'success':
+        return <SchemaEditor modelName={modelName} />;
+    }
+  };
+
+  return (
+    <SchemaEditorApp datamodels={datamodels} jsonSchema={data} save={mutate} modelPath={modelPath}>
+      {render()}
+    </SchemaEditorApp>
+  );
 };

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
@@ -6,13 +6,19 @@ import { Center } from 'app-shared/components/Center';
 import { Alert, ErrorMessage, Paragraph } from '@digdir/design-system-react';
 import { SchemaEditorApp } from '@altinn/schema-editor/SchemaEditorApp';
 import { useTranslation } from 'react-i18next';
+import { DatamodelMetadata } from 'app-shared/types/DatamodelMetadata';
 
 export interface SelectedSchemaEditorProps {
+  datamodels: DatamodelMetadata[];
   modelPath: string;
   modelName: string;
 }
 
-export const SelectedSchemaEditor = ({ modelPath, modelName }: SelectedSchemaEditorProps) => {
+export const SelectedSchemaEditor = ({
+  datamodels,
+  modelPath,
+  modelName,
+}: SelectedSchemaEditorProps) => {
   const { data, status, error } = useSchemaQuery(modelPath);
   const { mutate } = useSchemaMutation();
   const { t } = useTranslation();
@@ -35,6 +41,7 @@ export const SelectedSchemaEditor = ({ modelPath, modelName }: SelectedSchemaEdi
     case 'success':
       return (
         <SchemaEditorApp
+          datamodels={datamodels}
           jsonSchema={data}
           save={mutate}
           modelName={modelName}

--- a/frontend/app-development/hooks/mutations/useSchemaMutation.test.ts
+++ b/frontend/app-development/hooks/mutations/useSchemaMutation.test.ts
@@ -15,8 +15,10 @@ const app = 'app';
 describe('useSchemaMutation', () => {
   it('Returns correct state and calls saveDatamodel with the correct parameters', async () => {
     const saveDatamodel = jest.fn();
-    const { renderHookResult: { result } } = render({ saveDatamodel });
-    result.current.mutate(jsonSchemaMock);
+    const {
+      renderHookResult: { result },
+    } = render({ saveDatamodel });
+    result.current.mutate({ modelPath, model: jsonSchemaMock });
     await waitFor(() => result.current.isLoading);
     expect(saveDatamodel).toHaveBeenCalledTimes(1);
     expect(saveDatamodel).toHaveBeenCalledWith(org, app, modelPath, jsonSchemaMock);
@@ -25,14 +27,18 @@ describe('useSchemaMutation', () => {
 
   it('Updates the JsonSchema query cache', async () => {
     const queryClient = createQueryClientMock();
-    const { renderHookResult: { result } } = render({}, queryClient);
-    result.current.mutate(jsonSchemaMock);
+    const {
+      renderHookResult: { result },
+    } = render({}, queryClient);
+    result.current.mutate({ modelPath, model: jsonSchemaMock });
     await waitFor(() => result.current.isSuccess);
-    expect(queryClient.getQueryData([QueryKey.JsonSchema, org, app, modelPath])).toEqual(jsonSchemaMock);
+    expect(queryClient.getQueryData([QueryKey.JsonSchema, org, app, modelPath])).toEqual(
+      jsonSchemaMock
+    );
   });
 });
 
 const render = (
   queries: Partial<ServicesContextProps> = {},
-  queryClient: QueryClient = createQueryClientMock(),
-) => renderHookWithMockStore({}, queries, queryClient)(() => useSchemaMutation(modelPath));
+  queryClient: QueryClient = createQueryClientMock()
+) => renderHookWithMockStore({}, queries, queryClient)(() => useSchemaMutation());

--- a/frontend/app-development/hooks/mutations/useSchemaMutation.ts
+++ b/frontend/app-development/hooks/mutations/useSchemaMutation.ts
@@ -4,17 +4,15 @@ import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { JsonSchema } from 'app-shared/types/JsonSchema';
 import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
 
-export const useSchemaMutation = (modelPath: string) => {
+export const useSchemaMutation = () => {
   const queryClient = useQueryClient();
   const { org, app } = useStudioUrlParams();
   const { saveDatamodel } = useServicesContext();
   return useMutation({
-    mutationFn: async (payload: JsonSchema) => {
-      await saveDatamodel(org, app, modelPath, payload);
-      queryClient.setQueryData(
-        [QueryKey.JsonSchema, org, app, modelPath],
-        () => payload
-      );
+    mutationFn: async (args: { modelPath: string; schema: JsonSchema }) => {
+      const { modelPath, schema } = args;
+      await saveDatamodel(org, app, modelPath, schema);
+      queryClient.setQueryData([QueryKey.JsonSchema, org, app, modelPath], () => schema);
     },
   });
-}
+};

--- a/frontend/app-development/hooks/mutations/useSchemaMutation.ts
+++ b/frontend/app-development/hooks/mutations/useSchemaMutation.ts
@@ -9,10 +9,10 @@ export const useSchemaMutation = () => {
   const { org, app } = useStudioUrlParams();
   const { saveDatamodel } = useServicesContext();
   return useMutation({
-    mutationFn: async (args: { modelPath: string; schema: JsonSchema }) => {
-      const { modelPath, schema } = args;
-      await saveDatamodel(org, app, modelPath, schema);
-      queryClient.setQueryData([QueryKey.JsonSchema, org, app, modelPath], () => schema);
+    mutationFn: async (args: { modelPath: string; model: JsonSchema }) => {
+      const { modelPath, model } = args;
+      await saveDatamodel(org, app, modelPath, model);
+      queryClient.setQueryData([QueryKey.JsonSchema, org, app, modelPath], () => model);
     },
   });
 };

--- a/frontend/packages/schema-editor/src/SchemaEditorApp.test.tsx
+++ b/frontend/packages/schema-editor/src/SchemaEditorApp.test.tsx
@@ -1,35 +1,34 @@
 import React from 'react';
 import { render as rtlRender, screen } from '@testing-library/react';
 import { SchemaEditorApp } from './SchemaEditorApp';
-import { PreviewConnectionContextProvider } from "app-shared/providers/PreviewConnectionContext";
+import { PreviewConnectionContextProvider } from 'app-shared/providers/PreviewConnectionContext';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { dataMock } from '@altinn/schema-editor/mockData';
+import { DatamodelMetadata } from 'app-shared/types/DatamodelMetadata';
+import { jsonMetadataMock } from 'app-shared/mocks/datamodelMetadataMocks';
 
 // Mocks:
-const schemaEditorTestId = 'schema-editor';
-jest.mock('./components/SchemaEditor', () => ({
-  SchemaEditor: () => <div data-testid={schemaEditorTestId}/>,
-}));
+const schemaEditorAppTestId = 'schema-editor';
 
 export const render = () => {
   const getDatamodel = jest.fn().mockImplementation(() => Promise.resolve(dataMock));
+  const datamodels: DatamodelMetadata[] = [jsonMetadataMock];
   rtlRender(
-    <ServicesContextProvider
-      {...{ ...queriesMock, getDatamodel }}
-      client={createQueryClientMock()}
-    >
+    <ServicesContextProvider {...{ ...queriesMock, getDatamodel }} client={createQueryClientMock()}>
       <PreviewConnectionContextProvider>
-        <SchemaEditorApp jsonSchema={dataMock} save={jest.fn()}/>
+        <SchemaEditorApp datamodels={datamodels} jsonSchema={dataMock} save={jest.fn()}>
+          <div data-testid={schemaEditorAppTestId}></div>
+        </SchemaEditorApp>
       </PreviewConnectionContextProvider>
     </ServicesContextProvider>
   );
 };
 
 describe('SchemaEditorApp', () => {
-  it('Renders schema editor', async () => {
+  it('Renders children', async () => {
     render();
-    expect(screen.getByTestId(schemaEditorTestId)).toBeInTheDocument();
+    expect(screen.getByTestId(schemaEditorAppTestId)).toBeInTheDocument();
   });
 });

--- a/frontend/packages/schema-editor/src/SchemaEditorApp.tsx
+++ b/frontend/packages/schema-editor/src/SchemaEditorApp.tsx
@@ -11,7 +11,7 @@ import { AUTOSAVE_DEBOUNCE_INTERVAL } from 'app-shared/constants';
 import { DatamodelMetadata } from 'app-shared/types/DatamodelMetadata';
 
 export type SchemaEditorAppProps = {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   datamodels: DatamodelMetadata[];
   modelPath?: string;
   jsonSchema: JsonSchema;

--- a/frontend/packages/schema-editor/src/SchemaEditorApp.tsx
+++ b/frontend/packages/schema-editor/src/SchemaEditorApp.tsx
@@ -9,15 +9,23 @@ import { SchemaEditorAppContext } from '@altinn/schema-editor/contexts/SchemaEdi
 import { JsonSchema } from 'app-shared/types/JsonSchema';
 import { buildJsonSchema, buildUiSchema, UiSchemaNodes } from '@altinn/schema-model';
 import { AUTOSAVE_DEBOUNCE_INTERVAL } from 'app-shared/constants';
+import { DatamodelMetadata } from 'app-shared/types/DatamodelMetadata';
 
 export type SchemaEditorAppProps = {
+  datamodels: DatamodelMetadata[];
   modelPath?: string;
   modelName?: string;
   jsonSchema: JsonSchema;
   save: (args: { modelPath: string; model: JsonSchema }) => void;
 };
 
-export function SchemaEditorApp({ modelPath, modelName, jsonSchema, save }: SchemaEditorAppProps) {
+export function SchemaEditorApp({
+  datamodels,
+  modelPath,
+  modelName,
+  jsonSchema,
+  save,
+}: SchemaEditorAppProps) {
   const autoSaveTimeoutRef = useRef(undefined);
   const [model, setModel] = useState(() => buildUiSchema(jsonSchema));
   const prevModelPathRef = useRef(modelPath);
@@ -40,6 +48,11 @@ export function SchemaEditorApp({ modelPath, modelName, jsonSchema, save }: Sche
     const autoSaveOnModelChange = async () => {
       if (prevModelPathRef.current === modelPath) return;
 
+      const isExistingModel = datamodels.some(
+        (item) => item.repositoryRelativeUrl === prevModelPathRef.current
+      );
+      if (!isExistingModel) return;
+
       clearTimeout(autoSaveTimeoutRef.current);
       save({ modelPath: prevModelPathRef.current, model: buildJsonSchema(prevModelRef.current) });
 
@@ -47,7 +60,7 @@ export function SchemaEditorApp({ modelPath, modelName, jsonSchema, save }: Sche
     };
 
     autoSaveOnModelChange();
-  }, [modelPath, save]);
+  }, [datamodels, modelPath, save]);
 
   useEffect(() => {
     const newModel = buildUiSchema(jsonSchema);

--- a/frontend/packages/schema-editor/src/SchemaEditorApp.tsx
+++ b/frontend/packages/schema-editor/src/SchemaEditorApp.tsx
@@ -14,7 +14,7 @@ export type SchemaEditorAppProps = {
   modelPath?: string;
   modelName?: string;
   jsonSchema: JsonSchema;
-  save: (args: { modelPath: string; schema: JsonSchema }) => void;
+  save: (args: { modelPath: string; model: JsonSchema }) => void;
 };
 
 export function SchemaEditorApp({ modelPath, modelName, jsonSchema, save }: SchemaEditorAppProps) {
@@ -30,7 +30,7 @@ export function SchemaEditorApp({ modelPath, modelName, jsonSchema, save }: Sche
       clearTimeout(autoSaveTimeoutRef.current);
       autoSaveTimeoutRef.current = setTimeout(async () => {
         clearTimeout(autoSaveTimeoutRef.current);
-        save({ modelPath, schema: buildJsonSchema(newModel) });
+        save({ modelPath, model: buildJsonSchema(newModel) });
       }, saveAfterMs);
     },
     [modelPath, save]
@@ -41,7 +41,7 @@ export function SchemaEditorApp({ modelPath, modelName, jsonSchema, save }: Sche
       if (prevModelPathRef.current === modelPath) return;
 
       clearTimeout(autoSaveTimeoutRef.current);
-      save({ modelPath: prevModelPathRef.current, schema: buildJsonSchema(prevModelRef.current) });
+      save({ modelPath: prevModelPathRef.current, model: buildJsonSchema(prevModelRef.current) });
 
       prevModelPathRef.current = modelPath;
     };

--- a/frontend/packages/schema-editor/src/contexts/SchemaEditorAppContext.ts
+++ b/frontend/packages/schema-editor/src/contexts/SchemaEditorAppContext.ts
@@ -3,7 +3,7 @@ import { UiSchemaNodes } from '@altinn/schema-model';
 
 export interface SchemaEditorAppContextProps {
   data: UiSchemaNodes;
-  save: (datamodel: UiSchemaNodes) => void;
+  save: (datamodel: UiSchemaNodes, saveAfterMs?: number) => void;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added debounce for saving data
- Added a new temporary state to update inputs immediately, without waiting for data from react-query cache
- Auto-saved data when model changes. I used SchemaEditorApp as a wrapper for all render of SelectedSchemaEditor to keep it mounted when useSchemaQuery status changes

## Related Issue(s)
- #10627 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
