### PR TITLE
Fix css for text editor

### DIFF
--- a/frontend/packages/text-editor/src/TextEditor.module.css
+++ b/frontend/packages/text-editor/src/TextEditor.module.css
@@ -1,9 +1,7 @@
 .TextEditor {
-  background-color: #fff;
   width: 100%;
-  height: 100%;
+  height: calc(100vh - var(--header-height));
   display: grid;
-  gap: 2rem;
   grid-template-columns: auto minmax(20%, 400px);
   justify-items: center;
 }
@@ -40,7 +38,6 @@
   gap: 1rem;
   justify-content: space-between;
   border-bottom: 1px solid #bcc7cc;
-  margin-top: -2.4rem !important; /* to counteract builtin margin from AltinnRadioGroup - can be removed when we replace with design system components */
   padding-bottom: 1rem;
 }
 
@@ -51,25 +48,21 @@
 
 .TextEditor__topRow {
   border-bottom: 1px solid #bcc7cc;
-  margin-bottom: 2rem;
-  margin-left: 2rem;
-  padding: 2rem 0;
+  padding: 2rem;
   display: flex;
   justify-content: space-between;
 }
 
 .TextEditor__body {
   margin-left: 2rem;
+  overflow: auto;
 }
 
 .TextEditor__main {
-  padding-top: 2rem;
-  margin: 0 auto;
   width: 100%;
   background-color: #fff;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
   overflow: scroll;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adapt css in text editor so header is always visible. Also removed some unnecessary spacing

_Video comparing dev and this branch:_

https://github.com/Altinn/altinn-studio/assets/71079896/4b47d1c9-0b02-4972-9b5b-8a280b2a1e80


## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
