### PR TITLE
Fixing header component when displaying 404 page

### DIFF
--- a/frontend/app-development/layout/PageHeader.tsx
+++ b/frontend/app-development/layout/PageHeader.tsx
@@ -64,14 +64,14 @@ export const PageHeader = ({ org, app, showSubMenu, user, isRepoError }: PageHea
 
   return (
     <AltinnHeader
-      menuItems={menuItems}
+      menuItems={!isRepoError && menuItems}
       showSubMenu={showSubMenu && !isRepoError}
       subMenuContent={!isRepoError && subMenuContent({ org, app })}
       org={org}
-      app={app}
+      app={!isRepoError && app}
       user={user}
       repository={repository}
-      buttonActions={buttonActions(org, app)}
+      buttonActions={!isRepoError && buttonActions(org, app)}
     />
   );
 };

--- a/frontend/packages/shared/src/components/altinnHeader/AltinnHeader.tsx
+++ b/frontend/packages/shared/src/components/altinnHeader/AltinnHeader.tsx
@@ -41,8 +41,12 @@ export const AltinnHeader = ({
           <a href='/'>
             <AltinnStudioLogo />
           </a>
-          <span className={classes.bigSlash}>/</span>
-          <span className={classes.appName}>{app || ''}</span>
+          {app && (
+            <>
+              <span className={classes.bigSlash}>/</span>
+              <span className={classes.appName}>{app}</span>
+            </>
+          )}
         </div>
         <AltinnHeaderMenu menuItems={menuItems} />
         <div className={classes.rightContent}>


### PR DESCRIPTION
## Description
- Fixing so that header component does not show navigation menu and app name when app is not valid

## Related Issue(s)
- #11783 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Cypress tests run green locally (https://github.com/Altinn/altinn-studio/tree/master/frontend/testing/cypress#run-altinn-studio-tests)
