### PR TITLE
Adding timeout for Gitea push

### DIFF
--- a/frontend/testing/playwright/components/Header.ts
+++ b/frontend/testing/playwright/components/Header.ts
@@ -70,6 +70,7 @@ export class Header extends BasePage {
 
   public async waitForPushToGiteaSpinnerToDisappear(): Promise<void> {
     const spinner = this.page.getByTestId(DataTestId.PushToGiteaSpinner);
-    await expect(spinner).toBeHidden();
+    const timeoutForGiteaToDoThePush: number = 10000;
+    await expect(spinner).toBeHidden({ timeout: timeoutForGiteaToDoThePush });
   }
 }


### PR DESCRIPTION
## Description
- Adding a timeout for Gitea push so that the spinner can be removed. Sometimes it takes 4 seconds, and sometimes it takes 6-7 seconds. 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)