### PR TITLE
Support combination root nodes

### DIFF
--- a/frontend/packages/schema-model/src/lib/SchemaModel.test.ts
+++ b/frontend/packages/schema-model/src/lib/SchemaModel.test.ts
@@ -103,7 +103,7 @@ describe('SchemaModel', () => {
       expect(schemaModel.getRootNode()).toEqual(rootNodeMock);
     });
 
-    it('Throws an error if the root node is not a field node', () => {
+    it('Throws an error if the root node is not a field nor a combination node', () => {
       const invalidRootNode = { ...referenceNodeMock, pointer: ROOT_POINTER };
       const model = SchemaModel.fromArray([invalidRootNode]);
       expect(() => model.getRootNode()).toThrowError();

--- a/frontend/packages/schema-model/src/lib/SchemaModel.test.ts
+++ b/frontend/packages/schema-model/src/lib/SchemaModel.test.ts
@@ -104,7 +104,7 @@ describe('SchemaModel', () => {
     });
 
     it('Throws an error if the root node is not a field node', () => {
-      const invalidRootNode = { ...allOfNodeMock, pointer: ROOT_POINTER };
+      const invalidRootNode = { ...referenceNodeMock, pointer: ROOT_POINTER };
       const model = SchemaModel.fromArray([invalidRootNode]);
       expect(() => model.getRootNode()).toThrowError();
     });

--- a/frontend/packages/schema-model/src/lib/SchemaModel.ts
+++ b/frontend/packages/schema-model/src/lib/SchemaModel.ts
@@ -6,7 +6,6 @@ import type { NodeMap } from '../types/NodeMap';
 import {
   isCombination,
   isDefinition,
-  isField,
   isFieldOrCombination,
   isNodeValidParent,
   isProperty,
@@ -65,9 +64,9 @@ export class SchemaModel {
     return this.nodeMap.size <= 1;
   }
 
-  public getRootNode(): FieldNode {
+  public getRootNode(): FieldNode | CombinationNode {
     const rootNode = this.getNode(ROOT_POINTER);
-    if (!isField(rootNode)) throw new Error('Root node is not a field.');
+    if (!isFieldOrCombination(rootNode)) throw new Error('Root node is not a field nor a combination.');
     return rootNode;
   }
 


### PR DESCRIPTION
## Description
The `SchemaModel.getRootNode` wrongly assumes that the root node always is of the type `FieldNode`, but it can also be a `CombinationNode`. The reason why this was not thrown before is probably that the code used `getNode(ROOT_POINTER)` directly instead of `getRootNode()`.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test adjusted
