### PR TITLE
Fix wrong uri in task extension

### DIFF
--- a/frontend/packages/process-editor/src/extensions/altinnCustomTasks.ts
+++ b/frontend/packages/process-editor/src/extensions/altinnCustomTasks.ts
@@ -1,6 +1,6 @@
 export const altinnCustomTasks = {
   name: 'AltinnTask',
-  uri: 'http://altinn.no',
+  uri: 'http://altinn.no/process',
   prefix: 'altinn',
   xml: {
     tagAlias: 'lowerCase',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The URI referenced `http://altinn.no`, but should have referenced `http://altinn.no/process`. This resulted i 2 competing namespaces for processes which already had the `http://altinn.no/process` namespace. 

## Related Issue(s)

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
