### PR TITLE
Align datamodel field rows correctly

### DIFF
--- a/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab/ItemFieldsTable/ItemFieldsTable.module.css
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab/ItemFieldsTable/ItemFieldsTable.module.css
@@ -30,7 +30,7 @@
 }
 
 .tableCell {
-  vertical-align: middle;
+  vertical-align: top;
   padding-bottom: 1rem;
   box-sizing: border-box;
   padding-right: 1rem;


### PR DESCRIPTION
## Description
Set `vertical-align` to `top` so that the fields are aligned even when there is an error message:

<img width="260" alt="image" src="https://github.com/Altinn/altinn-studio/assets/29770305/eb8fb374-2979-48bb-aaaa-b0983d60a636">

The design system components will always have the same height, so there is no need for center alignment.

## Related Issue(s)
- #11352

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
