### PR TITLE
bugfix: change Spinner component used in resources table after breaking change

### DIFF
--- a/frontend/dashboard/components/ResourcesRepoList/ResourcesRepoList.tsx
+++ b/frontend/dashboard/components/ResourcesRepoList/ResourcesRepoList.tsx
@@ -7,7 +7,7 @@ import { getResourceDashboardURL, getResourcePageURL } from 'resourceadm/utils/u
 import { getReposLabel } from 'dashboard/utils/repoUtils';
 import { Organization } from 'app-shared/types/Organization';
 import { useTranslation } from 'react-i18next';
-import { AltinnSpinner } from 'app-shared/components';
+import { StudioSpinner } from '@studio/components';
 import { Alert, Heading, Link } from '@digdir/design-system-react';
 import { useSearchReposQuery } from 'dashboard/hooks/queries';
 import { User } from 'app-shared/types/User';
@@ -64,7 +64,7 @@ export const ResourcesRepoList = ({
         })}
       </Heading>
       {isLoadingResourceList ? (
-        <AltinnSpinner spinnerText={t('general.loading')} />
+        <StudioSpinner spinnerText={t('general.loading')} />
       ) : (
         <div data-testid='resource-table-wrapper'>
           <Link href={`${RESOURCEADM_BASENAME}${getResourceDashboardURL(selectedContext, repo)}`}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix import name of spinner in resources table

## Related Issue(s)
- None

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
