### PR TITLE
Solving datamodel binding CSS bug

### DIFF
--- a/frontend/packages/shared/src/components/InputActionWrapper/InputActionWrapper.module.css
+++ b/frontend/packages/shared/src/components/InputActionWrapper/InputActionWrapper.module.css
@@ -11,7 +11,6 @@
 
 .buttonWrapper {
   display: flex;
-  gap: 2px;
   background-color: var(--fds-semantic-background-subtle);
 }
 

--- a/frontend/packages/shared/src/components/InputActionWrapper/InputActionWrapper.module.css
+++ b/frontend/packages/shared/src/components/InputActionWrapper/InputActionWrapper.module.css
@@ -13,7 +13,6 @@
   display: flex;
   gap: 2px;
   background-color: var(--fds-semantic-background-subtle);
-  padding: 1px;
 }
 
 .standByButtonWrapper {

--- a/frontend/packages/shared/src/components/InputActionWrapper/InputActionWrapper.module.css
+++ b/frontend/packages/shared/src/components/InputActionWrapper/InputActionWrapper.module.css
@@ -4,3 +4,20 @@
   align-items: center;
   min-height: var(--fds-component-mode-height-medium);
 }
+
+.standByContainer {
+  position: relative;
+}
+
+.buttonWrapper {
+  display: flex;
+  gap: 2px;
+  background-color: var(--fds-semantic-background-subtle);
+  padding: 1px;
+}
+
+.standByButtonWrapper {
+  position: absolute;
+  right: 0;
+  top: 0.5;
+}

--- a/frontend/packages/shared/src/components/InputActionWrapper/InputActionWrapper.test.tsx
+++ b/frontend/packages/shared/src/components/InputActionWrapper/InputActionWrapper.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render as rtlRender, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import type { InputActionWrapperProps } from './InputActionWrapper';
 import { InputActionWrapper } from './InputActionWrapper';
 import { mockUseTranslation } from '../../../../../testing/mocks/i18nMock';
@@ -19,66 +19,72 @@ const mockProps: InputActionWrapperProps = {
 
 describe('InputActionWrapper', () => {
   it('renders save and delete buttons when mode is (editMode)', async () => {
-    await rtlRender(<InputActionWrapper {...mockProps} mode='editMode' />);
+    await render(<InputActionWrapper {...mockProps} mode='editMode' />);
     expect(screen.getByLabelText('general.save')).toBeInTheDocument();
     expect(screen.getByLabelText('general.delete')).toBeInTheDocument();
   });
 
   it('renders edit button when mode is (hoverMode)', async () => {
-    await rtlRender(<InputActionWrapper {...mockProps} mode='hoverMode' />);
+    await render(<InputActionWrapper {...mockProps} mode='hoverMode' />);
     expect(screen.getByLabelText('general.edit')).toBeInTheDocument();
   });
 
   it('renders delete button when mode is (hoverMode)', async () => {
-    await rtlRender(<InputActionWrapper {...mockProps} mode='hoverMode' />);
+    await render(<InputActionWrapper {...mockProps} mode='hoverMode' />);
     expect(screen.getByLabelText('general.delete')).toBeInTheDocument();
   });
 
   it('does not render save button when mode is (hoverMode)', async () => {
-    await rtlRender(<InputActionWrapper {...mockProps} mode='hoverMode' />);
+    await render(<InputActionWrapper {...mockProps} mode='hoverMode' />);
     expect(screen.queryByLabelText('general.save')).not.toBeInTheDocument();
   });
 
+  it('displays the edit and delete button when mode is (hoverMode)', async () => {
+    await render(<InputActionWrapper {...mockProps} mode='hoverMode' />);
+    expect(screen.getByLabelText('general.edit')).toBeInTheDocument();
+    expect(screen.getByLabelText('general.delete')).toBeInTheDocument();
+  });
+
   it('does not renders edit button when mode is (editMode)', async () => {
-    await rtlRender(<InputActionWrapper {...mockProps} mode='editMode' />);
+    await render(<InputActionWrapper {...mockProps} mode='editMode' />);
     expect(screen.queryByLabelText('general.edit')).not.toBeInTheDocument();
   });
 
   it('renders delete button when mode is (editMode)', async () => {
-    await rtlRender(<InputActionWrapper {...mockProps} mode='editMode' />);
+    await render(<InputActionWrapper {...mockProps} mode='editMode' />);
     expect(screen.getByLabelText('general.delete')).toBeInTheDocument();
   });
 
   it('triggers save click on save button click', async () => {
-    rtlRender(<InputActionWrapper {...mockProps} />);
+    render(<InputActionWrapper {...mockProps} />);
     const saveButton = screen.getByLabelText('general.save');
     await act(() => user.click(saveButton));
     expect(mockProps.onSaveClick).toBeCalledTimes(1);
   });
 
   it('triggers delete click on delete button click', async () => {
-    rtlRender(<InputActionWrapper {...mockProps} />);
+    render(<InputActionWrapper {...mockProps} />);
     const deleteButton = screen.getByLabelText('general.delete');
     await act(() => user.click(deleteButton));
     expect(mockProps.onDeleteClick).toBeCalledTimes(1);
   });
 
   it('check that handleActionClick is called when edit button is clicked', async () => {
-    rtlRender(<InputActionWrapper {...mockProps} mode='hoverMode' />);
+    render(<InputActionWrapper {...mockProps} mode='hoverMode' />);
     const editButton = screen.getByLabelText('general.edit');
     await act(() => user.click(editButton));
     expect(mockProps.onEditClick).toBeCalledTimes(1);
   });
 
   it('check that handleHover is called when onMouseOver is called ', async () => {
-    rtlRender(<InputActionWrapper {...mockProps} mode='standBy' />);
+    render(<InputActionWrapper {...mockProps} mode='standBy' />);
     const input = screen.getByRole('textbox');
     await act(() => user.hover(input));
     expect(screen.getByLabelText('general.edit')).toBeInTheDocument();
   });
 
   it('check that handleBlur is called when onMouseLeave is called ', async () => {
-    rtlRender(<InputActionWrapper {...mockProps} mode='standBy' />);
+    render(<InputActionWrapper {...mockProps} mode='standBy' />);
     const input = screen.getByRole('textbox');
     await act(() => user.hover(input));
     expect(screen.getByLabelText('general.edit')).toBeInTheDocument();
@@ -87,14 +93,14 @@ describe('InputActionWrapper', () => {
   });
 
   it('check that handleFocus is called when onFocus is called ', async () => {
-    rtlRender(<InputActionWrapper {...mockProps} mode='standBy' />);
+    render(<InputActionWrapper {...mockProps} mode='standBy' />);
     const input = screen.getByRole('textbox');
     await act(() => user.hover(input));
     expect(screen.getByLabelText('general.edit')).toBeInTheDocument();
   });
 
   it('renders right actions when switching mode', async () => {
-    const { rerender } = await rtlRender(<InputActionWrapper {...mockProps} mode={'editMode'} />);
+    const { rerender } = await render(<InputActionWrapper {...mockProps} mode={'editMode'} />);
     expect(screen.getByLabelText('general.save')).toBeInTheDocument();
     expect(screen.getByLabelText('general.delete')).toBeInTheDocument();
 

--- a/frontend/packages/shared/src/components/InputActionWrapper/InputActionWrapper.tsx
+++ b/frontend/packages/shared/src/components/InputActionWrapper/InputActionWrapper.tsx
@@ -3,6 +3,7 @@ import { CheckmarkIcon, TrashIcon, PencilWritingIcon } from '@altinn/icons';
 import { useText } from '../../../../ux-editor/src/hooks/index';
 import { Button, ButtonProps } from '@digdir/design-system-react';
 import classes from './InputActionWrapper.module.css';
+import cn from 'classnames';
 
 type AvailableAction = 'edit' | 'save' | 'delete';
 export type ActionGroup = 'editMode' | 'hoverMode' | 'standBy';
@@ -94,23 +95,31 @@ export const InputActionWrapper = ({
   };
 
   return (
-    <div className={classes.container} onMouseOver={handleHover} onMouseLeave={handleMouseLeave}>
+    <div
+      className={cn(classes.container, mode === 'standBy' && classes.standByContainer)}
+      onMouseOver={handleHover}
+      onMouseLeave={handleMouseLeave}
+    >
       {React.cloneElement(children, {
         ...rest,
         onFocus: handleFocus,
       })}
-      {actions.map((action) => (
-        <Button
-          variant='tertiary'
-          size='medium'
-          color={actionToColorMap[action]}
-          key={action}
-          onClick={() => handleActionClick(action)}
-          aria-label={actionToAriaLabelMap[action]}
-        >
-          {actionToIconMap[action]}
-        </Button>
-      ))}
+      <div
+        className={cn(classes.buttonWrapper, mode === 'standBy' && classes.standByButtonWrapper)}
+      >
+        {actions.map((action) => (
+          <Button
+            variant='tertiary'
+            size='medium'
+            color={actionToColorMap[action]}
+            key={action}
+            onClick={() => handleActionClick(action)}
+            aria-label={actionToAriaLabelMap[action]}
+          >
+            {actionToIconMap[action]}
+          </Button>
+        ))}
+      </div>
     </div>
   );
 };

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.module.css
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.module.css
@@ -17,6 +17,7 @@
   display: flex;
   align-items: center;
   gap: var(--fds-spacing-1);
+  padding-block: 0.75rem;
 }
 
 .selectedOption {

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.module.css
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.module.css
@@ -7,7 +7,7 @@
   font-size: 1.5rem;
 }
 
-.SelectDataModelComponent {
+.selectDataModelComponent {
   margin-top: -25px;
   width: 100%;
 }
@@ -22,5 +22,5 @@
 
 .selectedOption {
   gap: var(--fds-spacing-1);
-  width: 50%;
+  word-break: break-word;
 }

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.tsx
@@ -7,7 +7,7 @@ import { SelectDataModelComponent } from '../SelectDataModelComponent';
 import { useDatamodelMetadataQuery } from '../../../hooks/queries/useDatamodelMetadataQuery';
 import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
 import { LinkIcon } from '@altinn/icons';
-import { Button } from '@digdir/design-system-react';
+import { Button, Paragraph } from '@digdir/design-system-react';
 import classes from './EditDataModelBindings.module.css';
 import { InputActionWrapper } from 'app-shared/components/InputActionWrapper';
 
@@ -77,7 +77,7 @@ export const EditDataModelBindings = ({
           }}
           onSaveClick={() => setDataModelSelectVisible(false)}
         >
-          <div className={classes.SelectDataModelComponent}>
+          <div className={classes.selectDataModelComponent}>
             {dataModelSelectVisible ? (
               <SelectDataModelComponent
                 propertyPath={`definitions/component/properties/dataModelBindings/properties/${
@@ -117,7 +117,7 @@ const SelectedOption = ({ selectedOption }: { selectedOption: string }) => {
   return (
     <div className={classes.linkedDatamodelContainer}>
       <LinkIcon />
-      <div className={classes.selectedOption}>{selectedOption}</div>
+      <Paragraph className={classes.selectedOption}>{selectedOption}</Paragraph>
     </div>
   );
 };

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings.tsx
@@ -104,7 +104,7 @@ export const EditDataModelBindings = ({
                 helpText={helpText}
               />
             ) : (
-              <>{selectedOption && <SelectedOption selectedOption={selectedOption} />}</>
+              selectedOption && <SelectedOption selectedOption={selectedOption} />
             )}
           </div>
         </InputActionWrapper>


### PR DESCRIPTION
## Description
- Solving the CSS bug. The reason why the field jumped up and down was because of the ```div``` holding the text had a smaller height than the icon buttons that appeared next to it. As both the text and the buttons was inside the same parent-div, the text "jumped" up a bit to be positioned correctly based on its parent-div which also increased size as a result of the buttons entering the screen. The solution was to add some padding to the div around the text.

## Related Issue(s)
- #11704 

## Video

https://github.com/Altinn/altinn-studio/assets/133344438/6c0df6a7-e44b-4989-a59c-9aa9efce010e



## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
