### PR TITLE
feat(TreeView): turned off feature flag for TreeView on 'Lage'

### DIFF
--- a/frontend/packages/shared/src/utils/featureToggleUtils.ts
+++ b/frontend/packages/shared/src/utils/featureToggleUtils.ts
@@ -10,7 +10,6 @@ export type SupportedFeatureFlags =
   | 'processEditor'
   | 'configureLayoutSet'
   | 'newAdministration'
-  | 'formTree'
   | 'shouldOverrideAppLibCheck';
 
 /*

--- a/frontend/packages/ux-editor/src/containers/DesignView/FormLayout.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/FormLayout.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { FormLayout, FormLayoutProps } from './FormLayout';
 import { layoutMock } from '../../testing/layoutMock';
 import { screen } from '@testing-library/react';
-import { typedLocalStorage } from 'app-shared/utils/webStorage';
 import { renderWithMockStore } from '../../testing/mocks';
 import { BASE_CONTAINER_ID } from 'app-shared/constants';
 import { DragAndDropTree } from 'app-shared/components/DragAndDropTree';
@@ -15,15 +14,9 @@ const defaultProps: FormLayoutProps = {
 };
 
 describe('FormLayout', () => {
-  it('Does not display a tree view component by default', () => {
+  it('Does display a tree view component', () => {
     render();
-    expect(screen.queryByRole('tree')).not.toBeInTheDocument();
-  });
-
-  it('Displays the tree view version of the layout when the formTree feature flag is enabled', () => {
-    typedLocalStorage.setItem('featureFlags', ['formTree']);
-    render();
-    expect(screen.getByRole('tree')).toBeInTheDocument();
+    expect(screen.getByRole('tree'));
   });
 
   it('Displays warning about multi page groups when the layout has such groups', () => {

--- a/frontend/packages/ux-editor/src/containers/DesignView/FormLayout.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/FormLayout.tsx
@@ -1,8 +1,5 @@
 import { IInternalLayout } from '../../types/global';
-import { shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
 import { FormTree } from './FormTree';
-import { RenderedFormContainer } from './RenderedFormContainer';
-import { BASE_CONTAINER_ID } from 'app-shared/constants';
 import React from 'react';
 import { hasMultiPageGroup } from '../../utils/formLayoutUtils';
 import { useTranslation } from 'react-i18next';
@@ -12,28 +9,12 @@ export interface FormLayoutProps {
   layout: IInternalLayout;
 }
 
-export const FormLayout = ({ layout }: FormLayoutProps) => {
-  const { order, containers, components } = layout;
-
-  const renderForm = () =>
-    shouldDisplayFeature('formTree') ? (
-      <FormTree layout={layout} />
-    ) : (
-      <RenderedFormContainer
-        containerId={BASE_CONTAINER_ID}
-        formLayoutOrder={order}
-        formDesignerContainers={containers}
-        formDesignerComponents={components}
-      />
-    );
-
-  return (
-    <>
-      {hasMultiPageGroup(layout) && <MultiPageWarning />}
-      {renderForm()}
-    </>
-  );
-};
+export const FormLayout = ({ layout }: FormLayoutProps) => (
+  <>
+    {hasMultiPageGroup(layout) && <MultiPageWarning />}
+    <FormTree layout={layout} />
+  </>
+);
 
 const MultiPageWarning = () => {
   const { t } = useTranslation();

--- a/frontend/testing/cypress/src/integration/studio/designer.js
+++ b/frontend/testing/cypress/src/integration/studio/designer.js
@@ -54,10 +54,10 @@ context('Designer', () => {
     cy.wait(500);
     designer
       .getPageAccordionByName('Side1')
-      .findByRole('listitem', { name: texts['ux_editor.component_title.Input'] });
+      .findByRole('treeitem', { name: texts['ux_editor.component_title.Input'] });
 
-    // Delete components on page
-    cy.deleteComponents();
+    // Do not need to confirm alert.confirm dialog, since Cypress default to click "Ok".
+    cy.findByTitle(texts['general.delete']).click({ force: true });
   });
 
   it('should add navigation buttons when adding more than one page', () => {
@@ -84,9 +84,10 @@ context('Designer', () => {
 
     designer
       .getPageAccordionByName('Side2')
-      .findByRole('listitem', { name: `${texts['ux_editor.component_title.NavigationButtons']}` });
+      .findByRole('treeitem', { name: `${texts['ux_editor.component_title.NavigationButtons']}` });
 
-    cy.deleteComponents();
+    // Do not need to confirm alert.confirm dialog, since Cypress default to click "Ok".
+    cy.findByTitle(texts['general.delete']).click({ force: true });
   });
 
   // Disabled for now, as this generates too many copies of the same app


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed feature flag for TreeView for components within pages. Could not remove all the old code since the receipt pages still using it. 

## Related Issue(s)
- [11629](https://github.com/Altinn/altinn-studio/issues/11629)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
