### PR TITLE
Renovate(ApplicationInsights): Remove application insights from ignoreDeps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,6 @@
   "ignorePaths": ["testdata/**", "src/**"],
   "ignoreDeps": [
     "@mui/x-data-grid",
-    "@microsoft/applicationinsights-web",
-    "@microsoft/applicationinsights-react-js",
     "Moq",
     "Altinn.App.Core"
   ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The issue with Beacon sender causes flood of thousands of request on page unload is fixed, hence we can start updating application insights again.
https://github.com/microsoft/ApplicationInsights-JS/issues/2195

## Related Issue(s)
The PR itself

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
