### PR TITLE
return oldexpression if selected property is default and move divider in conditional rendering panel

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/Expressions/Expressions.tsx
+++ b/frontend/packages/ux-editor/src/components/config/Expressions/Expressions.tsx
@@ -135,7 +135,6 @@ export const Expressions = () => {
               rel='noopener noreferrer'
           />
         </Trans>
-        <Divider/>
       {Object.values(expressions).map((expression: Expression, index: number) => (
         <React.Fragment key={expression.id}>
           <ExpressionContent

--- a/frontend/packages/ux-editor/src/components/config/Expressions/Expressions.tsx
+++ b/frontend/packages/ux-editor/src/components/config/Expressions/Expressions.tsx
@@ -18,7 +18,6 @@ import {
 } from '../../../utils/expressionsUtils';
 import classes from './Expressions.module.css';
 import { v4 as uuidv4 } from 'uuid';
-import { Divider } from 'app-shared/primitives';
 import { deepCopy } from 'app-shared/pure';
 import { LayoutItemType } from '../../../types/global';
 import { FormComponent } from '../../../types/FormComponent';

--- a/frontend/packages/ux-editor/src/components/rightMenu/ConditionalRendering.tsx
+++ b/frontend/packages/ux-editor/src/components/rightMenu/ConditionalRendering.tsx
@@ -16,6 +16,7 @@ export const ConditionalRendering = () => {
     <div className={classes.conditionalRendering}>
         <div>
           <div className={classes.dynamicsVersionCheckBox}>
+            <Divider/>
             <Alert severity='warning'>
             <span>
               <Trans i18nKey={'right_menu.warning_dynamics_deprecated'}>
@@ -27,7 +28,6 @@ export const ConditionalRendering = () => {
               </Trans>
             </span>
             </Alert>
-            <Divider/>
           </div>
           <div className={classes.header}>
             <span>{t('right_menu.rules_conditional_rendering')}</span>

--- a/frontend/packages/ux-editor/src/utils/expressionsUtils.test.ts
+++ b/frontend/packages/ux-editor/src/utils/expressionsUtils.test.ts
@@ -400,7 +400,7 @@ describe('expressionsUtils', () => {
       const propertyToAdd = 'default';
       const newExpression = addProperty(internalExpressionWithMultipleSubExpressions, propertyToAdd);
 
-      expect(newExpression).toBeUndefined();
+      expect(newExpression).toStrictEqual(internalExpressionWithMultipleSubExpressions);
     });
     it('should create a new subExpression when there are no subExpressions', () => {
       const newExpression = addProperty(baseInternalExpression, ExpressionPropertyBase.ReadOnly);

--- a/frontend/packages/ux-editor/src/utils/expressionsUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/expressionsUtils.ts
@@ -187,10 +187,10 @@ export const removeInvalidExpressions = (oldExpressions: Expression[]): Expressi
 };
 
 export const addProperty = (oldExpression: Expression, property: string): Expression => {
-  if (property === 'default') {
-    return oldExpression;
-  }
   const newExpression = deepCopy(oldExpression);
+  if (property === 'default') {
+    return newExpression;
+  }
   newExpression.property = property as ExpressionPropertyBase;
   if (!newExpression.subExpressions) {
     const newSubExpression: SubExpression = { id: uuidv4() };

--- a/frontend/packages/ux-editor/src/utils/expressionsUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/expressionsUtils.ts
@@ -188,7 +188,7 @@ export const removeInvalidExpressions = (oldExpressions: Expression[]): Expressi
 
 export const addProperty = (oldExpression: Expression, property: string): Expression => {
   if (property === 'default') {
-    return;
+    return oldExpression;
   }
   const newExpression = deepCopy(oldExpression);
   newExpression.property = property as ExpressionPropertyBase;


### PR DESCRIPTION
## Description
- to avoid crash return old expression if selecting default as property
- move divider in conditional rendering panel to above deprecation alert

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

