### PR TITLE
11039 the api should return a 401 status code when a session is invalid

### DIFF
--- a/backend/src/Designer/Configuration/ServiceRepositorySettings.cs
+++ b/backend/src/Designer/Configuration/ServiceRepositorySettings.cs
@@ -172,7 +172,7 @@ namespace Altinn.Studio.Designer.Configuration
         public string GiteaLoginUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the BaseResourceFolderContainer that identifes where in the docker container the runtime can find files needed
+        /// Gets or sets the BaseResourceFolderContainer that identifies where in the docker container the runtime can find files needed
         /// </summary>
         public string BaseResourceFolderContainer { get; set; }
 

--- a/backend/src/Designer/Controllers/HomeController.cs
+++ b/backend/src/Designer/Controllers/HomeController.cs
@@ -153,7 +153,7 @@ namespace Altinn.Studio.Designer.Controllers
 
             _logger.LogInformation("Updating app key for " + userName);
             KeyValuePair<string, string> accessKeyValuePair = await _giteaApi.GetSessionAppKey() ?? default(KeyValuePair<string, string>);
-            List<Claim> claims = new ();
+            List<Claim> claims = new();
             const string Issuer = "https://altinn.no";
             if (!accessKeyValuePair.Equals(default(KeyValuePair<string, string>)))
             {
@@ -165,10 +165,10 @@ namespace Altinn.Studio.Designer.Controllers
             }
 
             claims.Add(new Claim(AltinnCoreClaimTypes.Developer, userName, ClaimValueTypes.String, Issuer));
-            ClaimsIdentity identity = new ("TestUserLogin");
+            ClaimsIdentity identity = new("TestUserLogin");
             identity.AddClaims(claims);
 
-            ClaimsPrincipal principal = new (identity);
+            ClaimsPrincipal principal = new(identity);
 
             string timeoutString = DateTime.UtcNow.AddMinutes(_generalSettings.SessionDurationInMinutes - 5).ToString();
             HttpContext.Response.Cookies.Append(
@@ -227,7 +227,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>The debug info you want</returns>
         public async Task<IActionResult> Debug()
         {
-            StringBuilder stringBuilder = new ();
+            StringBuilder stringBuilder = new();
             stringBuilder.AppendLine("Debug info");
             stringBuilder.AppendLine("App token is: " + _sourceControl.GetAppToken());
             stringBuilder.AppendLine("App token id is " + _sourceControl.GetAppTokenId());

--- a/backend/src/Designer/Controllers/HomeController.cs
+++ b/backend/src/Designer/Controllers/HomeController.cs
@@ -126,7 +126,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>The login page</returns>
         public async Task<IActionResult> Login()
         {
-            string userName = string.Empty;
+            string userName;
             string goToUrl = "/";
 
             // Verify that user is not logged in already.
@@ -141,7 +141,7 @@ namespace Altinn.Studio.Designer.Controllers
                 userName = await _giteaApi.GetUserNameFromUI();
                 if (string.IsNullOrEmpty(userName))
                 {
-                    return (Environment.GetEnvironmentVariable("ServiceRepositorySettings__GiteaLoginUrl") != null)
+                    return Environment.GetEnvironmentVariable("ServiceRepositorySettings__GiteaLoginUrl") != null
                     ? Redirect(Environment.GetEnvironmentVariable("ServiceRepositorySettings__GiteaLoginUrl"))
                     : Redirect(_settings.GiteaLoginUrl);
                 }
@@ -153,7 +153,7 @@ namespace Altinn.Studio.Designer.Controllers
 
             _logger.LogInformation("Updating app key for " + userName);
             KeyValuePair<string, string> accessKeyValuePair = await _giteaApi.GetSessionAppKey() ?? default(KeyValuePair<string, string>);
-            List<Claim> claims = new List<Claim>();
+            List<Claim> claims = new ();
             const string Issuer = "https://altinn.no";
             if (!accessKeyValuePair.Equals(default(KeyValuePair<string, string>)))
             {
@@ -165,10 +165,10 @@ namespace Altinn.Studio.Designer.Controllers
             }
 
             claims.Add(new Claim(AltinnCoreClaimTypes.Developer, userName, ClaimValueTypes.String, Issuer));
-            ClaimsIdentity identity = new ClaimsIdentity("TestUserLogin");
+            ClaimsIdentity identity = new ("TestUserLogin");
             identity.AddClaims(claims);
 
-            ClaimsPrincipal principal = new ClaimsPrincipal(identity);
+            ClaimsPrincipal principal = new (identity);
 
             string timeoutString = DateTime.UtcNow.AddMinutes(_generalSettings.SessionDurationInMinutes - 5).ToString();
             HttpContext.Response.Cookies.Append(
@@ -227,7 +227,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>The debug info you want</returns>
         public async Task<IActionResult> Debug()
         {
-            StringBuilder stringBuilder = new StringBuilder();
+            StringBuilder stringBuilder = new ();
             stringBuilder.AppendLine("Debug info");
             stringBuilder.AppendLine("App token is: " + _sourceControl.GetAppToken());
             stringBuilder.AppendLine("App token id is " + _sourceControl.GetAppTokenId());

--- a/backend/src/Designer/Controllers/RepositoryController.cs
+++ b/backend/src/Designer/Controllers/RepositoryController.cs
@@ -185,7 +185,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>The repository status</returns>
         [HttpGet]
         [Route("repo/{org}/{repository:regex(^(?!datamodels$)[[a-z]][[a-z0-9-]]{{1,28}}[[a-z0-9]]$)}/status")]
-        public RepoStatus RepoStatus(string org, string repository)
+        public async Task<RepoStatus> RepoStatus(string org, string repository)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
             SemaphoreSlim semaphore = _userRequestsSynchronizationService.GetRequestsSemaphore(org, repository, developer);

--- a/backend/src/Designer/Controllers/RepositoryController.cs
+++ b/backend/src/Designer/Controllers/RepositoryController.cs
@@ -185,7 +185,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>The repository status</returns>
         [HttpGet]
         [Route("repo/{org}/{repository:regex(^(?!datamodels$)[[a-z]][[a-z0-9-]]{{1,28}}[[a-z0-9]]$)}/status")]
-        public async Task<RepoStatus> RepoStatus(string org, string repository)
+        public RepoStatus RepoStatus(string org, string repository)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
             SemaphoreSlim semaphore = _userRequestsSynchronizationService.GetRequestsSemaphore(org, repository, developer);

--- a/backend/src/Designer/Controllers/SessionController.cs
+++ b/backend/src/Designer/Controllers/SessionController.cs
@@ -22,7 +22,7 @@ namespace Altinn.Studio.Designer.Controllers
     public class SessionController : ControllerBase
     {
         private readonly GeneralSettings _settings;
-        private readonly int _sessingExtensionInMinutes = 30;
+        private readonly int _sessionExtensionInMinutes = 30;
         private readonly IHttpContextAccessor _httpContextAccessor;
 
         /// <summary>
@@ -71,19 +71,19 @@ namespace Altinn.Studio.Designer.Controllers
                 return Unauthorized();
             }
 
-            HttpContext.Response.Cookies.Append(_settings.SessionTimeoutCookieName, DateTime.UtcNow.AddMinutes(_sessingExtensionInMinutes - 5).ToString());
+            HttpContext.Response.Cookies.Append(_settings.SessionTimeoutCookieName, DateTime.UtcNow.AddMinutes(_sessionExtensionInMinutes - 5).ToString());
 
             await HttpContext.SignInAsync(
               CookieAuthenticationDefaults.AuthenticationScheme,
               HttpContext.User,
               new AuthenticationProperties
               {
-                  ExpiresUtc = DateTime.UtcNow.AddMinutes(_sessingExtensionInMinutes),
+                  ExpiresUtc = DateTime.UtcNow.AddMinutes(_sessionExtensionInMinutes),
                   IsPersistent = false,
                   AllowRefresh = false,
               });
 
-            return Ok(_sessingExtensionInMinutes);
+            return Ok(_sessionExtensionInMinutes);
         }
 
         /// <summary>

--- a/backend/src/Designer/Filters/Git/GitErrorCodes.cs
+++ b/backend/src/Designer/Filters/Git/GitErrorCodes.cs
@@ -4,5 +4,6 @@
     {
         public const string NonFastForwardError = "GT_01";
         public const string RepositoryNotFound = "GT_02";
+        public const string GiteaSessionExpired = "GT_03";
     }
 }

--- a/backend/src/Designer/Filters/Git/GitExceptionFilterAttribute.cs
+++ b/backend/src/Designer/Filters/Git/GitExceptionFilterAttribute.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net;
-using Altinn.Studio.Designer.Models;
+﻿using System.Net;
+using Altinn.Studio.Designer.TypedHttpClients.Exceptions;
 using LibGit2Sharp;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -25,9 +23,14 @@ namespace Altinn.Studio.Designer.Filters.Git
                 context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, GitErrorCodes.NonFastForwardError, HttpStatusCode.Conflict)) { StatusCode = (int)HttpStatusCode.Conflict };
             }
 
-            if (context.Exception is LibGit2Sharp.RepositoryNotFoundException)
+            if (context.Exception is RepositoryNotFoundException)
             {
                 context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, GitErrorCodes.RepositoryNotFound, HttpStatusCode.NotFound)) { StatusCode = (int)HttpStatusCode.NotFound };
+            }
+
+            if (context.Exception is GiteaUnathorizedException)
+            {
+                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, GitErrorCodes.GiteaSessionExpired, HttpStatusCode.Unauthorized)) { StatusCode = (int)HttpStatusCode.Unauthorized };
             }
         }
     }

--- a/backend/src/Designer/Filters/Git/GitExceptionFilterAttribute.cs
+++ b/backend/src/Designer/Filters/Git/GitExceptionFilterAttribute.cs
@@ -28,7 +28,7 @@ namespace Altinn.Studio.Designer.Filters.Git
                 context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, GitErrorCodes.RepositoryNotFound, HttpStatusCode.NotFound)) { StatusCode = (int)HttpStatusCode.NotFound };
             }
 
-            if (context.Exception is GiteaUnathorizedException)
+            if (context.Exception is GiteaUnathorizedException || (context.Exception is LibGit2SharpException && context.Exception.Message.Contains("server requires authentication that we do not support")))
             {
                 context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, GitErrorCodes.GiteaSessionExpired, HttpStatusCode.Unauthorized)) { StatusCode = (int)HttpStatusCode.Unauthorized };
             }

--- a/backend/src/Designer/Helpers/AuthenticationHelper.cs
+++ b/backend/src/Designer/Helpers/AuthenticationHelper.cs
@@ -23,7 +23,6 @@ namespace Altinn.Studio.Designer.Helpers
 
             if (context.User != null)
             {
-                Console.WriteLine("user: " + context.User);
                 foreach (Claim claim in context.User.Claims)
                 {
                     if (claim.Type.Equals(AltinnCoreClaimTypes.Developer))

--- a/backend/src/Designer/Helpers/AuthenticationHelper.cs
+++ b/backend/src/Designer/Helpers/AuthenticationHelper.cs
@@ -23,6 +23,7 @@ namespace Altinn.Studio.Designer.Helpers
 
             if (context.User != null)
             {
+                Console.WriteLine("user: " + context.User);
                 foreach (Claim claim in context.User.Claims)
                 {
                     if (claim.Type.Equals(AltinnCoreClaimTypes.Developer))
@@ -106,7 +107,7 @@ namespace Altinn.Studio.Designer.Helpers
         }
 
         /// <summary>
-        /// Returns the designer cookie 
+        /// Returns the designer cookie
         /// </summary>
         /// <param name="context">Httpcontext with request</param>
         /// <param name="cookieHost">The cookie host</param>
@@ -124,7 +125,7 @@ namespace Altinn.Studio.Designer.Helpers
         /// <returns>A header value string</returns>
         public static string GetDeveloperTokenHeaderValue(HttpContext context)
         {
-            return "token " + AuthenticationHelper.GetDeveloperAppToken(context);
+            return "token " + GetDeveloperAppToken(context);
         }
 
         /// <summary>

--- a/backend/src/Designer/Infrastructure/AuthenticationConfiguration.cs
+++ b/backend/src/Designer/Infrastructure/AuthenticationConfiguration.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Threading.Tasks;
 
 using Altinn.Studio.Designer.Authorization;
@@ -37,12 +36,12 @@ namespace Altinn.Studio.Designer.Infrastructure
                 {
                     options.AccessDeniedPath = "/Home/NotAuthorized/";
                     options.LogoutPath = "/Home/Logout/";
-                    options.Cookie.Name = Altinn.Studio.Designer.Constants.General.DesignerCookieName;
+                    options.Cookie.Name = Constants.General.DesignerCookieName;
                     options.Events = new CookieAuthenticationEvents
                     {
                         // Add Custom Event handler to be able to redirect users for authentication upgrade
                         OnRedirectToAccessDenied = NotAuthorizedHandler.RedirectToNotAuthorized,
-                        OnRedirectToLogin = async (context) =>
+                        OnRedirectToLogin = async context =>
                         {
                             if (context.Request.Path.Value.Contains("keepalive", System.StringComparison.OrdinalIgnoreCase))
                             {

--- a/backend/src/Designer/Program.cs
+++ b/backend/src/Designer/Program.cs
@@ -72,7 +72,7 @@ void ConfigureSetupLogging()
 
 async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnvironment hostingEnvironment)
 {
-    logger.LogInformation($"// Program.cs // SetConfigurationProviders // Attempting to configure providers.");
+    logger.LogInformation("// Program.cs // SetConfigurationProviders // Attempting to configure providers");
     string basePath = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
     config.SetBasePath(basePath);
     config.AddJsonFile(basePath + "app/altinn-appsettings/altinn-appsettings-secret.json", optional: true, reloadOnChange: true);
@@ -98,7 +98,7 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
         !string.IsNullOrEmpty(keyVaultSettings.ClientSecret) &&
         !string.IsNullOrEmpty(keyVaultSettings.SecretUri))
     {
-        logger.LogInformation("// Program.cs // SetConfigurationProviders // Attempting to configure KeyVault.");
+        logger.LogInformation("// Program.cs // SetConfigurationProviders // Attempting to configure KeyVault");
         AzureServiceTokenProvider azureServiceTokenProvider = new($"RunAs=App;AppId={keyVaultSettings.ClientId};TenantId={keyVaultSettings.TenantId};AppKey={keyVaultSettings.ClientSecret}");
         KeyVaultClient keyVaultClient = new(
             new KeyVaultClient.AuthenticationCallback(
@@ -129,7 +129,7 @@ async Task SetConfigurationProviders(ConfigurationManager config, IWebHostEnviro
         }
     }
 
-    logger.LogInformation($"// Program.cs // SetConfigurationProviders // Configured providers.");
+    logger.LogInformation("// Program.cs // SetConfigurationProviders // Configured providers");
 }
 
 void ConfigureLogging(ILoggingBuilder builder)
@@ -171,7 +171,7 @@ void ConfigureLogging(ILoggingBuilder builder)
 
 void ConfigureServices(IServiceCollection services, IConfiguration configuration, IWebHostEnvironment env)
 {
-    logger.LogInformation($"// Program.cs // ConfigureServices // Attempting to configure services.");
+    logger.LogInformation("// Program.cs // ConfigureServices // Attempting to configure services");
 
     services.Configure<KestrelServerOptions>(options =>
     {
@@ -249,12 +249,12 @@ void ConfigureServices(IServiceCollection services, IConfiguration configuration
 
     // Auto register all settings classes
     services.RegisterSettingsByBaseType<ISettingsMarker>(configuration);
-    logger.LogInformation($"// Program.cs // ConfigureServices // Configuration complete");
+    logger.LogInformation("// Program.cs // ConfigureServices // Configuration complete");
 }
 
 void Configure(IConfiguration configuration)
 {
-    logger.LogInformation($"// Program.cs // Configure // Attempting to configure env.");
+    logger.LogInformation("// Program.cs // Configure // Attempting to configure env");
     if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
     {
         app.UseExceptionHandler("/error-local-development");

--- a/backend/src/Designer/RepositoryClient/Model/User.cs
+++ b/backend/src/Designer/RepositoryClient/Model/User.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using System.Text;
-using Newtonsoft.Json;
 
 namespace Altinn.Studio.Designer.RepositoryClient.Model
 {

--- a/backend/src/Designer/Services/Implementation/GiteaAPIWrapper/GiteaAPIWrapper.cs
+++ b/backend/src/Designer/Services/Implementation/GiteaAPIWrapper/GiteaAPIWrapper.cs
@@ -7,7 +7,6 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using Altinn.Studio.Designer.Configuration;
@@ -15,7 +14,6 @@ using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.RepositoryClient.Model;
 using Altinn.Studio.Designer.Services.Interfaces;
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;

--- a/backend/src/Designer/Services/Implementation/SourceControlLoggingDecorator.cs
+++ b/backend/src/Designer/Services/Implementation/SourceControlLoggingDecorator.cs
@@ -171,9 +171,14 @@ namespace Altinn.Studio.Designer.Services.Implementation
             {
                 _decoratedService.FetchRemoteChanges(org, repository);
             }
-            catch (LibGit2Sharp.LibGit2SharpException)
+            catch (LibGit2Sharp.LibGit2SharpException libGit2SharpException)
             {
-                throw new GiteaUnathorizedException("Gitea session is invalid.");
+                if (libGit2SharpException.Message.Contains("server requires authentication that we do not support"))
+                {
+                    throw new GiteaUnathorizedException("Gitea session is invalid.");
+                }
+
+                throw;
             }
             catch (Exception ex)
             {

--- a/backend/src/Designer/Services/Implementation/SourceControlLoggingDecorator.cs
+++ b/backend/src/Designer/Services/Implementation/SourceControlLoggingDecorator.cs
@@ -6,6 +6,7 @@ using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.RepositoryClient.Model;
 using Altinn.Studio.Designer.Services.Interfaces;
+using Altinn.Studio.Designer.TypedHttpClients.Exceptions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
@@ -169,6 +170,10 @@ namespace Altinn.Studio.Designer.Services.Implementation
             try
             {
                 _decoratedService.FetchRemoteChanges(org, repository);
+            }
+            catch (LibGit2Sharp.LibGit2SharpException)
+            {
+                throw new GiteaUnathorizedException("Gitea session is invalid.");
             }
             catch (Exception ex)
             {

--- a/backend/src/Designer/Services/Implementation/SourceControlLoggingDecorator.cs
+++ b/backend/src/Designer/Services/Implementation/SourceControlLoggingDecorator.cs
@@ -171,15 +171,6 @@ namespace Altinn.Studio.Designer.Services.Implementation
             {
                 _decoratedService.FetchRemoteChanges(org, repository);
             }
-            catch (LibGit2Sharp.LibGit2SharpException libGit2SharpException)
-            {
-                if (libGit2SharpException.Message.Contains("server requires authentication that we do not support"))
-                {
-                    throw new GiteaUnathorizedException("Gitea session is invalid.");
-                }
-
-                throw;
-            }
             catch (Exception ex)
             {
                 LogError(ex, "FetchRemoteChanges", org, repository);

--- a/backend/src/Designer/TypedHttpClients/AzureDevOps/AzureDevOpsBuildClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AzureDevOps/AzureDevOpsBuildClient.cs
@@ -83,7 +83,7 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AzureDevOps
         private async Task<Build> SendRequest(QueueBuildRequest queueBuildRequest)
         {
             string requestBody = JsonConvert.SerializeObject(queueBuildRequest);
-            using StringContent httpContent = new (requestBody, Encoding.UTF8, "application/json");
+            using StringContent httpContent = new(requestBody, Encoding.UTF8, "application/json");
             string requestUri = "?api-version=5.1";
             _logger.LogInformation("Doing a request toward: {HttpClientBaseAddress}{RequestUri}", _httpClient.BaseAddress, requestUri);
 

--- a/backend/src/Designer/TypedHttpClients/AzureDevOps/AzureDevOpsBuildClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AzureDevOps/AzureDevOpsBuildClient.cs
@@ -83,7 +83,7 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AzureDevOps
         private async Task<Build> SendRequest(QueueBuildRequest queueBuildRequest)
         {
             string requestBody = JsonConvert.SerializeObject(queueBuildRequest);
-            using StringContent httpContent = new StringContent(requestBody, Encoding.UTF8, "application/json");
+            using StringContent httpContent = new (requestBody, Encoding.UTF8, "application/json");
             string requestUri = "?api-version=5.1";
             _logger.LogInformation("Doing a request toward: {HttpClientBaseAddress}{RequestUri}", _httpClient.BaseAddress, requestUri);
 

--- a/backend/src/Designer/TypedHttpClients/DelegatingHandlers/Custom401Handler.cs
+++ b/backend/src/Designer/TypedHttpClients/DelegatingHandlers/Custom401Handler.cs
@@ -1,19 +1,15 @@
-using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
+using Altinn.Studio.Designer.TypedHttpClients.Exceptions;
 
 namespace Altinn.Studio.Designer.TypedHttpClients.DelegatingHandlers;
 
 public class Custom401Handler : DelegatingHandler
 {
-    private readonly IHttpContextAccessor _httpContextAccessor;
-
-    public Custom401Handler(IHttpContextAccessor httpContextAccessor, HttpClientHandler innerHandler) : base(innerHandler)
+    public Custom401Handler(HttpClientHandler innerHandler) : base(innerHandler)
     {
-        _httpContextAccessor = httpContextAccessor;
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -22,11 +18,8 @@ public class Custom401Handler : DelegatingHandler
 
         if (response.StatusCode == HttpStatusCode.Unauthorized)
         {
-            foreach (var cookie in _httpContextAccessor.HttpContext.Request.Cookies.Keys)
-            {
-                _httpContextAccessor.HttpContext.Response.Cookies.Delete(cookie);
-                _httpContextAccessor.HttpContext.Response.StatusCode = 401;
-            }
+            response.Dispose();
+            throw new GiteaUnathorizedException("Gitea session is invalid");
         }
 
         return response;

--- a/backend/src/Designer/TypedHttpClients/DelegatingHandlers/Custom401Handler.cs
+++ b/backend/src/Designer/TypedHttpClients/DelegatingHandlers/Custom401Handler.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Altinn.Studio.Designer.TypedHttpClients.DelegatingHandlers;
+
+public class Custom401Handler : DelegatingHandler
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public Custom401Handler(IHttpContextAccessor httpContextAccessor, HttpClientHandler innerHandler) : base(innerHandler)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            foreach (var cookie in _httpContextAccessor.HttpContext.Request.Cookies.Keys)
+            {
+                _httpContextAccessor.HttpContext.Response.Cookies.Delete(cookie);
+                _httpContextAccessor.HttpContext.Response.StatusCode = 401;
+            }
+        }
+
+        return response;
+    }
+}

--- a/backend/src/Designer/TypedHttpClients/Exceptions/GiteaUnathorizedException.cs
+++ b/backend/src/Designer/TypedHttpClients/Exceptions/GiteaUnathorizedException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Altinn.Studio.Designer.TypedHttpClients.Exceptions
+{
+    /// <summary>
+    /// Altinn specific exception which can be caught specifically when Gitea returns Unauthorized (401)
+    /// </summary>
+    public class GiteaUnathorizedException : Exception
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="message">A custom message for this specific exception</param>
+        public GiteaUnathorizedException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/backend/src/Designer/TypedHttpClients/TypedHttpClientRegistration.cs
+++ b/backend/src/Designer/TypedHttpClients/TypedHttpClientRegistration.cs
@@ -88,7 +88,7 @@ namespace Altinn.Studio.Designer.TypedHttpClients
                 {
                     var handler = new HttpClientHandler { AllowAutoRedirect = true };
 
-                    return new Custom401Handler(sp.GetRequiredService<IHttpContextAccessor>(), handler);
+                    return new Custom401Handler(handler);
                 });
 
 

--- a/backend/src/Designer/TypedHttpClients/TypedHttpClientRegistration.cs
+++ b/backend/src/Designer/TypedHttpClients/TypedHttpClientRegistration.cs
@@ -71,22 +71,26 @@ namespace Altinn.Studio.Designer.TypedHttpClients
             return services.AddHttpClient<IKubernetesWrapperClient, KubernetesWrapperClient>();
         }
 
-        private static IHttpClientBuilder AddGiteaTypedHttpClient(this IServiceCollection services, IConfiguration config)
+        private static IHttpClientBuilder AddGiteaTypedHttpClient(this IServiceCollection services,
+            IConfiguration config)
             => services.AddHttpClient<IGitea, GiteaAPIWrapper>((sp, httpClient) =>
                 {
                     IHttpContextAccessor httpContextAccessor = sp.GetRequiredService<IHttpContextAccessor>();
-                    ServiceRepositorySettings serviceRepSettings = config.GetSection("ServiceRepositorySettings").Get<ServiceRepositorySettings>();
-                    Uri uri = new Uri(serviceRepSettings.ApiEndPoint);
+                    ServiceRepositorySettings serviceRepoSettings =
+                        config.GetSection("ServiceRepositorySettings").Get<ServiceRepositorySettings>();
+                    Uri uri = new Uri(serviceRepoSettings.ApiEndPoint);
                     httpClient.BaseAddress = uri;
                     httpClient.DefaultRequestHeaders.Add(
                         General.AuthorizationTokenHeaderName,
                         AuthenticationHelper.GetDeveloperTokenHeaderValue(httpContextAccessor.HttpContext));
                 })
-                .ConfigurePrimaryHttpMessageHandler(() =>
-                    new HttpClientHandler
-                    {
-                        AllowAutoRedirect = true
-                    });
+                .ConfigurePrimaryHttpMessageHandler((sp) =>
+                {
+                    var handler = new HttpClientHandler { AllowAutoRedirect = true };
+
+                    return new Custom401Handler(sp.GetRequiredService<IHttpContextAccessor>(), handler);
+                });
+
 
         private static IHttpClientBuilder AddAltinnAuthenticationTypedHttpClient(this IServiceCollection services, IConfiguration config)
             => services.AddHttpClient<IAltinnAuthenticationClient, AltinnAuthenticationClient>((sp, httpClient) =>

--- a/backend/tests/Designer.Tests/Controllers/ApiTests/ApiTestsAuthAndCookieDelegatingHandler.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApiTests/ApiTestsAuthAndCookieDelegatingHandler.cs
@@ -40,14 +40,14 @@ internal class ApiTestsAuthAndCookieDelegatingHandler : DelegatingHandler
         if (loginResponse.Headers.Contains("Set-Cookie"))
         {
             cookies = loginResponse.Headers.GetValues("Set-Cookie");
-            SetAltinnStudiCookieFromResponseHeader(httpRequestMessageXsrf, cookies);
+            SetAltinnStudioCookieFromResponseHeader(httpRequestMessageXsrf, cookies);
         }
 
         var xsrfResponse = await base.SendAsync(httpRequestMessageXsrf, cancellationToken);
 
         var xsrfcookies = xsrfResponse.Headers.GetValues("Set-Cookie");
         var xsrfToken = GetXsrfTokenFromCookie(xsrfcookies);
-        SetAltinnStudiCookieFromResponseHeader(request, cookies, xsrfToken);
+        SetAltinnStudioCookieFromResponseHeader(request, cookies, xsrfToken);
 
         return await base.SendAsync(request, cancellationToken);
     }

--- a/backend/tests/Designer.Tests/Fixtures/GiteaAuthDelegatingHandler.cs
+++ b/backend/tests/Designer.Tests/Fixtures/GiteaAuthDelegatingHandler.cs
@@ -47,14 +47,14 @@ namespace Designer.Tests.Fixtures
 
             using var giteaGetLoginResponse = await giteaClient.GetAsync(giteaLoginUrl, cancellationToken);
             string htmlContent = await giteaGetLoginResponse.Content.ReadAsStringAsync(cancellationToken);
-            List<KeyValuePair<string, string>> formValues = new List<KeyValuePair<string, string>>
+            List<KeyValuePair<string, string>> formValues = new ()
             {
                 new KeyValuePair<string, string>("user_name", GiteaConstants.TestUser),
                 new KeyValuePair<string, string>("password", GiteaConstants.TestUserPassword),
                 new KeyValuePair<string, string>("_csrf", GetStringFromHtmlContent(htmlContent, "<input type=\"hidden\" name=\"_csrf\" value=\"", "\"")),
             };
 
-            using FormUrlEncodedContent content = new FormUrlEncodedContent(formValues);
+            using FormUrlEncodedContent content = new (formValues);
 
             using var giteaPostLoginMessage = new HttpRequestMessage(HttpMethod.Post, giteaLoginUrl)
             {

--- a/backend/tests/Designer.Tests/Fixtures/GiteaAuthDelegatingHandler.cs
+++ b/backend/tests/Designer.Tests/Fixtures/GiteaAuthDelegatingHandler.cs
@@ -47,14 +47,14 @@ namespace Designer.Tests.Fixtures
 
             using var giteaGetLoginResponse = await giteaClient.GetAsync(giteaLoginUrl, cancellationToken);
             string htmlContent = await giteaGetLoginResponse.Content.ReadAsStringAsync(cancellationToken);
-            List<KeyValuePair<string, string>> formValues = new ()
+            List<KeyValuePair<string, string>> formValues = new()
             {
                 new KeyValuePair<string, string>("user_name", GiteaConstants.TestUser),
                 new KeyValuePair<string, string>("password", GiteaConstants.TestUserPassword),
                 new KeyValuePair<string, string>("_csrf", GetStringFromHtmlContent(htmlContent, "<input type=\"hidden\" name=\"_csrf\" value=\"", "\"")),
             };
 
-            using FormUrlEncodedContent content = new (formValues);
+            using FormUrlEncodedContent content = new(formValues);
 
             using var giteaPostLoginMessage = new HttpRequestMessage(HttpMethod.Post, giteaLoginUrl)
             {

--- a/backend/tests/Designer.Tests/Fixtures/GiteaAuthDelegatingHandler.cs
+++ b/backend/tests/Designer.Tests/Fixtures/GiteaAuthDelegatingHandler.cs
@@ -82,14 +82,14 @@ namespace Designer.Tests.Fixtures
             if (loginResponse.Headers.Contains("Set-Cookie"))
             {
                 cookies = loginResponse.Headers.GetValues("Set-Cookie");
-                AuthenticationUtil.SetAltinnStudiCookieFromResponseHeader(httpRequestMessageXsrf, cookies);
+                AuthenticationUtil.SetAltinnStudioCookieFromResponseHeader(httpRequestMessageXsrf, cookies);
             }
 
             var xsrfResponse = await base.SendAsync(httpRequestMessageXsrf, cancellationToken);
 
             var xsrfcookies = xsrfResponse.Headers.GetValues("Set-Cookie");
             string xsrfToken = AuthenticationUtil.GetXsrfTokenFromCookie(xsrfcookies);
-            AuthenticationUtil.SetAltinnStudiCookieFromResponseHeader(request, cookies, xsrfToken);
+            AuthenticationUtil.SetAltinnStudioCookieFromResponseHeader(request, cookies, xsrfToken);
             SetCookies(request, GetGiteaAuthCookiesFromResponseMessage(xsrfResponse));
 
             return await base.SendAsync(request, cancellationToken);

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/UserControllerGiteaIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/UserControllerGiteaIntegrationTests.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Altinn.Studio.Designer.Controllers;
 using Altinn.Studio.Designer.RepositoryClient.Model;
 using Designer.Tests.Fixtures;
 using Designer.Tests.Utils;
@@ -27,7 +26,7 @@ namespace Designer.Tests.GiteaIntegrationTests
         public async Task GetCurrentUser_ShouldReturnOk(string expectedUserName, string expectedEmail)
         {
             string requestUrl = "designer/api/user/current";
-            using HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+            using HttpRequestMessage httpRequestMessage = new (HttpMethod.Get, requestUrl);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
 
@@ -51,7 +50,7 @@ namespace Designer.Tests.GiteaIntegrationTests
             string targetRepo = TestDataHelper.GenerateTestRepoName();
             await CreateAppUsingDesigner(org, targetRepo);
 
-            string requestUrl = $"designer/api/user/repos";
+            string requestUrl = "designer/api/user/repos";
             using var response = await HttpClient.GetAsync(requestUrl);
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             var content = await response.Content.ReadAsAsync<List<Repository>>();

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/UserControllerGiteaIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/UserControllerGiteaIntegrationTests.cs
@@ -26,7 +26,7 @@ namespace Designer.Tests.GiteaIntegrationTests
         public async Task GetCurrentUser_ShouldReturnOk(string expectedUserName, string expectedEmail)
         {
             string requestUrl = "designer/api/user/current";
-            using HttpRequestMessage httpRequestMessage = new (HttpMethod.Get, requestUrl);
+            using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, requestUrl);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
 

--- a/backend/tests/Designer.Tests/Utils/AuthenticationUtil.cs
+++ b/backend/tests/Designer.Tests/Utils/AuthenticationUtil.cs
@@ -27,14 +27,14 @@ namespace Designer.Tests.Utils
             if (loginResponse.Headers.Contains("Set-Cookie"))
             {
                 cookies = loginResponse.Headers.GetValues("Set-Cookie");
-                SetAltinnStudiCookieFromResponseHeader(httpRequestMessageXsrf, cookies);
+                SetAltinnStudioCookieFromResponseHeader(httpRequestMessageXsrf, cookies);
             }
 
             HttpResponseMessage xsrfResponse = await client.SendAsync(httpRequestMessageXsrf);
 
             IEnumerable<string> xsrfcookies = xsrfResponse.Headers.GetValues("Set-Cookie");
             string xsrfToken = GetXsrfTokenFromCookie(xsrfcookies);
-            SetAltinnStudiCookieFromResponseHeader(message, cookies, xsrfToken);
+            SetAltinnStudioCookieFromResponseHeader(message, cookies, xsrfToken);
         }
 
         internal static string GetXsrfTokenFromCookie(IEnumerable<string> setCookieHeader)
@@ -57,7 +57,7 @@ namespace Designer.Tests.Utils
             return null;
         }
 
-        internal static void SetAltinnStudiCookieFromResponseHeader(HttpRequestMessage requestMessage, IEnumerable<string> setCookieHeader, string xsrfToken = null)
+        internal static void SetAltinnStudioCookieFromResponseHeader(HttpRequestMessage requestMessage, IEnumerable<string> setCookieHeader, string xsrfToken = null)
         {
             if (setCookieHeader != null)
             {

--- a/backend/tests/Designer.Tests/Utils/PrincipalUtil.cs
+++ b/backend/tests/Designer.Tests/Utils/PrincipalUtil.cs
@@ -14,11 +14,11 @@ namespace Designer.Tests.Utils
 
         public static ClaimsPrincipal GetToken(string userName)
         {
-            List<Claim> claims = new ();
+            List<Claim> claims = new();
             const string Issuer = "https://altinn.no";
 
             claims.Add(new Claim(AltinnCoreClaimTypes.Developer, userName, ClaimValueTypes.String, Issuer));
-            ClaimsIdentity identity = new ("TestUserLogin");
+            ClaimsIdentity identity = new("TestUserLogin");
             identity.AddClaims(claims);
 
             return new ClaimsPrincipal(identity);

--- a/backend/tests/Designer.Tests/Utils/PrincipalUtil.cs
+++ b/backend/tests/Designer.Tests/Utils/PrincipalUtil.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Security.Claims;
 using AltinnCore.Authentication.Constants;
@@ -15,11 +14,11 @@ namespace Designer.Tests.Utils
 
         public static ClaimsPrincipal GetToken(string userName)
         {
-            List<Claim> claims = new List<Claim>();
+            List<Claim> claims = new ();
             const string Issuer = "https://altinn.no";
 
             claims.Add(new Claim(AltinnCoreClaimTypes.Developer, userName, ClaimValueTypes.String, Issuer));
-            ClaimsIdentity identity = new ClaimsIdentity("TestUserLogin");
+            ClaimsIdentity identity = new ("TestUserLogin");
             identity.AddClaims(claims);
 
             return new ClaimsPrincipal(identity);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a custom 401 delegation handler on the http client for the gitea service. The custom delegation handler checks if the response from the underlying gitea api is 401 when the appKeyToken is no longer valid and deletes all cookies.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
