### PR TITLE
Drag and drop tree view

### DIFF
--- a/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTree.test.tsx
+++ b/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTree.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { act, render as renderRtl, screen } from '@testing-library/react';
+import { DragAndDropTree } from 'app-shared/components/DragAndDropTree';
+import userEvent from '@testing-library/user-event';
+
+const user = userEvent.setup();
+
+// Test data:
+const onAdd = jest.fn();
+const onMove = jest.fn();
+const rootId = 'rootId';
+const rootNodeId1 = '1';
+const rootNodeLabel1 = 'Test 1';
+const subNodeId1_1 = '1.1';
+const subNodeLabel1_1 = 'Test 1.1';
+const subNodeId1_2 = '1.2';
+const subNodeLabel1_2 = 'Test 1.2';
+const subSubNodeId1_1_1 = '1.1.1';
+const subSubNodeLabel1_1_1 = 'Test 1.1.1';
+const rootNodeId2 = '2';
+const rootNodeLabel2 = 'Test 2';
+const subNodeId2_1 = '2.1';
+const subNodeLabel2_1 = 'Test 2.1';
+
+const render = () =>
+  renderRtl(
+    <DragAndDropTree.Provider onAdd={onAdd} onMove={onMove} rootId={rootId}>
+      <DragAndDropTree.Root>
+        <DragAndDropTree.Item label={rootNodeLabel1} nodeId={rootNodeId1}>
+          <DragAndDropTree.Item label={subNodeLabel1_1} nodeId={subNodeId1_1}>
+            <DragAndDropTree.Item label={subSubNodeLabel1_1_1} nodeId={subSubNodeId1_1_1} />
+          </DragAndDropTree.Item>
+          <DragAndDropTree.Item label={subNodeLabel1_2} nodeId={subNodeId1_2} />
+        </DragAndDropTree.Item>
+        <DragAndDropTree.Item label={rootNodeLabel2} nodeId={rootNodeId2}>
+          <DragAndDropTree.Item label={subNodeLabel2_1} nodeId={subNodeId2_1} />
+        </DragAndDropTree.Item>
+      </DragAndDropTree.Root>
+    </DragAndDropTree.Provider>,
+  );
+
+describe('DragAndDropTree', () => {
+  it('Reders root items', () => {
+    render();
+    expect(
+      screen.getByRole('treeitem', { name: rootNodeLabel1, expanded: false }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('treeitem', { name: rootNodeLabel2, expanded: false }),
+    ).toBeInTheDocument();
+  });
+
+  it('Expands an item when clicked', async () => {
+    render();
+    const firstItem = screen.getByRole('treeitem', { name: rootNodeLabel1, expanded: false });
+    await act(() => user.click(firstItem));
+    expect(screen.getByRole('treeitem', { name: subNodeLabel1_1 })).toBeInTheDocument();
+    expect(screen.getByRole('treeitem', { name: subNodeLabel1_2 })).toBeInTheDocument();
+  });
+
+  it('Focuses on first node when user presses the tab key', async () => {
+    render();
+    expect(screen.getByRole('treeitem', { name: rootNodeLabel1 })).not.toHaveFocus();
+    await act(() => user.tab());
+    expect(screen.getByRole('treeitem', { name: rootNodeLabel1 })).toHaveFocus();
+  });
+
+  it('Focuses on next node when user presses the down arrow key', async () => {
+    render();
+    const firstItem = screen.getByRole('treeitem', { name: rootNodeLabel1 });
+    await act(() => user.type(firstItem, '{arrowdown}'));
+    expect(screen.getByRole('treeitem', { name: rootNodeLabel2 })).toHaveFocus();
+  });
+});

--- a/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeItem/DragAndDropTreeItem.module.css
+++ b/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeItem/DragAndDropTreeItem.module.css
@@ -1,0 +1,7 @@
+.item {
+  border-radius: var(--fds-border_radius-small);
+}
+
+.item.hasHoveredItem {
+  outline: 1px dotted var(--fds-semantic-border-action-primary-hover);
+}

--- a/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeItem/DragAndDropTreeItem.test.tsx
+++ b/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeItem/DragAndDropTreeItem.test.tsx
@@ -1,0 +1,88 @@
+/* eslint-disable testing-library/no-container, testing-library/no-node-access, react/display-name  */
+
+import React from 'react';
+import { render as renderRtl, screen } from '@testing-library/react';
+import { DragAndDropTreeItem, DragAndDropTreeItemProps } from './DragAndDropTreeItem';
+import {
+  DragAndDropTreeRootContext,
+  DragAndDropTreeRootContextProps,
+} from '../DragAndDropTreeRoot';
+import { DragAndDropTreeProvider } from '../DragAndDropTreeProvider';
+import {
+  DragAndDropTreeItemContext,
+  DragAndDropTreeItemContextProps,
+} from 'app-shared/components/DragAndDropTree/DragAndDropTreeItem/DragAndDropTreeItemContext';
+import { TreeViewRoot } from 'app-shared/components/TreeView/TreeViewRoot';
+
+// Test data:
+const label = 'Test';
+const nodeId = 'node';
+const parentId = 'parent';
+const onAdd = jest.fn();
+const onMove = jest.fn();
+const rootId = 'rootId';
+const hoveredNodeParent = null;
+const setHoveredNodeParent = jest.fn();
+const defaultProps: DragAndDropTreeItemProps = { label, nodeId };
+const defaultItemContextProps: DragAndDropTreeItemContextProps = { nodeId: parentId };
+const defaultRootContextProps: DragAndDropTreeRootContextProps = {
+  hoveredNodeParent,
+  setHoveredNodeParent,
+};
+
+interface RenderProps {
+  props?: Partial<DragAndDropTreeItemProps>;
+  itemContextProps?: Partial<DragAndDropTreeItemContextProps>;
+  rootContextProps?: Partial<DragAndDropTreeRootContextProps>;
+}
+
+type RenderWrapperProps = Omit<RenderProps, 'props'>;
+
+const wrapper =
+  ({ itemContextProps = {}, rootContextProps = {} }: RenderWrapperProps = {}) =>
+  (
+    { children }, // eslint-disable-line react/prop-types
+  ) => (
+    <DragAndDropTreeProvider onAdd={onAdd} onMove={onMove} rootId={rootId}>
+      <DragAndDropTreeRootContext.Provider
+        value={{ ...defaultRootContextProps, ...rootContextProps }}
+      >
+        <TreeViewRoot>
+          <DragAndDropTreeItemContext.Provider
+            value={{ ...defaultItemContextProps, ...itemContextProps }}
+          >
+            {children}
+          </DragAndDropTreeItemContext.Provider>
+        </TreeViewRoot>
+      </DragAndDropTreeRootContext.Provider>
+    </DragAndDropTreeProvider>
+  );
+const render = ({ props = {}, itemContextProps = {}, rootContextProps = {} }: RenderProps = {}) =>
+  renderRtl(<DragAndDropTreeItem {...defaultProps} {...props} />, {
+    wrapper: wrapper({ itemContextProps, rootContextProps }),
+  });
+
+// Mocks:
+jest.mock('./DragAndDropTreeItem.module.css', () => ({
+  item: 'item',
+  hasHoveredItem: 'hasHoveredItem',
+}));
+
+describe('DragAndDropTreeItem', () => {
+  it('Renders a treeitem with the given label', () => {
+    render();
+    expect(screen.getByRole('treeitem', { name: label })).toBeInTheDocument();
+  });
+
+  it('Does not have the hasHoveredItem class name by default', () => {
+    const { container } = render();
+    const item = container.querySelector('.item');
+    expect(item).not.toHaveClass('hasHoveredItem');
+  });
+
+  it('Has the hasHoveredItem class name if hoveredNodeParent matches nodeId', () => {
+    const { container } = render({ rootContextProps: { hoveredNodeParent: nodeId } });
+    const item = container.querySelector('.item');
+    expect(item).toHaveClass('hasHoveredItem');
+  });
+});

--- a/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeItem/DragAndDropTreeItem.tsx
+++ b/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeItem/DragAndDropTreeItem.tsx
@@ -1,0 +1,49 @@
+import { DragAndDrop } from 'app-shared/components/dragAndDrop';
+import { TreeView } from 'app-shared/components/TreeView';
+import React, { ReactNode, useContext } from 'react';
+import { DragAndDropTreeRootContext } from '../DragAndDropTreeRoot';
+import { DragAndDropTreeItemContext } from './DragAndDropTreeItemContext';
+import classes from './DragAndDropTreeItem.module.css';
+import cn from 'classnames';
+
+export interface DragAndDropTreeItemProps {
+  children?: ReactNode;
+  label: string;
+  labelWrapper?: (children: ReactNode) => ReactNode;
+  nodeId: string;
+}
+
+export const DragAndDropTreeItem = ({
+  children,
+  label,
+  labelWrapper,
+  nodeId,
+}: DragAndDropTreeItemProps) => {
+  const { hoveredNodeParent, setHoveredNodeParent } = useContext(DragAndDropTreeRootContext);
+  const { nodeId: parentId } = useContext(DragAndDropTreeItemContext);
+
+  const subList = children ? <DragAndDrop.List>{children}</DragAndDrop.List> : null;
+  const renderLabel = labelWrapper ?? ((node) => node);
+  const handleDragOver = () => setHoveredNodeParent(parentId);
+
+  return (
+    <DragAndDrop.ListItem
+      as='li'
+      itemId={nodeId}
+      onDragOver={handleDragOver}
+      renderItem={(dragHandleRef) => (
+        <DragAndDropTreeItemContext.Provider value={{ nodeId }}>
+          <TreeView.Item
+            as='div'
+            className={cn(classes.item, hoveredNodeParent === nodeId && classes.hasHoveredItem)}
+            nodeId={nodeId}
+            label={label}
+            labelWrapper={(node) => renderLabel(<div ref={dragHandleRef}>{node}</div>)}
+          >
+            {subList}
+          </TreeView.Item>
+        </DragAndDropTreeItemContext.Provider>
+      )}
+    />
+  );
+};

--- a/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeItem/DragAndDropTreeItemContext.ts
+++ b/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeItem/DragAndDropTreeItemContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+export type DragAndDropTreeItemContextProps = {
+  nodeId: string;
+};
+
+export const DragAndDropTreeItemContext = createContext<DragAndDropTreeItemContextProps>({
+  nodeId: null,
+});

--- a/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeItem/index.ts
+++ b/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeItem/index.ts
@@ -1,0 +1,2 @@
+export { DragAndDropTreeItem } from './DragAndDropTreeItem';
+export type { DragAndDropTreeItemProps } from './DragAndDropTreeItem';

--- a/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeProvider/DragAndDropTreeProvider.tsx
+++ b/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeProvider/DragAndDropTreeProvider.tsx
@@ -1,0 +1,12 @@
+import { DragAndDrop, DragAndDropProviderProps } from 'app-shared/components/dragAndDrop';
+import React from 'react';
+
+export type DragAndDropTreeProviderProps<T> = Omit<DragAndDropProviderProps<T>, 'gap'>;
+
+export function DragAndDropTreeProvider<T>(props: DragAndDropTreeProviderProps<T>) {
+  return (
+    <DragAndDrop.Provider {...props} gap='4px'>
+      {props.children}
+    </DragAndDrop.Provider>
+  );
+}

--- a/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeProvider/index.ts
+++ b/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeProvider/index.ts
@@ -1,0 +1,2 @@
+export { DragAndDropTreeProvider } from './DragAndDropTreeProvider';
+export type { DragAndDropTreeProviderProps } from './DragAndDropTreeProvider';

--- a/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeRoot/DragAndDropTreeRoot.test.tsx
+++ b/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeRoot/DragAndDropTreeRoot.test.tsx
@@ -1,0 +1,46 @@
+import React, { ReactNode, useContext } from 'react';
+import { act, render as renderRtl, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DragAndDropTreeRoot } from './DragAndDropTreeRoot';
+import { DragAndDrop } from 'app-shared/components/dragAndDrop';
+import { DragAndDropTreeRootContext } from 'app-shared/components/DragAndDropTree/DragAndDropTreeRoot/DragAndDropTreeRootContext';
+
+const user = userEvent.setup();
+
+// Test data:
+const childrenTestId = 'test';
+const renderComponent = (children?: ReactNode) => (
+  <DragAndDrop.Provider onAdd={jest.fn()} onMove={jest.fn()} rootId='rootId'>
+    <DragAndDropTreeRoot>
+      <div data-testid={childrenTestId}>{children}</div>
+    </DragAndDropTreeRoot>
+  </DragAndDrop.Provider>
+);
+
+const render = (children?: ReactNode) => renderRtl(renderComponent(children));
+
+describe('DragAndDropTreeRoot', () => {
+  afterEach(jest.clearAllMocks);
+
+  it('Renders children', () => {
+    render();
+    expect(screen.getByTestId(childrenTestId)).toBeInTheDocument();
+  });
+
+  it('Sets hovered node parent to given value when `setHoveredNodeParent` is called and back to null when mouse leaves', async () => {
+    const { result } = renderHook(() => useContext(DragAndDropTreeRootContext), {
+      wrapper: ({ children }) => renderComponent(children),
+    });
+    const item = screen.getByTestId(childrenTestId);
+
+    expect(result.current.hoveredNodeParent).toBeNull(); // Should be null by default
+
+    const hoveredNodeParent = 'hoveredNodeParent';
+    await act(() => user.hover(item));
+    await act(() => result.current.setHoveredNodeParent(hoveredNodeParent)); // Simulate setHoveredNodeParent call from somewhere inside the children
+    expect(result.current.hoveredNodeParent).toBe(hoveredNodeParent);
+
+    await act(() => user.unhover(item)); // Simulate mouse leave
+    expect(result.current.hoveredNodeParent).toBeNull();
+  });
+});

--- a/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeRoot/DragAndDropTreeRoot.tsx
+++ b/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeRoot/DragAndDropTreeRoot.tsx
@@ -1,0 +1,19 @@
+import React, { ReactNode, useState } from 'react';
+import { DragAndDrop } from 'app-shared/components/dragAndDrop';
+import { TreeView } from 'app-shared/components/TreeView';
+import { DragAndDropTreeRootContext } from './DragAndDropTreeRootContext';
+
+export interface DragAndDropTreeRootProps {
+  children?: ReactNode;
+}
+
+export const DragAndDropTreeRoot = ({ children }: DragAndDropTreeRootProps) => {
+  const [hoveredNodeParent, setHoveredNodeParent] = useState<string | null>(null);
+  return (
+    <DragAndDropTreeRootContext.Provider value={{ hoveredNodeParent, setHoveredNodeParent }}>
+      <DragAndDrop.List>
+        <TreeView.Root onMouseOut={() => setHoveredNodeParent(null)}>{children}</TreeView.Root>
+      </DragAndDrop.List>
+    </DragAndDropTreeRootContext.Provider>
+  );
+};

--- a/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeRoot/DragAndDropTreeRootContext.ts
+++ b/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeRoot/DragAndDropTreeRootContext.ts
@@ -1,0 +1,8 @@
+import { createContext, Dispatch, SetStateAction } from 'react';
+
+export type DragAndDropTreeRootContextProps = {
+  hoveredNodeParent: string | null;
+  setHoveredNodeParent: Dispatch<SetStateAction<string | null>>;
+};
+
+export const DragAndDropTreeRootContext = createContext<DragAndDropTreeRootContextProps>(null);

--- a/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeRoot/index.ts
+++ b/frontend/packages/shared/src/components/DragAndDropTree/DragAndDropTreeRoot/index.ts
@@ -1,0 +1,4 @@
+export { DragAndDropTreeRoot } from './DragAndDropTreeRoot';
+export type { DragAndDropTreeRootProps } from './DragAndDropTreeRoot';
+export { DragAndDropTreeRootContext } from './DragAndDropTreeRootContext';
+export type { DragAndDropTreeRootContextProps } from './DragAndDropTreeRootContext';

--- a/frontend/packages/shared/src/components/DragAndDropTree/index.ts
+++ b/frontend/packages/shared/src/components/DragAndDropTree/index.ts
@@ -1,0 +1,18 @@
+import { DragAndDropTreeItem } from './DragAndDropTreeItem';
+import { DragAndDropTreeRoot } from './DragAndDropTreeRoot';
+import { DragAndDrop } from 'app-shared/components/dragAndDrop';
+import { DragAndDropTreeProvider } from './DragAndDropTreeProvider';
+
+type DragAndDropTreeComponent = {
+  Item: typeof DragAndDropTreeItem;
+  Root: typeof DragAndDropTreeRoot;
+  Provider: typeof DragAndDropTreeProvider;
+  NewItem: typeof DragAndDrop.NewItem;
+};
+
+export const DragAndDropTree: DragAndDropTreeComponent = {
+  Item: DragAndDropTreeItem,
+  Root: DragAndDropTreeRoot,
+  Provider: DragAndDropTreeProvider,
+  NewItem: DragAndDrop.NewItem,
+};

--- a/frontend/packages/shared/src/components/TreeView/TreeViewItem/TreeViewItem.tsx
+++ b/frontend/packages/shared/src/components/TreeView/TreeViewItem/TreeViewItem.tsx
@@ -1,4 +1,12 @@
-import React, { ElementType, KeyboardEvent, ReactNode, useEffect, useRef, useState } from 'react';
+import React, {
+  ElementType,
+  HTMLAttributes,
+  KeyboardEvent,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useTreeViewRootContext } from '../hooks/useTreeViewRootContext';
 import { useTreeViewItemContext } from '../hooks/useTreeViewItemContext';
 import {
@@ -16,21 +24,25 @@ import { TreeViewItemContext } from './TreeViewItemContext';
 import { ChevronDownIcon, ChevronRightIcon } from '@navikt/aksel-icons';
 import { Button } from '@digdir/design-system-react';
 import classes from './TreeViewItem.module.css';
+import cn from 'classnames';
 
-export interface TreeViewItemProps {
+export type TreeViewItemProps = {
   as?: ElementType;
   children?: ReactNode;
+  className?: string;
   label: ReactNode;
   labelWrapper?: (children: ReactNode) => ReactNode;
   nodeId: string;
-}
+} & HTMLAttributes<HTMLDivElement>;
 
 export const TreeViewItem = ({
   as = 'li',
+  className,
   children,
   label,
   labelWrapper = (lab) => lab,
   nodeId,
+  ...rest
 }: TreeViewItemProps) => {
   const [open, setOpen] = useState(false);
   const { selectedId, setSelectedId, rootId, focusedId, setFocusedId, focusableId } =
@@ -113,7 +125,7 @@ export const TreeViewItem = ({
 
   return (
     <TreeViewItemContext.Provider value={{ level: level + 1 }}>
-      <Component role='none' className={classes.listItem}>
+      <Component role='none' {...rest} className={cn(classes.listItem, className)}>
         {labelWrapper(renderLabel())}
         {children && (
           <AnimateHeight open={open}>

--- a/frontend/packages/shared/src/components/TreeView/TreeViewRoot/TreeViewRoot.tsx
+++ b/frontend/packages/shared/src/components/TreeView/TreeViewRoot/TreeViewRoot.tsx
@@ -1,19 +1,29 @@
-import React, { ReactNode, useEffect, useId, useLayoutEffect, useState } from 'react';
+import React, {
+  HTMLAttributes,
+  ReactNode,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useState,
+} from 'react';
 import { TreeViewRootContext } from '../TreeViewRoot';
 import classes from './TreeViewRoot.module.css';
 import { findFirstNodeId } from 'app-shared/components/TreeView/utils/domUtils';
 import { focusableNodeId } from 'app-shared/components/TreeView/utils/treeViewItemUtils';
+import cn from 'classnames';
 
-export interface TreeViewRootProps {
+export type TreeViewRootProps = {
   children: ReactNode;
   onSelect?: (nodeId: string) => void;
   selectedId?: string;
-}
+} & HTMLAttributes<HTMLUListElement>;
 
 export const TreeViewRoot = ({
   children,
+  className,
   onSelect,
   selectedId: selectedIdFromProps,
+  ...rest
 }: TreeViewRootProps) => {
   const rootId = useId();
   const [selectedId, setSelectedId] = useState<string | undefined>(selectedIdFromProps);
@@ -45,7 +55,7 @@ export const TreeViewRoot = ({
         focusableId,
       }}
     >
-      <ul role='tree' id={rootId} className={classes.list}>
+      <ul role='tree' {...rest} id={rootId} className={cn(classes.list, className)}>
         {children}
       </ul>
     </TreeViewRootContext.Provider>

--- a/frontend/packages/shared/src/components/dragAndDrop/DragAndDropList/DragAndDropList.test.tsx
+++ b/frontend/packages/shared/src/components/dragAndDrop/DragAndDropList/DragAndDropList.test.tsx
@@ -18,11 +18,13 @@ const itemId = 'id';
 const rootId = 'rootId';
 const uniqueDomId = ':r0:';
 const onDrop = jest.fn();
+const gap = '1rem';
 const defaultlistItemContextProps: DragAndDropListItemContextProps = {
   isDisabled: false,
   itemId,
 };
 const defaultRootContextProps: DragAndDropRootContextProps<string> = {
+  gap,
   onDrop,
   rootId,
   uniqueDomId,

--- a/frontend/packages/shared/src/components/dragAndDrop/DragAndDropListItem/DragAndDropListItem.module.css
+++ b/frontend/packages/shared/src/components/dragAndDrop/DragAndDropListItem/DragAndDropListItem.module.css
@@ -1,3 +1,7 @@
+.root {
+  list-style-type: none;
+}
+
 .wrapper {
   padding: calc(var(--list-item-gap) / 2) 0;
 }

--- a/frontend/packages/shared/src/components/dragAndDrop/DragAndDropListItem/DragAndDropListItem.test.tsx
+++ b/frontend/packages/shared/src/components/dragAndDrop/DragAndDropListItem/DragAndDropListItem.test.tsx
@@ -20,6 +20,7 @@ const rootId = 'rootId';
 const uniqueDomId = ':r0:';
 const onDrop = jest.fn();
 const renderItem = () => <div>test</div>;
+const gap = '1rem';
 const defaultlistItemProps: DragAndDropListItemProps = {
   itemId,
   renderItem,
@@ -29,6 +30,7 @@ const defaultlistItemContextProps: DragAndDropListItemContextProps = {
   itemId: parentId,
 };
 const defaultRootContextProps: DragAndDropRootContextProps<string> = {
+  gap,
   onDrop,
   rootId,
   uniqueDomId,

--- a/frontend/packages/shared/src/components/dragAndDrop/DragAndDropListItem/DragAndDropListItem.tsx
+++ b/frontend/packages/shared/src/components/dragAndDrop/DragAndDropListItem/DragAndDropListItem.tsx
@@ -1,10 +1,19 @@
 import {
-  DraggableEditorItemType,
-  DragCursorPosition,
   DndItem,
+  DragCursorPosition,
+  DraggableEditorItemType,
   ExistingDndItem,
 } from '../../../types/dndTypes';
-import React, { ReactNode, useCallback, useMemo, useRef, useState } from 'react';
+import React, {
+  CSSProperties,
+  ElementType,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { ConnectDragSource, useDrag, useDrop } from 'react-dnd';
 import { calculateNewPosition, getDragCursorPosition } from '../../../utils/dndUtils';
 import classes from './DragAndDropListItem.module.css';
@@ -14,10 +23,17 @@ import { useParentId } from '../hooks/useParentId';
 import { useOnDrop } from 'app-shared/components/dragAndDrop/hooks/useOnDrop';
 import { useDomSelectors } from 'app-shared/components/dragAndDrop/hooks/useDomSelectors';
 import { findPositionInList } from 'app-shared/components/dragAndDrop/utils/domUtils';
+import { useGapValue } from 'app-shared/components/dragAndDrop/hooks/useGapValue';
 
 export interface DragAndDropListItemProps {
+  /** The type of the HTML item to render as the root. */
+  as?: ElementType;
+
   /** The id of the item. */
   itemId: string;
+
+  /** Function that is called when something is being dragged over the item. */
+  onDragOver?: () => void;
 
   /** Function that renders the item content. It takes a drag handle ref as a parameter - this must be used as the ref to the drag handle component. */
   renderItem: (dragHandleRef: ConnectDragSource) => ReactNode;
@@ -27,7 +43,16 @@ interface DragCollectedProps {
   isDragging: boolean;
 }
 
-export function DragAndDropListItem<T>({ itemId, renderItem }: DragAndDropListItemProps) {
+type WrapperStyle = CSSProperties & {
+  '--list-item-gap': string;
+};
+
+export function DragAndDropListItem<T>({
+  as = 'div',
+  itemId,
+  onDragOver,
+  renderItem,
+}: DragAndDropListItemProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [dragCursorPosition, setDragCursorPosition] = useState<DragCursorPosition>(
     DragCursorPosition.Outside,
@@ -36,6 +61,17 @@ export function DragAndDropListItem<T>({ itemId, renderItem }: DragAndDropListIt
   const parentId = useParentId();
   const onDrop = useOnDrop<T>();
   const domSelectors = useDomSelectors(itemId);
+  const gap = useGapValue();
+
+  const isBeingDraggedOver = [
+    DragCursorPosition.UpperHalf,
+    DragCursorPosition.LowerHalf,
+    DragCursorPosition.Self,
+  ].includes(dragCursorPosition);
+
+  useEffect(() => {
+    if (isBeingDraggedOver) onDragOver?.();
+  }, [isBeingDraggedOver, onDragOver]);
 
   const boxShadow = useMemo(() => {
     switch (dragCursorPosition) {
@@ -81,7 +117,7 @@ export function DragAndDropListItem<T>({ itemId, renderItem }: DragAndDropListIt
         wrapperRef,
         isParentDisabled,
       );
-      if (currentDragPosition !== dragCursorPosition) setDragCursorPosition(currentDragPosition);
+      setDragCursorPosition(currentDragPosition);
     },
     collect: (monitor) => {
       if (!monitor.isOver({ shallow: true })) {
@@ -91,10 +127,18 @@ export function DragAndDropListItem<T>({ itemId, renderItem }: DragAndDropListIt
   });
 
   const opacity = isDragging ? 0.25 : 1;
+  const wrapperStyle: WrapperStyle = {
+    '--list-item-gap': gap,
+  };
+  const Component = as;
 
   return (
-    <div ref={wrapperRef} {...domSelectors.item}>
-      <div ref={drop} className={classes.wrapper}>
+    <Component
+      ref={wrapperRef}
+      className={classes.root + ' ' + domSelectors.item.className}
+      id={domSelectors.item.id}
+    >
+      <div ref={drop} style={wrapperStyle} className={classes.wrapper}>
         <div ref={dragPreview} style={{ opacity, boxShadow }}>
           <DragAndDropListItemContext.Provider
             value={{ isDisabled: isDragging || isParentDisabled, itemId }}
@@ -103,6 +147,6 @@ export function DragAndDropListItem<T>({ itemId, renderItem }: DragAndDropListIt
           </DragAndDropListItemContext.Provider>
         </div>
       </div>
-    </div>
+    </Component>
   );
 }

--- a/frontend/packages/shared/src/components/dragAndDrop/DragAndDropProvider/DragAndDropProvider.tsx
+++ b/frontend/packages/shared/src/components/dragAndDrop/DragAndDropProvider/DragAndDropProvider.tsx
@@ -5,24 +5,26 @@ import { DragAndDropRootContext } from './DragAndDropRootContext';
 import { HandleAdd, HandleDrop, HandleMove } from 'app-shared/types/dndTypes';
 
 export interface DragAndDropProviderProps<T> {
-  rootId: string;
   children: ReactNode;
+  gap?: string;
   onAdd: HandleAdd<T>;
   onMove: HandleMove;
+  rootId: string;
 }
 
 export function DragAndDropProvider<T>({
   children,
-  rootId,
+  gap = '1rem',
   onAdd,
   onMove,
+  rootId,
 }: DragAndDropProviderProps<T>) {
   const onDrop: HandleDrop<T> = (item, position) =>
     item.isNew === true ? onAdd(item.payload, position) : onMove(item.id, position);
   const uniqueDomId = useId(); // Can not be the same as root id because root id might not be unique (if there are multiple drag and drop lists)
   return (
     <DndProvider backend={HTML5Backend}>
-      <DragAndDropRootContext.Provider value={{ rootId, onDrop, uniqueDomId }}>
+      <DragAndDropRootContext.Provider value={{ gap, rootId, onDrop, uniqueDomId }}>
         {children}
       </DragAndDropRootContext.Provider>
     </DndProvider>

--- a/frontend/packages/shared/src/components/dragAndDrop/DragAndDropProvider/DragAndDropRootContext.ts
+++ b/frontend/packages/shared/src/components/dragAndDrop/DragAndDropProvider/DragAndDropRootContext.ts
@@ -2,6 +2,7 @@ import { createContext } from 'react';
 import { HandleDrop } from 'app-shared/types/dndTypes';
 
 export interface DragAndDropRootContextProps<T> {
+  gap: string;
   rootId: string;
   onDrop: HandleDrop<T>;
   uniqueDomId: string;

--- a/frontend/packages/shared/src/components/dragAndDrop/hooks/useDomSelectors.test.tsx
+++ b/frontend/packages/shared/src/components/dragAndDrop/hooks/useDomSelectors.test.tsx
@@ -18,7 +18,7 @@ describe('useDomSelectors', () => {
     const { result } = renderHook(() => useDomSelectors(id), {
       wrapper: ({ children }) => (
         <DragAndDropRootContext.Provider
-          value={{ uniqueDomId, rootId: 'rootId', onDrop: jest.fn() }}
+          value={{ uniqueDomId, rootId: 'rootId', onDrop: jest.fn(), gap: '1rem' }}
         >
           {children}
         </DragAndDropRootContext.Provider>

--- a/frontend/packages/shared/src/components/dragAndDrop/hooks/useGapValue.test.tsx
+++ b/frontend/packages/shared/src/components/dragAndDrop/hooks/useGapValue.test.tsx
@@ -1,0 +1,25 @@
+import { renderHook } from '@testing-library/react';
+import { useGapValue } from './useGapValue';
+import React from 'react';
+import { DragAndDrop } from 'app-shared/components/dragAndDrop';
+
+describe('useGapValue', () => {
+  it('Returns the gap value from the context', () => {
+    const gap = '1rem';
+    const { result } = renderHook(useGapValue, {
+      wrapper: ({ children }) => (
+        <DragAndDrop.Provider rootId='root' onAdd={jest.fn()} onMove={jest.fn()} gap={gap}>
+          {children}
+        </DragAndDrop.Provider>
+      ),
+    });
+    expect(result.current).toBe(gap);
+  });
+
+  it('Returns an error when it is called outside of a provider', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(useGapValue)).toThrowError(
+      'useGapValue must be used within a DragAndDropProvider',
+    );
+  });
+});

--- a/frontend/packages/shared/src/components/dragAndDrop/hooks/useGapValue.ts
+++ b/frontend/packages/shared/src/components/dragAndDrop/hooks/useGapValue.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { DragAndDropRootContext } from 'app-shared/components/dragAndDrop/DragAndDropProvider';
+
+export const useGapValue = (): string => {
+  const context = useContext(DragAndDropRootContext);
+  if (!context) {
+    throw new Error('useGapValue must be used within a DragAndDropProvider.');
+  }
+  return context.gap;
+};

--- a/frontend/packages/ux-editor/src/containers/DesignView.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView.tsx
@@ -57,7 +57,7 @@ export const DesignView = ({ className }: DesignViewProps) => {
       >
         <DragAndDrop.List<ComponentType>>
           {items?.length ? (
-            items.map((itemId: string, itemIndex: number) => (
+            items.map((itemId: string) => (
               <DragAndDrop.ListItem<ComponentType>
                 key={itemId}
                 itemId={itemId}


### PR DESCRIPTION
## Description
Added a component that merges the DragAndDrop and TreeView components. There is also some additional code that is supposed to make it easier to see which parent element the dragged object is being dragged into. I have also added a `gap` property to the `DragAndDrop` component to make it possible to customize the gap between elements.

Probably it will be necessary to make further changes, but this will be easier to see when we start using the component.

## Related Issue(s)
- #9227
- #11271

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally
