### PR TITLE
Place newly added texts at the beginning of list of text resources

### DIFF
--- a/backend/src/Designer/Services/Implementation/TextsService.cs
+++ b/backend/src/Designer/Services/Implementation/TextsService.cs
@@ -214,7 +214,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 TextResourceElement textResourceContainsKey = textResourceObject.Resources.Find(textResourceElement => textResourceElement.Id == kvp.Key);
                 if (textResourceContainsKey is null)
                 {
-                    textResourceObject.Resources.Add(new TextResourceElement() { Id = kvp.Key, Value = kvp.Value });
+                    textResourceObject.Resources.Insert(0, new TextResourceElement() { Id = kvp.Key, Value = kvp.Value });
                 }
                 else
                 {

--- a/backend/tests/Designer.Tests/Controllers/TextController/UpdateTextsForKeysTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TextController/UpdateTextsForKeysTests.cs
@@ -84,7 +84,7 @@ namespace Designer.Tests.Controllers.TextController
                 var textResourceContainsKey = resource.Resources.Find(textResourceElement => textResourceElement.Id == key);
                 if (textResourceContainsKey is null)
                 {
-                    resource.Resources.Add(new TextResourceElement
+                    resource.Resources.Insert(0, new TextResourceElement
                     { Id = key, Value = value });
                     continue;
                 }

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1211,6 +1211,7 @@
   "testing.testing_in_testenv_title": "Test i testmiljø",
   "text_editor.new_text": "Ny tekst",
   "text_editor.search_for_text": "Søk etter tekst eller id",
+  "text_editor.sort_alphabetically": "Sorter alfabetisk etter ID",
   "text_editor.variables_default_value": "<bold>Standardverdi:</bold> {{defaultValue}}",
   "text_editor.variables_editing_not_supported": "Det, er ikke lagt til støtte for redigering av variabler i Studio.",
   "top_menu.about": "Oversikt",

--- a/frontend/packages/shared/src/utils/textResourceUtils.test.ts
+++ b/frontend/packages/shared/src/utils/textResourceUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   convertTextResourcesArrayToObject,
-  convertTextResourcesObjectToArray, modifyTextResources
+  convertTextResourcesObjectToArray,
+  modifyTextResources,
 } from 'app-shared/utils/textResourceUtils';
 import { ITextResource, ITextResources } from 'app-shared/types/global';
 
@@ -12,20 +13,24 @@ const textResourceValue2 = 'value2';
 
 describe('textResourceUtils', () => {
   test('convertTextResourcesArrayToObject', () => {
-    expect(convertTextResourcesArrayToObject([
-      { id: textResourceId1, value: textResourceValue1 },
-      { id: textResourceId2, value: textResourceValue2 },
-    ])).toEqual({
+    expect(
+      convertTextResourcesArrayToObject([
+        { id: textResourceId1, value: textResourceValue1 },
+        { id: textResourceId2, value: textResourceValue2 },
+      ]),
+    ).toEqual({
       [textResourceId1]: textResourceValue1,
       [textResourceId2]: textResourceValue2,
     });
   });
 
   test('convertTextResourcesObjectToArray', () => {
-    expect(convertTextResourcesObjectToArray({
-      [textResourceId1]: textResourceValue1,
-      [textResourceId2]: textResourceValue2,
-    })).toEqual([
+    expect(
+      convertTextResourcesObjectToArray({
+        [textResourceId1]: textResourceValue1,
+        [textResourceId2]: textResourceValue2,
+      }),
+    ).toEqual([
       { id: textResourceId1, value: textResourceValue1 },
       { id: textResourceId2, value: textResourceValue2 },
     ]);
@@ -59,9 +64,9 @@ describe('textResourceUtils', () => {
       ];
       expect(modifyTextResources(existingTextResources, language1, newValues)).toEqual({
         [language1]: [
+          { id: newId3, value: newValue3Lang1 },
           { id: textResourceId1, value: value1Lang1 },
           { id: textResourceId2, value: newValue2Lang1 },
-          { id: newId3, value: newValue3Lang1 },
         ],
         [language2]: [
           { id: textResourceId1, value: value1Lang2 },
@@ -88,6 +93,23 @@ describe('textResourceUtils', () => {
           { id: textResourceId2, value: value2Lang2 },
         ],
         [newLanguage]: newResources,
+      });
+    });
+
+    it('Adds a non existing text in the top of file', () => {
+      const newId = 'new-id';
+      const newValue = '';
+      const newResources: ITextResource[] = [{ id: newId, value: newValue }];
+      expect(modifyTextResources(existingTextResources, language1, newResources)).toEqual({
+        [language1]: [
+          { id: newId, value: newValue },
+          { id: textResourceId1, value: value1Lang1 },
+          { id: textResourceId2, value: value2Lang1 },
+        ],
+        [language2]: [
+          { id: textResourceId1, value: value1Lang2 },
+          { id: textResourceId2, value: value2Lang2 },
+        ],
       });
     });
   });

--- a/frontend/packages/shared/src/utils/textResourceUtils.ts
+++ b/frontend/packages/shared/src/utils/textResourceUtils.ts
@@ -5,7 +5,9 @@ import { ITextResource, ITextResources, ITextResourcesObjectFormat } from 'app-s
  * @param textResources The text resources as an array of ITextResource.
  * @returns The text resources as an ITextResourcesObjectFormat object.
  */
-export const convertTextResourcesArrayToObject = (textResources: ITextResource[]): ITextResourcesObjectFormat =>
+export const convertTextResourcesArrayToObject = (
+  textResources: ITextResource[],
+): ITextResourcesObjectFormat =>
   Object.fromEntries(textResources.map((textResource) => [textResource.id, textResource.value]));
 
 /**
@@ -13,8 +15,9 @@ export const convertTextResourcesArrayToObject = (textResources: ITextResource[]
  * @param textResources The text resources as an ITextResourcesObjectFormat object.
  * @returns The text resources as an array of ITextResource.
  */
-export const convertTextResourcesObjectToArray = (textResources: ITextResourcesObjectFormat): ITextResource[] =>
-  Object.entries(textResources).map(([id, value]) => ({ id, value }));
+export const convertTextResourcesObjectToArray = (
+  textResources: ITextResourcesObjectFormat,
+): ITextResource[] => Object.entries(textResources).map(([id, value]) => ({ id, value }));
 
 /**
  * Modifies the text resources object with new text resources in the given language.
@@ -26,14 +29,20 @@ export const convertTextResourcesObjectToArray = (textResources: ITextResourcesO
 export const modifyTextResources = (
   existingResources: ITextResources,
   language: string,
-  newResources: ITextResource[]
+  newResources: ITextResource[],
 ): ITextResources => {
-  const unmodifiedResources = existingResources?.[language]?.filter(
-    (existingResource: ITextResource) =>
-      !newResources.some((newResource) => existingResource.id === newResource.id)
-  ) || [];
+  const newlyCreatedText = newResources.filter(
+    (nr) => !existingResources?.[language]?.some((er) => er.id === nr.id),
+  );
+  const updatedResources =
+    existingResources?.[language]?.map((existingResource: ITextResource): ITextResource => {
+      const updatedResource = newResources.find(
+        (newResource) => existingResource?.id === newResource.id,
+      );
+      return updatedResource ?? existingResource;
+    }) ?? [];
   return {
     ...existingResources,
-    [language]: [...unmodifiedResources, ...newResources]
+    [language]: [...newlyCreatedText, ...updatedResources],
   };
-}
+};

--- a/frontend/packages/text-editor/src/TextEditor.module.css
+++ b/frontend/packages/text-editor/src/TextEditor.module.css
@@ -53,6 +53,19 @@
   justify-content: space-between;
 }
 
+.TextEditor__topRow__filter {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 1rem;
+}
+
+.sortAlphabetically {
+  gap: 1rem;
+  display: flex;
+  align-items: center;
+}
+
 .TextEditor__body {
   margin-left: 2rem;
   overflow: auto;

--- a/frontend/packages/text-editor/src/TextEditor.module.css
+++ b/frontend/packages/text-editor/src/TextEditor.module.css
@@ -53,7 +53,7 @@
   justify-content: space-between;
 }
 
-.TextEditor__topRow__filter {
+.filterAndSearch {
   display: flex;
   flex-direction: row;
   align-items: flex-end;

--- a/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -11,14 +11,18 @@ const user = userEvent.setup();
 let mockScrollIntoView = jest.fn();
 
 describe('TextEditor', () => {
+  const textId1 = 'textId1';
+  const textId2 = 'a-textId2';
+  const textValue1 = 'norsk-1';
+  const textValue2 = 'norsk-2';
   const nb: ITextResource[] = [
     {
-      id: 'textId1',
-      value: 'norsk-1',
+      id: textId1,
+      value: textValue1,
     },
     {
-      id: 'textId2',
-      value: 'norsk-2',
+      id: textId2,
+      value: textValue2,
     },
   ];
   const textResourceFiles: ITextResources = { nb };
@@ -141,6 +145,22 @@ describe('TextEditor', () => {
     expect(mockScrollIntoView).toHaveBeenCalledTimes(1);
   });
 
+  it('Sorts texts when sort chip is clicked', async () => {
+    renderTextEditor({});
+    const translations = screen.getAllByRole('textbox', {
+      name: 'nb translation',
+    });
+    expect(translations[0]).toHaveValue(textValue1);
+
+    const sortAlphabeticallyButton = screen.getByText(textMock('text_editor.sort_alphabetically'));
+    await act(() => user.click(sortAlphabeticallyButton));
+
+    const sortedTranslations = screen.getAllByRole('textbox', {
+      name: 'nb translation',
+    });
+    expect(sortedTranslations[0]).toHaveValue(textValue2);
+  });
+
   it('signals correctly when a translation is changed', async () => {
     const upsertTextResource = jest.fn();
     renderTextEditor({
@@ -156,7 +176,7 @@ describe('TextEditor', () => {
     await act(() => user.keyboard(`${changedTranslations[0].value}{TAB}`));
     expect(upsertTextResource).toHaveBeenCalledWith({
       language: 'nb',
-      textId: 'textId1',
+      textId: textId1,
       translation: 'new translation',
     });
   });
@@ -217,7 +237,7 @@ describe('TextEditor', () => {
 
     it('signals that a textId has changed', async () => {
       await makeChangesToTextIds();
-      const textIdRefsAfter1 = screen.getAllByText('textId2');
+      const textIdRefsAfter1 = screen.getAllByText(textId2);
       expect(textIdRefsAfter1).toHaveLength(1); // The id is also on the delete button
     });
 
@@ -227,7 +247,7 @@ describe('TextEditor', () => {
       const { error, onTextIdChange } = setupError();
       const original = await makeChangesToTextIds(onTextIdChange);
       expect(error).toHaveBeenCalledWith('Renaming text-id failed:\n', 'some error');
-      const textIdRefsAfter1 = screen.getAllByText('textId2');
+      const textIdRefsAfter1 = screen.getAllByText(textId2);
       expect(textIdRefsAfter1).toHaveLength(1);
 
       const textIdRefsAfter2 = screen.queryAllByText(/new-key/i);

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import classes from './TextEditor.module.css';
 import type {
   LangCode,
@@ -7,7 +7,8 @@ import type {
   UpsertTextResourceMutation,
 } from './types';
 import { SearchField } from '@altinn/altinn-design-system';
-import { Button } from '@digdir/design-system-react';
+import { Button, Chip } from '@digdir/design-system-react';
+import { ArrowsUpDownIcon } from '@navikt/aksel-icons';
 import { RightMenu } from './RightMenu';
 import { getRandNumber, mapResourceFilesToTableRows } from './utils';
 import { defaultLangCode } from './constants';
@@ -42,10 +43,10 @@ export const TextEditor = ({
   upsertTextResource,
 }: TextEditorProps) => {
   const { t } = useTranslation();
-  const resourceRows = mapResourceFilesToTableRows(textResourceFiles);
-
+  const [sortTextsAlphabetically, setSortTextsAlphabetically] = useState<boolean>(false);
+  const resourceRows = mapResourceFilesToTableRows(textResourceFiles, sortTextsAlphabetically);
   const previousSelectedLanguages = useRef<string[]>([]);
-
+  
   const availableLangCodesFiltered = useMemo(
     () => availableLanguages?.filter((code) => ISO6391.validate(code)),
     [availableLanguages],
@@ -97,13 +98,26 @@ export const TextEditor = ({
           <Button variant='primary' color='first' onClick={handleAddNewEntryClick} size='small'>
             {t('text_editor.new_text')}
           </Button>
-          <div>
-            <SearchField
-              id='text-editor-search'
-              label={t('text_editor.search_for_text')}
-              value={searchQuery}
-              onChange={handleSearchChange}
-            />
+          <div className={classes.TextEditor__topRow__filter}>
+            <Chip.Toggle
+              onClick={() => setSortTextsAlphabetically(!sortTextsAlphabetically)}
+              selected={sortTextsAlphabetically}
+            >
+              {
+                <div className={classes.sortAlphabetically}>
+                  {t('text_editor.sort_alphabetically')}
+                  <ArrowsUpDownIcon />
+                </div>
+              }
+            </Chip.Toggle>
+            <div>
+              <SearchField
+                id='text-editor-search'
+                label={t('text_editor.search_for_text')}
+                value={searchQuery}
+                onChange={handleSearchChange}
+              />
+            </div>
           </div>
         </div>
         <div className={classes.TextEditor__body}>

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -8,7 +8,7 @@ import type {
 } from './types';
 import { SearchField } from '@altinn/altinn-design-system';
 import { Button, Chip } from '@digdir/design-system-react';
-import { ArrowsUpDownIcon } from '@navikt/aksel-icons';
+import { ArrowsUpDownIcon } from '@studio/icons';
 import { RightMenu } from './RightMenu';
 import { getRandNumber, mapResourceFilesToTableRows } from './utils';
 import { defaultLangCode } from './constants';
@@ -46,7 +46,7 @@ export const TextEditor = ({
   const [sortTextsAlphabetically, setSortTextsAlphabetically] = useState<boolean>(false);
   const resourceRows = mapResourceFilesToTableRows(textResourceFiles, sortTextsAlphabetically);
   const previousSelectedLanguages = useRef<string[]>([]);
-  
+
   const availableLangCodesFiltered = useMemo(
     () => availableLanguages?.filter((code) => ISO6391.validate(code)),
     [availableLanguages],

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -98,7 +98,7 @@ export const TextEditor = ({
           <Button variant='primary' color='first' onClick={handleAddNewEntryClick} size='small'>
             {t('text_editor.new_text')}
           </Button>
-          <div className={classes.TextEditor__topRow__filter}>
+          <div className={classes.filterAndSearch}>
             <Chip.Toggle
               onClick={() => setSortTextsAlphabetically(!sortTextsAlphabetically)}
               selected={sortTextsAlphabetically}

--- a/frontend/packages/text-editor/src/utils.test.ts
+++ b/frontend/packages/text-editor/src/utils.test.ts
@@ -55,19 +55,41 @@ describe('filterFunction', () => {
 });
 
 describe('mapResourceFilesToTableRows', () => {
-  test('Converts from ITextResources format to table format', () => {
+  test('Converts from ITextResources format to table format without sorting', () => {
     const id = 'some-key';
+    const id2 = 'a-key';
     const textResources: ITextResources = {
       nb: [
-        { id, value: 'Min nøkkel' }
+        { id, value: 'Min verdi 1' },
+        { id: id2, value: 'Min verdi 2' },
       ],
       en: [
-        { id, value: 'My key' }
-      ]
+        { id, value: 'My value 1' },
+        { id: id2, value: 'My value 2' },
+      ],
     };
-    const rows = mapResourceFilesToTableRows(textResources);
-    expect(rows).toHaveLength(1);
+    const rows = mapResourceFilesToTableRows(textResources, false);
+    expect(rows).toHaveLength(2);
     expect(rows[0].textKey).toBe(id);
+    expect(rows[0].translations).toHaveLength(2);
+  });
+
+  test('Converts from ITextResources format to table format and sorts them alphabetically', () => {
+    const id = 'some-key';
+    const id2 = 'a-key';
+    const textResources: ITextResources = {
+      nb: [
+        { id, value: 'Min verdi 1' },
+        { id: id2, value: 'Min verdi 2' },
+      ],
+      en: [
+        { id, value: 'My value 1' },
+        { id: id2, value: 'My value 2' },
+      ],
+    };
+    const rows = mapResourceFilesToTableRows(textResources, true);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].textKey).toBe(id2);
     expect(rows[0].translations).toHaveLength(2);
   });
 
@@ -76,14 +98,18 @@ describe('mapResourceFilesToTableRows', () => {
     const textResources: ITextResources = {
       nb: [
         { id, value: 'Min nøkkel' },
-        { id: 'some-other-key', value: 'en tekst med variabel {0}', variables: [ { key: 'some-key-in-data-model', dataSource: 'dataModel' } ] }
+        {
+          id: 'some-other-key',
+          value: 'en tekst med variabel {0}',
+          variables: [{ key: 'some-key-in-data-model', dataSource: 'dataModel' }],
+        },
       ],
       en: [
         { id, value: 'My key' },
-        { id: 'some-other-key', value: '' }
-      ]
+        { id: 'some-other-key', value: '' },
+      ],
     };
-    const rows = mapResourceFilesToTableRows(textResources);
+    const rows = mapResourceFilesToTableRows(textResources, true);
     expect(rows).toHaveLength(2);
     expect(rows[1].variables).toHaveLength(1);
   });
@@ -93,15 +119,19 @@ describe('mapResourceFilesToTableRows', () => {
     const textResources: ITextResources = {
       nb: [
         { id, value: 'Min nøkkel' },
-        { id: 'some-other-key', value: '' }
+        { id: 'some-other-key', value: '' },
       ],
       en: [
         { id, value: 'My key' },
-        { id: 'some-other-key', value: 'en tekst med variabel {0}', variables: [ { key: 'some-key-in-data-model', dataSource: 'dataModel' } ] }
-      ]
+        {
+          id: 'some-other-key',
+          value: 'en tekst med variabel {0}',
+          variables: [{ key: 'some-key-in-data-model', dataSource: 'dataModel' }],
+        },
+      ],
     };
-    const rows = mapResourceFilesToTableRows(textResources);
+    const rows = mapResourceFilesToTableRows(textResources, true);
     expect(rows).toHaveLength(2);
     expect(rows[1].variables).toHaveLength(1);
   });
-})
+});

--- a/frontend/packages/text-editor/src/utils.ts
+++ b/frontend/packages/text-editor/src/utils.ts
@@ -48,35 +48,41 @@ export const langOptions: Option[] = ISO6391.getAllCodes()
 export const filterFunction = (
   id: string | undefined,
   textTableRowEntries: TextTableRowEntry[] | undefined,
-  searchQuery: string | undefined
+  searchQuery: string | undefined,
 ) =>
   !searchQuery ||
   searchQuery.length < 1 ||
   id?.toLowerCase().includes(searchQuery.toLowerCase()) ||
   textTableRowEntries.filter((entry) => entry.translation.includes(searchQuery)).length > 0;
 
-export const mapResourceFilesToTableRows = (files: ITextResources): TextTableRow[] => {
+export const mapResourceFilesToTableRows = (
+  files: ITextResources,
+  sortAlphabetically: boolean,
+): TextTableRow[] => {
   const rows = new Map();
-  Object.entries(files).forEach(([lang, resources]) =>
-    resources
-      .sort((a, b) => alphabeticalCompareFunction(a.id, b.id))
-      .forEach((resource) => {
-        if (!rows.has(resource.id)) {
-          rows.set(resource.id, {
-            textKey: resource.id,
-            variables: resource.variables,
-            translations: [],
-          });
-        }
-        if (rows.has(resource.id) && !rows.has(resource.variables) && resource.variables) {
-          rows.get(resource.id).variables = resource.variables;
-        }
-        rows.get(resource.id).translations.push({
-          lang,
-          translation: resource.value,
+  Object.entries(files).forEach(([lang, resources]) => {
+    const orderedResources = sortAlphabetically
+      ? [...resources].sort((a, b) =>
+          alphabeticalCompareFunction(a.id.toLowerCase(), b.id.toLowerCase()),
+        )
+      : resources;
+    orderedResources.forEach((resource) => {
+      if (!rows.has(resource.id)) {
+        rows.set(resource.id, {
+          textKey: resource.id,
+          variables: resource.variables,
+          translations: [],
         });
-      })
-  );
+      }
+      if (rows.has(resource.id) && !rows.has(resource.variables) && resource.variables) {
+        rows.get(resource.id).variables = resource.variables;
+      }
+      rows.get(resource.id).translations.push({
+        lang,
+        translation: resource.value,
+      });
+    });
+  });
   return Array.from(rows.values());
 };
 

--- a/frontend/packages/text-editor/src/utils.ts
+++ b/frontend/packages/text-editor/src/utils.ts
@@ -1,6 +1,6 @@
 import ISO6391 from 'iso-639-1';
 import type { Option, TextTableRow, TextTableRowEntry } from './types';
-import { ITextResources } from 'app-shared/types/global';
+import { ITextResource, ITextResources } from 'app-shared/types/global';
 import { alphabeticalCompareFunction } from 'app-shared/utils/compareFunctions';
 
 const intlNb = new Intl.DisplayNames(['nb'], { type: 'language' });
@@ -61,30 +61,36 @@ export const mapResourceFilesToTableRows = (
 ): TextTableRow[] => {
   const rows = new Map();
   Object.entries(files).forEach(([lang, resources]) => {
-    const orderedResources = sortAlphabetically
-      ? [...resources].sort((a, b) =>
-          alphabeticalCompareFunction(a.id.toLowerCase(), b.id.toLowerCase()),
-        )
-      : resources;
+    const orderedResources = getOrderedTexts(resources, sortAlphabetically);
     orderedResources.forEach((resource) => {
-      if (!rows.has(resource.id)) {
-        rows.set(resource.id, {
-          textKey: resource.id,
-          variables: resource.variables,
-          translations: [],
-        });
-      }
-      if (rows.has(resource.id) && !rows.has(resource.variables) && resource.variables) {
-        rows.get(resource.id).variables = resource.variables;
-      }
-      rows.get(resource.id).translations.push({
-        lang,
-        translation: resource.value,
-      });
+      createTextRows(rows, resource, lang);
     });
   });
   return Array.from(rows.values());
 };
+
+const getOrderedTexts = (resources: ITextResource[], sortAlphabetically: boolean): ITextResource[] => sortAlphabetically
+  ? [...resources].sort((a, b) =>
+    alphabeticalCompareFunction(a.id.toLowerCase(), b.id.toLowerCase()),
+  )
+  : resources;
+
+const createTextRows = (rows: Map<any, any>, resource: ITextResource, lang: string) => {
+  if (!rows.has(resource.id)) {
+    rows.set(resource.id, {
+      textKey: resource.id,
+      variables: resource.variables,
+      translations: [],
+    });
+  }
+  if (rows.has(resource.id) && !rows.has(resource.variables) && resource.variables) {
+    rows.get(resource.id).variables = resource.variables;
+  }
+  rows.get(resource.id).translations.push({
+    lang,
+    translation: resource.value,
+  });
+}
 
 export const validateTextId = (textIdToValidate: string): string => {
   const isIllegalId = (textIdToCheck: string) => Boolean(textIdToCheck.toLowerCase().match(' ')); // TODO: create matcher


### PR DESCRIPTION
## Description
Adapt function that modifies text resources used when setting cache on newly added text so it places newly created texts first and modified texts at there existing place.

Also adds a button to sort the entries alphabetically

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
