### PR TITLE
use Element as superclass and uppercase types

### DIFF
--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
@@ -20,7 +20,7 @@ class SupportedPaletteProvider {
 
         const extensionElements = bpmnFactory.create('bpmn:ExtensionElements', {
           values: [
-            bpmnFactory.create('altinn:taskExtension', {
+            bpmnFactory.create('altinn:TaskExtension', {
               taskType: taskType,
             }),
           ],
@@ -42,7 +42,7 @@ class SupportedPaletteProvider {
 
         const extensionElements = bpmnFactory.create('bpmn:ExtensionElements', {
           values: [
-            bpmnFactory.create('altinn:taskExtension', {
+            bpmnFactory.create('altinn:TaskExtension', {
               taskType: taskType,
               actions: bpmnFactory.create('altinn:Actions', {
                 action: ['sign', 'reject'],

--- a/frontend/packages/process-editor/src/extensions/altinnCustomTasks.ts
+++ b/frontend/packages/process-editor/src/extensions/altinnCustomTasks.ts
@@ -7,8 +7,8 @@ export const altinnCustomTasks = {
   },
   types: [
     {
-      name: 'taskExtension',
-      superClass: ['bpmn:ExtensionElements'],
+      name: 'TaskExtension',
+      superClass: ['Element'],
       properties: [
         {
           name: 'taskType',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes issue with extensionElements being removed on import of bpmn.

References:
- https://forum.bpmn.io/t/extension-elements-cleared-when-loading-xml-in-modeler-editor/6702/8
- https://github.com/bpmn-io/bpmn-js-examples/tree/main/custom-meta-model#building-a-meta-model-extension (especially the section below the JSON with "A few things worth noting here")

## Related Issue(s)
- #11772

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
