### PR TITLE
adding beta tag in the header

### DIFF
--- a/frontend/app-development/layout/AppBar/appBarConfig.ts
+++ b/frontend/app-development/layout/AppBar/appBarConfig.ts
@@ -35,6 +35,7 @@ export const topBarMenuItem: TopBarMenuItem[] = [
     icon: TenancyIcon,
     repositoryTypes: [RepositoryType.App],
     featureFlagName: 'processEditor',
+    isBeta: true,
   },
 ];
 

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -273,6 +273,7 @@
   "general.add": "Legg til",
   "general.add_connection": "Legg til kobling",
   "general.back": "Tilbake",
+  "general.beta": "Beta",
   "general.cancel": "Avbryt",
   "general.choose": "Velg",
   "general.choose_label": "Velg navn",

--- a/frontend/packages/shared/src/components/altinnHeaderMenu/AltinnHeaderMenu.module.css
+++ b/frontend/packages/shared/src/components/altinnHeaderMenu/AltinnHeaderMenu.module.css
@@ -12,9 +12,12 @@
 .menuItem {
   color: #fff;
   font-size: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.menuItem :hover {
+.menuItem a:hover {
   border-bottom: 2px solid #fff;
 }
 

--- a/frontend/packages/shared/src/components/altinnHeaderMenu/AltinnHeaderMenu.module.css
+++ b/frontend/packages/shared/src/components/altinnHeaderMenu/AltinnHeaderMenu.module.css
@@ -14,7 +14,7 @@
   font-size: 1rem;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.25rem;
 }
 
 .menuItem a:hover {

--- a/frontend/packages/shared/src/components/altinnHeaderMenu/AltinnHeaderMenu.test.tsx
+++ b/frontend/packages/shared/src/components/altinnHeaderMenu/AltinnHeaderMenu.test.tsx
@@ -5,25 +5,36 @@ import { MemoryRouter } from 'react-router-dom';
 import { TopBarMenuItem } from 'app-shared/types/TopBarMenuItem';
 import { TopBarMenu } from 'app-shared/enums/TopBarMenu';
 import { RepositoryType } from 'app-shared/types/global';
+import { textMock } from '../../../../../testing/mocks/i18nMock';
+
+const mockMenuItems: TopBarMenuItem[] = [
+  {
+    key: TopBarMenu.About,
+    link: 'Link1',
+    repositoryTypes: [RepositoryType.App, RepositoryType.Datamodels],
+  },
+  {
+    key: TopBarMenu.Create,
+    link: 'Link2',
+    repositoryTypes: [RepositoryType.App],
+  },
+  {
+    key: TopBarMenu.Datamodel,
+    link: 'Link3',
+    repositoryTypes: [RepositoryType.App, RepositoryType.Datamodels],
+  },
+];
+
+const mockMenuItem4: TopBarMenuItem = {
+  key: TopBarMenu.ProcessEditor,
+  link: 'Link4',
+  repositoryTypes: [RepositoryType.App],
+  isBeta: true,
+};
 
 describe('AltinnHeaderMenu', () => {
-  const mockMenuItems: TopBarMenuItem[] = [
-    {
-      key: TopBarMenu.About,
-      link: 'Link1',
-      repositoryTypes: [RepositoryType.App, RepositoryType.Datamodels],
-    },
-    {
-      key: TopBarMenu.Create,
-      link: 'Link2',
-      repositoryTypes: [RepositoryType.App],
-    },
-    {
-      key: TopBarMenu.Datamodel,
-      link: 'Link3',
-      repositoryTypes: [RepositoryType.App, RepositoryType.Datamodels],
-    },
-  ];
+  afterEach(jest.clearAllMocks);
+
   it('Should render nothing if there are no provided meny items', () => {
     render();
     expect(screen.queryByTestId('altinn-header-menu')).not.toBeInTheDocument();
@@ -32,6 +43,18 @@ describe('AltinnHeaderMenu', () => {
   it('should render all provided menu items', () => {
     render({ menuItems: mockMenuItems });
     expect(screen.queryAllByRole('link')).toHaveLength(3);
+  });
+
+  it('shouldm not render the beta tag when there is no beta', () => {
+    render({ menuItems: mockMenuItems });
+
+    expect(screen.queryByText(textMock('general.beta'))).not.toBeInTheDocument();
+  });
+
+  it('should render the beta tag when an item is beta', () => {
+    render({ menuItems: [...mockMenuItems, mockMenuItem4] });
+
+    expect(screen.getByText(textMock('general.beta'))).toBeInTheDocument();
   });
 });
 

--- a/frontend/packages/shared/src/components/altinnHeaderMenu/AltinnHeaderMenu.tsx
+++ b/frontend/packages/shared/src/components/altinnHeaderMenu/AltinnHeaderMenu.tsx
@@ -22,7 +22,7 @@ export const AltinnHeaderMenu = ({ menuItems }: IAltinnHeaderMenuProps) => {
             {t(item.key)}
           </NavLink>
           {item.isBeta && (
-            <Tag color='info' size='small' variant='primary'>
+            <Tag color='info' size='xsmall' variant='primary'>
               {t('general.beta')}
             </Tag>
           )}

--- a/frontend/packages/shared/src/components/altinnHeaderMenu/AltinnHeaderMenu.tsx
+++ b/frontend/packages/shared/src/components/altinnHeaderMenu/AltinnHeaderMenu.tsx
@@ -3,6 +3,7 @@ import classes from './AltinnHeaderMenu.module.css';
 import { NavLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { TopBarMenuItem } from 'app-shared/types/TopBarMenuItem';
+import { Tag } from '@digdir/design-system-react';
 
 export interface IAltinnHeaderMenuProps {
   menuItems: TopBarMenuItem[];
@@ -20,6 +21,11 @@ export const AltinnHeaderMenu = ({ menuItems }: IAltinnHeaderMenuProps) => {
           <NavLink to={item.link} className={({ isActive }) => (isActive ? classes.active : '')}>
             {t(item.key)}
           </NavLink>
+          {item.isBeta && (
+            <Tag color='info' size='small' variant='primary'>
+              {t('general.beta')}
+            </Tag>
+          )}
         </li>
       ))}
     </ul>

--- a/frontend/packages/shared/src/types/TopBarMenuItem.ts
+++ b/frontend/packages/shared/src/types/TopBarMenuItem.ts
@@ -8,4 +8,5 @@ export interface TopBarMenuItem {
   icon?: React.FC<React.SVGProps<SVGSVGElement>>;
   repositoryTypes: RepositoryType[];
   featureFlagName?: SupportedFeatureFlags;
+  isBeta?: boolean;
 }


### PR DESCRIPTION
## Description
- Implementing beta tag in the header component to show that a feature is in beta mode.

## Related Issue(s)
- #11603 

## Images
- The beta tag is not added to "Lage", it is just for show-off in the picture. The "Prosess" link is also hidden behind a feature flag. 
<img width="1148" alt="image" src="https://github.com/Altinn/altinn-studio/assets/133344438/b53e4783-0809-4ac5-a6b7-0d31a1cfa5d3">

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)