### PR TITLE
fixing broken cypress test

### DIFF
--- a/frontend/testing/cypress/src/integration/studio/designer.js
+++ b/frontend/testing/cypress/src/integration/studio/designer.js
@@ -10,6 +10,8 @@ const designerAppId = `${Cypress.env('autoTestUser')}/${Cypress.env('designerApp
 
 context('Designer', () => {
   before(() => {
+    cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+
     cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
     cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
   });
@@ -54,8 +56,6 @@ context('Designer', () => {
     designer
       .getPageAccordionByName('Side1')
       .findByRole('listitem', { name: texts['ux_editor.component_input'] });
-    //.findAllByRole('listitem')
-    // .then(($elements) => expect($elements.length).eq(1));
 
     // Delete components on page
     cy.deleteComponents();


### PR DESCRIPTION
## Description
- Cypress test for lage page was still broken. This is now fixed. 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
