### PR TITLE
Changed PublishResource from GET to POST

### DIFF
--- a/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -318,7 +318,7 @@ namespace Altinn.Studio.Designer.Controllers
             return details;
         }
 
-        [HttpGet]
+        [HttpPost]
         [Route("designer/api/{org}/resources/publish/{repository}/{id}")]
         public async Task<ActionResult> PublishResource(string org, string repository, string id, string env)
         {

--- a/backend/src/Designer/Services/Implementation/ResourceRegistryService.cs
+++ b/backend/src/Designer/Services/Implementation/ResourceRegistryService.cs
@@ -131,7 +131,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             {
                 string putRequest = $"{publishResourceToResourceRegistryUrl}/{serviceResource.Identifier}";
                 HttpResponseMessage putResponse = await _httpClient.PutAsync(putRequest, new StringContent(serviceResourceString, Encoding.UTF8, "application/json"));
-                return putResponse.IsSuccessStatusCode ? new StatusCodeResult(200) : new StatusCodeResult(400);
+                return putResponse.IsSuccessStatusCode ? new StatusCodeResult(201) : new StatusCodeResult(400);
             }
 
             HttpResponseMessage response = await _httpClient.PostAsync(publishResourceToResourceRegistryUrl, new StringContent(serviceResourceString, Encoding.UTF8, "application/json"));


### PR DESCRIPTION
## Description
Changed PublishResource-endpoint from GET to POST and changed the response to 201 Created when the method uses PUT towards the ResourceRegistry.

## Related Issue(s)
- #11108 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
