### PR TITLE
feat(FormItemTitle): Improve clarity by informing users of child component deletion when deleting the container

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1346,7 +1346,7 @@
   "ux_editor.component_deletion_confirm": "Ja, slett komponenten",
   "ux_editor.component_deletion_text": "Er du sikker på at du vil slette denne komponenten?",
   "ux_editor.component_dropdown_set_preselected": "Sett forhåndsvalgt verdi for nedtrekksliste",
-  "ux_editor.component_group_deletion_text": "Er du sikker på at du vil slette denne komponenten?\nAlle komponenter i denne gruppen vil bli fjernet",
+  "ux_editor.component_group_deletion_text": "Er du sikker på at du vil slette denne gruppen?\nAlle komponenter i denne gruppen vil også bli fjernet",
   "ux_editor.component_help_text.Accordion": "Med Accordion kan du presentere mye innhold på liten plass i en eller flere rader. Hele raden er klikkbar og lar brukere åpne eller lukke visningen av innholdet under.",
   "ux_editor.component_help_text.AccordionGroup": "En samling med Accordions som vises vertikalt. Brukes for å gruppere Accordions som hører sammen.",
   "ux_editor.component_help_text.ActionButton": "Knapp for å trigge en spesifisert aksjon knyttet til prosess-steget sluttbruker befinner seg i. Eksempler inkluderer 'sign', 'confirm', 'reject'.",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1346,6 +1346,7 @@
   "ux_editor.component_deletion_confirm": "Ja, slett komponenten",
   "ux_editor.component_deletion_text": "Er du sikker på at du vil slette denne komponenten?",
   "ux_editor.component_dropdown_set_preselected": "Sett forhåndsvalgt verdi for nedtrekksliste",
+  "ux_editor.component_group_deletion_text": "Er du sikker på at du vil slette denne komponenten?\nAlle komponenter i denne gruppen vil bli fjernet",
   "ux_editor.component_help_text.Accordion": "Med Accordion kan du presentere mye innhold på liten plass i en eller flere rader. Hele raden er klikkbar og lar brukere åpne eller lukke visningen av innholdet under.",
   "ux_editor.component_help_text.AccordionGroup": "En samling med Accordions som vises vertikalt. Brukes for å gruppere Accordions som hører sammen.",
   "ux_editor.component_help_text.ActionButton": "Knapp for å trigge en spesifisert aksjon knyttet til prosess-steget sluttbruker befinner seg i. Eksempler inkluderer 'sign', 'confirm', 'reject'.",

--- a/frontend/packages/ux-editor-v3/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.test.tsx
+++ b/frontend/packages/ux-editor-v3/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.test.tsx
@@ -3,12 +3,11 @@ import { renderWithProviders } from '../../../../../testing/mocks';
 import { FormItemTitle } from './FormItemTitle';
 import type { FormComponent } from '../../../../../types/FormComponent';
 import { componentMocks } from '../../../../../testing/componentMocks';
+import { textMock } from '../../../../../../../../testing/mocks/i18nMock';
+import { type FormContainer } from '../../../../../types/FormContainer';
 import { ComponentType } from 'app-shared/types/ComponentType';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-
-import { textMock } from '../../../../../../../../testing/mocks/i18nMock';
-import { FormContainer } from '../../../../../types/FormContainer';
 
 // Mocks:
 const mockDeleteItem = jest.fn();

--- a/frontend/packages/ux-editor-v3/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.test.tsx
+++ b/frontend/packages/ux-editor-v3/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.test.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import { renderWithMockStore } from '../../../../../testing/mocks';
+import { renderWithProviders } from '../../../../../testing/mocks';
 import { FormItemTitle } from './FormItemTitle';
 import type { FormComponent } from '../../../../../types/FormComponent';
 import { componentMocks } from '../../../../../testing/componentMocks';
-import { ComponentTypeV3 } from 'app-shared/types/ComponentTypeV3';
-import { screen } from '@testing-library/react';
-import { textMock } from '../../../../../../../../testing/mocks/i18nMock';
+import { ComponentType } from 'app-shared/types/ComponentType';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-// Test data:
-const item: FormComponent = componentMocks[ComponentTypeV3.Input];
-const label = 'Test label';
+import { textMock } from '../../../../../../../../testing/mocks/i18nMock';
+import { FormContainer } from '../../../../../types/FormContainer';
 
 // Mocks:
 const mockDeleteItem = jest.fn();
@@ -21,24 +20,70 @@ describe('FormItemTitle', () => {
   afterEach(jest.clearAllMocks);
 
   it('Renders children', () => {
-    render();
-    expect(screen.getByText(label)).toBeInTheDocument();
+    const component = componentMocks[ComponentType.Input];
+    const label = 'Test label';
+
+    render(component, label);
+    expect(screen.getByText('Test label')).toBeInTheDocument();
   });
 
   it('Calls deleteItem with item id when delete button is clicked and deletion is confirmed', async () => {
+    // Test data
+    const component = componentMocks[ComponentType.Input];
+    const label = 'Test label';
+
+    const user = userEvent.setup();
     jest.spyOn(window, 'confirm').mockImplementation(jest.fn(() => true));
-    render();
-    await screen.getByRole('button', { name: textMock('general.delete') }).click();
+
+    render(component, label);
+
+    await act(() => user.click(screen.getByRole('button', { name: textMock('general.delete') })));
+
     expect(mockDeleteItem).toHaveBeenCalledTimes(1);
-    expect(mockDeleteItem).toHaveBeenCalledWith(item.id);
+    expect(mockDeleteItem).toHaveBeenCalledWith(component.id);
   });
 
   it('Does not call deleteItem when delete button is clicked, but deletion is not confirmed', async () => {
+    const component = componentMocks[ComponentType.Input];
+    const label = 'Test label';
+
+    const user = userEvent.setup();
     jest.spyOn(window, 'confirm').mockImplementation(jest.fn(() => false));
-    render();
-    await screen.getByRole('button', { name: textMock('general.delete') }).click();
+    render(component, label);
+
+    await act(() => user.click(screen.getByRole('button', { name: textMock('general.delete') })));
+
     expect(mockDeleteItem).not.toHaveBeenCalled();
+  });
+
+  it('should prompt the user for confirmation before deleting the component', async () => {
+    const component = componentMocks[ComponentType.Input];
+    const label = 'Test label';
+
+    const user = userEvent.setup();
+    const mockedConfirm = jest.fn(() => true);
+    jest.spyOn(window, 'confirm').mockImplementation(mockedConfirm);
+
+    render(component, label);
+
+    await act(() => user.click(screen.getByRole('button', { name: textMock('general.delete') })));
+    expect(mockedConfirm).toBeCalledWith(textMock('ux_editor.component_deletion_text'));
+  });
+
+  it('should prompt the user for confirmation before deleting the container component and its children', async () => {
+    const groupComponent = componentMocks[ComponentType.Group];
+    const label = 'Test label';
+
+    const user = userEvent.setup();
+    const mockedConfirm = jest.fn(() => true);
+    jest.spyOn(window, 'confirm').mockImplementation(mockedConfirm);
+
+    render(groupComponent, label);
+
+    await act(() => user.click(screen.getByRole('button', { name: textMock('general.delete') })));
+    expect(mockedConfirm).toBeCalledWith(textMock('ux_editor.component_group_deletion_text'));
   });
 });
 
-const render = () => renderWithMockStore()(<FormItemTitle formItem={item}>{label}</FormItemTitle>);
+const render = (formItem: FormComponent | FormContainer, label: string) =>
+  renderWithProviders(<FormItemTitle formItem={formItem}>{label}</FormItemTitle>);

--- a/frontend/packages/ux-editor-v3/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.tsx
+++ b/frontend/packages/ux-editor-v3/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.tsx
@@ -7,6 +7,7 @@ import classes from './FormItemTitle.module.css';
 import type { FormComponent } from '../../../../../types/FormComponent';
 import type { FormContainer } from '../../../../../types/FormContainer';
 import { useDeleteItem } from './useDeleteItem';
+import { isContainer } from '../../../../../utils/formItemUtils';
 
 export interface FormItemTitleProps {
   children: ReactNode;
@@ -18,7 +19,10 @@ export const FormItemTitle = ({ children, formItem }: FormItemTitleProps) => {
   const deleteItem = useDeleteItem(formItem);
 
   const handleDelete = useCallback(() => {
-    if (confirm(t('ux_editor.component_deletion_text'))) {
+    const confirmMessage = isContainer(formItem)
+      ? t('ux_editor.component_group_deletion_text')
+      : t('ux_editor.component_deletion_text');
+    if (confirm(confirmMessage)) {
       deleteItem(formItem.id);
     }
   }, [formItem.id, deleteItem, t]);

--- a/frontend/packages/ux-editor-v3/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.tsx
+++ b/frontend/packages/ux-editor-v3/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.tsx
@@ -22,10 +22,11 @@ export const FormItemTitle = ({ children, formItem }: FormItemTitleProps) => {
     const confirmMessage = isContainer(formItem)
       ? t('ux_editor.component_group_deletion_text')
       : t('ux_editor.component_deletion_text');
+
     if (confirm(confirmMessage)) {
       deleteItem(formItem.id);
     }
-  }, [formItem.id, deleteItem, t]);
+  }, [formItem, t, deleteItem]);
 
   return (
     <div className={classes.root}>

--- a/frontend/packages/ux-editor-v3/src/testing/componentMocks.ts
+++ b/frontend/packages/ux-editor-v3/src/testing/componentMocks.ts
@@ -1,6 +1,7 @@
 import type { FormComponent, FormComponentBase } from '../types/FormComponent';
 import { ComponentTypeV3 } from 'app-shared/types/ComponentTypeV3';
 import { FormPanelVariant } from 'app-shared/types/FormPanelVariant';
+import type { FormContainer } from '../types/FormContainer';
 
 const commonProps: Pick<FormComponentBase, 'id' | 'itemType' | 'dataModelBindings'> = {
   id: 'test',
@@ -89,8 +90,9 @@ const addressComponent: FormComponent<ComponentTypeV3.AddressComponent> = {
   type: ComponentTypeV3.AddressComponent,
   simplified: true,
 };
-const groupComponent: FormComponent<ComponentTypeV3.Group> = {
+const groupComponent: FormContainer = {
   ...commonProps,
+  itemType: 'CONTAINER',
   type: ComponentTypeV3.Group,
 };
 const navigationBarComponent: FormComponent<ComponentTypeV3.NavigationBar> = {

--- a/frontend/packages/ux-editor/src/App.tsx
+++ b/frontend/packages/ux-editor/src/App.tsx
@@ -33,7 +33,6 @@ export function App() {
   const { isSuccess: areTextResourcesFetched } = useTextResourcesQuery(org, app);
 
   useEffect(() => {
-    console.log('areLayoutSetsFetched', areLayoutSetsFetched);
     if (
       areLayoutSetsFetched &&
       selectedLayoutSet &&

--- a/frontend/packages/ux-editor/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.test.tsx
@@ -3,12 +3,11 @@ import { renderWithProviders } from '../../../../../testing/mocks';
 import { FormItemTitle } from './FormItemTitle';
 import type { FormComponent } from '../../../../../types/FormComponent';
 import { componentMocks } from '../../../../../testing/componentMocks';
+import { textMock } from '../../../../../../../../testing/mocks/i18nMock';
+import { type FormContainer } from '../../../../../types/FormContainer';
 import { ComponentType } from 'app-shared/types/ComponentType';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-
-import { textMock } from '../../../../../../../../testing/mocks/i18nMock';
-import { FormContainer } from '../../../../../types/FormContainer';
 
 // Mocks:
 const mockDeleteItem = jest.fn();

--- a/frontend/packages/ux-editor/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.test.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import { renderWithMockStore } from '../../../../../testing/mocks';
+import { renderWithProviders } from '../../../../../testing/mocks';
 import { FormItemTitle } from './FormItemTitle';
 import type { FormComponent } from '../../../../../types/FormComponent';
 import { componentMocks } from '../../../../../testing/componentMocks';
 import { ComponentType } from 'app-shared/types/ComponentType';
-import { screen } from '@testing-library/react';
-import { textMock } from '../../../../../../../../testing/mocks/i18nMock';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-// Test data:
-const item: FormComponent = componentMocks[ComponentType.Input];
-const label = 'Test label';
+import { textMock } from '../../../../../../../../testing/mocks/i18nMock';
+import { FormContainer } from '../../../../../types/FormContainer';
 
 // Mocks:
 const mockDeleteItem = jest.fn();
@@ -21,24 +20,70 @@ describe('FormItemTitle', () => {
   afterEach(jest.clearAllMocks);
 
   it('Renders children', () => {
-    render();
-    expect(screen.getByText(label)).toBeInTheDocument();
+    const component = componentMocks[ComponentType.Input];
+    const label = 'Test label';
+
+    render(component, label);
+    expect(screen.getByText('Test label')).toBeInTheDocument();
   });
 
   it('Calls deleteItem with item id when delete button is clicked and deletion is confirmed', async () => {
+    // Test data
+    const component = componentMocks[ComponentType.Input];
+    const label = 'Test label';
+
+    const user = userEvent.setup();
     jest.spyOn(window, 'confirm').mockImplementation(jest.fn(() => true));
-    render();
-    await screen.getByRole('button', { name: textMock('general.delete') }).click();
+
+    render(component, label);
+
+    await act(() => user.click(screen.getByRole('button', { name: textMock('general.delete') })));
+
     expect(mockDeleteItem).toHaveBeenCalledTimes(1);
-    expect(mockDeleteItem).toHaveBeenCalledWith(item.id);
+    expect(mockDeleteItem).toHaveBeenCalledWith(component.id);
   });
 
   it('Does not call deleteItem when delete button is clicked, but deletion is not confirmed', async () => {
+    const component = componentMocks[ComponentType.Input];
+    const label = 'Test label';
+
+    const user = userEvent.setup();
     jest.spyOn(window, 'confirm').mockImplementation(jest.fn(() => false));
-    render();
-    await screen.getByRole('button', { name: textMock('general.delete') }).click();
+    render(component, label);
+
+    await act(() => user.click(screen.getByRole('button', { name: textMock('general.delete') })));
+
     expect(mockDeleteItem).not.toHaveBeenCalled();
+  });
+
+  it('should prompt the user for confirmation before deleting the component', async () => {
+    const component = componentMocks[ComponentType.Input];
+    const label = 'Test label';
+
+    const user = userEvent.setup();
+    const mockedConfirm = jest.fn(() => true);
+    jest.spyOn(window, 'confirm').mockImplementation(mockedConfirm);
+
+    render(component, label);
+
+    await act(() => user.click(screen.getByRole('button', { name: textMock('general.delete') })));
+    expect(mockedConfirm).toBeCalledWith(textMock('ux_editor.component_deletion_text'));
+  });
+
+  it('should prompt the user for confirmation before deleting the container component and its children', async () => {
+    const groupComponent = componentMocks[ComponentType.Group];
+    const label = 'Test label';
+
+    const user = userEvent.setup();
+    const mockedConfirm = jest.fn(() => true);
+    jest.spyOn(window, 'confirm').mockImplementation(mockedConfirm);
+
+    render(groupComponent, label);
+
+    await act(() => user.click(screen.getByRole('button', { name: textMock('general.delete') })));
+    expect(mockedConfirm).toBeCalledWith(textMock('ux_editor.component_group_deletion_text'));
   });
 });
 
-const render = () => renderWithMockStore()(<FormItemTitle formItem={item}>{label}</FormItemTitle>);
+const render = (formItem: FormComponent | FormContainer, label: string) =>
+  renderWithProviders(<FormItemTitle formItem={formItem}>{label}</FormItemTitle>);

--- a/frontend/packages/ux-editor/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.tsx
@@ -7,6 +7,7 @@ import classes from './FormItemTitle.module.css';
 import type { FormComponent } from '../../../../../types/FormComponent';
 import type { FormContainer } from '../../../../../types/FormContainer';
 import { useDeleteItem } from './useDeleteItem';
+import { isContainer } from '../../../../../utils/formItemUtils';
 
 export interface FormItemTitleProps {
   children: ReactNode;
@@ -18,7 +19,10 @@ export const FormItemTitle = ({ children, formItem }: FormItemTitleProps) => {
   const deleteItem = useDeleteItem(formItem);
 
   const handleDelete = useCallback(() => {
-    if (confirm(t('ux_editor.component_deletion_text'))) {
+    const confirmMessage = isContainer(formItem)
+      ? t('ux_editor.component_group_deletion_text')
+      : t('ux_editor.component_deletion_text');
+    if (confirm(confirmMessage)) {
       deleteItem(formItem.id);
     }
   }, [formItem.id, deleteItem, t]);

--- a/frontend/packages/ux-editor/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/FormTree/FormItem/FormItemTitle/FormItemTitle.tsx
@@ -22,10 +22,11 @@ export const FormItemTitle = ({ children, formItem }: FormItemTitleProps) => {
     const confirmMessage = isContainer(formItem)
       ? t('ux_editor.component_group_deletion_text')
       : t('ux_editor.component_deletion_text');
+
     if (confirm(confirmMessage)) {
       deleteItem(formItem.id);
     }
-  }, [formItem.id, deleteItem, t]);
+  }, [formItem, t, deleteItem]);
 
   return (
     <div className={classes.root}>

--- a/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.test.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.test.tsx
@@ -125,7 +125,7 @@ describe('ImportResourceModal', () => {
     );
     await act(() => user.click(serviceSelect));
     await act(() => user.click(screen.getByRole('option', { name: mockOption })));
-    expect(serviceSelect).toHaveValue(mockOption);
+    await waitFor(() => expect(serviceSelect).toHaveValue(mockOption));
 
     await act(() => user.click(serviceSelect));
     await act(() => user.keyboard('{BACKSPACE}'));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Notify the user that all children of the container component will also be removed if the container component is deleted. Also, clean up some tests to adhere to best practices. 

_Note: The PR changes has been implemented in both versions, v3 and v4_

<!--- Describe your changes in detail -->

## Related Issue(s)

- #12300 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
