### PR TITLE
Use string inbuilt methods instead of regex to see if substring matches start of string before replacement

### DIFF
--- a/frontend/packages/schema-model/src/lib/SchemaModel.test.ts
+++ b/frontend/packages/schema-model/src/lib/SchemaModel.test.ts
@@ -616,6 +616,16 @@ describe('SchemaModel', () => {
       validateTestUiSchema(result.asArray());
     });
 
+    it('Updates the pointer in child nodes for a def node', () => {
+      const newPointer = '#/$defs/newName';
+      const newNode = { ...defNodeWithChildrenMock, pointer: newPointer };
+      const model = schemaModel.deepClone();
+      const result = model.updateNode(defNodeWithChildrenMock.pointer, newNode);
+      const children = result.getChildNodes(newPointer);
+      expect(children.map((child) => child.pointer)).toEqual(['#/$defs/newName/properties/child']);
+      validateTestUiSchema(result.asArray());
+    });
+
     it('Updates the pointer in grandchild nodes', () => {
       const newPointer = '#/properties/newName';
       const newNode = { ...parentNodeMock, pointer: newPointer };

--- a/frontend/packages/shared/src/utils/stringUtils.ts
+++ b/frontend/packages/shared/src/utils/stringUtils.ts
@@ -6,7 +6,8 @@ import { last } from 'app-shared/utils/arrayUtils';
  * @param separator The separator to search for.
  * @returns The substring after the last occurrence of the given separator.
  */
-export const substringAfterLast = (str: string, separator: string): string => last(str.split(separator)) || '';
+export const substringAfterLast = (str: string, separator: string): string =>
+  last(str.split(separator)) || '';
 
 /**
  * Returns substring before last occurrence of separator.
@@ -25,8 +26,12 @@ export const substringBeforeLast = (str: string, separator: string): string =>
  * @param replacement The replacement to replace the substring with.
  * @returns The string with the substring replaced at the start.
  */
-export const replaceStart = (str: string, substring: string, replacement: string): string =>
-  str.replace(new RegExp('^' + substring), replacement);
+export const replaceStart = (str: string, substring: string, replacement: string): string => {
+  if (str.startsWith(substring)) {
+    return replacement + str.slice(substring.length);
+  }
+  return str;
+};
 
 /**
  * Replaces the given substring with the given replacement at the end of the string.
@@ -53,7 +58,7 @@ export const removeStart = (str: string, ...substrings: string[]): string => {
     }
   }
   return str;
-}
+};
 
 /**
  * Removes any of the given substrings from the end of the string.
@@ -71,4 +76,4 @@ export const removeEnd = (str: string, ...substrings: string[]): string => {
     }
   }
   return str;
-}
+};


### PR DESCRIPTION
## Description
Use string inbuilt methods instead of regex to see if substring matches start of string before replacement in order for the replacement of parent nodes names in child pointers to be updated correctly

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
