### PR TITLE
Cypress improvements

### DIFF
--- a/frontend/app-development/features/overview/components/Overview.tsx
+++ b/frontend/app-development/features/overview/components/Overview.tsx
@@ -50,13 +50,14 @@ export const Overview = () => {
 
   return (
     <PageContainer>
-      <div className={classes.container}>
-        <header className={classes.header}>
-          <Heading size='xlarge'>{appConfigData?.serviceName || app}</Heading>
+      <main className={classes.container}>
+        <header className={classes.header} role='generic'>
+          {/* According to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header, the role of <header> should implicitly be "generic" when it is a descendant of <main>, but Testing Library still interprets it as "banner". */}
+          <Heading level={1} size='xlarge'>{appConfigData?.serviceName || app}</Heading>
         </header>
         <div className={classes.panel}>
           <div className={classes.content}>
-            <main className={classes.main}>
+            <div className={classes.main}>
               <section className={classes.mainSection}>
                 {repoOwnerIsOrg ? <AppEnvironments /> : <RepoOwnedByPersonInfo />}
               </section>
@@ -68,7 +69,7 @@ export const Overview = () => {
               <section className={classes.mainSection}>
                 <Navigation />
               </section>
-            </main>
+            </div>
             <aside className={classes.aside}>
               <section className={classes.asideSection}>
                 <Documentation />
@@ -82,7 +83,7 @@ export const Overview = () => {
             <Link href='/contact'>{t('general.contact')}</Link>
           </footer>
         </div>
-      </div>
+      </main>
     </PageContainer>
   );
 };

--- a/frontend/packages/shared/src/components/altinnHeader/AltinnHeader.tsx
+++ b/frontend/packages/shared/src/components/altinnHeader/AltinnHeader.tsx
@@ -38,7 +38,7 @@ export const AltinnHeader = ({
   repoOwnerIsOrg,
 }: AltinnHeaderProps) => {
   return (
-    <div id='altinn-header-container'>
+    <div role='banner'>
       <div className={classnames(classes.altinnHeaderBar, classes[variant])}>
         <div className={classes.leftContent}>
           <a href='/'>

--- a/frontend/packages/text-editor/src/RightMenu.tsx
+++ b/frontend/packages/text-editor/src/RightMenu.tsx
@@ -3,7 +3,7 @@ import classes from './RightMenu.module.css';
 import type { LangCode } from './types';
 import { LangSelector } from './LangSelector';
 import { getLangName, langOptions } from './utils';
-import { Button, Checkbox, Fieldset } from '@digdir/design-system-react';
+import { Button, Checkbox, Fieldset, Heading } from '@digdir/design-system-react';
 import { defaultLangCode } from './constants';
 import { removeItemByValue } from 'app-shared/utils/arrayUtils';
 import { useTranslation } from 'react-i18next';
@@ -44,9 +44,7 @@ export const RightMenu = ({
   return (
     <aside className={classes.RightMenu__sidebar}>
       <div className={classes.RightMenu__verticalContent}>
-        <header>
-          <div className={classes['LangEditor__title-md']}>{t('schema_editor.language')}</div>
-        </header>
+        <Heading level={2} size='small'>{t('schema_editor.language')}</Heading>
         <div> {t('schema_editor.language_info_melding')}</div>
       </div>
       <div className={classes.RightMenu__verticalContent}>

--- a/frontend/testing/cypress/src/integration/studio/datamodel.js
+++ b/frontend/testing/cypress/src/integration/studio/datamodel.js
@@ -15,7 +15,7 @@ context('datamodel', () => {
 
   beforeEach(() => {
     cy.visit('/dashboard');
-    cy.searchAndOpenApp(Cypress.env('designerAppName'));
+    cy.goToApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
 
     // Navigate to datamodels page and close dialog
     header.getDatamodelLink().click();
@@ -88,8 +88,10 @@ context('datamodel', () => {
     );
 
     // Delete datamodel
+    cy.findByRole('option', { name: 'datamodel' }).should('exist');
     cy.findByRole('button', { name: texts['schema_editor.delete_data_model'] }).click();
     cy.findByRole('button', { name: texts['schema_editor.confirm_deletion'] }).click();
+    cy.findByRole('option', { name: 'datamodel' }).should('not.exist');
   });
 
   it('Allows to upload and then delete an XSD file', () => {

--- a/frontend/testing/cypress/src/integration/studio/designer.js
+++ b/frontend/testing/cypress/src/integration/studio/designer.js
@@ -27,7 +27,7 @@ context('Designer', () => {
     cy.intercept('POST', '**/app-development/layout-settings?**').as('postLayoutSettings');
 
     // Navigate to designerApp
-    cy.visit('/editor/' + designerAppId);
+    cy.goToApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
     header.getCreateLink().click();
     cy.ensureCreatePageIsLoaded();
 
@@ -53,7 +53,7 @@ context('Designer', () => {
     cy.intercept('POST', '**/app-development/layout-settings?**').as('postLayoutSettings');
 
     // Navigate to designerApp
-    cy.visit('/editor/' + designerAppId);
+    cy.goToApp(Cypress.env('autoTestUser'), Cypress.env('designerAppName'));
     header.getCreateLink().click();
     cy.ensureCreatePageIsLoaded();
 

--- a/frontend/testing/cypress/src/integration/studio/overview.js
+++ b/frontend/testing/cypress/src/integration/studio/overview.js
@@ -10,7 +10,7 @@ const FeatureFlagEnum = Object.freeze({
   ProcessEditor: 'processEditor',
 });
 
-context('Designer', () => {
+context('Overview', () => {
   before(() => {
     cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
     cy.deleteApp(

--- a/frontend/testing/cypress/src/integration/studio/wcag.js
+++ b/frontend/testing/cypress/src/integration/studio/wcag.js
@@ -7,6 +7,11 @@ import { header } from '../../selectors/header';
 context('WCAG', () => {
   before(() => {
     cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.deleteApp(
+      Cypress.env('orgUserName'),
+      Cypress.env('designerAppName'),
+      Cypress.env('accessToken'),
+    );
     cy.studioLogin(Cypress.env('autoTestUser'), Cypress.env('autoTestUserPwd'));
     cy.createApp(Cypress.env('orgFullName'), Cypress.env('designerAppName'));
   });
@@ -24,6 +29,11 @@ context('WCAG', () => {
 
   after(() => {
     cy.deleteAllApps(Cypress.env('autoTestUser'), Cypress.env('accessToken'));
+    cy.deleteApp(
+      Cypress.env('orgUserName'),
+      Cypress.env('designerAppName'),
+      Cypress.env('accessToken'),
+    );
   });
 
   it('accessibility test for dashboard', () => {

--- a/frontend/testing/cypress/src/selectors/header.js
+++ b/frontend/testing/cypress/src/selectors/header.js
@@ -6,8 +6,8 @@ const getMenuItem = (name) => cy.findByRole('menuitem', { name });
 export const header = {
   getAvatar: () => cy.findByAltText(texts['shared.header_button_alt']),
   getCreateLink: () =>
-    cy.get('#altinn-header-container').findByRole('link', { name: texts['top_menu.create'] }),
-  getDatamodelLink: () => cy.findByRole('link', { name: texts['top_menu.datamodel'] }),
+    cy.findByRole('banner').findByRole('link', { name: texts['top_menu.create'] }),
+  getDatamodelLink: () => cy.findByRole('banner').findByRole('link', { name: texts['top_menu.datamodel'] }),
   getDeployButton: () => cy.findByRole('button', { name: texts['top_menu.deploy'] }),
   getDescribeChangesField: () =>
     cy.findByRole('textbox', { name: texts['sync_header.describe_and_validate'] }),

--- a/frontend/testing/cypress/src/support/index.d.ts
+++ b/frontend/testing/cypress/src/support/index.d.ts
@@ -81,6 +81,11 @@ declare namespace Cypress {
     searchAndOpenApp(appName: string): Chainable<Element>;
 
     /**
+     * Custom command to go directly to an app using url
+     */
+    goToApp(userName: string, appName: string): Chainable<Element>;
+
+    /**
      * Switch selected context in dashboard
      * @param context The context to switch to. Either 'self', 'all', or org user name.
      * @example cy.searchAndOpenApp('self')

--- a/frontend/testing/cypress/src/support/studio.js
+++ b/frontend/testing/cypress/src/support/studio.js
@@ -93,6 +93,10 @@ Cypress.Commands.add('searchAndOpenApp', (appName) => {
     .click();
 });
 
+Cypress.Commands.add('goToApp', (userName, appName) => {
+  cy.visit(`/editor/${userName}/${appName}`);
+});
+
 /**
  * Select an element in the application list
  */


### PR DESCRIPTION
## Description
- Added the `banner` role to the header so that it can be addressed by the role in tests
- Made sure that the "Testdepartementet" app is deleted in the Wcag test suite
- Added a check that makes the datamodel test fail if the datamodel deletion is not successful
- Added the `goToApp` command, that navigates directly to the given app

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
