### PR TITLE
Implementing 404 error when repo is not found

### DIFF
--- a/backend/src/Designer/Filters/Git/GitErrorCodes.cs
+++ b/backend/src/Designer/Filters/Git/GitErrorCodes.cs
@@ -3,5 +3,6 @@
     public class GitErrorCodes
     {
         public const string NonFastForwardError = "GT_01";
+        public const string RepositoryNotFound = "GT_02";
     }
 }

--- a/backend/src/Designer/Filters/Git/GitExceptionFilterAttribute.cs
+++ b/backend/src/Designer/Filters/Git/GitExceptionFilterAttribute.cs
@@ -25,6 +25,10 @@ namespace Altinn.Studio.Designer.Filters.Git
                 context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, GitErrorCodes.NonFastForwardError, HttpStatusCode.Conflict)) { StatusCode = (int)HttpStatusCode.Conflict };
             }
 
+            if (context.Exception is LibGit2Sharp.RepositoryNotFoundException)
+            {
+                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, GitErrorCodes.RepositoryNotFound, HttpStatusCode.NotFound)) { StatusCode = (int)HttpStatusCode.NotFound };
+            }
         }
     }
 }

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryControllerGiteaIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryControllerGiteaIntegrationTests.cs
@@ -159,6 +159,16 @@ namespace Designer.Tests.GiteaIntegrationTests
         [Theory]
         [Trait("Category", "GiteaIntegrationTest")]
         [InlineData(GiteaConstants.TestOrgUsername)]
+        public async Task RepoStatus_ShouldReturn404NotFoundWhenInvalidRepo(string org)
+        {
+            // Call status endpoint
+            using HttpResponseMessage statusResponse = await HttpClient.GetAsync($"designer/api/repos/repo/{org}/123/status");
+            statusResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+
+        [Theory]
+        [Trait("Category", "GiteaIntegrationTest")]
+        [InlineData(GiteaConstants.TestOrgUsername)]
         public async Task GetOrgRepos_ShouldBehaveAsExpected(string org)
         {
             string targetRepo = TestDataHelper.GenerateTestRepoName("-gitea");


### PR DESCRIPTION
## Description
- Adding more detailed error handling for repo status. If it does not exists, 404 is returned instead. 

## Related Issue(s)
- #11448

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
