### PR TITLE
Delete overview test app in Cypress

### DIFF
--- a/frontend/testing/cypress/src/integration/studio/overview.js
+++ b/frontend/testing/cypress/src/integration/studio/overview.js
@@ -23,6 +23,14 @@ context('Designer', () => {
     cy.visit('/dashboard');
   });
 
+  after(() => {
+    cy.deleteApp(
+      Cypress.env('orgUserName'),
+      Cypress.env('designerAppName'),
+      Cypress.env('accessToken'),
+    );
+  });
+
   it('loads the overview page when navigating to app for user with no environments', () => {
     // Ensure feature flag is toggled
     // TODO: remove this once feature flag is removed (https://github.com/Altinn/altinn-studio/issues/11495)


### PR DESCRIPTION
## Description
Added `after` hook to he `overview` test suite that deletes the test app it creates.

I have created a new issue to eliminate further errors related to finding and opening an app: #11638

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
