### PR TITLE
12305 container components lacks id/datamodel section

### DIFF
--- a/frontend/packages/ux-editor/src/components/Properties/Properties.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/Properties.tsx
@@ -7,7 +7,6 @@ import { useFormContext } from '../../containers/FormContext';
 import classes from './Properties.module.css';
 import { Dynamics } from './Dynamics';
 import { PropertiesHeader } from './PropertiesHeader';
-import { isContainer } from '../../utils/formItemUtils';
 import { EditFormComponent } from '../config/EditFormComponent';
 
 export const Properties = () => {
@@ -34,7 +33,7 @@ export const Properties = () => {
 
   return (
     <div className={classes.root}>
-      {form && !isContainer(form) && (
+      {form &&
         <PropertiesHeader
           form={form}
           formId={formId}
@@ -43,7 +42,7 @@ export const Properties = () => {
             debounceSave(formId, updatedComponent);
           }}
         />
-      )}
+      }
       <Accordion color='subtle'>
         <Accordion.Item open={openList.includes('text')}>
           <Accordion.Header onHeaderClick={() => toggleOpen('text')}>

--- a/frontend/packages/ux-editor/src/components/Properties/Properties.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/Properties.tsx
@@ -33,7 +33,7 @@ export const Properties = () => {
 
   return (
     <div className={classes.root}>
-      {form &&
+      {form && (
         <PropertiesHeader
           form={form}
           formId={formId}
@@ -42,7 +42,7 @@ export const Properties = () => {
             debounceSave(formId, updatedComponent);
           }}
         />
-      }
+      )}
       <Accordion color='subtle'>
         <Accordion.Item open={openList.includes('text')}>
           <Accordion.Header onHeaderClick={() => toggleOpen('text')}>

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/EditComponentIdRow/EditComponentIdRow.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/EditComponentIdRow/EditComponentIdRow.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { idExists } from '../../../../utils/formLayoutUtils';
 import { useTranslation } from 'react-i18next';
 import { useSelectedFormLayout } from '../../../../hooks';
-import type { FormComponent } from '../../../../types/FormComponent';
 import { FormField } from '../../../FormField';
 import { Textfield } from '@digdir/design-system-react';
+import {FormItem} from "../../../../types/FormItem";
 
 export interface EditComponentIdRowProps {
-  handleComponentUpdate: (component: FormComponent) => void;
-  component: FormComponent;
+  handleComponentUpdate: (component: FormItem) => void;
+  component: FormItem;
   helpText?: string;
 }
 export const EditComponentIdRow = ({

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/EditComponentIdRow/EditComponentIdRow.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/EditComponentIdRow/EditComponentIdRow.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelectedFormLayout } from '../../../../hooks';
 import { FormField } from '../../../FormField';
 import { Textfield } from '@digdir/design-system-react';
-import {FormItem} from "../../../../types/FormItem";
+import type { FormItem } from '../../../../types/FormItem';
 
 export interface EditComponentIdRowProps {
   handleComponentUpdate: (component: FormItem) => void;

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/PropertiesHeader.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/PropertiesHeader.tsx
@@ -9,11 +9,14 @@ import { useTranslation } from 'react-i18next';
 import { useComponentSchemaQuery } from '../../../hooks/queries/useComponentSchemaQuery';
 import { DataModelBindingRow } from './DataModelBindingRow';
 import { EditComponentIdRow } from './EditComponentIdRow';
+import {FormItem} from "../../../types/FormItem";
+import {isContainer} from "../../../utils/formItemUtils";
+import {EditGroupDataModelBindings} from "../../config/group/EditGroupDataModelBindings";
 
 export type PropertiesHeaderProps = {
-  form: FormComponent;
+  form: FormItem;
   formId: string;
-  handleComponentUpdate: (component: FormComponent) => void;
+  handleComponentUpdate: (component: FormItem) => void;
 };
 
 export const PropertiesHeader = ({
@@ -29,6 +32,15 @@ export const PropertiesHeader = ({
     : formItemConfigs[form.type]?.icon;
 
   const { data: schema } = useComponentSchemaQuery(form.type);
+
+  const handleDataModelGroupChange = (dataBindingName: string, key: string) => {
+    handleComponentUpdate({
+      ...form,
+      dataModelBindings: {
+        [key]: dataBindingName,
+      },
+    });
+  };
 
   return (
     <>
@@ -48,16 +60,21 @@ export const PropertiesHeader = ({
         <div className={classes.contentRow}>
           <EditComponentIdRow component={form} handleComponentUpdate={handleComponentUpdate} />
         </div>
-        {schema && (
-          <div className={classes.contentRow}>
+        {schema && (isContainer(form) ? (
+            <EditGroupDataModelBindings
+                dataModelBindings={form.dataModelBindings}
+                onDataModelChange={handleDataModelGroupChange}
+            />
+        ) : (
+            <div className={classes.contentRow}>
             <DataModelBindingRow
               schema={schema}
-              component={form}
+              component={form as FormComponent}
               formId={formId}
               handleComponentUpdate={handleComponentUpdate}
             />
           </div>
-        )}
+        ))}
       </div>
     </>
   );

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/PropertiesHeader.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/PropertiesHeader.tsx
@@ -9,9 +9,10 @@ import { useTranslation } from 'react-i18next';
 import { useComponentSchemaQuery } from '../../../hooks/queries/useComponentSchemaQuery';
 import { DataModelBindingRow } from './DataModelBindingRow';
 import { EditComponentIdRow } from './EditComponentIdRow';
-import {FormItem} from "../../../types/FormItem";
-import {isContainer} from "../../../utils/formItemUtils";
-import {EditGroupDataModelBindings} from "../../config/group/EditGroupDataModelBindings";
+import type { FormItem } from '../../../types/FormItem';
+import { isContainer } from '../../../utils/formItemUtils';
+import { EditGroupDataModelBindings } from '../../config/group/EditGroupDataModelBindings';
+import { ComponentType } from 'app-shared/types/ComponentType';
 
 export type PropertiesHeaderProps = {
   form: FormItem;
@@ -60,21 +61,24 @@ export const PropertiesHeader = ({
         <div className={classes.contentRow}>
           <EditComponentIdRow component={form} handleComponentUpdate={handleComponentUpdate} />
         </div>
-        {schema && (isContainer(form) ? (
-            <EditGroupDataModelBindings
+        {schema &&
+          (isContainer(form) ? (
+            form.type !== ComponentType.RepeatingGroup && (
+              <EditGroupDataModelBindings
                 dataModelBindings={form.dataModelBindings}
                 onDataModelChange={handleDataModelGroupChange}
-            />
-        ) : (
+              />
+            )
+          ) : (
             <div className={classes.contentRow}>
-            <DataModelBindingRow
-              schema={schema}
-              component={form as FormComponent}
-              formId={formId}
-              handleComponentUpdate={handleComponentUpdate}
-            />
-          </div>
-        ))}
+              <DataModelBindingRow
+                schema={schema}
+                component={form as FormComponent}
+                formId={formId}
+                handleComponentUpdate={handleComponentUpdate}
+              />
+            </div>
+          ))}
       </div>
     </>
   );

--- a/frontend/packages/ux-editor/src/components/config/EditFormComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/EditFormComponent.tsx
@@ -3,14 +3,13 @@ import type { EditSettings, IGenericEditComponent } from './componentConfig';
 import { configComponents } from './componentConfig';
 import { componentSpecificEditConfig } from './componentConfig';
 import { ComponentSpecificContent } from './componentSpecificContent';
-import { Switch, Fieldset, Heading } from '@digdir/design-system-react';
+import { Switch, Fieldset } from '@digdir/design-system-react';
 import classes from './EditFormComponent.module.css';
 import { selectedLayoutNameSelector } from '../../selectors/formLayoutSelectors';
 import { useComponentSchemaQuery } from '../../hooks/queries/useComponentSchemaQuery';
 import { StudioSpinner } from '@studio/components';
 import { FormComponentConfig } from './FormComponentConfig';
 import { useSelector } from 'react-redux';
-import { getComponentTitleByComponentType } from '../../utils/language';
 import { useTranslation } from 'react-i18next';
 import {
   addFeatureFlagToLocalStorage,
@@ -92,9 +91,6 @@ export const EditFormComponent = ({
           </Switch>
         )}
       />
-      <Heading level={2} size='xsmall'>
-        {getComponentTitleByComponentType(component.type, t)} ({component.type})
-      </Heading>
       {showComponentConfigBeta && isPending && <StudioSpinner spinnerText={t('general.loading')} />}
       {showComponentConfigBeta && !isPending && (
         <>

--- a/frontend/packages/ux-editor/src/components/config/EditFormComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/EditFormComponent.tsx
@@ -77,48 +77,51 @@ export const EditFormComponent = ({
   }
 
   return (
-    <Fieldset className={classes.root} legend=''>
-      <FormField
-        id={component.id}
-        value={showComponentConfigBeta || false}
-        onChange={toggleShowBetaFunc}
-        propertyPath={formItemConfig.propertyPath}
-        componentType={component.type}
-        helpText={t('ux_editor.edit_component.show_beta_func_help_text')}
-        renderField={({ fieldProps }) => (
-          <Switch {...fieldProps} checked={fieldProps.value} size='small'>
-            {t('ux_editor.edit_component.show_beta_func')}
-          </Switch>
-        )}
-      />
-      {showComponentConfigBeta && isPending && <StudioSpinner spinnerText={t('general.loading')} />}
-      {showComponentConfigBeta && !isPending && (
-        <>
-          {component.type === ComponentType.RepeatingGroup && (
-            <RepeatingGroupComponent
-              editFormId={editFormId}
+    <>
+      {component.type === ComponentType.RepeatingGroup ? (
+        <RepeatingGroupComponent
+          editFormId={editFormId}
+          component={component}
+          handleComponentUpdate={handleComponentUpdate}
+        />
+      ) : (
+        <Fieldset className={classes.root} legend=''>
+          <FormField
+            id={component.id}
+            value={showComponentConfigBeta || false}
+            onChange={toggleShowBetaFunc}
+            propertyPath={formItemConfig.propertyPath}
+            componentType={component.type}
+            helpText={t('ux_editor.edit_component.show_beta_func_help_text')}
+            renderField={({ fieldProps }) => (
+              <Switch {...fieldProps} checked={fieldProps.value} size='small'>
+                {t('ux_editor.edit_component.show_beta_func')}
+              </Switch>
+            )}
+          />
+          {showComponentConfigBeta && isPending && (
+            <StudioSpinner spinnerText={t('general.loading')} />
+          )}
+          {showComponentConfigBeta && !isPending && (
+            <FormComponentConfig
+              schema={schema}
               component={component}
+              editFormId={editFormId}
               handleComponentUpdate={handleComponentUpdate}
             />
           )}
-          <FormComponentConfig
-            schema={schema}
-            component={component}
-            editFormId={editFormId}
-            handleComponentUpdate={handleComponentUpdate}
-          />
-        </>
+          {!showComponentConfigBeta && (
+            <>
+              {renderFromComponentSpecificDefinition(getConfigDefinitionForComponent())}
+              <ComponentSpecificContent
+                component={component}
+                handleComponentChange={handleComponentUpdate}
+                layoutName={selectedLayout}
+              />
+            </>
+          )}
+        </Fieldset>
       )}
-      {!showComponentConfigBeta && (
-        <>
-          {renderFromComponentSpecificDefinition(getConfigDefinitionForComponent())}
-          <ComponentSpecificContent
-            component={component}
-            handleComponentChange={handleComponentUpdate}
-            layoutName={selectedLayout}
-          />
-        </>
-      )}
-    </Fieldset>
+    </>
   );
 };

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/RepeatingGroup/RepeatingGroupComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/RepeatingGroup/RepeatingGroupComponent.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import classes from './RepeatingGroupComponent.module.css';
 import { Checkbox, LegacyFieldSet, LegacyTextField } from '@digdir/design-system-react';
 import { FormField } from '../../../FormField';
-import { idExists } from '../../../../utils/formLayoutUtils';
 import { EditGroupDataModelBindings } from '../../group/EditGroupDataModelBindings';
 import { getTextResource } from '../../../../utils/language';
 import { useSelectedFormLayout, useText, useTextResourcesSelector } from '../../../../hooks';
@@ -29,7 +28,7 @@ export const RepeatingGroupComponent = ({
   const { selectedLayoutSet } = useAppContext();
   const { data: formLayouts } = useFormLayoutsQuery(org, app, selectedLayoutSet);
   const { data: dataModel } = useDatamodelMetadataQuery(org, app);
-  const { components, containers } = useSelectedFormLayout();
+  const { components } = useSelectedFormLayout();
   const textResources: ITextResource[] = useTextResourcesSelector<ITextResource[]>(
     textResourcesByLanguageSelector(DEFAULT_LANGUAGE),
   );
@@ -85,44 +84,9 @@ export const RepeatingGroupComponent = ({
     });
   };
 
-  const handleIdChange = (id: string) => {
-    handleComponentUpdate({
-      ...component,
-      id,
-    });
-  };
-
   return (
     <div className={classes.root}>
       <LegacyFieldSet className={classes.fieldset}>
-        <FormField
-          id={component.id}
-          label={t('ux_editor.modal_properties_group_change_id')}
-          value={component.id}
-          propertyPath='definitions/component/properties/id'
-          customValidationRules={(value: string) => {
-            if (value !== component.id && idExists(value, components, containers)) {
-              return 'unique';
-            }
-          }}
-          customValidationMessages={(errorCode: string) => {
-            if (errorCode === 'unique') {
-              return t('ux_editor.modal_properties_component_id_not_unique_error');
-            }
-            if (errorCode === 'pattern') {
-              return t('ux_editor.modal_properties_component_id_not_valid');
-            }
-          }}
-          onChange={handleIdChange}
-          renderField={({ fieldProps }) => (
-            <LegacyTextField
-              {...fieldProps}
-              name={`group-id${component.id}`}
-              onChange={(e) => fieldProps.onChange(e.target.value, e)}
-            />
-          )}
-        />
-        <>
           <EditGroupDataModelBindings
             dataModelBindings={component.dataModelBindings}
             onDataModelChange={handleDataModelGroupChange}
@@ -176,7 +140,6 @@ export const RepeatingGroupComponent = ({
               }}
             />
           )}
-        </>
       </LegacyFieldSet>
     </div>
   );

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/RepeatingGroup/RepeatingGroupComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/RepeatingGroup/RepeatingGroupComponent.tsx
@@ -87,59 +87,59 @@ export const RepeatingGroupComponent = ({
   return (
     <div className={classes.root}>
       <LegacyFieldSet className={classes.fieldset}>
-          <EditGroupDataModelBindings
-            dataModelBindings={component.dataModelBindings}
-            onDataModelChange={handleDataModelGroupChange}
-          />
-          <FormField
-            id={component.id}
-            label={t('ux_editor.modal_properties_group_max_occur')}
-            onChange={handleMaxOccurChange}
-            value={component.maxCount}
-            propertyPath={`${component.propertyPath}/properties/maxCount`}
-            renderField={({ fieldProps }) => (
-              <LegacyTextField
-                {...fieldProps}
-                id='modal-properties-maximum-files'
-                disabled={!!component.dataModelBindings?.group}
-                formatting={{ number: {} }}
-                onChange={(e) => fieldProps.onChange(parseInt(e.target.value), e)}
-              />
-            )}
-          />
-          {items?.length > 0 && (
-            <FormField
-              id={component.id}
-              value={items}
-              onChange={handleTableHeadersChange}
-              propertyPath={`${component.propertyPath}/properties/tableHeaders`}
-              renderField={({ fieldProps }) => {
-                const filteredItems = items.filter((id) => !!components[id]);
-                const checkboxes = filteredItems.map((id) => ({
-                  id,
-                  name: id,
-                  checked:
-                    component.tableHeaders === undefined || component.tableHeaders.includes(id),
-                }));
-                return (
-                  <Checkbox.Group
-                    {...fieldProps}
-                    error={tableHeadersError}
-                    legend={t('ux_editor.modal_properties_group_table_headers')}
-                  >
-                    {checkboxes.map(({ id, name, checked }) => (
-                      <Checkbox key={id} name={name} checked={checked} value={id}>
-                        {getTextResource(
-                          components[id]?.textResourceBindings?.title,
-                          textResources,
-                        ) || id}
-                      </Checkbox>
-                    ))}
-                  </Checkbox.Group>
-                );
-              }}
+        <EditGroupDataModelBindings
+          dataModelBindings={component.dataModelBindings}
+          onDataModelChange={handleDataModelGroupChange}
+        />
+        <FormField
+          id={component.id}
+          label={t('ux_editor.modal_properties_group_max_occur')}
+          onChange={handleMaxOccurChange}
+          value={component.maxCount}
+          propertyPath={`${component.propertyPath}/properties/maxCount`}
+          renderField={({ fieldProps }) => (
+            <LegacyTextField
+              {...fieldProps}
+              id='modal-properties-maximum-files'
+              disabled={!!component.dataModelBindings?.group}
+              formatting={{ number: {} }}
+              onChange={(e) => fieldProps.onChange(parseInt(e.target.value), e)}
             />
           )}
+        />
+        {items?.length > 0 && (
+          <FormField
+            id={component.id}
+            value={items}
+            onChange={handleTableHeadersChange}
+            propertyPath={`${component.propertyPath}/properties/tableHeaders`}
+            renderField={({ fieldProps }) => {
+              const filteredItems = items.filter((id) => !!components[id]);
+              const checkboxes = filteredItems.map((id) => ({
+                id,
+                name: id,
+                checked:
+                  component.tableHeaders === undefined || component.tableHeaders.includes(id),
+              }));
+              return (
+                <Checkbox.Group
+                  {...fieldProps}
+                  error={tableHeadersError}
+                  legend={t('ux_editor.modal_properties_group_table_headers')}
+                >
+                  {checkboxes.map(({ id, name, checked }) => (
+                    <Checkbox key={id} name={name} checked={checked} value={id}>
+                      {getTextResource(
+                        components[id]?.textResourceBindings?.title,
+                        textResources,
+                      ) || id}
+                    </Checkbox>
+                  ))}
+                </Checkbox.Group>
+              );
+            }}
+          />
+        )}
       </LegacyFieldSet>
     </div>
   );

--- a/frontend/packages/ux-editor/src/containers/FormContext.tsx
+++ b/frontend/packages/ux-editor/src/containers/FormContext.tsx
@@ -18,15 +18,16 @@ import { AUTOSAVE_DEBOUNCE_INTERVAL_MILLISECONDS } from 'app-shared/constants';
 import { LayoutItemType } from '../types/global';
 import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
 import { useAppContext } from '../hooks/useAppContext';
+import {FormItem} from "../types/FormItem";
 
 export type FormContext = {
   formId: string;
-  form: FormContainer | FormComponent;
+  form: FormItem;
   handleDiscard: () => void;
-  handleEdit: (updatedForm: FormContainer | FormComponent) => void;
-  handleUpdate: React.Dispatch<React.SetStateAction<FormContainer | FormComponent>>;
-  handleSave: (id?: string, updatedForm?: FormContainer | FormComponent) => Promise<void>;
-  debounceSave: (id?: string, updatedForm?: FormContainer | FormComponent) => Promise<void>;
+  handleEdit: (updatedForm: FormItem) => void;
+  handleUpdate: React.Dispatch<React.SetStateAction<FormItem>>;
+  handleSave: (id?: string, updatedForm?: FormItem) => Promise<void>;
+  debounceSave: (id?: string, updatedForm?: FormItem) => Promise<void>;
 };
 
 export const FormContext = createContext<FormContext>({
@@ -62,9 +63,9 @@ export const FormContextProvider = ({ children }: FormContextProviderProps): JSX
   const autoSaveTimeoutRef = useRef(undefined);
 
   const [formId, setFormId] = useState<string>();
-  const [form, setForm] = useState<FormContainer | FormComponent>();
+  const [form, setForm] = useState<FormItem>();
   const formIdRef = useRef<string>(formId);
-  const formRef = useRef<FormContainer | FormComponent>(form);
+  const formRef = useRef<FormItem>(form);
 
   const { mutateAsync: updateFormContainer } = useUpdateFormContainerMutation(
     org,
@@ -113,7 +114,7 @@ export const FormContextProvider = ({ children }: FormContextProviderProps): JSX
   const handleSave = useCallback(
     async (
       id: string = formIdRef.current,
-      updatedForm: FormContainer | FormComponent = formRef.current,
+      updatedForm: FormItem = formRef.current,
     ): Promise<void> => {
       clearTimeout(autoSaveTimeoutRef.current);
       if (updatedForm) {
@@ -128,7 +129,7 @@ export const FormContextProvider = ({ children }: FormContextProviderProps): JSX
   );
 
   const handleEdit = useCallback(
-    (updatedForm: FormContainer | FormComponent): void => {
+    (updatedForm: FormItem): void => {
       dispatch(setCurrentEditId(undefined));
       setFormId(updatedForm?.id);
       setForm(updatedForm);
@@ -142,7 +143,7 @@ export const FormContextProvider = ({ children }: FormContextProviderProps): JSX
   }, [handleEdit]);
 
   const debounceSave = useCallback(
-    async (id: string, updatedForm: FormContainer | FormComponent): Promise<void> => {
+    async (id: string, updatedForm: FormItem): Promise<void> => {
       clearTimeout(autoSaveTimeoutRef.current);
       autoSaveTimeoutRef.current = setTimeout(async () => {
         await handleSave(id, updatedForm);

--- a/frontend/packages/ux-editor/src/containers/FormContext.tsx
+++ b/frontend/packages/ux-editor/src/containers/FormContext.tsx
@@ -18,7 +18,7 @@ import { AUTOSAVE_DEBOUNCE_INTERVAL_MILLISECONDS } from 'app-shared/constants';
 import { LayoutItemType } from '../types/global';
 import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
 import { useAppContext } from '../hooks/useAppContext';
-import {FormItem} from "../types/FormItem";
+import type { FormItem } from '../types/FormItem';
 
 export type FormContext = {
   formId: string;

--- a/frontend/packages/ux-editor/src/testing/componentSchemaMocks.ts
+++ b/frontend/packages/ux-editor/src/testing/componentSchemaMocks.ts
@@ -31,7 +31,7 @@ import PanelSchema from './schemas/json/component/Panel.schema.v1.json';
 import ParagraphSchema from './schemas/json/component/Paragraph.schema.v1.json';
 import PrintButtonSchema from './schemas/json/component/PrintButton.schema.v1.json';
 import RadioButtonsSchema from './schemas/json/component/RadioButtons.schema.v1.json';
-//import RepeatingGroupSchema from './schemas/json/component/RepeatingGroup.schema.v1.json';
+import RepeatingGroupSchema from './schemas/json/component/RepeatingGroup.schema.v1.json';
 import SummarySchema from './schemas/json/component/Summary.schema.v1.json';
 import TextAreaSchema from './schemas/json/component/TextArea.schema.v1.json';
 
@@ -69,7 +69,7 @@ export const componentSchemaMocks = {
   Paragraph: ParagraphSchema,
   PrintButton: PrintButtonSchema,
   RadioButtons: RadioButtonsSchema,
-  //RepeatingGroup: RepeatingGroupSchema,
+  RepeatingGroup: RepeatingGroupSchema,
   Summary: SummarySchema,
   TextArea: TextAreaSchema,
 };


### PR DESCRIPTION
## Description
- Always show PropertiesHeader for all components (remove check for being container)
- Remove heading section in `EditFormComponent` component
- Check if component is container in PropertiesHeader and adapt data model field selection component
  - use regular for FormComponents
  - use group-adapted for all containers that is not `RepeatingGroup`
  - use custom with maxCount taken into considerations (in the content section, not propertiesHeader) for `RepeatingGroup` 

**Not part of issue:**
Enable schema for `RepeatingGroup` to enable text editing, but move custom code for repeating group in `EditFormComponent` in order to only show the custom code on the content pane and nothing else connected to the schema.

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

