### PR TITLE
Switch places on the conditional components for configureLayoutSet feature flag

### DIFF
--- a/frontend/packages/ux-editor/src/components/Elements/Elements.module.css
+++ b/frontend/packages/ux-editor/src/components/Elements/Elements.module.css
@@ -3,12 +3,6 @@
   flex: var(--elements-width-fraction);
 }
 
-.addButton {
-  display: flex;
-  justify-content: center;
-  padding-top: var(--fds-spacing-5);
-}
-
 .pagesContent {
   padding: var(--fds-spacing-2);
 }

--- a/frontend/packages/ux-editor/src/components/Elements/Elements.tsx
+++ b/frontend/packages/ux-editor/src/components/Elements/Elements.tsx
@@ -55,24 +55,12 @@ export const Elements = () => {
     dispatch(FormLayoutActions.updateSelectedLayout(name));
   }
 
-  function handleAddLayoutSet() {
-    // TODO: Add layout set with set-name as user-input
-    // auto-connect data model and process in backend?
-  }
-
   return (
     <div className={classes.root}>
       {shouldDisplayFeature('configureLayoutSet') && layoutSetNames ? (
-        <>
-          <LayoutSetsContainer />
-          <div className={classes.addButton}>
-            <Button icon={<PlusIcon />} onClick={handleAddLayoutSet} size='small'>
-              {t('left_menu.layout_sets_add')}
-            </Button>
-          </div>
-        </>
+          <ConfigureLayoutSetPanel />
       ) : (
-        <ConfigureLayoutSetPanel />
+          <LayoutSetsContainer />
       )}
       <Accordion color='subtle'>
         <Accordion.Item defaultOpen={true}>

--- a/frontend/packages/ux-editor/src/components/Elements/LayoutSetsContainer.module.css
+++ b/frontend/packages/ux-editor/src/components/Elements/LayoutSetsContainer.module.css
@@ -1,4 +1,4 @@
 .dropDownContainer {
   margin: var(--fds-spacing-5);
-  margin-bottom: 0;
+  margin-bottom: 5px;
 }

--- a/frontend/packages/ux-editor/src/components/Elements/LayoutSetsContainer.tsx
+++ b/frontend/packages/ux-editor/src/components/Elements/LayoutSetsContainer.tsx
@@ -21,7 +21,7 @@ export function LayoutSetsContainer() {
     dispatch(FormLayoutActions.updateSelectedLayoutSet(set));
     typedLocalStorage.setItem<string>('layoutSet/' + app, set);
   };
-
+  
   if (!layoutSetNames) return null;
 
   return (


### PR DESCRIPTION
## Description
- Switch places on the conditional components for the configureLayoutSet featureflag so layoutset selector is always shown for apps that have layoutsets and the configure layoutset button is hidden behind the featureflag
- Remove button for adding layoutset since this feature is not configured

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
