### PR TITLE
fix(Webpack): Ensure to load CSS in correct order.

### DIFF
--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -33,9 +33,25 @@ module.exports = {
         use: ['@svgr/webpack'],
       },
       {
+        test: /(?<!\.module)\.css$/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              url: false,
+            },
+          },
+        ],
+      },
+      {
         test: /\.module\.css$/,
         use: [
-          'style-loader',
+          {
+            loader: MiniCssExtractPlugin.loader,
+          },
           {
             loader: 'css-loader',
             options: {
@@ -48,20 +64,6 @@ module.exports = {
               modules: {
                 localIdentName: '[name]__[local]--[hash:base64:5]',
               },
-            },
-          },
-        ],
-      },
-      {
-        test: /(?<!\.module)\.css$/,
-        use: [
-          {
-            loader: MiniCssExtractPlugin.loader,
-          },
-          {
-            loader: 'css-loader',
-            options: {
-              url: false,
             },
           },
         ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, we're not loading CSS in the correct order in Studio. This may have gone unnoticed because the React package from the design system has been handling it for us. However, there's an upcoming release that will change this, requiring us to take control of the CSS loading order ourselves. I've made the necessary changes in this pull request. It's fine to merge this PR before we update the design system.


**Why this posed an issue:**
Failing to prioritize the inclusion of CSS from the design system first puts us at risk of needing to resort to using !important to override CSS. The last-loaded CSS takes precedence. If our custom CSS is loaded beforehand, it gets overwritten by the subsequently loaded design system CSS.




**Images that shows the difference:**
The image below illustrates that the design system (first referenced in Index.tsx) is the initial CSS included within the style tag, as anticipated.
![image](https://github.com/Altinn/altinn-studio/assets/46874830/c50fe511-3c4f-48dc-b373-5fb4cb9b8967)


Before these changes, we had the wrong order:
![image](https://github.com/Altinn/altinn-studio/assets/46874830/c531e5b2-22c0-41e4-a3ab-02243c2aefb7)


## Related Issue(s)

- PR itself.

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
