### PR TITLE
Return empty list from options in preview if not found

### DIFF
--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -801,7 +801,8 @@ namespace Altinn.Studio.Designer.Controllers
             }
             catch (NotFoundException)
             {
-                return NoContent();
+                // Return empty list since app-frontend don't handle a null result
+                return Ok(new List<string>());
             }
         }
 

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetOptionsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetOptionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -43,16 +44,16 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
-        public async Task Get_Options_when_no_options_exist_returns_NoContent()
+        public async Task Get_Options_when_no_options_exist_returns_Ok_empty_list()
         {
             string dataPathWithData = $"{Org}/{App}/api/options/non-existing-options";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
-            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            Assert.Equal("", responseBody);
+            Assert.Equal("[]", responseBody);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Return empty list from options in preview if not found, also for the simple endpoint that not take instance into account

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
