### PR TITLE
Fix child of combination check

### DIFF
--- a/frontend/packages/schema-model/src/lib/SchemaModel.test.ts
+++ b/frontend/packages/schema-model/src/lib/SchemaModel.test.ts
@@ -8,6 +8,7 @@ import {
   defNodeWithChildrenChildMock,
   defNodeWithChildrenMock,
   enumNodeMock,
+  nodeMockBase,
   nodeWithSameNameAsStringNodeMock,
   numberNodeMock,
   optionalNodeMock,
@@ -29,7 +30,7 @@ import {
 } from '../../test/uiSchemaMock';
 import { expect } from '@jest/globals';
 import { validateTestUiSchema } from '../../test/validateTestUiSchema';
-import type { NodePosition } from '../types';
+import type { NodePosition, UiSchemaNodes } from '../types';
 import { CombinationKind, FieldType, ObjectKind } from '../types';
 import type { FieldNode } from '../types/FieldNode';
 import type { ReferenceNode } from '../types/ReferenceNode';
@@ -827,6 +828,27 @@ describe('SchemaModel', () => {
 
     it('Returns false when the given node is not a direct child of a combination node', () => {
       expect(schemaModel.isChildOfCombination(simpleChildNodeMock.pointer)).toBe(false);
+    });
+
+    it('Returns false when the root node is a combination, but the given node is a definition', () => {
+      const definitionPointer = '#/$defs/test';
+      const rootNode: CombinationNode = {
+        ...rootNodeMock,
+        objectKind: ObjectKind.Combination,
+        combinationType: CombinationKind.AnyOf,
+        children: [definitionPointer],
+      };
+      const definitionNode: FieldNode = {
+        ...nodeMockBase,
+        objectKind: ObjectKind.Field,
+        fieldType: FieldType.Object,
+        pointer: definitionPointer,
+        children: [],
+      };
+      const nodes: UiSchemaNodes = [rootNode, definitionNode];
+      validateTestUiSchema(nodes);
+      const model = SchemaModel.fromArray(nodes);
+      expect(model.isChildOfCombination(definitionPointer)).toBe(false);
     });
   });
 

--- a/frontend/packages/schema-model/src/lib/SchemaModel.ts
+++ b/frontend/packages/schema-model/src/lib/SchemaModel.ts
@@ -11,6 +11,7 @@ import type { NodeMap } from '../types/NodeMap';
 import {
   isCombination,
   isDefinition,
+  isDefinitionPointer,
   isFieldOrCombination,
   isNodeValidParent,
   isProperty,
@@ -521,6 +522,7 @@ export class SchemaModel {
   }
 
   public isChildOfCombination(pointer: string): boolean {
+    if (isDefinitionPointer(pointer)) return false; // Todo: This is necessary because definitions are in the same list as the root object properties in our internal structure. Remove this check when the data structure is fixed: https://github.com/Altinn/altinn-studio/issues/11824
     const parent = this.getParentNode(pointer);
     return !!parent && isCombination(parent);
   }

--- a/frontend/packages/schema-model/src/lib/utils.ts
+++ b/frontend/packages/schema-model/src/lib/utils.ts
@@ -91,8 +91,10 @@ export const isReference = (node: UiSchemaNode): node is ReferenceNode =>
 export const isFieldOrCombination = (node: UiSchemaNode): node is FieldNode | CombinationNode =>
   isField(node) || isCombination(node);
 
-export const isDefinition = (node: UiSchemaNode): boolean =>
-  node.pointer.startsWith(makePointerFromArray([Keyword.Definitions]));
+export const isDefinition = (node: UiSchemaNode): boolean => isDefinitionPointer(node.pointer);
+
+export const isDefinitionPointer = (pointer: string): boolean =>
+  pointer.startsWith(makePointerFromArray([Keyword.Definitions]));
 
 export const isProperty = (node: UiSchemaNode): boolean => !isDefinition(node);
 


### PR DESCRIPTION
## Description
Made it possible to edit the type even when the root node is a combination:
![image](https://github.com/Altinn/altinn-studio/assets/29770305/13250fa8-1335-4fac-b09c-dafed1535ec2)

## Related Issue(s)
- #12156

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
