### PR TITLE
Feature/11043 adding left navigation bar to settings modal

### DIFF
--- a/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.module.css
+++ b/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.module.css
@@ -1,6 +1,7 @@
 .modalContent {
   display: flex;
   min-width: 500px;
+  max-height: calc(var(--modal-content-max-height));
 }
 
 .leftNavWrapper {
@@ -16,6 +17,7 @@
 
 .tabWrapper {
   flex-grow: 1;
+  overflow-y: auto;
 }
 
 .headingWrapper {

--- a/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.module.css
+++ b/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.module.css
@@ -1,6 +1,6 @@
 .modalContent {
   display: flex;
-  min-width: 500px;
+  min-width: 700px;
   max-height: calc(var(--modal-content-max-height));
 }
 
@@ -18,6 +18,7 @@
 .tabWrapper {
   flex-grow: 1;
   overflow-y: auto;
+  padding-left: 10px;
 }
 
 .headingWrapper {

--- a/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.module.css
+++ b/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.module.css
@@ -1,3 +1,23 @@
+.modalContent {
+  display: flex;
+  min-width: 500px;
+}
+
+.leftNavWrapper {
+  height: auto;
+  top: 0;
+  position: sticky;
+}
+
+.leftNavigationBar {
+  min-height: 200px;
+  border-bottom-left-radius: 20px;
+}
+
+.tabWrapper {
+  flex-grow: 1;
+}
+
 .headingWrapper {
   display: flex;
   align-items: center;

--- a/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.tsx
+++ b/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.tsx
@@ -7,35 +7,14 @@ import { Modal } from 'app-shared/components/Modal';
 import { LeftNavigationTab } from 'app-shared/types/LeftNavigationTab';
 import { LeftNavigationBar } from 'app-shared/components/LeftNavigationBar';
 import { SettingsModalTab } from 'app-development/types/SettingsModalTab';
-
-const getIsActiveTab = (currentTab: SettingsModalTab, tabId: SettingsModalTab) => {
-  return currentTab === tabId;
-};
-
-const createNavigationTab = (
-  icon: ReactNode,
-  tabId: SettingsModalTab,
-  onClick: () => void,
-  currentTab: SettingsModalTab
-): LeftNavigationTab => {
-  return {
-    icon,
-    tabName: `settings_modal.left_nav_tab_${tabId}`,
-    tabId,
-    action: {
-      type: 'button',
-      onClick,
-    },
-    isActiveTab: getIsActiveTab(currentTab, tabId),
-  };
-};
+import { createNavigationTab } from './utils';
 
 /**
  * Displays the settings modal.
  *
- * @returns {React.ReactNode}
+ * @returns {ReactNode}
  */
-export const SettingsModal = (): React.ReactNode => {
+export const SettingsModal = (): ReactNode => {
   const { t } = useTranslation();
 
   const [isOpen, setIsOpen] = useState(true);
@@ -59,6 +38,10 @@ export const SettingsModal = (): React.ReactNode => {
     ),
   ];
 
+  /**
+   * Changes the active tab
+   * @param tabId
+   */
   const changeTabTo = (tabId: SettingsModalTab) => {
     setCurrentTab(tabId);
   };

--- a/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.tsx
+++ b/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.tsx
@@ -6,8 +6,7 @@ import { CogIcon, InformationSquareIcon, ShieldLockIcon } from '@navikt/aksel-ic
 import { Modal } from 'app-shared/components/Modal';
 import { LeftNavigationTab } from 'app-shared/types/LeftNavigationTab';
 import { LeftNavigationBar } from 'app-shared/components/LeftNavigationBar';
-
-type SettingsModalTab = 'about' | 'policy';
+import { SettingsModalTab } from 'app-development/types/SettingsModalTab';
 
 const getIsActiveTab = (currentTab: SettingsModalTab, tabId: SettingsModalTab) => {
   return currentTab === tabId;
@@ -85,32 +84,6 @@ export const SettingsModal = (): React.ReactNode => {
             <LeftNavigationBar tabs={leftNavigationTabs} className={classes.leftNavigationBar} />
           </div>
           <div className={classes.tabWrapper}>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
-            <p> {currentTab}</p>
             <p> {currentTab}</p>
           </div>
         </div>

--- a/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.tsx
+++ b/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.tsx
@@ -84,7 +84,35 @@ export const SettingsModal = (): React.ReactNode => {
           <div className={classes.leftNavWrapper}>
             <LeftNavigationBar tabs={leftNavigationTabs} className={classes.leftNavigationBar} />
           </div>
-          <div className={classes.tabWrapper}>{currentTab}</div>
+          <div className={classes.tabWrapper}>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+            <p> {currentTab}</p>
+          </div>
         </div>
       </Modal>
     </>

--- a/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.tsx
+++ b/frontend/app-development/features/policyEditor/SettingsModal/SettingsModal.tsx
@@ -1,9 +1,35 @@
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import classes from './SettingsModal.module.css';
 import { Button, Heading } from '@digdir/design-system-react';
 import { useTranslation } from 'react-i18next';
-import { CogIcon } from '@navikt/aksel-icons';
+import { CogIcon, InformationSquareIcon, ShieldLockIcon } from '@navikt/aksel-icons';
 import { Modal } from 'app-shared/components/Modal';
+import { LeftNavigationTab } from 'app-shared/types/LeftNavigationTab';
+import { LeftNavigationBar } from 'app-shared/components/LeftNavigationBar';
+
+type SettingsModalTab = 'about' | 'policy';
+
+const getIsActiveTab = (currentTab: SettingsModalTab, tabId: SettingsModalTab) => {
+  return currentTab === tabId;
+};
+
+const createNavigationTab = (
+  icon: ReactNode,
+  tabId: SettingsModalTab,
+  onClick: () => void,
+  currentTab: SettingsModalTab
+): LeftNavigationTab => {
+  return {
+    icon,
+    tabName: `settings_modal.left_nav_tab_${tabId}`,
+    tabId,
+    action: {
+      type: 'button',
+      onClick,
+    },
+    isActiveTab: getIsActiveTab(currentTab, tabId),
+  };
+};
 
 /**
  * Displays the settings modal.
@@ -13,7 +39,30 @@ import { Modal } from 'app-shared/components/Modal';
 export const SettingsModal = (): React.ReactNode => {
   const { t } = useTranslation();
 
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
+  const [currentTab, setCurrentTab] = useState<SettingsModalTab>('about');
+
+  const aboutTabId: SettingsModalTab = 'about';
+  const policyTabId: SettingsModalTab = 'policy';
+
+  const leftNavigationTabs: LeftNavigationTab[] = [
+    createNavigationTab(
+      <InformationSquareIcon className={classes.icon} />,
+      aboutTabId,
+      () => changeTabTo(aboutTabId),
+      currentTab
+    ),
+    createNavigationTab(
+      <ShieldLockIcon className={classes.icon} />,
+      policyTabId,
+      () => changeTabTo(policyTabId),
+      currentTab
+    ),
+  ];
+
+  const changeTabTo = (tabId: SettingsModalTab) => {
+    setCurrentTab(tabId);
+  };
 
   return (
     <>
@@ -31,7 +80,12 @@ export const SettingsModal = (): React.ReactNode => {
           </div>
         }
       >
-        <div>TODO</div>
+        <div className={classes.modalContent}>
+          <div className={classes.leftNavWrapper}>
+            <LeftNavigationBar tabs={leftNavigationTabs} className={classes.leftNavigationBar} />
+          </div>
+          <div className={classes.tabWrapper}>{currentTab}</div>
+        </div>
       </Modal>
     </>
   );

--- a/frontend/app-development/features/policyEditor/SettingsModal/utils/index.ts
+++ b/frontend/app-development/features/policyEditor/SettingsModal/utils/index.ts
@@ -1,0 +1,1 @@
+export { getIsActiveTab, createNavigationTab } from './settingsModalUtils';

--- a/frontend/app-development/features/policyEditor/SettingsModal/utils/index.ts
+++ b/frontend/app-development/features/policyEditor/SettingsModal/utils/index.ts
@@ -1,1 +1,1 @@
-export { getIsActiveTab, createNavigationTab } from './settingsModalUtils';
+export { createNavigationTab } from './settingsModalUtils';

--- a/frontend/app-development/features/policyEditor/SettingsModal/utils/settingsModalUtils.test.tsx
+++ b/frontend/app-development/features/policyEditor/SettingsModal/utils/settingsModalUtils.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SettingsModalTab } from 'app-development/types/SettingsModalTab';
-import { getIsActiveTab, createNavigationTab } from './index';
+import { createNavigationTab } from './index';
 import { TestFlaskIcon } from '@navikt/aksel-icons';
 import { LeftNavigationTab } from 'app-shared/types/LeftNavigationTab';
 
@@ -9,18 +9,6 @@ const mockTabId2: SettingsModalTab = 'policy';
 const mockCurrentTab: SettingsModalTab = mockTabId1;
 
 describe('settingsModalUtils', () => {
-  describe('getIsActiveTab', () => {
-    it('returns true if the currentTab matches the tabId', () => {
-      const isActive = getIsActiveTab(mockCurrentTab, mockTabId1);
-      expect(isActive).toBe(true);
-    });
-
-    it('returns false if the currentTab does not match the tabId', () => {
-      const isActive = getIsActiveTab(mockCurrentTab, mockTabId2);
-      expect(isActive).toBe(false);
-    });
-  });
-
   describe('createNavigationTab', () => {
     const mockIcon = <TestFlaskIcon />;
     const mockOnClick = jest.fn();

--- a/frontend/app-development/features/policyEditor/SettingsModal/utils/settingsModalUtils.test.tsx
+++ b/frontend/app-development/features/policyEditor/SettingsModal/utils/settingsModalUtils.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { SettingsModalTab } from 'app-development/types/SettingsModalTab';
+import { getIsActiveTab, createNavigationTab } from './index';
+import { TestFlaskIcon } from '@navikt/aksel-icons';
+import { LeftNavigationTab } from 'app-shared/types/LeftNavigationTab';
+
+const mockTabId1: SettingsModalTab = 'about';
+const mockTabId2: SettingsModalTab = 'policy';
+const mockCurrentTab: SettingsModalTab = mockTabId1;
+
+describe('settingsModalUtils', () => {
+  describe('getIsActiveTab', () => {
+    it('returns true if the currentTab matches the tabId', () => {
+      const isActive = getIsActiveTab(mockCurrentTab, mockTabId1);
+      expect(isActive).toBe(true);
+    });
+
+    it('returns false if the currentTab does not match the tabId', () => {
+      const isActive = getIsActiveTab(mockCurrentTab, mockTabId2);
+      expect(isActive).toBe(false);
+    });
+  });
+
+  describe('createNavigationTab', () => {
+    const mockIcon = <TestFlaskIcon />;
+    const mockOnClick = jest.fn();
+
+    it('creates a LeftNavigationTab with the provided parameters', () => {
+      const navigationTab: LeftNavigationTab = createNavigationTab(
+        mockIcon,
+        mockTabId1,
+        mockOnClick,
+        mockCurrentTab
+      );
+
+      expect(navigationTab.icon).toEqual(mockIcon);
+      expect(navigationTab.tabName).toEqual(`settings_modal.left_nav_tab_${mockTabId1}`);
+      expect(navigationTab.tabId).toEqual(mockTabId1);
+      expect(navigationTab.action.type).toEqual('button');
+      expect(navigationTab.action.onClick).toEqual(mockOnClick);
+      expect(navigationTab.isActiveTab).toEqual(true);
+    });
+
+    it('creates a LeftNavigationTab with isActiveTab set to false when currentTab does not match tabId', () => {
+      const navigationTab: LeftNavigationTab = createNavigationTab(
+        mockIcon,
+        mockTabId2,
+        mockOnClick,
+        mockCurrentTab
+      );
+
+      expect(navigationTab.isActiveTab).toEqual(false);
+    });
+  });
+});

--- a/frontend/app-development/features/policyEditor/SettingsModal/utils/settingsModalUtils.ts
+++ b/frontend/app-development/features/policyEditor/SettingsModal/utils/settingsModalUtils.ts
@@ -1,0 +1,43 @@
+import { SettingsModalTab } from 'app-development/types/SettingsModalTab';
+import { LeftNavigationTab } from 'app-shared/types/LeftNavigationTab';
+import { ReactNode } from 'react';
+
+/**
+ * Function that gets if a tab is active or not
+ *
+ * @param currentTab the currently selected tab
+ * @param tabId the id of the tab to check
+ *
+ * @returns boolean for if it is active or not
+ */
+export const getIsActiveTab = (currentTab: SettingsModalTab, tabId: SettingsModalTab) => {
+  return currentTab === tabId;
+};
+
+/**
+ * Creates a new Navigation tab of the LeftNavigationTab type
+ *
+ * @param icon icon to display in the tab
+ * @param tabId the id of the tab
+ * @param onClick function to execute on click of the tab
+ * @param currentTab the current tab
+ *
+ * @returns a LeftNavigationTab
+ */
+export const createNavigationTab = (
+  icon: ReactNode,
+  tabId: SettingsModalTab,
+  onClick: () => void,
+  currentTab: SettingsModalTab
+): LeftNavigationTab => {
+  return {
+    icon,
+    tabName: `settings_modal.left_nav_tab_${tabId}`,
+    tabId,
+    action: {
+      type: 'button',
+      onClick,
+    },
+    isActiveTab: getIsActiveTab(currentTab, tabId),
+  };
+};

--- a/frontend/app-development/features/policyEditor/SettingsModal/utils/settingsModalUtils.ts
+++ b/frontend/app-development/features/policyEditor/SettingsModal/utils/settingsModalUtils.ts
@@ -3,18 +3,6 @@ import { LeftNavigationTab } from 'app-shared/types/LeftNavigationTab';
 import { ReactNode } from 'react';
 
 /**
- * Function that gets if a tab is active or not
- *
- * @param currentTab the currently selected tab
- * @param tabId the id of the tab to check
- *
- * @returns boolean for if it is active or not
- */
-export const getIsActiveTab = (currentTab: SettingsModalTab, tabId: SettingsModalTab) => {
-  return currentTab === tabId;
-};
-
-/**
  * Creates a new Navigation tab of the LeftNavigationTab type
  *
  * @param icon icon to display in the tab
@@ -38,6 +26,6 @@ export const createNavigationTab = (
       type: 'button',
       onClick,
     },
-    isActiveTab: getIsActiveTab(currentTab, tabId),
+    isActiveTab: currentTab === tabId,
   };
 };

--- a/frontend/app-development/layout/AppBar/appBarConfig.tsx
+++ b/frontend/app-development/layout/AppBar/appBarConfig.tsx
@@ -56,7 +56,7 @@ export const menu: TopBarMenuItem[] = [
     key: TopBarMenu.PolicyEditor,
     link: '/:org/:app/policy-editor',
     repositoryTypes: [RepositoryType.App],
-    featureFlagName: 'policyEditor',
+    // featureFlagName: 'policyEditor',
   },
 ];
 

--- a/frontend/app-development/layout/AppBar/appBarConfig.tsx
+++ b/frontend/app-development/layout/AppBar/appBarConfig.tsx
@@ -56,7 +56,7 @@ export const menu: TopBarMenuItem[] = [
     key: TopBarMenu.PolicyEditor,
     link: '/:org/:app/policy-editor',
     repositoryTypes: [RepositoryType.App],
-    // featureFlagName: 'policyEditor',
+    featureFlagName: 'policyEditor',
   },
 ];
 

--- a/frontend/app-development/types/SettingsModalTab.ts
+++ b/frontend/app-development/types/SettingsModalTab.ts
@@ -1,0 +1,1 @@
+export type SettingsModalTab = 'about' | 'policy';

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -953,6 +953,8 @@
   "session.expires": "Du blir snart logget ut",
   "session.inactive": "Du har vært innaktiv for lenge og vil snart bli logget ut. Trykk “fortsett” om du ønsker å jobbe videre med appen.",
   "settings_modal.heading": "Innstillinger",
+  "settings_modal.left_nav_tab_about": "Om applikasjonen",
+  "settings_modal.left_nav_tab_policy": "Tilgangsstyring",
   "settings_modal.open_button": "Åpne modal",
   "shared.header_all": "Alle",
   "shared.header_button_alt": "Altinn profilmeny",

--- a/frontend/packages/shared/src/components/LeftNavigationBar/LeftNavigationBar.module.css
+++ b/frontend/packages/shared/src/components/LeftNavigationBar/LeftNavigationBar.module.css
@@ -1,7 +1,6 @@
 .navigationBar {
   background-color: var(--fds-semantic-background-subtle);
   width: 250px;
-  min-height: 100vh;
   height: 100%;
   left: 0;
   border: 1px solid var(--fds-semantic-border-neutral-divider);

--- a/frontend/packages/shared/src/components/LeftNavigationBar/LeftNavigationBar.module.css
+++ b/frontend/packages/shared/src/components/LeftNavigationBar/LeftNavigationBar.module.css
@@ -29,9 +29,9 @@
 }
 
 .navigationElement:focus-visible {
-  border-bottom: 1px solid var(--fds-semantic-border-neutral-divider);
   background-color: var(--fds-semantic-background-default);
   z-index: 2;
+  border-bottom: none;
 
   --fds-inner-focus-border-color: var(--fds-semantic-border-focus-boxshadow);
   --fds-outer-focus-border-color: var(--fds-semantic-border-focus-outline);

--- a/frontend/packages/shared/src/components/LeftNavigationBar/LeftNavigationBar.module.css
+++ b/frontend/packages/shared/src/components/LeftNavigationBar/LeftNavigationBar.module.css
@@ -3,7 +3,7 @@
   width: 250px;
   height: 100%;
   left: 0;
-  border: 1px solid var(--fds-semantic-border-neutral-divider);
+  border-right: 1px solid var(--fds-semantic-border-neutral-divider);
   border-top: none;
 }
 

--- a/frontend/packages/shared/src/components/LeftNavigationBar/LeftNavigationBar.tsx
+++ b/frontend/packages/shared/src/components/LeftNavigationBar/LeftNavigationBar.tsx
@@ -3,6 +3,7 @@ import classes from './LeftNavigationBar.module.css';
 import { LeftNavigationTab } from 'app-shared/types/LeftNavigationTab';
 import { GoBackButton } from './GoBackButton';
 import { Tab } from './Tab';
+import cn from 'classnames';
 
 export type LeftNavigationBarProps = {
   /**
@@ -21,6 +22,10 @@ export type LeftNavigationBarProps = {
    * The text on the back link
    */
   backLinkText?: string;
+  /**
+   * Additional classnames
+   */
+  className?: string;
 };
 
 /**
@@ -39,6 +44,7 @@ export type LeftNavigationBarProps = {
  * @property {'backButton' | undefined}[upperTab] - The upper tab
  * @property {string}[backLink] - Href for the back link
  * @property {string}[backLinkText] - The text on the back link
+ * @property {string}[className] - Additional classnames
  *
  * @returns {ReactNode} - The rendered component
  */
@@ -47,6 +53,7 @@ export const LeftNavigationBar = ({
   upperTab = undefined,
   backLink,
   backLinkText = '',
+  className,
 }: LeftNavigationBarProps): ReactNode => {
   const [newTabIdClicked, setNewTabIdClicked] = useState<string | null>(null);
 
@@ -89,7 +96,7 @@ export const LeftNavigationBar = ({
   ));
 
   return (
-    <div className={classes.navigationBar}>
+    <div className={cn(classes.navigationBar, className)}>
       <div className={classes.navigationElements}>
         {displayUpperTab()}
         {displayTabs}

--- a/frontend/packages/shared/src/components/Modal/Modal.module.css
+++ b/frontend/packages/shared/src/components/Modal/Modal.module.css
@@ -19,7 +19,6 @@
   transform: translate(var(--modal-translate), var(--modal-translate));
   padding: 0;
   padding-top: 20px;
-  border: solid 1px var(--fds-semantic-border-neutral-subtle);
   background-color: var(--fds-semantic-background-default);
 }
 

--- a/frontend/packages/shared/src/components/Modal/Modal.module.css
+++ b/frontend/packages/shared/src/components/Modal/Modal.module.css
@@ -5,6 +5,9 @@
   --modal-position: 50%;
   --modal-translate: calc(var(--modal-position) * -1);
   --heading-height: 60px;
+  --modal-border-size: 1px;
+  --modal-content-max-height: calc(var(--modal-max-size) - var(--heading-height)) -
+    var(--modal-border-size);
 
   max-width: var(--modal-max-size);
   min-width: var(--modal-min-size);
@@ -20,6 +23,7 @@
   padding: 0;
   padding-top: 20px;
   background-color: var(--fds-semantic-background-default);
+  border: var(--modal-border-size) solid var(--fds-semantic-border-neutral-subtle);
 }
 
 .modalOverlay {
@@ -40,8 +44,7 @@
 }
 
 .contentWrapper {
-  max-height: calc(var(--modal-max-size) - var(--heading-height));
-  overflow-y: auto;
+  max-height: var(--modal-content-max-height);
 }
 
 .closeButtonWrapper {


### PR DESCRIPTION
## Description
- Adding ```LeftNavigationBar />``` to the ```<SettingsModal />```. 
- Moving some CSS from the modal to the settings modal to make the scrollbar only visible when needed, as well as making the tab colours on the left navigation display correctly. 
- Added the two tabs ```about``` and ```policy``` to the settings modal. 
- Created settings modal utils with tests
- Changing the border of the left navigation bar to only be right-border to make everything else on the screen (and modal) display correctly. 
- Adding className prop to the left navigation bar to make it possible to adjust the size of it from where it is being used. 
- Added more CSS variables to the modal

## Related Issue(s)
- #11043 

## Images
- Policy tab selected and tab accessed with keyboard. 
<img width="774" alt="Screenshot 2023-09-15 at 08 53 29" src="https://github.com/Altinn/altinn-studio/assets/133344438/621888cd-0e7a-41d2-a96d-0ff127287e7d">

- About tab selected 
<img width="771" alt="Screenshot 2023-09-15 at 08 53 18" src="https://github.com/Altinn/altinn-studio/assets/133344438/47c089d3-3782-418f-94c9-f0bb3805bdb3">

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

