### PR TITLE
Components that lack the 'component.dataModelBindings' experience crashes within the 'Lage' page

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.tsx
@@ -50,7 +50,7 @@ export const EditDataModelBindings = ({
 
   const [dataModelSelectVisible, setDataModelSelectVisible] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | undefined>(
-    component.dataModelBindings[key || 'simpleBinding'],
+    component.dataModelBindings ? component.dataModelBindings[key || 'simpleBinding'] : undefined,
   );
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When we add a component that lacks dataModelBindings, it results in a configuration error that can lead to a crash. This can be seen as an example with the attachment component.

![image](https://github.com/Altinn/altinn-studio/assets/46874830/b7f86103-bd32-496a-ac77-21aa9c0444e8)


## Related Issue(s)
- PR itself

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
