### PR TITLE
Fix wrong text key in expressions

### DIFF
--- a/frontend/packages/shared/src/components/Expression/useExpressionTexts.ts
+++ b/frontend/packages/shared/src/components/Expression/useExpressionTexts.ts
@@ -83,7 +83,7 @@ export const useExpressionTexts = (): ExpressionTexts => {
     saveAndClose: t('expression.saveAndClose'),
     secondOperand: t('expression.secondOperand'),
     simplified: t('expression.simplified'),
-    subexpression: (index: number) => t('expression.subExpression', { number: index + 1 }),
+    subexpression: (index: number) => t('expression.subexpression', { number: index + 1 }),
     transformToLogical: t('expression.transformToLogical'),
     true: t('expression.true'),
     value: t('expression.value'),


### PR DESCRIPTION
## Description
The reference to the subexpression text had wrong casing, so the text was not found.

## Related issue
- #12183

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
