### PR TITLE
feat(webpack): enable source-map for production-build

### DIFF
--- a/frontend/webpack.config.prod.js
+++ b/frontend/webpack.config.prod.js
@@ -4,7 +4,7 @@ const commonConfig = require('./webpack.common');
 module.exports = {
   ...commonConfig,
   mode: 'production',
-  devtool: false,
+  devtool: 'source-map',
   performance: {
     hints: false,
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We have activated the source-map feature for our production build. The mapping information is now stored in a file named "package-name.js.map." This file serves as a valuable tool for mapping minified production code back to the source file and specific lines within our code base. We will be using this source-map in Application Insights to make it easier to find  the file and line where the expectation occurs.
 
## Related Issue(s)
The PR itself

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
