### PR TITLE
Remove preview layout set from local storage

### DIFF
--- a/frontend/app-development/features/textEditor/TextEditor.tsx
+++ b/frontend/app-development/features/textEditor/TextEditor.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { LangCode } from '@altinn/text-editor';
 import { TextEditor as TextEditorImpl, defaultLangCode } from '@altinn/text-editor';
 import { PageSpinner } from 'app-shared/components';
-import { useLocalStorage } from 'app-shared/hooks/useWebStorage';
+import { useLocalStorage } from 'app-shared/hooks/useLocalStorage';
 import { useSearchParams } from 'react-router-dom';
 import { TextResourceIdMutation } from '@altinn/text-editor/src/types';
 import { useLanguagesQuery, useTextResourcesQuery } from '../../hooks/queries';
@@ -21,7 +21,7 @@ export const TextEditor = () => {
   const selectedLanguagesStorageKey = `${org}:${app}:selectedLanguages`;
   const [selectedLangCodes, setSelectedLangCodes] = useLocalStorage<string[]>(
     selectedLanguagesStorageKey,
-    [defaultLangCode]
+    [defaultLangCode],
   );
   const getSearchQuery = () => searchParams.get('search') || '';
 

--- a/frontend/app-preview/src/views/LandingPage.tsx
+++ b/frontend/app-preview/src/views/LandingPage.tsx
@@ -4,7 +4,7 @@ import { PreviewContext } from '../PreviewContext';
 import { useTranslation } from 'react-i18next';
 import { usePreviewConnection } from 'app-shared/providers/PreviewConnectionContext';
 import { useInstanceIdQuery, useRepoMetadataQuery, useUserQuery } from 'app-shared/hooks/queries';
-import { useLocalStorage } from 'app-shared/hooks/useWebStorage';
+import { useLocalStorage } from 'app-shared/hooks/useLocalStorage';
 import { AltinnHeader } from 'app-shared/components/altinnHeader';
 import { AltinnHeaderVariant } from 'app-shared/components/altinnHeader/types';
 import { getRepositoryType } from 'app-shared/utils/repository';
@@ -33,11 +33,11 @@ export const LandingPage = ({ variant = 'preview' }: LandingPageProps) => {
   const repoType = getRepositoryType(org, app);
   const menu = getTopBarAppPreviewMenu(org, app, repoType, t);
   const [selectedLayoutSetInEditor, setSelectedLayoutSetInEditor] = useLocalStorage<string>(
-    'layoutSet/' + app
+    'layoutSet/' + app,
   );
   const [previewViewSize, setPreviewViewSize] = useLocalStorage<PreviewAsViewSize>(
     'viewSize',
-    'desktop'
+    'desktop',
   );
   const isIFrame = (input: HTMLElement | null): input is HTMLIFrameElement =>
     input !== null && input.tagName === 'IFRAME';

--- a/frontend/packages/shared/src/hooks/useLocalStorage.test.ts
+++ b/frontend/packages/shared/src/hooks/useLocalStorage.test.ts
@@ -1,0 +1,32 @@
+import { typedLocalStorage } from 'app-shared/utils/webStorage';
+import { act, renderHook } from '@testing-library/react';
+import { useLocalStorage } from 'app-shared/hooks/useLocalStorage';
+
+describe('useLocalStorage', () => {
+  it('Gives access to the stored value', () => {
+    const key = 'someKey';
+    const value = 'value';
+    typedLocalStorage.setItem(key, value);
+    const { result } = renderHook(() => useLocalStorage(key));
+    expect(result.current[0]).toBe(value);
+  });
+
+  it('Provides a function that sets the stored value', async () => {
+    const key = 'keyThatIsNotYetSet';
+    const { result } = renderHook(() => useLocalStorage(key));
+    const value = 'value';
+    await act(() => result.current[1](value));
+    expect(typedLocalStorage.getItem(key)).toBe(value);
+    expect(result.current[0]).toBe(value);
+  });
+
+  it('Provides a function that removes the stored value', async () => {
+    const key = 'keyThatShouldBeRemoved';
+    const value = 'value';
+    typedLocalStorage.setItem(key, value);
+    const { result } = renderHook(() => useLocalStorage(key));
+    await act(() => result.current[2]());
+    expect(typedLocalStorage.getItem(key)).toBeUndefined();
+    expect(result.current[0]).toBeUndefined();
+  });
+});

--- a/frontend/packages/shared/src/hooks/useLocalStorage.ts
+++ b/frontend/packages/shared/src/hooks/useLocalStorage.ts
@@ -18,6 +18,7 @@ const useWebStorage = <T>(
 
   const removeStorageValue = useCallback(() => {
     typedStorage.removeItem(key);
+    setValue(undefined);
   }, [key, typedStorage]);
 
   return [value, setStorageValue, removeStorageValue];

--- a/frontend/packages/shared/src/hooks/useWebStorage.ts
+++ b/frontend/packages/shared/src/hooks/useWebStorage.ts
@@ -4,8 +4,8 @@ import { TypedStorage, typedLocalStorage } from 'app-shared/utils/webStorage';
 const useWebStorage = <T>(
   typedStorage: TypedStorage,
   key: string,
-  initialValue?: T
-): [T, (newValue: T) => void] => {
+  initialValue?: T,
+): [T, (newValue: T) => void, () => void] => {
   const [value, setValue] = useState<T>(typedStorage.getItem(key) || initialValue);
 
   const setStorageValue = useCallback(
@@ -13,15 +13,20 @@ const useWebStorage = <T>(
       typedStorage.setItem(key, newValue);
       setValue(newValue);
     },
-    [key, typedStorage]
+    [key, typedStorage],
   );
-  return [value, setStorageValue];
+
+  const removeStorageValue = useCallback(() => {
+    typedStorage.removeItem(key);
+  }, [key, typedStorage]);
+
+  return [value, setStorageValue, removeStorageValue];
 };
 
 /**
  * @param key - the key to use in local storage
  * @param initialValue - the initial value to use if there is no value in local storage
- * @returns [value, setValue] - the value and a function to set the value
+ * @returns [value, setValue, removeValue] - the value, a function to set the value and a function to remove it
  * @description
  * useLocalStorage is a hook that allows you to use local storage the same way you would with useState
  */

--- a/frontend/packages/ux-editor/src/App.test.tsx
+++ b/frontend/packages/ux-editor/src/App.test.tsx
@@ -3,17 +3,20 @@ import { screen, waitFor } from '@testing-library/react';
 import { renderWithMockStore } from './testing/mocks';
 import { App } from './App';
 import { textMock } from '../../../testing/mocks/i18nMock';
+import { typedLocalStorage } from 'app-shared/utils/webStorage';
+import { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
+import { appStateMock } from './testing/stateMocks';
 
 const render = () => {
-  const queries = {
-    getInstanceIdForPreview: jest.fn().mockImplementation(() => Promise.resolve('test'))
+  const queries: Partial<ServicesContextProps> = {
+    getInstanceIdForPreview: jest.fn().mockImplementation(() => Promise.resolve('test')),
   };
-  return renderWithMockStore({}, queries)(
-    <App />
-  );
+  return renderWithMockStore({}, queries)(<App />);
 };
 
 describe('App', () => {
+  afterEach(jest.clearAllMocks);
+
   it('should render the spinner', () => {
     render();
     expect(screen.getByText(textMock('general.loading'))).toBeInTheDocument();
@@ -21,6 +24,31 @@ describe('App', () => {
 
   it('should render the component', async () => {
     render();
-    await waitFor(() => expect(screen.queryByText(textMock('general.loading'))).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(textMock('general.loading'))).not.toBeInTheDocument(),
+    );
+  });
+
+  it('Removes the preview layout set from local storage if it does not exist', async () => {
+    const layoutSetThatDoesNotExist = 'layout-set-that-does-not-exist';
+    jest.spyOn(typedLocalStorage, 'getItem').mockReturnValue(layoutSetThatDoesNotExist);
+    const removeItem = jest.spyOn(typedLocalStorage, 'removeItem');
+    render();
+    await waitFor(() =>
+      expect(screen.queryByText(textMock('general.loading'))).not.toBeInTheDocument(),
+    );
+    expect(removeItem).toHaveBeenCalledTimes(1);
+    expect(removeItem).toHaveBeenCalledWith('layoutSet/app');
+  });
+
+  it('Does not remove the preview layout set from local storage if it exists', async () => {
+    const { selectedLayoutSet } = appStateMock.formDesigner.layout;
+    jest.spyOn(typedLocalStorage, 'getItem').mockReturnValue(selectedLayoutSet);
+    const removeItem = jest.spyOn(typedLocalStorage, 'removeItem');
+    render();
+    await waitFor(() =>
+      expect(screen.queryByText(textMock('general.loading'))).not.toBeInTheDocument(),
+    );
+    expect(removeItem).not.toHaveBeenCalled();
   });
 });

--- a/frontend/packages/ux-editor/src/App.tsx
+++ b/frontend/packages/ux-editor/src/App.tsx
@@ -15,7 +15,7 @@ import { useTextResourcesQuery } from 'app-shared/hooks/queries/useTextResources
 import { useLayoutSetsQuery } from './hooks/queries/useLayoutSetsQuery';
 import { typedLocalStorage } from 'app-shared/utils/webStorage';
 import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
-import { useLocalStorage } from 'app-shared/hooks/useWebStorage';
+import { useLocalStorage } from 'app-shared/hooks/useLocalStorage';
 
 /**
  * This is the main React component responsible for controlling
@@ -43,6 +43,7 @@ export function App() {
   useEffect(() => {
     if (
       areLayoutSetsFetched &&
+      selectedLayoutSetInPreview &&
       (!layoutSets || !layoutSets.sets.map((set) => set.id).includes(selectedLayoutSetInPreview))
     )
       removeSelectedLayoutSetInPreview();

--- a/frontend/packages/ux-editor/src/testing/mocks.tsx
+++ b/frontend/packages/ux-editor/src/testing/mocks.tsx
@@ -44,14 +44,17 @@ export const queriesMock: ServicesContextProps = {
   deleteAppAttachmentMetadata: jest.fn().mockImplementation(() => Promise.resolve({})),
   deleteFormLayout: jest.fn().mockImplementation(() => Promise.resolve({})),
   getDatamodelMetadata: jest.fn().mockImplementation(() => Promise.resolve({ elements: {} })),
+  getExpressionSchema: jest.fn().mockImplementation(() => Promise.resolve(expressionSchema)),
   getFormLayoutSettings: jest
     .fn()
     .mockImplementation(() => Promise.resolve(formLayoutSettingsMock)),
   getFormLayouts: jest.fn().mockImplementation(() => Promise.resolve(externalLayoutsMock)),
   getFrontEndSettings: jest.fn().mockImplementation(() => Promise.resolve({})),
   getInstanceIdForPreview: jest.fn(),
-  getOptionListIds: jest.fn().mockImplementation(() => Promise.resolve(optionListIdsMock)),
+  getLayoutSchema: jest.fn().mockImplementation(() => Promise.resolve(layoutSchema)),
   getLayoutSets: jest.fn().mockImplementation(() => Promise.resolve(layoutSetsMock)),
+  getNumberFormatSchema: jest.fn().mockImplementation(() => Promise.resolve(numberFormatSchema)),
+  getOptionListIds: jest.fn().mockImplementation(() => Promise.resolve(optionListIdsMock)),
   getRuleConfig: jest.fn().mockImplementation(() => Promise.resolve(ruleConfigMock)),
   getRuleModel: jest.fn().mockImplementation(() => Promise.resolve(ruleHandlerMock)),
   getTextLanguages: jest.fn().mockImplementation(() => Promise.resolve(textLanguagesMock)),
@@ -62,9 +65,6 @@ export const queriesMock: ServicesContextProps = {
   updateAppAttachmentMetadata: jest.fn().mockImplementation(() => Promise.resolve({})),
   updateFormLayoutName: jest.fn().mockImplementation(() => Promise.resolve({})),
   upsertTextResources: jest.fn().mockImplementation(() => Promise.resolve()),
-  getExpressionSchema: jest.fn().mockImplementation(() => Promise.resolve(expressionSchema)),
-  getLayoutSchema: jest.fn().mockImplementation(() => Promise.resolve(layoutSchema)),
-  getNumberFormatSchema: jest.fn().mockImplementation(() => Promise.resolve(numberFormatSchema)),
 };
 
 export const queryClientMock = new QueryClient({


### PR DESCRIPTION
## Description
If an app is deleted, its selected layout set in preview mode remains in the local storage. This leads to bugs when creating a new app with the same name. This pull request add code that deletes the layout set from local storage if it does not exist.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
