### PR TITLE
11493/cypress tests settings modal

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1132,7 +1132,7 @@
   "settings_modal.setup_tab_heading": "Oppsett",
   "settings_modal.setup_tab_switch_autoDeleteOnProcessEnd": "Automatisk sletting etter innsending",
   "settings_modal.setup_tab_switch_copyInstanceSettings_enabled": "Bruker kan kopiere instansen",
-  "settings_modal.setup_tab_switch_messageBoxConfig_hideSettings_hideAlways": "Skjul i arkiv hos bruker etter innsending ",
+  "settings_modal.setup_tab_switch_messageBoxConfig_hideSettings_hideAlways": "Skjul i arkiv hos bruker etter innsending",
   "settings_modal.setup_tab_switch_onEntry_show": "Vis påstartede instanser",
   "shared.header_all": "Alle",
   "shared.header_button": "Altinn profilmeny",

--- a/frontend/testing/cypress/src/integration/studio/settingsModal.js
+++ b/frontend/testing/cypress/src/integration/studio/settingsModal.js
@@ -1,0 +1,71 @@
+/// <reference types="cypress" />
+/// <reference types="../../support" />
+
+import * as texts from '../../../../../language/src/nb.json';
+import { accessControlTab } from '../../selectors/accessControlTab';
+import { administrationTab } from '../../selectors/administrationTab';
+import { policyEditorTab } from '../../selectors/policyEditorTab';
+import { settingsTab } from '../../selectors/settingsTab';
+
+const designerAppId = `${Cypress.env('autoTestUser')}/${Cypress.env('designerAppName')}`;
+
+context('Designer', () => {
+  before(() => {
+    // cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
+    // cy.createApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
+  });
+  beforeEach(() => {
+    cy.visit('/dashboard');
+    // Navigate to designerApp
+    cy.visit('/editor/' + designerAppId);
+    cy.openSettingsModal();
+  });
+
+  it('is possible to open the settings modal', () => {
+    cy.findByRole('heading', { name: texts['settings_modal.heading'] }).should('be.visible');
+  });
+
+  it('is possible to see and edit information on About App tab', () => {
+    administrationTab.getHeader().should('be.visible');
+    administrationTab.getAppNameField().clear().type('New app name');
+    administrationTab.getAppNameField().invoke('val').should('contain', 'New app name');
+  });
+
+  it('is possible to toggle settings on app settings tab', () => {
+    settingsTab.getTab().click();
+    settingsTab.getHeader().should('be.visible');
+    settingsTab.getAutoDelete().should('be.visible');
+    settingsTab.getEnableCopyInstance().should('be.visible');
+    settingsTab.getHideInInbox().should('be.visible');
+    settingsTab.getShowStartedInstances().should('be.visible');
+  });
+
+  it('is possible to load the policy editor tab', () => {
+    policyEditorTab.getTab().click();
+    policyEditorTab.getHeader().should('be.visible');
+    policyEditorTab.getSecurityLevelSelect().should('be.visible');
+  });
+
+  it('is possible to load the access control tab', () => {
+    accessControlTab.getTab().click();
+    accessControlTab.getHeader().should('be.visible');
+    accessControlTab.getBankruptcyParty().should('be.visible');
+    accessControlTab.getOrganisationParty().should('be.visible');
+    accessControlTab.getPersonParty().should('be.visible');
+    accessControlTab.getSubUnitParty().should('be.visible');
+  });
+
+  it.only('is possible to update settings on the access control tab', () => {
+    accessControlTab.getTab().click();
+    accessControlTab.getHeader().should('be.visible');
+    accessControlTab.getBankruptcyParty().should('be.visible').click();
+    accessControlTab.getBankruptcyPartyCheckbox().should('be.checked');
+
+    // Close modal and re-open to confirm data is set as expected
+    cy.findByRole('button', { name: texts['modal.close_icon'] }).click();
+    cy.openSettingsModal();
+    accessControlTab.getTab().click();
+    accessControlTab.getBankruptcyPartyCheckbox().should('be.checked');
+  });
+});

--- a/frontend/testing/cypress/src/selectors/accessControlTab.js
+++ b/frontend/testing/cypress/src/selectors/accessControlTab.js
@@ -1,0 +1,17 @@
+import * as texts from '@altinn-studio/language/src/nb.json';
+
+export const accessControlTab = {
+  getHeader: () =>
+    cy.findByRole('heading', { name: texts['settings_modal.access_control_tab_heading'] }),
+  getTab: () => cy.findByText(texts['settings_modal.access_control_tab_heading']),
+  getBankruptcyParty: () =>
+    cy.findByText(texts['settings_modal.access_control_tab_option_bankruptcy_estate']),
+  getBankruptcyPartyCheckbox: () =>
+    cy.findByRole('checkbox', {
+      name: texts['settings_modal.access_control_tab_option_bankruptcy_estate'],
+    }),
+  getOrganisationParty: () =>
+    cy.findByText(texts['settings_modal.access_control_tab_option_organisation']),
+  getPersonParty: () => cy.findByText(texts['settings_modal.access_control_tab_option_person']),
+  getSubUnitParty: () => cy.findByText(texts['settings_modal.access_control_tab_option_sub_unit']),
+};

--- a/frontend/testing/cypress/src/selectors/administrationTab.js
+++ b/frontend/testing/cypress/src/selectors/administrationTab.js
@@ -1,0 +1,7 @@
+import * as texts from '@altinn-studio/language/src/nb.json';
+
+export const administrationTab = {
+  getAppNameField: () =>
+    cy.findByRole('textbox', { name: texts['settings_modal.about_tab_name_label'] }),
+  getHeader: () => cy.findByRole('heading', { name: texts['administration.administration'] }),
+};

--- a/frontend/testing/cypress/src/selectors/administrationTab.js
+++ b/frontend/testing/cypress/src/selectors/administrationTab.js
@@ -3,5 +3,5 @@ import * as texts from '@altinn-studio/language/src/nb.json';
 export const administrationTab = {
   getAppNameField: () =>
     cy.findByRole('textbox', { name: texts['settings_modal.about_tab_name_label'] }),
-  getHeader: () => cy.findByRole('heading', { name: texts['administration.administration'] }),
+  getHeader: () => cy.findByRole('heading', { name: texts['settings_modal.about_tab_heading'] }),
 };

--- a/frontend/testing/cypress/src/selectors/localChangesTab.js
+++ b/frontend/testing/cypress/src/selectors/localChangesTab.js
@@ -1,0 +1,23 @@
+import * as texts from '@altinn-studio/language/src/nb.json';
+
+export const localChangesTab = {
+  getHeader: () =>
+    cy.findByRole('heading', { name: texts['settings_modal.local_changes_tab_heading'] }),
+  getTab: () => cy.findByText(texts['settings_modal.local_changes_tab_heading']),
+  getDownloadChangesLink: () =>
+    cy.findByRole('link', {
+      name: texts['settings_modal.local_changes_tab_download_only_changed_button'],
+    }),
+  getDownloadAllLink: () =>
+    cy.findByRole('link', { name: texts['settings_modal.local_changes_tab_download_all_button'] }),
+  getDeleteChangesButton: () =>
+    cy.findByRole('button', { name: texts['settings_modal.local_changes_tab_delete_button'] }),
+  getConfirmRepoNameField: () =>
+    cy.findByRole('textbox', {
+      name: texts['settings_modal.local_changes_tab_delete_modal_textfield_label'],
+    }),
+  getConfirmDeleteButton: () =>
+    cy.findByRole('button', {
+      name: texts['settings_modal.local_changes_tab_delete_modal_delete_button'],
+    }),
+};

--- a/frontend/testing/cypress/src/selectors/policyEditorTab.js
+++ b/frontend/testing/cypress/src/selectors/policyEditorTab.js
@@ -1,0 +1,8 @@
+import * as texts from '@altinn-studio/language/src/nb.json';
+
+export const policyEditorTab = {
+  getHeader: () => cy.findByRole('heading', { name: texts['settings_modal.policy_tab_heading'] }),
+  getTab: () => cy.findByText(texts['settings_modal.policy_tab_heading']),
+  getSecurityLevelSelect: () =>
+    cy.findByRole('combobox', { name: texts['policy_editor.select_auth_level_label'] }),
+};

--- a/frontend/testing/cypress/src/selectors/settingsTab.js
+++ b/frontend/testing/cypress/src/selectors/settingsTab.js
@@ -1,0 +1,16 @@
+import * as texts from '@altinn-studio/language/src/nb.json';
+
+export const settingsTab = {
+  getHeader: () => cy.findByRole('heading', { name: texts['settings_modal.setup_tab_heading'] }),
+  getTab: () => cy.findByText(texts['settings_modal.setup_tab_heading']),
+  getAutoDelete: () =>
+    cy.findByText(texts['settings_modal.setup_tab_switch_autoDeleteOnProcessEnd']),
+  getHideInInbox: () =>
+    cy.findByText(
+      texts['settings_modal.setup_tab_switch_messageBoxConfig_hideSettings_hideAlways'],
+    ),
+  getEnableCopyInstance: () =>
+    cy.findByText(texts['settings_modal.setup_tab_switch_copyInstanceSettings_enabled']),
+  getShowStartedInstances: () =>
+    cy.findByText(texts['settings_modal.setup_tab_switch_onEntry_show']),
+};

--- a/frontend/testing/cypress/src/support/studio.js
+++ b/frontend/testing/cypress/src/support/studio.js
@@ -107,3 +107,7 @@ Cypress.Commands.add('ensureCreatePageIsLoaded', () => {
   cy.wait('@getLayoutSettings').its('response.statusCode').should('eq', 200);
   cy.findByRole('button', { name: `${texts['ux_editor.pages_add']}` }).should('be.visible');
 });
+
+Cypress.Commands.add('openSettingsModal', () => {
+  cy.findByRole('button', { name: texts['settings_modal.heading'] }).click();
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added cypress tests for the settings modal.
Included tabs:
- Overview/app name
- App settings
- Policy editor (only loading, no testing of the actual functionality)
- Access control
- Local changes

## Related Issue(s)
- #11493 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
