### PR TITLE
added datalists endpoint

### DIFF
--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -845,11 +845,11 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>The options list if it exists, otherwise nothing</returns>
         [HttpGet]
         [Route("instances/{partyId}/{instanceGuid}/datalists/{dataListId}")]
-        public async Task<ActionResult<string>> GetDatalistsForInstance(string org, string app, string dataListId, [FromQuery] string language, [FromQuery] string size, CancellationToken cancellationToken)
+        public async Task<ActionResult<List<string>>> GetDatalistsForInstance(string org, string app, string dataListId, [FromQuery] string language, [FromQuery] string size, CancellationToken cancellationToken)
         {
             // TODO: Should look into whether we can get some actual data here, or if we can make an "informed" mock based on the setup.
             // For now, we just return an empty list.
-            return Ok("[]");
+            return Ok(new List<string>());
         }
 
         /// <summary>

--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -834,6 +834,25 @@ namespace Altinn.Studio.Designer.Controllers
         }
 
         /// <summary>
+        /// Action for getting data list for a given data list id for a given instance
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="app">Application identifier which is unique within an organisation.</param>
+        /// <param name="dataListId">The id of the data list</param>
+        /// <param name="language">The language for the data list</param>
+        /// <param name="size">The number of items to return</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
+        /// <returns>The options list if it exists, otherwise nothing</returns>
+        [HttpGet]
+        [Route("instances/{partyId}/{instanceGuid}/datalists/{dataListId}")]
+        public async Task<ActionResult<string>> GetDatalistsForInstance(string org, string app, string dataListId, [FromQuery] string language, [FromQuery] string size, CancellationToken cancellationToken)
+        {
+            // TODO: Should look into whether we can get some actual data here, or if we can make an "informed" mock based on the setup.
+            // For now, we just return an empty list.
+            return Ok("[]");
+        }
+
+        /// <summary>
         /// Action for updating data model with tag for attachment component // TODO: Figure out what actually happens here
         /// </summary>
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ref. [this slack thread](https://altinn.slack.com/archives/C02EJ9HKQA3/p1704374921473059), we are missing an endpoint in our preview mock for `datalists`.
This is causing rendering of app-frontend preview to fail in Designer, as we get a 404 from the endpoint.

The issue is easily resolved by adding a basic endpoint that returns an empty list. We can later look into if there are some ways of mocking up this data in a good way to present in preview, but the data is dynamic and usually fetched from an external source. For now, returning an empty list.

Also aware that there are some unused input params here. Included them for future use, but open for removing them for now as well.

## Verification

- [x] **Your** code builds clean without any errors or warnings
