### PR TITLE
allow both uppercase and lowercase in model metadata response

### DIFF
--- a/frontend/packages/shared/src/types/api/DatamodelMetadataResponse.ts
+++ b/frontend/packages/shared/src/types/api/DatamodelMetadataResponse.ts
@@ -1,12 +1,6 @@
 import type { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
 import type { DatamodelFieldElement } from 'app-shared/types/DatamodelFieldElement';
 
-export type DataodelMetadataResponse = DatamodelMetadataLowerCased | DataModelMetadataUpperCased;
-
-interface DatamodelMetadataLowerCased {
+export interface DatamodelMetadataResponse {
   elements: KeyValuePairs<DatamodelFieldElement>;
-}
-
-interface DataModelMetadataUpperCased {
-  Elements: KeyValuePairs<DatamodelFieldElement>;
 }

--- a/frontend/packages/shared/src/types/api/DatamodelMetadataResponse.ts
+++ b/frontend/packages/shared/src/types/api/DatamodelMetadataResponse.ts
@@ -1,6 +1,12 @@
 import type { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
 import type { DatamodelFieldElement } from 'app-shared/types/DatamodelFieldElement';
 
-export interface DatamodelMetadataResponse {
+export type DataodelMetadataResponse = DatamodelMetadataLowerCased | DataModelMetadataUpperCased;
+
+interface DatamodelMetadataLowerCased {
   elements: KeyValuePairs<DatamodelFieldElement>;
+}
+
+interface DataModelMetadataUpperCased {
+  Elements: KeyValuePairs<DatamodelFieldElement>;
 }

--- a/frontend/packages/ux-editor/src/hooks/queries/useDatamodelMetadataQuery.ts
+++ b/frontend/packages/ux-editor/src/hooks/queries/useDatamodelMetadataQuery.ts
@@ -15,8 +15,12 @@ export const useDatamodelMetadataQuery = (
     queryFn: () =>
       getDatamodelMetadata(org, app, layoutSetName).then((res) => {
         const dataModelFields: DatamodelFieldElement[] = [];
-        const elements = res.elements || res.Elements; // Hack because we don't know if the response is upper or lower cased
-        console.log(elements);
+
+        // Hack because we don't know if the response is upper or lower cased. Should be reverted once
+        // https://github.com/Altinn/altinn-studio/pull/12457 is ready, this should fix the issue in the API.
+        const response = res as unknown as any;
+        const elements = response.elements || response.Elements; // End of hack.
+
         Object.keys(elements).forEach((dataModelField) => {
           if (dataModelField) {
             dataModelFields.push(elements[dataModelField]);

--- a/frontend/packages/ux-editor/src/hooks/queries/useDatamodelMetadataQuery.ts
+++ b/frontend/packages/ux-editor/src/hooks/queries/useDatamodelMetadataQuery.ts
@@ -15,9 +15,11 @@ export const useDatamodelMetadataQuery = (
     queryFn: () =>
       getDatamodelMetadata(org, app, layoutSetName).then((res) => {
         const dataModelFields: DatamodelFieldElement[] = [];
-        Object.keys(res.elements).forEach((dataModelField) => {
+        const elements = res.elements || res.Elements; // Hack because we don't know if the response is upper or lower cased
+        console.log(elements);
+        Object.keys(elements).forEach((dataModelField) => {
           if (dataModelField) {
-            dataModelFields.push(res.elements[dataModelField]);
+            dataModelFields.push(elements[dataModelField]);
           }
         });
         return dataModelFields;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added a hack to allow for receiving both uppercase and lowercase `element` property in the `useDatamodelMetadataQuery`api.
Should solve the problems we have seen with #12400 in the short run.

A more permanent solution would be f.ex. https://github.com/Altinn/altinn-studio/pull/12457, but it needs more work.

## Related Issue(s)

- #12400 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
