### PR TITLE
Adding wait to try to fix playwright tests

### DIFF
--- a/frontend/testing/playwright/tests/ui-editor/ui-editor-data-model-binding-and-gitea.spec.ts
+++ b/frontend/testing/playwright/tests/ui-editor/ui-editor-data-model-binding-and-gitea.spec.ts
@@ -99,9 +99,11 @@ test('That it is possible to add a data model binding, and that the files are up
   await uiEditorPage.waitForXAmountOfMilliseconds(WAIT_ONE_SECOND);
 
   await uiEditorPage.clickOnSaveDataModel();
+  await uiEditorPage.waitForXAmountOfMilliseconds(WAIT_ONE_SECOND);
 
   await header.clickOnUploadLocalChangesButton();
   await header.clickOnValidateChanges();
+  await uiEditorPage.waitForXAmountOfMilliseconds(WAIT_ONE_SECOND);
   await header.checkThatUploadSuccessMessageIsVisible();
   await header.clickOnThreeDotsMenu();
   await header.clickOnGoToGiteaRepository();


### PR DESCRIPTION
## Description
- Adding waits to try to force playwright to wait after an API call is made before next action is made

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

