### PR TITLE
Add random single digit to end of generated password for .env file used for setup

### DIFF
--- a/development/utils/ensure-dot-env.js
+++ b/development/utils/ensure-dot-env.js
@@ -3,9 +3,9 @@ const fs = require('fs');
 const os = require('os');
 const getCommit = require('./git-commit-hash');
 const randomPass = () =>
-  [Math.random().toString(36).substring(2, 5), Math.random().toString(36).substring(2, 5)].join(
-    'DIG@',
-  );
+  [Math.random().toString(36).substring(2, 5), Math.random().toString(36).substring(2, 5)]
+    .join('DIG@')
+    .concat(Math.floor(Math.random() * 10).toString());
 
 const defaultEnvVars = {
   CYPRESS_TEST_APP: 'autodeploy-v3',


### PR DESCRIPTION
## Description
To meet new password requirements, without needing to adapt the `.env` file manually, this PR adds a random digit to the end of the password generated when running the setup script.

**NB: In order to generate a new passord when running the script, all passwords for the `.env` file must be deleted before running the script again** 

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
