### PR TITLE
Fixing the task text undefined bug on process editor page

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -646,6 +646,7 @@
   "process_editor.configuration_panel_header_help_text_signing": "Signerings-oppgave (signing) brukes når sluttbruker skal bekrefte med signatur.",
   "process_editor.configuration_panel_header_help_text_title": "Informasjon om valgt oppgave",
   "process_editor.configuration_panel_id_label": "ID:",
+  "process_editor.configuration_panel_missing_task": "Oppgave",
   "process_editor.configuration_panel_name_label": "Navn: ",
   "process_editor.configuration_panel_no_task": "Velg et element i prosessen for å se detaljer.",
   "process_editor.configuration_panel_signing_task": "Oppgave: Signering",

--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/ConfigContent.test.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/ConfigContent.test.tsx
@@ -89,7 +89,7 @@ describe('ConfigContent', () => {
     expect(screen.getByText(mockBpmnDetails.name)).toBeInTheDocument();
   });
 
-  it('should display the details about the selected task when a task not of type "BpmnTaskType" is selected task is selected', () => {
+  it('should display the details about the selected task when a task not of type "BpmnTaskType" is selected', () => {
     render({ bpmnDetails: { ...mockBpmnDetails, taskType: undefined } });
 
     expect(

--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/ConfigContent.test.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/ConfigContent.test.tsx
@@ -88,6 +88,20 @@ describe('ConfigContent', () => {
     expect(screen.getByText(mockBpmnDetails.id)).toBeInTheDocument();
     expect(screen.getByText(mockBpmnDetails.name)).toBeInTheDocument();
   });
+
+  it('should display the details about the selected task when a task not of type "BpmnTaskType" is selected task is selected', () => {
+    render({ bpmnDetails: { ...mockBpmnDetails, taskType: undefined } });
+
+    expect(
+      screen.getByRole('heading', {
+        name: textMock('process_editor.configuration_panel_missing_task'),
+        level: 2,
+      }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(mockBpmnDetails.id)).toBeInTheDocument();
+    expect(screen.getByText(mockBpmnDetails.name)).toBeInTheDocument();
+  });
 });
 
 const render = (rootContextProps: Partial<BpmnContextProps> = {}) => {

--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/ConfigContent.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/ConfigContent.tsx
@@ -13,7 +13,8 @@ export const ConfigContent = (): JSX.Element => {
   const { bpmnDetails } = useBpmnContext();
 
   const configTitle = t(getConfigTitleKey(bpmnDetails?.taskType));
-  const configHeaderHelpText = t(getConfigTitleHelpTextKey(bpmnDetails?.taskType));
+  const configHeaderHelpText =
+    bpmnDetails?.taskType && t(getConfigTitleHelpTextKey(bpmnDetails?.taskType));
 
   return (
     <>
@@ -24,12 +25,14 @@ export const ConfigContent = (): JSX.Element => {
             {configTitle}
           </Heading>
         </div>
-        <HelpText
-          size='medium'
-          title={t('process_editor.configuration_panel_header_help_text_title')}
-        >
-          <Paragraph size='small'>{configHeaderHelpText}</Paragraph>
-        </HelpText>
+        {configHeaderHelpText && (
+          <HelpText
+            size='medium'
+            title={t('process_editor.configuration_panel_header_help_text_title')}
+          >
+            <Paragraph size='small'>{configHeaderHelpText}</Paragraph>
+          </HelpText>
+        )}
       </div>
       <Divider />
       <ConfigSectionWrapper>

--- a/frontend/packages/process-editor/src/utils/configPanelUtils/configPanelUtils.ts
+++ b/frontend/packages/process-editor/src/utils/configPanelUtils/configPanelUtils.ts
@@ -7,7 +7,7 @@ import { BpmnTaskType } from '../../types/BpmnTaskType';
  *
  */
 export const getConfigTitleKey = (taskType: BpmnTaskType) => {
-  return `process_editor.configuration_panel_${taskType}_task`;
+  return `process_editor.configuration_panel_${taskType ?? 'missing'}_task`;
 };
 
 /**


### PR DESCRIPTION
## Description
- Fixing the undefined bug of when a task does not have a task type

## Related Issue(s)
- PR itself

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
