### PR TITLE
Add check for JsonArray when iterating textResourceBindings

### DIFF
--- a/backend/src/Designer/Services/Implementation/TextsService.cs
+++ b/backend/src/Designer/Services/Implementation/TextsService.cs
@@ -346,7 +346,6 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 {
                     continue;
                 }
-                Console.WriteLine("value" + value);
                 var valueElement = value.AsValue().GetValue<JsonElement>();
                 // Only update if the value is a string and the value is the same as the old key
                 if (valueElement.ValueKind != JsonValueKind.String || valueElement.GetString() != keyMutation.OldId)

--- a/backend/src/Designer/Services/Implementation/TextsService.cs
+++ b/backend/src/Designer/Services/Implementation/TextsService.cs
@@ -340,12 +340,13 @@ namespace Altinn.Studio.Designer.Services.Implementation
         private static JsonNode UpdateKey(JsonNode textResourceBindings, TextIdMutation keyMutation)
         {
             JsonNode updatedTextResourceBindings = JsonNode.Parse(textResourceBindings.ToJsonString());
-            foreach ((string key, var value) in (textResourceBindings as JsonObject)!)
+            foreach ((string key, JsonNode value) in (textResourceBindings as JsonObject)!)
             {
-                if (value is null)
+                if (value is null or JsonArray)
                 {
                     continue;
                 }
+                Console.WriteLine("value" + value);
                 var valueElement = value.AsValue().GetValue<JsonElement>();
                 // Only update if the value is a string and the value is the same as the old key
                 if (valueElement.ValueKind != JsonValueKind.String || valueElement.GetString() != keyMutation.OldId)

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layoutSet1/layouts/layoutFile1InSet1.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layoutSet1/layouts/layoutFile1InSet1.json
@@ -9,6 +9,18 @@
           "title": "some-old-id",
           "body": "another-key"
         }
+      },
+      {
+        "id": "component-id",
+        "type": "Header",
+        "textResourceBindings": {
+          "title": ["concat", "Endringer med fra-verdi over ", ["dataModel", "hideRowValue"], " NOK"],
+          "label": [
+            "concat",
+            ["text", "optionsFromRepeatingGroup"],
+            ["concat", " ", ["text", "question-2"]]
+          ]
+        }
       }
     ]
   }


### PR DESCRIPTION
## Description
Check for values being arrays in textResourceBindings in layout files when deleting a text so endpoint does not return 400 Bad Request due to trying to perform method `.AsValue()` on a JsonElement which can only be done on JsonNodes. 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
