### PR TITLE
change routing dynamic segments in resourceadm

### DIFF
--- a/frontend/resourceadm/app/App.tsx
+++ b/frontend/resourceadm/app/App.tsx
@@ -47,8 +47,8 @@ export const App = (): JSX.Element => {
     return <ErrorMessage title={error.title} message={error.message} />;
   }
 
-  // PageLayout banner uses organization, named as selectedContext
-  const basePath = '/:selectedContext/:repo';
+  // PageLayout banner uses organization, named as org
+  const basePath = '/:org/:app';
 
   if (componentIsReady) {
     return (
@@ -67,7 +67,7 @@ export const App = (): JSX.Element => {
             <Route path={basePath} element={<ResourceDashboardPage />} />
             <Route path={`${basePath}/resource/:resourceId/:pageType`} element={<ResourcePage />} />
             <Route path='/' element={<ErrorPage />} />
-            <Route path='/:selectedContext' element={<RedirectPage />} />
+            <Route path='/:org' element={<RedirectPage />} />
           </Route>
         </Routes>
       </div>

--- a/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.tsx
@@ -40,7 +40,7 @@ export const ImportResourceModal = ({
 }: ImportResourceModalProps): React.ReactNode => {
   const { t } = useTranslation();
 
-  const { selectedContext } = useParams();
+  const { org: selectedContext } = useParams();
   const repo = `${selectedContext}-resources`;
 
   const navigate = useNavigate();

--- a/frontend/resourceadm/components/NewResourceModal/NewResourceModal.tsx
+++ b/frontend/resourceadm/components/NewResourceModal/NewResourceModal.tsx
@@ -30,7 +30,7 @@ export const NewResourceModal = ({ isOpen, onClose }: NewResourceModalProps): Re
 
   const navigate = useNavigate();
 
-  const { selectedContext } = useParams();
+  const { org: selectedContext } = useParams();
   const repo = `${selectedContext}-resources`;
 
   const [id, setId] = useState('');

--- a/frontend/resourceadm/hooks/useSelectedContext/useSelectedContext.ts
+++ b/frontend/resourceadm/hooks/useSelectedContext/useSelectedContext.ts
@@ -1,7 +1,7 @@
-import { useParams } from "react-router-dom";
-import { SelectedContextType } from "app-shared/navigation/main-header/Header";
+import { useParams } from 'react-router-dom';
+import { SelectedContextType } from 'app-shared/navigation/main-header/Header';
 
 export const useSelectedContext = () => {
-  const { selectedContext = SelectedContextType.Self } = useParams();
+  const { org: selectedContext = SelectedContextType.Self } = useParams();
   return selectedContext;
 };

--- a/frontend/resourceadm/pages/DeployResourcePage/DeployResourcePage.tsx
+++ b/frontend/resourceadm/pages/DeployResourcePage/DeployResourcePage.tsx
@@ -51,7 +51,7 @@ export const DeployResourcePage = ({
 }: DeployResourcePageProps): React.ReactNode => {
   const { t } = useTranslation();
 
-  const { selectedContext, resourceId } = useParams();
+  const { org: selectedContext, resourceId } = useParams();
   const repo = `${selectedContext}-resources`;
 
   const [isLocalRepoInSync, setIsLocalRepoInSync] = useState(false);

--- a/frontend/resourceadm/pages/MigrationPage/MigrationPage.tsx
+++ b/frontend/resourceadm/pages/MigrationPage/MigrationPage.tsx
@@ -40,7 +40,7 @@ export const MigrationPage = ({
 }: MigrationPageProps): React.ReactNode => {
   // TODO - translation. Issue: #10715
 
-  const { selectedContext, resourceId } = useParams();
+  const { org: selectedContext, resourceId } = useParams();
   const repo = `${selectedContext}-resources`;
 
   const { data: validatePolicyData, isLoading: validatePolicyLoading } = useValidatePolicyQuery(

--- a/frontend/resourceadm/pages/PolicyEditorPage/PolicyEditorPage.tsx
+++ b/frontend/resourceadm/pages/PolicyEditorPage/PolicyEditorPage.tsx
@@ -29,7 +29,7 @@ export type PolicyEditorPageProps = {
 export const PolicyEditorPage = ({ showAllErrors, id }: PolicyEditorPageProps): React.ReactNode => {
   const { t } = useTranslation();
 
-  const { resourceId, selectedContext } = useParams();
+  const { resourceId, org: selectedContext } = useParams();
   const repo = `${selectedContext}-resources`;
 
   // Get the data

--- a/frontend/resourceadm/pages/RedirectPage/RedirectPage.tsx
+++ b/frontend/resourceadm/pages/RedirectPage/RedirectPage.tsx
@@ -10,7 +10,7 @@ import { ErrorPage } from '../ErrorPage';
  * @returns {React.ReactNode} - The rendered component
  */
 export const RedirectPage = (): React.ReactNode => {
-  const { selectedContext } = useParams();
+  const { org: selectedContext } = useParams();
 
   return (
     <div className={classes.pageWrapper}>

--- a/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.tsx
+++ b/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.tsx
@@ -21,7 +21,7 @@ import { getResourcePageURL } from 'resourceadm/utils/urlUtils';
  * @returns {React.ReactNode} - The rendered component
  */
 export const ResourceDashboardPage = (): React.ReactNode => {
-  const { selectedContext } = useParams();
+  const { org: selectedContext } = useParams();
   const repo = `${selectedContext}-resources`;
 
   const { t } = useTranslation();

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
@@ -40,7 +40,7 @@ export const ResourcePage = (): React.ReactNode => {
 
   const navigate = useNavigate();
 
-  const { pageType, resourceId, selectedContext } = useParams();
+  const { pageType, resourceId, org: selectedContext } = useParams();
   const repo = `${selectedContext}-resources`;
 
   const [currentPage, setCurrentPage] = useState<NavigationBarPage>(pageType as NavigationBarPage);


### PR DESCRIPTION
Purpose: using the same routing params as dashboard; the generated url to repo generated in GiteaHeader will be correct. With another route, some parts of the route will be undefined.

## Description
Change basePath routing from "/:selectedContext/:repo" to "/:org/:app" in resourceadm, and fix related calls to read url parameters using useParam()

## Related Issue(s)
None

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
