### PR TITLE
fix failing cypress test

### DIFF
--- a/frontend/testing/cypress/src/integration/studio/designer.js
+++ b/frontend/testing/cypress/src/integration/studio/designer.js
@@ -11,8 +11,8 @@ context('Designer', () => {
     cy.visit('/');
     cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
     cy.deleteallapps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
-    cy.createapp(Cypress.env('autoTestUser'), 'designer');
-    cy.createapp(Cypress.env('autoTestUser'), 'appwithout-dm');
+    const [orgName, appName] = Cypress.env('designerApp').split('/');
+    cy.createapp(orgName, appName);
     cy.clearCookies();
     cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
   });
@@ -22,7 +22,8 @@ context('Designer', () => {
 
   it('is possible to edit information about the app', () => {
     const designerApp = Cypress.env('designerApp');
-    cy.searchAndOpenApp(designerApp);
+    // Navigate to designerApp
+    cy.visit('/editor/' + Cypress.env('designerApp'));
     administration.getHeader().should('be.visible');
     cy.findByRole('button', { name: texts['general.edit'] }).click();
     administration.getAppNameField().clear().type('New app name');
@@ -32,17 +33,32 @@ context('Designer', () => {
   });
 
   it('is possible to add and delete form components', () => {
-    cy.searchAndOpenApp(Cypress.env('designerApp'));
+    cy.intercept('GET', '**/app-development/layout-settings?**').as('getLayoutSettings');
+    cy.intercept('POST', '**/app-development/layout-settings?**').as('postLayoutSettings');
+
+    // Navigate to designerApp
+    cy.visit('/editor/' + Cypress.env('designerApp'));
     header.getCreateLink().click();
+    cy.ensureCreatePageIsLoaded();
+
+    // Add new page and ensure updated data is loaded
     designer.getAddPageButton().click();
-    designer.getAddPageButton().click();
+    cy.wait('@postLayoutSettings').its('response.statusCode').should('eq', 200);
+    cy.wait('@getLayoutSettings').its('response.statusCode').should('eq', 200);
+    cy.findByText(texts['general.page'] + '2').should('be.visible');
+
+    // Verify navigation button exists in form
     designer.getDroppableList().findByRole('listitem', { name: texts['ux_editor.component_navigation_buttons'] }).should('be.visible');
+
+    // Add an input component
     designer.getToolbarItemByText(texts['ux_editor.component_input']).trigger('dragstart');
     designer.getDroppableList().trigger('drop');
     cy.wait(500);
     designer.getDroppableList()
       .findAllByRole('listitem')
       .then(($elements) => expect($elements.length).eq(2));
+
+    // Delete components on page
     cy.deletecomponents();
   });
 

--- a/frontend/testing/cypress/src/support/studio.js
+++ b/frontend/testing/cypress/src/support/studio.js
@@ -5,7 +5,8 @@ import { dashboard } from '../selectors/dashboard';
 import { designer } from '../selectors/designer';
 import { header } from '../selectors/header';
 import { login } from '../selectors/login';
-import {gitea} from "../selectors/gitea";
+import { gitea } from '../selectors/gitea';
+import { DEFAULT_SELECTED_LAYOUT_NAME } from '../../../../packages/shared/src/constants';
 
 /**
  * Login to studio with user name and password
@@ -93,4 +94,13 @@ Cypress.Commands.add('searchAndOpenApp', (appId) => {
  */
 Cypress.Commands.add('selectElementInApplicationList', (appListHeaderText, elementSelector) => {
   return cy.contains('h2', appListHeaderText).siblings().find(elementSelector);
+});
+
+Cypress.Commands.add('ensureCreatePageIsLoaded', () => {
+  cy.intercept('GET', '**/app-development/form-layouts?**').as('formLayouts');
+  cy.intercept('GET', '**/app-development/layout-settings?**').as('getLayoutSettings');
+  cy.wait('@formLayouts').its('response.statusCode').should('eq', 200);
+  cy.wait('@getLayoutSettings').its('response.statusCode').should('eq', 200);
+  cy.findByRole('heading', { name: DEFAULT_SELECTED_LAYOUT_NAME }).should('be.visible');
+  cy.findByRole('heading', { name: `${texts['general.page']}1` }).should('be.visible');
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This had nothing to do with Gitea.
- In the `before`-hook, all apps for `AutoTest` user were deleted, and 2 apps (with hard coded names) were created:
  - `designer` and `app-without-dm`
- Neither app was used in the actual test, as the `searchAndOpenApp` method looked for the `designerApp` variable which was set to `AutoTest/auto-designer-app` in dev environment.
- However, this app did not exist for `AutoTest` user. It did, however, exist for TTD org, which `AutoTest` can represent. Searching for `auto-designer-app` yielded results from TTD as expected, and that app was used.
- That app is not deleted at the end of the test run, as it does not belong to `AutoTest` user.
- After a while, after adding many components, the `NavigationButtons` component that the test searches for ends up outside the visible window, and is not found by the test - thus the test fails.

There were some other issues as well:
- There was no mechanism for waiting for the Lage-page to complete loading before starting the test. This resulted in some weird behaviour around adding pages, with duplicate pages appearing.
- There was no mechanisms for waiting for new page to be created before moving on to the rest of the test, which could potentially cause flaky tests.
- As mentioned, none of the 2 apps created at the `before`-hook were actually used in the tests.

Fixes:
- Removed line creating `app-without-dm`-app, as this is not used at all in the designer tests.
- Updated line creating `designer` app to use the env variable rather than hard coded name, to ensure correct app is used.
- Set up navigation to the correct app (defined by env variable) directly by using `cy.visit` rather than the `searchAndOpenApp` method, as we are testing the designer/editor and not the dashboard in these tests. So no need to actually use the dashboard search function here.
- Added a helper function that ensures the  form designer is completely loaded before continuing to the tests
- Added some api interceptors to ensure new page is added/loaded before continuing on with the tests

## Related Issue(s)
- #11193 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

