### PR TITLE
10863 add freestyle expression building in dynamics tool as an always available alternative

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -779,6 +779,7 @@
   "right_menu.dynamics_link": "Mer info",
   "right_menu.expression_delete": "Slett uttrykk",
   "right_menu.expression_edit": "Rediger uttrykk",
+  "right_menu.expression_enable_free_style_editing": "Rediger med fritekst",
   "right_menu.expression_successfully_added_text": "Lagt til",
   "right_menu.expressions_add": "Lag en ny logikkregel",
   "right_menu.expressions_add_expression": "Utvid regelen",

--- a/frontend/packages/ux-editor/src/components/config/Expressions/ComplexExpression.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/Expressions/ComplexExpression.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
-import { internalParsableComplexExpression } from '../../../testing/expressionMocks';
+import { internalParsableComplexExpression, internalUnParsableComplexExpression } from '../../../testing/expressionMocks';
 import { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
 import { renderWithMockStore } from '../../../testing/mocks';
 import { ComplexExpression, ComplexExpressionProps } from './ComplexExpression';
 import { stringifyData } from '../../../utils/jsonUtils';
+import { textMock } from '../../../../../../testing/mocks/i18nMock';
 
 describe('ComplexExpression', () => {
   beforeEach(() => {
@@ -13,7 +14,36 @@ describe('ComplexExpression', () => {
   it('displays textArea with complex expression as value', () => {
     render({});
     const complexExpression = screen.getByRole('textbox');
-    expect(complexExpression).toHaveTextContent(stringifyData(internalParsableComplexExpression.complexExpression));
+    expect(complexExpression).toHaveTextContent(stringifyData(internalUnParsableComplexExpression.complexExpression));
+  });
+  it('displays an editable textArea', () => {
+    render({});
+    const complexExpression = screen.getByRole('textbox');
+    expect(complexExpression).not.toHaveAttribute('disabled');
+  });
+  it('displays an non-editable textArea when expression is preview', () => {
+    render({
+      props: {
+        disabled: true
+      }
+    });
+    const complexExpression = screen.getByRole('textbox');
+    expect(complexExpression).toHaveAttribute('disabled');
+  });
+  it('displays too complex expression info message if expression can not be interpreted by Studio', () => {
+    render({});
+    const tooComplexExpressionAlert = screen.getByText(textMock('right_menu.expressions_complex_expression_message'));
+    expect(tooComplexExpressionAlert).toBeInTheDocument();
+  });
+  it('does not display too complex expression info message if expression can be interpreted by Studio', () => {
+    render({
+      props: {
+        expression: internalParsableComplexExpression.complexExpression,
+        isStudioFriendly: true
+      }
+    });
+    const tooComplexExpressionAlert = screen.queryByText(textMock('right_menu.expressions_complex_expression_message'));
+    expect(tooComplexExpressionAlert).not.toBeInTheDocument();
   });
 });
 
@@ -22,8 +52,9 @@ const render = ({ props = {}, queries = {}, }: {
   queries?: Partial<ServicesContextProps>;
 }) => {
   const defaultProps: ComplexExpressionProps = {
-    expression: internalParsableComplexExpression,
+    expression: internalUnParsableComplexExpression,
     onChange: jest.fn(),
+    isStudioFriendly: false,
   };
   return renderWithMockStore({}, queries)(<ComplexExpression {...defaultProps} {...props} />);
 };

--- a/frontend/packages/ux-editor/src/components/config/Expressions/ComplexExpression.tsx
+++ b/frontend/packages/ux-editor/src/components/config/Expressions/ComplexExpression.tsx
@@ -9,9 +9,10 @@ export type ComplexExpressionProps = {
   disabled?: boolean;
   expression: Expression;
   onChange?: (expression: string) => void;
+  isStudioFriendly?: boolean;
 };
 
-export const ComplexExpression = ({ disabled = false, expression, onChange }: ComplexExpressionProps) => {
+export const ComplexExpression = ({ disabled = false, expression, onChange, isStudioFriendly }: ComplexExpressionProps) => {
   const { t } = useTranslation();
   return (
     <div className={classes.root}>
@@ -20,9 +21,9 @@ export const ComplexExpression = ({ disabled = false, expression, onChange }: Co
         onChange={event => onChange?.(event.target.value)}
         value={stringifyData(expression.complexExpression)}
       />
-      <Alert>
-        {t('right_menu.expressions_complex_expression_message')}
-      </Alert>
+        {!isStudioFriendly && <Alert>
+            {t('right_menu.expressions_complex_expression_message')}
+        </Alert>}
     </div>
   );
 }

--- a/frontend/packages/ux-editor/src/components/config/Expressions/ExpressionContent.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/Expressions/ExpressionContent.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
+  internalParsableComplexExpression,
   internalUnParsableComplexExpression,
   simpleInternalExpression,
   subExpression0
@@ -229,6 +230,29 @@ describe('ExpressionContent', () => {
     await act(() => user.click(editExpressionButton));
     expect(mockOnEditExpression).toHaveBeenCalledWith(simpleInternalExpression);
     expect(mockOnEditExpression).toHaveBeenCalledTimes(1);
+  });
+  it('displays disabled free-style-editing-switch if complex expression can not be interpreted by Studio', () => {
+    render({
+      props: {
+        expression: internalUnParsableComplexExpression,
+    }
+  });
+  const enableFreeStyleEditingSwitch = screen.getByRole('checkbox', { name: textMock('right_menu.expression_enable_free_style_editing') });
+  expect(enableFreeStyleEditingSwitch).toHaveAttribute('readonly');
+  });
+  it('displays toggled on free-style-editing-switch which is not readOnly if complex expression can be interpreted by Studio', () => {
+    render({
+      props: {
+        expression: internalParsableComplexExpression,
+      }
+    });
+    const enableFreeStyleEditingSwitch = screen.getByRole('checkbox', { name: textMock('right_menu.expression_enable_free_style_editing') });
+    expect(enableFreeStyleEditingSwitch).toHaveAttribute('checked');
+  });
+  it('displays toggled off free-style-editing-switch if expression is not complex', () => {
+    render({});
+    const enableFreeStyleEditingSwitch = screen.getByRole('checkbox', { name: textMock('right_menu.expression_enable_free_style_editing') });
+    expect(enableFreeStyleEditingSwitch).not.toHaveAttribute('checked');
   });
 });
 

--- a/frontend/packages/ux-editor/src/components/config/Expressions/ExpressionContent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/Expressions/ExpressionContent.tsx
@@ -24,7 +24,7 @@ import { useText } from '../../../hooks';
 import { ComplexExpression } from './ComplexExpression';
 import { SimpleExpression } from './SimpleExpression';
 import { SimpleExpressionPreview } from './SimpleExpressionPreview';
-import {stringifyData} from '../../../utils/jsonUtils';
+import { stringifyData } from '../../../utils/jsonUtils';
 
 export interface ExpressionContentProps {
   componentName: string;
@@ -69,7 +69,7 @@ export const ExpressionContent = ({
   );
   const propertiesList = onGetProperties(expression).availableProperties;
   const externalExpression = convertInternalExpressionToExternal(expression);
-  const isStudioFriendly = isStudioFriendlyExpression(tryParseExpression(expression, externalExpression).complexExpression)
+  const isStudioFriendly = isStudioFriendlyExpression(tryParseExpression(expression, externalExpression).complexExpression);
 
   const addPropertyToExpression = (property: string) => {
     const newExpression: Expression = addProperty(expression, property);

--- a/frontend/packages/ux-editor/src/components/config/Expressions/ExpressionContent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/Expressions/ExpressionContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Expression,
   SubExpression,
@@ -6,7 +6,7 @@ import {
   expressionPropertyTexts,
   Operator,
 } from '../../../types/Expressions';
-import { Button, Select } from '@digdir/design-system-react';
+import { Button, Select, Switch } from '@digdir/design-system-react';
 import { CheckmarkIcon, PencilIcon, TrashIcon } from '@navikt/aksel-icons';
 import { Trans } from 'react-i18next';
 import classes from './ExpressionContent.module.css';
@@ -14,6 +14,8 @@ import {
   addProperty,
   addSubExpressionToExpression,
   complexExpressionIsSet,
+  convertInternalExpressionToExternal,
+  isStudioFriendlyExpression, tryParseExpression,
   updateComplexExpression,
   updateExpression,
   updateOperator
@@ -22,6 +24,7 @@ import { useText } from '../../../hooks';
 import { ComplexExpression } from './ComplexExpression';
 import { SimpleExpression } from './SimpleExpression';
 import { SimpleExpressionPreview } from './SimpleExpressionPreview';
+import {stringifyData} from '../../../utils/jsonUtils';
 
 export interface ExpressionContentProps {
   componentName: string;
@@ -50,8 +53,9 @@ export const ExpressionContent = ({
   onRemoveSubExpression,
   onEditExpression,
 }: ExpressionContentProps) => {
+  const [freeStyleEditing, setFreeStyleEditing] = useState<boolean>(!!expression.complexExpression);
   const t = useText();
-  
+
   const allowToSpecifyExpression = Object.values(onGetProperties(expression).expressionProperties).includes(expression.property);
   const allowToSaveExpression = (
     expression.subExpressions?.filter(subExp => !subExp.function)?.length === 0
@@ -64,6 +68,8 @@ export const ExpressionContent = ({
     && !!expression.property
   );
   const propertiesList = onGetProperties(expression).availableProperties;
+  const externalExpression = convertInternalExpressionToExternal(expression);
+  const isStudioFriendly = isStudioFriendlyExpression(tryParseExpression(expression, externalExpression).complexExpression)
 
   const addPropertyToExpression = (property: string) => {
     const newExpression: Expression = addProperty(expression, property);
@@ -90,10 +96,30 @@ export const ExpressionContent = ({
     onUpdateExpression(newExpression);
   };
 
+  const handleToggleFreeStyleEditing = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setFreeStyleEditing(event.target.checked);
+    if (event.target.checked) {
+      const stringRepresentationOfExpression = stringifyData(externalExpression);
+      updateExpressionComplexExpression(stringRepresentationOfExpression);
+    } else {
+      updateExpressionComplexExpression(undefined);
+    }
+  };
+
+
   return (
     <>
       {expressionInEditMode ? (
         <div className={classes.editMode}>
+          <Switch
+              name={'Expression_enable_free_style_editing'}
+              onChange={handleToggleFreeStyleEditing}
+              checked={freeStyleEditing}
+              size={'small'}
+              readOnly={!isStudioFriendly}
+          >
+            {t('right_menu.expression_enable_free_style_editing')}
+          </Switch>
           <div className={classes.topBar}>
             <p>
               <Trans
@@ -127,6 +153,7 @@ export const ExpressionContent = ({
             <ComplexExpression
               expression={expression}
               onChange={updateExpressionComplexExpression}
+              isStudioFriendly={isStudioFriendly}
             />
           ) : (
             <SimpleExpression

--- a/frontend/packages/ux-editor/src/utils/expressionsUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/expressionsUtils.ts
@@ -18,7 +18,10 @@ export const convertInternalExpressionToExternal = (expression: Expression): any
   if (complexExpressionIsSet(expression.complexExpression)) {
     return expression.complexExpression;
   }
-  const expressions: any[] = [];
+  const subExpressions: any[] = [];
+  if (!expression.subExpressions) {
+    return subExpressions;
+  }
   expression.subExpressions.map(subEXp => {
     const expressionObject = [];
     expressionObject[0] = subEXp.function;
@@ -42,12 +45,17 @@ export const convertInternalExpressionToExternal = (expression: Expression): any
     } else {
       expressionObject[2] = subEXp.comparableValue;
     }
-    expressions.push(expressionObject);
+    subExpressions.push(expressionObject);
   });
-  return expression.operator ? [expression.operator].concat(expressions) : expressions[0];
+  return expression.operator ? [expression.operator].concat(subExpressions) : subExpressions[0];
 };
 
 export const isStudioFriendlyExpression = (expression: any): boolean => {
+  
+  if (expression?.length === 0) {
+    // For building expressions free style from beginning
+    return true;
+  }
 
   const isStudioFriendlySubExpression = (subExp: any): boolean => {
     // SubExpression is Studio friendly if it is an array of three elements where the two last elements

--- a/frontend/packages/ux-editor/src/utils/expressionsUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/expressionsUtils.ts
@@ -19,7 +19,7 @@ export const convertInternalExpressionToExternal = (expression: Expression): any
     return expression.complexExpression;
   }
   const subExpressions: any[] = [];
-  if (!expression.subExpressions) {
+  if (!expression.subExpressions || expression.subExpressions.length === 0) {
     return subExpressions;
   }
   expression.subExpressions.map(subEXp => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "@altinn/altinn-design-system": "0.29.1",
     "@altinn/figma-design-tokens": "6.0.1",
-    "@digdir/design-system-react": "0.24.0",
+    "@digdir/design-system-react": "0.24.2",
     "@digdir/design-system-tokens": "0.5.0",
     "@microsoft/applicationinsights-react-js": "^17.0.0",
     "@microsoft/applicationinsights-web": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,23 +1714,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/design-system-react@npm:0.24.0":
-  version: 0.24.0
-  resolution: "@digdir/design-system-react@npm:0.24.0"
+"@digdir/design-system-react@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@digdir/design-system-react@npm:0.24.2"
   dependencies:
     "@altinn/figma-design-tokens": ^6.0.1
-    "@digdir/design-system-tokens": ^0.5.0
-    "@floating-ui/react": 0.24.1
+    "@digdir/design-system-tokens": ^0.6.1
+    "@floating-ui/react": 0.25.2
     "@navikt/aksel-icons": ^3.2.4
     react-number-format: 5.2.2
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 7dc13e6dc9d30ae4a0e9c29f891ad578899879c5f9ff2bc8afeaf5d16fb9e7853bdfce8160ffd218cf525da8d3cb9196d8b0cbc2c54c09b269f44c3ea0dbb6bf
+  checksum: 153c2e41640f92ab1b468223dee4e7c5ba5bbdf816df8bad7fe3e76e42410040a5178ce4a11183fcc1f6d4376ea131bbb8abc1dff7b56b1493210f6d1e9139c3
   languageName: node
   linkType: hard
 
-"@digdir/design-system-tokens@npm:0.5.0, @digdir/design-system-tokens@npm:^0.5.0":
+"@digdir/design-system-tokens@npm:0.5.0":
   version: 0.5.0
   resolution: "@digdir/design-system-tokens@npm:0.5.0"
   checksum: f73f90d2d8d9343cf14f614fe6c2f846ded87938d36d1308d04470a32050db53bb0b352319e9daf5643601f26c16074d1e01d31d86c01e3bc24e3eb67ef3c6ed
@@ -1741,6 +1741,13 @@ __metadata:
   version: 0.1.7
   resolution: "@digdir/design-system-tokens@npm:0.1.7"
   checksum: dabe357c8d262cd6f6430a722f30dc3aa70243bd12cdc39886b655b1ee9a22c471e5131906944a6164c166ef54b86e69526fec5fa8750ad8c9f4444a4aeedf0d
+  languageName: node
+  linkType: hard
+
+"@digdir/design-system-tokens@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@digdir/design-system-tokens@npm:0.6.1"
+  checksum: b3866dd27831c0a9943f904e32a0e04da963dd70f183e947cbd54ff802b65a588388bef61e22215e02e79a2ff5ab4bd62a2be4116dd563f353877f02346f4619
   languageName: node
   linkType: hard
 
@@ -2166,7 +2173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/react-dom@npm:^2.0.2":
+"@floating-ui/react-dom@npm:^2.0.1, @floating-ui/react-dom@npm:^2.0.2":
   version: 2.0.2
   resolution: "@floating-ui/react-dom@npm:2.0.2"
   dependencies:
@@ -2189,6 +2196,20 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 89e525412a5f71be1437ce74a3a76f4a6c771074e1dca62dddf11062dd9eca7b967091906c369427a0c8f9c9a7c6c7ae06525917e6809d60d832443a4acfc3f3
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@floating-ui/react@npm:0.25.2"
+  dependencies:
+    "@floating-ui/react-dom": ^2.0.1
+    "@floating-ui/utils": ^0.1.1
+    tabbable: ^6.0.1
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 851aedc2e327f7a82553270669ce613d1b03fbb5ea8a7137f959cf7db95ecdab05d4402320d613ad2b662f6920f2fac366fdfd82d273d83d3070de532ecb0728
   languageName: node
   linkType: hard
 
@@ -5311,7 +5332,7 @@ __metadata:
   dependencies:
     "@altinn/altinn-design-system": 0.29.1
     "@altinn/figma-design-tokens": 6.0.1
-    "@digdir/design-system-react": 0.24.0
+    "@digdir/design-system-react": 0.24.2
     "@digdir/design-system-tokens": 0.5.0
     "@emotion/react": 11.11.1
     "@emotion/styled": 11.11.0


### PR DESCRIPTION
## Description
- Add a switch on the top of the expression content when in editing mode. 
  - The switch should be off if default expression is a new expression or if it is possible to interpret by the studio expression tool.
  - When toggling it on it should present a text area with either an empty bracket (if starting with a new empty expression) or have the content of the already configured expression in the Studio expression editing tool. The switch should be enabled and there should not be any info message that the expression is too complex
  - If changing the expression in free style editing, the switch should be disabled/readonly (as long as the expression being built can not be interpreted by studio) and an info message saying that the expression is too complex should be displayed. 
  - When entering a condition where the free style expression is valid and can be interpreted by the studio expression tool the info message should go away and the switch should be enabled again
  - Clicking the switch should bring you back to the studio expression tool with the correct content in the tool as you entered in the free style text area. 
  - It should always be possible to click "Lagre"
- Add tests

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

https://github.com/Altinn/altinn-studio-docs/pull/1170
