### PR TITLE
fix(BPMNModeler): save Modeler Instance between renders

### DIFF
--- a/frontend/packages/process-editor/src/hooks/useBpmnModeler.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnModeler.ts
@@ -1,0 +1,45 @@
+﻿import { useEffect } from 'react';
+import Modeler from 'bpmn-js/lib/Modeler';
+import BpmnModeler from 'bpmn-js/lib/Modeler';
+import SupportedPaletteProvider from '../bpmnProviders/SupportedPaletteProvider';
+import SupportedContextPadProvider from '../bpmnProviders/SupportedContextPadProvider';
+import { altinnCustomTasks } from '../extensions/altinnCustomTasks';
+
+// Save the instance outside React Ecosystem, ensures to not creating new instances between renders.
+let modelerInstance: Modeler | null = null;
+
+type UseBpmnModelerResult = {
+  getModeler: (canvasContainer: HTMLDivElement) => Modeler;
+};
+
+export const useBpmnModeler = (): UseBpmnModelerResult => {
+  useEffect(() => {
+    // Kill/reset the modelerInstance on unMount
+    return (): void => {
+      modelerInstance = null;
+    };
+  }, []);
+  const initializeModeler = (canvasContainer: HTMLDivElement) => {
+    return new BpmnModeler({
+      container: canvasContainer,
+      keyboard: {
+        bindTo: document,
+      },
+      additionalModules: [SupportedPaletteProvider, SupportedContextPadProvider],
+      moddleExtensions: {
+        altinn: altinnCustomTasks,
+      },
+    });
+  };
+
+  const getModeler = (canvasContainer: HTMLDivElement): Modeler => {
+    if (!modelerInstance) {
+      modelerInstance = initializeModeler(canvasContainer);
+    }
+    return modelerInstance;
+  };
+
+  return {
+    getModeler,
+  };
+};

--- a/frontend/packages/process-editor/src/hooks/useBpmnModeler/index.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnModeler/index.ts
@@ -1,0 +1,1 @@
+﻿export { useBpmnModeler } from './useBpmnModeler';

--- a/frontend/packages/process-editor/src/hooks/useBpmnModeler/useBpmnModeler.test.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnModeler/useBpmnModeler.test.ts
@@ -1,0 +1,42 @@
+﻿import { renderHook } from '@testing-library/react';
+import { useBpmnModeler } from './useBpmnModeler';
+import Modeler from 'bpmn-js/lib/Modeler';
+
+type ModelerMock = Modeler & { container: { container: HTMLDivElement } };
+
+jest.mock(
+  'bpmn-js/lib/Modeler',
+  () =>
+    class BpmnModelerMockImpl {
+      public container: HTMLDivElement;
+
+      constructor(_container: HTMLDivElement) {
+        this.container = _container;
+      }
+    },
+);
+
+const mockedCanvasHTMLDivElement = `<div>MockedHtml</div>` as unknown as HTMLDivElement;
+const mockedCanvasHTMLDivElement2 = `<div>MockedHtml2</div>` as unknown as HTMLDivElement;
+
+describe('useBpmnModeler', () => {
+  it('should create instance of the BpmnModeler when calling getModeler', () => {
+    const { result } = renderHook(() => useBpmnModeler());
+    const { getModeler } = result.current;
+
+    const modelerInstance = getModeler(mockedCanvasHTMLDivElement) as ModelerMock;
+    expect(modelerInstance.container.container).toBe(mockedCanvasHTMLDivElement);
+  });
+
+  it('should avoid creating a new instance of the class if it already has an instance', () => {
+    const { result } = renderHook(() => useBpmnModeler());
+    const { getModeler } = result.current;
+
+    const modelerInstance = getModeler(mockedCanvasHTMLDivElement) as ModelerMock;
+    expect(modelerInstance.container.container).toBe(mockedCanvasHTMLDivElement);
+
+    const modelerInstance2 = getModeler(mockedCanvasHTMLDivElement2) as ModelerMock;
+    expect(modelerInstance2.container.container).not.toBe(mockedCanvasHTMLDivElement2);
+    expect(modelerInstance2.container.container).toBe(mockedCanvasHTMLDivElement);
+  });
+});

--- a/frontend/packages/process-editor/src/hooks/useBpmnModeler/useBpmnModeler.test.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnModeler/useBpmnModeler.test.ts
@@ -39,4 +39,16 @@ describe('useBpmnModeler', () => {
     expect(modelerInstance2.container.container).not.toBe(mockedCanvasHTMLDivElement2);
     expect(modelerInstance2.container.container).toBe(mockedCanvasHTMLDivElement);
   });
+
+  it('should kill the instance when unMounting and should be able to create a new instance', () => {
+    const { result, unmount } = renderHook(() => useBpmnModeler());
+    const { getModeler } = result.current;
+
+    getModeler(mockedCanvasHTMLDivElement) as ModelerMock;
+
+    unmount();
+
+    const modelerInstance2 = getModeler(mockedCanvasHTMLDivElement2) as ModelerMock;
+    expect(modelerInstance2.container.container).toBe(mockedCanvasHTMLDivElement2);
+  });
 });

--- a/frontend/packages/process-editor/src/hooks/useBpmnModeler/useBpmnModeler.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnModeler/useBpmnModeler.ts
@@ -1,9 +1,9 @@
 ﻿import { useEffect } from 'react';
 import Modeler from 'bpmn-js/lib/Modeler';
 import BpmnModeler from 'bpmn-js/lib/Modeler';
-import SupportedPaletteProvider from '../bpmnProviders/SupportedPaletteProvider';
-import SupportedContextPadProvider from '../bpmnProviders/SupportedContextPadProvider';
-import { altinnCustomTasks } from '../extensions/altinnCustomTasks';
+import SupportedPaletteProvider from '../../bpmnProviders/SupportedPaletteProvider';
+import SupportedContextPadProvider from '../../bpmnProviders/SupportedContextPadProvider';
+import { altinnCustomTasks } from '../../extensions/altinnCustomTasks';
 
 // Save the instance outside React Ecosystem, ensures to not creating new instances between renders.
 let modelerInstance: Modeler | null = null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The bug was that the code was creating a new instance of the  BpmnModeler class on every render of the `BpmnEditorComponent` component. When saving the XML we are sending it as payload to the backend and the response (the updated XML) will be passed back down to the React Component, which will cause a re-render of the component, which again creates a new instance of the BpmnModeler class.

Within this PR I have created a custom hook which ensures to creation of the BpmnModeler instance and avoids re-creating a new instance if we already have one.

## Related Issue(s)
- #11500 (Test Feedback, see comment on issue)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
