### PR TITLE
Return custom error message when reading xml fails and show it in frontend

### DIFF
--- a/backend/src/DataModeling/Converter/Xml/InvalidXmlException.cs
+++ b/backend/src/DataModeling/Converter/Xml/InvalidXmlException.cs
@@ -5,32 +5,32 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
 {
 
 
-  /// <summary>
-  /// Represents errors thrown when converting from XSD to Json Schema.
-  /// </summary>
-  [Serializable]
-  public class InvalidXmlException : Exception
-  {
-
-    public List<string> CustomErrorMessages { get; }
-
     /// <summary>
-    /// <inheritdoc/>
+    /// Represents errors thrown when converting from XSD to Json Schema.
     /// </summary>
-    public InvalidXmlException() : base()
+    [Serializable]
+    public class InvalidXmlException : Exception
     {
-    }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public InvalidXmlException(string message) : base(message)
-    {
-    }
+        public List<string> CustomErrorMessages { get; }
 
-    public InvalidXmlException(string message, List<string> customErrorMessages) : base(message)
-    {
-      CustomErrorMessages = customErrorMessages;
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public InvalidXmlException() : base()
+        {
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public InvalidXmlException(string message) : base(message)
+        {
+        }
+
+        public InvalidXmlException(string message, List<string> customErrorMessages) : base(message)
+        {
+            CustomErrorMessages = customErrorMessages;
+        }
     }
-  }
 }

--- a/backend/src/DataModeling/Converter/Xml/InvalidXmlException.cs
+++ b/backend/src/DataModeling/Converter/Xml/InvalidXmlException.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace Altinn.Studio.DataModeling.Converter.Xml
+{
+
+
+  /// <summary>
+  /// Represents errors thrown when converting from XSD to Json Schema.
+  /// </summary>
+  [Serializable]
+  public class InvalidXmlException : Exception
+  {
+
+    public List<string> CustomErrorMessages { get; }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public InvalidXmlException() : base()
+    {
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public InvalidXmlException(string message) : base(message)
+    {
+    }
+
+    public InvalidXmlException(string message, List<string> customErrorMessages) : base(message)
+    {
+      CustomErrorMessages = customErrorMessages;
+    }
+  }
+}

--- a/backend/src/DataModeling/Converter/Xml/XmlSchemaConvertException.cs
+++ b/backend/src/DataModeling/Converter/Xml/XmlSchemaConvertException.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Altinn.Studio.DataModeling.Converter.Xml
@@ -10,9 +9,6 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
     [Serializable]
     public class XmlSchemaConvertException : Exception
     {
-
-        public List<string> CustomErrorMessages { get; }
-
         /// <summary>
         /// <inheritdoc/>
         /// </summary>
@@ -25,11 +21,6 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
         /// </summary>
         public XmlSchemaConvertException(string message) : base(message)
         {
-        }
-
-        public XmlSchemaConvertException(string message, List<string> customErrorMessages) : base(message)
-        {
-            CustomErrorMessages = customErrorMessages;
         }
 
         /// <summary>

--- a/backend/src/DataModeling/Converter/Xml/XmlSchemaConvertException.cs
+++ b/backend/src/DataModeling/Converter/Xml/XmlSchemaConvertException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Altinn.Studio.DataModeling.Converter.Xml
@@ -9,6 +10,9 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
     [Serializable]
     public class XmlSchemaConvertException : Exception
     {
+
+        public List<string> CustomErrorMessages { get; }
+
         /// <summary>
         /// <inheritdoc/>
         /// </summary>
@@ -21,6 +25,11 @@ namespace Altinn.Studio.DataModeling.Converter.Xml
         /// </summary>
         public XmlSchemaConvertException(string message) : base(message)
         {
+        }
+
+        public XmlSchemaConvertException(string message, List<string> customErrorMessages) : base(message)
+        {
+            CustomErrorMessages = customErrorMessages;
         }
 
         /// <summary>

--- a/backend/src/Designer/Filters/DataModeling/DataModelingErrorCodes.cs
+++ b/backend/src/Designer/Filters/DataModeling/DataModelingErrorCodes.cs
@@ -6,5 +6,6 @@
         public const string XmlSchemaConvertError = "DM_02";
         public const string JsonSchemaConvertError = "DM_03";
         public const string ModelMetadataConvertError = "DM_04";
+        public const string InvalidXmlError = "DM_05";
     }
 }

--- a/backend/src/Designer/Filters/DataModeling/DataModelingExceptionFilterAttribute.cs
+++ b/backend/src/Designer/Filters/DataModeling/DataModelingExceptionFilterAttribute.cs
@@ -30,9 +30,9 @@ namespace Altinn.Studio.Designer.Filters.DataModeling
                 context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.CsharpGenerationError, HttpStatusCode.UnprocessableEntity)) { StatusCode = (int)HttpStatusCode.UnprocessableEntity };
             }
 
-            if (context.Exception is XmlSchemaConvertException xmlSchemaConvertException)
+            if (context.Exception is XmlSchemaConvertException)
             {
-                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.XmlSchemaConvertError, HttpStatusCode.UnprocessableEntity, xmlSchemaConvertException.CustomErrorMessages)) { StatusCode = (int)HttpStatusCode.UnprocessableEntity };
+                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.XmlSchemaConvertError, HttpStatusCode.UnprocessableEntity)) { StatusCode = (int)HttpStatusCode.UnprocessableEntity };
             }
 
             if (context.Exception is JsonSchemaConvertException)
@@ -43,6 +43,11 @@ namespace Altinn.Studio.Designer.Filters.DataModeling
             if (context.Exception is MetamodelConvertException)
             {
                 context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.ModelMetadataConvertError, HttpStatusCode.UnprocessableEntity)) { StatusCode = (int)HttpStatusCode.UnprocessableEntity };
+            }
+
+            if (context.Exception is InvalidXmlException invalidXmlError)
+            {
+                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.InvalidXmlError, HttpStatusCode.BadRequest, invalidXmlError.CustomErrorMessages)) { StatusCode = (int)HttpStatusCode.UnprocessableEntity };
             }
         }
     }

--- a/backend/src/Designer/Filters/DataModeling/DataModelingExceptionFilterAttribute.cs
+++ b/backend/src/Designer/Filters/DataModeling/DataModelingExceptionFilterAttribute.cs
@@ -27,22 +27,22 @@ namespace Altinn.Studio.Designer.Filters.DataModeling
 
             if (context.Exception is CsharpGenerationException)
             {
-                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.CsharpGenerationError, HttpStatusCode.InternalServerError)) { StatusCode = (int)HttpStatusCode.InternalServerError };
+                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.CsharpGenerationError, HttpStatusCode.UnprocessableEntity)) { StatusCode = (int)HttpStatusCode.UnprocessableEntity };
             }
 
-            if (context.Exception is XmlSchemaConvertException)
+            if (context.Exception is XmlSchemaConvertException xmlSchemaConvertException)
             {
-                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.XmlSchemaConvertError, HttpStatusCode.InternalServerError)) { StatusCode = (int)HttpStatusCode.InternalServerError };
+                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.XmlSchemaConvertError, HttpStatusCode.UnprocessableEntity, xmlSchemaConvertException.CustomErrorMessages)) { StatusCode = (int)HttpStatusCode.UnprocessableEntity };
             }
 
             if (context.Exception is JsonSchemaConvertException)
             {
-                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.JsonSchemaConvertError, HttpStatusCode.InternalServerError)) { StatusCode = (int)HttpStatusCode.InternalServerError };
+                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.JsonSchemaConvertError, HttpStatusCode.UnprocessableEntity)) { StatusCode = (int)HttpStatusCode.UnprocessableEntity };
             }
 
             if (context.Exception is MetamodelConvertException)
             {
-                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.ModelMetadataConvertError, HttpStatusCode.InternalServerError)) { StatusCode = (int)HttpStatusCode.InternalServerError };
+                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, DataModelingErrorCodes.ModelMetadataConvertError, HttpStatusCode.UnprocessableEntity)) { StatusCode = (int)HttpStatusCode.UnprocessableEntity };
             }
         }
     }

--- a/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -286,7 +286,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             catch (Exception ex)
             {
                 List<string> customErrorMessages = new() { ex.Message };
-                throw new XmlSchemaConvertException("Xml could not be generated successfully", customErrorMessages);
+                throw new InvalidXmlException("Could not read invalid xml", customErrorMessages);
             }
             Json.Schema.JsonSchema convertedJsonSchema = _xmlSchemaToJsonSchemaConverter.Convert(originalXsd);
 

--- a/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -13,6 +13,7 @@ using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.DataModeling.Converter.Interfaces;
 using Altinn.Studio.DataModeling.Converter.Json.Strategy;
 using Altinn.Studio.DataModeling.Converter.Metadata;
+using Altinn.Studio.DataModeling.Converter.Xml;
 using Altinn.Studio.DataModeling.Metamodel;
 using Altinn.Studio.DataModeling.Templates;
 using Altinn.Studio.Designer.Configuration;
@@ -276,11 +277,21 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
         private Json.Schema.JsonSchema GenerateJsonSchemaFromXsd(Stream xsdStream)
         {
-            XmlSchema originalXsd = XmlSchema.Read(xsdStream, (_, _) => { });
+            XmlSchema originalXsd;
+            try
+            {
+                originalXsd = XmlSchema.Read(xsdStream, (_, _) => { });
 
+            }
+            catch (Exception ex)
+            {
+                List<string> customErrorMessages = new() { ex.Message };
+                throw new XmlSchemaConvertException("Xml could not be generated successfully", customErrorMessages);
+            }
             Json.Schema.JsonSchema convertedJsonSchema = _xmlSchemaToJsonSchemaConverter.Convert(originalXsd);
 
             return convertedJsonSchema;
+
         }
 
         private async Task UpdateCSharpClasses(AltinnAppGitRepository altinnAppGitRepository, ModelMetadata modelMetadata, string schemaName)

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.test.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.test.tsx
@@ -11,6 +11,7 @@ import { dataMock } from '@altinn/schema-editor/mockData';
 import { AUTOSAVE_DEBOUNCE_INTERVAL_MILLISECONDS } from 'app-shared/constants';
 import { SchemaEditorAppProps } from '@altinn/schema-editor/SchemaEditorApp';
 import { QueryKey } from 'app-shared/types/QueryKey';
+import { createApiErrorMock } from "app-shared/mocks/apiErrorMock";
 
 const user = userEvent.setup();
 
@@ -46,6 +47,14 @@ describe('SelectedSchemaEditor', () => {
     render({ getDatamodel });
     await waitForElementToBeRemoved(() => screen.queryByTitle(textMock('general.loading')));
     expect(screen.getByText(message)).toBeInTheDocument();
+  });
+
+  it('Displays custom error message if it exists when invalid xml response', async () => {
+    const customMessage = 'The \'xsd:schema\' start tag on line 2 position 2 does not match the end tag of \'xs:schema\'. Line 86, position 3';
+    const getDatamodel = jest.fn().mockImplementation(() => Promise.reject(createApiErrorMock(400, 'DM_05', [customMessage])));
+    render({ getDatamodel });
+    await waitForElementToBeRemoved(() => screen.queryByTitle(textMock('general.loading')));
+    expect(screen.getByText(customMessage)).toBeInTheDocument();
   });
 
   it('Renders SchemaEditorApp when finished loading', async () => {

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
@@ -27,7 +27,7 @@ export const SelectedSchemaEditor = ({ modelPath }: SelectedSchemaEditorProps) =
           <Alert severity='danger'>
             <Paragraph>{t('general.fetch_error_message')}</Paragraph>
             <Paragraph>{t('general.error_message_with_colon')}</Paragraph>
-            <ErrorMessage>{error.message}</ErrorMessage>
+            <ErrorMessage>{error.response?.data?.customErrorMessages[0] ?? error.message}</ErrorMessage>
           </Alert>
         </StudioCenter>
       );

--- a/frontend/app-development/hooks/queries/useSchemaQuery.ts
+++ b/frontend/app-development/hooks/queries/useSchemaQuery.ts
@@ -6,13 +6,14 @@ import { JsonSchema } from 'app-shared/types/JsonSchema';
 import { isXsdFile } from 'app-shared/utils/filenameUtils';
 import { removeStart } from 'app-shared/utils/stringUtils';
 import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { ApiError } from "app-shared/types/api/ApiError";
 
 export const useSchemaQuery = (
   modelPath: string,
-): UseQueryResult<JsonSchema | null, AxiosError> => {
+): UseQueryResult<JsonSchema | null, AxiosError<ApiError, any>> => {
   const { org, app } = useStudioUrlParams();
   const { getDatamodel, addXsdFromRepo } = useServicesContext();
-  return useQuery<JsonSchema | null, AxiosError>({
+  return useQuery<JsonSchema | null, AxiosError<ApiError, any>>({
     queryKey: [QueryKey.JsonSchema, org, app, modelPath],
     queryFn: async (): Promise<JsonSchema> =>
       isXsdFile(modelPath)

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -14,6 +14,7 @@
   "address_component.validation_error_house_number": "Bolignummer er ugyldig",
   "address_component.validation_error_zipcode": "Postnummer er ugyldig",
   "api_errors.DM_01": "Noe gikk galt under bygging av datamodellen.",
+  "api_errors.DM_05": "Kunne ikke lese ugyldig XML.",
   "api_errors.DM_CsharpCompiler_NameCollision": "Navnet <bold>{{nodeName}}</bold> er i bruk på et element som har et overordnet element med samme navn. Gi et av disse elementene et annet navn.",
   "api_errors.GT_01": "Deling av endringer mislyktes. Vennligst prøv igjen.",
   "api_errors.ResourceNotFound": "Fant ikke en fil applikasjonen din prøvde å få tak i.",

--- a/frontend/packages/shared/src/contexts/ServicesContext.test.tsx
+++ b/frontend/packages/shared/src/contexts/ServicesContext.test.tsx
@@ -82,7 +82,7 @@ describe('ServicesContext', () => {
       () =>
         useQuery({
           queryKey: ['fetchData'],
-          queryFn: () => Promise.reject(createApiErrorMock(500, 'DM_01')),
+          queryFn: () => Promise.reject(createApiErrorMock(422, 'DM_01')),
           retry: false,
         }),
       { wrapper },

--- a/frontend/packages/shared/src/contexts/ServicesContext.test.tsx
+++ b/frontend/packages/shared/src/contexts/ServicesContext.test.tsx
@@ -77,7 +77,7 @@ describe('ServicesContext', () => {
     expect(await screen.findByText(textMock('api_errors.GT_01'))).toBeInTheDocument();
   });
 
-  it('displays a specific error message if API returns an error code and the error messages does exist', async () => {
+  it('displays a specific error message if API returns error code DM_01', async () => {
     const { result } = renderHook(
       () =>
         useQuery({
@@ -92,6 +92,22 @@ describe('ServicesContext', () => {
 
     expect(await screen.findByText(textMock('api_errors.DM_01'))).toBeInTheDocument();
   });
+
+    it('displays a specific error message if API returns error code DM_05', async () => {
+        const { result } = renderHook(
+            () =>
+                useQuery({
+                    queryKey: ['fetchData'],
+                    queryFn: () => Promise.reject(createApiErrorMock(400, 'DM_05')),
+                    retry: false,
+                }),
+            { wrapper },
+        );
+
+        await waitFor(() => result.current.isError);
+
+        expect(await screen.findByText(textMock('api_errors.DM_05'))).toBeInTheDocument();
+    });
 
   it('displays a default error message if API returns an error code but the error message does not exist', async () => {
     const {} = renderHook(


### PR DESCRIPTION
## Description
Add a try/catch when reading xml after saving it before trying to convert to json. Return custom error message if reading fails due to invalid xml and visualize in frontend.

![Skjermbilde 2024-01-18 kl  08 55 25](https://github.com/Altinn/altinn-studio/assets/71079896/756f7ed6-7c78-4e8f-b1cf-ddf105c69ace)

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
