### PR TITLE
clear session before studio login and run studio login before all test specs

### DIFF
--- a/frontend/testing/cypress/cypress.config.js
+++ b/frontend/testing/cypress/cypress.config.js
@@ -4,6 +4,7 @@ const path = require('path');
 module.exports = defineConfig({
   projectId: 'o7mikf',
   e2e: {
+    experimentalRunAllSpecs: true,
     supportFile: 'src/support/index.js',
     specPattern: 'src/integration/',
     testIsolation: false,

--- a/frontend/testing/cypress/src/integration/studio/dashboard.js
+++ b/frontend/testing/cypress/src/integration/studio/dashboard.js
@@ -8,11 +8,11 @@ import { common } from '../../selectors/common';
 
 context('Dashboard', () => {
   before(() => {
-    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
-    cy.visit('/');
     cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.createApp(Cypress.env('autoTestUser'), 'auto-app');
-    cy.createApp(Cypress.env('autoTestUser'), 'test-app');
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken')).then(() => {
+      cy.createApp(Cypress.env('autoTestUser'), 'auto-app');
+      cy.createApp(Cypress.env('autoTestUser'), 'test-app');
+    });
   });
 
   beforeEach(() => {

--- a/frontend/testing/cypress/src/integration/studio/datamodel.js
+++ b/frontend/testing/cypress/src/integration/studio/datamodel.js
@@ -7,10 +7,10 @@ import * as texts from '../../../../../language/src/nb.json';
 
 context('datamodel', () => {
   before(() => {
-    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
-    cy.visit('/');
-    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken')).then(() => {
+      cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+      cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
+    });
   });
 
   beforeEach(() => {

--- a/frontend/testing/cypress/src/integration/studio/designer.js
+++ b/frontend/testing/cypress/src/integration/studio/designer.js
@@ -10,12 +10,10 @@ const designerAppId = `${Cypress.env('autoTestUser')}/${Cypress.env('designerApp
 
 context('Designer', () => {
   before(() => {
-    cy.visit('/');
     cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
-    cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
-    cy.clearCookies();
-    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken')).then(() => {
+      cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
+    });
   });
   beforeEach(() => {
     cy.visit('/dashboard');

--- a/frontend/testing/cypress/src/integration/studio/login.js
+++ b/frontend/testing/cypress/src/integration/studio/login.js
@@ -8,6 +8,7 @@ import {gitea} from "../../selectors/gitea";
 
 context('Login', () => {
   beforeEach(() => {
+    cy.clearCookies();
     cy.visit('/');
   });
 
@@ -21,7 +22,12 @@ context('Login', () => {
   });
 
   it('is not possible to login with invalid user credentials', () => {
-    cy.studioLogin(Cypress.env('autoTestUser'), 'test123');
+    login.getLoginButton().should('be.visible').click();
+    gitea.getLanguageMenu().should('be.visible').click();
+    gitea.getLanguageMenuItem('Norsk').should('be.visible').click();
+    gitea.getUsernameField().should('be.visible').type(Cypress.env('autoTestUser'));
+    gitea.getPasswordField().should('be.visible').type('123', { log: false });
+    gitea.getLoginButton().should('be.visible').click();
     gitea.getLoginErrorMessage().should('be.visible');
   });
 });

--- a/frontend/testing/cypress/src/integration/studio/new-app.js
+++ b/frontend/testing/cypress/src/integration/studio/new-app.js
@@ -8,9 +8,8 @@ import { gitea } from "../../selectors/gitea";
 
 context('New App', () => {
   before(() => {
-    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
-    cy.visit('/');
     cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
   });
   beforeEach(() => {
     cy.visit('/dashboard');
@@ -22,7 +21,6 @@ context('New App', () => {
   });
 
   it('is possible to start app creation and exit', () => {
-    cy.visit('/dashboard');
     dashboard.getNewAppLink().should('be.visible').click();
     dashboard.getAppOwnerField().should('be.visible').click();
     dashboard.getOrgOption(Cypress.env('autoTestUser')).click();

--- a/frontend/testing/cypress/src/integration/studio/repos.js
+++ b/frontend/testing/cypress/src/integration/studio/repos.js
@@ -6,10 +6,10 @@ import { header } from '../../selectors/header';
 
 context('Repository', () => {
   before(() => {
-    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
-    cy.visit('/');
     cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken')).then(() => {
+      cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
+    });
   });
 
   beforeEach(() => {

--- a/frontend/testing/cypress/src/integration/studio/sync-app.js
+++ b/frontend/testing/cypress/src/integration/studio/sync-app.js
@@ -7,10 +7,10 @@ import { header } from "../../selectors/header";
 
 context('Sync app and deploy', () => {
   before(() => {
-    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
-    cy.visit('/');
     cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken')).then(() => {
+      cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
+    });
   });
 
   beforeEach(() => {

--- a/frontend/testing/cypress/src/integration/studio/wcag.js
+++ b/frontend/testing/cypress/src/integration/studio/wcag.js
@@ -6,10 +6,10 @@ import { header } from "../../selectors/header";
 
 context('WCAG', () => {
   before(() => {
-    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
-    cy.visit('/');
     cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
-    cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken')).then(() => {
+      cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
+    });
   });
 
   beforeEach(() => {

--- a/frontend/testing/cypress/src/support/studio.js
+++ b/frontend/testing/cypress/src/support/studio.js
@@ -9,9 +9,11 @@ import { gitea } from '../selectors/gitea';
 import { DEFAULT_SELECTED_LAYOUT_NAME } from '../../../../packages/shared/src/constants';
 
 /**
- * Login to studio with user name and password
+ * Clear cookies and login to studio with user name and password
  */
 Cypress.Commands.add('studioLogin', (userName, userPwd) => {
+  cy.clearCookies();
+  Cypress.session.clearAllSavedSessions();
   cy.session([userName, userPwd], () => {
     cy.visit('/');
     login.getLoginButton().should('be.visible').click();
@@ -20,6 +22,7 @@ Cypress.Commands.add('studioLogin', (userName, userPwd) => {
     gitea.getUsernameField().should('be.visible').type(userName);
     gitea.getPasswordField().should('be.visible').type(userPwd, { log: false });
     gitea.getLoginButton().should('be.visible').click();
+    cy.url().should('contain', '/dashboard');
   });
 });
 


### PR DESCRIPTION
## Description
- clear all sessions before studio login
- make sure studio login command is run in beginning of all test specs
- make it possible to run all tests in cypress gui by adding a field in config

## Related Issue(s)
- #{issue number}

## Verification
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

