### PR TITLE
move contributing.md to root

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ However we do recommend that you check our pages on
 [how to contribute to our development](https://docs.altinn.studio/community/contributing/) first.
 
 You can also contribute by:
+
 - Reporting a bug
 - Discussing the current state of the code
 - Proposing new features
@@ -49,7 +50,7 @@ Report a bug by [opening a new issue](https://github.com/Altinn/altinn-studio/is
 - What actually happens
 - Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
 
-People *love* thorough bug reports. I'm not even kidding.
+People _love_ thorough bug reports. I'm not even kidding.
 
 ## License
 

--- a/backend/src/Designer/Views/Home/StartPage.cshtml
+++ b/backend/src/Designer/Views/Home/StartPage.cshtml
@@ -290,7 +290,7 @@
                     <p>Du kan følge teamet som jobber med utviklingen og bidra direkte med
                       endringsønsker, feil og spørsmål gjennom&nbsp;<a
                         href="https://github.com/Altinn/altinn-studio/issues">backlogen i Github&nbsp;</a></p>
-                    <p>Se mer <a href="https://github.com/Altinn/altinn-studio/blob/master/docs/CONTRIBUTING.md">informasjon
+                    <p>Se mer <a href="https://github.com/Altinn/altinn-studio/blob/master/CONTRIBUTING.md">informasjon
                         om hvordan du kan bidra</a> på vårt Github-prosjekt.
                     </p>
                   </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Github expects the CONTRIBUTING.md file to be in the root of the project - when it is placed there, it will f.ex. automatically be linked to from our "Contributing" overview page.