### PR TITLE
Adapt expression ref

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/FormComponentConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/config/FormComponentConfig.tsx
@@ -5,7 +5,10 @@ import { EditBooleanValue } from './editModal/EditBooleanValue';
 import { EditNumberValue } from './editModal/EditNumberValue';
 import { EditStringValue } from './editModal/EditStringValue';
 import { useText } from '../../hooks';
-import { getUnsupportedPropertyTypes } from '../../utils/component';
+import {
+  ExpressionSchemaBooleanDefinitionReference,
+  getUnsupportedPropertyTypes,
+} from '../../utils/component';
 import { EditGrid } from './editModal/EditGrid';
 
 export interface IEditFormComponentProps {
@@ -119,7 +122,7 @@ export const FormComponentConfig = ({
         if (!rest[propertyKey]) return null;
         if (
           rest[propertyKey].type === 'boolean' ||
-          rest[propertyKey].$ref?.endsWith('expression.schema.v1.json#/definitions/boolean')
+          rest[propertyKey].$ref?.endsWith(ExpressionSchemaBooleanDefinitionReference)
         ) {
           return (
             <EditBooleanValue

--- a/frontend/packages/ux-editor/src/components/config/FormComponentConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/config/FormComponentConfig.tsx
@@ -119,7 +119,7 @@ export const FormComponentConfig = ({
         if (!rest[propertyKey]) return null;
         if (
           rest[propertyKey].type === 'boolean' ||
-          rest[propertyKey].$ref?.endsWith('layout/expression.schema.v1.json#/definitions/boolean')
+          rest[propertyKey].$ref?.endsWith('expression.schema.v1.json#/definitions/boolean')
         ) {
           return (
             <EditBooleanValue

--- a/frontend/packages/ux-editor/src/utils/component.test.ts
+++ b/frontend/packages/ux-editor/src/utils/component.test.ts
@@ -3,6 +3,7 @@ import {
   addOptionToComponent,
   changeComponentOptionLabel,
   changeTextResourceBinding,
+  ExpressionSchemaBooleanDefinitionReference,
   generateFormItem,
   getUnsupportedPropertyTypes,
   isPropertyTypeSupported,
@@ -215,7 +216,7 @@ describe('Component utils', () => {
           },
         },
         testProperty4: {
-          $ref: 'expression.schema.v1.json#/definitions/boolean',
+          $ref: ExpressionSchemaBooleanDefinitionReference,
         },
         testProperty5: {
           type: 'integer',
@@ -271,7 +272,7 @@ describe('Component utils', () => {
     it('should return true if property ref is supported', () => {
       expect(
         isPropertyTypeSupported({
-          $ref: 'expression.schema.v1.json#/definitions/boolean',
+          $ref: ExpressionSchemaBooleanDefinitionReference,
         }),
       ).toBe(true);
     });

--- a/frontend/packages/ux-editor/src/utils/component.test.ts
+++ b/frontend/packages/ux-editor/src/utils/component.test.ts
@@ -215,7 +215,7 @@ describe('Component utils', () => {
           },
         },
         testProperty4: {
-          $ref: 'https://altinncdn.no/schemas/json/layout/expression.schema.v1.json#/definitions/boolean',
+          $ref: 'expression.schema.v1.json#/definitions/boolean',
         },
         testProperty5: {
           type: 'integer',
@@ -271,7 +271,7 @@ describe('Component utils', () => {
     it('should return true if property ref is supported', () => {
       expect(
         isPropertyTypeSupported({
-          $ref: 'https://altinncdn.no/schemas/json/layout/expression.schema.v1.json#/definitions/boolean',
+          $ref: 'expression.schema.v1.json#/definitions/boolean',
         }),
       ).toBe(true);
     });

--- a/frontend/packages/ux-editor/src/utils/component.ts
+++ b/frontend/packages/ux-editor/src/utils/component.ts
@@ -143,9 +143,7 @@ export const getUnsupportedPropertyTypes = (
 };
 
 const supportedPropertyTypes = ['boolean', 'number', 'integer', 'string'];
-const supportedPropertyRefs = [
-  'https://altinncdn.no/schemas/json/layout/expression.schema.v1.json#/definitions/boolean',
-];
+const supportedPropertyRefs = ['expression.schema.v1.json#/definitions/boolean'];
 
 /**
  * Checks if a given property with optional property key is supported by component config view.

--- a/frontend/packages/ux-editor/src/utils/component.ts
+++ b/frontend/packages/ux-editor/src/utils/component.ts
@@ -116,6 +116,9 @@ export const setComponentProperty = <
   [propertyKey]: value,
 });
 
+export const ExpressionSchemaBooleanDefinitionReference =
+  'expression.schema.v1.json#/definitions/boolean';
+
 /**
  * Gets an array of unsupported property keys
  * @param properties The properties object to check.
@@ -143,7 +146,7 @@ export const getUnsupportedPropertyTypes = (
 };
 
 const supportedPropertyTypes = ['boolean', 'number', 'integer', 'string'];
-const supportedPropertyRefs = ['expression.schema.v1.json#/definitions/boolean'];
+const supportedPropertyRefs = [ExpressionSchemaBooleanDefinitionReference];
 
 /**
  * Checks if a given property with optional property key is supported by component config view.


### PR DESCRIPTION
## Description
- Adapt expression ref in schema config rendering to make sure the `hidden` prop is included in the config panel as a boolean.
- Adapt expression ref in check for unsupported properties to list in the Alert component at the end of the schema config to make sure the `hidden` prop is not added to the list.

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
