### PR TITLE
Remove unnecessary cy.wait

### DIFF
--- a/frontend/testing/cypress/src/integration/studio/dashboard.js
+++ b/frontend/testing/cypress/src/integration/studio/dashboard.js
@@ -19,7 +19,6 @@ context('Dashboard', () => {
     cy.switchSelectedContext('self');
     cy.intercept('GET', '**/repos/search**').as('fetchApps');
     dashboard.getSearchReposField().should('be.visible');
-    cy.wait('@fetchApps').its('response.statusCode').should('eq', 200);
   });
 
   after(() => {

--- a/frontend/testing/cypress/src/integration/studio/wcag.js
+++ b/frontend/testing/cypress/src/integration/studio/wcag.js
@@ -20,11 +20,6 @@ context('WCAG', () => {
     cy.visit('/');
     cy.intercept('GET', '**/repos/search**').as('fetchApps');
     dashboard.getSearchReposField().should('be.visible');
-    cy.wait('@fetchApps')
-      .its('response.statusCode')
-      .should((statusCode) => {
-        expect([200, 302]).to.contain(statusCode);
-      });
   });
 
   after(() => {


### PR DESCRIPTION
## Description
It is not necessary to wait for the `@fetchApps` in the `before` hook of the Cypress tests.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)