### PR TITLE
fixing autofocus error on datamodel page

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1058,6 +1058,7 @@
   "schema_editor.textRow-deletion-confirm": "Ja, slett raden",
   "schema_editor.textRow-deletion-text": "Er du sikker på at du vil slette denne raden?",
   "schema_editor.textRow-title-confirmCancel-popover": "Er du sikker på at du vil slette denne raden?",
+  "schema_editor.textfield_label": "Rad i listen med gyldige verdier med id {{ id }}",
   "schema_editor.title": "Tittel",
   "schema_editor.type": "Type",
   "schema_editor.types": "Typer",

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/EnumField.test.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/EnumField.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EnumField, EnumFieldProps } from './EnumField';
+import { textMock } from '../../../../../testing/mocks/i18nMock';
+
+const mockPath: string = 'mockPath';
+const mockValue: string = 'test';
+const mockBaseId: string = 'id123';
+const mockId: string = `${mockBaseId}-enum-${mockValue}`;
+
+const mockOnChange = jest.fn();
+const mockOnDelete = jest.fn();
+const mockOnEnterKeyPress = jest.fn();
+
+const defaultProps: EnumFieldProps = {
+  path: mockPath,
+  value: mockValue,
+  readOnly: false,
+  isValid: true,
+  onChange: mockOnChange,
+  onEnterKeyPress: mockOnEnterKeyPress,
+  baseId: mockBaseId,
+};
+
+describe('EnumField', () => {
+  afterEach(jest.clearAllMocks);
+
+  it('calls onChange when input value changes', async () => {
+    const user = userEvent.setup();
+    render(<EnumField {...defaultProps} />);
+
+    const textField = screen.getByLabelText(
+      textMock('schema_editor.textfield_label', { id: mockId }),
+    );
+    expect(textField).toHaveValue(mockValue);
+
+    const newValue: string = '1';
+
+    await act(() => user.type(textField, newValue));
+    await act(() => user.tab());
+
+    const updatedValue: string = `${mockValue}${newValue}`;
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith(updatedValue, mockValue);
+
+    const textFieldAfter = screen.getByLabelText(
+      textMock('schema_editor.textfield_label', { id: mockId }),
+    );
+    expect(textFieldAfter).toHaveValue(updatedValue);
+  });
+
+  it('hides delete button when onDelete is not present', () => {
+    render(<EnumField {...defaultProps} />);
+
+    const deleteButton = screen.queryByRole('button', {
+      name: textMock('schema_editor.delete_field'),
+    });
+    expect(deleteButton).not.toBeInTheDocument();
+  });
+
+  it('calls onDelete when delete button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<EnumField {...defaultProps} onDelete={mockOnDelete} />);
+
+    const deleteButton = screen.getByRole('button', {
+      name: textMock('schema_editor.delete_field'),
+    });
+    expect(deleteButton).toBeInTheDocument();
+
+    await act(() => user.click(deleteButton));
+
+    expect(mockOnDelete).toHaveBeenCalledTimes(1);
+    expect(mockOnDelete).toHaveBeenCalledWith(mockPath, mockValue);
+  });
+
+  it('calls onEnterKeyPress when "Enter" key is pressed', async () => {
+    const user = userEvent.setup();
+    render(<EnumField {...defaultProps} />);
+
+    const textField = screen.getByLabelText(
+      textMock('schema_editor.textfield_label', { id: mockId }),
+    );
+
+    const newValue: string = '1';
+
+    await act(() => user.type(textField, newValue));
+    await act(() => user.keyboard('{Enter}'));
+
+    expect(mockOnEnterKeyPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/EnumField.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/EnumField.tsx
@@ -1,61 +1,71 @@
 import type { KeyboardEvent } from 'react';
 import React, { useEffect, useState } from 'react';
 import { IconButton } from '../common/IconButton';
-import { LegacyTextField } from '@digdir/design-system-react';
+import { Textfield } from '@digdir/design-system-react';
 import classes from './EnumField.module.css';
-import { getDomFriendlyID } from '../../utils/ui-schema-utils';
 import { IconImage } from '../common/Icon';
 import { useTranslation } from 'react-i18next';
 
-export interface IEnumFieldProps {
+export type EnumFieldProps = {
   path: string;
   value: string;
   readOnly?: boolean;
-  fullWidth?: boolean;
   isValid?: boolean;
   onChange: (value: string, oldValue?: string) => void;
   onDelete?: (path: string, key: string) => void;
   onEnterKeyPress?: () => void;
-}
+  baseId: string;
+};
 
-export const EnumField = (props: IEnumFieldProps) => {
-  const [val, setVal] = useState(props.value);
+export const EnumField = ({
+  path,
+  value,
+  readOnly,
+  isValid,
+  onChange,
+  onDelete,
+  onEnterKeyPress,
+  baseId,
+}: EnumFieldProps) => {
+  const [val, setVal] = useState(value);
   useEffect(() => {
-    setVal(props.value);
-  }, [props.value]);
+    setVal(value);
+  }, [value]);
   const { t } = useTranslation();
 
   const onBlur = () => {
-    props.onChange(val, props.value);
+    onChange(val, value);
   };
 
-  const onChange = (e: any) => {
+  const handleChange = (e: any) => {
     e.stopPropagation();
     setVal(e.target.value);
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) =>
-    e?.key === 'Enter' && props.onEnterKeyPress && props.onEnterKeyPress();
+    e?.key === 'Enter' && onEnterKeyPress && onEnterKeyPress();
 
-  const baseId = getDomFriendlyID(props.path);
+  const id = `${baseId}-enum-${value}`;
+
   return (
     <div className={classes.root}>
-      <LegacyTextField
-        id={`${baseId}-enum-${props.value}`}
-        disabled={props.readOnly}
+      <Textfield
+        label={t('schema_editor.textfield_label', { id })}
+        hideLabel
+        disabled={readOnly}
         value={val}
-        onChange={onChange}
+        onChange={handleChange}
         onBlur={onBlur}
         onKeyDown={onKeyDown}
-        isValid={props.isValid}
+        error={!isValid}
       />
-      {props.onDelete && (
+      {onDelete && (
         <IconButton
           ariaLabel={t('schema_editor.delete_field')}
           className={classes.delete}
           icon={IconImage.Wastebucket}
-          id={`${baseId}-delete-${props.value}`}
-          onClick={() => props.onDelete?.(props.path, props.value)}
+          id={`${baseId}-delete-${value}`}
+          onClick={() => onDelete?.(path, value)}
         />
       )}
     </div>

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/EnumField.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/EnumField.tsx
@@ -47,7 +47,6 @@ export const EnumField = (props: IEnumFieldProps) => {
         onChange={onChange}
         onBlur={onBlur}
         onKeyDown={onKeyDown}
-        autoFocus
         isValid={props.isValid}
       />
       {props.onDelete && (

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/EnumField.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/EnumField.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent } from 'react';
+import type { ChangeEvent, KeyboardEvent } from 'react';
 import React, { useEffect, useState } from 'react';
 import { IconButton } from '../common/IconButton';
 import { Textfield } from '@digdir/design-system-react';
@@ -27,33 +27,33 @@ export const EnumField = ({
   onEnterKeyPress,
   baseId,
 }: EnumFieldProps) => {
-  const [val, setVal] = useState(value);
+  const [inputValue, setInputValue] = useState(value);
   useEffect(() => {
-    setVal(value);
+    setInputValue(value);
   }, [value]);
   const { t } = useTranslation();
 
   const onBlur = () => {
-    onChange(val, value);
+    onChange(inputValue, value);
   };
 
-  const handleChange = (e: any) => {
-    e.stopPropagation();
-    setVal(e.target.value);
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    event.stopPropagation();
+    setInputValue(event.target.value);
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) =>
     e?.key === 'Enter' && onEnterKeyPress && onEnterKeyPress();
 
-  const id = `${baseId}-enum-${value}`;
+  const label = t('schema_editor.textfield_label', { id: `${baseId}-enum-${value}` });
 
   return (
     <div className={classes.root}>
       <Textfield
-        label={t('schema_editor.textfield_label', { id })}
+        label={label}
         hideLabel
         disabled={readOnly}
-        value={val}
+        value={inputValue}
         onChange={handleChange}
         onBlur={onBlur}
         onKeyDown={onKeyDown}

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/ItemRestrictions.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/ItemRestrictions.tsx
@@ -21,6 +21,7 @@ import { PlusIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 import { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
 import { useSchemaEditorAppContext } from '@altinn/schema-editor/hooks/useSchemaEditorAppContext';
+import { getDomFriendlyID } from '@altinn/schema-editor/utils/ui-schema-utils';
 
 export interface RestrictionItemProps {
   restrictions: any;
@@ -125,7 +126,6 @@ export const ItemRestrictions = ({ schemaNode }: ItemRestrictionsProps) => {
             )}
             {enums?.map((value: string, index) => (
               <EnumField
-                fullWidth={true}
                 key={`add-enum-field-${index}`}
                 onChange={onChangeEnumValue}
                 onDelete={onDeleteEnumClick}
@@ -133,6 +133,7 @@ export const ItemRestrictions = ({ schemaNode }: ItemRestrictionsProps) => {
                 path={pointer}
                 value={value}
                 isValid={enumError !== value}
+                baseId={getDomFriendlyID(pointer)}
               />
             ))}
             <div className={classes.addEnumButton}>


### PR DESCRIPTION
## Description
- Removed ```autofocus``` to prevent textfield from auto focusing
- Added test for the component
- Replaced LegacyTextField with Textfield
- Added labels to the textfields to comply with WCAG.

## New bugs discovered
- The value fields does not show an error when names are the same
- Deleting a value makes the text "jump" a bit 
Both bugs are shown in this issue: #11701 

## Related Issue(s)
- #11209 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)