### PR TITLE
Make varaiblename- and variable-usage in cypress tests consistent

### DIFF
--- a/development/utils/ensure-dot-env.js
+++ b/development/utils/ensure-dot-env.js
@@ -10,7 +10,7 @@ const randomPass = () =>
 const defaultEnvVars = {
   CYPRESS_TEST_APP: 'autodeploy-v3',
   DEVELOP_APP_DEVELOPMENT: 0,
-  DEVELOP_RESOURCE_ADMIN: true,
+  DEVELOP_RESOURCE_ADMIN: 0,
   DEVELOP_BACKEND: 0,
   DEVELOP_DASHBOARD: 0,
   DEVELOP_PREVIEW: 0,

--- a/frontend/testing/cypress/config/dev.json
+++ b/frontend/testing/cypress/config/dev.json
@@ -2,14 +2,12 @@
   "$schema": "https://on.cypress.io/cypress.schema.json",
   "baseUrl": "https://dev.altinn.studio",
   "env": {
-    "autoTestUser": "AutoTest",
-    "useCaseUser": "bruksmonsterDev",
-    "datamodelApp": "AutoTest/datamodel",
-    "deployApp": "ttd/auto-deploy-app-v3",
-    "designerApp": "AutoTest/auto-designer-app",
-    "withoutDataModelApp": "AutoTest/appwithout-dm",
-    "appOwner": "Testdepartementet",
-    "appOwnerUsername": "ttd"
+    "autoTestUser": "dev_cypress_testuser",
+    "useCaseUser": "dev_bruksmonster",
+    "orgFullName": "Testdepartementet",
+    "orgUserName": "ttd",
+    "deployAppName": "auto-deploy-app-v3",
+    "designerAppName": "auto-designer-app-dev"
   },
   "defaultCommandTimeout": 20000,
   "requestTimeout": 20000,

--- a/frontend/testing/cypress/config/dev.json
+++ b/frontend/testing/cypress/config/dev.json
@@ -2,8 +2,8 @@
   "$schema": "https://on.cypress.io/cypress.schema.json",
   "baseUrl": "https://dev.altinn.studio",
   "env": {
-    "autoTestUser": "dev_cypress_testuser",
-    "useCaseUser": "dev_bruksmonster",
+    "autoTestUser": "AutoTest",
+    "useCaseUser": "bruksmonsterDev",
     "orgFullName": "Testdepartementet",
     "orgUserName": "ttd",
     "deployAppName": "auto-deploy-app-v3",

--- a/frontend/testing/cypress/config/local.json
+++ b/frontend/testing/cypress/config/local.json
@@ -5,8 +5,7 @@
     "orgFullName": "Testdepartementet",
     "orgUserName": "ttd",
     "deployAppName": "auto-deploy-app-v3",
-    "designerAppName": "auto-designer-app-local",
-    "testEmail": "test1@test.com"
+    "designerAppName": "auto-designer-app-local"
   },
   "defaultCommandTimeout": 10000,
   "requestTimeout": 10000

--- a/frontend/testing/cypress/config/local.json
+++ b/frontend/testing/cypress/config/local.json
@@ -2,13 +2,11 @@
   "$schema": "https://on.cypress.io/cypress.schema.json",
   "baseUrl": "http://studio.localhost",
   "env": {
-    "testEmail": "test1@test.com",
-    "deployApp": "ttd/auto-deploy-app-v3",
-    "designerApp": "ttd/designer",
-    "datamodelApp": "cypress_testuser/datamodel",
-    "withoutDataModelApp": "ttd/appwithout-dm",
-    "appOwner": "Testdepartementet",
-    "appOwnerUsername": "ttd"
+    "orgFullName": "Testdepartementet",
+    "orgUserName": "ttd",
+    "deployAppName": "auto-deploy-app-v3",
+    "designerAppName": "auto-designer-app-local",
+    "testEmail": "test1@test.com"
   },
   "defaultCommandTimeout": 10000,
   "requestTimeout": 10000

--- a/frontend/testing/cypress/config/prod.json
+++ b/frontend/testing/cypress/config/prod.json
@@ -2,8 +2,8 @@
   "$schema": "https://on.cypress.io/cypress.schema.json",
   "baseUrl": "https://altinn.studio",
   "env": {
-    "autoTestUser": "prod_cypress_testuser",
-    "useCaseUser": "prod_bruksmonster",
+    "autoTestUser": "AutoTest",
+    "useCaseUser": "bruksmonster",
     "orgFullName": "Testdepartementet",
     "orgUserName": "ttd",
     "deployAppName": "auto-deploy-app-v3",

--- a/frontend/testing/cypress/config/prod.json
+++ b/frontend/testing/cypress/config/prod.json
@@ -2,14 +2,12 @@
   "$schema": "https://on.cypress.io/cypress.schema.json",
   "baseUrl": "https://altinn.studio",
   "env": {
-    "autoTestUser": "AutoTest",
-    "useCaseUser": "bruksmonster",
-    "datamodelApp": "AutoTest/datamodel",
-    "deployApp": "ttd/auto-deploy-app-v3",
-    "designerApp": "AutoTest/auto-designer-app",
-    "withoutDataModelApp": "AutoTest/appwithout-dm",
-    "appOwner": "Testdepartementet",
-    "appOwnerUsername": "ttd"
+    "autoTestUser": "prod_cypress_testuser",
+    "useCaseUser": "prod_bruksmonster",
+    "orgFullName": "Testdepartementet",
+    "orgUserName": "ttd",
+    "deployAppName": "auto-deploy-app-v3",
+    "designerAppName": "auto-designer-app-prod"
   },
   "defaultCommandTimeout": 20000,
   "requestTimeout": 20000

--- a/frontend/testing/cypress/config/staging.json
+++ b/frontend/testing/cypress/config/staging.json
@@ -2,12 +2,11 @@
   "$schema": "https://on.cypress.io/cypress.schema.json",
   "baseUrl": "https://staging.altinn.studio",
   "env": {
-    "autoTestUser": "dev_cypress_testuser",
-    "useCaseUser": "dev_bruksmonster",
+    "autoTestUser": "AutoTest",
     "orgFullName": "Testdepartementet",
     "orgUserName": "ttd",
     "deployAppName": "auto-deploy-app-v3-dev",
-    "designerAppName": "auto-designer-app-dev",
+    "designerAppName": "auto-designer-app-dev"
   },
   "defaultCommandTimeout": 20000,
   "requestTimeout": 20000

--- a/frontend/testing/cypress/config/staging.json
+++ b/frontend/testing/cypress/config/staging.json
@@ -2,12 +2,12 @@
   "$schema": "https://on.cypress.io/cypress.schema.json",
   "baseUrl": "https://staging.altinn.studio",
   "env": {
-    "autoTestUser": "AutoTest",
-    "datamodelApp": "AutoTest/datamodel",
-    "deployApp": "ttd/autodeploy-v3",
-    "designerApp": "AutoTest/auto-designer-app",
-    "withoutDataModelApp": "AutoTest/appwithout-dm",
-    "appOwner": "Testdepartementet"
+    "autoTestUser": "dev_cypress_testuser",
+    "useCaseUser": "dev_bruksmonster",
+    "orgFullName": "Testdepartementet",
+    "orgUserName": "ttd",
+    "deployAppName": "auto-deploy-app-v3-dev",
+    "designerAppName": "auto-designer-app-dev",
   },
   "defaultCommandTimeout": 20000,
   "requestTimeout": 20000

--- a/frontend/testing/cypress/src/integration/studio/dashboard.js
+++ b/frontend/testing/cypress/src/integration/studio/dashboard.js
@@ -8,11 +8,11 @@ import { common } from '../../selectors/common';
 
 context('Dashboard', () => {
   before(() => {
-    cy.deleteallapps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
     cy.visit('/');
-    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.createapp(Cypress.env('autoTestUser'), 'auto-app');
-    cy.createapp(Cypress.env('autoTestUser'), 'test-app');
+    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.createApp(Cypress.env('autoTestUser'), 'auto-app');
+    cy.createApp(Cypress.env('autoTestUser'), 'test-app');
   });
 
   beforeEach(() => {
@@ -74,11 +74,11 @@ context('Dashboard', () => {
   it('is possible to change context and view only Testdepartementet apps', () => {
     cy.visit('/dashboard');
     header.getAvatar().should('be.visible').click();
-    header.getMenuItemOrg(Cypress.env('appOwnerUsername'))
+    header.getMenuItemOrg(Cypress.env('orgUserName'))
       .should('be.visible')
       .click();
     cy.wait('@fetchApps');
-    dashboard.getOrgAppsHeader(Cypress.env('appOwner')).should('be.visible');
+    dashboard.getOrgAppsHeader(Cypress.env('orgFullName')).should('be.visible');
   });
 
   it('is possible to search an app by name', () => {
@@ -158,6 +158,6 @@ context('Dashboard', () => {
   });
 
   after(() => {
-    cy.deleteallapps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
   });
 });

--- a/frontend/testing/cypress/src/integration/studio/datamodel.js
+++ b/frontend/testing/cypress/src/integration/studio/datamodel.js
@@ -7,22 +7,22 @@ import * as texts from '../../../../../language/src/nb.json';
 
 context('datamodel', () => {
   before(() => {
-    cy.deleteallapps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
     cy.visit('/');
-    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.createapp(Cypress.env('autoTestUser'), 'datamodel-app');
+    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
   });
 
   beforeEach(() => {
     cy.visit('/dashboard');
-    cy.searchAndOpenApp(`${Cypress.env('autoTestUser')}/datamodel-app`);
+    cy.searchAndOpenApp(Cypress.env('designerAppName'));
 
     // Navigate to datamodels page and close dialog
     header.getDatamodelLink().click();
   });
 
   after(() => {
-    cy.deleteallapps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
   });
 
   it('add a new data model', () => {

--- a/frontend/testing/cypress/src/integration/studio/designer.js
+++ b/frontend/testing/cypress/src/integration/studio/designer.js
@@ -6,24 +6,24 @@ import { administration } from "../../selectors/administration";
 import { designer } from "../../selectors/designer";
 import { header } from "../../selectors/header";
 
+const designerAppId = `${Cypress.env('autoTestUser')}/${Cypress.env('designerAppName')}`;
+
 context('Designer', () => {
   before(() => {
     cy.visit('/');
-    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.deleteallapps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
-    const [orgName, appName] = Cypress.env('designerApp').split('/');
-    cy.createapp(orgName, appName);
+    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
     cy.clearCookies();
-    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
   });
   beforeEach(() => {
     cy.visit('/dashboard');
   });
 
   it('is possible to edit information about the app', () => {
-    const designerApp = Cypress.env('designerApp');
     // Navigate to designerApp
-    cy.visit('/editor/' + Cypress.env('designerApp'));
+    cy.visit('/editor/' + designerAppId);
     administration.getHeader().should('be.visible');
     cy.findByRole('button', { name: texts['general.edit'] }).click();
     administration.getAppNameField().clear().type('New app name');
@@ -37,7 +37,7 @@ context('Designer', () => {
     cy.intercept('POST', '**/app-development/layout-settings?**').as('postLayoutSettings');
 
     // Navigate to designerApp
-    cy.visit('/editor/' + Cypress.env('designerApp'));
+    cy.visit('/editor/' + designerAppId);
     header.getCreateLink().click();
     cy.ensureCreatePageIsLoaded();
 
@@ -58,12 +58,12 @@ context('Designer', () => {
       .then(($elements) => expect($elements.length).eq(2));
 
     // Delete components on page
-    cy.deletecomponents();
+    cy.deleteComponents();
   });
 
   // Disabled for now, as this generates too many copies of the same app
   // it('is possible to delete local changes of an app ', () => {
-  //   cy.searchAndOpenApp(Cypress.env('designerApp'));
+  //   cy.searchAndOpenApp(Cypress.env('designerAppName'));
   //   cy.intercept('GET', '**/layout-settings').as('getLayoutSettings');
   //   cy.get(designer.appMenu['edit']).click();
   //   cy.wait('@getLayoutSettings');

--- a/frontend/testing/cypress/src/integration/studio/login.js
+++ b/frontend/testing/cypress/src/integration/studio/login.js
@@ -12,7 +12,7 @@ context('Login', () => {
   });
 
   it('is possible to login with valid user credentials and logout', () => {
-    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
     dashboard.getSearchReposField().should('be.visible');
     header.getAvatar().should('be.visible').click();
     header.getMenuItemLogout().should('be.visible').click();
@@ -21,7 +21,7 @@ context('Login', () => {
   });
 
   it('is not possible to login with invalid user credentials', () => {
-    cy.studiologin(Cypress.env('autoTestUser'), 'test123');
+    cy.studioLogin(Cypress.env('autoTestUser'), 'test123');
     gitea.getLoginErrorMessage().should('be.visible');
   });
 });

--- a/frontend/testing/cypress/src/integration/studio/new-app.js
+++ b/frontend/testing/cypress/src/integration/studio/new-app.js
@@ -8,9 +8,9 @@ import { gitea } from "../../selectors/gitea";
 
 context('New App', () => {
   before(() => {
-    cy.deleteallapps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
     cy.visit('/');
-    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
   });
   beforeEach(() => {
     cy.visit('/dashboard');
@@ -18,7 +18,7 @@ context('New App', () => {
     dashboard.getSearchReposField().should('be.visible');
   });
   after(() => {
-    cy.deleteallapps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
   });
 
   it('is possible to start app creation and exit', () => {
@@ -34,7 +34,7 @@ context('New App', () => {
   it('shows error on app creation with existing name', () => {
     // Create an app
     const appName = 'my-existing-app';
-    cy.createapp(Cypress.env('autoTestUser'), appName);
+    cy.createApp(Cypress.env('autoTestUser'), appName);
     administration.getHeader().should('be.visible');
 
     // Return to dashboard
@@ -64,10 +64,11 @@ context('New App', () => {
   });
 
   it('is possible to create an app and delete it', () => {
-    cy.createapp(Cypress.env('autoTestUser'), 'new-app');
+    const appName = 'new-app';
+    cy.createApp(Cypress.env('autoTestUser'), appName);
     administration.getHeader().should('be.visible');
-    cy.visit(`/repos/${Cypress.env('autoTestUser')}/new-app/settings`);
+    cy.visit(`/repos/${Cypress.env('autoTestUser')}/${appName}/settings`);
     gitea.getDeleteButton().should('be.visible').click();
-    gitea.getDeleteRepositoryNameField().should('be.visible').type('new-app');
+    gitea.getDeleteRepositoryNameField().should('be.visible').type(appName);
   });
 });

--- a/frontend/testing/cypress/src/integration/studio/repos.js
+++ b/frontend/testing/cypress/src/integration/studio/repos.js
@@ -6,16 +6,16 @@ import { header } from '../../selectors/header';
 
 context('Repository', () => {
   before(() => {
-    cy.deleteallapps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
     cy.visit('/');
-    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.createapp(Cypress.env('autoTestUser'), 'designer');
+    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
   });
 
   beforeEach(() => {
     cy.visit('/');
-    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.searchAndOpenApp(Cypress.env('designerApp'));
+    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.searchAndOpenApp(Cypress.env('designerAppName'));
   });
 
   it('is possible to open repository of an app from app development page', () => {

--- a/frontend/testing/cypress/src/integration/studio/resourceadm.js
+++ b/frontend/testing/cypress/src/integration/studio/resourceadm.js
@@ -7,7 +7,7 @@ import * as texts from '@altinn-studio/language/src/nb.json';
 
 context('Resourceadm', () => {
   before(() => {
-    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
   });
 
   beforeEach(() => {

--- a/frontend/testing/cypress/src/integration/studio/sync-app.js
+++ b/frontend/testing/cypress/src/integration/studio/sync-app.js
@@ -7,10 +7,10 @@ import { header } from "../../selectors/header";
 
 context('Sync app and deploy', () => {
   before(() => {
-    cy.deleteallapps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
     cy.visit('/');
-    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.createapp(Cypress.env('autoTestUser'), 'designer');
+    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
   });
 
   beforeEach(() => {
@@ -26,7 +26,7 @@ context('Sync app and deploy', () => {
   });
 
   it('is possible to sync changes', () => {
-    cy.searchAndOpenApp(Cypress.env('designerApp'));
+    cy.searchAndOpenApp(Cypress.env('designerAppName'));
     // Make some changes
     cy.findByRole('button', { name: 'Endre' }).click();
     administration.getAppNameField().should('be.enabled').clear().type(Date.now());

--- a/frontend/testing/cypress/src/integration/studio/wcag.js
+++ b/frontend/testing/cypress/src/integration/studio/wcag.js
@@ -6,10 +6,10 @@ import { header } from "../../selectors/header";
 
 context('WCAG', () => {
   before(() => {
-    cy.deleteallapps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
     cy.visit('/');
-    cy.studiologin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.createapp(Cypress.env('autoTestUser'), 'designer');
+    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
   });
 
   beforeEach(() => {
@@ -33,7 +33,7 @@ context('WCAG', () => {
   });
 
   it('accessibility test for app designer', () => {
-    cy.searchAndOpenApp(Cypress.env('designerApp'));
+    cy.searchAndOpenApp(Cypress.env('designerAppName'));
     cy.testWcag();
 
     // Forms editor

--- a/frontend/testing/cypress/src/integration/usecase/usecase.js
+++ b/frontend/testing/cypress/src/integration/usecase/usecase.js
@@ -20,18 +20,18 @@ context(
   },
   () => {
     before(() => {
-      cy.studiologin(Cypress.env('useCaseUser'), Cypress.env('useCaseUserPwd'));
-      cy.getrepo(Cypress.env('deployApp'), Cypress.env('accessToken')).then((response) => {
+      cy.studioLogin(Cypress.env('useCaseUser'), Cypress.env('useCaseUserPwd'));
+      const deployAppId = `${Cypress.env('orgUserName')}/${Cypress.env('deployAppName')}`;
+      cy.getRepoByAppId(deployAppId, Cypress.env('accessToken')).then((response) => {
         if (response.status === 404) {
-          const [_, appName] = Cypress.env('deployApp').split('/');
-          cy.createapp('Testdepartementet', appName);
+          cy.createApp(Cypress.env('orgFullName'), Cypress.env('deployAppName'));
         }
       });
     });
     beforeEach(() => {
-      cy.studiologin(Cypress.env('useCaseUser'), Cypress.env('useCaseUserPwd'));
+      cy.studioLogin(Cypress.env('useCaseUser'), Cypress.env('useCaseUserPwd'));
       cy.visit('/');
-      cy.searchAndOpenApp(Cypress.env('deployApp'));
+      cy.searchAndOpenApp(Cypress.env('deployAppName'));
       administration.getHeader().should('be.visible');
     });
 
@@ -40,7 +40,7 @@ context(
       administration
         .getAppNameField()
         .invoke('val')
-        .should('contain', Cypress.env('deployApp').split('/')[1]);
+        .should('contain', Cypress.env('deployAppName'));
 
       // Forms editor
       header.getCreateLink().click();
@@ -52,7 +52,7 @@ context(
 
       // Preview
       header.getPreviewButton().should('be.visible').click();
-      cy.visit('/preview/' + Cypress.env('deployApp'));
+      cy.visit(`/preview/${Cypress.env('orgUserName')}/${Cypress.env('deployAppName')}`);
       preview.getBackToEditorButton().should('be.visible').click();
 
       // Repos

--- a/frontend/testing/cypress/src/support/gitea-api.js
+++ b/frontend/testing/cypress/src/support/gitea-api.js
@@ -5,7 +5,7 @@ const giteaBaseUrl = Cypress.config().baseUrl + '/repos/api/v1';
 /**
  * create an org with org name, authenticated using access token
  */
-Cypress.Commands.add('createorg', (orgName, accessToken) =>
+Cypress.Commands.add('createOrg', (orgName, accessToken) =>
   cy.request('POST', `${giteaBaseUrl}/orgs?token=${accessToken}`, {
     username: orgName,
   })
@@ -14,7 +14,7 @@ Cypress.Commands.add('createorg', (orgName, accessToken) =>
 /**
  * delete an org with org name, authenticated using access token
  */
-Cypress.Commands.add('deleteorg', (orgName, accessToken) =>
+Cypress.Commands.add('deleteOrg', (orgName, accessToken) =>
   cy
     .request({
       method: 'GET',
@@ -30,7 +30,7 @@ Cypress.Commands.add('deleteorg', (orgName, accessToken) =>
 /**
  * delete all the apps of an org, authenticated using access token
  */
-Cypress.Commands.add('deleteallapps', (ownerName, accessToken, isOrg) => {
+Cypress.Commands.add('deleteAllApps', (ownerName, accessToken, isOrg) => {
   const getReposEndpoint = isOrg
     ? `${giteaBaseUrl}/orgs/${ownerName}/repos?token=${accessToken}`
     : `${giteaBaseUrl}/users/${ownerName}/repos?token=${accessToken}`;
@@ -48,7 +48,7 @@ Cypress.Commands.add('deleteallapps', (ownerName, accessToken, isOrg) => {
 /**
  * make an user as the owner of an org's repo, authenticated using access token
  */
-Cypress.Commands.add('makeuserowner', (orgName, userName, accessToken) =>
+Cypress.Commands.add('makeUserOwner', (orgName, userName, accessToken) =>
   cy
     .request('GET', `${giteaBaseUrl}/orgs/${orgName}/teams?token=${accessToken}`)
     .then((response) => {
@@ -68,7 +68,7 @@ Cypress.Commands.add('makeuserowner', (orgName, userName, accessToken) =>
 /**
  * Delete an user by username, authenticated using access token
  */
-Cypress.Commands.add('deleteuser', (userName, accessToken) => {
+Cypress.Commands.add('deleteUser', (userName, accessToken) => {
   const endpoint = `${giteaBaseUrl}/admin/users/${userName}?token=${accessToken}`;
   cy.request('DELETE', endpoint);
 });
@@ -76,7 +76,7 @@ Cypress.Commands.add('deleteuser', (userName, accessToken) => {
 /**
  * create a repo with app name, authenticated using access token
  */
-Cypress.Commands.add('createrepository', (userName, appName, accessToken) => {
+Cypress.Commands.add('createRepository', (userName, appName, accessToken) => {
   cy.request('POST', `${giteaBaseUrl}/admin/users/${userName}/repos?token=${accessToken}`, {
     auto_init: false,
     default_branch: 'master',
@@ -88,7 +88,7 @@ Cypress.Commands.add('createrepository', (userName, appName, accessToken) => {
 /**
  * get an app repo and return response
  */
-Cypress.Commands.add('getrepo', (appId, accessToken) =>
+Cypress.Commands.add('getRepoByAppId', (appId, accessToken) =>
   cy.request({
     method: 'GET',
     url: `${giteaBaseUrl}/repos/${appId}?token=${accessToken}`,

--- a/frontend/testing/cypress/src/support/index.d.ts
+++ b/frontend/testing/cypress/src/support/index.d.ts
@@ -2,51 +2,51 @@ declare namespace Cypress {
   interface Chainable {
     /**
      * Custom command to create an org using gitea api
-     * @example cy.createorg(ttd, token)
+     * @example cy.createOrg(ttd, token)
      */
-    createorg(orgname: string, token: string): Chainable<Element>;
+    createOrg(orgName: string, token: string): Chainable<Element>;
 
     /**
      * Custom command to delete an org using gitea api
-     * @example cy.deleteorg(ttd, token)
+     * @example cy.deleteOrg(ttd, token)
      */
-    deleteorg(orgname: string, token: string): Chainable<Element>;
+    deleteOrg(orgName: string, token: string): Chainable<Element>;
 
     /**
      * Custom command to delete all apps of an org using gitea api
-     * @example cy.deleteallapps(ttd, token)
+     * @example cy.deleteAllApps(ttd, token)
      */
-    deleteallapps(orgname: string, token: string): Chainable<Element>;
+    deleteAllApps(orgName: string, token: string): Chainable<Element>;
 
     /**
      * Custom command to make an user owner of an org using gitea api
-     * @example cy.makeuserowner(ttd, testuser, token)
+     * @example cy.makeUserOwner(ttd, testUser, token)
      */
-    makeuserowner(orgname: string, username: string, token: string): Chainable<Element>;
+    makeUserOwner(orgName: string, userName: string, token: string): Chainable<Element>;
 
     /**
      * Custom command to delete an user using gitea api
-     * @example cy.deleteuser(testuser, token)
+     * @example cy.deleteUser(testUser, token)
      */
-    deleteuser(username: string, token: string): Chainable<Element>;
+    deleteUser(userName: string, token: string): Chainable<Element>;
 
     /**
      * Custom command to login to studio with username and pwd
-     * @example cy.studiologin(testuser, userpwd)
+     * @example cy.studioLogin(testUser, userPwd)
      */
-    studiologin(username: string, userpwd: string): Chainable<Element>;
+    studioLogin(userName: string, userPwd: string): Chainable<Element>;
 
     /**
      * Custom command to create an app from studio dashboard
-     * @example cy.createapp(ttd, testapp)
+     * @example cy.createApp(ttd, testApp)
      */
-    createapp(orgname: string, appname: string): Chainable<Element>;
+    createApp(orgName: string, appName: string): Chainable<Element>;
 
     /**
      * Select and delete all the added ui components in an app's ui editor
-     * @example cy.deletecomponents()
+     * @example cy.deleteComponents()
      */
-    deletecomponents(): Chainable<Element>;
+    deleteComponents(): Chainable<Element>;
 
     /**
      * Test for WCAG violations of impact critical, serious, moderate
@@ -61,7 +61,7 @@ declare namespace Cypress {
     deleteLocalChanges(appId: String): Chainable<Element>;
 
     /**
-     * Get body of ifram from the DOM
+     * Get body of iframe from the DOM
      * @example cy.getIframeBody()
      */
     getIframeBody(): Chainable<Element>;
@@ -72,22 +72,29 @@ declare namespace Cypress {
     isVisible(): Chainable<Element>;
 
     /**
-     * Custom command to search and open an app
-     * @example cy.searchAndOpenApp('ttd/app')
+     * Custom command to search and open an app based on only app name
+     * @example cy.searchAndOpenApp('appName')
      */
-    searchAndOpenApp(appId: string): Chainable<Element>;
+    searchAndOpenApp(appName: string): Chainable<Element>;
+
+    /**
+     * Switch selected context in dashboard
+     * @param context The context to switch to. Either 'self', 'all', or org user name.
+     * @example cy.searchAndOpenApp('self')
+     */
+    switchSelectedContext(context: string): Chainable<Element>;
 
     /**
      * Custom command to create a repo for an user
-     * @example cy.createrepository(user, app, token)
+     * @example cy.createRepository(user, app, token)
      */
-    createrepository(username: string, appName: string, token: string): Chainable<Element>;
+    createRepository(username: string, appName: string, token: string): Chainable<Element>;
 
     /**
      * Custom command to get a repo and return response
-     * @example cy.getrepo('ttd/app', token)
+     * @example cy.getRepoByAppId('ttd/app', token)
      */
-    getrepo(appId: string, token: string): Chainable<Element>;
+    getRepoByAppId(appId: string, token: string): Chainable<Element>;
 
   }
 }

--- a/frontend/testing/cypress/src/support/studio.js
+++ b/frontend/testing/cypress/src/support/studio.js
@@ -11,7 +11,7 @@ import { DEFAULT_SELECTED_LAYOUT_NAME } from '../../../../packages/shared/src/co
 /**
  * Login to studio with user name and password
  */
-Cypress.Commands.add('studiologin', (userName, userPwd) => {
+Cypress.Commands.add('studioLogin', (userName, userPwd) => {
   cy.session([userName, userPwd], () => {
     cy.visit('/');
     login.getLoginButton().should('be.visible').click();
@@ -45,7 +45,7 @@ Cypress.Commands.add('switchSelectedContext', (context) => {
 /**
  * create an app in studio with user logged in and in dashboard
  */
-Cypress.Commands.add('createapp', (orgName, appName) => {
+Cypress.Commands.add('createApp', (orgName, appName) => {
   cy.visit('/dashboard');
   dashboard.getNewAppLink().should('be.visible').click();
   dashboard.getAppOwnerField().should('be.visible').click();
@@ -59,7 +59,7 @@ Cypress.Commands.add('createapp', (orgName, appName) => {
 /**
  * Delete all the added components in ux-editor
  */
-Cypress.Commands.add('deletecomponents', () => {
+Cypress.Commands.add('deleteComponents', () => {
   designer
     .getDroppableList()
     .findAllByRole('listitem')
@@ -79,8 +79,7 @@ Cypress.Commands.add('deletecomponents', () => {
 /**
  * Search an app from dashboard and open app
  */
-Cypress.Commands.add('searchAndOpenApp', (appId) => {
-  const [_, appName] = appId.split('/');
+Cypress.Commands.add('searchAndOpenApp', (appName) => {
   cy.visit('/dashboard');
   dashboard.getSearchReposField().type(appName);
   dashboard


### PR DESCRIPTION
## Description
Adapt variables and variablenames used in the different envs for cypress tests to be more consistent. This includes only using app-names and usernames/orgnames separate and not involve appIds, e.g. not `ttd/auto-app` but `ttd` and `auto-app`

Also changed all command names in cypress to use camel case

## Related Issue(s)
- #{issue number}

## Verification
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
