### PR TITLE
Include usecase tests in Cypress run on PR

### DIFF
--- a/.github/workflows/run-cypress-on-pr.yaml
+++ b/.github/workflows/run-cypress-on-pr.yaml
@@ -11,6 +11,7 @@ on:
       - 'docker-compose.yml'
       - 'Dockerfile'
       - 'gitea/**'
+      - 'package.json'
   workflow_dispatch:
 
 jobs:
@@ -60,7 +61,7 @@ jobs:
           install: true
           working-directory: frontend/testing/cypress
           env: environment=local
-          spec: src/integration/studio/*.js
+          spec: src/integration/**/*.js
           record: false
           parallel: false
 


### PR DESCRIPTION
- Updated the Cypress test file path so that the usecase tests are also included
- Added `package.json` to the list of trigger paths, so that the tests are also run on dependency updates
