### PR TITLE
Base successfully added expression on the expression property

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/Expressions/Expressions.tsx
+++ b/frontend/packages/ux-editor/src/components/config/Expressions/Expressions.tsx
@@ -6,7 +6,7 @@ import { useText } from '../../../hooks';
 import {
   Expression,
   SubExpression,
-  getExpressionPropertiesBasedOnComponentType
+  getExpressionPropertiesBasedOnComponentType, ExpressionProperty
 } from '../../../types/Expressions';
 import {
   addExpressionIfLimitNotReached,
@@ -30,7 +30,7 @@ export const Expressions = () => {
   const { formId, form, handleUpdate, handleSave } = useContext(FormContext);
   const [expressions, setExpressions] = React.useState<Expression[]>([]);
   const [expressionInEditModeId, setExpressionInEditModeId] = React.useState<string | undefined>(undefined);
-  const [successfullyAddedExpressionIndex, setSuccessfullyAddedExpressionIndex] = React.useState<number | undefined>(undefined);
+  const [successfullyAddedExpressionProperty, setSuccessfullyAddedExpressionProperty] = React.useState<ExpressionProperty | undefined>(undefined);
   const t = useText();
   
   useEffect(() => {
@@ -61,8 +61,8 @@ export const Expressions = () => {
   const saveExpressionAndSetCheckMark = async (index: number, expression: Expression) => {
     const updatedComponent = convertAndAddExpressionToComponent(form, expression);
     await updateAndSaveLayout(updatedComponent);
-    // Need to use index as expression reference since the id will be changed when the component is updated.
-    setSuccessfullyAddedExpressionIndex(index);
+    // Need to use property as expression reference since the id will be changed when the component is updated.
+    setSuccessfullyAddedExpressionProperty(expression.property);
     setExpressionInEditModeId(undefined);
   };
 
@@ -142,7 +142,7 @@ export const Expressions = () => {
             onGetProperties={() => getProperties(expression)}
             showRemoveExpressionButton={showRemoveExpressionButton}
             onSaveExpression={() => saveExpressionAndSetCheckMark(index, expression)}
-            successfullyAddedExpression={index === successfullyAddedExpressionIndex}
+            successfullyAddedExpression={expression.property === successfullyAddedExpressionProperty}
             expressionInEditMode={expression.id === expressionInEditModeId}
             onUpdateExpression={newExpression => updateExpression(index, newExpression)}
             onRemoveExpression={() => deleteExpression(expression)}

--- a/frontend/packages/ux-editor/src/components/config/Expressions/Expressions.tsx
+++ b/frontend/packages/ux-editor/src/components/config/Expressions/Expressions.tsx
@@ -6,7 +6,8 @@ import { useText } from '../../../hooks';
 import {
   Expression,
   SubExpression,
-  getExpressionPropertiesBasedOnComponentType, ExpressionProperty
+  getExpressionPropertiesBasedOnComponentType,
+  ExpressionProperty
 } from '../../../types/Expressions';
 import {
   addExpressionIfLimitNotReached,


### PR DESCRIPTION
## Description
Since the expressions might change order when saving to backend due to backend formatting of the layout file which will effect what properties (with connected expressions) that will be converted in what order. To make sure the `Lagt til` check mark is connected to the correct expression, this state is connected to the `expression.property` field in stead of the index.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
