### PR TITLE
Fixing the broken and flaky playwright tests

### DIFF
--- a/frontend/testing/playwright/pages/DataModelPage.ts
+++ b/frontend/testing/playwright/pages/DataModelPage.ts
@@ -144,13 +144,23 @@ export class DataModelPage extends BasePage {
 
   public async selectFileToUpload(fileName: string): Promise<void> {
     await this.page
+      .getByRole('toolbar')
       .getByTestId(DataTestId.FileSelectorInput)
-      .first()
       .setInputFiles(path.join(__dirname, fileName));
+  }
+
+  public async waitForDataModelToBeUploaded(): Promise<void> {
+    const spinner = this.page.getByText(this.textMock('app_data_modelling.uploading_xsd'));
+    await expect(spinner).toBeHidden();
   }
 
   public async getDataModelOptionValue(option: string): Promise<string> {
     return await this.page.getByRole('option', { name: option }).getAttribute('value');
+  }
+
+  public async waitForDataModelToAppear(dataModelName: string): Promise<void> {
+    const dataModelButton = this.page.getByRole('button', { name: dataModelName, exact: true });
+    await expect(dataModelButton).toBeVisible();
   }
 
   public async waitForSuccessAlertToDisappear(): Promise<void> {

--- a/frontend/testing/playwright/tests/data-model/data-model.spec.ts
+++ b/frontend/testing/playwright/tests/data-model/data-model.spec.ts
@@ -30,9 +30,10 @@ test('Allows to add a datamodel, include an object with custom name and fields i
 
   // Add datamodel
   await dataModelPage.clickOnCreateNewDataModelButton();
-  const dataModelName: string = 'datamodel';
+  const dataModelName: string = 'testdatamodel';
   await dataModelPage.typeDataModelName(dataModelName);
   await dataModelPage.clickOnCreateModelButton();
+  await dataModelPage.waitForDataModelToAppear(dataModelName);
 
   // Add object
   await dataModelPage.clickOnAddPropertyButton();
@@ -116,6 +117,8 @@ test('Allows to upload and then delete an XSD file', async ({ page, testAppName 
   const dataModelName: string = 'testdatamodel';
   const dataModelFileName: string = `${dataModelName}.xsd`;
   await dataModelPage.selectFileToUpload(dataModelFileName);
+  await dataModelPage.waitForDataModelToBeUploaded();
+  await dataModelPage.waitForDataModelToAppear(dataModelName);
   const dataModelComboboxValue = await dataModelPage.getDataModelOptionValue(dataModelName);
   expect(dataModelComboboxValue).toMatch(/\/testdatamodel.schema.json$/);
 

--- a/frontend/testing/playwright/tests/ui-editor/ui-editor-data-model-binding-and-gitea.spec.ts
+++ b/frontend/testing/playwright/tests/ui-editor/ui-editor-data-model-binding-and-gitea.spec.ts
@@ -12,8 +12,6 @@ import { GiteaPage } from '../../pages/GiteaPage';
 
 const getAppTestName = (app: string) => `bindings-${app}`;
 
-// const WAIT_ONE_SECOND = 2000;
-
 // Before the tests starts, we need to create the data model app
 test.beforeAll(async ({ testAppName, request, storageState }) => {
   // Create a new app
@@ -80,6 +78,7 @@ test('That it is possible to add a data model binding, and that the files are up
   const dataModelName: string = 'testdatamodel';
   await dataModelPage.typeDataModelName(dataModelName);
   await dataModelPage.clickOnCreateModelButton();
+  await dataModelPage.waitForDataModelToAppear(dataModelName);
   await dataModelPage.clickOnGenerateDataModelButton();
   await dataModelPage.checkThatSuccessAlertIsVisibleOnScreen();
   await dataModelPage.waitForSuccessAlertToDisappear();


### PR DESCRIPTION
## Description
- Adding waits for correct elements on data model page to ensure the upload and creation of data models are done correctly. This might solve the flaky tests on data model page. 

## Related Issue(s)

- This PR

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)