### PR TITLE
Set hideLabel on object fields in table

### DIFF
--- a/frontend/libs/studio-components/src/hooks/useTextInputProps.tsx
+++ b/frontend/libs/studio-components/src/hooks/useTextInputProps.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, FocusEvent } from 'react';
 import { useEffect, useState } from 'react';
 import type { AdditionalProps, SharedTextInputProps } from '../types/SharedTextInputProps';
-import { StudioLabelWrapper } from '../components/StudioLabelWrapper';
+import { StudioLabelWrapper } from '../components';
 import React from 'react';
 
 type ElementType = HTMLInputElement | HTMLTextAreaElement;

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab/ItemFieldsTable/ItemFieldsTableRow.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/ItemFieldsTab/ItemFieldsTable/ItemFieldsTableRow.tsx
@@ -72,6 +72,7 @@ export const ItemFieldsTableRow = ({
           className={nameFieldClass}
           disabled={readonly}
           handleSave={handleChangeNodeName}
+          hideLabel
           onKeyDown={onKeyDown}
           pointer={fullPath}
           size='small'

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/NameField.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/NameField.tsx
@@ -12,10 +12,11 @@ export type NameFieldProps = TextfieldProps & {
   id?: string;
   pointer: string;
   handleSave: (newNodeName: string, errorCode: string) => void;
+  hideLabel?: boolean;
   label?: string;
 };
 
-export function NameField({ id, pointer, handleSave, label, ...props }: NameFieldProps) {
+export function NameField({ id, pointer, handleSave, label, hideLabel, ...props }: NameFieldProps) {
   const { t } = useTranslation();
   const { schemaModel } = useSchemaEditorAppContext();
   const [nodeName, setNodeName] = useState(extractNameFromPointer(pointer));
@@ -56,6 +57,7 @@ export function NameField({ id, pointer, handleSave, label, ...props }: NameFiel
       renderField={({ errorCode, customRequired, fieldProps }) => (
         <StudioTextfield
           {...fieldProps}
+          hideLabel={hideLabel}
           id={id}
           onChange={(e) => fieldProps.onChange(e.target.value, e)}
           onBlur={(e) => onNameBlur(e.target.value, errorCode)}


### PR DESCRIPTION
## Description
Set `hideLabel` on text fields without labels to remove unexpected label styling.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
