### PR TITLE
Use the Select icon for MultipleSelect component

### DIFF
--- a/frontend/packages/ux-editor/src/data/formItemConfig.ts
+++ b/frontend/packages/ux-editor/src/data/formItemConfig.ts
@@ -359,7 +359,7 @@ export const formItemConfigs: FormItemConfigs = {
       required: true,
       propertyPath: 'definitions/selectionComponents',
     },
-    icon: ChevronDownIcon,
+    icon: Select,
   },
   [ComponentType.NavigationBar]: {
     name: ComponentType.NavigationBar,

--- a/frontend/packages/ux-editor/src/data/formItemConfig.ts
+++ b/frontend/packages/ux-editor/src/data/formItemConfig.ts
@@ -8,7 +8,6 @@ import {
   CalendarIcon,
   Checkbox,
   ChevronDownDoubleIcon,
-  ChevronDownIcon,
   ExclamationmarkTriangleIcon,
   FileTextIcon,
   FingerButtonIcon,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I noticed that the MultipleSelect component used the same icon as the treeview component uses for a parent element that contains children. This looked a confusing together with the group component, which can actually expand:
<img width="655" alt="Screenshot 2023-11-03 at 14 42 21" src="https://github.com/Altinn/altinn-studio/assets/1636323/c3cf52ae-d630-45f3-aeaf-8792403b6f21">


Suggest we use the same icon as the regular Select component to differentiate these:
<img width="646" alt="Screenshot 2023-11-03 at 14 42 44" src="https://github.com/Altinn/altinn-studio/assets/1636323/a483a424-79c8-4cea-bcc3-25df0cc85f57">

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
