### PR TITLE
set loading to true while fetching push status

### DIFF
--- a/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/VersionControlButtons.tsx
+++ b/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/VersionControlButtons.tsx
@@ -105,6 +105,10 @@ export const VersionControlButtons = ({ hasPushRight, org, app }: IVersionContro
 
   const shareChanges = async (currentTarget: any) => {
     setSyncModalAnchorEl(currentTarget);
+    setModalState({
+      ...initialModalState,
+      isLoading: true,
+    });
     const { data: repoStatusResult } = await refetchRepoStatus();
     if (!hasLocalChanges(repoStatusResult)) {
       setModalState({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Set the loading prop to true to display the spinner while fetching the push status.

https://github.com/Altinn/altinn-studio/assets/74791975/aba87bb2-dd82-4872-b0c7-bdccef14b0bc




<!--- Describe your changes in detail -->

## Related Issue(s)

- #10629 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
