### PR TITLE
11177 move sidegrupper to dropdownselect

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -504,6 +504,8 @@
   "left_menu.configure_layout_sets": "Konverter skjema til å håndtere sidegrupper",
   "left_menu.configure_layout_sets_info": "Obs, ved å velge denne handlingen endrer du mappestrukturen i applikasjonen. Les mer om hva det vil si på <0 href=\"{{layoutSetsDocs}}\" >Altinn Docs</0>.",
   "left_menu.configure_layout_sets_name": "Navn på første gruppe:",
+  "left_menu.layout_dropdown_menu_default_choice": "Velg...",
+  "left_menu.layout_dropdown_menu_label": "Velg sidegruppe",
   "left_menu.layout_sets": "Sidegrupper",
   "left_menu.layout_sets_add": "Legg til ny sidegruppe",
   "left_menu.page": "Side",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -504,7 +504,6 @@
   "left_menu.configure_layout_sets": "Konverter skjema til å håndtere sidegrupper",
   "left_menu.configure_layout_sets_info": "Obs, ved å velge denne handlingen endrer du mappestrukturen i applikasjonen. Les mer om hva det vil si på <0 href=\"{{layoutSetsDocs}}\" >Altinn Docs</0>.",
   "left_menu.configure_layout_sets_name": "Navn på første gruppe:",
-  "left_menu.layout_dropdown_menu_default_choice": "Velg...",
   "left_menu.layout_dropdown_menu_label": "Velg sidegruppe",
   "left_menu.layout_sets": "Sidegrupper",
   "left_menu.layout_sets_add": "Legg til ny sidegruppe",

--- a/frontend/packages/ux-editor/src/components/leftMenu/LeftMenu.module.css
+++ b/frontend/packages/ux-editor/src/components/leftMenu/LeftMenu.module.css
@@ -12,3 +12,18 @@
   padding-bottom: var(--fds-spacing-3);
   padding-top: var(--fds-spacing-2);
 }
+
+.dropDownContainer {
+  margin: 10px;
+}
+
+.selectLabelAndIcon {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.innstillingIcon {
+  font-size: 1.5rem;
+}

--- a/frontend/packages/ux-editor/src/components/leftMenu/LeftMenu.tsx
+++ b/frontend/packages/ux-editor/src/components/leftMenu/LeftMenu.tsx
@@ -78,7 +78,6 @@ export const LeftMenu = ({ className }: LeftMenuProps) => {
                 <CogIcon className={classes.innstillingIcon} />
               </div>
               <NativeSelect>
-                <option>{t('left_menu.layout_dropdown_menu_default_choice')}</option>
                 <option>
                   <LayoutSetsContainer />
                 </option>

--- a/frontend/packages/ux-editor/src/components/leftMenu/LeftMenu.tsx
+++ b/frontend/packages/ux-editor/src/components/leftMenu/LeftMenu.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { ConfPageToolbar } from './ConfPageToolbar';
 import { DefaultToolbar } from './DefaultToolbar';
-import { PlusIcon } from '@navikt/aksel-icons';
+import { PlusIcon, CogIcon } from '@navikt/aksel-icons';
 import { Button } from '@digdir/design-system-react';
 import { PagesContainer } from './PagesContainer';
 import { _useIsProdHack } from 'app-shared/utils/_useIsProdHack';
@@ -27,6 +27,7 @@ import { Accordion } from '@digdir/design-system-react';
 import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
 import { shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
 import { useInstanceIdQuery } from 'app-shared/hooks/queries';
+import { NativeSelect } from '@digdir/design-system-react';
 
 export interface LeftMenuProps {
   className?: string;
@@ -68,26 +69,31 @@ export const LeftMenu = ({ className }: LeftMenuProps) => {
 
   return (
     <div className={cn(className, classes.rightMenu)}>
-      <Accordion color='subtle'>
-        {shouldDisplayFeature('configureLayoutSet') && (
-          <Accordion.Item defaultOpen={layoutSetNames?.length > 0}>
-            <Accordion.Header>{t('left_menu.layout_sets')}</Accordion.Header>
-            <Accordion.Content>
-              {layoutSetNames ? (
-                <>
+      {shouldDisplayFeature('configureLayoutSet') &&
+        (layoutSetNames ? (
+          <>
+            <div className={classes.dropDownContainer}>
+              <div className={classes.selectLabelAndIcon}>
+                <span>{t('left_menu.layout_dropdown_menu_label')}</span>
+                <CogIcon className={classes.innstillingIcon} />
+              </div>
+              <NativeSelect>
+                <option>{t('left_menu.layout_dropdown_menu_default_choice')}</option>
+                <option>
                   <LayoutSetsContainer />
-                  <div className={classes.addButton}>
-                    <Button icon={<PlusIcon />} onClick={handleAddLayoutSet} size='small'>
-                      {t('left_menu.layout_sets_add')}
-                    </Button>
-                  </div>
-                </>
-              ) : (
-                <ConfigureLayoutSetPanel />
-              )}
-            </Accordion.Content>
-          </Accordion.Item>
-        )}
+                </option>
+              </NativeSelect>
+            </div>
+            <div className={classes.addButton}>
+              <Button icon={<PlusIcon />} onClick={handleAddLayoutSet} size='small'>
+                {t('left_menu.layout_sets_add')}
+              </Button>
+            </div>
+          </>
+        ) : (
+          <ConfigureLayoutSetPanel />
+        ))}
+      <Accordion color='subtle'>
         <Accordion.Item defaultOpen={true}>
           <Accordion.Header>{t('left_menu.pages')}</Accordion.Header>
           <Accordion.Content className={classes.pagesContent}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added dropdown menu for pages group in the left menu in "Lage" page, It will be shown just when we have a page group. 

## Related Issue(s)
- #11177 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
