### PR TITLE
9423 chore upgrade altinn studio backend to net 8

### DIFF
--- a/.github/workflows/designer-dotnet-test.yaml
+++ b/.github/workflows/designer-dotnet-test.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
+            8.0.x
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/dotnet-format.yaml
+++ b/.github/workflows/dotnet-format.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Format check
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/dotnet/sdk:6.0.419-alpine3.18 # hardcode version until microsoft fixes issue in github runners
+      image: mcr.microsoft.com/dotnet/sdk:8.0-alpine3.18 # hardcode version until microsoft fixes issue in github runners
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/dotnet-format.yaml
+++ b/.github/workflows/dotnet-format.yaml
@@ -15,9 +15,12 @@ jobs:
   dotnet-format-check:
     name: Format check
     runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/dotnet/sdk:8.0-alpine3.18 # hardcode version until microsoft fixes issue in github runners
     steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/gitea-designer-integration-tests.yaml
+++ b/.github/workflows/gitea-designer-integration-tests.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
+            8.0.x
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN yarn --immutable
 RUN yarn build
 
 # Building the backend
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS generate-studio-backend
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS generate-studio-backend
 WORKDIR /build
 COPY backend .
 RUN dotnet build src/Designer/Designer.csproj -c Release -o /app_output
@@ -19,12 +19,12 @@ RUN apk add jq zip
 RUN wget -O - https://api.github.com/repos/Altinn/app-template-dotnet/releases/latest | jq '.assets[]|select(.name | startswith("app-template-dotnet-") and endswith(".zip"))' | jq '.browser_download_url' | xargs wget -O apptemplate.zip && unzip apptemplate.zip && rm apptemplate.zip
 
 # Building the final image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS final
 EXPOSE 80
 WORKDIR /app
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
   DOTNET_RUNNING_IN_CONTAINER=true
-RUN apk add --no-cache icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib
+RUN apk add --no-cache icu-libs krb5-libs libgcc libintl openssl libstdc++ zlib
 
 COPY --from=generate-studio-backend /app_output .
 COPY --from=generate-studio-frontend /build/frontend/dist/app-development ./wwwroot/designer/frontend/app-development

--- a/backend/packagegroups/NuGet.props
+++ b/backend/packagegroups/NuGet.props
@@ -1,8 +1,7 @@
 <Project>
 
   <ItemGroup Label="Altinn specific packages">
-    <!-- Need to update to .NET8 before upgrading App Core from 8.0.0-preview.10 -->
-    <PackageReference Update="Altinn.App.Core" Version="8.0.0-preview.10" />
+    <PackageReference Update="Altinn.App.Core" Version="8.0.0-preview.11" />
     <PackageReference Update="Altinn.Common.AccessToken" Version="3.0.3" />
     <PackageReference Update="Altinn.Common.AccessTokenClient" Version="1.1.5" />
     <PackageReference Update="Altinn.Platform.Storage.Interface" Version="3.24.0" />
@@ -20,7 +19,7 @@
     <PackageReference Update="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Update="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.24" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.27" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.2" />
     <PackageReference Update="Microsoft.Azure.KeyVault" Version="3.0.5" />
     <PackageReference Update="Microsoft.Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Update="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
@@ -29,7 +28,7 @@
     <PackageReference Update="HtmlAgilityPack" Version="1.11.59" />
     <PackageReference Update="Microsoft.DiaSymReader.Native" Version="1.7.0" />
     <PackageReference Update="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.16" />
-    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.22" />
+    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
     <PackageReference Update="Scrutor" Version="4.2.2" />
     <PackageReference Update="Yuniql.AspNetCore" Version="1.2.25" />
     <PackageReference Update="Yuniql.PostgreSql" Version="1.3.15" />
@@ -42,7 +41,7 @@
 
   <ItemGroup Label="Packages used for testing">
     <PackageReference Update="FluentAssertions" Version="6.12.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.27" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.2" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <!-- Do not upgrade Moq version from 4.18.4 -->
     <PackageReference Update="Moq" Version="4.18.4" />

--- a/backend/src/DataModeling/Converter/Csharp/Compiler.cs
+++ b/backend/src/DataModeling/Converter/Csharp/Compiler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -23,12 +24,26 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
         {
             var syntaxTree = SyntaxFactory.ParseSyntaxTree(SourceText.From(csharpCode));
 
-            var compilation = CSharpCompilation.Create(Guid.NewGuid().ToString())
-                .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-                .WithReferenceAssemblies(ReferenceAssemblyKind.Net60)
-                .AddReferences(MetadataReference.CreateFromFile(typeof(Microsoft.AspNetCore.Mvc.ModelBinding.BindNeverAttribute).GetTypeInfo().Assembly.Location))
-                .AddReferences(MetadataReference.CreateFromFile(typeof(Newtonsoft.Json.JsonPropertyAttribute).GetTypeInfo().Assembly.Location))
-                .AddSyntaxTrees(syntaxTree);
+            List<string> assemblyFilePaths =
+            [
+                typeof(object).Assembly.Location,
+                typeof(System.Runtime.AssemblyTargetedPatchBandAttribute).Assembly.Location,
+                Path.Combine(Path.GetDirectoryName(typeof(object).Assembly.Location), "System.Runtime.dll"),
+                typeof(List<>).GetTypeInfo().Assembly.Location,
+                typeof(System.ComponentModel.DataAnnotations.ValidationAttribute).GetTypeInfo().Assembly.Location,
+                typeof(Enumerable).GetTypeInfo().Assembly.Location,
+                typeof(System.Text.Json.Serialization.JsonConverterAttribute).GetTypeInfo().Assembly.Location,
+                typeof(System.Xml.Serialization.XmlAttributeAttribute).GetTypeInfo().Assembly.Location,
+                typeof(Microsoft.AspNetCore.Mvc.ModelBinding.BindNeverAttribute).GetTypeInfo().Assembly.Location,
+                typeof(Newtonsoft.Json.JsonPropertyAttribute).GetTypeInfo().Assembly.Location
+            ];
+
+            var compilation = CSharpCompilation.Create(
+                Guid.NewGuid().ToString(),
+                syntaxTrees: new[] { syntaxTree },
+                references: assemblyFilePaths.Select(filePath => MetadataReference.CreateFromFile(filePath)),
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+            );
 
             Assembly assembly;
             using (var ms = new MemoryStream())

--- a/backend/src/DataModeling/Converter/Csharp/CsharpCompilationException.cs
+++ b/backend/src/DataModeling/Converter/Csharp/CsharpCompilationException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 
 namespace Altinn.Studio.DataModeling.Converter.Csharp;
 

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -34,11 +34,11 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
 
             StringBuilder writer = new StringBuilder()
                 .AppendLine("using System;")
+                .AppendLine("using System.Runtime;")
                 .AppendLine("using System.Collections.Generic;")
                 .AppendLine("using System.ComponentModel.DataAnnotations;")
                 .AppendLine("using System.Linq;")
                 .AppendLine("using System.Text.Json.Serialization;")
-                .AppendLine("using System.Threading.Tasks;")
                 .AppendLine("using System.Xml.Serialization;")
                 .AppendLine("using Microsoft.AspNetCore.Mvc.ModelBinding;")
                 .AppendLine("using Newtonsoft.Json;")

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -34,7 +34,6 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
 
             StringBuilder writer = new StringBuilder()
                 .AppendLine("using System;")
-                .AppendLine("using System.Runtime;")
                 .AppendLine("using System.Collections.Generic;")
                 .AppendLine("using System.ComponentModel.DataAnnotations;")
                 .AppendLine("using System.Linq;")

--- a/backend/src/DataModeling/DataModeling.csproj
+++ b/backend/src/DataModeling/DataModeling.csproj
@@ -1,13 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Altinn.Studio.DataModeling</AssemblyName>
     <Company>Altinn</Company>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Altinn.Studio.DataModeling</RootNamespace>
-    <!-- SonarCloud needs this -->
-    <ProjectGuid>{B5B494B4-88BA-407E-9CA3-9516FACD58CC}</ProjectGuid>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/src/Designer/Controllers/DatamodelsController.cs
+++ b/backend/src/Designer/Controllers/DatamodelsController.cs
@@ -151,21 +151,21 @@ namespace Altinn.Studio.Designer.Controllers
         /// </remarks>
         /// <param name="org">The short name of the application owner.</param>
         /// <param name="repository">The name of the repository to which the file is being added.</param>
-        /// <param name="thefile">The XSD file being uploaded.</param>
+        /// <param name="theFile">The XSD file being uploaded.</param>
         /// <param name="cancellationToken">An <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
         [HttpPost]
         [Route("upload")]
-        public async Task<IActionResult> AddXsd(string org, string repository, [FromForm(Name = "file")] IFormFile thefile, CancellationToken cancellationToken)
+        public async Task<IActionResult> AddXsd(string org, string repository, [FromForm(Name = "file")] IFormFile theFile, CancellationToken cancellationToken)
         {
-            Guard.AssertArgumentNotNull(thefile, nameof(thefile));
+            Guard.AssertArgumentNotNull(theFile, nameof(theFile));
 
-            string fileName = GetFileNameFromUploadedFile(thefile);
+            string fileName = GetFileNameFromUploadedFile(theFile);
             Guard.AssertFileExtensionIsOfType(fileName, ".xsd");
 
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
 
             var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, repository, developer);
-            string jsonSchema = await _schemaModelService.BuildSchemaFromXsd(editingContext, fileName, thefile.OpenReadStream(), cancellationToken);
+            string jsonSchema = await _schemaModelService.BuildSchemaFromXsd(editingContext, fileName, theFile.OpenReadStream(), cancellationToken);
 
             return Created(Uri.EscapeDataString(fileName), jsonSchema);
         }
@@ -195,7 +195,7 @@ namespace Altinn.Studio.Designer.Controllers
             // because the latter overrides the content type and sets it to text/plain.
             string baseUrl = GetBaseUrl();
             string locationUrl = $"{baseUrl}/designer/api/{org}/{repository}/datamodels/datamodel?modelPath={relativePath}";
-            Response.Headers.Add("Location", locationUrl);
+            Response.Headers.Append("Location", locationUrl);
             Response.StatusCode = (int)HttpStatusCode.Created;
 
             return Content(model, "application/json");

--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -354,7 +354,7 @@ namespace Altinn.Studio.Designer.Controllers
         [Route("api/v1/parties/validateInstantiation")]
         public IActionResult ValidateInstantiation()
         {
-            return Content(@"{""valid"": true}");
+            return Content("""{"valid": true}""");
         }
 
         /// <summary>
@@ -588,7 +588,7 @@ namespace Altinn.Studio.Designer.Controllers
             string layoutSetName = GetSelectedLayoutSetInEditorFromRefererHeader(refererHeader);
             if (string.IsNullOrEmpty(layoutSetName))
             {
-                string endProcess = @"{""ended"": ""ended""}";
+                string endProcess = """{"ended": "ended"}""";
                 return Ok(endProcess);
             }
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);

--- a/backend/src/Designer/Designer.csproj
+++ b/backend/src/Designer/Designer.csproj
@@ -11,8 +11,6 @@
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
     <UserSecretsId>c958e7e5-da9b-411d-8ee0-70bcfe1f64ed</UserSecretsId>
     <RootNamespace>Altinn.Studio.Designer</RootNamespace>
-    <!-- SonarCloud needs this -->
-    <ProjectGuid>{6D0AC0E2-5A9A-4804-AA89-48000067AEB0}</ProjectGuid>
     <InvariantGlobalization>false</InvariantGlobalization>
     <Configurations>Release;Debug</Configurations>
   </PropertyGroup>

--- a/backend/src/Designer/Designer.csproj
+++ b/backend/src/Designer/Designer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Altinn.Studio.Designer</AssemblyName>
     <Company>Altinn</Company>

--- a/backend/src/Designer/Filters/UseSystemTextJsonAttribute.cs
+++ b/backend/src/Designer/Filters/UseSystemTextJsonAttribute.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -21,11 +22,12 @@ namespace Altinn.Studio.Designer.Filters
     /// </summary>
     public class UseSystemTextJsonAttribute : ActionFilterAttribute, IActionModelConvention
     {
-        private static readonly JsonSerializerOptions s_jsonSerializerOptions = new JsonSerializerOptions()
+        private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
         {
             PropertyNameCaseInsensitive = true,
             Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
         };
 
         public void Apply(ActionModel action)
@@ -41,8 +43,7 @@ namespace Altinn.Studio.Designer.Filters
         // Use System.Text.Json for all ObjectResult responses
         public override void OnActionExecuted(ActionExecutedContext context)
         {
-            var formatter = new SystemTextJsonOutputFormatter(
-                s_jsonSerializerOptions);
+            var formatter = new SystemTextJsonOutputFormatter(s_jsonSerializerOptions);
             if (context.Result is ObjectResult objectResult)
             {
                 // remove Newtonsoft formatter

--- a/backend/tests/DataModeling.Tests/DataModeling.Tests.csproj
+++ b/backend/tests/DataModeling.Tests/DataModeling.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/AddXsdTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/AddXsdTests.cs
@@ -2,7 +2,6 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using Altinn.Studio.Designer.Controllers;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
 using Microsoft.AspNetCore.Mvc.Testing;

--- a/backend/tests/Designer.Tests/Controllers/RepositorySettingsController/PutTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/RepositorySettingsController/PutTests.cs
@@ -27,7 +27,7 @@ namespace Designer.Tests.Controllers.RepositorySettingsController
             await CopyRepositoryForTest(org, repo, developer, targetRepository);
 
             string requestUrl = VersionPrefix(org, targetRepository);
-            const string requestBody = @"{""repoType"": ""Datamodels"", ""datamodelling.preference"": ""JsonSchema""}";
+            const string requestBody = """{"repoType": "Datamodels", "datamodelling.preference": "JsonSchema"}""";
 
             using var payload = new StringContent(requestBody, Encoding.UTF8, MediaTypeNames.Application.Json);
 

--- a/backend/tests/Designer.Tests/Designer.Tests.csproj
+++ b/backend/tests/Designer.Tests/Designer.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Altinn.Studio.Designer.Tests</AssemblyName>
     <RootNamespace>Designer.Tests</RootNamespace>

--- a/backend/tests/SharedResources.Tests/SharedResources.Tests.csproj
+++ b/backend/tests/SharedResources.Tests/SharedResources.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
       <IsPackable>false</IsPackable>
     </PropertyGroup>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
upgrade altinn studio backend to net 8

Involved:
- adding a TypeInfoResolver to the jsonSerializerOptions 
- using .netStandard2 when adding reference assemblies in compilation class, and adding some manually

Extra:
- use setup .net step instead of container for dotnet format workflow
- use new syntax for defining inline json string in preview controller

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

