### PR TITLE
Fix lint-staged scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
     "whatwg-fetch": "3.6.18"
   },
   "lint-staged": {
-    "*{js,jsx,tsx,ts,css,md}": "yarn prettier -w",
-    "./frontend/language/src/*.json": "yarn run sort-texts"
+    "*{js,jsx,tsx,ts,css,md}": "prettier -w",
+    "./frontend/language/src/*.json": "sort-texts"
   },
   "packageManager": "yarn@3.6.3",
   "private": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The Husky pre-commit hook fails on my machine because of the lint-staged scripts. Removing the `yarn` and `yarn run` commands from the scripts should fix the problem.