### PR TITLE
fix navigation from overview page

### DIFF
--- a/frontend/app-development/features/administration/components/Navigation.tsx
+++ b/frontend/app-development/features/administration/components/Navigation.tsx
@@ -20,7 +20,12 @@ export const Navigation = () => {
       <div className={classes.links}>
         {menuItems.map((menuItem) => {
           return (
-            <Link key={menuItem.key} to={menuItem.link} className={classes.link}>
+            <Link
+              key={menuItem.key}
+              to={`../${menuItem.link}`}
+              className={classes.link}
+              title={t(menuItem.key)}
+            >
               <menuItem.icon className={classes.icon} />
               <span>{t(menuItem.key)}</span>
             </Link>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Navigate to correct url by ensuring that we go up one level on the route before appending the relative route.

This is challenging to actually unit-test, as switching routes also switches "sub-app", and mocking the store for an entire application just to test navigation seems like overkill. 
However, I have added cypress tests for the new overview page that test the navigation.

## Related Issue(s)
- #11601

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
