### PR TITLE
some bugfixes on EditOptions component

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+
+import { EditOptions } from './EditOptions';
+import { renderWithMockStore, renderHookWithMockStore } from '../../../testing/mocks';
+import { useLayoutSchemaQuery } from '../../../hooks/queries/useLayoutSchemaQuery';
+import { textMock } from '../../../../../../testing/mocks/i18nMock';
+import { ComponentType } from 'app-shared/types/ComponentType';
+import { FormCheckboxesComponent, FormRadioButtonsComponent } from '../../../types/FormComponent';
+
+const waitForData = async () => {
+  const layoutSchemaResult = renderHookWithMockStore()(() => useLayoutSchemaQuery())
+    .renderHookResult.result;
+  await waitFor(() => expect(layoutSchemaResult.current[0].isSuccess).toBe(true));
+};
+
+const mockComponent: FormCheckboxesComponent | FormRadioButtonsComponent = {
+  id: 'c24d0812-0c34-4582-8f31-ff4ce9795e96',
+  type: ComponentType.RadioButtons,
+  textResourceBindings: {
+    title: 'ServiceName',
+  },
+  maxLength: 10,
+  itemType: 'COMPONENT',
+  dataModelBindings: {},
+};
+
+const render = async ({ component = mockComponent, handleComponentChange = jest.fn() } = {}) => {
+  await waitForData();
+
+  return renderWithMockStore()(
+    <EditOptions handleComponentChange={handleComponentChange} component={component} />,
+  );
+};
+
+describe('EditOptions', () => {
+  it('should render', async () => {
+    await render();
+    expect(
+      screen.getByText(textMock('ux_editor.modal_properties_add_radio_button_options')),
+    ).toBeInTheDocument();
+  });
+
+  it('should show code list input by default when neither options nor optionId are set', async () => {
+    await render();
+    expect(screen.getByText(textMock('ux_editor.modal_add_options_codelist'))).toBeInTheDocument();
+  });
+
+  it('should show manual input when component has options defined', async () => {
+    await render({
+      component: {
+        ...mockComponent,
+        options: [{ label: 'option1', value: 'option1' }],
+      },
+    });
+    expect(screen.getByText(textMock('ux_editor.modal_add_options_manual'))).toBeInTheDocument();
+  });
+
+  it('should show code list input when component has optionsId defined', async () => {
+    await render({
+      component: {
+        ...mockComponent,
+        optionsId: 'optionsId',
+      },
+    });
+    expect(screen.getByText(textMock('ux_editor.modal_add_options_manual'))).toBeInTheDocument();
+  });
+});

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions.tsx
@@ -28,13 +28,10 @@ export enum SelectedOptionsType {
 }
 
 const getSelectedOptionsType = (codeListId: string, options: IOption[]): SelectedOptionsType => {
-  if (codeListId) {
-    return SelectedOptionsType.CodeList;
-  }
   if (options?.length) {
     return SelectedOptionsType.Manual;
   }
-  return SelectedOptionsType.Unknown;
+  return SelectedOptionsType.CodeList;
 };
 
 export function EditOptions({
@@ -104,8 +101,6 @@ export function EditOptions({
   const handleAddOption = () =>
     handleComponentChange(addOptionToComponent(component, generateRandomOption()));
 
-  if (component.type != 'RadioButtons') return null;
-
   return (
     <>
       <Radio.Group
@@ -114,8 +109,9 @@ export function EditOptions({
         name={`${component.id}-options`}
         value={selectedOptionsType}
         inline={true}
+        size='small'
       >
-        <Radio value={SelectedOptionsType.CodeList} defaultChecked>
+        <Radio value={SelectedOptionsType.CodeList}>
           {t('ux_editor.modal_add_options_codelist')}
         </Radio>
         <Radio value={SelectedOptionsType.Manual}>{t('ux_editor.modal_add_options_manual')}</Radio>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Removed check for `ComponentType.RadioButtons`, as any checks on relevant component type should be done outside of this component, and this was causing the EditOptions component to not be rendered for components where it is configured to be shown (Checkboxes & Dropdown)
- Added some unit tests, and found some issues to fix from failing tests:
  - Removed the `defaultChecked` prop, as the radioGroup is controlled by the `value` prop, and setting `defaultChecked` on one of the options results in console.error message about switching from uncontrolled to controlled component.
  - Instead, updated the function for getting selected options type to return `CodeList` by default.

## Related Issue(s)
- #11388

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
