### PR TITLE
Add check for formItem[key] before fetching formItem[key][subKey]

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/Expressions/utils/utils.test.ts
+++ b/frontend/packages/ux-editor/src/components/config/Expressions/utils/utils.test.ts
@@ -224,8 +224,23 @@ describe('utils', () => {
         pageIndex: null,
         type: ComponentType.Input,
       };
+      const repeatingGroupWithoutEditProp: FormContainer<ComponentType.RepeatingGroup> = {
+        id: 'repeatingGroup',
+        itemType: 'CONTAINER',
+        type: ComponentType.RepeatingGroup,
+      };
       const hiddenProp: FormItemProperty<ComponentType.Input> = { key: 'hidden' };
+      const addButtonProp: FormItemProperty<ComponentType.RepeatingGroup> = {
+        key: 'edit',
+        subKey: 'addButton',
+      };
       expect(getPropertyValue<ComponentType.Input>(inputComponent, hiddenProp)).toBeUndefined();
+      expect(
+        getPropertyValue<ComponentType.RepeatingGroup>(
+          repeatingGroupWithoutEditProp,
+          addButtonProp,
+        ),
+      ).toBeUndefined();
     });
   });
 });

--- a/frontend/packages/ux-editor/src/components/config/Expressions/utils/utils.ts
+++ b/frontend/packages/ux-editor/src/components/config/Expressions/utils/utils.ts
@@ -107,7 +107,7 @@ export const getPropertyValue = <T extends ComponentType>(
   property: FormItemProperty<T>,
 ): Expression => {
   const { key, subKey } = property;
-  if (subKey) {
+  if (subKey && formItem[key]) {
     return formItem[key][subKey] as BooleanExpression | undefined;
   }
   return formItem[key] as BooleanExpression | undefined;


### PR DESCRIPTION
## Description
fix `cannot read properties of undefined reading 'addButton'` on `edit` prop on RepeatingGroup when filtering properties on component that have expressions set

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
