### PR TITLE
Return 204 from get rule handler endpoint when file not found

### DIFF
--- a/backend/src/Designer/Controllers/AppDevelopmentController.cs
+++ b/backend/src/Designer/Controllers/AppDevelopmentController.cs
@@ -376,7 +376,7 @@ namespace Altinn.Studio.Designer.Controllers
             }
             catch (FileNotFoundException)
             {
-                return NotFound("Could not find rule handler in app.");
+                return NoContent();
             }
             catch (BadHttpRequestException exception)
             {

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetRuleHandlerTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetRuleHandlerTests.cs
@@ -51,9 +51,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-            string content = await response.Content.ReadAsStringAsync();
-            content.Should().Be("Could not find rule handler in app.");
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
         }
 
         private static async Task<string> AddRuleHandler(string createdFolderPath, string layoutSetName, string expectedRuleHandlerPath)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Return 204 from api when rule handler file is not found

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
