### PR TITLE
Fixed issue with create form and clean up Cypress tests

### DIFF
--- a/frontend/dashboard/components/ServiceOwnerSelector/ServiceOwnerSelector.tsx
+++ b/frontend/dashboard/components/ServiceOwnerSelector/ServiceOwnerSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useId } from 'react';
-import { ErrorMessage, Label, Select } from '@digdir/design-system-react';
+import { Label, NativeSelect } from '@digdir/design-system-react';
 import { useTranslation } from 'react-i18next';
 import { Organization } from 'app-shared/types/Organization';
 import { User } from 'app-shared/types/User';
@@ -21,7 +21,6 @@ export const ServiceOwnerSelector = ({
 }: ServiceOwnerSelectorProps) => {
   const { t } = useTranslation();
   const serviceOwnerId: string = useId();
-  const serviceOwnerErrorId: string = `error-message-${serviceOwnerId}`;
 
   const selectableUser: SelectableItem = mapUserToSelectableItem(user);
   const selectableOrganizations: SelectableItem[] = mapOrganizationToSelectableItems(organizations);
@@ -30,23 +29,18 @@ export const ServiceOwnerSelector = ({
   const defaultValue: string =
     selectableOptions.length === 1 ? selectableOptions[0].value : selectedOrgOrUser;
 
-  const hasError: boolean = !!errorMessage;
-
   return (
     <div>
       <Label spacing htmlFor={serviceOwnerId}>
         {t('general.service_owner')}
       </Label>
-      <Select
-        hideLabel
-        error={hasError}
-        inputId={serviceOwnerId}
-        inputName={name}
-        options={selectableOptions}
-        value={defaultValue}
-        aria-describedby={hasError ? serviceOwnerErrorId : undefined}
-      />
-      <ErrorMessage id={serviceOwnerErrorId}>{errorMessage}</ErrorMessage>
+      <NativeSelect hideLabel error={errorMessage} id={serviceOwnerId} name={name}>
+        {selectableOptions.map(({ value, label }) => (
+          <option key={value} value={value} selected={defaultValue === value}>
+            {label}
+          </option>
+        ))}
+      </NativeSelect>
     </div>
   );
 };

--- a/frontend/dashboard/components/ServiceOwnerSelector/ServiceOwnerSelector.tsx
+++ b/frontend/dashboard/components/ServiceOwnerSelector/ServiceOwnerSelector.tsx
@@ -26,9 +26,6 @@ export const ServiceOwnerSelector = ({
   const selectableOrganizations: SelectableItem[] = mapOrganizationToSelectableItems(organizations);
   const selectableOptions: SelectableItem[] = [selectableUser, ...selectableOrganizations];
 
-  const defaultValue: string =
-    selectableOptions.length === 1 ? selectableOptions[0].value : selectedOrgOrUser;
-
   return (
     <div>
       <Label spacing htmlFor={serviceOwnerId}>

--- a/frontend/dashboard/components/ServiceOwnerSelector/ServiceOwnerSelector.tsx
+++ b/frontend/dashboard/components/ServiceOwnerSelector/ServiceOwnerSelector.tsx
@@ -36,7 +36,7 @@ export const ServiceOwnerSelector = ({
       </Label>
       <NativeSelect hideLabel error={errorMessage} id={serviceOwnerId} name={name}>
         {selectableOptions.map(({ value, label }) => (
-          <option key={value} value={value} selected={defaultValue === value}>
+          <option key={value} value={value}>
             {label}
           </option>
         ))}

--- a/frontend/dashboard/pages/CreateService/CreateService.test.tsx
+++ b/frontend/dashboard/pages/CreateService/CreateService.test.tsx
@@ -155,9 +155,8 @@ describe('CreateService', () => {
     renderWithMockServices({ addRepo: addRepoMock }, [orgMock]);
 
     await act(() =>
-      user.click(screen.getByRole('combobox', { name: textMock('general.service_owner') })),
+      user.selectOptions(screen.getByLabelText(textMock('general.service_owner')), 'unit-test'),
     );
-    await act(() => user.click(screen.getByRole('option', { name: 'unit-test' })));
 
     await act(() =>
       user.type(screen.getByLabelText(textMock('general.service_name')), 'this-app-name-exists'),
@@ -170,8 +169,7 @@ describe('CreateService', () => {
 
     expect(addRepoMock).rejects.toEqual({ response: { status: 409 } });
 
-    const emptyFieldErrors = await screen.findAllByText(textMock('dashboard.app_already_exists'));
-    expect(emptyFieldErrors.length).toBe(1);
+    await waitFor(() => screen.getByText(textMock('dashboard.app_already_exists')));
   });
 
   it('should show generic error message when trying to create an app and something unknown went wrong', async () => {
@@ -179,8 +177,9 @@ describe('CreateService', () => {
     const addRepoMock = jest.fn(() => Promise.reject({ response: { status: 500 } }));
     renderWithMockServices({ addRepo: addRepoMock }, [orgMock]);
 
-    await act(() => user.click(screen.getByRole('combobox')));
-    await act(() => user.click(screen.getByRole('option', { name: 'unit-test' })));
+    await act(() =>
+      user.selectOptions(screen.getByLabelText(textMock('general.service_owner')), 'unit-test'),
+    );
     await act(() => user.type(screen.getByLabelText(textMock('general.service_name')), 'new-app'));
 
     const createButton = await screen.findByText(textMock('dashboard.create_service_btn'));

--- a/frontend/dashboard/pages/CreateService/CreateService.test.tsx
+++ b/frontend/dashboard/pages/CreateService/CreateService.test.tsx
@@ -169,7 +169,7 @@ describe('CreateService', () => {
 
     expect(addRepoMock).rejects.toEqual({ response: { status: 409 } });
 
-    await waitFor(() => screen.getByText(textMock('dashboard.app_already_exists')));
+    await screen.findByText(textMock('dashboard.app_already_exists'));
   });
 
   it('should show generic error message when trying to create an app and something unknown went wrong', async () => {

--- a/frontend/testing/cypress/src/integration/studio/new-app.js
+++ b/frontend/testing/cypress/src/integration/studio/new-app.js
@@ -22,8 +22,7 @@ context('New App', () => {
 
   it('is possible to start app creation and exit', () => {
     dashboard.getNewAppLink().should('be.visible').click();
-    dashboard.getAppOwnerField().should('be.visible').click();
-    dashboard.getOrgOption(Cypress.env('autoTestUser')).click();
+    dashboard.getAppOwnerField().should('be.visible').select('autoTestUser');
     dashboard.getSavedNameField().should('be.visible').type('dashboard');
     dashboard.getCancelLink().should('be.visible').click();
     dashboard.getSearchReposField().should('be.visible');
@@ -40,8 +39,7 @@ context('New App', () => {
 
     // Try to create app with the same name
     dashboard.getNewAppLink().should('be.visible').click();
-    dashboard.getAppOwnerField().should('be.visible').click();
-    dashboard.getOrgOption(Cypress.env('autoTestUser')).click();
+    dashboard.getAppOwnerField().should('be.visible').select('autoTestUser');
     dashboard.getSavedNameField().should('be.visible').type(appName);
     cy.intercept('POST', '**/designer/api/repos/create-app?**').as('postCreateApp');
     dashboard.getCreateAppButton().should('be.visible').click();
@@ -54,8 +52,7 @@ context('New App', () => {
     const appName = '123-app';
     // Try to create app with invalid name
     dashboard.getNewAppLink().should('be.visible').click();
-    dashboard.getAppOwnerField().should('be.visible').click();
-    dashboard.getOrgOption(Cypress.env('autoTestUser')).click();
+    dashboard.getAppOwnerField().should('be.visible').select('autoTestUser');
     dashboard.getSavedNameField().should('be.visible').type(appName);
     dashboard.getCreateAppButton().should('be.visible').click();
     cy.findByText(texts['dashboard.service_name_has_illegal_characters']).should('be.visible');

--- a/frontend/testing/cypress/src/integration/studio/new-app.js
+++ b/frontend/testing/cypress/src/integration/studio/new-app.js
@@ -22,7 +22,7 @@ context('New App', () => {
 
   it('is possible to start app creation and exit', () => {
     dashboard.getNewAppLink().should('be.visible').click();
-    dashboard.getAppOwnerField().should('be.visible').select('autoTestUser');
+    dashboard.getAppOwnerField().should('be.visible').select(Cypress.env('autoTestUser'));
     dashboard.getSavedNameField().should('be.visible').type('dashboard');
     dashboard.getCancelLink().should('be.visible').click();
     dashboard.getSearchReposField().should('be.visible');
@@ -39,7 +39,7 @@ context('New App', () => {
 
     // Try to create app with the same name
     dashboard.getNewAppLink().should('be.visible').click();
-    dashboard.getAppOwnerField().should('be.visible').select('autoTestUser');
+    dashboard.getAppOwnerField().should('be.visible').select(Cypress.env('autoTestUser'));
     dashboard.getSavedNameField().should('be.visible').type(appName);
     cy.intercept('POST', '**/designer/api/repos/create-app?**').as('postCreateApp');
     dashboard.getCreateAppButton().should('be.visible').click();
@@ -52,7 +52,7 @@ context('New App', () => {
     const appName = '123-app';
     // Try to create app with invalid name
     dashboard.getNewAppLink().should('be.visible').click();
-    dashboard.getAppOwnerField().should('be.visible').select('autoTestUser');
+    dashboard.getAppOwnerField().should('be.visible').select(Cypress.env('autoTestUser'));
     dashboard.getSavedNameField().should('be.visible').type(appName);
     dashboard.getCreateAppButton().should('be.visible').click();
     cy.findByText(texts['dashboard.service_name_has_illegal_characters']).should('be.visible');

--- a/frontend/testing/cypress/src/integration/studio/new-app.js
+++ b/frontend/testing/cypress/src/integration/studio/new-app.js
@@ -25,7 +25,7 @@ context('New App', () => {
     dashboard.getAppOwnerField().should('be.visible').click();
     dashboard.getOrgOption(Cypress.env('autoTestUser')).click();
     dashboard.getSavedNameField().should('be.visible').type('dashboard');
-    dashboard.getCancelButton().should('be.visible').click();
+    dashboard.getCancelLink().should('be.visible').click();
     dashboard.getSearchReposField().should('be.visible');
   });
 

--- a/frontend/testing/cypress/src/selectors/dashboard.js
+++ b/frontend/testing/cypress/src/selectors/dashboard.js
@@ -15,7 +15,7 @@ const getLinksCellForApp = (table, name) =>
 
 export const dashboard = {
   getAllAppsHeader,
-  getAppOwnerField: () => cy.findByRole('combobox', { name: texts['general.service_owner'] }),
+  getAppOwnerField: () => cy.findByLabelText(texts['general.service_owner']),
   getCancelLink: () => cy.findByRole('link', { name: texts['general.cancel'] }),
   getCreateAppButton: () =>
     cy.findByRole('button', { name: texts['dashboard.create_service_btn'] }),
@@ -24,7 +24,6 @@ export const dashboard = {
   getLinksCellForSearchResultApp: (name) => getLinksCellForApp(getSearchResults(), name),
   getNewAppLink: () => cy.findByRole('link', { name: texts['dashboard.new_service'] }),
   getOrgAppsHeader,
-  getOrgOption: (org) => cy.findByRole('listbox').findByRole('option', { name: org }),
   getSavedNameField: () => cy.findByRole('textbox', { name: texts['general.service_name'] }),
   getSearchReposField: () => cy.findByTestId(testids.searchReposField),
   getSearchResults,

--- a/frontend/testing/cypress/src/selectors/dashboard.js
+++ b/frontend/testing/cypress/src/selectors/dashboard.js
@@ -16,13 +16,12 @@ const getLinksCellForApp = (table, name) =>
 export const dashboard = {
   getAllAppsHeader,
   getAppOwnerField: () => cy.findByRole('combobox', { name: texts['general.service_owner'] }),
-  getCancelButton: () => cy.findByRole('button', { name: texts['general.cancel'] }),
+  getCancelLink: () => cy.findByRole('link', { name: texts['general.cancel'] }),
   getCreateAppButton: () =>
     cy.findByRole('button', { name: texts['dashboard.create_service_btn'] }),
   getFavourites: () => getFavouritesHeader().next(),
   getFavouritesHeader,
   getLinksCellForSearchResultApp: (name) => getLinksCellForApp(getSearchResults(), name),
-  getLinksCellForUserApp: (name) => getLinksCellForApp(getUserAppsList(), name),
   getNewAppLink: () => cy.findByRole('link', { name: texts['dashboard.new_service'] }),
   getOrgAppsHeader,
   getOrgOption: (org) => cy.findByRole('listbox').findByRole('option', { name: org }),
@@ -30,7 +29,6 @@ export const dashboard = {
   getSearchReposField: () => cy.findByTestId(testids.searchReposField),
   getSearchResults,
   getSearchResultsHeader,
-  getStarAppButton: () => cy.findByRole('button', { name: texts['dashboard.star'] }),
   getUserAppsList,
   getUserAppsListHeader,
 };

--- a/frontend/testing/cypress/src/support/studio.js
+++ b/frontend/testing/cypress/src/support/studio.js
@@ -51,8 +51,7 @@ Cypress.Commands.add('switchSelectedContext', (context) => {
 Cypress.Commands.add('createApp', (orgName, appName) => {
   cy.visit('/dashboard');
   dashboard.getNewAppLink().should('be.visible').click();
-  dashboard.getAppOwnerField().should('be.visible').click();
-  dashboard.getOrgOption(orgName).click();
+  dashboard.getAppOwnerField().should('be.visible').select(orgName);
   dashboard.getSavedNameField().should('be.visible').type(appName);
   cy.intercept('POST', '**/designer/api/repos/**').as('postCreateApp');
   dashboard.getCreateAppButton().should('be.visible').click();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Needed to change from `Select` to `NativeSelect`, since the `Select` did not follow the native behaviour when using the name to get form data. I was receiving the label instead of the value. This caused our form to submit "Testdepartementet" instead of "ttd" as an organization after the refactoring. I have also updated the e2e-tests and unit tests to ensure behaviour works as expected.

## Related Issue(s)
- PR itself

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
