### PR TITLE
Update readme to install husky on setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The fastest way to get things running from scratch is to use our setup-script. T
 ensure that the setup is up to date. As we add more features this script will be updated. It can be run as follows:
 
 ```bash
-node ./development/setup.js
+yarn setup
 ```
 
 More about that script and development in general, [can be found here](development/README.md).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We currently use `node ./development/setup.js` to setup the application.
We should instead use `yarn setup` to ensure that husky is installed and lint-staged scripts (code formatting + sorting of translated texts) work properly.

We should also make sure we all run `yarn husky install` once on our existing repositories to ensure that Husky is properly installed.