### PR TITLE
Inactivate failing Cypress tests temporarily

### DIFF
--- a/frontend/testing/cypress/src/integration/studio/resourceadm.js
+++ b/frontend/testing/cypress/src/integration/studio/resourceadm.js
@@ -35,6 +35,8 @@ context('Resourceadm', () => {
     cy.url().should('include', '/dashboard');
   });
 
+  /* Temporary inactivation of Resourceadm cypress tests
+
   it('is possible to switch to all, and return via Redirect page', () => {
     cy.switchSelectedContext('all');
     cy.url().should('include', '/resourceadm/all');
@@ -171,4 +173,6 @@ context('Resourceadm', () => {
     cy.get('button').contains(texts['resourceadm.left_nav_bar_about']).click();
     cy.url().should('include', '/about');
   });
+  */
+
 });


### PR DESCRIPTION
## Description
We inactivate Cypress tests untill app backend problems have been resolved.


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
