### PR TITLE
Fix command chain errors in Cypress

### DIFF
--- a/frontend/testing/cypress/src/integration/studio/datamodel.js
+++ b/frontend/testing/cypress/src/integration/studio/datamodel.js
@@ -52,19 +52,20 @@ context('datamodel', () => {
     // Add text1
     addFieldToTestObject();
     datamodel.getProperty('name0').should('exist').click();
-    const nameField = datamodel.getNameField();
-    nameField.clear().type('text1');
-    nameField.blur();
-    datamodel.getNameField().invoke('val').should('eq', 'text1');
+    datamodel.getNameField().as('nameField');
+    cy.get('@nameField').clear();
+    cy.get('@nameField').type('text1');
+    cy.get('@nameField').blur();
+    cy.get('@nameField').invoke('val').should('eq', 'text1');
     datamodel.getProperty('text1').should('exist');
 
     // Add text2
     addFieldToTestObject();
     datamodel.getProperty('name0').should('exist');
-    const nameField2 = datamodel.getNameField();
-    nameField2.clear().type('text2');
-    nameField2.blur();
-    datamodel.getNameField().invoke('val').should('eq', 'text2');
+    cy.get('@nameField').clear();
+    cy.get('@nameField').type('text2');
+    cy.get('@nameField').blur();
+    cy.get('@nameField').invoke('val').should('eq', 'text2');
     datamodel.getProperty('text2').should('exist');
 
     //Add number1
@@ -73,9 +74,10 @@ context('datamodel', () => {
     datamodel.getTypeField().click();
     cy.findByRole('option', { name: texts['schema_editor.integer'] }).should('exist').click();
     datamodel.getTypeField().invoke('val').should('eq', texts['schema_editor.integer']);
-    const nameField3 = datamodel.getNameField();
-    nameField3.clear().type('number1');
-    nameField3.blur();
+    cy.get('@nameField').clear();
+    cy.get('@nameField').type('number1');
+    cy.get('@nameField').blur();
+    cy.get('@nameField').invoke('val').should('eq', 'number1');
     datamodel.getProperty('number1').should('exist');
 
     // Ensure changes are saved


### PR DESCRIPTION
## Description
The datamodel test occasionally fails with the following error message:
```
cy.blur() failed because the page updated as a result of this command, but you tried to continue the command chain. The subject is no longer attached to the DOM, and Cypress cannot requery the page after commands such as cy.blur().

Common situations why this happens:

Your JS framework re-rendered asynchronously
Your app code reacted to an event firing and removed the element
You can typically solve this by breaking up a chain. For example, rewrite:

> cy.get('button').click().should('have.class', 'active')

to

> cy.get('button').as('btn').click()

> cy.get('@btn').should('have.class', 'active')
```
This is probably due to debouncing effects that make things rerender. I have updated the test by breaking up the chains as recommended by the message.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
