### PR TITLE
refactor: prop drill org and app url parameters into ThreeDotsMenu component from GiteaHeader component

### DIFF
--- a/frontend/packages/shared/src/components/GiteaHeader/GiteaHeader.tsx
+++ b/frontend/packages/shared/src/components/GiteaHeader/GiteaHeader.tsx
@@ -63,7 +63,12 @@ export const GiteaHeader = ({
       <div className={classes.leftContentWrapper}>{leftComponent}</div>
       <div className={`${classes.rightContentWrapper} ${rightContentClassName}`}>
         <VersionControlButtons org={org} app={app} />
-        <ThreeDotsMenu onlyShowRepository={menuOnlyHasRepository} hasCloneModal={hasCloneModal} />
+        <ThreeDotsMenu
+          onlyShowRepository={menuOnlyHasRepository}
+          hasCloneModal={hasCloneModal}
+          org={org}
+          app={app}
+        />
       </div>
     </div>
   );

--- a/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/ThreeDotsMenu.tsx
+++ b/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/ThreeDotsMenu.tsx
@@ -7,19 +7,21 @@ import { GiteaIcon } from 'app-shared/icons';
 import { LegacyPopover, Button } from '@digdir/design-system-react';
 import { MenuElipsisVerticalIcon } from '@navikt/aksel-icons';
 import { CloneModal } from './CloneModal';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
 
 type ThreeDotsMenuProps = {
   onlyShowRepository?: boolean;
   hasCloneModal?: boolean;
+  org: string;
+  app: string;
 };
 
 export const ThreeDotsMenu = ({
   onlyShowRepository = false,
   hasCloneModal = false,
+  org,
+  app,
 }: ThreeDotsMenuProps) => {
   const [cloneModalAnchor, setCloneModalAnchor] = useState(null);
-  const { org, app } = useStudioUrlParams();
   const { t } = useTranslation();
   const closeCloneModal = () => setCloneModalAnchor(null);
   const openCloneModal = (event: React.MouseEvent) => setCloneModalAnchor(event.currentTarget);


### PR DESCRIPTION
## Description
This is instead of using useParams() in <ThreeDotsMenu> to get these values again. This makes it easier to reuse <GiteaHeader> component in resourceadm suprepo, and the app and org props sent to <GiteaHeader> are used as props in child components as well.

## Related Issue(s)
None

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
