### PR TITLE
fix(Cypress): sleep for 10 minutes

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -46,8 +46,8 @@ jobs:
           YARN_NM_MODE: 'hardlinks-local'
           HUSKY: '0'
 
-      - name: Wait for deploy to environment
-        run: sleep 6m
+      - name: Attempt to wait for deploy to environment (10 minutes sleep)
+        run: sleep 10m
         shell: bash
 
       - name: Cypress run


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Renamed to "wait for deployment" to "Attempt to wait for deployment to environment (10 minutes sleep)" to clarify that is not actually waiting for the release to be done. I increased the sleep by 4 minutes since our build and release takes all from 7-9 minutes.

Yes, it will take longer time to run the pipeline now, but at least we might running Cypress on right version of Studio and we should see a decrease of 502 Bad Gateway errors.

### Note
This is just a temporary fix until the following issue is fixed: https://github.com/Altinn/altinn-studio/issues/11683

## Related Issue(s)
- PR itself

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
