### PR TITLE
Fix(Playwrigth): Attempt longer timeout before closing the browser and context

### DIFF
--- a/frontend/testing/playwright/playwright.config.ts
+++ b/frontend/testing/playwright/playwright.config.ts
@@ -14,6 +14,7 @@ export default defineConfig<ExtendedTestOptions>({
     baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL,
   },
   fullyParallel: false,
+  timeout: 3 * 60 * 1000,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've observed an error in the logs indicating a 'Target page, context, or browser has been closed.' Let's investigate if extending the timeout resolves this issue

## Related Issue(s)
PR itself.

## Verification

- [x] **Your** code builds clean without any errors or warnings
