### PR TITLE
Refactor Altinn header buttons to links

### DIFF
--- a/frontend/app-development/layout/PageHeader.tsx
+++ b/frontend/app-development/layout/PageHeader.tsx
@@ -33,17 +33,13 @@ export const buttonActions = (org: string, app: string): AltinnButtonActionItem[
     {
       title: 'top_menu.preview',
       menuKey: TopBarMenu.Preview,
-      buttonVariant: 'secondary',
-      buttonColor: 'inverted',
-      headerButtonsClasses: undefined,
-      handleClick: () => packagesRouter.navigateToPackage('preview'),
+      to: packagesRouter.getPackageNavigationUrl('preview'),
+      isInverted: true,
     },
     {
       title: 'top_menu.deploy',
       menuKey: TopBarMenu.Deploy,
-      buttonVariant: 'secondary',
-      headerButtonsClasses: undefined,
-      handleClick: () => packagesRouter.navigateToPackage('editorPublish'),
+      to: packagesRouter.getPackageNavigationUrl('editorPublish'),
     },
   ];
   return actions;

--- a/frontend/app-development/layout/PageLayout.test.tsx
+++ b/frontend/app-development/layout/PageLayout.test.tsx
@@ -67,7 +67,7 @@ describe('PageLayout', () => {
   it('renders header with no publish button when repoOwner is a private person', async () => {
     await resolveAndWaitForSpinnerToDisappear();
 
-    expect(screen.getByRole('button', { name: textMock('top_menu.preview') })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: textMock('top_menu.preview') })).toBeInTheDocument();
 
     expect(
       screen.queryByRole('button', { name: textMock('top_menu.deploy') }),

--- a/frontend/app-preview/src/components/AppBarConfig/AppPreviewBarConfig.tsx
+++ b/frontend/app-preview/src/components/AppBarConfig/AppPreviewBarConfig.tsx
@@ -108,9 +108,7 @@ export const appPreviewButtonActions = (
     {
       title: 'top_menu.preview_back_to_editing',
       menuKey: TopBarMenu.Preview,
-      buttonVariant: 'secondary',
-      headerButtonsClasses: classes.backToEditorBtn,
-      handleClick: () => packagesRouter.navigateToPackage('editorUiEditor', queryParams),
+      to: `${packagesRouter.getPackageNavigationUrl('editorUiEditor')}${queryParams}`,
     },
   ];
   return action;

--- a/frontend/packages/shared/src/components/altinnHeader/AltinnHeader.test.tsx
+++ b/frontend/packages/shared/src/components/altinnHeader/AltinnHeader.test.tsx
@@ -6,8 +6,19 @@ import { textMock } from '../../../../../testing/mocks/i18nMock';
 import { RepositoryType } from 'app-shared/types/global';
 import { TopBarMenu } from 'app-shared/enums/TopBarMenu';
 import { MemoryRouter } from 'react-router-dom';
+import { AltinnButtonActionItem } from './types';
+
+const mockTo: string = '/test';
+const mockButtonTitle: string = 'title';
+const mockAction: AltinnButtonActionItem = {
+  menuKey: 'menu-1',
+  title: mockButtonTitle,
+  to: mockTo,
+};
 
 describe('AltinnHeader', () => {
+  afterEach(jest.clearAllMocks);
+
   it('should render AltinnHeaderMenu', () => {
     render({
       menuItems: [
@@ -23,18 +34,10 @@ describe('AltinnHeader', () => {
 
   it('should render AltinnHeaderButtons when buttonActions are provided', () => {
     render({
-      buttonActions: [
-        {
-          buttonVariant: 'tertiary',
-          headerButtonsClasses: undefined,
-          menuKey: 'test-button',
-          title: 'TestButton',
-          handleClick: jest.fn(),
-        },
-      ],
+      buttonActions: [mockAction],
     });
-    expect(screen.getByRole('button', { name: textMock('TestButton') })).toBeInTheDocument();
-    expect(screen.getAllByRole('button').length).toEqual(2); // TestButton + Profile Menu
+    expect(screen.getByRole('link', { name: textMock(mockButtonTitle) })).toBeInTheDocument();
+    expect(screen.getAllByRole('button').length).toEqual(1); // Profile Menu
   });
 
   it('should not render AltinnHeaderButtons when buttonActions are not provided', () => {
@@ -61,36 +64,17 @@ describe('AltinnHeader', () => {
   });
 
   it('should render Deploy header button when repo is owned by an org', () => {
-    const mockTextDeployButton = 'TestDeployButton';
     render({
       repoOwnerIsOrg: true,
-      buttonActions: [
-        {
-          buttonVariant: 'tertiary',
-          headerButtonsClasses: undefined,
-          menuKey: TopBarMenu.Deploy,
-          title: mockTextDeployButton,
-          handleClick: jest.fn(),
-        },
-      ],
+      buttonActions: [mockAction],
     });
-    expect(
-      screen.getByRole('button', { name: textMock(mockTextDeployButton) }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: textMock(mockButtonTitle) })).toBeInTheDocument();
   });
 
   it('should not render Deploy header button when repo is owned by a private person', () => {
     render({
       repoOwnerIsOrg: false,
-      buttonActions: [
-        {
-          buttonVariant: 'tertiary',
-          headerButtonsClasses: undefined,
-          menuKey: TopBarMenu.Deploy,
-          title: 'TestButton',
-          handleClick: jest.fn(),
-        },
-      ],
+      buttonActions: [mockAction],
     });
     expect(
       screen.queryByRole('button', { name: textMock(TopBarMenu.Deploy) }),

--- a/frontend/packages/shared/src/components/altinnHeader/types.ts
+++ b/frontend/packages/shared/src/components/altinnHeader/types.ts
@@ -1,12 +1,8 @@
-import { ButtonProps } from '@digdir/design-system-react';
-
 export type AltinnHeaderVariant = 'regular' | 'preview';
 
 export interface AltinnButtonActionItem {
   title: string;
   menuKey: string;
-  buttonVariant: ButtonProps['variant'];
-  buttonColor?: ButtonProps['color'];
-  headerButtonsClasses: any;
-  handleClick: () => void;
+  to: string;
+  isInverted?: boolean;
 }

--- a/frontend/packages/shared/src/components/altinnHeaderButtons/AltinnHeaderButton.module.css
+++ b/frontend/packages/shared/src/components/altinnHeaderButtons/AltinnHeaderButton.module.css
@@ -1,27 +1,51 @@
-.properties {
-  align-items: center;
-  padding-right: 8rem;
-  gap: 1rem;
-}
-
-.rightContentButtons {
-  align-items: center;
+.linkButton {
   display: flex;
-  gap: 1rem;
+  justify-content: center;
+  align-items: center;
+  border: var(--fds-border_width-default) solid transparent;
+  padding: 0 var(--fds-spacing-3);
+  cursor: pointer;
+  font-family: inherit;
+  text-decoration: none;
+  position: relative;
+  border-radius: var(--fds-border_radius-interactive);
+  min-height: var(--fds-sizing-8);
 }
 
-.rightContentButtons > * {
-  flex: 1;
+.linkButton:focus-visible {
+  --fds-focus-border-width: 3px;
+
+  outline: var(--fds-focus-border-width) solid var(--fds-semantic-border-focus-outline);
+  outline-offset: var(--fds-focus-border-width);
+  box-shadow: 0 0 0 var(--fds-focus-border-width) var(--fds-semantic-border-focus-boxshadow);
 }
 
-.infoPreviewIsBetaMessage {
-  padding: 20px;
-  display: inline-block;
+.invertedButton {
+  border: 1px solid var(--fds-semantic-border-on_inverted-default);
+  background: transparent;
+  color: var(--fds-semantic-text-neutral-on_inverted);
 }
 
-.infoIcon {
-  border: white 1px solid;
-  border-radius: 50%;
-  font-size: larger;
-  margin-top: 6px;
+.invertedButton:not([aria-disabled='true'], :disabled):hover {
+  background: var(--fds-semantic-surface-on_inverted-no_fill-hover);
+}
+
+.invertedButton:not([aria-disabled='true'], :disabled):active {
+  background: var(--fds-semantic-surface-on_inverted-no_fill-active);
+}
+
+.normalButton {
+  border-color: var(--fds-semantic-border-action-first-default);
+  background: var(--fds-semantic-surface-action-first-no_fill);
+  color: var(--fds-semantic-text-neutral-default);
+}
+
+.normalButton:not([aria-disabled='true'], :disabled):hover {
+  border-color: var(--fds-semantic-border-action-first-hover);
+  background: var(--fds-semantic-surface-action-first-no_fill-hover);
+}
+
+.normalButton:not([aria-disabled='true'], :disabled):active {
+  border-color: var(--fds-semantic-border-action-first-active);
+  background: var(--fds-semantic-surface-action-first-no_fill-active);
 }

--- a/frontend/packages/shared/src/components/altinnHeaderButtons/AltinnHeaderButton.test.tsx
+++ b/frontend/packages/shared/src/components/altinnHeaderButtons/AltinnHeaderButton.test.tsx
@@ -1,57 +1,36 @@
 import React from 'react';
-import { render as rtlRender, screen, waitFor, act } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render as rtlRender, screen } from '@testing-library/react';
 import { AltinnHeaderButton, AltinnHeaderButtonProps } from './AltinnHeaderButton';
 import { textMock } from '../../../../../testing/mocks/i18nMock';
+import { AltinnButtonActionItem } from '../altinnHeader/types';
+
+const mockTo: string = '/test';
+const mockButtonTitle: string = 'title';
+const mockAction: AltinnButtonActionItem = {
+  menuKey: 'menu-1',
+  title: mockButtonTitle,
+  to: mockTo,
+};
 
 describe('AltinnHeaderbuttons', () => {
+  afterEach(jest.clearAllMocks);
+
   it('should render nothing if action is undefined', () => {
     render({ action: undefined });
     expect(screen.queryByRole('button')).toBeNull();
   });
 
-  it('should render the button for the provided action', () => {
-    render({
-      action: {
-        buttonVariant: 'primary',
-        headerButtonsClasses: undefined,
-        menuKey: 'menu-1',
-        title: 'Button1',
-        handleClick: jest.fn(),
-      },
-    });
-    expect(screen.getByRole('button', { name: textMock('Button1') })).toBeInTheDocument();
-  });
+  it('should render the button for the provided action with the correct href', () => {
+    render();
 
-  it('should trigger the handleClick function when a button is clicked', async () => {
-    const user = userEvent.setup();
-
-    const handleClick = jest.fn();
-    render({
-      action: {
-        buttonVariant: 'primary',
-        headerButtonsClasses: undefined,
-        menuKey: 'menu-1',
-        title: 'Button1',
-        handleClick,
-      },
-    });
-
-    const button = screen.getByRole('button', { name: textMock('Button1') });
-    await act(() => user.click(button));
-    await waitFor(() => expect(handleClick).toHaveBeenCalledTimes(1));
+    const link = screen.getByRole('link', { name: textMock(mockButtonTitle) });
+    expect(link).toHaveAttribute('href', mockTo);
   });
 });
 
 const render = (props?: Partial<AltinnHeaderButtonProps>) => {
   const defaultProps: AltinnHeaderButtonProps = {
-    action: {
-      buttonVariant: 'primary',
-      headerButtonsClasses: undefined,
-      menuKey: 'menu-1',
-      title: 'Button1',
-      handleClick: jest.fn(),
-    },
+    action: mockAction,
   };
   rtlRender(<AltinnHeaderButton {...defaultProps} {...props} />, { wrapper: undefined });
 };

--- a/frontend/packages/shared/src/components/altinnHeaderButtons/AltinnHeaderButton.tsx
+++ b/frontend/packages/shared/src/components/altinnHeaderButtons/AltinnHeaderButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button } from '@digdir/design-system-react';
+import classes from './AltinnHeaderButton.module.css';
+import cn from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { AltinnButtonActionItem } from '../altinnHeader/types';
 
@@ -12,18 +13,19 @@ export const AltinnHeaderButton = ({ action }: AltinnHeaderButtonProps) => {
 
   if (!action) return null;
 
+  // Need to keep the link as an 'a' element because the <Link /> component from the designsystem only shows purple color text
   return (
-    <Button
-      className={action.headerButtonsClasses}
+    <a
+      href={action.to}
+      className={cn(
+        classes.linkButton,
+        action.isInverted ? classes.invertedButton : classes.normalButton,
+      )}
       key={action.menuKey}
-      onClick={action.handleClick}
-      variant={action.buttonVariant}
-      color={action.buttonColor || 'first'}
       data-testid={action.menuKey}
       aria-label={t(action.title)}
-      size='small'
     >
       {t(action.title)}
-    </Button>
+    </a>
   );
 };


### PR DESCRIPTION
## Description
- Refactored the buttons from ```button``` to ```a```. 
- Added CSS styling in the exact same way as the designsystem is styling their buttons

## Related Issue(s)
- #11363 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
