### PR TITLE
Add timeout to toast on unauthorised response

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -17,6 +17,7 @@
   "api_errors.DM_CsharpCompiler_NameCollision": "Navnet <bold>{{nodeName}}</bold> er i bruk på et element som har et overordnet element med samme navn. Gi et av disse elementene et annet navn.",
   "api_errors.GT_01": "Deling av endringer mislyktes. Vennligst prøv igjen.",
   "api_errors.ResourceNotFound": "Fant ikke en fil applikasjonen din prøvde å få tak i.",
+  "api_errors.Unauthorized": "Handlingen du prøver å utføre krever rettigheter du ikke har. Du blir nå logget ut.",
   "app_create_release.application_builds_based_on": "Applikasjonen bygges basert på",
   "app_create_release.build_version": "Bygg versjon",
   "app_create_release.check_status": "Sjekker status på applikasjonen din...",

--- a/frontend/packages/shared/src/contexts/ServicesContext.tsx
+++ b/frontend/packages/shared/src/contexts/ServicesContext.tsx
@@ -32,6 +32,8 @@ export type ServicesContextProviderProps = ServicesContextProps & {
   clientConfig?: QueryClientConfig;
 };
 
+const LOG_OUT_TIMER_MS = 5000;
+
 const ServicesContext = createContext<ServicesContextProps>(null);
 
 const handleError = (
@@ -44,7 +46,13 @@ const handleError = (
   // TODO : log axios errors
 
   if (error?.response?.status === ServerCodes.Unauthorized) {
-    logout().then(() => window.location.assign(userLogoutAfterPath()));
+    const errorMessageKey = 'api_errors.Unauthorized';
+    if (i18n.exists(errorMessageKey)) {
+      toast.error(t(errorMessageKey), { toastId: errorMessageKey, autoClose: LOG_OUT_TIMER_MS });
+    }
+    setTimeout(() => {
+      logout().then(() => window.location.assign(userLogoutAfterPath()));
+    }, LOG_OUT_TIMER_MS);
     return;
   }
 


### PR DESCRIPTION
## Description
Add timeout to toast when api response is unauthorised. Also move logout function to setTimeOut function with a global time constant on `5000 ms` 

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
