### PR TITLE
Changing save bpmn success message from english to norwegian

### DIFF
--- a/frontend/app-development/features/processEditor/ProcessEditor.tsx
+++ b/frontend/app-development/features/processEditor/ProcessEditor.tsx
@@ -23,7 +23,7 @@ export const ProcessEditor = () => {
       { bpmnXml: xml },
       {
         onSuccess: () => {
-          toast.success('Bpmn saved successfully');
+          toast.success(t('process_editor.saved_successfully'));
         },
       },
     );

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -648,6 +648,7 @@
   "process_editor.not_found_process_error_message": "Det finnes ingen prosess definert innenfor BPMN, Du kan verifisere om prosessen finnes i BPMN-filen.",
   "process_editor.not_found_process_heading": "Ingen tilgjengelig prosess",
   "process_editor.save": "Lagre",
+  "process_editor.saved_successfully": "Bpmn prosessen ble lagret",
   "process_editor.too_old_version_text": "Applikasjonen din har versjon {{ version }} av app-lib-pakken.\nVi støtter kun redigering av prosesser for applikasjoner som bruker versjon 8 eller nyere.",
   "process_editor.too_old_version_title": "Du kan ikke redigere denne prosessen",
   "process_editor.unknown_heading_error_message": "Obs, noe gikk galt!",


### PR DESCRIPTION
## Description
- Fixing the language 

## Related Issue(s)
- #11860 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
