### PR TITLE
updated calculation for layout files

### DIFF
--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'frontend/**'
       - '!frontend/testing/cypress/**'
+      - '!frontend/stats/**'
       - 'testdata/**'
       - '.github/workflows/frontend-unit-tests.yml'
       - 'package.json'

--- a/frontend/stats/configurationStats/run.ts
+++ b/frontend/stats/configurationStats/run.ts
@@ -26,6 +26,7 @@ const generateLayoutFilesStats = async () => {
     'Layout files',
     'component',
   );
+  const componentCount = layout.items.length;
 
   const layoutSettingsSchemaResult = await axios.get(
     'https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json',
@@ -36,8 +37,13 @@ const generateLayoutFilesStats = async () => {
     'LayoutSettings',
   );
 
+  const settingsCount = layoutSettings.items.length;
+
   // Only the 'sets' property exists in the layout-sets schema, and it is not supported
   const meanSupportedLayoutSetsSuport = 0;
+  const layoutSetsItemCount = 1;
+
+  const totalItemCount = componentCount + settingsCount + layoutSetsItemCount;
 
   console.log('');
   console.log('**********************************************************');
@@ -55,10 +61,10 @@ const generateLayoutFilesStats = async () => {
   console.log(
     'Mean support layout files total: ',
     Math.round(
-      (meanSupportedComponentPropertyPercentage +
-        meanSupportedLayoutSettingsSupport +
-        meanSupportedLayoutSetsSuport) /
-        3,
+      (meanSupportedComponentPropertyPercentage * componentCount +
+        meanSupportedLayoutSettingsSupport * settingsCount +
+        meanSupportedLayoutSetsSuport * layoutSetsItemCount) /
+        totalItemCount,
     ),
     '%',
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated the calculation for layout files, so that the FILES are not weighted equally, but the content is:
- Layout: each component carries weight 1
- LayoutSettings: each setting (`pages` and `components`) carries weight 1
- Layout sets: weight 1 on whole file
