### PR TITLE
breaking the chained cypress actions in datamodel

### DIFF
--- a/frontend/testing/cypress/src/integration/studio/datamodel.js
+++ b/frontend/testing/cypress/src/integration/studio/datamodel.js
@@ -45,21 +45,25 @@ context('datamodel', () => {
 
     const addFieldToTestObject = () => {
       datamodel.getProperty(/^test($| )/).focus();
-      cy.findAllByRole('button', {name: texts['schema_editor.add_node_of_type']}).click();
+      cy.findAllByRole('button', { name: texts['schema_editor.add_node_of_type'] }).click();
       cy.findByRole('menuitem', { name: texts['schema_editor.add_field'] }).should('exist').click();
     };
 
     // Add text1
     addFieldToTestObject();
     datamodel.getProperty('name0').should('exist').click();
-    datamodel.getNameField().clear().type('text1').blur();
+    const nameField = datamodel.getNameField();
+    nameField.clear().type('text1');
+    nameField.blur();
     datamodel.getNameField().invoke('val').should('eq', 'text1');
     datamodel.getProperty('text1').should('exist');
 
     // Add text2
     addFieldToTestObject();
     datamodel.getProperty('name0').should('exist');
-    datamodel.getNameField().clear().type('text2').blur();
+    const nameField2 = datamodel.getNameField();
+    nameField2.clear().type('text2');
+    nameField2.blur();
     datamodel.getNameField().invoke('val').should('eq', 'text2');
     datamodel.getProperty('text2').should('exist');
 
@@ -69,7 +73,9 @@ context('datamodel', () => {
     datamodel.getTypeField().click();
     cy.findByRole('option', { name: texts['schema_editor.integer'] }).should('exist').click();
     datamodel.getTypeField().invoke('val').should('eq', texts['schema_editor.integer']);
-    datamodel.getNameField().clear().type('number1').blur();
+    const nameField3 = datamodel.getNameField();
+    nameField3.clear().type('number1');
+    nameField3.blur();
     datamodel.getProperty('number1').should('exist');
 
     // Ensure changes are saved


### PR DESCRIPTION
## Description

Split up the chained actions in the cypress tests for datamodel tests as an attempt of fixing the sporadic failing cypress test in dev-env. This was a suggestion from cypress due to the use of `.blur()`:

```
cy.blur() failed because the page updated as a result of this command, but you tried to continue the command chain. The subject is no longer attached to the DOM, and Cypress cannot requery the page after commands such as cy.blur().



Common situations why this happens:

  - Your JS framework re-rendered asynchronously

  - Your app code reacted to an event firing and removed the element



You can typically solve this by breaking up a chain.
```
