### PR TITLE
Use apps extended version of appmetadata csharp model

### DIFF
--- a/backend/packagegroups/NuGet.props
+++ b/backend/packagegroups/NuGet.props
@@ -21,6 +21,7 @@
     <PackageReference Update="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.23" />
     <PackageReference Update="Microsoft.Azure.KeyVault" Version="3.0.5" />
+    <PackageReference Update="Microsoft.Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Update="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Update="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.24" />
     <PackageReference Update="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />

--- a/backend/packagegroups/NuGet.props
+++ b/backend/packagegroups/NuGet.props
@@ -1,6 +1,7 @@
 <Project>
 
   <ItemGroup Label="Altinn specific packages">
+    <PackageReference Update="Altinn.App.Core" Version="8.0.0-preview.10" />
     <PackageReference Update="Altinn.Common.AccessToken" Version="3.0.3" />
     <PackageReference Update="Altinn.Common.AccessTokenClient" Version="1.1.5" />
     <PackageReference Update="Altinn.Platform.Storage.Interface" Version="3.24.0" />

--- a/backend/src/Designer/Controllers/ApplicationMetadataController.cs
+++ b/backend/src/Designer/Controllers/ApplicationMetadataController.cs
@@ -1,6 +1,6 @@
 using System.IO;
 using System.Threading.Tasks;
-using Altinn.Platform.Storage.Interface.Models;
+using Altinn.App.Core.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
 
 using Microsoft.AspNetCore.Authorization;
@@ -37,7 +37,7 @@ namespace Altinn.Studio.Designer.Controllers
         [HttpGet]
         public async Task<ActionResult> GetApplicationMetadata(string org, string app)
         {
-            Application application = await _applicationMetadataService.GetApplicationMetadataFromRepository(org, app);
+            ApplicationMetadata application = await _applicationMetadataService.GetApplicationMetadataFromRepository(org, app);
             if (application == null)
             {
                 return NotFound();
@@ -54,10 +54,10 @@ namespace Altinn.Studio.Designer.Controllers
         /// <param name="applicationMetadata">The application metadata</param>
         /// <returns>The updated application metadata</returns>
         [HttpPut]
-        public async Task<ActionResult> UpdateApplicationMetadata(string org, string app, [FromBody] Application applicationMetadata)
+        public async Task<ActionResult> UpdateApplicationMetadata(string org, string app, [FromBody] ApplicationMetadata applicationMetadata)
         {
             await _applicationMetadataService.UpdateApplicationMetaDataLocally(org, app, applicationMetadata);
-            Application updatedApplicationMetadata = await _applicationMetadataService.GetApplicationMetadataFromRepository(org, app);
+            ApplicationMetadata updatedApplicationMetadata = await _applicationMetadataService.GetApplicationMetadataFromRepository(org, app);
             return Ok(updatedApplicationMetadata);
         }
 
@@ -77,7 +77,7 @@ namespace Altinn.Studio.Designer.Controllers
             }
 
             await _applicationMetadataService.CreateApplicationMetadata(org, app, app);
-            Application createdApplication = await _applicationMetadataService.GetApplicationMetadataFromRepository(org, app);
+            ApplicationMetadata createdApplication = await _applicationMetadataService.GetApplicationMetadataFromRepository(org, app);
             if (createdApplication == null)
             {
                 return StatusCode(500);

--- a/backend/src/Designer/Controllers/EnvironmentsController.cs
+++ b/backend/src/Designer/Controllers/EnvironmentsController.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Altinn.Studio.Designer.Services.Models;
 using Microsoft.AspNetCore.Authorization;

--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using Altinn.App.Core.Models;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
@@ -18,6 +19,8 @@ using LibGit2Sharp;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using ApplicationLanguage = Altinn.Studio.Designer.Models.ApplicationLanguage;
+using LayoutSets = Altinn.Studio.Designer.Models.LayoutSets;
 
 namespace Altinn.Studio.Designer.Controllers
 {
@@ -120,11 +123,11 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>The application metadata for the app</returns>
         [HttpGet]
         [Route("api/v1/applicationmetadata")]
-        public async Task<ActionResult<Application>> ApplicationMetadata(string org, string app, CancellationToken cancellationToken)
+        public async Task<ActionResult<ApplicationMetadata>> ApplicationMetadata(string org, string app, CancellationToken cancellationToken)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
             AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
-            Application applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata(cancellationToken);
+            ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata(cancellationToken);
             return Ok(applicationMetadata);
         }
 
@@ -141,7 +144,7 @@ namespace Altinn.Studio.Designer.Controllers
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
             AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
-            Application applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata(cancellationToken);
+            ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata(cancellationToken);
             ApplicationSettings applicationSettings = new()
             {
                 Id = applicationMetadata.Id,

--- a/backend/src/Designer/Designer.csproj
+++ b/backend/src/Designer/Designer.csproj
@@ -18,12 +18,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Altinn.App.Core" />
     <PackageReference Include="Altinn.Authorization.ABAC" />
     <PackageReference Include="Altinn.ApiClients.Maskinporten" />
     <PackageReference Include="Altinn.Common.AccessToken" />
     <PackageReference Include="Altinn.Common.AccessTokenClient" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" />
-    <PackageReference Include="Altinn.Platform.Models" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="CompilerAttributes" />
     <PackageReference Include="ini-parser-netstandard" />

--- a/backend/src/Designer/Designer.csproj
+++ b/backend/src/Designer/Designer.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Altinn.Common.AccessToken" />
     <PackageReference Include="Altinn.Common.AccessTokenClient" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="CompilerAttributes" />
     <PackageReference Include="ini-parser-netstandard" />
     <PackageReference Include="JWTCookieAuthentication" />

--- a/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Altinn.Platform.Storage.Interface.Models;
+using Altinn.App.Core.Models;
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Models;
@@ -17,6 +17,7 @@ using LibGit2Sharp;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Tokens;
 using JsonSerializer = System.Text.Json.JsonSerializer;
+using LayoutSets = Altinn.Studio.Designer.Models.LayoutSets;
 
 namespace Altinn.Studio.Designer.Infrastructure.GitRepository
 {
@@ -74,12 +75,12 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         /// <summary>
         /// Gets the application metadata.
         /// </summary>
-        public async Task<Application> GetApplicationMetadata(CancellationToken cancellationToken = default)
+        public async Task<ApplicationMetadata> GetApplicationMetadata(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             string appMetadataRelativeFilePath = Path.Combine(CONFIG_FOLDER_PATH, APP_METADATA_FILENAME);
             string fileContent = await ReadTextByRelativePathAsync(appMetadataRelativeFilePath, cancellationToken);
-            Application applicationMetaData = JsonSerializer.Deserialize<Application>(fileContent, _jsonOptions);
+            ApplicationMetadata applicationMetaData = JsonSerializer.Deserialize<ApplicationMetadata>(fileContent, _jsonOptions);
 
             return applicationMetaData;
         }
@@ -94,7 +95,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         /// Saves the application metadata file to disk.
         /// </summary>
         /// <param name="applicationMetadata">The updated application metadata to persist.</param>
-        public async Task SaveApplicationMetadata(Application applicationMetadata)
+        public async Task SaveApplicationMetadata(ApplicationMetadata applicationMetadata)
         {
             string metadataAsJson = JsonSerializer.Serialize(applicationMetadata, _jsonOptions);
             string appMetadataRelativeFilePath = Path.Combine(CONFIG_FOLDER_PATH, APP_METADATA_FILENAME);

--- a/backend/src/Designer/Services/Implementation/ApplicationInformationService.cs
+++ b/backend/src/Designer/Services/Implementation/ApplicationInformationService.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Services.Interfaces;
-using Altinn.Studio.Designer.Services.Models;
 
 namespace Altinn.Studio.Designer.Services.Implementation
 {

--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+using Altinn.App.Core.Models;
 using Altinn.Authorization.ABAC.Utils;
 using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Studio.DataModeling.Metamodel;
@@ -312,7 +313,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
             await targetAppRepository.SearchAndReplaceInFile(".git/config", $"repos/{org}/{sourceRepository}.git", $"repos/{org}/{targetRepository}.git");
 
-            PlatformStorageModels.Application appMetadata = await targetAppRepository.GetApplicationMetadata();
+            ApplicationMetadata appMetadata = await targetAppRepository.GetApplicationMetadata();
             appMetadata.Id = $"{org}/{targetRepository}";
             appMetadata.CreatedBy = developer;
             appMetadata.LastChangedBy = developer;
@@ -662,7 +663,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
         private async Task<string> GetModelName(string org, string app)
         {
-            PlatformStorageModels.Application application = await _applicationMetadataService.GetApplicationMetadataFromRepository(org, app);
+            ApplicationMetadata application = await _applicationMetadataService.GetApplicationMetadataFromRepository(org, app);
             string dataTypeId = string.Empty;
 
             if (application == null)

--- a/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -8,7 +8,7 @@ using System.Text.Unicode;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Schema;
-
+using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.DataModeling.Converter.Interfaces;
 using Altinn.Studio.DataModeling.Converter.Json.Strategy;
@@ -291,7 +291,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
         private static async Task UpdateApplicationMetadata(AltinnAppGitRepository altinnAppGitRepository, string schemaName, string typeName)
         {
-            Application application = await altinnAppGitRepository.GetApplicationMetadata();
+            ApplicationMetadata application = await altinnAppGitRepository.GetApplicationMetadata();
 
             UpdateApplicationWithAppLogicModel(application, schemaName, "Altinn.App.Models." + typeName);
 
@@ -305,7 +305,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
         /// <param name="application">The <see cref="Application"/> object to be updated.</param>
         /// <param name="dataTypeId">The id of the datatype to bed added.</param>
         /// <param name="classRef">The C# class reference of the data type.</param>
-        private static void UpdateApplicationWithAppLogicModel(Application application, string dataTypeId, string classRef)
+        private static void UpdateApplicationWithAppLogicModel(ApplicationMetadata application, string dataTypeId, string classRef)
         {
             if (application.DataTypes == null)
             {

--- a/backend/src/Designer/Services/Interfaces/IApplicationInformationService.cs
+++ b/backend/src/Designer/Services/Interfaces/IApplicationInformationService.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Altinn.Studio.Designer.Services.Models;
 
 namespace Altinn.Studio.Designer.Services.Interfaces
 {

--- a/backend/src/Designer/Services/Interfaces/IApplicationMetadataService.cs
+++ b/backend/src/Designer/Services/Interfaces/IApplicationMetadataService.cs
@@ -1,5 +1,5 @@
 using System.Threading.Tasks;
-using Altinn.Platform.Storage.Interface.Models;
+using Altinn.App.Core.Models;
 using Altinn.Studio.Designer.Configuration;
 
 namespace Altinn.Studio.Designer.Services.Interfaces
@@ -48,7 +48,7 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <param name="applicationMetadata">The application metadata to be updated</param>
-        public Task UpdateApplicationMetaDataLocally(string org, string app, Application applicationMetadata);
+        public Task UpdateApplicationMetaDataLocally(string org, string app, ApplicationMetadata applicationMetadata);
 
         /// <summary>
         /// Returns the application metadata for an application.
@@ -56,7 +56,7 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <returns>The application  metadata for an application.</returns>
-        public Task<Application> GetApplicationMetadataFromRepository(string org, string app);
+        public Task<ApplicationMetadata> GetApplicationMetadataFromRepository(string org, string app);
 
         /// <summary>
         /// Returns the application metadata exists in repo.

--- a/backend/src/Designer/Services/Interfaces/IAuthorizationPolicyService.cs
+++ b/backend/src/Designer/Services/Interfaces/IAuthorizationPolicyService.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Altinn.Studio.Designer.Services.Models;
 
 namespace Altinn.Studio.Designer.Services.Interfaces
 {

--- a/backend/src/Designer/Services/Interfaces/ITextResourceService.cs
+++ b/backend/src/Designer/Services/Interfaces/ITextResourceService.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Altinn.Studio.Designer.Services.Models;
 
 namespace Altinn.Studio.Designer.Services.Interfaces
 {

--- a/backend/src/Designer/TypedHttpClients/AltinnAuthorization/IAltinnAuthorizationPolicyClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnAuthorization/IAltinnAuthorizationPolicyClient.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Altinn.Studio.Designer.Services.Models;
 
 namespace Altinn.Studio.Designer.TypedHttpClients.AltinnAuthorization
 {

--- a/backend/src/Designer/TypedHttpClients/AltinnStorage/AltinnStorageAppMetadataClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnStorage/AltinnStorageAppMetadataClient.cs
@@ -3,7 +3,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Altinn.Platform.Storage.Interface.Models;
+using Altinn.App.Core.Models;
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Services.Interfaces;
@@ -41,7 +41,7 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
         }
 
         /// <inheritdoc />
-        public async Task<Application> GetApplicationMetadata(string org, string app, string envName)
+        public async Task<ApplicationMetadata> GetApplicationMetadata(string org, string app, string envName)
         {
             var storageUri = await CreateStorageUri(envName);
             Uri uri = new($"{storageUri}{org}/{app}");
@@ -54,14 +54,14 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
             using HttpRequestMessage request = new(HttpMethod.Get, uri);
             HttpResponseMessage response = await _httpClient.SendAsync(request);
 
-            return await response.Content.ReadAsAsync<Application>();
+            return await response.Content.ReadAsAsync<ApplicationMetadata>();
         }
 
         /// <inheritdoc />
         public async Task CreateApplicationMetadata(
             string org,
             string app,
-            Application applicationMetadata,
+            ApplicationMetadata applicationMetadata,
             string envName)
         {
             var storageUri = await CreateStorageUri(envName);
@@ -84,7 +84,7 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
         public async Task UpdateApplicationMetadata(
             string org,
             string app,
-            Application applicationMetadata,
+            ApplicationMetadata applicationMetadata,
             string envName)
         {
             var storageUri = await CreateStorageUri(envName);

--- a/backend/src/Designer/TypedHttpClients/AltinnStorage/IAltinnStorageAppMetadataClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnStorage/IAltinnStorageAppMetadataClient.cs
@@ -1,6 +1,5 @@
 using System.Threading.Tasks;
-using Altinn.Platform.Storage.Interface.Models;
-using Altinn.Studio.Designer.Services.Models;
+using Altinn.App.Core.Models;
 
 namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
 {
@@ -16,7 +15,7 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
         /// <param name="app">Application</param>
         /// <param name="envName">Environment Name</param>
         /// <returns></returns>
-        Task<Application> GetApplicationMetadata(string org, string app, string envName);
+        Task<ApplicationMetadata> GetApplicationMetadata(string org, string app, string envName);
 
         /// <summary>
         /// Creates application metadata for an application in Platform.Storage
@@ -26,7 +25,7 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
         /// <param name="applicationMetadata">Application</param>
         /// <param name="envName">Environment Name</param>
         /// <returns></returns>
-        Task CreateApplicationMetadata(string org, string app, Application applicationMetadata, string envName);
+        Task CreateApplicationMetadata(string org, string app, ApplicationMetadata applicationMetadata, string envName);
 
         /// <summary>
         /// Updates application metadata for an application in Platform.Storage
@@ -36,6 +35,6 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
         /// <param name="applicationMetadata">Application</param>
         /// <param name="envName">Environment Name</param>
         /// <returns></returns>
-        Task UpdateApplicationMetadata(string org, string app, Application applicationMetadata, string envName);
+        Task UpdateApplicationMetadata(string org, string app, ApplicationMetadata applicationMetadata, string envName);
     }
 }

--- a/backend/src/Designer/TypedHttpClients/AltinnStorage/IAltinnStorageTextResourceClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnStorage/IAltinnStorageTextResourceClient.cs
@@ -1,6 +1,5 @@
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
-using Altinn.Studio.Designer.Services.Models;
 
 namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
 {

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/AddMetadataForAttachmentTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/AddMetadataForAttachmentTests.cs
@@ -7,6 +7,7 @@ using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
@@ -39,7 +40,7 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             string applicationMetadataFile = await File.ReadAllTextAsync(Path.Combine(TestRepoPath, "App", "config", "applicationmetadata.json"));
-            var applicationMetadata = JsonSerializer.Deserialize<Application>(applicationMetadataFile, JsonSerializerOptions);
+            var applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataFile, JsonSerializerOptions);
 
             var attachmentDataType = applicationMetadata.DataTypes.Single(x => x.Id == payload.Id);
             attachmentDataType.MaxCount.Should().Be(payload.MaxCount);

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/DeleteMetadataForAttachmentTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/DeleteMetadataForAttachmentTests.cs
@@ -4,7 +4,7 @@ using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Altinn.Platform.Storage.Interface.Models;
+using Altinn.App.Core.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
 using FluentAssertions;
@@ -27,7 +27,7 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
             string targetRepository = TestDataHelper.GenerateTestRepoName();
             await CopyRepositoryForTest(org, app, developer, targetRepository);
             string previousMetadata = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
-            Application applicationMetadataPreDelete = JsonSerializer.Deserialize<Application>(previousMetadata, JsonSerializerOptions);
+            ApplicationMetadata applicationMetadataPreDelete = JsonSerializer.Deserialize<ApplicationMetadata>(previousMetadata, JsonSerializerOptions);
             Assert.Contains(applicationMetadataPreDelete.DataTypes, x => x.Id == attacmentIdToDelete);
             string url = $"{VersionPrefix(org, targetRepository)}/attachment-component";
 
@@ -38,7 +38,7 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             string currentMetadata = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
-            Application applicationMetadataAfterDelete = JsonSerializer.Deserialize<Application>(currentMetadata, JsonSerializerOptions);
+            ApplicationMetadata applicationMetadataAfterDelete = JsonSerializer.Deserialize<ApplicationMetadata>(currentMetadata, JsonSerializerOptions);
             Assert.DoesNotContain(applicationMetadataAfterDelete.DataTypes, x => x.Id == attacmentIdToDelete);
         }
     }

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/GetApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/GetApplicationMetadataTests.cs
@@ -2,7 +2,7 @@
 using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Altinn.Platform.Storage.Interface.Models;
+using Altinn.App.Core.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
 using FluentAssertions;
@@ -36,7 +36,7 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             string responseContent = await response.Content.ReadAsStringAsync();
-            string expectedJson = JsonSerializer.Serialize(JsonSerializer.Deserialize<Application>(metadataFile, JsonSerializerOptions), JsonSerializerOptions);
+            string expectedJson = JsonSerializer.Serialize(JsonSerializer.Deserialize<ApplicationMetadata>(metadataFile, JsonSerializerOptions), JsonSerializerOptions);
             JsonUtils.DeepEquals(expectedJson, responseContent).Should().BeTrue();
         }
     }

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateApplicationMetadataTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Net.Mime;
 using System.Text;

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateApplicationMetadataTests.cs
@@ -4,7 +4,7 @@ using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Altinn.Platform.Storage.Interface.Models;
+using Altinn.App.Core.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
 using FluentAssertions;
@@ -29,7 +29,7 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
             await CopyRepositoryForTest(org, app, developer, targetRepository);
 
             string metadata = SharedResourcesHelper.LoadTestDataAsString(metadataToUpdate);
-            string expectedMetadataJson = JsonSerializer.Serialize(JsonSerializer.Deserialize<Application>(metadata, JsonSerializerOptions), JsonSerializerOptions);
+            string expectedMetadataJson = JsonSerializer.Serialize(JsonSerializer.Deserialize<ApplicationMetadata>(metadata, JsonSerializerOptions), JsonSerializerOptions);
 
             string url = VersionPrefix(org, targetRepository);
 

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateMetadataForAttachmentTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateMetadataForAttachmentTests.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using Altinn.Platform.Storage.Interface.Models;
+using Altinn.App.Core.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
 using FluentAssertions;
@@ -46,7 +46,7 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             string applicationMetadataFile = await File.ReadAllTextAsync(Path.Combine(TestRepoPath, "App", "config", "applicationmetadata.json"));
-            var applicationMetadata = JsonSerializer.Deserialize<Application>(applicationMetadataFile, _jsonSerializerOptions);
+            var applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataFile, _jsonSerializerOptions);
 
             var attachmentDataType = applicationMetadata.DataTypes.Single(x => x.Id == payloadNode!["id"]!.ToString());
             attachmentDataType.MaxCount.Should().Be(payloadNode!["maxCount"]!.GetValue<int>());

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/ApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/ApplicationMetadataTests.cs
@@ -2,7 +2,7 @@
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Altinn.Platform.Storage.Interface.Models;
+using Altinn.App.Core.Models;
 using Designer.Tests.Utils;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -30,7 +30,7 @@ namespace Designer.Tests.Controllers.PreviewController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            string expectedJson = JsonSerializer.Serialize(JsonSerializer.Deserialize<Application>(expectedApplicationMetadata, SerializerOptions), SerializerOptions);
+            string expectedJson = JsonSerializer.Serialize(JsonSerializer.Deserialize<ApplicationMetadata>(expectedApplicationMetadata, SerializerOptions), SerializerOptions);
             JsonUtils.DeepEquals(expectedJson, responseBody).Should().BeTrue();
         }
     }

--- a/backend/tests/Designer.Tests/Infrastructure/GitRepository/AltinnAppGitRepositoryTests.cs
+++ b/backend/tests/Designer.Tests/Infrastructure/GitRepository/AltinnAppGitRepositoryTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Designer.Tests.Utils;
@@ -37,7 +38,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
             string developer = "testUser";
             AltinnAppGitRepository altinnAppGitRepository = PrepareRepositoryForTest(org, repository, developer);
 
-            Application applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
+            ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
 
             applicationMetadata.Id.Should().Be("yabbin/hvem-er-hvem");
             applicationMetadata.Org.Should().Be("yabbin");

--- a/backend/tests/Designer.Tests/Services/TextResourceServiceTest.cs
+++ b/backend/tests/Designer.Tests/Services/TextResourceServiceTest.cs
@@ -3,7 +3,6 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 
 using Altinn.Studio.Designer.Services.Implementation;
-using Altinn.Studio.Designer.Services.Models;
 using Altinn.Studio.Designer.TypedHttpClients.AltinnStorage;
 
 using AltinnCore.Authentication.Constants;

--- a/testdata/App/config/applicationmetadata.json
+++ b/testdata/App/config/applicationmetadata.json
@@ -168,9 +168,6 @@
     "subUnit": false
   },
   "autoDeleteOnProcessEnd": false,
-  "onEntry": {
-    "show": "select-instance"
-  },
   "created": "2021-02-06T15:18:12.2060944Z",
   "createdBy": "jeeva",
   "lastChanged": "2021-02-06T15:18:12.2062288Z",

--- a/testdata/App/config/applicationmetadata.json
+++ b/testdata/App/config/applicationmetadata.json
@@ -1,5 +1,10 @@
 {
   "id": "ttd/frontend-test",
+  "logo": {
+    "source": "resource",
+    "displayAppOwnerNameInHeader": false,
+    "size": "medium"
+  },
   "org": "ttd",
   "title": {
     "nb": "frontend-test",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add packagereference from Altinn.Apps.Api
Change all usages of Platform Application Metadata model to use Apps extended model instead

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
