### PR TITLE
Add multi page group warning

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1460,6 +1460,7 @@
   "ux_editor.modal_text_key": "Tekstnøkkel",
   "ux_editor.modal_text_resource_body": "Tekstinnhold",
   "ux_editor.modal_text_resource_body_add": "Legg til tekst",
+  "ux_editor.multi_page_warning": "Denne siden inneholder grupper med flere sider. Denne funksjonaliteten er på nåværende tidspunkt ikke støttet i Altinn Studio. Du kan se og redigere komponentene, men ikke sideinformasjonen. Hvis en komponent legges til eller flyttes i en slik gruppe, blir den automatisk plassert på samme side som komponenten over.",
   "ux_editor.no_components_selected": "Velg en side for å se forhåndsvisningen",
   "ux_editor.no_text": "Ingen tekst",
   "ux_editor.page": "Side",

--- a/frontend/packages/ux-editor/src/containers/DesignView/DesignView.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/DesignView.test.tsx
@@ -1,20 +1,21 @@
 import React from 'react';
 import {
   formLayoutSettingsMock,
-  renderHookWithMockStore,
   renderWithMockStore,
 } from '../../testing/mocks';
 import { DesignView } from './DesignView';
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import { textMock } from '../../../../../testing/mocks/i18nMock';
-import { useFormLayoutsQuery } from '../../hooks/queries/useFormLayoutsQuery';
 import { FormContextProvider } from '../FormContext';
 import { DragAndDrop } from 'app-shared/components/dragAndDrop';
 import { BASE_CONTAINER_ID } from 'app-shared/constants';
-import { useFormLayoutSettingsQuery } from '../../hooks/queries/useFormLayoutSettingsQuery';
 import userEvent from '@testing-library/user-event';
 import { queriesMock } from '../../testing/mocks';
 import { typedLocalStorage } from 'app-shared/utils/webStorage';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import { externalLayoutsMock } from '../../testing/layoutMock';
+import { convertExternalLayoutsToInternalFormat } from '../../utils/formLayoutsUtils';
 
 const mockOrg = 'org';
 const mockApp = 'app';
@@ -78,34 +79,24 @@ describe('DesignView', () => {
     expect(queriesMock.saveFormLayout).toHaveBeenCalled();
   });
 
-  it('Does not display a tree view component by default', async () => {
-    await render();
-    expect(screen.queryByRole('tree')).not.toBeInTheDocument();
-  });
-
   it('Displays the tree view version of the layout when the formTree feature flag is enabled', async () => {
     typedLocalStorage.setItem('featureFlags', ['formTree']);
     await render();
     expect(screen.getByRole('tree')).toBeInTheDocument();
   });
 });
-
-const waitForData = async () => {
-  const formLayoutsResult = renderHookWithMockStore()(() =>
-    useFormLayoutsQuery(mockOrg, mockApp, mockSelectedLayoutSet),
-  ).renderHookResult.result;
-
-  const settingsResult = renderHookWithMockStore()(() =>
-    useFormLayoutSettingsQuery(mockOrg, mockApp, mockSelectedLayoutSet),
-  ).renderHookResult.result;
-
-  await waitFor(() => expect(formLayoutsResult.current.isSuccess).toBe(true));
-  await waitFor(() => expect(settingsResult.current.isSuccess).toBe(true));
-};
-
 const render = async () => {
-  await waitForData();
-  return renderWithMockStore()(
+  const queryClient = createQueryClientMock();
+  queryClient.setQueryData(
+    [QueryKey.FormLayouts, mockOrg, mockApp, mockSelectedLayoutSet],
+    convertExternalLayoutsToInternalFormat(externalLayoutsMock).convertedLayouts,
+  );
+  queryClient.setQueryData(
+    [QueryKey.FormLayoutSettings, mockOrg, mockApp, mockSelectedLayoutSet],
+    formLayoutSettingsMock,
+  );
+
+  return renderWithMockStore({}, {}, queryClient)(
     <DragAndDrop.Provider rootId={BASE_CONTAINER_ID} onMove={jest.fn()} onAdd={jest.fn()}>
       <FormContextProvider>
         <DesignView />

--- a/frontend/packages/ux-editor/src/containers/DesignView/DesignView.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/DesignView.tsx
@@ -1,13 +1,12 @@
 import React, { ReactNode, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useFormLayoutsQuery } from '../../hooks/queries/useFormLayoutsQuery';
-import { BASE_CONTAINER_ID } from 'app-shared/constants';
 import classes from './DesignView.module.css';
 import { useTranslation } from 'react-i18next';
 import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
 import { Accordion, Button } from '@digdir/design-system-react';
 import { IFormLayouts } from '../../types/global';
-import type { FormLayout } from '../../types/FormLayout';
+import type { FormLayoutPage } from '../../types/FormLayoutPage';
 import { FormLayoutActions } from '../../features/formDesigner/formLayout/formLayoutSlice';
 import { useInstanceIdQuery } from 'app-shared/hooks/queries';
 import { useSearchParams } from 'react-router-dom';
@@ -17,16 +16,14 @@ import { useAddLayoutMutation } from '../../hooks/mutations/useAddLayoutMutation
 import cn from 'classnames';
 import { setSelectedLayoutInLocalStorage } from '../../utils/localStorageUtils';
 import { PageAccordion } from './PageAccordion';
-import { RenderedFormContainer } from './RenderedFormContainer';
 import { ReceiptContent } from './ReceiptContent';
-import { FormTree } from './FormTree';
-import { shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
 import { useAppContext } from '../../hooks/useAppContext';
+import { FormLayout } from './FormLayout';
 
 /**
  * Maps the IFormLayouts object to a list of FormLayouts
  */
-const mapIFormLayoutsToFormLayouts = (formLayouts: IFormLayouts): FormLayout[] => {
+const mapFormLayoutsToFormLayoutPages = (formLayouts: IFormLayouts): FormLayoutPage[] => {
   return Object.entries(formLayouts).map(([key, value]) => ({
     page: key,
     data: value,
@@ -60,7 +57,7 @@ export const DesignView = (): ReactNode => {
     setOpenAccordion(searchParamsLayout);
   }, [searchParamsLayout]);
 
-  const formLayoutData = mapIFormLayoutsToFormLayouts(layouts);
+  const formLayoutData = mapFormLayoutsToFormLayoutPages(layouts);
 
   /**
    * Checks if the layout name provided is valid
@@ -132,20 +129,6 @@ export const DesignView = (): ReactNode => {
     // If the layout does not exist, return null
     if (layout === undefined) return null;
 
-    const { order, containers, components } = layout.data;
-
-    const renderForm = () =>
-      shouldDisplayFeature('formTree') ? (
-        <FormTree layout={layout.data} />
-      ) : (
-        <RenderedFormContainer
-          containerId={BASE_CONTAINER_ID}
-          formLayoutOrder={order}
-          formDesignerContainers={containers}
-          formDesignerComponents={components}
-        />
-      );
-
     return (
       <PageAccordion
         pageName={layout.page}
@@ -153,7 +136,7 @@ export const DesignView = (): ReactNode => {
         isOpen={layout.page === openAccordion}
         onClick={() => handleClickAccordion(layout.page)}
       >
-        {layout.page === openAccordion && renderForm()}
+        {layout.page === openAccordion && <FormLayout layout={layout.data} />}
       </PageAccordion>
     );
   });

--- a/frontend/packages/ux-editor/src/containers/DesignView/FormLayout.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/FormLayout.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { FormLayout, FormLayoutProps } from './FormLayout';
+import { layoutMock } from '../../testing/layoutMock';
+import { screen } from '@testing-library/react';
+import { typedLocalStorage } from 'app-shared/utils/webStorage';
+import { renderWithMockStore } from '../../testing/mocks';
+import { BASE_CONTAINER_ID } from 'app-shared/constants';
+import { DragAndDropTree } from 'app-shared/components/DragAndDropTree';
+import { FormContextProvider } from '../FormContext';
+import { textMock } from '../../../../../testing/mocks/i18nMock';
+import { internalLayoutWithMultiPageGroup } from '../../testing/layoutWithMultiPageGroupMocks';
+
+const defaultProps: FormLayoutProps = {
+  layout: layoutMock,
+};
+
+describe('FormLayout', () => {
+
+  it('Does not display a tree view component by default', () => {
+    render();
+    expect(screen.queryByRole('tree')).not.toBeInTheDocument();
+  });
+
+  it('Displays the tree view version of the layout when the formTree feature flag is enabled', () => {
+    typedLocalStorage.setItem('featureFlags', ['formTree']);
+    render();
+    expect(screen.getByRole('tree')).toBeInTheDocument();
+  });
+
+  it('Displays warning about multi page groups when the layout has such groups', () => {
+    render({ layout: internalLayoutWithMultiPageGroup });
+    expect(screen.getByText(textMock('ux_editor.multi_page_warning'))).toBeInTheDocument();
+  });
+
+  it('Does not display warning about multi page groups when the layout does not have such groups', () => {
+    render();
+    expect(screen.queryByText(textMock('ux_editor.multi_page_warning'))).not.toBeInTheDocument();
+  });
+});
+
+const render = (props?: Partial<FormLayoutProps>) =>
+  renderWithMockStore()(
+    <DragAndDropTree.Provider rootId={BASE_CONTAINER_ID} onMove={jest.fn()} onAdd={jest.fn()}>
+      <FormContextProvider>
+        <FormLayout {...defaultProps} {...props} />
+      </FormContextProvider>
+    </DragAndDropTree.Provider>
+  );

--- a/frontend/packages/ux-editor/src/containers/DesignView/FormLayout.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/FormLayout.tsx
@@ -1,0 +1,45 @@
+import { IInternalLayout } from '../../types/global';
+import { shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
+import { FormTree } from './FormTree';
+import { RenderedFormContainer } from './RenderedFormContainer';
+import { BASE_CONTAINER_ID } from 'app-shared/constants';
+import React from 'react';
+import { hasMultiPageGroup } from '../../utils/formLayoutUtils';
+import { useTranslation } from 'react-i18next';
+import { Alert, Paragraph } from '@digdir/design-system-react';
+
+export interface FormLayoutProps {
+  layout: IInternalLayout;
+}
+
+export const FormLayout = ({ layout }: FormLayoutProps) => {
+  const { order, containers, components } = layout;
+
+  const renderForm = () =>
+    shouldDisplayFeature('formTree') ? (
+      <FormTree layout={layout} />
+    ) : (
+      <RenderedFormContainer
+        containerId={BASE_CONTAINER_ID}
+        formLayoutOrder={order}
+        formDesignerContainers={containers}
+        formDesignerComponents={components}
+      />
+    );
+
+  return (
+    <>
+      {hasMultiPageGroup(layout) && <MultiPageWarning />}
+      {renderForm()}
+    </>
+  );
+};
+
+const MultiPageWarning = () => {
+  const { t } = useTranslation();
+  return (
+    <Alert severity='warning'>
+      <Paragraph size='small'>{t('ux_editor.multi_page_warning')}</Paragraph>
+    </Alert>
+  );
+};

--- a/frontend/packages/ux-editor/src/containers/DesignView/ReceiptContent/ReceiptContent.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/ReceiptContent/ReceiptContent.test.tsx
@@ -3,7 +3,7 @@ import { act, screen, waitFor } from '@testing-library/react';
 import { ReceiptContent, ReceiptContentProps } from './ReceiptContent';
 import userEvent from '@testing-library/user-event';
 import { textMock } from '../../../../../../testing/mocks/i18nMock';
-import { FormLayout } from '../../../types/FormLayout';
+import { FormLayoutPage } from '../../../types/FormLayoutPage';
 import {
   component1Mock,
   component2Mock,
@@ -35,7 +35,7 @@ const mockPageData: IInternalLayout = {
   order: { mockContainerId: [] },
 };
 
-const mockFormLayoutData: FormLayout[] = [
+const mockFormLayoutData: FormLayoutPage[] = [
   { page: mockPageName1, data: mockPageData },
   { page: mockPageName2, data: mockPageData },
   { page: mockReceiptName, data: mockPageData },

--- a/frontend/packages/ux-editor/src/containers/DesignView/ReceiptContent/ReceiptContent.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/ReceiptContent/ReceiptContent.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import classes from './ReceiptContent.module.css';
-import type { FormLayout } from '../../../types/FormLayout';
+import type { FormLayoutPage } from '../../../types/FormLayoutPage';
 import { PageAccordion } from '../PageAccordion';
 import { RenderedFormContainer } from '../RenderedFormContainer';
 import { BASE_CONTAINER_ID } from 'app-shared/constants';
@@ -19,7 +19,7 @@ export type ReceiptContentProps = {
   /**
    * The list of all form layouts
    */
-  formLayoutData: FormLayout[];
+  formLayoutData: FormLayoutPage[];
   /**
    * To be executed when clicking the accordion
    * @returns void
@@ -38,7 +38,7 @@ export type ReceiptContentProps = {
  *
  * @property {string}[receiptName] - Name of receipt page
  * @property {string}[selectedAccordion] - The currently open accordion
- * @property {FormLayout[]}[formLayoutData] - The list of all form layouts
+ * @property {FormLayoutPage[]}[formLayoutData] - The list of all form layouts
  * @property {function}[onClickAccordion] - To be executed when clicking the accordion
  * @property {function}[onClickAddPage] - To be executed when clicking add receipt
  *

--- a/frontend/packages/ux-editor/src/hooks/queries/useFormLayoutsQuery.ts
+++ b/frontend/packages/ux-editor/src/hooks/queries/useFormLayoutsQuery.ts
@@ -7,17 +7,20 @@ import { useDispatch } from 'react-redux';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { convertExternalLayoutsToInternalFormat } from '../../utils/formLayoutsUtils';
 
-export const useFormLayoutsQuery =
-  (org: string, app: string, layoutSetName: string): UseQueryResult<IFormLayouts> => {
-    const { getFormLayouts } = useServicesContext();
-    const dispatch = useDispatch();
-    return useQuery(
-  [QueryKey.FormLayouts, org, app, layoutSetName],
-      () => getFormLayouts(org, app, layoutSetName).then((formLayouts) => {
-        const { convertedLayouts, invalidLayouts } = convertExternalLayoutsToInternalFormat(formLayouts);
-        dispatch(FormLayoutActions.setInvalidLayouts(invalidLayouts));
-        return convertedLayouts;
-      }
-    )
-    );
-  }
+export const useFormLayoutsQuery = (
+  org: string,
+  app: string,
+  layoutSetName: string,
+): UseQueryResult<IFormLayouts> => {
+  const { getFormLayouts } = useServicesContext();
+  const dispatch = useDispatch();
+  return useQuery(
+    [QueryKey.FormLayouts, org, app, layoutSetName],
+    () => getFormLayouts(org, app, layoutSetName).then((formLayouts) => {
+      const { convertedLayouts, invalidLayouts } =
+        convertExternalLayoutsToInternalFormat(formLayouts);
+      dispatch(FormLayoutActions.setInvalidLayouts(invalidLayouts));
+      return convertedLayouts;
+    }),
+  );
+};

--- a/frontend/packages/ux-editor/src/types/FormLayoutPage.ts
+++ b/frontend/packages/ux-editor/src/types/FormLayoutPage.ts
@@ -1,6 +1,6 @@
 import { IInternalLayout } from './global';
 
-export interface FormLayout {
+export interface FormLayoutPage {
   page: string;
   data: IInternalLayout;
 }

--- a/frontend/packages/ux-editor/src/utils/formLayoutUtils.test.tsx
+++ b/frontend/packages/ux-editor/src/utils/formLayoutUtils.test.tsx
@@ -8,6 +8,7 @@ import {
   getChildIds,
   getDepth,
   getItem,
+  hasMultiPageGroup,
   hasNavigationButtons,
   hasSubContainers,
   isContainer,
@@ -482,6 +483,16 @@ describe('formLayoutUtils', () => {
 
     it('Returns the item with the given id when it is a container', () => {
       expect(getItem(mockInternal, groupId)).toEqual(groupContainer);
+    });
+  });
+
+  describe('hasMultiPageGroup', () => {
+    it('Returns true if the layout contains a multi page group', () => {
+      expect(hasMultiPageGroup(internalLayoutWithMultiPageGroup)).toBe(true);
+    });
+
+    it('Returns false if the layout does not contain a multi page group', () => {
+      expect(hasMultiPageGroup(mockInternal)).toBe(false);
     });
   });
 });

--- a/frontend/packages/ux-editor/src/utils/formLayoutUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/formLayoutUtils.ts
@@ -382,3 +382,6 @@ export const getChildIds = (layout: IInternalLayout, parentId: string): string[]
 
 export const getItem = (layout: IInternalLayout, itemId: string): FormComponent | FormContainer =>
   layout.components[itemId] || layout.containers[itemId];
+
+export const hasMultiPageGroup = (layout: IInternalLayout): boolean =>
+  Object.values(layout.containers).some((container) => container.edit?.multiPage);


### PR DESCRIPTION
## Description
This change is an extension to the work done in #11382, that made multi page group configuration valid. Now the user will see a message explaining why they are not visible in the editor.

<img width="450" alt="image" src="https://github.com/Altinn/altinn-studio/assets/29770305/ac1d3645-4721-49a7-9a4b-77b74c0612ea">

I have also moved form layout specific code in the `DesignView` component to a new component called `FormLayout`.

## Related Issue(s)
- #11309 
- #11281

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
