### PR TITLE
Add logging in delegationhandler and jsonSerializerOptions to appmetadata

### DIFF
--- a/backend/src/Designer/TypedHttpClients/DelegatingHandlers/EnsureSuccessHandler.cs
+++ b/backend/src/Designer/TypedHttpClients/DelegatingHandlers/EnsureSuccessHandler.cs
@@ -1,7 +1,8 @@
-using System.Net;
+using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Rest.TransientFaultHandling;
 
 namespace Altinn.Studio.Designer.TypedHttpClients.DelegatingHandlers
@@ -11,6 +12,18 @@ namespace Altinn.Studio.Designer.TypedHttpClients.DelegatingHandlers
     /// </summary>
     public class EnsureSuccessHandler : DelegatingHandler
     {
+
+        private readonly ILogger<EnsureSuccessHandler> _logger;
+
+        /// <summary>
+        /// Constructor to inject logger
+        /// </summary>
+        /// <param name="logger">ILogger instance</param>
+        public EnsureSuccessHandler(ILogger<EnsureSuccessHandler> logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
         /// <summary>
         /// Checks to see if response is success
         /// Otherwise, throws Exception
@@ -24,6 +37,10 @@ namespace Altinn.Studio.Designer.TypedHttpClients.DelegatingHandlers
 
             if (!response.IsSuccessStatusCode)
             {
+
+                string errorMessage = await response.Content.ReadAsStringAsync();
+                _logger.LogError("// UpdateApplicationMetadata // Failed with status code {StatusCode} and message {ResponseMessage}.\r\n Content: {AppMetadata}", response.StatusCode, errorMessage, request.Content);
+
                 throw new HttpRequestWithStatusException(response.ReasonPhrase)
                 {
                     StatusCode = response.StatusCode

--- a/backend/src/Designer/TypedHttpClients/DelegatingHandlers/EnsureSuccessHandler.cs
+++ b/backend/src/Designer/TypedHttpClients/DelegatingHandlers/EnsureSuccessHandler.cs
@@ -19,9 +19,9 @@ namespace Altinn.Studio.Designer.TypedHttpClients.DelegatingHandlers
         /// Constructor to inject logger
         /// </summary>
         /// <param name="logger">ILogger instance</param>
-        public EnsureSuccessHandler(ILogger<EnsureSuccessHandler> logger)
+        public EnsureSuccessHandler(ILogger<EnsureSuccessHandler> logger = null)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _logger = logger;
         }
 
         /// <summary>

--- a/backend/tests/Designer.Tests/Fixtures/GiteaFixture.cs
+++ b/backend/tests/Designer.Tests/Fixtures/GiteaFixture.cs
@@ -15,6 +15,7 @@ using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Images;
 using DotNet.Testcontainers.Networks;
+using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Retry;
 using Testcontainers.PostgreSql;
@@ -34,9 +35,9 @@ namespace Designer.Tests.Fixtures
         private Lazy<HttpClient> _giteaClient;
         public Lazy<HttpClient> GiteaClient
         {
-            get => _giteaClient ??= new Lazy<HttpClient>(() => new HttpClient(new EnsureSuccessHandler
+            get => _giteaClient ??= new Lazy<HttpClient>(() => new HttpClient(new EnsureSuccessHandler()
             {
-                InnerHandler = new HttpClientHandler()
+                InnerHandler = new HttpClientHandler(),
             })
             {
                 BaseAddress = new Uri("http://localhost:" + _giteaContainer.GetMappedPublicPort(3000) + "/api/v1/"),


### PR DESCRIPTION
Add logging to delegationhandler since it catches the error in appmetadataclient before it will be able to log it.
And add jsonserializeroptions to appmetadataclient 