### PR TITLE
account for different screen sizes & scrolling

### DIFF
--- a/frontend/testing/cypress/src/integration/studio/designer.js
+++ b/frontend/testing/cypress/src/integration/studio/designer.js
@@ -45,7 +45,6 @@ context('Designer', () => {
     designer.getAddPageButton().click();
     cy.wait('@postLayoutSettings').its('response.statusCode').should('eq', 200);
     cy.wait('@getLayoutSettings').its('response.statusCode').should('eq', 200);
-    cy.findByText(texts['general.page'] + '2').should('be.visible');
 
     // Verify navigation button exists in form
     designer.getDroppableList().findByRole('listitem', { name: texts['ux_editor.component_navigation_buttons'] }).should('be.visible');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The check to make sure `Side2` was loaded fails on the server because it runs on a different screen size/zoom to my local machine, and there is some scrolling that moves the `Side2` text out of the window.

The check is not actually necessary, as the next test will wait for the relevant element (navigationButtons) to appear.

## Related Issue(s)
- #11193 

## Verification
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
