### PR TITLE
Revert 'refactoring studio modal to use designsystem modal (#11792)'

### DIFF
--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.module.css
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.module.css
@@ -12,6 +12,7 @@
 
 .leftNavigationBar {
   min-height: 200px;
+  border-bottom-left-radius: 20px;
 }
 
 .headingWrapper {
@@ -19,7 +20,6 @@
   align-items: center;
   padding-block: 10px;
   padding-inline: 20px;
-  border-bottom: 1px solid var(--fds-semantic-border-divider-default);
 }
 
 .headingWrapper > :first-child {

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.test.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.test.tsx
@@ -1,5 +1,10 @@
-import React, { useRef } from 'react';
-import { render as rtlRender, screen, act } from '@testing-library/react';
+import React from 'react';
+import {
+  render as rtlRender,
+  screen,
+  act,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SettingsModal, SettingsModalProps } from './SettingsModal';
 import { textMock } from '../../../../testing/mocks/i18nMock';
@@ -10,8 +15,6 @@ import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { AppConfig } from 'app-shared/types/AppConfig';
 import { useAppConfigMutation } from 'app-development/hooks/mutations';
 import { MemoryRouter } from 'react-router-dom';
-
-const mockButtonText: string = 'Mock Button';
 
 const mockApp: string = 'app';
 const mockOrg: string = 'org';
@@ -36,15 +39,8 @@ mockUpdateAppConfigMutation.mockReturnValue({
   mutate: updateAppConfigMutation,
 } as unknown as UseMutationResult<void, Error, AppConfig, unknown>);
 
-const mockOnClose = jest.fn();
-
-const defaultProps: SettingsModalProps = {
-  onClose: mockOnClose,
-  org: mockOrg,
-  app: mockApp,
-};
-
 describe('SettingsModal', () => {
+  const user = userEvent.setup();
   beforeEach(() => {
     global.console = {
       ...console,
@@ -56,8 +52,26 @@ describe('SettingsModal', () => {
     jest.clearAllMocks();
   });
 
+  const mockOnClose = jest.fn();
+
+  const defaultProps: SettingsModalProps = {
+    isOpen: true,
+    onClose: mockOnClose,
+    org: mockOrg,
+    app: mockApp,
+  };
+
+  it('closes the modal when the close button is clicked', async () => {
+    render(defaultProps);
+
+    const closeButton = screen.getByRole('button', { name: textMock('modal.close_icon') });
+    await act(() => user.click(closeButton));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
   it('displays left navigation bar when promises resolves', async () => {
-    await renderAndOpenModal();
+    await resolveAndWaitForSpinnerToDisappear();
 
     expect(
       screen.getByRole('tab', { name: textMock('settings_modal.left_nav_tab_about') }),
@@ -77,7 +91,7 @@ describe('SettingsModal', () => {
   });
 
   it('displays the about tab, and not the other tabs, when promises resolves first time', async () => {
-    await renderAndOpenModal();
+    await resolveAndWaitForSpinnerToDisappear();
 
     expect(screen.getByText(textMock('settings_modal.about_tab_heading'))).toBeInTheDocument();
     expect(
@@ -95,8 +109,7 @@ describe('SettingsModal', () => {
   });
 
   it('changes the tab from "about" to "policy" when policy tab is clicked', async () => {
-    const user = userEvent.setup();
-    await renderAndOpenModal();
+    await resolveAndWaitForSpinnerToDisappear();
 
     expect(
       screen.queryByRole('heading', {
@@ -123,8 +136,7 @@ describe('SettingsModal', () => {
   });
 
   it('changes the tab from "policy" to "about" when about tab is clicked', async () => {
-    const user = userEvent.setup();
-    await renderAndOpenModal();
+    await resolveAndWaitForSpinnerToDisappear();
 
     const policyTab = screen.getByRole('tab', {
       name: textMock('settings_modal.left_nav_tab_policy'),
@@ -145,9 +157,8 @@ describe('SettingsModal', () => {
     expect(screen.getByText(textMock('settings_modal.about_tab_heading'))).toBeInTheDocument();
   });
 
-  it('changes the tab from "about" to "localChanges" when local changes tab is clicked', async () => {
-    const user = userEvent.setup();
-    await renderAndOpenModal();
+  it.only('changes the tab from "about" to "localChanges" when local changes tab is clicked', async () => {
+    await resolveAndWaitForSpinnerToDisappear();
 
     expect(
       screen.queryByRole('heading', {
@@ -173,8 +184,7 @@ describe('SettingsModal', () => {
   });
 
   it('changes the tab from "about" to "accessControl" when access control tab is clicked', async () => {
-    const user = userEvent.setup();
-    await renderAndOpenModal();
+    await resolveAndWaitForSpinnerToDisappear();
 
     expect(
       screen.queryByRole('heading', {
@@ -201,8 +211,7 @@ describe('SettingsModal', () => {
   });
 
   it('changes the tab from "about" to "setup" when setup control tab is clicked', async () => {
-    const user = userEvent.setup();
-    await renderAndOpenModal();
+    await resolveAndWaitForSpinnerToDisappear();
 
     expect(
       screen.queryByRole('heading', {
@@ -227,10 +236,22 @@ describe('SettingsModal', () => {
       screen.queryByText(textMock('settings_modal.about_tab_heading')),
     ).not.toBeInTheDocument();
   });
+
+  /**
+   * Resolves the mocks, renders the component and waits for the spinner
+   * to be removed from the screen
+   */
+  const resolveAndWaitForSpinnerToDisappear = async () => {
+    render(defaultProps);
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTitle(textMock('settings_modal.loading_content')),
+    );
+  };
 });
 
 const render = (
-  props: Partial<SettingsModalProps> = {},
+  props: SettingsModalProps,
   queries: Partial<ServicesContextProps> = {},
   queryClient: QueryClient = createQueryClientMock(),
 ) => {
@@ -241,27 +262,8 @@ const render = (
   return rtlRender(
     <MemoryRouter>
       <ServicesContextProvider {...allQueries} client={queryClient}>
-        <TestComponentWithButton {...defaultProps} {...props} />
+        <SettingsModal {...props} />
       </ServicesContextProvider>
     </MemoryRouter>,
-  );
-};
-
-const renderAndOpenModal = async (props: Partial<SettingsModalProps> = {}) => {
-  const user = userEvent.setup();
-  render(props);
-
-  const openModalButton = screen.getByRole('button', { name: mockButtonText });
-  await act(() => user.click(openModalButton));
-};
-
-const TestComponentWithButton = (props: Partial<SettingsModalProps> = {}) => {
-  const modalRef = useRef<HTMLDialogElement>(null);
-
-  return (
-    <>
-      <button onClick={() => modalRef.current?.showModal()}>{mockButtonText}</button>
-      <SettingsModal ref={modalRef} {...defaultProps} {...props} />
-    </>
   );
 };

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import classes from './SettingsModal.module.css';
 import { Heading } from '@digdir/design-system-react';
 import {
@@ -22,6 +22,7 @@ import { AccessControlTab } from './components/Tabs/AccessControlTab';
 import { SetupTab } from './components/Tabs/SetupTab';
 
 export type SettingsModalProps = {
+  isOpen: boolean;
   onClose: () => void;
   org: string;
   app: string;
@@ -31,111 +32,118 @@ export type SettingsModalProps = {
  * @component
  *    Displays the settings modal.
  *
- * @property {function}[onClose] - Function to execute on close
+ * @property {boolean}[isOpen] - Flag for if the modal is open
+ * @property {function}[onClose] - Function to be executed on close
  * @property {string}[org] - The org
  * @property {string}[app] - The app
  *
- * @returns {JSX.Element} - The rendered component
+ * @returns {ReactNode} - The rendered component
  */
-export const SettingsModal = forwardRef<HTMLDialogElement, SettingsModalProps>(
-  ({ onClose, org, app }, ref): JSX.Element => {
-    const { t } = useTranslation();
+export const SettingsModal = ({ isOpen, onClose, org, app }: SettingsModalProps): ReactNode => {
+  const { t } = useTranslation();
 
-    const [currentTab, setCurrentTab] = useState<SettingsModalTab>('about');
+  const [currentTab, setCurrentTab] = useState<SettingsModalTab>('about');
 
-    /**
-     * Ids for the navigation tabs
-     */
-    const aboutTabId: SettingsModalTab = 'about';
-    const setupTabId: SettingsModalTab = 'setup';
-    const policyTabId: SettingsModalTab = 'policy';
-    const localChangesTabId: SettingsModalTab = 'localChanges';
-    const accessControlTabId: SettingsModalTab = 'accessControl';
+  /**
+   * Ids for the navigation tabs
+   */
+  const aboutTabId: SettingsModalTab = 'about';
+  const setupTabId: SettingsModalTab = 'setup';
+  const policyTabId: SettingsModalTab = 'policy';
+  const localChangesTabId: SettingsModalTab = 'localChanges';
+  const accessControlTabId: SettingsModalTab = 'accessControl';
 
-    const leftNavigationTabs: LeftNavigationTab[] = [
-      createNavigationTab(
-        <InformationSquareIcon className={classes.icon} />,
-        aboutTabId,
-        () => changeTabTo(aboutTabId),
-        currentTab,
-      ),
-      createNavigationTab(
-        <SidebarBothIcon className={classes.icon} />,
-        setupTabId,
-        () => changeTabTo(setupTabId),
-        currentTab,
-      ),
-      createNavigationTab(
-        <ShieldLockIcon className={classes.icon} />,
-        policyTabId,
-        () => changeTabTo(policyTabId),
-        currentTab,
-      ),
-      createNavigationTab(
-        <PersonSuitIcon className={classes.icon} />,
-        accessControlTabId,
-        () => changeTabTo(accessControlTabId),
-        currentTab,
-      ),
-      createNavigationTab(
-        <MonitorIcon className={classes.icon} />,
-        localChangesTabId,
-        () => changeTabTo(localChangesTabId),
-        currentTab,
-      ),
-    ];
+  /**
+   * The tabs to display in the navigation bar
+   */
+  const leftNavigationTabs: LeftNavigationTab[] = [
+    createNavigationTab(
+      <InformationSquareIcon className={classes.icon} />,
+      aboutTabId,
+      () => changeTabTo(aboutTabId),
+      currentTab,
+    ),
+    createNavigationTab(
+      <SidebarBothIcon className={classes.icon} />,
+      setupTabId,
+      () => changeTabTo(setupTabId),
+      currentTab,
+    ),
+    createNavigationTab(
+      <ShieldLockIcon className={classes.icon} />,
+      policyTabId,
+      () => changeTabTo(policyTabId),
+      currentTab,
+    ),
+    createNavigationTab(
+      <PersonSuitIcon className={classes.icon} />,
+      accessControlTabId,
+      () => changeTabTo(accessControlTabId),
+      currentTab,
+    ),
+    createNavigationTab(
+      <MonitorIcon className={classes.icon} />,
+      localChangesTabId,
+      () => changeTabTo(localChangesTabId),
+      currentTab,
+    ),
+  ];
 
-    const changeTabTo = (tabId: SettingsModalTab) => {
-      setCurrentTab(tabId);
-    };
+  /**
+   * Changes the active tab
+   * @param tabId
+   */
+  const changeTabTo = (tabId: SettingsModalTab) => {
+    setCurrentTab(tabId);
+  };
 
-    const displayTabs = () => {
-      switch (currentTab) {
-        case 'about': {
-          return <AboutTab org={org} app={app} />;
-        }
-        case 'setup': {
-          return <SetupTab org={org} app={app} />;
-        }
-        case 'policy': {
-          return <PolicyTab org={org} app={app} />;
-        }
-        case 'accessControl': {
-          return <AccessControlTab org={org} app={app} />;
-        }
-        case 'localChanges': {
-          return <LocalChangesTab org={org} app={app} />;
-        }
+  /**
+   * Displays the currently selected tab and its content
+   * @returns
+   */
+  const displayTabs = () => {
+    switch (currentTab) {
+      case 'about': {
+        return <AboutTab org={org} app={app} />;
       }
-    };
+      case 'setup': {
+        return <SetupTab org={org} app={app} />;
+      }
+      case 'policy': {
+        return <PolicyTab org={org} app={app} />;
+      }
+      case 'accessControl': {
+        return <AccessControlTab org={org} app={app} />;
+      }
+      case 'localChanges': {
+        return <LocalChangesTab org={org} app={app} />;
+      }
+    }
+  };
 
-    return (
-      <StudioModal
-        ref={ref}
-        onClose={onClose}
-        header={
-          <div className={classes.headingWrapper}>
-            <CogIcon className={classes.icon} />
-            <Heading level={1} size='medium'>
-              {t('settings_modal.heading')}
-            </Heading>
-          </div>
-        }
-        content={
-          <div className={classes.modalContent}>
-            <div className={classes.leftNavWrapper}>
-              <LeftNavigationBar
-                tabs={leftNavigationTabs}
-                className={classes.leftNavigationBar}
-                selectedTab={currentTab}
-              />
-            </div>
-            {displayTabs()}
-          </div>
-        }
-      />
-    );
-  },
-);
-
-SettingsModal.displayName = 'SettingsModal';
+  return (
+    <StudioModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={
+        <div className={classes.headingWrapper}>
+          <CogIcon className={classes.icon} />
+          <Heading level={1} size='medium'>
+            {t('settings_modal.heading')}
+          </Heading>
+        </div>
+      }
+    >
+      <div className={classes.modalContent}>
+        <div className={classes.leftNavWrapper}>
+          <LeftNavigationBar
+            tabs={leftNavigationTabs}
+            className={classes.leftNavigationBar}
+            selectedTab={currentTab}
+          />
+        </div>
+        {displayTabs()}
+      </div>
+    </StudioModal>
+  );
+};

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/LocalChangesTab/DeleteModal/DeleteModal.test.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/LocalChangesTab/DeleteModal/DeleteModal.test.tsx
@@ -1,37 +1,35 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import { DeleteModal, DeleteModalProps } from './DeleteModal';
 import { textMock } from '../../../../../../../../testing/mocks/i18nMock';
 import userEvent from '@testing-library/user-event';
 
 const mockAppName: string = 'TestApp';
-const mockButtonText: string = 'Mock Button';
-
-const mockOnClose = jest.fn();
-const mockOnDelete = jest.fn();
-
-const defaultProps: DeleteModalProps = {
-  onClose: mockOnClose,
-  onDelete: mockOnDelete,
-  appName: mockAppName,
-};
 
 describe('DeleteModal', () => {
+  const user = userEvent.setup();
   afterEach(jest.clearAllMocks);
 
+  const mockOnClose = jest.fn();
+  const mockOnDelete = jest.fn();
+
+  const defaultProps: DeleteModalProps = {
+    isOpen: true,
+    onClose: mockOnClose,
+    onDelete: mockOnDelete,
+    appName: mockAppName,
+  };
+
   it('calls the onClose function when the Cancel button is clicked', async () => {
-    const user = userEvent.setup();
-    await renderAndOpenModal();
+    render(<DeleteModal {...defaultProps} />);
 
     const cancelButton = screen.getByRole('button', { name: textMock('general.cancel') });
     await act(() => user.click(cancelButton));
-
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
   it('updates the value of the text field when typing', async () => {
-    const user = userEvent.setup();
-    await renderAndOpenModal();
+    render(<DeleteModal {...defaultProps} />);
 
     const textfield = screen.getByLabelText(
       textMock('settings_modal.local_changes_tab_delete_modal_textfield_label'),
@@ -47,8 +45,7 @@ describe('DeleteModal', () => {
   });
 
   it('calls the onDelete function when the Delete button is clicked with a matching app name', async () => {
-    const user = userEvent.setup();
-    await renderAndOpenModal();
+    render(<DeleteModal {...defaultProps} />);
 
     const deleteButton = screen.getByRole('button', {
       name: textMock('settings_modal.local_changes_tab_delete_modal_delete_button'),
@@ -69,22 +66,3 @@ describe('DeleteModal', () => {
     expect(mockOnDelete).toHaveBeenCalledTimes(1);
   });
 });
-
-const renderAndOpenModal = async (props: Partial<DeleteModalProps> = {}) => {
-  const user = userEvent.setup();
-  render(<TestComponentWithButton {...props} />);
-
-  const openModalButton = screen.getByRole('button', { name: mockButtonText });
-  await act(() => user.click(openModalButton));
-};
-
-const TestComponentWithButton = (props: Partial<DeleteModalProps> = {}) => {
-  const modalRef = useRef<HTMLDialogElement>(null);
-
-  return (
-    <>
-      <button onClick={() => modalRef.current?.showModal()}>{mockButtonText}</button>
-      <DeleteModal ref={modalRef} {...defaultProps} {...props} />
-    </>
-  );
-};

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/LocalChangesTab/DeleteModal/DeleteModal.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/LocalChangesTab/DeleteModal/DeleteModal.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import classes from './DeleteModal.module.css';
 import { useTranslation } from 'react-i18next';
 import { StudioModal } from '@studio/components';
@@ -6,6 +6,7 @@ import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Heading, Paragraph, Textfield } from '@digdir/design-system-react';
 
 export type DeleteModalProps = {
+  isOpen: boolean;
   onClose: () => void;
   onDelete: () => void;
   appName: string;
@@ -16,70 +17,71 @@ export type DeleteModalProps = {
  *    Displays a Warning modal to the user to ensure they really want to
  *    do an action.
  *
+ * @property {boolean}[isOpen] - If the modal is open or not
  * @property {function}[onClose] - Function to execute on close
  * @property {function}[onDelete] - Function to execute on click delete
  * @property {string}[appName] - The name of the app to delete changes on
  *
- * @returns {JSX.Element} - The rendered component
+ * @returns {ReactNode} - The rendered component
  */
-export const DeleteModal = forwardRef<HTMLDialogElement, DeleteModalProps>(
-  ({ onClose, onDelete, appName }, ref): JSX.Element => {
-    const { t } = useTranslation();
+export const DeleteModal = ({
+  isOpen,
+  onClose,
+  onDelete,
+  appName,
+}: DeleteModalProps): ReactNode => {
+  const { t } = useTranslation();
 
-    const [nameToDelete, setNameToDelete] = useState('');
+  const [nameToDelete, setNameToDelete] = useState('');
 
-    const handleClose = () => {
-      setNameToDelete('');
-      onClose();
-    };
+  const handleClose = () => {
+    setNameToDelete('');
+    onClose();
+  };
 
-    const handleDelete = () => {
-      setNameToDelete('');
-      onDelete();
-    };
+  const handleDelete = () => {
+    setNameToDelete('');
+    onDelete();
+  };
 
-    return (
-      <StudioModal
-        ref={ref}
-        onClose={handleClose}
-        header={
-          <div className={classes.titleWrapper}>
-            <TrashIcon className={classes.modalIcon} />
-            <Heading level={1} size='xsmall'>
-              {t('settings_modal.local_changes_tab_delete_modal_title')}
-            </Heading>
-          </div>
-        }
-        content={
-          <div className={classes.contentWrapper}>
-            <Paragraph size='small' spacing>
-              {t('settings_modal.local_changes_tab_delete_modal_text')}
-            </Paragraph>
-            <Textfield
-              label={t('settings_modal.local_changes_tab_delete_modal_textfield_label')}
-              size='small'
-              value={nameToDelete}
-              onChange={(e) => setNameToDelete(e.target.value)}
-            />
-            <div className={classes.buttonWrapper}>
-              <Button
-                variant='secondary'
-                color='danger'
-                onClick={handleDelete}
-                disabled={appName !== nameToDelete}
-                size='small'
-              >
-                {t('settings_modal.local_changes_tab_delete_modal_delete_button')}
-              </Button>
-              <Button variant='secondary' onClick={handleClose} size='small'>
-                {t('general.cancel')}
-              </Button>
-            </div>
-          </div>
-        }
-      />
-    );
-  },
-);
-
-DeleteModal.displayName = 'DeleteModal';
+  return (
+    <StudioModal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={
+        <div className={classes.titleWrapper}>
+          <TrashIcon className={classes.modalIcon} />
+          <Heading level={1} size='xsmall'>
+            {t('settings_modal.local_changes_tab_delete_modal_title')}
+          </Heading>
+        </div>
+      }
+    >
+      <div className={classes.contentWrapper}>
+        <Paragraph size='small' spacing>
+          {t('settings_modal.local_changes_tab_delete_modal_text')}
+        </Paragraph>
+        <Textfield
+          label={t('settings_modal.local_changes_tab_delete_modal_textfield_label')}
+          size='small'
+          value={nameToDelete}
+          onChange={(e) => setNameToDelete(e.target.value)}
+        />
+        <div className={classes.buttonWrapper}>
+          <Button
+            variant='secondary'
+            color='danger'
+            onClick={handleDelete}
+            disabled={appName !== nameToDelete}
+            size='small'
+          >
+            {t('settings_modal.local_changes_tab_delete_modal_delete_button')}
+          </Button>
+          <Button variant='secondary' onClick={handleClose} size='small'>
+            {t('general.cancel')}
+          </Button>
+        </div>
+      </div>
+    </StudioModal>
+  );
+};

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/LocalChangesTab/LocalChangesTab.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/LocalChangesTab/LocalChangesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { ReactNode, useState } from 'react';
 import classes from './LocalChangesTab.module.css';
 import { useTranslation } from 'react-i18next';
 import { TabHeader } from '../../TabHeader';
@@ -23,25 +23,23 @@ export type LocalChangesTabProps = {
  * @property {string}[org] - The org
  * @property {string}[app] - The app
  *
- * @returns {JSX.Element} - The rendered component
+ * @returns {ReactNode} - The rendered component
  */
-export const LocalChangesTab = ({ org, app }: LocalChangesTabProps): JSX.Element => {
+export const LocalChangesTab = ({ org, app }: LocalChangesTabProps): ReactNode => {
   const { t } = useTranslation();
 
   const { mutate: deleteLocalChanges } = useResetRepositoryMutation(org, app);
 
-  const modalRef = useRef<HTMLDialogElement>(null);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
   const handleDelete = () => {
     deleteLocalChanges(undefined, {
       onSuccess: () => {
-        modalRef.current?.close();
+        setDeleteModalOpen(false);
         toast.success(t('settings_modal.local_changes_tab_deleted_success'));
       },
     });
   };
-
-  const handleCloseModal = () => modalRef.current?.close();
 
   return (
     <TabContent>
@@ -68,12 +66,12 @@ export const LocalChangesTab = ({ org, app }: LocalChangesTabProps): JSX.Element
           color='danger'
           icon={<TrashIcon />}
           text={t('settings_modal.local_changes_tab_delete_button')}
-          action={{ type: 'button', onClick: () => modalRef.current?.showModal() }}
+          action={{ type: 'button', onClick: () => setDeleteModalOpen(true) }}
         />
       </div>
       <DeleteModal
-        ref={modalRef}
-        onClose={handleCloseModal}
+        isOpen={deleteModalOpen}
+        onClose={() => setDeleteModalOpen(false)}
         onDelete={handleDelete}
         appName={app}
       />

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModalButton.test.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModalButton.test.tsx
@@ -68,7 +68,7 @@ describe('SettingsModal', () => {
     });
     expect(modalHeading).toBeInTheDocument();
 
-    const closeButton = screen.getByRole('button', { name: 'close modal' });
+    const closeButton = screen.getByRole('button', { name: textMock('modal.close_icon') });
     await act(() => user.click(closeButton));
 
     const modalHeadingAfter = screen.queryByRole('heading', {

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModalButton.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModalButton.tsx
@@ -1,17 +1,23 @@
-import React, { ReactNode, useRef } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { Button } from '@digdir/design-system-react';
 import { CogIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 import { SettingsModal } from './SettingsModal';
 
 export type SettingsModalButtonProps = {
+  /**
+   * The org
+   */
   org: string;
+  /**
+   * The app
+   */
   app: string;
 };
 
 /**
  * @component
- *    Displays a button to open the Settings modal and the Settings modal
+ *    Displays a button to open the Settings modal
  *
  * @property {string}[org] - The org
  * @property {string}[app] - The app
@@ -20,13 +26,12 @@ export type SettingsModalButtonProps = {
  */
 export const SettingsModalButton = ({ org, app }: SettingsModalButtonProps): ReactNode => {
   const { t } = useTranslation();
-
-  const modalRef = useRef<HTMLDialogElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
 
   return (
     <>
       <Button
-        onClick={() => modalRef.current?.showModal()}
+        onClick={() => setIsOpen(true)}
         size='small'
         variant='tertiary'
         color='inverted'
@@ -34,7 +39,12 @@ export const SettingsModalButton = ({ org, app }: SettingsModalButtonProps): Rea
       >
         {t('settings_modal.heading')}
       </Button>
-      <SettingsModal ref={modalRef} onClose={() => modalRef.current?.close()} org={org} app={app} />
+      {
+        // Done to prevent API calls to be executed before the modal is open
+        isOpen && (
+          <SettingsModal isOpen={isOpen} onClose={() => setIsOpen(false)} org={org} app={app} />
+        )
+      }
     </>
   );
 };

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -514,6 +514,7 @@
   "merge_conflict.download_zip_file": "Last ned zip-fil",
   "merge_conflict.headline": "Det er en konflikt i applikasjonen",
   "merge_conflict.remove_my_changes": "Fjern mine endringer",
+  "modal.close_icon": "Lukk modalen",
   "not_found_page.heading": "Vi finner ikke siden",
   "not_found_page.redirect_to_dashboard": "Gå tilbake til Dashboard",
   "not_found_page.text": "Vi finner ikke siden du leter etter. Har du skrevet inn riktig URL? \nDu kan prøve å gå tilbake til dashboardet for å sjekke eller snakke med <0>Altinn Servicedesk</0> om du ønsker hjelp.",

--- a/frontend/libs/studio-components/src/components/StudioModal/StudioModal.module.css
+++ b/frontend/libs/studio-components/src/components/StudioModal/StudioModal.module.css
@@ -3,6 +3,12 @@
   --modal-min-height: 100px;
   --modal-max-height: 80vh;
   --modal-max-width: 80%;
+  --modal-position: 50%;
+  --modal-translate: calc(var(--modal-position) * -1);
+  --heading-height: 60px;
+  --modal-border-size: 1px;
+  --modal-content-max-height: calc(var(--modal-max-height) - var(--heading-height)) -
+    var(--modal-border-size);
 
   max-width: var(--modal-max-width);
   min-width: var(--modal-min-width);
@@ -10,20 +16,41 @@
   max-height: var(--modal-max-height);
   min-height: var(--modal-min-height);
   height: max-content;
+  border-radius: 20px;
+  position: absolute;
+  top: var(--modal-position);
+  left: var(--modal-position);
+  transform: translate(var(--modal-translate), var(--modal-translate));
+  padding: 0;
   padding-top: 20px;
+  background-color: var(--fds-semantic-background-default);
+  border: var(--modal-border-size) solid var(--fds-semantic-border-neutral-subtle);
 }
 
-.header {
-  margin: 0;
-  padding: 0;
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(30, 43, 60, 0.5);
+  z-index: 1000;
 }
 
-.content {
-  margin: 0;
-  padding: 0;
+.headingWrapper {
+  border-bottom: 1px solid var(--fds-semantic-border-divider-default);
+  height: var(--heading-height);
+  position: sticky;
+  top: 0;
+  background-color: var(--fds-semantic-background-default);
 }
 
-.footer {
-  margin: 0;
-  padding: 0;
+.contentWrapper {
+  max-height: var(--modal-content-max-height);
+}
+
+.closeButtonWrapper {
+  position: absolute;
+  top: -0.5rem;
+  right: 0.5rem;
 }

--- a/frontend/libs/studio-components/src/components/StudioModal/StudioModal.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioModal/StudioModal.test.tsx
@@ -1,58 +1,46 @@
 import React, { ReactNode } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { StudioModal, StudioModalProps } from './StudioModal';
+import { textMock } from '../../../../../testing/mocks/i18nMock';
 
-const mockHeaderText: string = 'Title';
-const mockContentText: string = 'Modal test';
-const mockFooterText: string = 'Footer content';
-
-const MockHeader: ReactNode = (
+const mockTitle: ReactNode = (
   <div>
-    <h3>{mockHeaderText}</h3>
+    <h2>Title</h2>
   </div>
 );
 
-const MockContent: ReactNode = (
+const mockChildren = (
   <div>
-    <p>{mockContentText}</p>
+    <p>Modal test</p>
   </div>
 );
 
-const MockFooter: ReactNode = (
-  <div>
-    <p>{mockFooterText}</p>
-  </div>
-);
-
-const mockOnClose = jest.fn();
-
-const defaultProps: StudioModalProps = {
-  onClose: mockOnClose,
-  header: MockHeader,
-  content: MockContent,
-  open: true,
-};
-
-describe('StudioModal', () => {
+describe('Modal', () => {
   afterEach(jest.clearAllMocks);
 
-  it('shows the header and content components correctly, and hides the footer when not present', () => {
+  const mockOnClose = jest.fn();
+
+  const defaultProps: StudioModalProps = {
+    isOpen: true,
+    onClose: mockOnClose,
+    title: mockTitle,
+    children: mockChildren,
+  };
+
+  it('calls onClose when the close button is clicked', async () => {
+    const user = userEvent.setup();
     render(<StudioModal {...defaultProps} />);
 
-    const header = screen.getByRole('heading', { name: 'Title', level: 3 });
-    expect(header).toBeInTheDocument();
-
-    const content = screen.getByText(mockContentText);
-    expect(content).toBeInTheDocument();
-
-    const footer = screen.queryByText(mockFooterText);
-    expect(footer).not.toBeInTheDocument();
+    const closeButton = screen.getByRole('button', { name: textMock('modal.close_icon') });
+    await act(() => user.click(closeButton));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
-  it('shows the footer component when it is present', () => {
-    render(<StudioModal {...defaultProps} footer={MockFooter} />);
+  it('does not show content when modal is clsoed', () => {
+    render(<StudioModal {...defaultProps} isOpen={false} />);
 
-    const footer = screen.getByText(mockFooterText);
-    expect(footer).toBeInTheDocument();
+    const closeButton = screen.queryByRole('button', { name: textMock('modal.close_icon') });
+    expect(closeButton).not.toBeInTheDocument();
   });
 });

--- a/frontend/libs/studio-components/src/components/StudioModal/StudioModal.tsx
+++ b/frontend/libs/studio-components/src/components/StudioModal/StudioModal.tsx
@@ -1,12 +1,16 @@
 import React, { ReactNode, forwardRef } from 'react';
 import classes from './StudioModal.module.css';
-import { Modal, ModalProps } from '@digdir/design-system-react';
+import ReactModal from 'react-modal'; // TODO - Replace with component from Designsystemet. Issue:
+import { Button } from '@digdir/design-system-react';
+import { useTranslation } from 'react-i18next';
+import { MultiplyIcon } from '@studio/icons';
 
 export type StudioModalProps = {
-  header: ReactNode;
-  content: ReactNode;
-  footer?: ReactNode;
-} & Omit<ModalProps, 'header' | 'content' | 'footer'>;
+  isOpen: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  children: ReactNode;
+};
 
 /**
  * @component
@@ -14,26 +18,54 @@ export type StudioModalProps = {
  *
  * @example
  *    <StudioModal
- *        ref={ref}
- *        header={<SomeHeaderComponent />}
- *        content={<SomeContentComponent />}
- *        footer={<SomeFooterComponent />}
- *    />
+ *      isOpen={isOpen}
+ *      onClose={() => setIsOpen(false)}
+ *      title={
+ *        <div>
+ *          <SomeIcon />
+ *          <Heading level={1} size='small'>Some name</Heading>
+ *        </div>
+ *      }
+ *    >
+ *      <div>
+ *        <SomeChildrenComponents />
+ *      </div>
+ *    </StudioModal>
  *
- * @property {ReactNode}[header] - Header of the modal
- * @property {ReactNode}[content] - Content in the mdoal
- * @property {ReactNode}[footer] - Optioanl footer in the modal
+ * @property {boolean}[isOpen] - Flag for if the modal is open
+ * @property {function}[onClose] - Fucntion to execute when closing modal
+ * @property {ReactNode}[title] - Title of the modal
+ * @property {ReactNode}[children] - Content in the modal
  *
- * @returns {JSX.Element} - The rendered component
+ * @returns {ReactNode} - The rendered component
  */
 export const StudioModal = forwardRef<HTMLDialogElement, StudioModalProps>(
-  ({ header, content, footer, ...rest }: StudioModalProps, ref): JSX.Element => {
+  ({ isOpen, onClose, title, children, ...rest }: StudioModalProps, ref): ReactNode => {
+    const { t } = useTranslation();
+
     return (
-      <Modal ref={ref} className={classes.modal} {...rest}>
-        <Modal.Header className={classes.header}>{header}</Modal.Header>
-        <Modal.Content className={classes.content}>{content}</Modal.Content>
-        {footer && <Modal.Footer className={classes.footer}>{footer}</Modal.Footer>}
-      </Modal>
+      <ReactModal
+        isOpen={isOpen}
+        onRequestClose={onClose}
+        className={classes.modal}
+        overlayClassName={classes.modalOverlay}
+        ariaHideApp={false}
+        ref={ref}
+        {...rest}
+      >
+        <div className={classes.headingWrapper}>
+          {title}
+          <div className={classes.closeButtonWrapper}>
+            <Button
+              variant='tertiary'
+              icon={<MultiplyIcon />}
+              onClick={onClose}
+              aria-label={t('modal.close_icon')}
+            />
+          </div>
+        </div>
+        <div className={classes.contentWrapper}>{children}</div>
+      </ReactModal>
     );
   },
 );

--- a/frontend/packages/policy-editor/src/PolicyEditor.tsx
+++ b/frontend/packages/policy-editor/src/PolicyEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Alert, Heading, Paragraph } from '@digdir/design-system-react';
 import type {
   PolicyAction,
@@ -57,7 +57,6 @@ export const PolicyEditor = ({
   usageType,
 }: PolicyEditorProps): React.ReactNode => {
   const { t } = useTranslation();
-  const modalRef = useRef<HTMLDialogElement>(null);
 
   // TODO - Find out how this should be set. Issue: #10880
   const resourceType = usageType === 'app' ? 'urn:altinn' : 'urn:altinn:resource';
@@ -68,6 +67,8 @@ export const PolicyEditor = ({
 
   // Handle the new updated IDs of the rules when a rule is deleted / duplicated
   const [lastRuleId, setLastRuleId] = useState((policy?.rules?.length ?? 0) + 1);
+
+  const [verificationModalOpen, setVerificationModalOpen] = useState(false);
 
   // To keep track of which rule to delete
   const [ruleIdToDelete, setRuleIdToDelete] = useState('0');
@@ -89,7 +90,7 @@ export const PolicyEditor = ({
           resourceType={resourceType}
           handleCloneRule={() => handleCloneRule(i)}
           handleDeleteRule={() => {
-            modalRef.current?.showModal();
+            setVerificationModalOpen(true);
             setRuleIdToDelete(pr.ruleId);
           }}
           showErrors={
@@ -167,7 +168,7 @@ export const PolicyEditor = ({
     setPolicyRules(updatedRules);
 
     // Reset
-    modalRef.current?.close();
+    setVerificationModalOpen(false);
     setRuleIdToDelete('0');
 
     handleSavePolicy(updatedRules);
@@ -215,8 +216,8 @@ export const PolicyEditor = ({
         <CardButton buttonText={t('policy_editor.card_button_text')} onClick={handleAddCardClick} />
       </div>
       <VerificationModal
-        ref={modalRef}
-        onClose={() => modalRef.current?.close()}
+        isOpen={verificationModalOpen}
+        onClose={() => setVerificationModalOpen(false)}
         text={t('policy_editor.verification_modal_text')}
         closeButtonText={t('policy_editor.verification_modal_close_button')}
         actionButtonText={t('policy_editor.verification_modal_action_button')}

--- a/frontend/packages/policy-editor/src/components/VerificationModal/VerificationModal.test.tsx
+++ b/frontend/packages/policy-editor/src/components/VerificationModal/VerificationModal.test.tsx
@@ -1,31 +1,31 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { VerificationModal, VerificationModalProps } from './VerificationModal';
 import { textMock } from '../../../../../testing/mocks/i18nMock';
 import { act } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
 
-const mockButtonText: string = 'Mock Button';
 const mockModalText: string = 'Mock modal text';
 const mockCloseButtonText: string = 'Close';
 const mockActionButtonText: string = 'Confirm';
 
-const mockOnClose = jest.fn();
-const mockOnPerformAction = jest.fn();
-
-const defaultProps: VerificationModalProps = {
-  onClose: mockOnClose,
-  text: mockModalText,
-  closeButtonText: mockCloseButtonText,
-  actionButtonText: mockActionButtonText,
-  onPerformAction: mockOnPerformAction,
-};
-
 describe('VerificationModal', () => {
   afterEach(jest.clearAllMocks);
 
-  it('does render the modal when it is open', async () => {
-    await renderAndOpenModal();
+  const mockOnClose = jest.fn();
+  const mockOnPerformAction = jest.fn();
+
+  const defaultProps: VerificationModalProps = {
+    isOpen: true,
+    onClose: mockOnClose,
+    text: mockModalText,
+    closeButtonText: mockCloseButtonText,
+    actionButtonText: mockActionButtonText,
+    onPerformAction: mockOnPerformAction,
+  };
+
+  it('does render the modal when it is open', () => {
+    render(<VerificationModal {...defaultProps} />);
 
     const modalHeader = screen.getByRole('heading', {
       name: textMock('policy_editor.verification_modal_heading'),
@@ -36,7 +36,7 @@ describe('VerificationModal', () => {
   });
 
   it('does not render the modal when it is closed', () => {
-    render(<TestComponentWithButton />);
+    render(<VerificationModal {...defaultProps} isOpen={false} />);
 
     const modalHeader = screen.queryByRole('heading', {
       name: textMock('policy_editor.verification_modal_heading'),
@@ -48,7 +48,7 @@ describe('VerificationModal', () => {
 
   it('calls "onClose" when the close button is clicked', async () => {
     const user = userEvent.setup();
-    await renderAndOpenModal();
+    render(<VerificationModal {...defaultProps} />);
 
     const closeButton = screen.getByText(mockCloseButtonText);
     await act(() => user.click(closeButton));
@@ -58,7 +58,7 @@ describe('VerificationModal', () => {
 
   it('calls "onPerformAction" when the action button is clicked', async () => {
     const user = userEvent.setup();
-    await renderAndOpenModal();
+    render(<VerificationModal {...defaultProps} />);
 
     const actionButton = screen.getByText(mockActionButtonText);
     await act(() => user.click(actionButton));
@@ -66,22 +66,3 @@ describe('VerificationModal', () => {
     expect(mockOnPerformAction).toHaveBeenCalledTimes(1);
   });
 });
-
-const renderAndOpenModal = async (props: Partial<VerificationModalProps> = {}) => {
-  const user = userEvent.setup();
-  render(<TestComponentWithButton {...props} />);
-
-  const openModalButton = screen.getByRole('button', { name: mockButtonText });
-  await act(() => user.click(openModalButton));
-};
-
-const TestComponentWithButton = (props: Partial<VerificationModalProps> = {}) => {
-  const modalRef = useRef<HTMLDialogElement>(null);
-
-  return (
-    <>
-      <button onClick={() => modalRef.current?.showModal()}>{mockButtonText}</button>
-      <VerificationModal ref={modalRef} {...defaultProps} {...props} />
-    </>
-  );
-};

--- a/frontend/packages/policy-editor/src/components/VerificationModal/VerificationModal.tsx
+++ b/frontend/packages/policy-editor/src/components/VerificationModal/VerificationModal.tsx
@@ -1,10 +1,11 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import classes from './VerificationModal.module.css';
 import { Button, Heading, Paragraph } from '@digdir/design-system-react';
 import { useTranslation } from 'react-i18next';
 import { StudioModal } from '@studio/components';
 
 export type VerificationModalProps = {
+  isOpen: boolean;
   onClose: () => void;
   text: string;
   closeButtonText: string;
@@ -17,47 +18,50 @@ export type VerificationModalProps = {
  *    Displays a verification modal. To be used when the user needs one extra level
  *    of chekcing if they really want to perform an action.
  *
+ * @property {boolean}[isOpen] - Boolean for if the modal is open or not
  * @property {function}[onClose] - Function to be executed when closing the modal
  * @property {string}[text] -The text to display in the modal
  * @property {string}[closeButtonText] - The text to display on the close button
  * @property {string}[actionButtonText] - The text to display on the action button
  * @property {function}[onPerformAction] - Function to be executed when the action button is clicked
  *
- * @returns {JSX.Element} - The rendered component
+ * @returns {React.ReactNode} - The rendered component
  */
-export const VerificationModal = forwardRef<HTMLDialogElement, VerificationModalProps>(
-  ({ onClose, text, closeButtonText, actionButtonText, onPerformAction }, ref): JSX.Element => {
-    const { t } = useTranslation();
+export const VerificationModal = ({
+  isOpen,
+  onClose,
+  text,
+  closeButtonText,
+  actionButtonText,
+  onPerformAction,
+}: VerificationModalProps): React.ReactNode => {
+  const { t } = useTranslation();
 
-    return (
-      <StudioModal
-        onClose={onClose}
-        ref={ref}
-        header={
-          <div className={classes.headingWrapper}>
-            <Heading size='xsmall' spacing level={1}>
-              {t('policy_editor.verification_modal_heading')}
-            </Heading>
+  return (
+    <StudioModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={
+        <div className={classes.headingWrapper}>
+          <Heading size='xsmall' spacing level={1}>
+            {t('policy_editor.verification_modal_heading')}
+          </Heading>
+        </div>
+      }
+    >
+      <div className={classes.content}>
+        <Paragraph size='small'>{text}</Paragraph>
+        <div className={classes.buttonWrapper}>
+          <div className={classes.closeButtonWrapper}>
+            <Button onClick={onClose} variant='tertiary' size='small'>
+              {closeButtonText}
+            </Button>
           </div>
-        }
-        content={
-          <div className={classes.content}>
-            <Paragraph size='small'>{text}</Paragraph>
-            <div className={classes.buttonWrapper}>
-              <div className={classes.closeButtonWrapper}>
-                <Button onClick={onClose} variant='tertiary' size='small'>
-                  {closeButtonText}
-                </Button>
-              </div>
-              <Button onClick={onPerformAction} color='danger' size='small'>
-                {actionButtonText}
-              </Button>
-            </div>
-          </div>
-        }
-      />
-    );
-  },
-);
-
-VerificationModal.displayName = 'VerificationModal';
+          <Button onClick={onPerformAction} color='danger' size='small'>
+            {actionButtonText}
+          </Button>
+        </div>
+      </div>
+    </StudioModal>
+  );
+};

--- a/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.test.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.test.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { render as rtlRender, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ImportResourceModal, ImportResourceModalProps } from './ImportResourceModal';
@@ -9,8 +9,6 @@ import { ServicesContextProps, ServicesContextProvider } from 'app-shared/contex
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { Altinn2LinkService } from 'app-shared/types/Altinn2LinkService';
-
-const mockButtonText: string = 'Mock Button';
 
 const mockAltinn2LinkService: Altinn2LinkService = {
   externalServiceCode: 'code1',
@@ -27,6 +25,7 @@ const getAltinn2LinkServices = jest
   .mockImplementation(() => Promise.resolve(mockAltinn2LinkServices));
 
 const defaultProps: ImportResourceModalProps = {
+  isOpen: true,
   onClose: mockOnClose,
 };
 
@@ -35,7 +34,7 @@ describe('ImportResourceModal', () => {
 
   it('selects environment and service, then checks if import button exists', async () => {
     const user = userEvent.setup();
-    await renderAndOpenModal();
+    render();
 
     const importButtonText = textMock('resourceadm.dashboard_import_modal_import_button');
     const importButton = screen.queryByRole('button', { name: importButtonText });
@@ -66,7 +65,7 @@ describe('ImportResourceModal', () => {
 
   it('calls onClose function when close button is clicked', async () => {
     const user = userEvent.setup();
-    await renderAndOpenModal();
+    render();
 
     const closeButton = screen.getByRole('button', { name: textMock('general.cancel') });
     await act(() => user.click(closeButton));
@@ -75,7 +74,7 @@ describe('ImportResourceModal', () => {
   });
 
   it('should be closed by default', () => {
-    render();
+    render({ isOpen: false });
 
     const closeButton = screen.queryByRole('button', { name: textMock('general.cancel') });
     expect(closeButton).not.toBeInTheDocument();
@@ -83,7 +82,7 @@ describe('ImportResourceModal', () => {
 
   it('calls import resource from Altinn 2 when import is clicked', async () => {
     const user = userEvent.setup();
-    await renderAndOpenModal();
+    render();
 
     const [, environmentSelect] = screen.getAllByLabelText(
       textMock('resourceadm.dashboard_import_modal_select_env'),
@@ -118,27 +117,8 @@ const render = (props: Partial<ImportResourceModalProps> = {}) => {
   return rtlRender(
     <MemoryRouter>
       <ServicesContextProvider {...allQueries} client={createQueryClientMock()}>
-        <TestComponentWithButton {...defaultProps} {...props} />
+        <ImportResourceModal {...defaultProps} {...props} />
       </ServicesContextProvider>
     </MemoryRouter>,
-  );
-};
-
-const renderAndOpenModal = async (props: Partial<ImportResourceModalProps> = {}) => {
-  const user = userEvent.setup();
-  render(props);
-
-  const openModalButton = screen.getByRole('button', { name: mockButtonText });
-  await act(() => user.click(openModalButton));
-};
-
-const TestComponentWithButton = (props: Partial<ImportResourceModalProps> = {}) => {
-  const modalRef = useRef<HTMLDialogElement>(null);
-
-  return (
-    <>
-      <button onClick={() => modalRef.current?.showModal()}>{mockButtonText}</button>
-      <ImportResourceModal ref={modalRef} {...defaultProps} {...props} />
-    </>
   );
 };

--- a/frontend/resourceadm/components/MergeConflictModal/MergeConflictModal.tsx
+++ b/frontend/resourceadm/components/MergeConflictModal/MergeConflictModal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, forwardRef } from 'react';
+import React, { useState } from 'react';
 import classes from './MergeConflictModal.module.css';
 import { useTranslation } from 'react-i18next';
 import { Button, Link, Paragraph, Label } from '@digdir/design-system-react';
@@ -8,8 +8,22 @@ import { get } from 'app-shared/utils/networking';
 import { Modal } from '../Modal';
 
 type MergeConflictModalProps = {
+  /**
+   * Boolean for if the modal is open
+   */
+  isOpen: boolean;
+  /**
+   * Function to be executed when the merge is solved
+   * @returns void
+   */
   handleSolveMerge: () => void;
+  /**
+   * The name of the organisation
+   */
   org: string;
+  /**
+   * The name of the repo
+   */
   repo: string;
 };
 
@@ -17,54 +31,59 @@ type MergeConflictModalProps = {
  * @component
  *    Displays the modal telling the user that there is a merge conflict
  *
+ * @property {boolean}[isOpen] - Boolean for if the modal is open
  * @property {function}[handleSolveMerge] - Function to be executed when the merge is solved
  * @property {string}[org] - The name of the organisation
  * @property {string}[repo] - The name of the repo
  *
- * @returns {JSX.Element} - The rendered component
+ * @returns {React.ReactNode} - The rendered component
  */
-export const MergeConflictModal = forwardRef<HTMLDialogElement, MergeConflictModalProps>(
-  ({ handleSolveMerge, org, repo }, ref): JSX.Element => {
-    const { t } = useTranslation();
+export const MergeConflictModal = ({
+  isOpen,
+  handleSolveMerge,
+  org,
+  repo,
+}: MergeConflictModalProps): React.ReactNode => {
+  const { t } = useTranslation();
 
-    const removeChangesModalRef = useRef<HTMLDialogElement>(null);
+  const [resetModalOpen, setResetModalOpen] = useState(false);
 
-    const handleClickResetRepo = () => {
-      get(repoResetPath(org, repo));
-      handleSolveMerge();
-    };
+  /**
+   * Function that resets the repo
+   */
+  const handleClickResetRepo = () => {
+    get(repoResetPath(org, repo));
+    handleSolveMerge();
+  };
 
-    return (
-      <Modal ref={ref} title={t('merge_conflict.headline')}>
-        <Paragraph size='small'>{t('merge_conflict.body1')}</Paragraph>
-        <Paragraph size='small'>{t('merge_conflict.body2')}</Paragraph>
-        <div className={classes.buttonWrapper}>
-          <div className={classes.downloadWrapper}>
-            <Label size='medium' spacing weight='medium'>
-              {t('merge_conflict.download')}
-            </Label>
-            <Link href={repoDownloadPath(org, repo)}>
-              {t('merge_conflict.download_edited_files')}
+  return (
+    <Modal isOpen={isOpen} title={t('merge_conflict.headline')}>
+      <Paragraph size='small'>{t('merge_conflict.body1')}</Paragraph>
+      <Paragraph size='small'>{t('merge_conflict.body2')}</Paragraph>
+      <div className={classes.buttonWrapper}>
+        <div className={classes.downloadWrapper}>
+          <Label size='medium' spacing weight='medium'>
+            {t('merge_conflict.download')}
+          </Label>
+          <Link href={repoDownloadPath(org, repo)}>
+            {t('merge_conflict.download_edited_files')}
+          </Link>
+          <div className={classes.linkDivider}>
+            <Link href={repoDownloadPath(org, repo, true)}>
+              {t('merge_conflict.download_entire_repo')}
             </Link>
-            <div className={classes.linkDivider}>
-              <Link href={repoDownloadPath(org, repo, true)}>
-                {t('merge_conflict.download_entire_repo')}
-              </Link>
-            </div>
           </div>
-          <Button onClick={() => removeChangesModalRef.current?.showModal()} size='small'>
-            {t('merge_conflict.remove_my_changes')}
-          </Button>
-          <RemoveChangesModal
-            ref={removeChangesModalRef}
-            onClose={() => removeChangesModalRef.current?.close()}
-            handleClickResetRepo={handleClickResetRepo}
-            repo={repo}
-          />
         </div>
-      </Modal>
-    );
-  },
-);
-
-MergeConflictModal.displayName = 'MergeConflictModal';
+        <Button onClick={() => setResetModalOpen(true)} size='small'>
+          {t('merge_conflict.remove_my_changes')}
+        </Button>
+        <RemoveChangesModal
+          isOpen={resetModalOpen}
+          onClose={() => setResetModalOpen(false)}
+          handleClickResetRepo={handleClickResetRepo}
+          repo={repo}
+        />
+      </div>
+    </Modal>
+  );
+};

--- a/frontend/resourceadm/components/MergeConflictModal/RemoveChangesModal/RemoveChangesModal.tsx
+++ b/frontend/resourceadm/components/MergeConflictModal/RemoveChangesModal/RemoveChangesModal.tsx
@@ -1,13 +1,28 @@
-import React, { forwardRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { Button, Textfield, Paragraph } from '@digdir/design-system-react';
 import classes from './RemoveChangesModal.module.css';
 import { Modal } from 'resourceadm/components/Modal';
 import { ScreenReaderSpan } from 'resourceadm/components/ScreenReaderSpan';
 
 type RemoveChangesModalProps = {
+  /**
+   * Boolean for if the modal is open
+   */
+  isOpen: boolean;
+  /**
+   * Function to handle close
+   * @returns void
+   */
   onClose: () => void;
+  /**
+   * Function to be executed when the reset repo is clicked
+   * @returns void
+   */
   handleClickResetRepo: () => void;
+  /**
+   * The name of the repo
+   */
   repo: string;
 };
 
@@ -15,66 +30,78 @@ type RemoveChangesModalProps = {
  * @Component
  *    Content to be displayed inside the modal where the user removes their changes in a merge conflict
  *
+ * @property {boolean}[isOpen] - Boolean for if the modal is open
  * @property {function}[onClose] - Function to handle close
  * @property {function}[handleClickResetRepo] - Function to be executed when the reset repo is clicked
  * @property {string}[repo] - The name of the repo
  *
- * @returns {JSX.Element} - The rendered component
+ * @returns {React.ReactNode} - The rendered component
  */
-export const RemoveChangesModal = forwardRef<HTMLDialogElement, RemoveChangesModalProps>(
-  ({ onClose, handleClickResetRepo, repo }, ref): JSX.Element => {
-    const { t } = useTranslation();
+export const RemoveChangesModal = ({
+  isOpen,
+  onClose,
+  handleClickResetRepo,
+  repo,
+}: RemoveChangesModalProps): React.ReactNode => {
+  const { t } = useTranslation();
 
-    const [deleteRepoName, setDeleteRepoName] = useState('');
+  const [deleteRepoName, setDeleteRepoName] = useState('');
 
-    const handleClose = () => {
-      setDeleteRepoName('');
-      onClose();
-    };
+  /**
+   * Handles the closing of the modal
+   */
+  const handleClose = () => {
+    setDeleteRepoName('');
+    onClose();
+  };
 
-    const handleDelete = () => {
-      handleClose();
-      handleClickResetRepo();
-    };
+  /**
+   * Handles the deletion of the changes
+   */
+  const handleDelete = () => {
+    handleClose();
+    handleClickResetRepo();
+  };
 
-    return (
-      <Modal
-        ref={ref}
-        onClose={onClose}
-        title={t('settings_modal.local_changes_tab_delete_modal_title')}
-      >
-        <Paragraph size='small'>
-          {t('settings_modal.local_changes_tab_delete_modal_text')}
-        </Paragraph>
-        <div className={classes.textFieldWrapper}>
-          <Textfield
-            label={t('resourceadm.reset_repo_confirm_repo_name')}
-            value={deleteRepoName}
-            onChange={(e) => setDeleteRepoName(e.target.value)}
-            aria-labelledby='delete-changes'
-          />
-          <ScreenReaderSpan
-            id='delete-changes'
-            label={t('resourceadm.reset_repo_confirm_repo_name')}
-          />
-        </div>
-        <div className={classes.buttonWrapper}>
-          <Button
-            color='danger'
-            aria-disabled={repo !== deleteRepoName}
-            onClick={repo === deleteRepoName && handleDelete}
-            variant='secondary'
-            size='small'
-          >
-            {t('settings_modal.local_changes_tab_delete_modal_delete_button')}
-          </Button>
-          <Button color='second' onClick={handleClose} variant='secondary' size='small'>
-            {t('general.cancel')}
-          </Button>
-        </div>
-      </Modal>
-    );
-  },
-);
-
-RemoveChangesModal.displayName = 'RemoveChangesModal';
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('settings_modal.local_changes_tab_delete_modal_title')}
+    >
+      <Paragraph size='small'>
+        <Trans
+          i18nKey={'settings_modal.local_changes_tab_delete_modal_text'}
+          values={{ repositoryName: repo }}
+          components={{ bold: <strong /> }}
+        />
+      </Paragraph>
+      <div className={classes.textFieldWrapper}>
+        <Textfield
+          label={t('resourceadm.reset_repo_confirm_repo_name')}
+          value={deleteRepoName}
+          onChange={(e) => setDeleteRepoName(e.target.value)}
+          aria-labelledby='delete-changes'
+        />
+        <ScreenReaderSpan
+          id='delete-changes'
+          label={t('resourceadm.reset_repo_confirm_repo_name')}
+        />
+      </div>
+      <div className={classes.buttonWrapper}>
+        <Button
+          color='danger'
+          aria-disabled={repo !== deleteRepoName}
+          onClick={repo === deleteRepoName && handleDelete}
+          variant='secondary'
+          size='small'
+        >
+          {t('settings_modal.local_changes_tab_delete_modal_delete_button')}
+        </Button>
+        <Button color='second' onClick={handleClose} variant='secondary' size='small'>
+          {t('general.cancel')}
+        </Button>
+      </div>
+    </Modal>
+  );
+};

--- a/frontend/resourceadm/components/Modal/Modal.tsx
+++ b/frontend/resourceadm/components/Modal/Modal.tsx
@@ -1,10 +1,11 @@
-import React, { ReactNode, forwardRef } from 'react';
+import React, { ReactNode } from 'react';
 import classes from './Modal.module.css';
 import cn from 'classnames';
 import { Heading } from '@digdir/design-system-react';
 import { StudioModal } from '@studio/components';
 
 type ModalProps = {
+  isOpen: boolean;
   title: string;
   onClose?: () => void;
   children: ReactNode;
@@ -16,10 +17,11 @@ type ModalProps = {
  *    Modal component implementing the react-modal.
  *
  * @example
- *    <Modal ref={ref} onClose={handleClose} title='Some title'>
+ *    <Modal isOpen={isOpen} onClose={handleClose} title='Some title'>
  *      <div>...</div>
  *    </Modal>
  *
+ * @property {boolean}[isOpen] - Boolean for if the modal is open
  * @property {string}[title] - Title to be displayed in the modal
  * @property {function}[onClose] - Function to handle close of the modal
  * @property {ReactNode}[children] - React components inside the Modal
@@ -27,23 +29,26 @@ type ModalProps = {
  *
  * @returns {React.ReactNode} - The rendered component
  */
-export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
-  ({ title, onClose, children, contentClassName }, ref): React.ReactNode => {
-    return (
-      <StudioModal
-        ref={ref}
-        onClose={onClose}
-        header={
-          <div className={classes.headingWrapper}>
-            <Heading size='xsmall' spacing level={1}>
-              {title}
-            </Heading>
-          </div>
-        }
-        content={<div className={cn(classes.content, contentClassName)}>{children}</div>}
-      />
-    );
-  },
-);
-
-Modal.displayName = 'Modal';
+export const Modal = ({
+  isOpen,
+  title,
+  onClose,
+  children,
+  contentClassName,
+}: ModalProps): React.ReactNode => {
+  return (
+    <StudioModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={
+        <div className={classes.headingWrapper}>
+          <Heading size='xsmall' spacing level={1}>
+            {title}
+          </Heading>
+        </div>
+      }
+    >
+      <div className={cn(classes.content, contentClassName)}>{children}</div>
+    </StudioModal>
+  );
+};

--- a/frontend/resourceadm/components/NavigationModal/NavigationModal.test.tsx
+++ b/frontend/resourceadm/components/NavigationModal/NavigationModal.test.tsx
@@ -1,33 +1,32 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NavigationModal, NavigationModalProps } from './NavigationModal';
 import { textMock } from '../../../testing/mocks/i18nMock';
 import { act } from 'react-dom/test-utils';
 
-const mockButtonText: string = 'Mock Button';
-
-const mockOnClose = jest.fn();
-const mockOnNavigate = jest.fn();
-
-const defaultProps: NavigationModalProps = {
-  onClose: mockOnClose,
-  onNavigate: mockOnNavigate,
-  title: textMock('resourceadm.resource_navigation_modal_title_policy'),
-};
-
 describe('NavigationModal', () => {
-  afterEach(jest.clearAllMocks);
+  const mockOnClose = jest.fn();
+  const mockOnNavigate = jest.fn();
+
+  const defaultProps: NavigationModalProps = {
+    isOpen: true,
+    onClose: mockOnClose,
+    onNavigate: mockOnNavigate,
+    title: textMock('resourceadm.resource_navigation_modal_title_policy'),
+  };
 
   it('should be closed by default', () => {
-    render(<TestComponentWithButton />);
+    render(
+      <NavigationModal isOpen={false} onClose={() => {}} onNavigate={mockOnNavigate} title='tit' />,
+    );
     const closeButton = screen.queryByRole('button', { name: textMock('general.cancel') });
     expect(closeButton).not.toBeInTheDocument();
   });
 
   it('calls onClose function when close button is clicked', async () => {
     const user = userEvent.setup();
-    await renderAndOpenModal();
+    render(<NavigationModal {...defaultProps} />);
 
     const closeButton = screen.getByRole('button', {
       name: textMock('resourceadm.resource_navigation_modal_button_stay'),
@@ -39,7 +38,7 @@ describe('NavigationModal', () => {
 
   it('calls onNavigate function when navigate button is clicked', async () => {
     const user = userEvent.setup();
-    await renderAndOpenModal();
+    render(<NavigationModal {...defaultProps} />);
 
     const navigateButton = screen.getByRole('button', {
       name: textMock('resourceadm.resource_navigation_modal_button_move_on'),
@@ -49,22 +48,3 @@ describe('NavigationModal', () => {
     expect(mockOnNavigate).toHaveBeenCalled();
   });
 });
-
-const renderAndOpenModal = async (props: Partial<NavigationModalProps> = {}) => {
-  const user = userEvent.setup();
-  render(<TestComponentWithButton {...props} />);
-
-  const openModalButton = screen.getByRole('button', { name: mockButtonText });
-  await act(() => user.click(openModalButton));
-};
-
-const TestComponentWithButton = (props: Partial<NavigationModalProps> = {}) => {
-  const modalRef = useRef<HTMLDialogElement>(null);
-
-  return (
-    <>
-      <button onClick={() => modalRef.current?.showModal()}>{mockButtonText}</button>
-      <NavigationModal ref={modalRef} {...defaultProps} {...props} />
-    </>
-  );
-};

--- a/frontend/resourceadm/components/NavigationModal/NavigationModal.tsx
+++ b/frontend/resourceadm/components/NavigationModal/NavigationModal.tsx
@@ -1,12 +1,27 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import classes from './NavigationModal.module.css';
 import { Button, Paragraph } from '@digdir/design-system-react';
 import { Modal } from '../Modal';
 import { useTranslation } from 'react-i18next';
 
 export type NavigationModalProps = {
+  /**
+   * Boolean for if the modal is open
+   */
+  isOpen: boolean;
+  /**
+   * Function to handle close
+   * @returns void
+   */
   onClose: () => void;
+  /**
+   * Function to be executed when navigating
+   * @returns void
+   */
   onNavigate: () => void;
+  /**
+   * The title in the modal
+   */
   title: string;
 };
 
@@ -14,34 +29,36 @@ export type NavigationModalProps = {
  * @component
  *    Displays the modal telling the user that there is a merge conflict
  *
+ * @property {boolean}[isOpen] - Boolean for if the modal is open
  * @property {function}[onClose] - Function to handle close
  * @property {function}[onNavigate] - Function to be executed when navigating
  * @property {string}[title] - The title in the modal
  *
- * @returns {JSX.Element} - The rendered component
+ * @returns {React.ReactNode} - The rendered component
  */
-export const NavigationModal = forwardRef<HTMLDialogElement, NavigationModalProps>(
-  ({ onClose, onNavigate, title }, ref): JSX.Element => {
-    const { t } = useTranslation();
+export const NavigationModal = ({
+  isOpen,
+  onClose,
+  onNavigate,
+  title,
+}: NavigationModalProps): React.ReactNode => {
+  const { t } = useTranslation();
 
-    return (
-      <Modal ref={ref} onClose={onClose} title={title}>
-        <Paragraph size='small' className={classes.text}>
-          {t('resourceadm.resource_navigation_modal_text')}
-        </Paragraph>
-        <div className={classes.buttonWrapper}>
-          <div className={classes.closeButton}>
-            <Button onClick={onClose} color='first' variant='tertiary' size='small'>
-              {t('resourceadm.resource_navigation_modal_button_stay')}
-            </Button>
-          </div>
-          <Button onClick={onNavigate} color='first' size='small'>
-            {t('resourceadm.resource_navigation_modal_button_move_on')}
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title}>
+      <Paragraph size='small' className={classes.text}>
+        {t('resourceadm.resource_navigation_modal_text')}
+      </Paragraph>
+      <div className={classes.buttonWrapper}>
+        <div className={classes.closeButton}>
+          <Button onClick={onClose} color='first' variant='tertiary' size='small'>
+            {t('resourceadm.resource_navigation_modal_button_stay')}
           </Button>
         </div>
-      </Modal>
-    );
-  },
-);
-
-NavigationModal.displayName = 'NavigationModal';
+        <Button onClick={onNavigate} color='first' size='small'>
+          {t('resourceadm.resource_navigation_modal_button_move_on')}
+        </Button>
+      </div>
+    </Modal>
+  );
+};

--- a/frontend/resourceadm/components/NewResourceModal/NewResourceModal.test.tsx
+++ b/frontend/resourceadm/components/NewResourceModal/NewResourceModal.test.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NewResourceModal, NewResourceModalProps } from './NewResourceModal';
@@ -9,26 +9,23 @@ import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 
-const mockButtonText: string = 'Mock Button';
-
-const mockOnClose = jest.fn();
-
-const defaultProps: NewResourceModalProps = {
-  onClose: mockOnClose,
-};
-
 describe('NewResourceModal', () => {
-  afterEach(jest.clearAllMocks);
+  const mockOnClose = jest.fn();
+
+  const defaultProps: NewResourceModalProps = {
+    isOpen: true,
+    onClose: mockOnClose,
+  };
 
   it('should be closed by default', () => {
-    render();
+    render({ isOpen: false, onClose: () => {} });
     const closeButton = screen.queryByRole('button', { name: textMock('general.cancel') });
     expect(closeButton).not.toBeInTheDocument();
   });
 
   it('calls onClose function when close button is clicked', async () => {
     const user = userEvent.setup();
-    await renderAndOpenModal();
+    render(defaultProps);
 
     const closeButton = screen.getByRole('button', { name: textMock('general.cancel') });
     await act(() => user.click(closeButton));
@@ -36,8 +33,8 @@ describe('NewResourceModal', () => {
     expect(mockOnClose).toHaveBeenCalled();
   });
 
-  test('that create button should be disabled until the form is valid', async () => {
-    await renderAndOpenModal();
+  test('that create button should be disabled until the form is valid', () => {
+    render(defaultProps);
 
     const createButton = screen.getByRole('button', {
       name: textMock('resourceadm.dashboard_create_modal_create_button'),
@@ -47,7 +44,7 @@ describe('NewResourceModal', () => {
 
   test('that create button should be enabled when the form is valid', async () => {
     const user = userEvent.setup();
-    await renderAndOpenModal();
+    render(defaultProps);
 
     const titleInput = screen.getByLabelText(
       textMock('resourceadm.dashboard_resource_name_and_id_resource_name'),
@@ -61,31 +58,12 @@ describe('NewResourceModal', () => {
   });
 });
 
-const render = (props: Partial<NewResourceModalProps> = {}) => {
+const render = (props: NewResourceModalProps) => {
   return rtlRender(
     <MemoryRouter>
       <ServicesContextProvider {...queriesMock} client={createQueryClientMock()}>
-        <TestComponentWithButton {...defaultProps} {...props} />
+        <NewResourceModal {...props} />
       </ServicesContextProvider>
     </MemoryRouter>,
-  );
-};
-
-const renderAndOpenModal = async (props: Partial<NewResourceModalProps> = {}) => {
-  const user = userEvent.setup();
-  render(props);
-
-  const openModalButton = screen.getByRole('button', { name: mockButtonText });
-  await act(() => user.click(openModalButton));
-};
-
-const TestComponentWithButton = (props: Partial<NewResourceModalProps> = {}) => {
-  const modalRef = useRef<HTMLDialogElement>(null);
-
-  return (
-    <>
-      <button onClick={() => modalRef.current?.showModal()}>{mockButtonText}</button>
-      <NewResourceModal ref={modalRef} {...defaultProps} {...props} />
-    </>
   );
 };

--- a/frontend/resourceadm/components/NewResourceModal/NewResourceModal.tsx
+++ b/frontend/resourceadm/components/NewResourceModal/NewResourceModal.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from 'react';
+import React, { useState } from 'react';
 import classes from './NewResourceModal.module.css';
 import { Button } from '@digdir/design-system-react';
 import { Modal } from '../Modal';
@@ -12,6 +12,7 @@ import { replaceWhiteSpaceWithHyphens } from 'resourceadm/utils/stringUtils';
 import { ServerCodes } from 'app-shared/enums/ServerCodes';
 
 export type NewResourceModalProps = {
+  isOpen: boolean;
   onClose: () => void;
 };
 
@@ -19,148 +20,145 @@ export type NewResourceModalProps = {
  * @component
  *    Displays the modal telling the user that there is a merge conflict
  *
+ * @property {boolean}[isOpen] - Boolean for if the modal is open
  * @property {function}[onClose] - Function to handle close
  *
- * @returns {JSX.Element} - The rendered component
+ * @returns {React.ReactNode} - The rendered component
  */
-export const NewResourceModal = forwardRef<HTMLDialogElement, NewResourceModalProps>(
-  ({ onClose }, ref): JSX.Element => {
-    const { t } = useTranslation();
+export const NewResourceModal = ({ isOpen, onClose }: NewResourceModalProps): React.ReactNode => {
+  const { t } = useTranslation();
 
-    const navigate = useNavigate();
+  const navigate = useNavigate();
 
-    const { selectedContext } = useParams();
-    const repo = `${selectedContext}-resources`;
+  const { selectedContext } = useParams();
+  const repo = `${selectedContext}-resources`;
 
-    const [id, setId] = useState('');
-    const [title, setTitle] = useState('');
-    const [editIdFieldOpen, setEditIdFieldOpen] = useState(false);
-    const [resourceIdExists, setResourceIdExists] = useState(false);
-    const [bothFieldsHaveSameValue, setBothFieldsHaveSameValue] = useState(true);
+  const [id, setId] = useState('');
+  const [title, setTitle] = useState('');
+  const [editIdFieldOpen, setEditIdFieldOpen] = useState(false);
+  const [resourceIdExists, setResourceIdExists] = useState(false);
+  const [bothFieldsHaveSameValue, setBothFieldsHaveSameValue] = useState(true);
 
-    // Mutation function to create new resource
-    const { mutate: createNewResource } = useCreateResourceMutation(selectedContext);
+  // Mutation function to create new resource
+  const { mutate: createNewResource } = useCreateResourceMutation(selectedContext);
 
-    /**
-     * Creates a new resource in backend, and navigates if success
-     */
-    const handleCreateNewResource = () => {
-      const idAndTitle: NewResource = {
-        identifier: id,
-        title: {
-          nb: title,
-          nn: '',
-          en: '',
-        },
-      };
-
-      createNewResource(idAndTitle, {
-        onSuccess: () =>
-          navigate(getResourcePageURL(selectedContext, repo, idAndTitle.identifier, 'about')),
-        onError: (error: any) => {
-          if (error.response.status === ServerCodes.Conflict) {
-            setResourceIdExists(true);
-            setEditIdFieldOpen(true);
-          }
-        },
-      });
+  /**
+   * Creates a new resource in backend, and navigates if success
+   */
+  const handleCreateNewResource = () => {
+    const idAndTitle: NewResource = {
+      identifier: id,
+      title: {
+        nb: title,
+        nn: '',
+        en: '',
+      },
     };
 
-    /**
-     * Replaces the spaces in the value typed with '-'.
-     */
-    const handleIDInput = (val: string) => {
-      setId(replaceWhiteSpaceWithHyphens(val));
-      setResourceIdExists(false);
-    };
-
-    /**
-     * Updates the value of the title. If the edit field is not open,
-     * then it updates the ID to the same as the title.
-     *
-     * @param val the title value typed
-     */
-    const handleEditTitle = (val: string) => {
-      if (!editIdFieldOpen && bothFieldsHaveSameValue) {
-        setId(replaceWhiteSpaceWithHyphens(val));
-      }
-      setTitle(val);
-    };
-
-    /**
-     * Handles the click of the edit button. If we click the edit button
-     * so that it closes the edit field, the id is set to the title.
-     *
-     * @param isOpened the value of the button when it is pressed
-     * @param saveChanges if the save button is pressed, keep id and title separate
-     */
-    const handleClickEditButton = (isOpened: boolean, saveChanges: boolean) => {
-      setEditIdFieldOpen(isOpened);
-      if (saveChanges) {
-        setBothFieldsHaveSameValue(false);
-        return;
-      }
-      if (!isOpened) {
-        setBothFieldsHaveSameValue(true);
-        const shouldSetTitleToId = title !== id;
-        if (shouldSetTitleToId) {
-          setId(replaceWhiteSpaceWithHyphens(title));
+    createNewResource(idAndTitle, {
+      onSuccess: () =>
+        navigate(getResourcePageURL(selectedContext, repo, idAndTitle.identifier, 'about')),
+      onError: (error: any) => {
+        if (error.response.status === ServerCodes.Conflict) {
+          setResourceIdExists(true);
+          setEditIdFieldOpen(true);
         }
+      },
+    });
+  };
+
+  /**
+   * Replaces the spaces in the value typed with '-'.
+   */
+  const handleIDInput = (val: string) => {
+    setId(replaceWhiteSpaceWithHyphens(val));
+    setResourceIdExists(false);
+  };
+
+  /**
+   * Updates the value of the title. If the edit field is not open,
+   * then it updates the ID to the same as the title.
+   *
+   * @param val the title value typed
+   */
+  const handleEditTitle = (val: string) => {
+    if (!editIdFieldOpen && bothFieldsHaveSameValue) {
+      setId(replaceWhiteSpaceWithHyphens(val));
+    }
+    setTitle(val);
+  };
+
+  /**
+   * Handles the click of the edit button. If we click the edit button
+   * so that it closes the edit field, the id is set to the title.
+   *
+   * @param isOpened the value of the button when it is pressed
+   * @param saveChanges if the save button is pressed, keep id and title separate
+   */
+  const handleClickEditButton = (isOpened: boolean, saveChanges: boolean) => {
+    setEditIdFieldOpen(isOpened);
+    if (saveChanges) {
+      setBothFieldsHaveSameValue(false);
+      return;
+    }
+    if (!isOpened) {
+      setBothFieldsHaveSameValue(true);
+      const shouldSetTitleToId = title !== id;
+      if (shouldSetTitleToId) {
+        setId(replaceWhiteSpaceWithHyphens(title));
       }
-    };
+    }
+  };
 
-    /**
-     * Closes the modal and resets the fields
-     */
-    const handleClose = () => {
-      onClose();
-      setId('');
-      setTitle('');
-      setEditIdFieldOpen(false);
-      setResourceIdExists(false);
-    };
+  /**
+   * Closes the modal and resets the fields
+   */
+  const handleClose = () => {
+    onClose();
+    setId('');
+    setTitle('');
+    setEditIdFieldOpen(false);
+    setResourceIdExists(false);
+  };
 
-    return (
-      <Modal
-        ref={ref}
-        onClose={handleClose}
-        title={t('resourceadm.dashboard_create_modal_title')}
-        contentClassName={classes.contentWidth}
-      >
-        <ResourceNameAndId
-          isEditOpen={editIdFieldOpen}
-          title={title}
-          text={t('resourceadm.dashboard_create_modal_resource_name_and_id_text')}
-          id={id}
-          handleEditTitle={handleEditTitle}
-          handleIdInput={handleIDInput}
-          handleClickEditButton={(saveChanges: boolean) =>
-            handleClickEditButton(!editIdFieldOpen, saveChanges)
-          }
-          resourceIdExists={resourceIdExists}
-          bothFieldsHaveSameValue={bothFieldsHaveSameValue}
-          className={classes.resourceNameAndId}
-        />
-        <div className={classes.buttonWrapper}>
-          <div className={classes.closeButton}>
-            <Button onClick={onClose} color='first' variant='tertiary' size='small'>
-              {t('general.cancel')}
-            </Button>
-          </div>
-          <Button
-            onClick={() =>
-              !(id.length === 0 || title.length === 0) ? handleCreateNewResource() : undefined
-            }
-            color='first'
-            aria-disabled={id.length === 0 || title.length === 0}
-            size='small'
-          >
-            {t('resourceadm.dashboard_create_modal_create_button')}
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={t('resourceadm.dashboard_create_modal_title')}
+      contentClassName={classes.contentWidth}
+    >
+      <ResourceNameAndId
+        isEditOpen={editIdFieldOpen}
+        title={title}
+        text={t('resourceadm.dashboard_create_modal_resource_name_and_id_text')}
+        id={id}
+        handleEditTitle={handleEditTitle}
+        handleIdInput={handleIDInput}
+        handleClickEditButton={(saveChanges: boolean) =>
+          handleClickEditButton(!editIdFieldOpen, saveChanges)
+        }
+        resourceIdExists={resourceIdExists}
+        bothFieldsHaveSameValue={bothFieldsHaveSameValue}
+        className={classes.resourceNameAndId}
+      />
+      <div className={classes.buttonWrapper}>
+        <div className={classes.closeButton}>
+          <Button onClick={onClose} color='first' variant='tertiary' size='small'>
+            {t('general.cancel')}
           </Button>
         </div>
-      </Modal>
-    );
-  },
-);
-
-NewResourceModal.displayName = 'NewResourceModal';
+        <Button
+          onClick={() =>
+            !(id.length === 0 || title.length === 0) ? handleCreateNewResource() : undefined
+          }
+          color='first'
+          aria-disabled={id.length === 0 || title.length === 0}
+          size='small'
+        >
+          {t('resourceadm.dashboard_create_modal_create_button')}
+        </Button>
+      </div>
+    </Modal>
+  );
+};

--- a/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.tsx
+++ b/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import classes from './ResourceDashboardPage.module.css';
 import { Button, Spinner, Heading } from '@digdir/design-system-react';
@@ -33,9 +33,8 @@ export const ResourceDashboardPage = (): React.ReactNode => {
   const [searchValue, setSearchValue] = useState('');
   const [hasMergeConflict, setHasMergeConflict] = useState(false);
 
-  const importModalRef = useRef<HTMLDialogElement>(null);
-  const newResourceModalRef = useRef<HTMLDialogElement>(null);
-  const mergeConflictModalRef = useRef<HTMLDialogElement>(null);
+  const [newResourceModalOpen, setNewResourceModalOpen] = useState(false);
+  const [importModalOpen, setImportModalOpen] = useState(false);
 
   // Get metadata with queries
   const { data: repoStatus, refetch } = useRepoStatusQuery(selectedContext, repo);
@@ -53,13 +52,6 @@ export const ResourceDashboardPage = (): React.ReactNode => {
       setHasMergeConflict(repoStatus.hasMergeConflict);
     }
   }, [repoStatus]);
-
-  // Open the modal when there is a merge conflict
-  useEffect(() => {
-    if (hasMergeConflict && mergeConflictModalRef.current) {
-      mergeConflictModalRef.current.showModal();
-    }
-  }, [hasMergeConflict]);
 
   const filteredResourceList = filterTableData(searchValue, resourceListData ?? []);
 
@@ -111,7 +103,7 @@ export const ResourceDashboardPage = (): React.ReactNode => {
             color='second'
             icon={<MigrationIcon />}
             iconPlacement='right'
-            onClick={() => importModalRef.current?.showModal()}
+            onClick={() => setImportModalOpen(true)}
             size='medium'
           >
             <strong>{t('resourceadm.dashboard_import_resource')}</strong>
@@ -122,7 +114,7 @@ export const ResourceDashboardPage = (): React.ReactNode => {
             color='second'
             icon={<PlusCircleIcon />}
             iconPlacement='right'
-            onClick={() => newResourceModalRef.current?.showModal()}
+            onClick={() => setNewResourceModalOpen(true)}
             size='medium'
           >
             <strong>{t('resourceadm.dashboard_create_resource')}</strong>
@@ -131,17 +123,19 @@ export const ResourceDashboardPage = (): React.ReactNode => {
       </div>
       <div className={classes.horizontalDivider} />
       <div className={classes.componentWrapper}>{displayContent()}</div>
-      <MergeConflictModal
-        ref={mergeConflictModalRef}
-        handleSolveMerge={refetch}
-        org={selectedContext}
-        repo={repo}
-      />
+      {hasMergeConflict && (
+        <MergeConflictModal
+          isOpen={hasMergeConflict}
+          handleSolveMerge={refetch}
+          org={selectedContext}
+          repo={repo}
+        />
+      )}
       <NewResourceModal
-        ref={newResourceModalRef}
-        onClose={() => newResourceModalRef.current?.close()}
+        isOpen={newResourceModalOpen}
+        onClose={() => setNewResourceModalOpen(false)}
       />
-      <ImportResourceModal ref={importModalRef} onClose={() => importModalRef.current?.close()} />
+      <ImportResourceModal isOpen={importModalOpen} onClose={() => setImportModalOpen(false)} />
     </div>
   );
 };

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import type { NavigationBarPage } from 'resourceadm/types/global';
 import classes from './ResourcePage.module.css';
@@ -53,6 +53,8 @@ export const ResourcePage = (): React.ReactNode => {
   // Handle the state of resource and policy errors
   const [showResourceErrors, setShowResourceErrors] = useState(false);
   const [showPolicyErrors, setShowPolicyErrors] = useState(false);
+  const [resourceErrorModalOpen, setResourceErrorModalOpen] = useState(false);
+  const [policyErrorModalOpen, setPolicyErrorModalOpen] = useState(false);
 
   // Get the metadata for Gitea
   const { data: repoStatus, refetch } = useRepoStatusQuery(selectedContext, repo);
@@ -79,10 +81,6 @@ export const ResourcePage = (): React.ReactNode => {
   // Mutation function for editing a resource
   const { mutate: editResource } = useEditResourceMutation(selectedContext, repo, resourceId);
 
-  const resourceErrorModalRef = useRef<HTMLDialogElement>(null);
-  const policyErrorModalRef = useRef<HTMLDialogElement>(null);
-  const mergeConflictModalRef = useRef<HTMLDialogElement>(null);
-
   /**
    * If repostatus is not undefined, set the flags for if the repo has merge
    * conflict and if the repo is in sync
@@ -99,13 +97,6 @@ export const ResourcePage = (): React.ReactNode => {
   useEffect(() => {
     setCurrentPage(pageType as NavigationBarPage);
   }, [pageType]);
-
-  // Open the modal when there is a merge conflict
-  useEffect(() => {
-    if (hasMergeConflict && mergeConflictModalRef.current) {
-      mergeConflictModalRef.current.showModal();
-    }
-  }, [hasMergeConflict]);
 
   /**
    * Navigates to the selected page
@@ -125,7 +116,7 @@ export const ResourcePage = (): React.ReactNode => {
         } else {
           setShowResourceErrors(true);
           setNextPage(page);
-          resourceErrorModalRef.current?.showModal();
+          setResourceErrorModalOpen(true);
         }
       }
       // Validate Ppolicy and display errors + modal
@@ -139,7 +130,7 @@ export const ResourcePage = (): React.ReactNode => {
         } else {
           setShowPolicyErrors(true);
           setNextPage(page);
-          policyErrorModalRef.current?.showModal();
+          setPolicyErrorModalOpen(true);
         }
       }
       // Else navigate
@@ -154,8 +145,8 @@ export const ResourcePage = (): React.ReactNode => {
    */
   const handleNavigation = (newPage: NavigationBarPage) => {
     setCurrentPage(newPage);
-    policyErrorModalRef.current?.close();
-    resourceErrorModalRef.current?.close();
+    setPolicyErrorModalOpen(false);
+    setResourceErrorModalOpen(false);
     refetch();
     navigate(getResourcePageURL(selectedContext, repo, resourceId, newPage));
   };
@@ -300,28 +291,34 @@ export const ResourcePage = (): React.ReactNode => {
           )}
         </div>
       )}
-      <MergeConflictModal
-        ref={mergeConflictModalRef}
-        handleSolveMerge={refetch}
-        org={selectedContext}
-        repo={repo}
-      />
-      <NavigationModal
-        ref={policyErrorModalRef}
-        onClose={() => {
-          policyErrorModalRef.current?.close();
-        }}
-        onNavigate={() => handleNavigation(nextPage)}
-        title={t('resourceadm.resource_navigation_modal_title_policy')}
-      />
-      <NavigationModal
-        ref={resourceErrorModalRef}
-        onClose={() => {
-          resourceErrorModalRef.current?.close();
-        }}
-        onNavigate={() => handleNavigation(nextPage)}
-        title={t('resourceadm.resource_navigation_modal_title_resource')}
-      />
+      {hasMergeConflict && (
+        <MergeConflictModal
+          isOpen={hasMergeConflict}
+          handleSolveMerge={refetch}
+          org={selectedContext}
+          repo={repo}
+        />
+      )}
+      {policyErrorModalOpen && (
+        <NavigationModal
+          isOpen={policyErrorModalOpen}
+          onClose={() => {
+            setPolicyErrorModalOpen(false);
+          }}
+          onNavigate={() => handleNavigation(nextPage)}
+          title={t('resourceadm.resource_navigation_modal_title_policy')}
+        />
+      )}
+      {resourceErrorModalOpen && (
+        <NavigationModal
+          isOpen={resourceErrorModalOpen}
+          onClose={() => {
+            setResourceErrorModalOpen(false);
+          }}
+          onNavigate={() => handleNavigation(nextPage)}
+          title={t('resourceadm.resource_navigation_modal_title_resource')}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/testing/setupTests.ts
+++ b/frontend/testing/setupTests.ts
@@ -40,14 +40,6 @@ class ResizeObserver {
 }
 window.ResizeObserver = ResizeObserver;
 
-// Workaround for the known issue. For more info, see this: https://github.com/jsdom/jsdom/issues/3294#issuecomment-1268330372
-HTMLDialogElement.prototype.showModal = jest.fn(function mock(this: HTMLDialogElement) {
-  this.open = true;
-});
-HTMLDialogElement.prototype.close = jest.fn(function mock(this: HTMLDialogElement) {
-  this.open = false;
-});
-
 // I18next mocks. The useTranslation and Trans mocks apply the textMock function on the text key, so that it can be used to address the texts in the tests.
 jest.mock('i18next', () => ({ use: () => ({ init: jest.fn() }) }));
 jest.mock('react-i18next', () => ({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Reverted all changes related to switching from `react-modal` to `@digdir/designsysten`, as the designsystem modal was causing some issues with both the Select component and sizing.

## Related Issue(s)
- #11045
- 
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
