### PR TITLE
resourceadm: improvements for conditional fields + bugfix import modal

### DIFF
--- a/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.test.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.test.tsx
@@ -68,6 +68,38 @@ describe('ImportResourceModal', () => {
     expect(screen.getByRole('button', { name: importButtonText })).not.toBeDisabled();
   });
 
+  it('should clear service field when environment is changed', async () => {
+    const user = userEvent.setup();
+    renderImportResourceModal();
+
+    const environmentSelect = screen.getByLabelText(
+      textMock('resourceadm.dashboard_import_modal_select_env'),
+    );
+    await act(() => user.click(environmentSelect));
+    await act(() => user.click(screen.getByRole('option', { name: 'AT21' })));
+
+    // wait for the second combobox to appear, instead of waiting for the spinner to disappear.
+    // (sometimes the spinner disappears) too quick and the test will fail
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(textMock('resourceadm.dashboard_import_modal_select_service')),
+      ).toBeInTheDocument();
+    });
+
+    const serviceSelect = screen.getByLabelText(
+      textMock('resourceadm.dashboard_import_modal_select_service'),
+    );
+    await act(() => user.click(serviceSelect));
+    await act(() => user.click(screen.getByRole('option', { name: mockOption })));
+    expect(serviceSelect).toHaveValue(mockOption);
+
+    await act(() => user.click(environmentSelect));
+    await act(() => user.click(screen.getByRole('option', { name: 'AT22' })));
+    expect(
+      screen.queryByLabelText(textMock('resourceadm.dashboard_resource_name_and_id_resource_id')),
+    ).not.toBeInTheDocument();
+  });
+
   it('calls onClose function when close button is clicked', async () => {
     const user = userEvent.setup();
     renderImportResourceModal();

--- a/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.tsx
@@ -47,8 +47,8 @@ export const ImportResourceModal = ({
 
   const navigate = useNavigate();
 
-  const [selectedEnv, setSelectedEnv] = useState<EnvironmentType>();
-  const [selectedService, setSelectedService] = useState<Altinn2LinkService>();
+  const [selectedEnv, setSelectedEnv] = useState<EnvironmentType | undefined>(undefined);
+  const [selectedService, setSelectedService] = useState<Altinn2LinkService | undefined>(undefined);
   const [id, setId] = useState('');
   const [resourceIdExists, setResourceIdExists] = useState(false);
 
@@ -61,6 +61,8 @@ export const ImportResourceModal = ({
   const handleClose = () => {
     onClose();
     setSelectedEnv(undefined);
+    setSelectedService(undefined);
+    setId('');
   };
 
   /**
@@ -98,7 +100,11 @@ export const ImportResourceModal = ({
         <Combobox
           value={selectedEnv ? [selectedEnv] : undefined}
           label={t('resourceadm.dashboard_import_modal_select_env')}
-          onValueChange={(newValue: EnvironmentType[]) => setSelectedEnv(newValue[0])}
+          onValueChange={(newValue: EnvironmentType[]) => {
+            setSelectedEnv(newValue[0]);
+            setSelectedService(undefined);
+            setId('');
+          }}
         >
           {environmentOptions.map((env) => (
             <Combobox.Option key={env} value={env}>

--- a/frontend/resourceadm/components/ResourcePageInputs/ResourceRadioGroup.tsx
+++ b/frontend/resourceadm/components/ResourcePageInputs/ResourceRadioGroup.tsx
@@ -34,11 +34,11 @@ type ResourceRadioGroupProps = {
    */
   onFocus: () => void;
   /**
-   * Function to be executed on blur
+   * Function to be executed on change
    * @param selected the value selected
    * @returns void
    */
-  onBlur: (selected: string) => void;
+  onChange: (selected: string) => void;
   /**
    * The error text to be shown
    */
@@ -56,7 +56,7 @@ type ResourceRadioGroupProps = {
  * @property {{value: string, lable: string}[]}[options] - List of the options in the dropdown
  * @property {function}[onFocus] - unction to be executed when the field is focused
  * @property {boolean}[hasError] - If the dropdown has an error
- * @property {function}[onBlur] - Function to be executed on blur
+ * @property {function}[onChange] - Function to be executed on change
  * @property {string}[errorText] - The error text to be shown
  *
  * @returns {React.JSX.Element} - The rendered component
@@ -69,14 +69,10 @@ export const ResourceRadioGroup = ({
   options,
   hasError = false,
   onFocus,
-  onBlur,
+  onChange,
   errorText,
 }: ResourceRadioGroupProps): React.JSX.Element => {
   const [selected, setSelected] = useState(value);
-
-  const handleChangeInput = (val: string) => {
-    setSelected(val);
-  };
 
   const error = hasError && (selected === null || selected === undefined);
 
@@ -86,13 +82,15 @@ export const ResourceRadioGroup = ({
       <div className={classes.inputWrapper}>
         <Radio.Group
           size='small'
-          onChange={handleChangeInput}
+          onChange={(val: string) => {
+            setSelected(val);
+            onChange(val);
+          }}
           value={selected}
           legend={label}
           description={description}
           onFocus={onFocus}
           error={error ? <InputFieldErrorMessage message={errorText} /> : undefined}
-          onBlur={() => onBlur(selected)}
         >
           {options.map((opt) => {
             return (

--- a/frontend/resourceadm/components/ResourcePageInputs/ResourceSwitchInput.tsx
+++ b/frontend/resourceadm/components/ResourcePageInputs/ResourceSwitchInput.tsx
@@ -22,11 +22,11 @@ type ResourceSwitchInputProps = {
    */
   onFocus: () => void;
   /**
-   * Function to be executed on blur
+   * Function to be executed on change
    * @param isChecked the value used in the switch
    * @returns void
    */
-  onBlur: (isChecked: boolean) => void;
+  onChange: (isChecked: boolean) => void;
   /**
    * The id of the field
    */
@@ -49,7 +49,7 @@ type ResourceSwitchInputProps = {
  * @property {string}[description] - The description of the switch
  * @property {string}[value] - The value in the switch
  * @property {function}[onFocus] - unction to be executed when the field is focused
- * @property {function}[onBlur] - Function to be executed on blur
+ * @property {function}[onChange] - Function to be executed on change
  * @property {string}[id] - The id of the field
  * @property {string}[descriptionId] - The id of the description of the field
  * @property {string}[toggleTextTranslationKey] - The translation key to be put inside the translation function
@@ -61,7 +61,7 @@ export const ResourceSwitchInput = ({
   description,
   value,
   onFocus,
-  onBlur,
+  onChange,
   id,
   descriptionId,
   toggleTextTranslationKey,
@@ -82,9 +82,12 @@ export const ResourceSwitchInput = ({
         </Paragraph>
         <Switch
           checked={isChecked}
-          onChange={() => setIsChecked((b: boolean) => !b)}
+          onChange={(event) => {
+            const newValue = event.target.checked;
+            setIsChecked(newValue);
+            onChange(newValue);
+          }}
           onFocus={onFocus}
-          onBlur={() => onBlur(isChecked)}
           id={id}
           aria-describedby={descriptionId}
           size='small'

--- a/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
+++ b/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
@@ -116,7 +116,7 @@ export const AboutResourcePage = ({
             showAllErrors && !Object.keys(resourceTypeMap).includes(resourceData.resourceType)
           }
           onFocus={() => setTranslationType('none')}
-          onBlur={(selected: ResourceTypeOption) =>
+          onChange={(selected: ResourceTypeOption) =>
             handleSave({ ...resourceData, resourceType: selected })
           }
           errorText={t('resourceadm.about_resource_resource_type_error')}
@@ -161,7 +161,7 @@ export const AboutResourcePage = ({
           description={t('resourceadm.about_resource_delegable_text')}
           value={resourceData.delegable ?? true}
           onFocus={() => setTranslationType('none')}
-          onBlur={(isChecked: boolean) => handleSave({ ...resourceData, delegable: isChecked })}
+          onChange={(isChecked: boolean) => handleSave({ ...resourceData, delegable: isChecked })}
           id='isDelegableSwitch'
           descriptionId='isDelegableSwitchDescription'
           toggleTextTranslationKey='resourceadm.about_resource_delegable_show_text'
@@ -201,7 +201,7 @@ export const AboutResourcePage = ({
           options={statusOptions}
           hasError={showAllErrors && !Object.keys(resourceStatusMap).includes(resourceData.status)}
           onFocus={() => setTranslationType('none')}
-          onBlur={(selected: ResourceStatusOption) =>
+          onChange={(selected: ResourceStatusOption) =>
             handleSave({ ...resourceData, status: selected })
           }
           errorText={t('resourceadm.about_resource_status_error')}
@@ -212,7 +212,7 @@ export const AboutResourcePage = ({
             description={t('resourceadm.about_resource_self_identified_text')}
             value={resourceData.selfIdentifiedUserEnabled ?? false}
             onFocus={() => setTranslationType('none')}
-            onBlur={(isChecked: boolean) =>
+            onChange={(isChecked: boolean) =>
               handleSave({ ...resourceData, selfIdentifiedUserEnabled: isChecked })
             }
             id='selfIdentifiedUsersEnabledSwitch'
@@ -226,7 +226,7 @@ export const AboutResourcePage = ({
             description={t('resourceadm.about_resource_enterprise_text')}
             value={resourceData.enterpriseUserEnabled ?? false}
             onFocus={() => setTranslationType('none')}
-            onBlur={(isChecked: boolean) =>
+            onChange={(isChecked: boolean) =>
               handleSave({ ...resourceData, enterpriseUserEnabled: isChecked })
             }
             id='enterpriseUserEnabledSwitch'
@@ -270,7 +270,7 @@ export const AboutResourcePage = ({
           description={t('resourceadm.about_resource_visible_text')}
           value={resourceData.visible ?? false}
           onFocus={() => setTranslationType('none')}
-          onBlur={(isChecked: boolean) => handleSave({ ...resourceData, visible: isChecked })}
+          onChange={(isChecked: boolean) => handleSave({ ...resourceData, visible: isChecked })}
           id='isVisibleSwitch'
           descriptionId='isVisibleSwitchDescription'
           toggleTextTranslationKey='resourceadm.about_resource_visible_show_text'
@@ -282,7 +282,7 @@ export const AboutResourcePage = ({
               description={t('resourceadm.about_resource_limited_by_rrr_description')}
               value={resourceData.limitedByRRR ?? false}
               onFocus={() => setTranslationType('none')}
-              onBlur={(isChecked: boolean) =>
+              onChange={(isChecked: boolean) =>
                 handleSave({ ...resourceData, limitedByRRR: isChecked })
               }
               id='limitedByRRRSwitch'


### PR DESCRIPTION
## Description

- Save resource when changing radio button and slider on change instead of on blur in about resource page. We have some fields which are shown only when a slider is enabled, and this will show the conditional field immediately on slider change, instead of user having to change the slider and then click somewhere else on the page to blur the slider component for the conditional field to be shown.
- Clear selected service and id field when changing environment in import resource modal. This fixes the issue where the user can select an environment and a service, and when changing to a different enviroment will produce a nullpointer exception since the chosen service is not available in the new enviroment

## Related Issue(s)

- None

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
