### PR TITLE
Changing success message when uploading to gitea to prevent flaky test in Playwright

### DIFF
--- a/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/VersionControlButtons.tsx
+++ b/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/VersionControlButtons.tsx
@@ -13,6 +13,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useRepoCommitAndPushMutation } from 'app-shared/hooks/mutations';
 import * as testids from '../../../../../../testing/testids';
+import { toast } from 'react-toastify';
 
 const initialModalState = {
   header: '',
@@ -188,12 +189,9 @@ export const VersionControlButtons = ({ hasPushRight, org, app }: IVersionContro
 
     const { data: result } = await fetchPullData();
     if (result.repositoryStatus === 'Ok') {
-      setModalState({
-        ...initialModalState,
-        header: t('sync_header.sharing_changes_completed'),
-        descriptionText: [t('sync_header.sharing_changes_completed_submessage')],
-        shouldShowDoneIcon: true,
-      });
+      setModalState(initialModalState);
+      setSyncModalAnchorEl(null);
+      toast.success(t('sync_header.sharing_changes_completed'));
     } else if (
       result.repositoryStatus === 'MergeConflict' ||
       result.repositoryStatus === 'CheckoutConflict'

--- a/frontend/testing/playwright/components/Header.ts
+++ b/frontend/testing/playwright/components/Header.ts
@@ -56,10 +56,6 @@ export class Header extends BasePage {
       .isVisible();
   }
 
-  public async closeSuccessMessageBox(): Promise<void> {
-    await this.page.keyboard.press('Escape');
-  }
-
   public async clickOnLocalChangesButton(): Promise<void> {
     await this.page
       .getByRole('button', { name: this.textMock('sync_header.local_changes') })

--- a/frontend/testing/playwright/tests/git-sync/git-sync.spec.ts
+++ b/frontend/testing/playwright/tests/git-sync/git-sync.spec.ts
@@ -57,7 +57,6 @@ test('That new changes are pushed to gitea and are visible on Gitea after they h
   await header.clickOnUploadLocalChangesButton();
   await header.clickOnValidateChanges();
   await header.checkThatUploadSuccessMessageIsVisible();
-  await header.closeSuccessMessageBox();
 
   await goToGiteaAndNavigateToUiLayoutFiles(header, giteaPage);
   await giteaPage.verifyThatTheNewPageIsPresent(newPageName);


### PR DESCRIPTION
## Description
- Changing success message when uploading to gitea to prevent flaky test in Playwright

## Related Issue(s)

- The PR itself

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
