### PR TITLE
Add access token to use cases script

### DIFF
--- a/frontend/testing/cypress/use-cases.yaml
+++ b/frontend/testing/cypress/use-cases.yaml
@@ -36,7 +36,7 @@ steps:
     yarn run cy:cachelist
     yarn run cy:version
     yarn run cy:verify
-    yarn run cy:run -s 'src/integration/usecase/usecase.js' -e environment=$(environment),useCaseUserPwd=$(userPassword)
+    yarn run cy:run -s 'src/integration/usecase/usecase.js' -e environment=$(environment),useCaseUserPwd=$(userPassword),accessToken=$(accessToken)
 
   workingDirectory: '$(cypressTestDir)'
   displayName: 'Studio Tests'


### PR DESCRIPTION
Add access token to the use cases script, so that it can be used to delete the test app.