### PR TITLE
Fix design for popover and storage type for previewlimitationsinfo

### DIFF
--- a/frontend/app-preview/src/views/LandingPage.module.css
+++ b/frontend/app-preview/src/views/LandingPage.module.css
@@ -15,47 +15,22 @@
   border: none;
 }
 
-.previewLimitationsInfo {
-  max-width: 1000px;
-  width: 100%;
-  margin: 10px auto;
-}
-
 .iframeContainer {
   display: flex;
   justify-content: center;
-  background-color: #efefef;
-  height: calc(100vh - var(--header-height));
+  background-color: var(--fds-semantic-surface-neutral-dark);
+  flex: 1;
 }
 
 .iframeMobile {
-  height: 844px;
-  width: calc(390px + 48px);
-  padding: 20px 0;
+  --phone-width: 390px;
+  width: var(--phone-width);
   border: none;
-  margin: 0;
 }
 
-.alert {
+.previewArea {
   display: flex;
-  flex-direction: row;
-  align-self: center;
-  align-items: center;
-  width: fit-content;
-  font-family: var(--font-family);
+  flex-direction: column;
+  height: calc(100vh - var(--header-height));
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: min-content min-content;
-  gap: .5rem;
-}
-.message { grid-area: 1 / 1 / 2 / 3; margin: 0 }
-.yes { grid-area: 2 / 1 / 3 / 2 }
-.no { grid-area: 2 / 2 / 3 / 3 }
-.button { white-space: nowrap }
-
-.gridContainer {
-  display: grid;
-  grid-template-rows: max-content max-content;
-}

--- a/frontend/app-preview/src/views/LandingPage.module.css
+++ b/frontend/app-preview/src/views/LandingPage.module.css
@@ -45,7 +45,7 @@
   font-family: var(--font-family);
 }
 
-.popOver {
+.popover {
   max-width: 320px;
 }
 

--- a/frontend/app-preview/src/views/LandingPage.module.css
+++ b/frontend/app-preview/src/views/LandingPage.module.css
@@ -45,6 +45,10 @@
   font-family: var(--font-family);
 }
 
+.popOver {
+  max-width: 320px;
+}
+
 .row {
   display: flex;
   flex-direction: row;

--- a/frontend/app-preview/src/views/LandingPage.module.css
+++ b/frontend/app-preview/src/views/LandingPage.module.css
@@ -45,15 +45,15 @@
   font-family: var(--font-family);
 }
 
-.popover {
-  max-width: 320px;
+.grid {
+  display: grid;
+  grid-template-columns: min-content min-content;
+  gap: .5rem;
 }
-
-.row {
-  display: flex;
-  flex-direction: row;
-  gap: 1rem;
-}
+.message { grid-area: 1 / 1 / 2 / 3; margin: 0 }
+.yes { grid-area: 2 / 1 / 3 / 2 }
+.no { grid-area: 2 / 2 / 3 / 3 }
+.button { white-space: nowrap }
 
 .gridContainer {
   display: grid;

--- a/frontend/app-preview/src/views/LandingPage.test.tsx
+++ b/frontend/app-preview/src/views/LandingPage.test.tsx
@@ -58,7 +58,7 @@ describe('LandingPage', () => {
         await act(() => user.click(hidePreviewLimitationsTemporaryButton));
 
         expect(hidePreviewLimitationsPopover).not.toBeInTheDocument();
-        expect(window.sessionStorage.getItem('showPreviewLimitationsInfo')).toBeNull();
+        expect(window.localStorage.getItem('showPreviewLimitationsInfo')).toBeNull();
     });
 
     it('should close popover and set value in session storage when hidePreviewLimitationsForSessionButton is clicked', async () => {
@@ -79,6 +79,6 @@ describe('LandingPage', () => {
         await act(() => user.click(hidePreviewLimitationsForSessionButton));
 
         expect(hidePreviewLimitationsPopover).not.toBeInTheDocument();
-        expect(window.sessionStorage.getItem('showPreviewLimitationsInfo')).toBe('false');
+        expect(window.localStorage.getItem('showPreviewLimitationsInfo')).toBe('false');
     });
 });

--- a/frontend/app-preview/src/views/LandingPage.test.tsx
+++ b/frontend/app-preview/src/views/LandingPage.test.tsx
@@ -39,46 +39,4 @@ describe('LandingPage', () => {
         expect(hidePreviewLimitationsTemporaryButton).toBeInTheDocument();
         expect(hidePreviewLimitationsForSessionButton).toBeInTheDocument();
     });
-
-    it('should close popover and not set value in session storage when hidePreviewLimitationsTemporaryButton is clicked', async () => {
-        renderWithMockStore()(<LandingPage variant={'preview'} />);
-
-        const user = userEvent.setup();
-
-        // Open popover
-        const previewLimitationsAlert = screen.getByText(textMock('preview.limitations_info'));
-        const alert = within(previewLimitationsAlert);
-        const hidePreviewLimitationsAlertButton = alert.getByRole('button');
-        await act(() => user.click(hidePreviewLimitationsAlertButton));
-        const hidePreviewLimitationsPopover = screen.getByText(textMock('session.reminder'));
-        expect(hidePreviewLimitationsPopover).toBeInTheDocument();
-        const hidePreviewLimitationsTemporaryButton = screen.getByRole('button', { name: textMock('session.do_show_again') });
-
-        // Click hide temporary button
-        await act(() => user.click(hidePreviewLimitationsTemporaryButton));
-
-        expect(hidePreviewLimitationsPopover).not.toBeInTheDocument();
-        expect(window.localStorage.getItem('showPreviewLimitationsInfo')).toBeNull();
-    });
-
-    it('should close popover and set value in session storage when hidePreviewLimitationsForSessionButton is clicked', async () => {
-        renderWithMockStore()(<LandingPage variant={'preview'} />);
-
-        const user = userEvent.setup();
-
-        // Open popover
-        const previewLimitationsAlert = screen.getByText(textMock('preview.limitations_info'));
-        const alert = within(previewLimitationsAlert);
-        const hidePreviewLimitationsAlertButton = alert.getByRole('button');
-        await act(() => user.click(hidePreviewLimitationsAlertButton));
-        const hidePreviewLimitationsPopover = screen.getByText(textMock('session.reminder'));
-        expect(hidePreviewLimitationsPopover).toBeInTheDocument();
-        const hidePreviewLimitationsForSessionButton = screen.getByRole('button', { name: textMock('session.dont_show_again') });
-
-        // Click hide forever button
-        await act(() => user.click(hidePreviewLimitationsForSessionButton));
-
-        expect(hidePreviewLimitationsPopover).not.toBeInTheDocument();
-        expect(window.localStorage.getItem('showPreviewLimitationsInfo')).toBe('false');
-    });
 });

--- a/frontend/app-preview/src/views/LandingPage.tsx
+++ b/frontend/app-preview/src/views/LandingPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import classes from './LandingPage.module.css';
+import cn from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { usePreviewConnection } from 'app-shared/providers/PreviewConnectionContext';
 import { useInstanceIdQuery, useRepoMetadataQuery, useUserQuery } from 'app-shared/hooks/queries';
@@ -107,13 +108,11 @@ export const LandingPage = ({ variant = 'preview' }: LandingPageProps) => {
                 trigger={<Button onClick={() => setOpenShowSaveChoiceInSession(!openSaveChoiceInSession)} size='small' variant='tertiary' icon={<XMarkIcon />}/>}
                 open={openSaveChoiceInSession}
             >
-              <div className={classes.popover}>
-                {t('session.reminder')}
+              <div className={classes.grid}>
+                <p className={classes.message}>{t('session.reminder')}</p>
+                <Button className={cn(classes.yes, classes.button)}  onClick={handleHidePreviewLimitations} size='small' variant='secondary'>{t('session.do_show_again')}</Button>
+                <Button className={cn(classes.no, classes.button)} onClick={handleRememberChoiceForSession} size='small' variant='secondary'>{t('session.dont_show_again')}</Button>
               </div>
-              <span className={classes.row}>
-                <Button onClick={handleHidePreviewLimitations} size='small' variant='secondary'>{t('session.do_show_again')}</Button>
-                <Button onClick={handleRememberChoiceForSession} size='small' variant='secondary'>{t('session.dont_show_again')}</Button>
-              </span>
             </LegacyPopover>
           </div>
         </Alert>}

--- a/frontend/app-preview/src/views/LandingPage.tsx
+++ b/frontend/app-preview/src/views/LandingPage.tsx
@@ -107,7 +107,7 @@ export const LandingPage = ({ variant = 'preview' }: LandingPageProps) => {
                 trigger={<Button onClick={() => setOpenShowSaveChoiceInSession(!openSaveChoiceInSession)} size='small' variant='tertiary' icon={<XMarkIcon />}/>}
                 open={openSaveChoiceInSession}
             >
-              <div className={classes.popOver}>
+              <div className={classes.popover}>
                 {t('session.reminder')}
               </div>
               <span className={classes.row}>

--- a/frontend/app-preview/src/views/LandingPage.tsx
+++ b/frontend/app-preview/src/views/LandingPage.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react';
+import React from 'react';
 import classes from './LandingPage.module.css';
-import cn from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { usePreviewConnection } from 'app-shared/providers/PreviewConnectionContext';
 import { useInstanceIdQuery, useRepoMetadataQuery, useUserQuery } from 'app-shared/hooks/queries';
@@ -14,11 +13,9 @@ import {
 } from '../components/AppBarConfig/AppPreviewBarConfig';
 import { appPreviewButtonActions } from '../components/AppBarConfig/AppPreviewBarConfig';
 import { AppPreviewSubMenu } from '../components/AppPreviewSubMenu';
-import { Alert, Button, LegacyPopover } from '@digdir/design-system-react';
-import { XMarkIcon } from '@navikt/aksel-icons';
 import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
 import { previewPage } from 'app-shared/api/paths';
-import { typedLocalStorage } from 'app-shared/utils/webStorage';
+import { PreviewLimitationsInfo } from 'app-shared/components/PreviewLimitationsInfo/PreviewLimitationsInfo';
 
 export interface LandingPageProps {
   variant?: AltinnHeaderVariant;
@@ -33,9 +30,6 @@ export const LandingPage = ({ variant = 'preview' }: LandingPageProps) => {
   const { data: user } = useUserQuery();
   const { data: repository } = useRepoMetadataQuery(org, app);
   const { data: instanceId } = useInstanceIdQuery(org, app);
-  const [openSaveChoiceInSession, setOpenShowSaveChoiceInSession] = useState<boolean>(false);
-  const showPreviewLimitationsInfoSession: boolean = typedLocalStorage.getItem('showPreviewLimitationsInfo');
-  const [showPreviewLimitationsInfo, setShowPreviewLimitationsInfo] = useState<boolean>(showPreviewLimitationsInfoSession ?? true);
   const [selectedLayoutSet, setSelectedLayoutSet] = useLocalStorage<string>('layoutSet/' + app, null);
   const [previewViewSize, setPreviewViewSize] = useLocalStorage<PreviewAsViewSize>(
     'viewSize',
@@ -52,17 +46,7 @@ export const LandingPage = ({ variant = 'preview' }: LandingPageProps) => {
     // might need to remove selected layout from local storage to make sure first page is selected
     window.location.reload();
   };
-
-  const handleHidePreviewLimitations = () => {
-    setShowPreviewLimitationsInfo(false);
-    setOpenShowSaveChoiceInSession(false);
-  };
-
-  const handleRememberChoiceForSession = () => {
-    typedLocalStorage.setItem('showPreviewLimitationsInfo', false);
-    handleHidePreviewLimitations();
-  };
-
+  
   if (previewConnection) {
     previewConnection.on('ReceiveMessage', function (message) {
       const frame = document.getElementById('app-frontend-react-iframe');
@@ -99,23 +83,8 @@ export const LandingPage = ({ variant = 'preview' }: LandingPageProps) => {
           }
         />
       </div>
-      <div className={classes.gridContainer}>
-      {showPreviewLimitationsInfo &&
-        <Alert severity='info' className={classes.previewLimitationsInfo}>
-          <div className={classes.alert}>
-            {t('preview.limitations_info')}
-            <LegacyPopover
-                trigger={<Button onClick={() => setOpenShowSaveChoiceInSession(!openSaveChoiceInSession)} size='small' variant='tertiary' icon={<XMarkIcon />}/>}
-                open={openSaveChoiceInSession}
-            >
-              <div className={classes.grid}>
-                <p className={classes.message}>{t('session.reminder')}</p>
-                <Button className={cn(classes.yes, classes.button)}  onClick={handleHidePreviewLimitations} size='small' variant='secondary'>{t('session.do_show_again')}</Button>
-                <Button className={cn(classes.no, classes.button)} onClick={handleRememberChoiceForSession} size='small' variant='secondary'>{t('session.dont_show_again')}</Button>
-              </div>
-            </LegacyPopover>
-          </div>
-        </Alert>}
+      <div className={classes.previewArea}>
+        <PreviewLimitationsInfo />
         <div className={classes.iframeContainer}>
           <iframe
             title={t('preview.iframe_title')}

--- a/frontend/app-preview/src/views/LandingPage.tsx
+++ b/frontend/app-preview/src/views/LandingPage.tsx
@@ -17,7 +17,7 @@ import { Alert, Button, LegacyPopover } from '@digdir/design-system-react';
 import { XMarkIcon } from '@navikt/aksel-icons';
 import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
 import { previewPage } from 'app-shared/api/paths';
-import { typedSessionStorage } from 'app-shared/utils/webStorage';
+import { typedLocalStorage } from 'app-shared/utils/webStorage';
 
 export interface LandingPageProps {
   variant?: AltinnHeaderVariant;
@@ -33,7 +33,7 @@ export const LandingPage = ({ variant = 'preview' }: LandingPageProps) => {
   const { data: repository } = useRepoMetadataQuery(org, app);
   const { data: instanceId } = useInstanceIdQuery(org, app);
   const [openSaveChoiceInSession, setOpenShowSaveChoiceInSession] = useState<boolean>(false);
-  const showPreviewLimitationsInfoSession: boolean = typedSessionStorage.getItem('showPreviewLimitationsInfo');
+  const showPreviewLimitationsInfoSession: boolean = typedLocalStorage.getItem('showPreviewLimitationsInfo');
   const [showPreviewLimitationsInfo, setShowPreviewLimitationsInfo] = useState<boolean>(showPreviewLimitationsInfoSession ?? true);
   const [selectedLayoutSet, setSelectedLayoutSet] = useLocalStorage<string>('layoutSet/' + app, null);
   const [previewViewSize, setPreviewViewSize] = useLocalStorage<PreviewAsViewSize>(
@@ -58,7 +58,7 @@ export const LandingPage = ({ variant = 'preview' }: LandingPageProps) => {
   };
 
   const handleRememberChoiceForSession = () => {
-    typedSessionStorage.setItem('showPreviewLimitationsInfo', false);
+    typedLocalStorage.setItem('showPreviewLimitationsInfo', false);
     handleHidePreviewLimitations();
   };
 
@@ -107,7 +107,9 @@ export const LandingPage = ({ variant = 'preview' }: LandingPageProps) => {
                 trigger={<Button onClick={() => setOpenShowSaveChoiceInSession(!openSaveChoiceInSession)} size='small' variant='tertiary' icon={<XMarkIcon />}/>}
                 open={openSaveChoiceInSession}
             >
-              {t('session.reminder')}
+              <div className={classes.popOver}>
+                {t('session.reminder')}
+              </div>
               <span className={classes.row}>
                 <Button onClick={handleHidePreviewLimitations} size='small' variant='secondary'>{t('session.do_show_again')}</Button>
                 <Button onClick={handleRememberChoiceForSession} size='small' variant='secondary'>{t('session.dont_show_again')}</Button>

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -612,7 +612,7 @@
   "popover.popover_button_helptext": "Klikk her for hjelpetekst popover",
   "popover.popover_open": "Popover åpen",
   "preview.iframe_title": "Forhåndsvisning",
-  "preview.limitations_info": "Forhåndsvisningen til Altinn Studio er en forenkling som lar deg se sluttresultatet av skjemasider som ikke krever logikk. Du kan derfor ikke teste hele flyten i applikasjonen her.",
+  "preview.limitations_info": "Forhåndsvisningen til Altinn Studio lar deg se en forenklet visning av skjemasidene. Visningen tar ikke hensyn til forhåndsutfylling og egendefinerte funksjoner. Du får derfor ikke testet hele flyten i applikasjonen her.",
   "preview.subheader.restart": "Restart",
   "preview.subheader.sharelink": "Del lenke",
   "preview.subheader.showas": "Vis som",

--- a/frontend/packages/shared/src/components/PreviewLimitationsInfo/PreviewLimitationsInfo.module.css
+++ b/frontend/packages/shared/src/components/PreviewLimitationsInfo/PreviewLimitationsInfo.module.css
@@ -1,0 +1,16 @@
+.alert {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    font-family: var(--font-family);
+}
+
+.popoverContent {
+    display: grid;
+    grid-template-columns: min-content min-content;
+    gap: .5rem;
+}
+.message { grid-area: 1 / 1 / 2 / 3; margin: 0 }
+.popoverContent .yesButton { grid-area: 2 / 1 / 3 / 2 }
+.popoverContent .noButton { grid-area: 2 / 2 / 3 / 3 }
+.popoverContent .button { white-space: nowrap }

--- a/frontend/packages/shared/src/components/PreviewLimitationsInfo/PreviewLimitationsInfo.test.tsx
+++ b/frontend/packages/shared/src/components/PreviewLimitationsInfo/PreviewLimitationsInfo.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, act, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PreviewLimitationsInfo } from './PreviewLimitationsInfo';
+import { textMock } from '../../../../../testing/mocks/i18nMock';
+
+describe('PreviewLimitationsInfo', () => {
+
+    it('should close popover and not set value in session storage when hidePreviewLimitationsTemporaryButton is clicked', async () => {
+        render(<PreviewLimitationsInfo/>);
+
+        const user = userEvent.setup();
+
+        // Open popover
+        const previewLimitationsAlert = screen.getByText(textMock('preview.limitations_info'));
+        const alert = within(previewLimitationsAlert);
+        const hidePreviewLimitationsAlertButton = alert.getByRole('button');
+        await act(() => user.click(hidePreviewLimitationsAlertButton));
+        const hidePreviewLimitationsPopover = screen.getByText(textMock('session.reminder'));
+        expect(hidePreviewLimitationsPopover).toBeInTheDocument();
+        const hidePreviewLimitationsTemporaryButton = screen.getByRole('button', { name: textMock('session.do_show_again') });
+
+        // Click hide temporary button
+        await act(() => user.click(hidePreviewLimitationsTemporaryButton));
+
+        expect(hidePreviewLimitationsPopover).not.toBeInTheDocument();
+        expect(window.localStorage.getItem('showPreviewLimitationsInfo')).toBeNull();
+    });
+
+    it('should close popover and set value in session storage when hidePreviewLimitationsForSessionButton is clicked', async () => {
+        render(<PreviewLimitationsInfo/>);
+
+        const user = userEvent.setup();
+
+        // Open popover
+        const previewLimitationsAlert = screen.getByText(textMock('preview.limitations_info'));
+        const alert = within(previewLimitationsAlert);
+        const hidePreviewLimitationsAlertButton = alert.getByRole('button');
+        await act(() => user.click(hidePreviewLimitationsAlertButton));
+        const hidePreviewLimitationsPopover = screen.getByText(textMock('session.reminder'));
+        expect(hidePreviewLimitationsPopover).toBeInTheDocument();
+        const hidePreviewLimitationsForSessionButton = screen.getByRole('button', { name: textMock('session.dont_show_again') });
+
+        // Click hide forever button
+        await act(() => user.click(hidePreviewLimitationsForSessionButton));
+
+        expect(hidePreviewLimitationsPopover).not.toBeInTheDocument();
+        expect(window.localStorage.getItem('showPreviewLimitationsInfo')).toBe('false');
+    });
+});

--- a/frontend/packages/shared/src/components/PreviewLimitationsInfo/PreviewLimitationsInfo.tsx
+++ b/frontend/packages/shared/src/components/PreviewLimitationsInfo/PreviewLimitationsInfo.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import classes from './PreviewLimitationsInfo.module.css';
+import cn from 'classnames';
+import { useTranslation } from 'react-i18next';
+import { Alert, Button, LegacyPopover } from '@digdir/design-system-react';
+import { XMarkIcon } from '@navikt/aksel-icons';
+import { typedLocalStorage } from 'app-shared/utils/webStorage';
+
+export const PreviewLimitationsInfo = () => {
+    const { t } = useTranslation();
+    const [openSaveChoiceInSession, setOpenShowSaveChoiceInSession] = useState<boolean>(false);
+    const showPreviewLimitationsInfoSession: boolean = typedLocalStorage.getItem('showPreviewLimitationsInfo');
+    const [showPreviewLimitationsInfo, setShowPreviewLimitationsInfo] = useState<boolean>(showPreviewLimitationsInfoSession ?? true);
+
+    const handleHidePreviewLimitations = () => {
+        setShowPreviewLimitationsInfo(false);
+        setOpenShowSaveChoiceInSession(false);
+    };
+
+    const handleRememberChoiceForSession = () => {
+        typedLocalStorage.setItem('showPreviewLimitationsInfo', false);
+        handleHidePreviewLimitations();
+    };
+    
+    if (!showPreviewLimitationsInfo) return null;
+    
+    return (
+    <Alert severity='info'>
+        <div className={classes.alert}>
+            {t('preview.limitations_info')}
+            <LegacyPopover
+                trigger={<Button onClick={() => setOpenShowSaveChoiceInSession(!openSaveChoiceInSession)} size='small'
+                                 variant='tertiary' icon={<XMarkIcon/>}/>}
+                open={openSaveChoiceInSession}
+            >
+                <div className={classes.popoverContent}>
+                    <p className={classes.message}>{t('session.reminder')}</p>
+                    <Button className={cn(classes.yesButton, classes.button)} onClick={handleHidePreviewLimitations}
+                            size='small' variant='secondary'>{t('session.do_show_again')}</Button>
+                    <Button className={cn(classes.noButton, classes.button)} onClick={handleRememberChoiceForSession}
+                            size='small' variant='secondary'>{t('session.dont_show_again')}</Button>
+                </div>
+            </LegacyPopover>
+        </div>
+    </Alert>
+    );
+};

--- a/frontend/packages/shared/src/components/PreviewLimitationsInfo/PreviewLimitationsInfo.tsx
+++ b/frontend/packages/shared/src/components/PreviewLimitationsInfo/PreviewLimitationsInfo.tsx
@@ -7,41 +7,63 @@ import { XMarkIcon } from '@navikt/aksel-icons';
 import { typedLocalStorage } from 'app-shared/utils/webStorage';
 
 export const PreviewLimitationsInfo = () => {
-    const { t } = useTranslation();
-    const [openSaveChoiceInSession, setOpenShowSaveChoiceInSession] = useState<boolean>(false);
-    const showPreviewLimitationsInfoSession: boolean = typedLocalStorage.getItem('showPreviewLimitationsInfo');
-    const [showPreviewLimitationsInfo, setShowPreviewLimitationsInfo] = useState<boolean>(showPreviewLimitationsInfoSession ?? true);
+  const { t } = useTranslation();
+  const [openSaveChoiceInSession, setOpenShowSaveChoiceInSession] = useState<boolean>(false);
+  const showPreviewLimitationsInfoSession: boolean = typedLocalStorage.getItem(
+    'showPreviewLimitationsInfo',
+  );
+  const [showPreviewLimitationsInfo, setShowPreviewLimitationsInfo] = useState<boolean>(
+    showPreviewLimitationsInfoSession ?? true,
+  );
 
-    const handleHidePreviewLimitations = () => {
-        setShowPreviewLimitationsInfo(false);
-        setOpenShowSaveChoiceInSession(false);
-    };
+  const handleHidePreviewLimitations = () => {
+    setShowPreviewLimitationsInfo(false);
+    setOpenShowSaveChoiceInSession(false);
+  };
 
-    const handleRememberChoiceForSession = () => {
-        typedLocalStorage.setItem('showPreviewLimitationsInfo', false);
-        handleHidePreviewLimitations();
-    };
-    
-    if (!showPreviewLimitationsInfo) return null;
-    
-    return (
+  const handleRememberChoiceForSession = () => {
+    typedLocalStorage.setItem('showPreviewLimitationsInfo', false);
+    handleHidePreviewLimitations();
+  };
+
+  if (!showPreviewLimitationsInfo) return null;
+
+  return (
     <Alert severity='info'>
-        <div className={classes.alert}>
-            {t('preview.limitations_info')}
-            <LegacyPopover
-                trigger={<Button onClick={() => setOpenShowSaveChoiceInSession(!openSaveChoiceInSession)} size='small'
-                                 variant='tertiary' icon={<XMarkIcon/>}/>}
-                open={openSaveChoiceInSession}
+      <div className={classes.alert}>
+        {t('preview.limitations_info')}
+        <LegacyPopover
+          trigger={
+            <Button
+              onClick={() => setOpenShowSaveChoiceInSession(!openSaveChoiceInSession)}
+              size='small'
+              variant='tertiary'
+              icon={<XMarkIcon />}
+            />
+          }
+          open={openSaveChoiceInSession}
+        >
+          <div className={classes.popoverContent}>
+            <p className={classes.message}>{t('session.reminder')}</p>
+            <Button
+              className={cn(classes.yesButton, classes.button)}
+              onClick={handleHidePreviewLimitations}
+              size='small'
+              variant='secondary'
             >
-                <div className={classes.popoverContent}>
-                    <p className={classes.message}>{t('session.reminder')}</p>
-                    <Button className={cn(classes.yesButton, classes.button)} onClick={handleHidePreviewLimitations}
-                            size='small' variant='secondary'>{t('session.do_show_again')}</Button>
-                    <Button className={cn(classes.noButton, classes.button)} onClick={handleRememberChoiceForSession}
-                            size='small' variant='secondary'>{t('session.dont_show_again')}</Button>
-                </div>
-            </LegacyPopover>
-        </div>
+              {t('session.do_show_again')}
+            </Button>
+            <Button
+              className={cn(classes.noButton, classes.button)}
+              onClick={handleRememberChoiceForSession}
+              size='small'
+              variant='secondary'
+            >
+              {t('session.dont_show_again')}
+            </Button>
+          </div>
+        </LegacyPopover>
+      </div>
     </Alert>
-    );
+  );
 };

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.module.css
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.module.css
@@ -50,3 +50,7 @@
   flex-direction: row;
   gap: 1rem;
 }
+
+.popover {
+  max-width: 320px;
+}

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.module.css
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.module.css
@@ -4,53 +4,30 @@
   flex: var(--preview-width-fraction);
 }
 
+.iframeContainer {
+  display: flex;
+  justify-content: center;
+  flex: 1;
+  background-color: var(--fds-semantic-surface-neutral-dark);
+}
+
 .iframe {
   border: 0;
   margin: 0 auto;
 }
 
-.iframe.mobile {
-  width: 390px;
-  height: 844px;
+.previewArea {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
 
-  /* Next four lines of CSS is for visually emulate a phone */
-  margin-top: 22px;
-  border-radius: 40px;
-  border: 16px solid #1f1f1f;
-  outline: 8px solid #000;
+.iframe.mobile {
+  --phone-width: 390px;
+  width: var(--phone-width);
 }
 
 .iframe.desktop {
   width: 100%;
   height: 100%;
 }
-
-.previewLimitationsInfo {
-  padding: 10px;
-  font-size: 9px;
-  align-content: center;
-}
-
-.alert {
-  display: flex;
-  flex-direction: row;
-  align-self: center;
-  align-items: center;
-  width: fit-content;
-}
-
-.gridContainer {
-  display: grid;
-  grid-template-rows: auto max-content;
-  height: 100%;
-}
-
-.grid {
-  display: grid;
-  grid-template-columns: min-content min-content;
-  gap: .5rem;
-}
-.message { grid-area: 1 / 1 / 2 / 3; margin: 0 }
-.yes { grid-area: 2 / 1 / 3 / 2 }
-.no { grid-area: 2 / 2 / 3 / 3 }
-.button { white-space: nowrap }

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.module.css
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.module.css
@@ -45,12 +45,12 @@
   height: 100%;
 }
 
-.row {
-  display: flex;
-  flex-direction: row;
-  gap: 1rem;
+.grid {
+  display: grid;
+  grid-template-columns: min-content min-content;
+  gap: .5rem;
 }
-
-.popover {
-  max-width: 320px;
-}
+.message { grid-area: 1 / 1 / 2 / 3; margin: 0 }
+.yes { grid-area: 2 / 1 / 3 / 2 }
+.no { grid-area: 2 / 2 / 3 / 3 }
+.button { white-space: nowrap }

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
@@ -12,7 +12,7 @@ import { Alert, Button, Paragraph, LegacyPopover } from '@digdir/design-system-r
 import { XMarkIcon } from '@navikt/aksel-icons';
 import { Center } from 'app-shared/components/Center';
 import { SupportedView, ViewToggler } from './ViewToggler/ViewToggler';
-import { typedSessionStorage } from "app-shared/utils/webStorage";
+import { typedLocalStorage } from 'app-shared/utils/webStorage';
 
 export const Preview = () => {
   const layoutName = useSelector(selectedLayoutNameSelector);
@@ -44,7 +44,7 @@ const PreviewFrame = () => {
   const { previewIframeRef } = useAppContext();
   const layoutName = useSelector(selectedLayoutNameSelector);
   const [openSaveChoiceInSession, setOpenShowSaveChoiceInSession] = useState<boolean>(false);
-  const showPreviewLimitationsInfoSession: boolean = typedSessionStorage.getItem('showPreviewLimitationsInfo');
+  const showPreviewLimitationsInfoSession: boolean = typedLocalStorage.getItem('showPreviewLimitationsInfo');
   const [showPreviewLimitationsInfo, setShowPreviewLimitationsInfo] = useState<boolean>(showPreviewLimitationsInfoSession ?? true);
 
   const handleHidePreviewLimitations = () => {
@@ -53,7 +53,7 @@ const PreviewFrame = () => {
   };
 
   const handleRememberChoiceForSession = () => {
-    typedSessionStorage.setItem('showPreviewLimitationsInfo', false);
+    typedLocalStorage.setItem('showPreviewLimitationsInfo', false);
     handleHidePreviewLimitations();
   };
 

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
@@ -79,7 +79,9 @@ const PreviewFrame = () => {
                   trigger={<Button onClick={() => setOpenShowSaveChoiceInSession(!openSaveChoiceInSession)} size='small' variant='tertiary' icon={<XMarkIcon />}/>}
                   open={openSaveChoiceInSession}
               >
-                {t('session.reminder')}
+                <div className={classes.popover}>
+                  {t('session.reminder')}
+                </div>
                 <span className={classes.row}>
                   <Button onClick={handleHidePreviewLimitations} size='small' variant='secondary'>{t('session.do_show_again')}</Button>
                   <Button onClick={handleRememberChoiceForSession} size='small' variant='secondary'>{t('session.dont_show_again')}</Button>

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
@@ -8,11 +8,10 @@ import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../hooks/useAppContext';
 import { useUpdate } from 'app-shared/hooks/useUpdate';
 import { previewPage } from 'app-shared/api/paths';
-import { Alert, Button, Paragraph, LegacyPopover } from '@digdir/design-system-react';
-import { XMarkIcon } from '@navikt/aksel-icons';
+import { Paragraph } from '@digdir/design-system-react';
 import { Center } from 'app-shared/components/Center';
 import { SupportedView, ViewToggler } from './ViewToggler/ViewToggler';
-import { typedLocalStorage } from 'app-shared/utils/webStorage';
+import { PreviewLimitationsInfo } from 'app-shared/components/PreviewLimitationsInfo/PreviewLimitationsInfo';
 
 export const Preview = () => {
   const layoutName = useSelector(selectedLayoutNameSelector);
@@ -43,19 +42,6 @@ const PreviewFrame = () => {
   const { t } = useTranslation();
   const { previewIframeRef } = useAppContext();
   const layoutName = useSelector(selectedLayoutNameSelector);
-  const [openSaveChoiceInSession, setOpenShowSaveChoiceInSession] = useState<boolean>(false);
-  const showPreviewLimitationsInfoSession: boolean = typedLocalStorage.getItem('showPreviewLimitationsInfo');
-  const [showPreviewLimitationsInfo, setShowPreviewLimitationsInfo] = useState<boolean>(showPreviewLimitationsInfoSession ?? true);
-
-  const handleHidePreviewLimitations = () => {
-    setShowPreviewLimitationsInfo(false);
-    setOpenShowSaveChoiceInSession(false);
-  };
-
-  const handleRememberChoiceForSession = () => {
-    typedLocalStorage.setItem('showPreviewLimitationsInfo', false);
-    handleHidePreviewLimitations();
-  };
 
   useUpdate(() => {
     previewIframeRef.current?.contentWindow?.location.reload();
@@ -64,29 +50,16 @@ const PreviewFrame = () => {
   return (
     <div className={classes.root}>
       <ViewToggler onChange={setViewportToSimulate} />
-      <div className={classes.gridContainer}>
-      <iframe
-        ref={previewIframeRef}
-        className={cn(classes.iframe, classes[viewportToSimulate])}
-        title={t('ux_editor.preview')}
-        src={previewPage(org, app, selectedLayoutSet)}
-      />
-      {showPreviewLimitationsInfo &&
-          <Alert severity='info' className={classes.previewLimitationsInfo}>
-            <div className={classes.alert}>
-              {t('preview.limitations_info')}
-              <LegacyPopover
-                  trigger={<Button onClick={() => setOpenShowSaveChoiceInSession(!openSaveChoiceInSession)} size='small' variant='tertiary' icon={<XMarkIcon />}/>}
-                  open={openSaveChoiceInSession}
-              >
-                <div className={classes.grid}>
-                  <p className={classes.message}>{t('session.reminder')}</p>
-                  <Button className={cn(classes.yes, classes.button)}  onClick={handleHidePreviewLimitations} size='small' variant='secondary'>{t('session.do_show_again')}</Button>
-                  <Button className={cn(classes.no, classes.button)} onClick={handleRememberChoiceForSession} size='small' variant='secondary'>{t('session.dont_show_again')}</Button>
-                </div>
-              </LegacyPopover>
-            </div>
-          </Alert>}
+      <div className={classes.previewArea}>
+          <div className={classes.iframeContainer}>
+          <iframe
+            ref={previewIframeRef}
+            className={cn(classes.iframe, classes[viewportToSimulate])}
+            title={t('ux_editor.preview')}
+            src={previewPage(org, app, selectedLayoutSet)}
+          />
+          </div>
+          <PreviewLimitationsInfo />
       </div>
     </div>
   );

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
@@ -79,13 +79,11 @@ const PreviewFrame = () => {
                   trigger={<Button onClick={() => setOpenShowSaveChoiceInSession(!openSaveChoiceInSession)} size='small' variant='tertiary' icon={<XMarkIcon />}/>}
                   open={openSaveChoiceInSession}
               >
-                <div className={classes.popover}>
-                  {t('session.reminder')}
+                <div className={classes.grid}>
+                  <p className={classes.message}>{t('session.reminder')}</p>
+                  <Button className={cn(classes.yes, classes.button)}  onClick={handleHidePreviewLimitations} size='small' variant='secondary'>{t('session.do_show_again')}</Button>
+                  <Button className={cn(classes.no, classes.button)} onClick={handleRememberChoiceForSession} size='small' variant='secondary'>{t('session.dont_show_again')}</Button>
                 </div>
-                <span className={classes.row}>
-                  <Button onClick={handleHidePreviewLimitations} size='small' variant='secondary'>{t('session.do_show_again')}</Button>
-                  <Button onClick={handleRememberChoiceForSession} size='small' variant='secondary'>{t('session.dont_show_again')}</Button>
-                </span>
               </LegacyPopover>
             </div>
           </Alert>}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- save showPreviewLimitationsInfo in local storage instead of session storage
- wrap text in popover for previewLimitationsInfo
- update text for previewLimitationsInfo to new suggestion from design

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
