### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Format all frontend code with Prettier:
+a41e3b9d016bd1b824c0e793484e2d6d6e2b1e20
+
+# Apply type import on all type imports in Typescript:
+690b2f16d3f6389c36e64c6a7357f8f0c28a10cc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,17 @@ Report a bug by [opening a new issue](https://github.com/Altinn/altinn-studio/is
 
 People _love_ thorough bug reports. I'm not even kidding.
 
+## Ignore reformatting commits with Git Blame
+
+Some commits only contain automatic reformatting. These should be listed in [the .git-blame-ignore-revs file](.git-blame-ignore-revs).
+They will then be ignored when using the blame feature on Github. This makes it easier to find the commits that actually changed the code.
+In order to make this work when running then `git blame` command, or when using corresponding features in the code editor,
+the file must be specified in the Git configuration. This can be done by running the following command:
+
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the project's [3-Clause BSD License](https://github.com/Altinn/altinn-studio/blob/main/LICENSE.md).

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lint:fix": "yarn run lint --fix",
     "codestyle:check": "prettier frontend --check",
     "codestyle:fix": "prettier frontend --write",
-    "setup": "husky install && node development/setup.js",
+    "setup": "husky install && node development/setup.js && yarn run git:ignore-revs",
     "sort-texts": "yarn workspace @altinn-studio/language run sort",
     "start-app-development": "yarn workspace app-development start",
     "start-app-preview": "yarn workspace app-preview start",
@@ -103,7 +103,8 @@
     "test": "jest --maxWorkers=50% --config=frontend/jest.config.js",
     "test:ci": "jest --ci --coverage --max-workers=2 --cacheDirectory=$(yarn config get cacheFolder) --config=frontend/jest.config.js",
     "typecheck": "yarn workspaces foreach -A run typecheck",
-    "playwright:test:all": "yarn workspace playwright-studio test:all"
+    "playwright:test:all": "yarn workspace playwright-studio test:all",
+    "git:ignore-revs": "git config blame.ignoreRevsFile .git-blame-ignore-revs"
   },
   "syncpack": {
     "semverRange": ""


### PR DESCRIPTION
## Description
- Added file that contains commits that should be ignored by Git's `blame` command.
- Added paragraph that describes how to apply this in `CONTRIBUTING.md`.
- Modified the `setup` script in `package.json` so that this is configured automatically when running `yarn run setup`.

## Related Issue(s)
- #11241

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
