### PR TITLE
Remove unnecessary signalR script in razor page, since react imports its own

### DIFF
--- a/backend/src/Designer/Views/Preview/index.cshtml
+++ b/backend/src/Designer/Views/Preview/index.cshtml
@@ -20,6 +20,5 @@
     <link href="https://altinncdn.no/fonts/altinn-din/altinn-din.css" rel="stylesheet">
     <link href="/designer/frontend/app-preview/app-preview.css" asp-append-version="true" rel="stylesheet">
     <script src="/designer/frontend/app-preview/app-preview.js" asp-append-version="true" type="text/javascript"></script>
-    <script src="/designer/js/signalr/dist/browser/signalr.js"></script>
     </body>
 </html>


### PR DESCRIPTION
## Description
Remove unnecessary signalR script in razor page, since react imports its own

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
