### PR TITLE
refactoring studio modal to use designsystem modal

### DIFF
--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.module.css
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.module.css
@@ -12,7 +12,6 @@
 
 .leftNavigationBar {
   min-height: 200px;
-  border-bottom-left-radius: 20px;
 }
 
 .headingWrapper {
@@ -20,6 +19,7 @@
   align-items: center;
   padding-block: 10px;
   padding-inline: 20px;
+  border-bottom: 1px solid var(--fds-semantic-border-divider-default);
 }
 
 .headingWrapper > :first-child {

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import classes from './SettingsModal.module.css';
 import { Heading } from '@digdir/design-system-react';
 import {
@@ -22,7 +22,6 @@ import { AccessControlTab } from './components/Tabs/AccessControlTab';
 import { SetupTab } from './components/Tabs/SetupTab';
 
 export type SettingsModalProps = {
-  isOpen: boolean;
   onClose: () => void;
   org: string;
   app: string;
@@ -32,118 +31,111 @@ export type SettingsModalProps = {
  * @component
  *    Displays the settings modal.
  *
- * @property {boolean}[isOpen] - Flag for if the modal is open
- * @property {function}[onClose] - Function to be executed on close
+ * @property {function}[onClose] - Function to execute on close
  * @property {string}[org] - The org
  * @property {string}[app] - The app
  *
- * @returns {ReactNode} - The rendered component
+ * @returns {JSX.Element} - The rendered component
  */
-export const SettingsModal = ({ isOpen, onClose, org, app }: SettingsModalProps): ReactNode => {
-  const { t } = useTranslation();
+export const SettingsModal = forwardRef<HTMLDialogElement, SettingsModalProps>(
+  ({ onClose, org, app }, ref): JSX.Element => {
+    const { t } = useTranslation();
 
-  const [currentTab, setCurrentTab] = useState<SettingsModalTab>('about');
+    const [currentTab, setCurrentTab] = useState<SettingsModalTab>('about');
 
-  /**
-   * Ids for the navigation tabs
-   */
-  const aboutTabId: SettingsModalTab = 'about';
-  const setupTabId: SettingsModalTab = 'setup';
-  const policyTabId: SettingsModalTab = 'policy';
-  const localChangesTabId: SettingsModalTab = 'localChanges';
-  const accessControlTabId: SettingsModalTab = 'accessControl';
+    /**
+     * Ids for the navigation tabs
+     */
+    const aboutTabId: SettingsModalTab = 'about';
+    const setupTabId: SettingsModalTab = 'setup';
+    const policyTabId: SettingsModalTab = 'policy';
+    const localChangesTabId: SettingsModalTab = 'localChanges';
+    const accessControlTabId: SettingsModalTab = 'accessControl';
 
-  /**
-   * The tabs to display in the navigation bar
-   */
-  const leftNavigationTabs: LeftNavigationTab[] = [
-    createNavigationTab(
-      <InformationSquareIcon className={classes.icon} />,
-      aboutTabId,
-      () => changeTabTo(aboutTabId),
-      currentTab,
-    ),
-    createNavigationTab(
-      <SidebarBothIcon className={classes.icon} />,
-      setupTabId,
-      () => changeTabTo(setupTabId),
-      currentTab,
-    ),
-    createNavigationTab(
-      <ShieldLockIcon className={classes.icon} />,
-      policyTabId,
-      () => changeTabTo(policyTabId),
-      currentTab,
-    ),
-    createNavigationTab(
-      <PersonSuitIcon className={classes.icon} />,
-      accessControlTabId,
-      () => changeTabTo(accessControlTabId),
-      currentTab,
-    ),
-    createNavigationTab(
-      <MonitorIcon className={classes.icon} />,
-      localChangesTabId,
-      () => changeTabTo(localChangesTabId),
-      currentTab,
-    ),
-  ];
+    const leftNavigationTabs: LeftNavigationTab[] = [
+      createNavigationTab(
+        <InformationSquareIcon className={classes.icon} />,
+        aboutTabId,
+        () => changeTabTo(aboutTabId),
+        currentTab,
+      ),
+      createNavigationTab(
+        <SidebarBothIcon className={classes.icon} />,
+        setupTabId,
+        () => changeTabTo(setupTabId),
+        currentTab,
+      ),
+      createNavigationTab(
+        <ShieldLockIcon className={classes.icon} />,
+        policyTabId,
+        () => changeTabTo(policyTabId),
+        currentTab,
+      ),
+      createNavigationTab(
+        <PersonSuitIcon className={classes.icon} />,
+        accessControlTabId,
+        () => changeTabTo(accessControlTabId),
+        currentTab,
+      ),
+      createNavigationTab(
+        <MonitorIcon className={classes.icon} />,
+        localChangesTabId,
+        () => changeTabTo(localChangesTabId),
+        currentTab,
+      ),
+    ];
 
-  /**
-   * Changes the active tab
-   * @param tabId
-   */
-  const changeTabTo = (tabId: SettingsModalTab) => {
-    setCurrentTab(tabId);
-  };
+    const changeTabTo = (tabId: SettingsModalTab) => {
+      setCurrentTab(tabId);
+    };
 
-  /**
-   * Displays the currently selected tab and its content
-   * @returns
-   */
-  const displayTabs = () => {
-    switch (currentTab) {
-      case 'about': {
-        return <AboutTab org={org} app={app} />;
+    const displayTabs = () => {
+      switch (currentTab) {
+        case 'about': {
+          return <AboutTab org={org} app={app} />;
+        }
+        case 'setup': {
+          return <SetupTab org={org} app={app} />;
+        }
+        case 'policy': {
+          return <PolicyTab org={org} app={app} />;
+        }
+        case 'accessControl': {
+          return <AccessControlTab org={org} app={app} />;
+        }
+        case 'localChanges': {
+          return <LocalChangesTab org={org} app={app} />;
+        }
       }
-      case 'setup': {
-        return <SetupTab org={org} app={app} />;
-      }
-      case 'policy': {
-        return <PolicyTab org={org} app={app} />;
-      }
-      case 'accessControl': {
-        return <AccessControlTab org={org} app={app} />;
-      }
-      case 'localChanges': {
-        return <LocalChangesTab org={org} app={app} />;
-      }
-    }
-  };
+    };
 
-  return (
-    <StudioModal
-      isOpen={isOpen}
-      onClose={onClose}
-      title={
-        <div className={classes.headingWrapper}>
-          <CogIcon className={classes.icon} />
-          <Heading level={1} size='medium'>
-            {t('settings_modal.heading')}
-          </Heading>
-        </div>
-      }
-    >
-      <div className={classes.modalContent}>
-        <div className={classes.leftNavWrapper}>
-          <LeftNavigationBar
-            tabs={leftNavigationTabs}
-            className={classes.leftNavigationBar}
-            selectedTab={currentTab}
-          />
-        </div>
-        {displayTabs()}
-      </div>
-    </StudioModal>
-  );
-};
+    return (
+      <StudioModal
+        ref={ref}
+        onClose={onClose}
+        header={
+          <div className={classes.headingWrapper}>
+            <CogIcon className={classes.icon} />
+            <Heading level={1} size='medium'>
+              {t('settings_modal.heading')}
+            </Heading>
+          </div>
+        }
+        content={
+          <div className={classes.modalContent}>
+            <div className={classes.leftNavWrapper}>
+              <LeftNavigationBar
+                tabs={leftNavigationTabs}
+                className={classes.leftNavigationBar}
+                selectedTab={currentTab}
+              />
+            </div>
+            {displayTabs()}
+          </div>
+        }
+      />
+    );
+  },
+);
+
+SettingsModal.displayName = 'SettingsModal';

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/LocalChangesTab/DeleteModal/DeleteModal.test.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/LocalChangesTab/DeleteModal/DeleteModal.test.tsx
@@ -1,35 +1,37 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { render, screen, act } from '@testing-library/react';
 import { DeleteModal, DeleteModalProps } from './DeleteModal';
 import { textMock } from '../../../../../../../../testing/mocks/i18nMock';
 import userEvent from '@testing-library/user-event';
 
 const mockAppName: string = 'TestApp';
+const mockButtonText: string = 'Mock Button';
+
+const mockOnClose = jest.fn();
+const mockOnDelete = jest.fn();
+
+const defaultProps: DeleteModalProps = {
+  onClose: mockOnClose,
+  onDelete: mockOnDelete,
+  appName: mockAppName,
+};
 
 describe('DeleteModal', () => {
-  const user = userEvent.setup();
   afterEach(jest.clearAllMocks);
 
-  const mockOnClose = jest.fn();
-  const mockOnDelete = jest.fn();
-
-  const defaultProps: DeleteModalProps = {
-    isOpen: true,
-    onClose: mockOnClose,
-    onDelete: mockOnDelete,
-    appName: mockAppName,
-  };
-
   it('calls the onClose function when the Cancel button is clicked', async () => {
-    render(<DeleteModal {...defaultProps} />);
+    const user = userEvent.setup();
+    await renderAndOpenModal();
 
     const cancelButton = screen.getByRole('button', { name: textMock('general.cancel') });
     await act(() => user.click(cancelButton));
+
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
   it('updates the value of the text field when typing', async () => {
-    render(<DeleteModal {...defaultProps} />);
+    const user = userEvent.setup();
+    await renderAndOpenModal();
 
     const textfield = screen.getByLabelText(
       textMock('settings_modal.local_changes_tab_delete_modal_textfield_label'),
@@ -45,7 +47,8 @@ describe('DeleteModal', () => {
   });
 
   it('calls the onDelete function when the Delete button is clicked with a matching app name', async () => {
-    render(<DeleteModal {...defaultProps} />);
+    const user = userEvent.setup();
+    await renderAndOpenModal();
 
     const deleteButton = screen.getByRole('button', {
       name: textMock('settings_modal.local_changes_tab_delete_modal_delete_button'),
@@ -66,3 +69,22 @@ describe('DeleteModal', () => {
     expect(mockOnDelete).toHaveBeenCalledTimes(1);
   });
 });
+
+const renderAndOpenModal = async (props: Partial<DeleteModalProps> = {}) => {
+  const user = userEvent.setup();
+  render(<TestComponentWithButton {...props} />);
+
+  const openModalButton = screen.getByRole('button', { name: mockButtonText });
+  await act(() => user.click(openModalButton));
+};
+
+const TestComponentWithButton = (props: Partial<DeleteModalProps> = {}) => {
+  const modalRef = useRef<HTMLDialogElement>(null);
+
+  return (
+    <>
+      <button onClick={() => modalRef.current?.showModal()}>{mockButtonText}</button>
+      <DeleteModal ref={modalRef} {...defaultProps} {...props} />
+    </>
+  );
+};

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/LocalChangesTab/DeleteModal/DeleteModal.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/LocalChangesTab/DeleteModal/DeleteModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import classes from './DeleteModal.module.css';
 import { useTranslation } from 'react-i18next';
 import { StudioModal } from '@studio/components';
@@ -6,7 +6,6 @@ import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Heading, Paragraph, Textfield } from '@digdir/design-system-react';
 
 export type DeleteModalProps = {
-  isOpen: boolean;
   onClose: () => void;
   onDelete: () => void;
   appName: string;
@@ -17,71 +16,70 @@ export type DeleteModalProps = {
  *    Displays a Warning modal to the user to ensure they really want to
  *    do an action.
  *
- * @property {boolean}[isOpen] - If the modal is open or not
  * @property {function}[onClose] - Function to execute on close
  * @property {function}[onDelete] - Function to execute on click delete
  * @property {string}[appName] - The name of the app to delete changes on
  *
- * @returns {ReactNode} - The rendered component
+ * @returns {JSX.Element} - The rendered component
  */
-export const DeleteModal = ({
-  isOpen,
-  onClose,
-  onDelete,
-  appName,
-}: DeleteModalProps): ReactNode => {
-  const { t } = useTranslation();
+export const DeleteModal = forwardRef<HTMLDialogElement, DeleteModalProps>(
+  ({ onClose, onDelete, appName }, ref): JSX.Element => {
+    const { t } = useTranslation();
 
-  const [nameToDelete, setNameToDelete] = useState('');
+    const [nameToDelete, setNameToDelete] = useState('');
 
-  const handleClose = () => {
-    setNameToDelete('');
-    onClose();
-  };
+    const handleClose = () => {
+      setNameToDelete('');
+      onClose();
+    };
 
-  const handleDelete = () => {
-    setNameToDelete('');
-    onDelete();
-  };
+    const handleDelete = () => {
+      setNameToDelete('');
+      onDelete();
+    };
 
-  return (
-    <StudioModal
-      isOpen={isOpen}
-      onClose={handleClose}
-      title={
-        <div className={classes.titleWrapper}>
-          <TrashIcon className={classes.modalIcon} />
-          <Heading level={1} size='xsmall'>
-            {t('settings_modal.local_changes_tab_delete_modal_title')}
-          </Heading>
-        </div>
-      }
-    >
-      <div className={classes.contentWrapper}>
-        <Paragraph size='small' spacing>
-          {t('settings_modal.local_changes_tab_delete_modal_text')}
-        </Paragraph>
-        <Textfield
-          label={t('settings_modal.local_changes_tab_delete_modal_textfield_label')}
-          size='small'
-          value={nameToDelete}
-          onChange={(e) => setNameToDelete(e.target.value)}
-        />
-        <div className={classes.buttonWrapper}>
-          <Button
-            variant='secondary'
-            color='danger'
-            onClick={handleDelete}
-            disabled={appName !== nameToDelete}
-            size='small'
-          >
-            {t('settings_modal.local_changes_tab_delete_modal_delete_button')}
-          </Button>
-          <Button variant='secondary' onClick={handleClose} size='small'>
-            {t('general.cancel')}
-          </Button>
-        </div>
-      </div>
-    </StudioModal>
-  );
-};
+    return (
+      <StudioModal
+        ref={ref}
+        onClose={handleClose}
+        header={
+          <div className={classes.titleWrapper}>
+            <TrashIcon className={classes.modalIcon} />
+            <Heading level={1} size='xsmall'>
+              {t('settings_modal.local_changes_tab_delete_modal_title')}
+            </Heading>
+          </div>
+        }
+        content={
+          <div className={classes.contentWrapper}>
+            <Paragraph size='small' spacing>
+              {t('settings_modal.local_changes_tab_delete_modal_text')}
+            </Paragraph>
+            <Textfield
+              label={t('settings_modal.local_changes_tab_delete_modal_textfield_label')}
+              size='small'
+              value={nameToDelete}
+              onChange={(e) => setNameToDelete(e.target.value)}
+            />
+            <div className={classes.buttonWrapper}>
+              <Button
+                variant='secondary'
+                color='danger'
+                onClick={handleDelete}
+                disabled={appName !== nameToDelete}
+                size='small'
+              >
+                {t('settings_modal.local_changes_tab_delete_modal_delete_button')}
+              </Button>
+              <Button variant='secondary' onClick={handleClose} size='small'>
+                {t('general.cancel')}
+              </Button>
+            </div>
+          </div>
+        }
+      />
+    );
+  },
+);
+
+DeleteModal.displayName = 'DeleteModal';

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/LocalChangesTab/LocalChangesTab.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/LocalChangesTab/LocalChangesTab.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { useRef } from 'react';
 import classes from './LocalChangesTab.module.css';
 import { useTranslation } from 'react-i18next';
 import { TabHeader } from '../../TabHeader';
@@ -23,23 +23,25 @@ export type LocalChangesTabProps = {
  * @property {string}[org] - The org
  * @property {string}[app] - The app
  *
- * @returns {ReactNode} - The rendered component
+ * @returns {JSX.Element} - The rendered component
  */
-export const LocalChangesTab = ({ org, app }: LocalChangesTabProps): ReactNode => {
+export const LocalChangesTab = ({ org, app }: LocalChangesTabProps): JSX.Element => {
   const { t } = useTranslation();
 
   const { mutate: deleteLocalChanges } = useResetRepositoryMutation(org, app);
 
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const modalRef = useRef<HTMLDialogElement>(null);
 
   const handleDelete = () => {
     deleteLocalChanges(undefined, {
       onSuccess: () => {
-        setDeleteModalOpen(false);
+        modalRef.current?.close();
         toast.success(t('settings_modal.local_changes_tab_deleted_success'));
       },
     });
   };
+
+  const handleCloseModal = () => modalRef.current?.close();
 
   return (
     <TabContent>
@@ -66,12 +68,12 @@ export const LocalChangesTab = ({ org, app }: LocalChangesTabProps): ReactNode =
           color='danger'
           icon={<TrashIcon />}
           text={t('settings_modal.local_changes_tab_delete_button')}
-          action={{ type: 'button', onClick: () => setDeleteModalOpen(true) }}
+          action={{ type: 'button', onClick: () => modalRef.current?.showModal() }}
         />
       </div>
       <DeleteModal
-        isOpen={deleteModalOpen}
-        onClose={() => setDeleteModalOpen(false)}
+        ref={modalRef}
+        onClose={handleCloseModal}
         onDelete={handleDelete}
         appName={app}
       />

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModalButton.test.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModalButton.test.tsx
@@ -68,7 +68,7 @@ describe('SettingsModal', () => {
     });
     expect(modalHeading).toBeInTheDocument();
 
-    const closeButton = screen.getByRole('button', { name: textMock('modal.close_icon') });
+    const closeButton = screen.getByRole('button', { name: 'close modal' });
     await act(() => user.click(closeButton));
 
     const modalHeadingAfter = screen.queryByRole('heading', {

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModalButton.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModalButton.tsx
@@ -1,23 +1,17 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useRef } from 'react';
 import { Button } from '@digdir/design-system-react';
 import { CogIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 import { SettingsModal } from './SettingsModal';
 
 export type SettingsModalButtonProps = {
-  /**
-   * The org
-   */
   org: string;
-  /**
-   * The app
-   */
   app: string;
 };
 
 /**
  * @component
- *    Displays a button to open the Settings modal
+ *    Displays a button to open the Settings modal and the Settings modal
  *
  * @property {string}[org] - The org
  * @property {string}[app] - The app
@@ -26,12 +20,13 @@ export type SettingsModalButtonProps = {
  */
 export const SettingsModalButton = ({ org, app }: SettingsModalButtonProps): ReactNode => {
   const { t } = useTranslation();
-  const [isOpen, setIsOpen] = useState(false);
+
+  const modalRef = useRef<HTMLDialogElement>(null);
 
   return (
     <>
       <Button
-        onClick={() => setIsOpen(true)}
+        onClick={() => modalRef.current?.showModal()}
         size='small'
         variant='tertiary'
         color='inverted'
@@ -39,12 +34,7 @@ export const SettingsModalButton = ({ org, app }: SettingsModalButtonProps): Rea
       >
         {t('settings_modal.heading')}
       </Button>
-      {
-        // Done to prevent API calls to be executed before the modal is open
-        isOpen && (
-          <SettingsModal isOpen={isOpen} onClose={() => setIsOpen(false)} org={org} app={app} />
-        )
-      }
+      <SettingsModal ref={modalRef} onClose={() => modalRef.current?.close()} org={org} app={app} />
     </>
   );
 };

--- a/frontend/libs/studio-components/src/components/StudioModal/StudioModal.module.css
+++ b/frontend/libs/studio-components/src/components/StudioModal/StudioModal.module.css
@@ -3,8 +3,7 @@
   --modal-min-height: 100px;
   --modal-max-height: 80vh;
   --modal-max-width: 80%;
-  --modal-position: 50%;
-  --modal-translate: calc(var(--modal-position) * -1);
+
   --heading-height: 60px;
   --modal-border-size: 1px;
   --modal-content-max-height: calc(var(--modal-max-height) - var(--heading-height)) -
@@ -16,25 +15,22 @@
   max-height: var(--modal-max-height);
   min-height: var(--modal-min-height);
   height: max-content;
-  border-radius: 20px;
-  position: absolute;
-  top: var(--modal-position);
-  left: var(--modal-position);
-  transform: translate(var(--modal-translate), var(--modal-translate));
-  padding: 0;
   padding-top: 20px;
-  background-color: var(--fds-semantic-background-default);
-  border: var(--modal-border-size) solid var(--fds-semantic-border-neutral-subtle);
 }
 
-.modalOverlay {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  background-color: rgba(30, 43, 60, 0.5);
-  z-index: 1000;
+.header {
+  margin: 0;
+  padding: 0;
+}
+
+.content {
+  margin: 0;
+  padding: 0;
+}
+
+.footer {
+  margin: 0;
+  padding: 0;
 }
 
 .headingWrapper {
@@ -43,14 +39,4 @@
   position: sticky;
   top: 0;
   background-color: var(--fds-semantic-background-default);
-}
-
-.contentWrapper {
-  max-height: var(--modal-content-max-height);
-}
-
-.closeButtonWrapper {
-  position: absolute;
-  top: -0.5rem;
-  right: 0.5rem;
 }

--- a/frontend/libs/studio-components/src/components/StudioModal/StudioModal.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioModal/StudioModal.test.tsx
@@ -1,46 +1,58 @@
 import React, { ReactNode } from 'react';
-import { render, screen, act } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { StudioModal, StudioModalProps } from './StudioModal';
-import { textMock } from '../../../../../testing/mocks/i18nMock';
 
-const mockTitle: ReactNode = (
+const mockHeaderText: string = 'Title';
+const mockContentText: string = 'Modal test';
+const mockFooterText: string = 'Footer content';
+
+const MockHeader: ReactNode = (
   <div>
-    <h2>Title</h2>
+    <h3>{mockHeaderText}</h3>
   </div>
 );
 
-const mockChildren = (
+const MockContent: ReactNode = (
   <div>
-    <p>Modal test</p>
+    <p>{mockContentText}</p>
   </div>
 );
 
-describe('Modal', () => {
+const MockFooter: ReactNode = (
+  <div>
+    <p>{mockFooterText}</p>
+  </div>
+);
+
+const mockOnClose = jest.fn();
+
+const defaultProps: StudioModalProps = {
+  onClose: mockOnClose,
+  header: MockHeader,
+  content: MockContent,
+  open: true,
+};
+
+describe('StudioModal', () => {
   afterEach(jest.clearAllMocks);
 
-  const mockOnClose = jest.fn();
-
-  const defaultProps: StudioModalProps = {
-    isOpen: true,
-    onClose: mockOnClose,
-    title: mockTitle,
-    children: mockChildren,
-  };
-
-  it('calls onClose when the close button is clicked', async () => {
-    const user = userEvent.setup();
+  it('shows the header and content components correctly, and hides the footer when not present', () => {
     render(<StudioModal {...defaultProps} />);
 
-    const closeButton = screen.getByRole('button', { name: textMock('modal.close_icon') });
-    await act(() => user.click(closeButton));
-    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    const header = screen.getByRole('heading', { name: 'Title', level: 3 });
+    expect(header).toBeInTheDocument();
+
+    const content = screen.getByText(mockContentText);
+    expect(content).toBeInTheDocument();
+
+    const footer = screen.queryByText(mockFooterText);
+    expect(footer).not.toBeInTheDocument();
   });
 
-  it('does not show content when modal is clsoed', () => {
-    render(<StudioModal {...defaultProps} isOpen={false} />);
+  it('shows the footer component when it is present', () => {
+    render(<StudioModal {...defaultProps} footer={MockFooter} />);
 
-    const closeButton = screen.queryByRole('button', { name: textMock('modal.close_icon') });
-    expect(closeButton).not.toBeInTheDocument();
+    const footer = screen.getByText(mockFooterText);
+    expect(footer).toBeInTheDocument();
   });
 });

--- a/frontend/libs/studio-components/src/components/StudioModal/StudioModal.tsx
+++ b/frontend/libs/studio-components/src/components/StudioModal/StudioModal.tsx
@@ -1,16 +1,12 @@
 import React, { ReactNode, forwardRef } from 'react';
 import classes from './StudioModal.module.css';
-import ReactModal from 'react-modal'; // TODO - Replace with component from Designsystemet. Issue:
-import { Button } from '@digdir/design-system-react';
-import { useTranslation } from 'react-i18next';
-import { MultiplyIcon } from '@studio/icons';
+import { Modal, ModalProps } from '@digdir/design-system-react';
 
 export type StudioModalProps = {
-  isOpen: boolean;
-  onClose: () => void;
-  title: ReactNode;
-  children: ReactNode;
-};
+  header: ReactNode;
+  content: ReactNode;
+  footer?: ReactNode;
+} & Omit<ModalProps, 'header' | 'content' | 'footer'>;
 
 /**
  * @component
@@ -18,54 +14,26 @@ export type StudioModalProps = {
  *
  * @example
  *    <StudioModal
- *      isOpen={isOpen}
- *      onClose={() => setIsOpen(false)}
- *      title={
- *        <div>
- *          <SomeIcon />
- *          <Heading level={1} size='small'>Some name</Heading>
- *        </div>
- *      }
- *    >
- *      <div>
- *        <SomeChildrenComponents />
- *      </div>
- *    </StudioModal>
+ *        ref={ref}
+ *        header={<SomeHeaderComponent />}
+ *        content={<SomeContentComponent />}
+ *        footer={<SomeFooterComponent />}
+ *    />
  *
- * @property {boolean}[isOpen] - Flag for if the modal is open
- * @property {function}[onClose] - Fucntion to execute when closing modal
- * @property {ReactNode}[title] - Title of the modal
- * @property {ReactNode}[children] - Content in the modal
+ * @property {ReactNode}[header] - Header of the modal
+ * @property {ReactNode}[content] - Content in the mdoal
+ * @property {ReactNode}[footer] - Optioanl footer in the modal
  *
- * @returns {ReactNode} - The rendered component
+ * @returns {JSX.Element} - The rendered component
  */
 export const StudioModal = forwardRef<HTMLDialogElement, StudioModalProps>(
-  ({ isOpen, onClose, title, children, ...rest }: StudioModalProps, ref): ReactNode => {
-    const { t } = useTranslation();
-
+  ({ header, content, footer, ...rest }: StudioModalProps, ref): JSX.Element => {
     return (
-      <ReactModal
-        isOpen={isOpen}
-        onRequestClose={onClose}
-        className={classes.modal}
-        overlayClassName={classes.modalOverlay}
-        ariaHideApp={false}
-        ref={ref}
-        {...rest}
-      >
-        <div className={classes.headingWrapper}>
-          {title}
-          <div className={classes.closeButtonWrapper}>
-            <Button
-              variant='tertiary'
-              icon={<MultiplyIcon />}
-              onClick={onClose}
-              aria-label={t('modal.close_icon')}
-            />
-          </div>
-        </div>
-        <div className={classes.contentWrapper}>{children}</div>
-      </ReactModal>
+      <Modal ref={ref} className={classes.modal} {...rest}>
+        <Modal.Header className={classes.header}>{header}</Modal.Header>
+        <Modal.Content className={classes.content}>{content}</Modal.Content>
+        {footer && <Modal.Footer className={classes.footer}>{footer}</Modal.Footer>}
+      </Modal>
     );
   },
 );

--- a/frontend/packages/policy-editor/src/PolicyEditor.tsx
+++ b/frontend/packages/policy-editor/src/PolicyEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Alert, Heading, Paragraph } from '@digdir/design-system-react';
 import type {
   PolicyAction,
@@ -57,6 +57,7 @@ export const PolicyEditor = ({
   usageType,
 }: PolicyEditorProps): React.ReactNode => {
   const { t } = useTranslation();
+  const modalRef = useRef<HTMLDialogElement>(null);
 
   // TODO - Find out how this should be set. Issue: #10880
   const resourceType = usageType === 'app' ? 'urn:altinn' : 'urn:altinn:resource';
@@ -67,8 +68,6 @@ export const PolicyEditor = ({
 
   // Handle the new updated IDs of the rules when a rule is deleted / duplicated
   const [lastRuleId, setLastRuleId] = useState((policy?.rules?.length ?? 0) + 1);
-
-  const [verificationModalOpen, setVerificationModalOpen] = useState(false);
 
   // To keep track of which rule to delete
   const [ruleIdToDelete, setRuleIdToDelete] = useState('0');
@@ -90,7 +89,7 @@ export const PolicyEditor = ({
           resourceType={resourceType}
           handleCloneRule={() => handleCloneRule(i)}
           handleDeleteRule={() => {
-            setVerificationModalOpen(true);
+            modalRef.current?.showModal();
             setRuleIdToDelete(pr.ruleId);
           }}
           showErrors={
@@ -168,7 +167,7 @@ export const PolicyEditor = ({
     setPolicyRules(updatedRules);
 
     // Reset
-    setVerificationModalOpen(false);
+    modalRef.current?.close();
     setRuleIdToDelete('0');
 
     handleSavePolicy(updatedRules);
@@ -216,8 +215,8 @@ export const PolicyEditor = ({
         <CardButton buttonText={t('policy_editor.card_button_text')} onClick={handleAddCardClick} />
       </div>
       <VerificationModal
-        isOpen={verificationModalOpen}
-        onClose={() => setVerificationModalOpen(false)}
+        ref={modalRef}
+        onClose={() => modalRef.current?.close()}
         text={t('policy_editor.verification_modal_text')}
         closeButtonText={t('policy_editor.verification_modal_close_button')}
         actionButtonText={t('policy_editor.verification_modal_action_button')}

--- a/frontend/packages/policy-editor/src/components/VerificationModal/VerificationModal.test.tsx
+++ b/frontend/packages/policy-editor/src/components/VerificationModal/VerificationModal.test.tsx
@@ -1,31 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { VerificationModal, VerificationModalProps } from './VerificationModal';
 import { textMock } from '../../../../../testing/mocks/i18nMock';
 import { act } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
 
+const mockButtonText: string = 'Mock Button';
 const mockModalText: string = 'Mock modal text';
 const mockCloseButtonText: string = 'Close';
 const mockActionButtonText: string = 'Confirm';
 
+const mockOnClose = jest.fn();
+const mockOnPerformAction = jest.fn();
+
+const defaultProps: VerificationModalProps = {
+  onClose: mockOnClose,
+  text: mockModalText,
+  closeButtonText: mockCloseButtonText,
+  actionButtonText: mockActionButtonText,
+  onPerformAction: mockOnPerformAction,
+};
+
 describe('VerificationModal', () => {
   afterEach(jest.clearAllMocks);
 
-  const mockOnClose = jest.fn();
-  const mockOnPerformAction = jest.fn();
-
-  const defaultProps: VerificationModalProps = {
-    isOpen: true,
-    onClose: mockOnClose,
-    text: mockModalText,
-    closeButtonText: mockCloseButtonText,
-    actionButtonText: mockActionButtonText,
-    onPerformAction: mockOnPerformAction,
-  };
-
-  it('does render the modal when it is open', () => {
-    render(<VerificationModal {...defaultProps} />);
+  it('does render the modal when it is open', async () => {
+    await renderAndOpenModal();
 
     const modalHeader = screen.getByRole('heading', {
       name: textMock('policy_editor.verification_modal_heading'),
@@ -36,7 +36,7 @@ describe('VerificationModal', () => {
   });
 
   it('does not render the modal when it is closed', () => {
-    render(<VerificationModal {...defaultProps} isOpen={false} />);
+    render(<TestComponentWithButton />);
 
     const modalHeader = screen.queryByRole('heading', {
       name: textMock('policy_editor.verification_modal_heading'),
@@ -48,7 +48,7 @@ describe('VerificationModal', () => {
 
   it('calls "onClose" when the close button is clicked', async () => {
     const user = userEvent.setup();
-    render(<VerificationModal {...defaultProps} />);
+    await renderAndOpenModal();
 
     const closeButton = screen.getByText(mockCloseButtonText);
     await act(() => user.click(closeButton));
@@ -58,7 +58,7 @@ describe('VerificationModal', () => {
 
   it('calls "onPerformAction" when the action button is clicked', async () => {
     const user = userEvent.setup();
-    render(<VerificationModal {...defaultProps} />);
+    await renderAndOpenModal();
 
     const actionButton = screen.getByText(mockActionButtonText);
     await act(() => user.click(actionButton));
@@ -66,3 +66,22 @@ describe('VerificationModal', () => {
     expect(mockOnPerformAction).toHaveBeenCalledTimes(1);
   });
 });
+
+const renderAndOpenModal = async (props: Partial<VerificationModalProps> = {}) => {
+  const user = userEvent.setup();
+  render(<TestComponentWithButton {...props} />);
+
+  const openModalButton = screen.getByRole('button', { name: mockButtonText });
+  await act(() => user.click(openModalButton));
+};
+
+const TestComponentWithButton = (props: Partial<VerificationModalProps> = {}) => {
+  const modalRef = useRef<HTMLDialogElement>(null);
+
+  return (
+    <>
+      <button onClick={() => modalRef.current?.showModal()}>{mockButtonText}</button>
+      <VerificationModal ref={modalRef} {...defaultProps} {...props} />
+    </>
+  );
+};

--- a/frontend/packages/policy-editor/src/components/VerificationModal/VerificationModal.tsx
+++ b/frontend/packages/policy-editor/src/components/VerificationModal/VerificationModal.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import classes from './VerificationModal.module.css';
 import { Button, Heading, Paragraph } from '@digdir/design-system-react';
 import { useTranslation } from 'react-i18next';
 import { StudioModal } from '@studio/components';
 
 export type VerificationModalProps = {
-  isOpen: boolean;
   onClose: () => void;
   text: string;
   closeButtonText: string;
@@ -18,50 +17,47 @@ export type VerificationModalProps = {
  *    Displays a verification modal. To be used when the user needs one extra level
  *    of chekcing if they really want to perform an action.
  *
- * @property {boolean}[isOpen] - Boolean for if the modal is open or not
  * @property {function}[onClose] - Function to be executed when closing the modal
  * @property {string}[text] -The text to display in the modal
  * @property {string}[closeButtonText] - The text to display on the close button
  * @property {string}[actionButtonText] - The text to display on the action button
  * @property {function}[onPerformAction] - Function to be executed when the action button is clicked
  *
- * @returns {React.ReactNode} - The rendered component
+ * @returns {JSX.Element} - The rendered component
  */
-export const VerificationModal = ({
-  isOpen,
-  onClose,
-  text,
-  closeButtonText,
-  actionButtonText,
-  onPerformAction,
-}: VerificationModalProps): React.ReactNode => {
-  const { t } = useTranslation();
+export const VerificationModal = forwardRef<HTMLDialogElement, VerificationModalProps>(
+  ({ onClose, text, closeButtonText, actionButtonText, onPerformAction }, ref): JSX.Element => {
+    const { t } = useTranslation();
 
-  return (
-    <StudioModal
-      isOpen={isOpen}
-      onClose={onClose}
-      title={
-        <div className={classes.headingWrapper}>
-          <Heading size='xsmall' spacing level={1}>
-            {t('policy_editor.verification_modal_heading')}
-          </Heading>
-        </div>
-      }
-    >
-      <div className={classes.content}>
-        <Paragraph size='small'>{text}</Paragraph>
-        <div className={classes.buttonWrapper}>
-          <div className={classes.closeButtonWrapper}>
-            <Button onClick={onClose} variant='tertiary' size='small'>
-              {closeButtonText}
-            </Button>
+    return (
+      <StudioModal
+        onClose={onClose}
+        ref={ref}
+        header={
+          <div className={classes.headingWrapper}>
+            <Heading size='xsmall' spacing level={1}>
+              {t('policy_editor.verification_modal_heading')}
+            </Heading>
           </div>
-          <Button onClick={onPerformAction} color='danger' size='small'>
-            {actionButtonText}
-          </Button>
-        </div>
-      </div>
-    </StudioModal>
-  );
-};
+        }
+        content={
+          <div className={classes.content}>
+            <Paragraph size='small'>{text}</Paragraph>
+            <div className={classes.buttonWrapper}>
+              <div className={classes.closeButtonWrapper}>
+                <Button onClick={onClose} variant='tertiary' size='small'>
+                  {closeButtonText}
+                </Button>
+              </div>
+              <Button onClick={onPerformAction} color='danger' size='small'>
+                {actionButtonText}
+              </Button>
+            </div>
+          </div>
+        }
+      />
+    );
+  },
+);
+
+VerificationModal.displayName = 'VerificationModal';

--- a/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import classes from './ImportResourceModal.module.css';
 import { Modal } from '../Modal';
 import { Button, Select } from '@digdir/design-system-react';
@@ -16,7 +16,6 @@ import { ServerCodes } from 'app-shared/enums/ServerCodes';
 const environmentOptions = ['AT21', 'AT22', 'AT23', 'AT24', 'TT02', 'PROD'];
 
 export type ImportResourceModalProps = {
-  isOpen: boolean;
   onClose: () => void;
 };
 
@@ -29,99 +28,96 @@ export type ImportResourceModalProps = {
  *    When the environment and service is selected, the button to start planning the
  *    importing will be available.
  *
- * @property {boolean}[isOpen] - Boolean for if the modal is open
  * @property {function}[onClose] - Function to handle close
  *
- * @returns {React.ReactNode} - The rendered component
+ * @returns {JSX.Element} - The rendered component
  */
-export const ImportResourceModal = ({
-  isOpen,
-  onClose,
-}: ImportResourceModalProps): React.ReactNode => {
-  const { t } = useTranslation();
+export const ImportResourceModal = forwardRef<HTMLDialogElement, ImportResourceModalProps>(
+  ({ onClose }, ref): JSX.Element => {
+    const { t } = useTranslation();
 
-  const { selectedContext } = useParams();
-  const repo = `${selectedContext}-resources`;
+    const { selectedContext } = useParams();
+    const repo = `${selectedContext}-resources`;
 
-  const navigate = useNavigate();
+    const navigate = useNavigate();
 
-  const [selectedEnv, setSelectedEnv] = useState<EnvironmentType>();
-  const [selectedService, setSelectedService] = useState<Altinn2LinkService>();
+    const [selectedEnv, setSelectedEnv] = useState<EnvironmentType>();
+    const [selectedService, setSelectedService] = useState<Altinn2LinkService>();
 
-  const [resourceIdExists, setResourceIdExists] = useState(false);
+    const [resourceIdExists, setResourceIdExists] = useState(false);
 
-  const { mutate: importResourceFromAltinn2Mutation } =
-    useImportResourceFromAltinn2Mutation(selectedContext);
+    const { mutate: importResourceFromAltinn2Mutation } =
+      useImportResourceFromAltinn2Mutation(selectedContext);
 
-  /**
-   * Reset fields on close
-   */
-  const handleClose = () => {
-    onClose();
-    setSelectedEnv(undefined);
-  };
+    const handleClose = () => {
+      onClose();
+      setSelectedEnv(undefined);
+    };
 
-  /**
-   * Import the resource from Altinn 2, and navigate to about page on success
-   */
-  const handleImportResource = () => {
-    importResourceFromAltinn2Mutation(
-      {
-        environment: selectedEnv,
-        serviceCode: selectedService.externalServiceCode,
-        serviceEdition: selectedService.externalServiceEditionCode,
-      },
-      {
-        onSuccess: (resource: Resource) => {
-          navigate(getResourcePageURL(selectedContext, repo, resource.identifier, 'about'));
+    /**
+     * Import the resource from Altinn 2, and navigate to about page on success
+     */
+    const handleImportResource = () => {
+      importResourceFromAltinn2Mutation(
+        {
+          environment: selectedEnv,
+          serviceCode: selectedService.externalServiceCode,
+          serviceEdition: selectedService.externalServiceEditionCode,
         },
-        onError: (error: AxiosError) => {
-          if (error.response.status === ServerCodes.Conflict) {
-            setResourceIdExists(true);
-          }
+        {
+          onSuccess: (resource: Resource) => {
+            navigate(getResourcePageURL(selectedContext, repo, resource.identifier, 'about'));
+          },
+          onError: (error: AxiosError) => {
+            if (error.response.status === ServerCodes.Conflict) {
+              setResourceIdExists(true);
+            }
+          },
         },
-      },
-    );
-  };
+      );
+    };
 
-  return (
-    <Modal
-      isOpen={isOpen}
-      onClose={handleClose}
-      title={t('resourceadm.dashboard_import_modal_title')}
-      contentClassName={classes.contentWidth}
-    >
-      <div className={classes.dropdownWraper}>
-        <Select
-          options={environmentOptions.map((e) => ({ value: e, label: e }))}
-          onChange={(e: EnvironmentType) => setSelectedEnv(e)}
-          value={selectedEnv}
-          label={t('resourceadm.dashboard_import_modal_select_env')}
-        />
-      </div>
-      {selectedEnv && (
-        <ServiceContent
-          selectedContext={selectedContext}
-          env={selectedEnv}
-          selectedService={selectedService}
-          onSelectService={(altinn2LinkService: Altinn2LinkService) =>
-            setSelectedService(altinn2LinkService)
-          }
-          resourceIdExists={resourceIdExists}
-        />
-      )}
-      <div className={classes.buttonWrapper}>
-        <Button onClick={handleClose} color='first' variant='tertiary' size='small'>
-          {t('general.cancel')}
-        </Button>
-        {selectedEnv && selectedService && (
-          <div className={classes.importButton}>
-            <Button onClick={handleImportResource} color='first' size='small'>
-              {t('resourceadm.dashboard_import_modal_import_button')}
-            </Button>
-          </div>
+    return (
+      <Modal
+        ref={ref}
+        onClose={handleClose}
+        title={t('resourceadm.dashboard_import_modal_title')}
+        contentClassName={classes.contentWidth}
+      >
+        <div className={classes.dropdownWraper}>
+          <Select
+            options={environmentOptions.map((e) => ({ value: e, label: e }))}
+            onChange={(e: EnvironmentType) => setSelectedEnv(e)}
+            value={selectedEnv}
+            label={t('resourceadm.dashboard_import_modal_select_env')}
+          />
+        </div>
+        {selectedEnv && (
+          <ServiceContent
+            selectedContext={selectedContext}
+            env={selectedEnv}
+            selectedService={selectedService}
+            onSelectService={(altinn2LinkService: Altinn2LinkService) =>
+              setSelectedService(altinn2LinkService)
+            }
+            resourceIdExists={resourceIdExists}
+          />
         )}
-      </div>
-    </Modal>
-  );
-};
+        <div className={classes.buttonWrapper}>
+          <Button onClick={handleClose} color='first' variant='tertiary' size='small'>
+            {t('general.cancel')}
+          </Button>
+          {selectedEnv && selectedService && (
+            <div className={classes.importButton}>
+              <Button onClick={handleImportResource} color='first' size='small'>
+                {t('resourceadm.dashboard_import_modal_import_button')}
+              </Button>
+            </div>
+          )}
+        </div>
+      </Modal>
+    );
+  },
+);
+
+ImportResourceModal.displayName = 'ImportResourceModal';

--- a/frontend/resourceadm/components/MergeConflictModal/MergeConflictModal.tsx
+++ b/frontend/resourceadm/components/MergeConflictModal/MergeConflictModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, forwardRef } from 'react';
 import classes from './MergeConflictModal.module.css';
 import { useTranslation } from 'react-i18next';
 import { Button, Link, Paragraph, Label } from '@digdir/design-system-react';
@@ -8,22 +8,8 @@ import { get } from 'app-shared/utils/networking';
 import { Modal } from '../Modal';
 
 type MergeConflictModalProps = {
-  /**
-   * Boolean for if the modal is open
-   */
-  isOpen: boolean;
-  /**
-   * Function to be executed when the merge is solved
-   * @returns void
-   */
   handleSolveMerge: () => void;
-  /**
-   * The name of the organisation
-   */
   org: string;
-  /**
-   * The name of the repo
-   */
   repo: string;
 };
 
@@ -31,59 +17,54 @@ type MergeConflictModalProps = {
  * @component
  *    Displays the modal telling the user that there is a merge conflict
  *
- * @property {boolean}[isOpen] - Boolean for if the modal is open
  * @property {function}[handleSolveMerge] - Function to be executed when the merge is solved
  * @property {string}[org] - The name of the organisation
  * @property {string}[repo] - The name of the repo
  *
- * @returns {React.ReactNode} - The rendered component
+ * @returns {JSX.Element} - The rendered component
  */
-export const MergeConflictModal = ({
-  isOpen,
-  handleSolveMerge,
-  org,
-  repo,
-}: MergeConflictModalProps): React.ReactNode => {
-  const { t } = useTranslation();
+export const MergeConflictModal = forwardRef<HTMLDialogElement, MergeConflictModalProps>(
+  ({ handleSolveMerge, org, repo }, ref): JSX.Element => {
+    const { t } = useTranslation();
 
-  const [resetModalOpen, setResetModalOpen] = useState(false);
+    const removeChangesModalRef = useRef<HTMLDialogElement>(null);
 
-  /**
-   * Function that resets the repo
-   */
-  const handleClickResetRepo = () => {
-    get(repoResetPath(org, repo));
-    handleSolveMerge();
-  };
+    const handleClickResetRepo = () => {
+      get(repoResetPath(org, repo));
+      handleSolveMerge();
+    };
 
-  return (
-    <Modal isOpen={isOpen} title={t('merge_conflict.headline')}>
-      <Paragraph size='small'>{t('merge_conflict.body1')}</Paragraph>
-      <Paragraph size='small'>{t('merge_conflict.body2')}</Paragraph>
-      <div className={classes.buttonWrapper}>
-        <div className={classes.downloadWrapper}>
-          <Label size='medium' spacing weight='medium'>
-            {t('merge_conflict.download')}
-          </Label>
-          <Link href={repoDownloadPath(org, repo)}>
-            {t('merge_conflict.download_edited_files')}
-          </Link>
-          <div className={classes.linkDivider}>
-            <Link href={repoDownloadPath(org, repo, true)}>
-              {t('merge_conflict.download_entire_repo')}
+    return (
+      <Modal ref={ref} title={t('merge_conflict.headline')}>
+        <Paragraph size='small'>{t('merge_conflict.body1')}</Paragraph>
+        <Paragraph size='small'>{t('merge_conflict.body2')}</Paragraph>
+        <div className={classes.buttonWrapper}>
+          <div className={classes.downloadWrapper}>
+            <Label size='medium' spacing weight='medium'>
+              {t('merge_conflict.download')}
+            </Label>
+            <Link href={repoDownloadPath(org, repo)}>
+              {t('merge_conflict.download_edited_files')}
             </Link>
+            <div className={classes.linkDivider}>
+              <Link href={repoDownloadPath(org, repo, true)}>
+                {t('merge_conflict.download_entire_repo')}
+              </Link>
+            </div>
           </div>
+          <Button onClick={() => removeChangesModalRef.current?.showModal()} size='small'>
+            {t('merge_conflict.remove_my_changes')}
+          </Button>
+          <RemoveChangesModal
+            ref={removeChangesModalRef}
+            onClose={() => removeChangesModalRef.current?.close()}
+            handleClickResetRepo={handleClickResetRepo}
+            repo={repo}
+          />
         </div>
-        <Button onClick={() => setResetModalOpen(true)} size='small'>
-          {t('merge_conflict.remove_my_changes')}
-        </Button>
-        <RemoveChangesModal
-          isOpen={resetModalOpen}
-          onClose={() => setResetModalOpen(false)}
-          handleClickResetRepo={handleClickResetRepo}
-          repo={repo}
-        />
-      </div>
-    </Modal>
-  );
-};
+      </Modal>
+    );
+  },
+);
+
+MergeConflictModal.displayName = 'MergeConflictModal';

--- a/frontend/resourceadm/components/MergeConflictModal/RemoveChangesModal/RemoveChangesModal.tsx
+++ b/frontend/resourceadm/components/MergeConflictModal/RemoveChangesModal/RemoveChangesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Textfield, Paragraph } from '@digdir/design-system-react';
 import classes from './RemoveChangesModal.module.css';
@@ -7,23 +7,8 @@ import { ScreenReaderSpan } from 'resourceadm/components/ScreenReaderSpan';
 import { Trans } from 'react-i18next';
 
 type RemoveChangesModalProps = {
-  /**
-   * Boolean for if the modal is open
-   */
-  isOpen: boolean;
-  /**
-   * Function to handle close
-   * @returns void
-   */
   onClose: () => void;
-  /**
-   * Function to be executed when the reset repo is clicked
-   * @returns void
-   */
   handleClickResetRepo: () => void;
-  /**
-   * The name of the repo
-   */
   repo: string;
 };
 
@@ -31,74 +16,66 @@ type RemoveChangesModalProps = {
  * @Component
  *    Content to be displayed inside the modal where the user removes their changes in a merge conflict
  *
- * @property {boolean}[isOpen] - Boolean for if the modal is open
  * @property {function}[onClose] - Function to handle close
  * @property {function}[handleClickResetRepo] - Function to be executed when the reset repo is clicked
  * @property {string}[repo] - The name of the repo
  *
- * @returns {React.ReactNode} - The rendered component
+ * @returns {JSX.Element} - The rendered component
  */
-export const RemoveChangesModal = ({
-  isOpen,
-  onClose,
-  handleClickResetRepo,
-  repo,
-}: RemoveChangesModalProps): React.ReactNode => {
-  const { t } = useTranslation();
+export const RemoveChangesModal = forwardRef<HTMLDialogElement, RemoveChangesModalProps>(
+  ({ onClose, handleClickResetRepo, repo }, ref): JSX.Element => {
+    const { t } = useTranslation();
 
-  const [deleteRepoName, setDeleteRepoName] = useState('');
+    const [deleteRepoName, setDeleteRepoName] = useState('');
 
-  /**
-   * Handles the closing of the modal
-   */
-  const handleClose = () => {
-    setDeleteRepoName('');
-    onClose();
-  };
+    const handleClose = () => {
+      setDeleteRepoName('');
+      onClose();
+    };
 
-  /**
-   * Handles the deletion of the changes
-   */
-  const handleDelete = () => {
-    handleClose();
-    handleClickResetRepo();
-  };
+    const handleDelete = () => {
+      handleClose();
+      handleClickResetRepo();
+    };
 
-  return (
-    <Modal isOpen={isOpen} onClose={onClose} title={t('administration.reset_repo_confirm_heading')}>
-      <Paragraph size='small'>
-        <Trans
-          i18nKey={'administration.reset_repo_confirm_info'}
-          values={{ repositoryName: repo }}
-          components={{ bold: <strong /> }}
-        />
-      </Paragraph>
-      <div className={classes.textFieldWrapper}>
-        <Textfield
-          label={t('resourceadm.reset_repo_confirm_repo_name')}
-          value={deleteRepoName}
-          onChange={(e) => setDeleteRepoName(e.target.value)}
-          aria-labelledby='delete-changes'
-        />
-        <ScreenReaderSpan
-          id='delete-changes'
-          label={t('resourceadm.reset_repo_confirm_repo_name')}
-        />
-      </div>
-      <div className={classes.buttonWrapper}>
-        <Button
-          color='danger'
-          aria-disabled={repo !== deleteRepoName}
-          onClick={repo === deleteRepoName && handleDelete}
-          variant='secondary'
-          size='small'
-        >
-          {t('administration.reset_repo_button')}
-        </Button>
-        <Button color='second' onClick={handleClose} variant='secondary' size='small'>
-          {t('general.cancel')}
-        </Button>
-      </div>
-    </Modal>
-  );
-};
+    return (
+      <Modal ref={ref} onClose={onClose} title={t('administration.reset_repo_confirm_heading')}>
+        <Paragraph size='small'>
+          <Trans
+            i18nKey={'administration.reset_repo_confirm_info'}
+            values={{ repositoryName: repo }}
+            components={{ bold: <strong /> }}
+          />
+        </Paragraph>
+        <div className={classes.textFieldWrapper}>
+          <Textfield
+            label={t('resourceadm.reset_repo_confirm_repo_name')}
+            value={deleteRepoName}
+            onChange={(e) => setDeleteRepoName(e.target.value)}
+            aria-labelledby='delete-changes'
+          />
+          <ScreenReaderSpan
+            id='delete-changes'
+            label={t('resourceadm.reset_repo_confirm_repo_name')}
+          />
+        </div>
+        <div className={classes.buttonWrapper}>
+          <Button
+            color='danger'
+            aria-disabled={repo !== deleteRepoName}
+            onClick={repo === deleteRepoName && handleDelete}
+            variant='secondary'
+            size='small'
+          >
+            {t('administration.reset_repo_button')}
+          </Button>
+          <Button color='second' onClick={handleClose} variant='secondary' size='small'>
+            {t('general.cancel')}
+          </Button>
+        </div>
+      </Modal>
+    );
+  },
+);
+
+RemoveChangesModal.displayName = 'RemoveChangesModal';

--- a/frontend/resourceadm/components/Modal/Modal.tsx
+++ b/frontend/resourceadm/components/Modal/Modal.tsx
@@ -1,11 +1,10 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, forwardRef } from 'react';
 import classes from './Modal.module.css';
 import cn from 'classnames';
 import { Heading } from '@digdir/design-system-react';
 import { StudioModal } from '@studio/components';
 
 type ModalProps = {
-  isOpen: boolean;
   title: string;
   onClose?: () => void;
   children: ReactNode;
@@ -17,11 +16,10 @@ type ModalProps = {
  *    Modal component implementing the react-modal.
  *
  * @example
- *    <Modal isOpen={isOpen} onClose={handleClose} title='Some title'>
+ *    <Modal ref={ref} onClose={handleClose} title='Some title'>
  *      <div>...</div>
  *    </Modal>
  *
- * @property {boolean}[isOpen] - Boolean for if the modal is open
  * @property {string}[title] - Title to be displayed in the modal
  * @property {function}[onClose] - Function to handle close of the modal
  * @property {ReactNode}[children] - React components inside the Modal
@@ -29,26 +27,23 @@ type ModalProps = {
  *
  * @returns {React.ReactNode} - The rendered component
  */
-export const Modal = ({
-  isOpen,
-  title,
-  onClose,
-  children,
-  contentClassName,
-}: ModalProps): React.ReactNode => {
-  return (
-    <StudioModal
-      isOpen={isOpen}
-      onClose={onClose}
-      title={
-        <div className={classes.headingWrapper}>
-          <Heading size='xsmall' spacing level={1}>
-            {title}
-          </Heading>
-        </div>
-      }
-    >
-      <div className={cn(classes.content, contentClassName)}>{children}</div>
-    </StudioModal>
-  );
-};
+export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
+  ({ title, onClose, children, contentClassName }, ref): React.ReactNode => {
+    return (
+      <StudioModal
+        ref={ref}
+        onClose={onClose}
+        header={
+          <div className={classes.headingWrapper}>
+            <Heading size='xsmall' spacing level={1}>
+              {title}
+            </Heading>
+          </div>
+        }
+        content={<div className={cn(classes.content, contentClassName)}>{children}</div>}
+      />
+    );
+  },
+);
+
+Modal.displayName = 'Modal';

--- a/frontend/resourceadm/components/NavigationModal/NavigationModal.test.tsx
+++ b/frontend/resourceadm/components/NavigationModal/NavigationModal.test.tsx
@@ -1,32 +1,37 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NavigationModal, NavigationModalProps } from './NavigationModal';
 import { textMock } from '../../../testing/mocks/i18nMock';
 import { act } from 'react-dom/test-utils';
 
-describe('NavigationModal', () => {
-  const mockOnClose = jest.fn();
-  const mockOnNavigate = jest.fn();
+const mockButtonText: string = 'Mock Button';
 
-  const defaultProps: NavigationModalProps = {
-    isOpen: true,
-    onClose: mockOnClose,
-    onNavigate: mockOnNavigate,
-    title: textMock('resourceadm.resource_navigation_modal_title_policy'),
-  };
+const mockOnClose = jest.fn();
+const mockOnNavigate = jest.fn();
+
+const defaultProps: NavigationModalProps = {
+  onClose: mockOnClose,
+  onNavigate: mockOnNavigate,
+  title: textMock('resourceadm.resource_navigation_modal_title_policy'),
+};
+
+describe('NavigationModal', () => {
+  afterEach(jest.clearAllMocks);
 
   it('should be closed by default', () => {
-    render(<NavigationModal isOpen={false} onClose={() => {}} onNavigate={mockOnNavigate} title='tit' />);
+    render(<TestComponentWithButton />);
     const closeButton = screen.queryByRole('button', { name: textMock('general.cancel') });
     expect(closeButton).not.toBeInTheDocument();
   });
 
   it('calls onClose function when close button is clicked', async () => {
     const user = userEvent.setup();
-    render(<NavigationModal {...defaultProps} />);
+    await renderAndOpenModal();
 
-    const closeButton = screen.getByRole('button', { name: textMock('resourceadm.resource_navigation_modal_button_stay') });
+    const closeButton = screen.getByRole('button', {
+      name: textMock('resourceadm.resource_navigation_modal_button_stay'),
+    });
     await act(() => user.click(closeButton));
 
     expect(mockOnClose).toHaveBeenCalled();
@@ -34,16 +39,32 @@ describe('NavigationModal', () => {
 
   it('calls onNavigate function when navigate button is clicked', async () => {
     const user = userEvent.setup();
-    render(<NavigationModal {...defaultProps} />);
+    await renderAndOpenModal();
 
-    const navigateButton = screen.getByRole('button', { name: textMock('resourceadm.resource_navigation_modal_button_move_on') });
+    const navigateButton = screen.getByRole('button', {
+      name: textMock('resourceadm.resource_navigation_modal_button_move_on'),
+    });
     await act(() => user.click(navigateButton));
 
     expect(mockOnNavigate).toHaveBeenCalled();
   });
 });
 
+const renderAndOpenModal = async (props: Partial<NavigationModalProps> = {}) => {
+  const user = userEvent.setup();
+  render(<TestComponentWithButton {...props} />);
 
+  const openModalButton = screen.getByRole('button', { name: mockButtonText });
+  await act(() => user.click(openModalButton));
+};
 
+const TestComponentWithButton = (props: Partial<NavigationModalProps> = {}) => {
+  const modalRef = useRef<HTMLDialogElement>(null);
 
-
+  return (
+    <>
+      <button onClick={() => modalRef.current?.showModal()}>{mockButtonText}</button>
+      <NavigationModal ref={modalRef} {...defaultProps} {...props} />
+    </>
+  );
+};

--- a/frontend/resourceadm/components/NavigationModal/NavigationModal.tsx
+++ b/frontend/resourceadm/components/NavigationModal/NavigationModal.tsx
@@ -1,27 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import classes from './NavigationModal.module.css';
 import { Button, Paragraph } from '@digdir/design-system-react';
 import { Modal } from '../Modal';
 import { useTranslation } from 'react-i18next';
 
 export type NavigationModalProps = {
-  /**
-   * Boolean for if the modal is open
-   */
-  isOpen: boolean;
-  /**
-   * Function to handle close
-   * @returns void
-   */
   onClose: () => void;
-  /**
-   * Function to be executed when navigating
-   * @returns void
-   */
   onNavigate: () => void;
-  /**
-   * The title in the modal
-   */
   title: string;
 };
 
@@ -29,36 +14,34 @@ export type NavigationModalProps = {
  * @component
  *    Displays the modal telling the user that there is a merge conflict
  *
- * @property {boolean}[isOpen] - Boolean for if the modal is open
  * @property {function}[onClose] - Function to handle close
  * @property {function}[onNavigate] - Function to be executed when navigating
  * @property {string}[title] - The title in the modal
  *
- * @returns {React.ReactNode} - The rendered component
+ * @returns {JSX.Element} - The rendered component
  */
-export const NavigationModal = ({
-  isOpen,
-  onClose,
-  onNavigate,
-  title,
-}: NavigationModalProps): React.ReactNode => {
-  const { t } = useTranslation();
+export const NavigationModal = forwardRef<HTMLDialogElement, NavigationModalProps>(
+  ({ onClose, onNavigate, title }, ref): JSX.Element => {
+    const { t } = useTranslation();
 
-  return (
-    <Modal isOpen={isOpen} onClose={onClose} title={title}>
-      <Paragraph size='small' className={classes.text}>
-        {t('resourceadm.resource_navigation_modal_text')}
-      </Paragraph>
-      <div className={classes.buttonWrapper}>
-        <div className={classes.closeButton}>
-          <Button onClick={onClose} color='first' variant='tertiary' size='small'>
-            {t('resourceadm.resource_navigation_modal_button_stay')}
+    return (
+      <Modal ref={ref} onClose={onClose} title={title}>
+        <Paragraph size='small' className={classes.text}>
+          {t('resourceadm.resource_navigation_modal_text')}
+        </Paragraph>
+        <div className={classes.buttonWrapper}>
+          <div className={classes.closeButton}>
+            <Button onClick={onClose} color='first' variant='tertiary' size='small'>
+              {t('resourceadm.resource_navigation_modal_button_stay')}
+            </Button>
+          </div>
+          <Button onClick={onNavigate} color='first' size='small'>
+            {t('resourceadm.resource_navigation_modal_button_move_on')}
           </Button>
         </div>
-        <Button onClick={onNavigate} color='first' size='small'>
-          {t('resourceadm.resource_navigation_modal_button_move_on')}
-        </Button>
-      </div>
-    </Modal>
-  );
-};
+      </Modal>
+    );
+  },
+);
+
+NavigationModal.displayName = 'NavigationModal';

--- a/frontend/resourceadm/components/NewResourceModal/NewResourceModal.test.tsx
+++ b/frontend/resourceadm/components/NewResourceModal/NewResourceModal.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NewResourceModal, NewResourceModalProps } from './NewResourceModal';
@@ -9,23 +9,26 @@ import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 
-describe('NewResourceModal', () => {
-  const mockOnClose = jest.fn();
+const mockButtonText: string = 'Mock Button';
 
-  const defaultProps: NewResourceModalProps = {
-    isOpen: true,
-    onClose: mockOnClose,
-  };
+const mockOnClose = jest.fn();
+
+const defaultProps: NewResourceModalProps = {
+  onClose: mockOnClose,
+};
+
+describe('NewResourceModal', () => {
+  afterEach(jest.clearAllMocks);
 
   it('should be closed by default', () => {
-    render({ isOpen: false, onClose: () => {} });
+    render();
     const closeButton = screen.queryByRole('button', { name: textMock('general.cancel') });
     expect(closeButton).not.toBeInTheDocument();
   });
 
   it('calls onClose function when close button is clicked', async () => {
     const user = userEvent.setup();
-    render(defaultProps);
+    await renderAndOpenModal();
 
     const closeButton = screen.getByRole('button', { name: textMock('general.cancel') });
     await act(() => user.click(closeButton));
@@ -33,31 +36,56 @@ describe('NewResourceModal', () => {
     expect(mockOnClose).toHaveBeenCalled();
   });
 
-  test('that create button should be disabled until the form is valid', () => {
-    render(defaultProps);
+  test('that create button should be disabled until the form is valid', async () => {
+    await renderAndOpenModal();
 
-    const createButton = screen.getByRole('button', { name: textMock('resourceadm.dashboard_create_modal_create_button') });
+    const createButton = screen.getByRole('button', {
+      name: textMock('resourceadm.dashboard_create_modal_create_button'),
+    });
     expect(createButton).toHaveAttribute('aria-disabled', 'true');
   });
 
   test('that create button should be enabled when the form is valid', async () => {
     const user = userEvent.setup();
-    render(defaultProps);
+    await renderAndOpenModal();
 
-    const titleInput = screen.getByLabelText(textMock('resourceadm.dashboard_resource_name_and_id_resource_name'))
-    await act(() => user.type(titleInput, 'test'))
+    const titleInput = screen.getByLabelText(
+      textMock('resourceadm.dashboard_resource_name_and_id_resource_name'),
+    );
+    await act(() => user.type(titleInput, 'test'));
 
-    const createButton = screen.getByRole('button', { name: textMock('resourceadm.dashboard_create_modal_create_button') });
+    const createButton = screen.getByRole('button', {
+      name: textMock('resourceadm.dashboard_create_modal_create_button'),
+    });
     expect(createButton).toHaveAttribute('aria-disabled', 'false');
   });
 });
 
-const render = (props: NewResourceModalProps) => {
+const render = (props: Partial<NewResourceModalProps> = {}) => {
   return rtlRender(
     <MemoryRouter>
       <ServicesContextProvider {...queriesMock} client={createQueryClientMock()}>
-        <NewResourceModal {...props} />
+        <TestComponentWithButton {...defaultProps} {...props} />
       </ServicesContextProvider>
-    </MemoryRouter>
-  )
-}
+    </MemoryRouter>,
+  );
+};
+
+const renderAndOpenModal = async (props: Partial<NewResourceModalProps> = {}) => {
+  const user = userEvent.setup();
+  render(props);
+
+  const openModalButton = screen.getByRole('button', { name: mockButtonText });
+  await act(() => user.click(openModalButton));
+};
+
+const TestComponentWithButton = (props: Partial<NewResourceModalProps> = {}) => {
+  const modalRef = useRef<HTMLDialogElement>(null);
+
+  return (
+    <>
+      <button onClick={() => modalRef.current?.showModal()}>{mockButtonText}</button>
+      <NewResourceModal ref={modalRef} {...defaultProps} {...props} />
+    </>
+  );
+};

--- a/frontend/resourceadm/components/NewResourceModal/NewResourceModal.tsx
+++ b/frontend/resourceadm/components/NewResourceModal/NewResourceModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import classes from './NewResourceModal.module.css';
 import { Button } from '@digdir/design-system-react';
 import { Modal } from '../Modal';
@@ -12,7 +12,6 @@ import { replaceWhiteSpaceWithHyphens } from 'resourceadm/utils/stringUtils';
 import { ServerCodes } from 'app-shared/enums/ServerCodes';
 
 export type NewResourceModalProps = {
-  isOpen: boolean;
   onClose: () => void;
 };
 
@@ -20,145 +19,148 @@ export type NewResourceModalProps = {
  * @component
  *    Displays the modal telling the user that there is a merge conflict
  *
- * @property {boolean}[isOpen] - Boolean for if the modal is open
  * @property {function}[onClose] - Function to handle close
  *
- * @returns {React.ReactNode} - The rendered component
+ * @returns {JSX.Element} - The rendered component
  */
-export const NewResourceModal = ({ isOpen, onClose }: NewResourceModalProps): React.ReactNode => {
-  const { t } = useTranslation();
+export const NewResourceModal = forwardRef<HTMLDialogElement, NewResourceModalProps>(
+  ({ onClose }, ref): JSX.Element => {
+    const { t } = useTranslation();
 
-  const navigate = useNavigate();
+    const navigate = useNavigate();
 
-  const { selectedContext } = useParams();
-  const repo = `${selectedContext}-resources`;
+    const { selectedContext } = useParams();
+    const repo = `${selectedContext}-resources`;
 
-  const [id, setId] = useState('');
-  const [title, setTitle] = useState('');
-  const [editIdFieldOpen, setEditIdFieldOpen] = useState(false);
-  const [resourceIdExists, setResourceIdExists] = useState(false);
-  const [bothFieldsHaveSameValue, setBothFieldsHaveSameValue] = useState(true);
+    const [id, setId] = useState('');
+    const [title, setTitle] = useState('');
+    const [editIdFieldOpen, setEditIdFieldOpen] = useState(false);
+    const [resourceIdExists, setResourceIdExists] = useState(false);
+    const [bothFieldsHaveSameValue, setBothFieldsHaveSameValue] = useState(true);
 
-  // Mutation function to create new resource
-  const { mutate: createNewResource } = useCreateResourceMutation(selectedContext);
+    // Mutation function to create new resource
+    const { mutate: createNewResource } = useCreateResourceMutation(selectedContext);
 
-  /**
-   * Creates a new resource in backend, and navigates if success
-   */
-  const handleCreateNewResource = () => {
-    const idAndTitle: NewResource = {
-      identifier: id,
-      title: {
-        nb: title,
-        nn: '',
-        en: '',
-      },
+    /**
+     * Creates a new resource in backend, and navigates if success
+     */
+    const handleCreateNewResource = () => {
+      const idAndTitle: NewResource = {
+        identifier: id,
+        title: {
+          nb: title,
+          nn: '',
+          en: '',
+        },
+      };
+
+      createNewResource(idAndTitle, {
+        onSuccess: () =>
+          navigate(getResourcePageURL(selectedContext, repo, idAndTitle.identifier, 'about')),
+        onError: (error: any) => {
+          if (error.response.status === ServerCodes.Conflict) {
+            setResourceIdExists(true);
+            setEditIdFieldOpen(true);
+          }
+        },
+      });
     };
 
-    createNewResource(idAndTitle, {
-      onSuccess: () =>
-        navigate(getResourcePageURL(selectedContext, repo, idAndTitle.identifier, 'about')),
-      onError: (error: any) => {
-        if (error.response.status === ServerCodes.Conflict) {
-          setResourceIdExists(true);
-          setEditIdFieldOpen(true);
-        }
-      },
-    });
-  };
-
-  /**
-   * Replaces the spaces in the value typed with '-'.
-   */
-  const handleIDInput = (val: string) => {
-    setId(replaceWhiteSpaceWithHyphens(val));
-    setResourceIdExists(false);
-  };
-
-  /**
-   * Updates the value of the title. If the edit field is not open,
-   * then it updates the ID to the same as the title.
-   *
-   * @param val the title value typed
-   */
-  const handleEditTitle = (val: string) => {
-    if (!editIdFieldOpen && bothFieldsHaveSameValue) {
+    /**
+     * Replaces the spaces in the value typed with '-'.
+     */
+    const handleIDInput = (val: string) => {
       setId(replaceWhiteSpaceWithHyphens(val));
-    }
-    setTitle(val);
-  };
+      setResourceIdExists(false);
+    };
 
-  /**
-   * Handles the click of the edit button. If we click the edit button
-   * so that it closes the edit field, the id is set to the title.
-   *
-   * @param isOpened the value of the button when it is pressed
-   * @param saveChanges if the save button is pressed, keep id and title separate
-   */
-  const handleClickEditButton = (isOpened: boolean, saveChanges: boolean) => {
-    setEditIdFieldOpen(isOpened);
-    if (saveChanges) {
-      setBothFieldsHaveSameValue(false);
-      return;
-    }
-    if (!isOpened) {
-      setBothFieldsHaveSameValue(true);
-      const shouldSetTitleToId = title !== id;
-      if (shouldSetTitleToId) {
-        setId(replaceWhiteSpaceWithHyphens(title));
+    /**
+     * Updates the value of the title. If the edit field is not open,
+     * then it updates the ID to the same as the title.
+     *
+     * @param val the title value typed
+     */
+    const handleEditTitle = (val: string) => {
+      if (!editIdFieldOpen && bothFieldsHaveSameValue) {
+        setId(replaceWhiteSpaceWithHyphens(val));
       }
-    }
-  };
+      setTitle(val);
+    };
 
-  /**
-   * Closes the modal and resets the fields
-   */
-  const handleClose = () => {
-    onClose();
-    setId('');
-    setTitle('');
-    setEditIdFieldOpen(false);
-    setResourceIdExists(false);
-  };
-
-  return (
-    <Modal
-      isOpen={isOpen}
-      onClose={handleClose}
-      title={t('resourceadm.dashboard_create_modal_title')}
-      contentClassName={classes.contentWidth}
-    >
-      <ResourceNameAndId
-        isEditOpen={editIdFieldOpen}
-        title={title}
-        text={t('resourceadm.dashboard_create_modal_resource_name_and_id_text')}
-        id={id}
-        handleEditTitle={handleEditTitle}
-        handleIdInput={handleIDInput}
-        handleClickEditButton={(saveChanges: boolean) =>
-          handleClickEditButton(!editIdFieldOpen, saveChanges)
+    /**
+     * Handles the click of the edit button. If we click the edit button
+     * so that it closes the edit field, the id is set to the title.
+     *
+     * @param isOpened the value of the button when it is pressed
+     * @param saveChanges if the save button is pressed, keep id and title separate
+     */
+    const handleClickEditButton = (isOpened: boolean, saveChanges: boolean) => {
+      setEditIdFieldOpen(isOpened);
+      if (saveChanges) {
+        setBothFieldsHaveSameValue(false);
+        return;
+      }
+      if (!isOpened) {
+        setBothFieldsHaveSameValue(true);
+        const shouldSetTitleToId = title !== id;
+        if (shouldSetTitleToId) {
+          setId(replaceWhiteSpaceWithHyphens(title));
         }
-        resourceIdExists={resourceIdExists}
-        bothFieldsHaveSameValue={bothFieldsHaveSameValue}
-        className={classes.resourceNameAndId}
-      />
-      <div className={classes.buttonWrapper}>
-        <div className={classes.closeButton}>
-          <Button onClick={onClose} color='first' variant='tertiary' size='small'>
-            {t('general.cancel')}
+      }
+    };
+
+    /**
+     * Closes the modal and resets the fields
+     */
+    const handleClose = () => {
+      onClose();
+      setId('');
+      setTitle('');
+      setEditIdFieldOpen(false);
+      setResourceIdExists(false);
+    };
+
+    return (
+      <Modal
+        ref={ref}
+        onClose={handleClose}
+        title={t('resourceadm.dashboard_create_modal_title')}
+        contentClassName={classes.contentWidth}
+      >
+        <ResourceNameAndId
+          isEditOpen={editIdFieldOpen}
+          title={title}
+          text={t('resourceadm.dashboard_create_modal_resource_name_and_id_text')}
+          id={id}
+          handleEditTitle={handleEditTitle}
+          handleIdInput={handleIDInput}
+          handleClickEditButton={(saveChanges: boolean) =>
+            handleClickEditButton(!editIdFieldOpen, saveChanges)
+          }
+          resourceIdExists={resourceIdExists}
+          bothFieldsHaveSameValue={bothFieldsHaveSameValue}
+          className={classes.resourceNameAndId}
+        />
+        <div className={classes.buttonWrapper}>
+          <div className={classes.closeButton}>
+            <Button onClick={onClose} color='first' variant='tertiary' size='small'>
+              {t('general.cancel')}
+            </Button>
+          </div>
+          <Button
+            onClick={() =>
+              !(id.length === 0 || title.length === 0) ? handleCreateNewResource() : undefined
+            }
+            color='first'
+            aria-disabled={id.length === 0 || title.length === 0}
+            size='small'
+          >
+            {t('resourceadm.dashboard_create_modal_create_button')}
           </Button>
         </div>
-        <Button
-          onClick={() =>
-            !(id.length === 0 || title.length === 0) ? handleCreateNewResource() : undefined
-          }
-          color='first'
-          aria-disabled={id.length === 0 || title.length === 0}
-          size='small'
-        >
-          {t('resourceadm.dashboard_create_modal_create_button')}
-        </Button>
-      </div>
-    </Modal>
-  );
-};
+      </Modal>
+    );
+  },
+);
+
+NewResourceModal.displayName = 'NewResourceModal';

--- a/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.tsx
+++ b/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import classes from './ResourceDashboardPage.module.css';
 import { Button, Spinner, Heading } from '@digdir/design-system-react';
@@ -33,8 +33,9 @@ export const ResourceDashboardPage = (): React.ReactNode => {
   const [searchValue, setSearchValue] = useState('');
   const [hasMergeConflict, setHasMergeConflict] = useState(false);
 
-  const [newResourceModalOpen, setNewResourceModalOpen] = useState(false);
-  const [importModalOpen, setImportModalOpen] = useState(false);
+  const importModalRef = useRef<HTMLDialogElement>(null);
+  const newResourceModalRef = useRef<HTMLDialogElement>(null);
+  const mergeConflictModalRef = useRef<HTMLDialogElement>(null);
 
   // Get metadata with queries
   const { data: repoStatus, refetch } = useRepoStatusQuery(selectedContext, repo);
@@ -52,6 +53,13 @@ export const ResourceDashboardPage = (): React.ReactNode => {
       setHasMergeConflict(repoStatus.hasMergeConflict);
     }
   }, [repoStatus]);
+
+  // Open the modal when there is a merge conflict
+  useEffect(() => {
+    if (hasMergeConflict && mergeConflictModalRef.current) {
+      mergeConflictModalRef.current.showModal();
+    }
+  }, [hasMergeConflict]);
 
   const filteredResourceList = filterTableData(searchValue, resourceListData ?? []);
 
@@ -103,7 +111,7 @@ export const ResourceDashboardPage = (): React.ReactNode => {
             color='second'
             icon={<MigrationIcon />}
             iconPlacement='right'
-            onClick={() => setImportModalOpen(true)}
+            onClick={() => importModalRef.current?.showModal()}
             size='medium'
           >
             <strong>{t('resourceadm.dashboard_import_resource')}</strong>
@@ -114,7 +122,7 @@ export const ResourceDashboardPage = (): React.ReactNode => {
             color='second'
             icon={<PlusCircleIcon />}
             iconPlacement='right'
-            onClick={() => setNewResourceModalOpen(true)}
+            onClick={() => newResourceModalRef.current?.showModal()}
             size='medium'
           >
             <strong>{t('resourceadm.dashboard_create_resource')}</strong>
@@ -123,19 +131,17 @@ export const ResourceDashboardPage = (): React.ReactNode => {
       </div>
       <div className={classes.horizontalDivider} />
       <div className={classes.componentWrapper}>{displayContent()}</div>
-      {hasMergeConflict && (
-        <MergeConflictModal
-          isOpen={hasMergeConflict}
-          handleSolveMerge={refetch}
-          org={selectedContext}
-          repo={repo}
-        />
-      )}
-      <NewResourceModal
-        isOpen={newResourceModalOpen}
-        onClose={() => setNewResourceModalOpen(false)}
+      <MergeConflictModal
+        ref={mergeConflictModalRef}
+        handleSolveMerge={refetch}
+        org={selectedContext}
+        repo={repo}
       />
-      <ImportResourceModal isOpen={importModalOpen} onClose={() => setImportModalOpen(false)} />
+      <NewResourceModal
+        ref={newResourceModalRef}
+        onClose={() => newResourceModalRef.current?.close()}
+      />
+      <ImportResourceModal ref={importModalRef} onClose={() => importModalRef.current?.close()} />
     </div>
   );
 };

--- a/frontend/testing/setupTests.ts
+++ b/frontend/testing/setupTests.ts
@@ -40,6 +40,14 @@ class ResizeObserver {
 }
 window.ResizeObserver = ResizeObserver;
 
+// Workaround for the known issue. For more info, see this: https://github.com/jsdom/jsdom/issues/3294#issuecomment-1268330372
+HTMLDialogElement.prototype.showModal = jest.fn(function mock(this: HTMLDialogElement) {
+  this.open = true;
+});
+HTMLDialogElement.prototype.close = jest.fn(function mock(this: HTMLDialogElement) {
+  this.open = false;
+});
+
 // I18next mocks. The useTranslation and Trans mocks apply the textMock function on the text key, so that it can be used to address the texts in the tests.
 jest.mock('i18next', () => ({ use: () => ({ init: jest.fn() }) }));
 jest.mock('react-i18next', () => ({


### PR DESCRIPTION
## Description
- Replacing ```react-modal``` with ```<Modal />``` from Designsystemet. 
- Fixing tests
- Changing logic from using state to using useRef to control if the modal is open/closed. 

## Related Issue(s)
- #11045 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)