### PR TITLE
use old feat-flag for overview page

### DIFF
--- a/frontend/app-development/config/routes.tsx
+++ b/frontend/app-development/config/routes.tsx
@@ -47,7 +47,7 @@ export const routes: IRoute[] = [
     activeSubHeaderSelection: TopBarMenu.About,
     activeLeftMenuSelection: 'Om appen',
     menu: 'about',
-    subapp: shouldDisplayFeature('settingsModal') ? Administration : LegacyAdministration,
+    subapp: shouldDisplayFeature('newAdministration') ? Administration : LegacyAdministration,
   },
   {
     path: '/:org/:app/datamodel',

--- a/frontend/packages/shared/src/utils/featureToggleUtils.ts
+++ b/frontend/packages/shared/src/utils/featureToggleUtils.ts
@@ -9,7 +9,8 @@ export type SupportedFeatureFlags =
   | 'expressions'
   | 'settingsModal'
   | 'processEditor'
-  | 'configureLayoutSet';
+  | 'configureLayoutSet'
+  | 'newAdministration';
 
 /*
  * Please add all the features that you want to be toggle on by default here.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Should use own feature-flag for the overview page.

## Related Issue(s)
- PR itself

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
