### PR TITLE
Fix link to CONTRIBUTING.md

### DIFF
--- a/backend/src/Designer/Views/Home/StartPage.cshtml
+++ b/backend/src/Designer/Views/Home/StartPage.cshtml
@@ -290,7 +290,7 @@
                     <p>Du kan følge teamet som jobber med utviklingen og bidra direkte med
                       endringsønsker, feil og spørsmål gjennom&nbsp;<a
                         href="https://github.com/Altinn/altinn-studio/issues">backlogen i Github&nbsp;</a></p>
-                    <p>Se mer <a href="https://github.com/Altinn/altinn-studio/blob/master/CONTRIBUTING.md">informasjon
+                    <p>Se mer <a href="https://github.com/Altinn/altinn-studio/blob/master/docs/CONTRIBUTING.md">informasjon
                         om hvordan du kan bidra</a> på vårt Github-prosjekt.
                     </p>
                   </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

At the home page [altinn.studio](https://altinn.studio/), under section "Hvordan kan jeg bidra", one of the links pointed to "https://github.com/Altinn/altinn-studio/blob/master/CONTRIBUTING.md", which returned 404. The link has now been changed to "https://github.com/Altinn/altinn-studio/blob/master/docs/CONTRIBUTING.md".

## Related Issue(s)

- #10870

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
