### PR TITLE
Support [org] in addition to [ORG] in policy.xml fiels on deploy

### DIFF
--- a/backend/src/Designer/Services/Implementation/AuthorizationPolicyService.cs
+++ b/backend/src/Designer/Services/Implementation/AuthorizationPolicyService.cs
@@ -43,7 +43,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             FileSystemObject policyFile = await GetAuthorizationPolicyFileFromGitea(org, app, shortCommitId);
             byte[] data = Convert.FromBase64String(policyFile.Content);
             string policyFileContent = Encoding.UTF8.GetString(data);
-            policyFileContent = policyFileContent.Replace("[ORG]", org).Replace("[APP]", app);
+            policyFileContent = policyFileContent.Replace("[ORG]", org).Replace("[org]", org).Replace("[APP]", app);
             await _authorizationPolicyClient.SavePolicy(org, app, policyFileContent, envName);
         }
 


### PR DESCRIPTION
After the policy editor started chaining instances of `[ORG]` to `[org]` in the policy.xml files, I think it makes sense to actually support the change on deploy.

Not sure what the correct way forward is. We should probably update localtest as well, but that will cause issues for everyone not updating localtest. 

## Related Issue(s)
- Stopgap for https://github.com/Altinn/altinn-studio/issues/11545

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
