### PR TITLE
Fixing appname id when adding name text language

### DIFF
--- a/frontend/app-development/hooks/mutations/useAddLanguageMutation.ts
+++ b/frontend/app-development/hooks/mutations/useAddLanguageMutation.ts
@@ -9,6 +9,9 @@ export const useAddLanguageMutation = (owner, app) => {
   return useMutation({
     mutationFn: (payload: AddLanguagePayload) =>
       addLanguageCode(owner, app, payload.language, payload),
-    onSuccess: () => q.invalidateQueries({ queryKey: [QueryKey.TextLanguages, owner, app] }),
+    onSuccess: async () => {
+      q.invalidateQueries({ queryKey: [QueryKey.TextLanguages, owner, app] });
+      q.invalidateQueries({ queryKey: [QueryKey.TextResources, owner, app] });
+    },
   });
 };


### PR DESCRIPTION
## Description
- Fixed so that when you add a new language to text editor, the app name id is added directly to the field. 

https://github.com/Altinn/altinn-studio/assets/133344438/ad3b6b33-c2be-48da-ad5b-f311035eab20



## Related Issue(s)
- #12061 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)