### PR TITLE
tweak design for security level selection

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -620,7 +620,7 @@
   "policy_editor.rules": "Regler for tilgang til applikasjonen",
   "policy_editor.security_level_description": "Sikkerhetsnivået du setter her blir minstekrav for innloggingsmetoden til bruker. Sikkerhetsnivå 1 og 2 er kun tilgjengelig via API. Skal bruker logge seg inn via ID-porten blir minstekrav sikkerhetsnivå 3.",
   "policy_editor.security_level_label": "Sikkerhetsnivå",
-  "policy_editor.select_auth_level_help_text_content": "Ler mer om sikkerhetsnivå og innlogging for sluttbruker.",
+  "policy_editor.select_auth_level_help_text_content": "Les mer om sikkerhetsnivå og innlogging for sluttbruker.",
   "policy_editor.select_auth_level_label": "Velg minimum påkrevd sikkerhetsnivå for bruker",
   "policy_editor.verification_modal_action_button": "Ja, slett regel",
   "policy_editor.verification_modal_close_button": "Nei, gå tilbake",

--- a/frontend/packages/policy-editor/src/PolicyEditor.module.css
+++ b/frontend/packages/policy-editor/src/PolicyEditor.module.css
@@ -1,5 +1,6 @@
 .alertWrapper {
   margin-bottom: 20px;
+  max-width: 650px;
 }
 
 .alert {

--- a/frontend/packages/policy-editor/src/components/SecurityLevelSelect/SecurityLevelSelect.module.css
+++ b/frontend/packages/policy-editor/src/components/SecurityLevelSelect/SecurityLevelSelect.module.css
@@ -15,4 +15,9 @@
 
 .link {
   display: inline;
+  font: var(--fds-typography-paragraph-small);
+}
+
+.securityLevelContainer {
+  max-width: 650px;
 }

--- a/frontend/packages/policy-editor/src/components/SecurityLevelSelect/SecurityLevelSelect.tsx
+++ b/frontend/packages/policy-editor/src/components/SecurityLevelSelect/SecurityLevelSelect.tsx
@@ -44,7 +44,7 @@ export const SecurityLevelSelect = ({
   }, [t]);
 
   return (
-    <div>
+    <div className={classes.securityLevelContainer}>
       <Heading level={2} size='xxsmall' spacing>
         {t('policy_editor.security_level_label')}
       </Heading>
@@ -57,7 +57,7 @@ export const SecurityLevelSelect = ({
           <Label size='small' htmlFor={SELECT_AUTH_LEVEL_ID}>
             {t('policy_editor.select_auth_level_label')}
           </Label>
-          <HelpText title={t('policy_editor.select_auth_level_help_text')}>
+          <HelpText size='small' title={t('policy_editor.select_auth_level_help_text')}>
             <Link
               href={URL_TO_SECURITY_LEVEL_PAGE}
               target='_newTab'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Tweaked design based on feedback in test:
- Set max-width for SecurityLevel select (to limit width of the descriptive text)
- Set max-width for info alert on "minimum 1 rule"
- Set smaller font for link in help text
- Fix typo in help text

<img width="1083" alt="Screenshot 2023-11-15 at 18 19 40" src="https://github.com/Altinn/altinn-studio/assets/1636323/6039f28f-6f28-4eeb-8bf4-78158a0fd3d7">

## Related Issue(s)
- #11470 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
