### PR TITLE
Pass usecase tests when test app does not exist

### DIFF
--- a/frontend/testing/cypress/src/support/gitea-api.js
+++ b/frontend/testing/cypress/src/support/gitea-api.js
@@ -48,7 +48,11 @@ Cypress.Commands.add('deleteAllApps', (ownerName, accessToken, isOrg) => {
 Cypress.Commands.add(
   'deleteApp',
   (ownerName, appName, accessToken) =>
-    cy.request('DELETE', `${giteaBaseUrl}/repos/${ownerName}/${appName}?token=${accessToken}`)
+    cy.request({
+      method: 'DELETE',
+      url: `${giteaBaseUrl}/repos/${ownerName}/${appName}?token=${accessToken}`,
+      failOnStatusCode: false,
+    })
 );
 
 /**


### PR DESCRIPTION
## Description
By default, `cy.request` fails on response codes like 404. This makes the usecase test fail if the test app does not exist when it tries to delete it. The tests should not be dependent of that, so I have set `failOnStatusCode` to `false`.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
