### PR TITLE
Removing waits from Playwright tests

### DIFF
--- a/frontend/testing/playwright/components/Header.ts
+++ b/frontend/testing/playwright/components/Header.ts
@@ -1,6 +1,8 @@
+import { DataTestId } from '../enum/DataTestId';
 import { BasePage } from '../helpers/BasePage';
 import type { Environment } from '../helpers/StudioEnvironment';
 import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 type TopMenuNames =
   | 'about'
@@ -64,5 +66,10 @@ export class Header extends BasePage {
 
   public async clickOnOpenSettingsModalButton(): Promise<void> {
     await this.page.getByRole('button', { name: this.textMock('sync_header.settings') }).click();
+  }
+
+  public async waitForPushToGiteaSpinnerToDisappear(): Promise<void> {
+    const spinner = this.page.getByTestId(DataTestId.PushToGiteaSpinner);
+    await expect(spinner).toBeHidden();
   }
 }

--- a/frontend/testing/playwright/enum/DataTestId.ts
+++ b/frontend/testing/playwright/enum/DataTestId.ts
@@ -1,0 +1,8 @@
+import * as testids from '../../testids';
+
+export enum DataTestId {
+  PushToGiteaSpinner = 'studio-spinner-test-id',
+  DraggableToolbarItem = testids.draggableToolbarItem,
+  DroppableList = testids.droppableList,
+  FileSelectorInput = testids.fileSelectorInput,
+}

--- a/frontend/testing/playwright/pages/DataModelPage.ts
+++ b/frontend/testing/playwright/pages/DataModelPage.ts
@@ -1,8 +1,9 @@
 import { BasePage } from '../helpers/BasePage';
 import type { Locator, Page } from '@playwright/test';
 import type { Environment } from '../helpers/StudioEnvironment';
-import * as testids from '../../testids';
 import path from 'path';
+import { expect } from '@playwright/test';
+import { DataTestId } from '../enum/DataTestId';
 
 export class DataModelPage extends BasePage {
   constructor(page: Page, environment?: Environment) {
@@ -143,13 +144,20 @@ export class DataModelPage extends BasePage {
 
   public async selectFileToUpload(fileName: string): Promise<void> {
     await this.page
-      .getByTestId(testids.fileSelectorInput)
+      .getByTestId(DataTestId.FileSelectorInput)
       .first()
       .setInputFiles(path.join(__dirname, fileName));
   }
 
   public async getDataModelOptionValue(option: string): Promise<string> {
     return await this.page.getByRole('option', { name: option }).getAttribute('value');
+  }
+
+  public async waitForSuccessAlertToDisappear(): Promise<void> {
+    const successAlert = this.page.getByRole('alert', {
+      name: this.textMock('schema_editor.datamodel_generation_success_message'),
+    });
+    await expect(successAlert).toBeHidden();
   }
 
   // Helper function to get the name field

--- a/frontend/testing/playwright/pages/UiEditorPage.ts
+++ b/frontend/testing/playwright/pages/UiEditorPage.ts
@@ -1,9 +1,10 @@
 import { BasePage } from '../helpers/BasePage';
 import type { Environment } from '../helpers/StudioEnvironment';
 import type { Locator, Page } from '@playwright/test';
-import * as testids from '../../testids';
 import type { ComponentType } from '../enum/ComponentType';
 import type { DragAndDropComponents } from '../types/DragAndDropComponents';
+import { expect } from '@playwright/test';
+import { DataTestId } from '../enum/DataTestId';
 
 export class UiEditorPage extends BasePage {
   constructor(page: Page, environment?: Environment) {
@@ -60,14 +61,14 @@ export class UiEditorPage extends BasePage {
     await this.dropComponent();
   }
 
-  public async verifyThatComponentTreeItemIsVisibleInDroppableList(
+  public async waitForComponentTreeItemToBeVisibleInDroppableList(
     component: ComponentType,
   ): Promise<void> {
-    await this.getDroppableList()
-      .getByRole('treeitem', {
-        name: this.textMock(`ux_editor.component_title.${component}`),
-      })
-      .isVisible();
+    const treeItem = this.getDroppableList().getByRole('treeitem', {
+      name: this.textMock(`ux_editor.component_title.${component}`),
+    });
+
+    await expect(treeItem).toBeVisible();
   }
 
   public async clickOnDeleteInputComponentButton(): Promise<void> {
@@ -106,6 +107,14 @@ export class UiEditorPage extends BasePage {
         name: this.textMock('ux_editor.collapsable_text_components'),
       })
       .click();
+  }
+
+  public async waitForDraggableToolbarItemToBeVisible(component: ComponentType): Promise<void> {
+    const textTreeItem = this.page
+      .getByTestId(DataTestId.DraggableToolbarItem)
+      .getByText(this.textMock(`ux_editor.component_title.${component}`));
+
+    await expect(textTreeItem).toBeVisible();
   }
 
   public async getBetaConfigSwitchValue(): Promise<boolean> {
@@ -208,17 +217,30 @@ export class UiEditorPage extends BasePage {
       .click();
   }
 
+  public async waitForDataModelToBeSelected(): Promise<void> {
+    const saveButton = this.page.getByRole('button', {
+      name: this.textMock('ux_editor.input_popover_save_button'),
+    });
+
+    await expect(saveButton).toBeHidden();
+  }
+
+  public async waitForTreeItemToGetNewLabel(label: string): Promise<void> {
+    const newTreeItemLabel = this.page.getByRole('treeitem', { name: label });
+    await expect(newTreeItemLabel).toBeVisible();
+  }
+
   private getToolbarItems(): Locator {
-    return this.page.getByTestId(testids.draggableToolbarItem);
+    return this.page.getByTestId(DataTestId.DraggableToolbarItem);
   }
 
   private getDroppableList(): Locator {
-    return this.page.getByTestId(testids.droppableList);
+    return this.page.getByTestId(DataTestId.DroppableList);
   }
 
   private async hoverOverComponentToDrag(componentToDrag: ComponentType): Promise<void> {
     await this.page
-      .getByTestId(testids.draggableToolbarItem)
+      .getByTestId(DataTestId.DraggableToolbarItem)
       .getByText(this.textMock(`ux_editor.component_title.${componentToDrag}`))
       .hover();
   }

--- a/frontend/testing/playwright/tests/main-navigation-between-sub-apps/main-navigation-between-sub-apps.spec.ts
+++ b/frontend/testing/playwright/tests/main-navigation-between-sub-apps/main-navigation-between-sub-apps.spec.ts
@@ -174,8 +174,6 @@ test('That it is possible to navigate from overview to the deploy page and back 
   deployPage.updateOrgNameEnv(testDepartmentOrg);
   header.updateOrgNameEnv(testDepartmentOrg);
 
-  // overviewPage.waitForXAmountOfMilliseconds(3000);
-
   await overviewPage.verifyOverviewPage();
 
   // Check Navigation

--- a/frontend/testing/playwright/tests/ui-editor/ui-editor-data-model-binding-and-gitea.spec.ts
+++ b/frontend/testing/playwright/tests/ui-editor/ui-editor-data-model-binding-and-gitea.spec.ts
@@ -12,7 +12,7 @@ import { GiteaPage } from '../../pages/GiteaPage';
 
 const getAppTestName = (app: string) => `bindings-${app}`;
 
-const WAIT_ONE_SECOND = 2000;
+// const WAIT_ONE_SECOND = 2000;
 
 // Before the tests starts, we need to create the data model app
 test.beforeAll(async ({ testAppName, request, storageState }) => {
@@ -52,10 +52,11 @@ test('That it is possible to add a data model binding, and that the files are up
 
   const pageName: string = 'Side1';
   await openPageAccordionAndVerifyUpdatedUrl(uiEditorPage, pageName);
-  await uiEditorPage.verifyThatComponentTreeItemIsVisibleInDroppableList(ComponentType.Input);
+  await uiEditorPage.verifyThatPageIsEmpty();
 
   const newInputLabel: string = 'Input Label 1';
   await uiEditorPage.dragComponentInToDroppableList(ComponentType.Input);
+  await uiEditorPage.waitForComponentTreeItemToBeVisibleInDroppableList(ComponentType.Input);
   await addNewLabelToTreeItemComponent(uiEditorPage, newInputLabel);
 
   await uiEditorPage.clickOnAddDataModelButton();
@@ -81,8 +82,7 @@ test('That it is possible to add a data model binding, and that the files are up
   await dataModelPage.clickOnCreateModelButton();
   await dataModelPage.clickOnGenerateDataModelButton();
   await dataModelPage.checkThatSuccessAlertIsVisibleOnScreen();
-
-  await uiEditorPage.waitForXAmountOfMilliseconds(WAIT_ONE_SECOND);
+  await dataModelPage.waitForSuccessAlertToDisappear();
 
   await header.clickOnNavigateToPageInTopMenuHeader('create');
   await uiEditorPage.verifyUiEditorPage();
@@ -93,17 +93,14 @@ test('That it is possible to add a data model binding, and that the files are up
   await uiEditorPage.clickOnDataModelBindingsCombobox();
   await uiEditorPage.verifyThatThereAreOptionsInTheDataModelList();
 
-  await uiEditorPage.waitForXAmountOfMilliseconds(WAIT_ONE_SECOND);
   const dataModelBindingName = 'property1';
   await uiEditorPage.clickOnDataModelPropertyOption(dataModelBindingName);
-  await uiEditorPage.waitForXAmountOfMilliseconds(WAIT_ONE_SECOND);
-
   await uiEditorPage.clickOnSaveDataModel();
-  await uiEditorPage.waitForXAmountOfMilliseconds(WAIT_ONE_SECOND);
+  await uiEditorPage.waitForDataModelToBeSelected();
 
   await header.clickOnUploadLocalChangesButton();
   await header.clickOnValidateChanges();
-  await uiEditorPage.waitForXAmountOfMilliseconds(WAIT_ONE_SECOND);
+  await header.waitForPushToGiteaSpinnerToDisappear();
   await header.checkThatUploadSuccessMessageIsVisible();
   await header.clickOnThreeDotsMenu();
   await header.clickOnGoToGiteaRepository();
@@ -127,9 +124,7 @@ const addNewLabelToTreeItemComponent = async (
   await uiEditorPage.clickOnAddLabelText();
   await uiEditorPage.writeLabelTextInTextarea(newInputLabel);
   await uiEditorPage.clickOnSaveNewLabelName();
-
-  // We need to wait a few seconds to make sure that the API call is made and that the changes are saved to backend
-  await uiEditorPage.waitForXAmountOfMilliseconds(WAIT_ONE_SECOND);
+  await uiEditorPage.waitForTreeItemToGetNewLabel(newInputLabel);
 
   await uiEditorPage.verifyThatTreeItemByNameIsNotVisibleInDroppableList(ComponentType.Input);
   await uiEditorPage.verifyThatTreeItemByNameIsVisibleInDroppableList(newInputLabel);

--- a/frontend/testing/playwright/tests/ui-editor/ui-editor.spec.ts
+++ b/frontend/testing/playwright/tests/ui-editor/ui-editor.spec.ts
@@ -50,7 +50,7 @@ test('That it is possible to add and delete form components', async ({
   await uiEditorPage.verifyThatPageIsEmpty();
 
   await uiEditorPage.dragComponentInToDroppableList(ComponentType.Input);
-  await uiEditorPage.verifyThatComponentTreeItemIsVisibleInDroppableList(ComponentType.Input);
+  await uiEditorPage.waitForComponentTreeItemToBeVisibleInDroppableList(ComponentType.Input);
   await uiEditorPage.verifyThatPageEmptyMessageIsHidden();
 });
 
@@ -87,15 +87,13 @@ test('That it is possible to add a Header component to the page when there is al
   await openPageAccordionAndVerifyUpdatedUrl(uiEditorPage, PAGE_1);
 
   await uiEditorPage.openTextComponentSection();
+  await uiEditorPage.waitForDraggableToolbarItemToBeVisible(ComponentType.Header);
 
-  await uiEditorPage.waitForXAmountOfMilliseconds(2000);
   await uiEditorPage.dragComponentInToDroppableListItem({
     componentToDrag: ComponentType.Header,
     componentToDropOn: ComponentType.Input,
   });
-  await uiEditorPage.waitForXAmountOfMilliseconds(1000);
-
-  await uiEditorPage.verifyThatComponentTreeItemIsVisibleInDroppableList(ComponentType.Header);
+  await uiEditorPage.waitForComponentTreeItemToBeVisibleInDroppableList(ComponentType.Header);
 
   const newHeaderName: string = 'New Header';
   await addNewLabelToTreeItemComponent(uiEditorPage, newHeaderName);
@@ -116,9 +114,7 @@ const addNewLabelToTreeItemComponent = async (
   await uiEditorPage.clickOnAddLabelText();
   await uiEditorPage.writeLabelTextInTextarea(newInputLabel);
   await uiEditorPage.clickOnSaveNewLabelName();
-
-  // We need to wait a few seconds to make sure that the API call is made and that the changes are saved to backend
-  await uiEditorPage.waitForXAmountOfMilliseconds(1000);
+  await uiEditorPage.waitForTreeItemToGetNewLabel(newInputLabel);
 
   await uiEditorPage.verifyThatTreeItemByNameIsNotVisibleInDroppableList(ComponentType.Input);
   await uiEditorPage.verifyThatTreeItemByNameIsVisibleInDroppableList(newInputLabel);


### PR DESCRIPTION
## Description
- Removing waits in Playwright test. Changing logic so that the tests wait for elements to appear or disappear on the screen instead. 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)