### PR TITLE
resourceadm: convert resource identifier to lower case in resourceadm frontend

### DIFF
--- a/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.test.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.test.tsx
@@ -140,7 +140,7 @@ describe('ImportResourceModal', () => {
     );
     await act(() => user.type(idField, '?/test'));
 
-    expect(idField).toHaveValue(`${mockAltinn2LinkService.serviceName}--test`);
+    expect(idField).toHaveValue(`${mockAltinn2LinkService.serviceName.toLowerCase()}--test`);
   });
 
   it('displays conflict message if identifier is in use', async () => {

--- a/frontend/resourceadm/components/ResourceAccessLists/ResourceAccessLists.tsx
+++ b/frontend/resourceadm/components/ResourceAccessLists/ResourceAccessLists.tsx
@@ -142,7 +142,7 @@ export const ResourceAccessLists = ({
         })}
       </div>
       <StudioButton
-        variant='secondary'
+        variant='tertiary'
         size='small'
         icon={<PlusIcon />}
         iconPlacement='left'

--- a/frontend/resourceadm/utils/stringUtils/stringUtils.test.ts
+++ b/frontend/resourceadm/utils/stringUtils/stringUtils.test.ts
@@ -3,7 +3,7 @@ import { formatIdString } from './stringUtils';
 describe('stringUtils', () => {
   describe('formatIdString', () => {
     const mockStringBefore: string = 'Test 123?/id';
-    const mockStringAfter: string = 'Test-123-id';
+    const mockStringAfter: string = 'test-123-id';
 
     it('replaces illegal characters with "-"', () => {
       const result = formatIdString(mockStringBefore);

--- a/frontend/resourceadm/utils/stringUtils/stringUtils.ts
+++ b/frontend/resourceadm/utils/stringUtils/stringUtils.ts
@@ -5,5 +5,5 @@
  * @returns the string formatted
  */
 export const formatIdString = (s: string): string => {
-  return s.replace(/[^A-Za-z0-9-_.!~*'()%]+/g, '-');
+  return s.replace(/[^A-Za-z0-9-_.!~*'()%]+/g, '-').toLowerCase();
 };


### PR DESCRIPTION
## Description

When creating a new resource in Altinn Studio, the resource identifier should not contain uppercase letters: convert identifier to lowercase letters.

+ small design change after review with design: change a button from secondary to tertiary

## Related Issue(s)

- #12165

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
