### PR TITLE
Fixing modal z index and SetupTab

### DIFF
--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/SetupTab/SetupTab.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/SetupTab/SetupTab.tsx
@@ -6,6 +6,7 @@ import { TabDataError } from '../../TabDataError';
 import { ErrorMessage } from '@digdir/design-system-react';
 import { TabHeader } from '../../TabHeader';
 import { SetupTabContent } from './SetupTabContent';
+import { TabContent } from '../../TabContent';
 
 export type SetupTabProps = {
   org: string;
@@ -46,9 +47,9 @@ export const SetupTab = ({ org, app }: SetupTabProps): ReactNode => {
   };
 
   return (
-    <div>
+    <TabContent>
       <TabHeader text={t('settings_modal.setup_tab_heading')} />
       {displayContent()}
-    </div>
+    </TabContent>
   );
 };

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/SetupTab/SetupTabContent/SetupTabContent.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/SetupTab/SetupTabContent/SetupTabContent.tsx
@@ -6,7 +6,6 @@ import { useAppMetadataMutation } from 'app-development/hooks/mutations';
 import { ErrorMessage, Paragraph, Switch, Textfield } from '@digdir/design-system-react';
 import { Divider } from 'app-shared/primitives';
 import { getIsDatesValid } from 'app-development/layout/SettingsModalButton/SettingsModal/utils/tabUtils/setupTabUtils';
-import { TabContent } from '../../../TabContent';
 
 export type SetupTabContentProps = {
   appMetadata: ApplicationMetadata;
@@ -36,7 +35,7 @@ export const SetupTabContent = ({ appMetadata, org, app }: SetupTabContentProps)
   const isInvalidDates: boolean = !getIsDatesValid(appMetadata?.validFrom, appMetadata?.validTo);
 
   return (
-    <TabContent>
+    <>
       <Switch
         size='small'
         className={classes.switch}
@@ -156,6 +155,6 @@ export const SetupTabContent = ({ appMetadata, org, app }: SetupTabContentProps)
       >
         <Paragraph size='small'>{t('settings_modal.setup_tab_switch_onEntry_show')}</Paragraph>
       </Switch>
-    </TabContent>
+    </>
   );
 };

--- a/frontend/packages/shared/src/components/Modal/Modal.module.css
+++ b/frontend/packages/shared/src/components/Modal/Modal.module.css
@@ -34,6 +34,7 @@
   bottom: 0;
   left: 0;
   background-color: rgba(30, 43, 60, 0.5);
+  z-index: 1000;
 }
 
 .headingWrapper {


### PR DESCRIPTION
## Description
- The setup tab had weird placement (mentioned in [here](https://github.com/Altinn/altinn-studio/issues/11197)). This is now fixed, as shown in the photo: 
<img width="589" alt="Screenshot 2023-10-23 at 16 57 12" src="https://github.com/Altinn/altinn-studio/assets/133344438/c04468aa-81c9-4e91-855c-aaeca2a00f89">

- The Modal did not have z-index, making content on the data modelling page appear on top of the modal, as mention [here](https://github.com/Altinn/altinn-studio/issues/11424). This is now fixed. 

## Related Issue(s)
- #11423 
- #11424

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
