### PR TITLE
set applibversion in applicationmetadata in preview mock

### DIFF
--- a/backend/src/Designer/Models/AltinnApplicationMetadata.cs
+++ b/backend/src/Designer/Models/AltinnApplicationMetadata.cs
@@ -1,0 +1,24 @@
+using Altinn.App.Core.Models;
+using Newtonsoft.Json;
+
+namespace Altinn.Studio.Designer.Models;
+
+public class AltinnApplicationMetadata : ApplicationMetadata
+{
+    //
+    // Summary
+    //     Create new instance of ApplicationMetadata
+    //
+    // Parameters:
+    //   id:
+    public AltinnApplicationMetadata(string id) : base(id)
+    {
+        Id = id;
+    }
+
+    /// <summary>
+    /// Frontend sometimes need to have knowledge of the nuget package version for backwards compatibility
+    /// </summary>
+    [JsonProperty(PropertyName = "altinnNugetVersion")]
+    public string AltinnNugetVersion { get; set; }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added an internal class `AltinnApplicationMetadata` that extends app-lib-core version with the `AltinnNugetVersion` property.
In the apps, this property is set runtime, based on the assembly of the app-lib version that the app is using. Because of this, the only need we have for this property in Studio is for preview. I have therefore fetched AppLibVersion from the repo and updated the preview mock application metadata to include this value.

Since this is a workaround that can potentially be removed once we support .NET 8 and can upgrade to the latest app-lib version, I have only used the extended model in the PreviewController application metadata mock.

## Related Issue(s)

- #12366 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
