### PR TITLE
Return empty list from options in preview if not found

### DIFF
--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -829,7 +829,8 @@ namespace Altinn.Studio.Designer.Controllers
             }
             catch (NotFoundException)
             {
-                return NoContent();
+                // Return empty list since app-frontend don't handle a null result
+                return Ok(new List<string>());
             }
         }
 


### PR DESCRIPTION
## Description
Return empty list from options endpoint in preview controller if no options is found. 

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
