### PR TITLE
Replace border CSS token 

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioModal/StudioModal.module.css
+++ b/frontend/libs/studio-components/src/components/StudioModal/StudioModal.module.css
@@ -38,7 +38,7 @@
 }
 
 .headingWrapper {
-  border-bottom: 1px solid var(--fds-semantic-border-neutral-divider);
+  border-bottom: 1px solid var(--fds-semantic-border-divider-default);
   height: var(--heading-height);
   position: sticky;
   top: 0;

--- a/frontend/packages/policy-editor/src/components/CardButton/CardButton.module.css
+++ b/frontend/packages/policy-editor/src/components/CardButton/CardButton.module.css
@@ -7,7 +7,7 @@
   margin: 0;
   background-color: var(--fds-semantic-surface-neutral-default);
   border-radius: 12px;
-  border: solid 1px var(--fds-semantic-border-neutral-divider);
+  border: solid 1px var(--fds-semantic-border-divider-default);
   cursor: pointer;
 }
 
@@ -17,7 +17,7 @@
 
 .button:focus-visible,
 .button:focus-within {
-  border-bottom: 1px solid var(--fds-semantic-border-neutral-divider);
+  border-bottom: 1px solid var(--fds-semantic-border-divider-default);
   background-color: var(--fds-semantic-background-default);
 
   --fds-inner-focus-border-color: var(--fds-semantic-border-focus-boxshadow);

--- a/frontend/packages/policy-editor/src/components/ExpandablePolicyCard/ExpandablePolicyElement/ExpandablePolicyElement.module.css
+++ b/frontend/packages/policy-editor/src/components/ExpandablePolicyCard/ExpandablePolicyElement/ExpandablePolicyElement.module.css
@@ -1,10 +1,10 @@
 .wrapper {
   width: 100%;
-  border: solid 1px var(--fds-semantic-border-neutral-divider);
+  border: solid 1px var(--fds-semantic-border-divider-default);
 }
 
 .wrapper.buttonHovered {
-  box-shadow: 0 0 0 2px var(--fds-semantic-border-neutral-divider);
+  box-shadow: 0 0 0 2px var(--fds-semantic-border-divider-default);
 }
 
 .buttonFocused:focus-visible,

--- a/frontend/packages/shared/src/components/LeftNavigationBar/GoBackButton/GoBackButton.module.css
+++ b/frontend/packages/shared/src/components/LeftNavigationBar/GoBackButton/GoBackButton.module.css
@@ -4,7 +4,7 @@
 }
 
 .backButton {
-  border-bottom: 2px solid var(--fds-semantic-border-neutral-divider);
+  border-bottom: 2px solid var(--fds-semantic-border-divider-default);
 }
 
 .backButton:hover {

--- a/frontend/packages/shared/src/components/LeftNavigationBar/LeftNavigationBar.module.css
+++ b/frontend/packages/shared/src/components/LeftNavigationBar/LeftNavigationBar.module.css
@@ -3,7 +3,7 @@
   width: 250px;
   height: 100%;
   left: 0;
-  border-right: 1px solid var(--fds-semantic-border-neutral-divider);
+  border-right: 1px solid var(--fds-semantic-border-divider-default);
   border-top: none;
 }
 
@@ -18,7 +18,7 @@
   padding-left: 15px;
   padding-block: 20px;
   border: none;
-  border-bottom: 1px solid var(--fds-semantic-border-neutral-divider);
+  border-bottom: 1px solid var(--fds-semantic-border-divider-default);
   background-color: var(--fds-semantic-background-subtle);
   cursor: pointer;
 }

--- a/frontend/packages/shared/src/components/LeftNavigationBar/Tab/Tab.module.css
+++ b/frontend/packages/shared/src/components/LeftNavigationBar/Tab/Tab.module.css
@@ -15,7 +15,7 @@
   padding-left: 15px;
   padding-block: 20px;
   border: none;
-  border-bottom: 1px solid var(--fds-semantic-border-neutral-divider);
+  border-bottom: 1px solid var(--fds-semantic-border-divider-default);
   background-color: var(--fds-semantic-background-subtle);
   cursor: pointer;
 }

--- a/frontend/packages/shared/src/components/TreeView/TreeViewItem/TreeViewItem.module.css
+++ b/frontend/packages/shared/src/components/TreeView/TreeViewItem/TreeViewItem.module.css
@@ -1,5 +1,5 @@
 .listItem {
-  --vertical-line-colour: var(--fds-semantic-border-neutral-divider);
+  --vertical-line-colour: var(--fds-semantic-border-divider-default);
   --vertical-line-width: 2px;
 
   list-style-type: none;

--- a/frontend/packages/ux-editor/src/components/Preview/ViewToggler/ViewToggler.module.css
+++ b/frontend/packages/ux-editor/src/components/Preview/ViewToggler/ViewToggler.module.css
@@ -3,7 +3,7 @@
   justify-content: flex-end;
   padding: 4px 2rem;
   box-sizing: border-box;
-  border-bottom: 1px solid var(--fds-semantic-border-neutral-divider);
+  border-bottom: 1px solid var(--fds-semantic-border-divider-default);
 }
 
 .toggler {

--- a/frontend/resourceadm/components/ResourceDeployEnvCard/ResourceDeployEnvCard.module.css
+++ b/frontend/resourceadm/components/ResourceDeployEnvCard/ResourceDeployEnvCard.module.css
@@ -7,7 +7,7 @@
   margin: 0;
   background-color: var(--fds-semantic-surface-neutral-default);
   border-radius: 12px;
-  border: solid 1px var(--fds-semantic-border-neutral-divider);
+  border: solid 1px var(--fds-semantic-border-divider-default);
 }
 
 .envName {

--- a/frontend/resourceadm/components/RightTranslationBar/RightTranslationBar.module.css
+++ b/frontend/resourceadm/components/RightTranslationBar/RightTranslationBar.module.css
@@ -3,7 +3,7 @@
   min-height: 100vh;
   height: 100%;
   right: 0;
-  border: 1px solid var(--fds-semantic-border-neutral-divider);
+  border: 1px solid var(--fds-semantic-border-divider-default);
   border-top: none;
 }
 


### PR DESCRIPTION
## Description
- replacing all occurrences of ```--fds-semantic-border-neutral-divider``` with ```--fds-semantic-border-divider-default``` as it seems like it has been removed from Designsystemet. This change caused the ```<LeftNavigationBar />``` and ```<PolicyEditor />``` to look weird in dev. View the issue to see old photos. 

## Related Issue(s)
- #11647 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)