### PR TITLE
update link href to studio documentation

### DIFF
--- a/frontend/app-development/features/administration/components/Documentation.tsx
+++ b/frontend/app-development/features/administration/components/Documentation.tsx
@@ -14,7 +14,10 @@ export const Documentation = () => {
       <Paragraph size='small' className={classes.content}>
         {t('administration.documentation.content')}
       </Paragraph>
-      <Link href='https://docs.altinn.studio/nb/app/' className={classes.link}>
+      <Link
+        href='https://docs.altinn.studio/nb/app/getting-started/create-app/'
+        className={classes.link}
+      >
         <span>{t('administration.documentation.link')}</span>
         <ExternalLinkIcon className={classes.linkIcon} />
       </Link>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Suggest we change the link to point to the getting-started guide for Studio. Will probably need to update a bit in this documentation, but seems like a natural starting point.
Discovered during manual test

## Related Issue(s)
- #11160 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
