### PR TITLE
Remove version override of log4j

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.PDF/pom.xml
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/pom.xml
@@ -8,7 +8,6 @@
   <properties>
     <build.source>17</build.source>
     <build.target>17</build.target>
-    <log4j2.version>2.17.2</log4j2.version>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
## Description
Removing a property override used to define the log4j library version. The value isn't detected by the version lens extension we use in vs code. This has lead to us being a bit behind in log4j version.

## Verification
- [x] **Your** code builds clean without any errors or warnings
