### PR TITLE
centralized .net version in props file

### DIFF
--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Company>Altinn</Company>
+    <Product>Altinn Studio</Product>
+  </PropertyGroup>
+</Project>
+

--- a/backend/PolicyAdmin/PolicyAdmin.csproj
+++ b/backend/PolicyAdmin/PolicyAdmin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Altinn.Studio.PolicyAdmin</PackageId>

--- a/backend/src/DataModeling/DataModeling.csproj
+++ b/backend/src/DataModeling/DataModeling.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Altinn.Studio.DataModeling</AssemblyName>
-    <Company>Altinn</Company>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Altinn.Studio.DataModeling</RootNamespace>
   </PropertyGroup>

--- a/backend/src/Designer/Designer.csproj
+++ b/backend/src/Designer/Designer.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Altinn.Studio.Designer</AssemblyName>
     <Company>Altinn</Company>

--- a/backend/tests/DataModeling.Tests/DataModeling.Tests.csproj
+++ b/backend/tests/DataModeling.Tests/DataModeling.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodel_CsharpNamespaceTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodel_CsharpNamespaceTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Altinn.App.Core.Models;
 using Altinn.Studio.DataModeling.Templates;
@@ -43,7 +44,7 @@ public class PutDatamodel_CsharpNamespaceTests : DisagnerEndpointsTestsBase<PutD
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
         // get the csharp model from repo
         string csharpModel = TestDataHelper.GetFileFromRepo(org, targetRepo, developer, expectedModelPath);
-        csharpModel.Should().Contain($"namespace {expectedNamespace}{Environment.NewLine}{{");
+        Regex.Match(csharpModel, $"^namespace {expectedNamespace}$".Replace(".", "\\."), RegexOptions.Multiline).Success.Should().BeTrue();
 
         string applicationMetadataContent = TestDataHelper.GetFileFromRepo(org, targetRepo, developer, "App/config/applicationmetadata.json");
         var applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataContent, JsonSerializerOptions);

--- a/backend/tests/Designer.Tests/Designer.Tests.csproj
+++ b/backend/tests/Designer.Tests/Designer.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Altinn.Studio.Designer.Tests</AssemblyName>
     <RootNamespace>Designer.Tests</RootNamespace>

--- a/backend/tests/SharedResources.Tests/SharedResources.Tests.csproj
+++ b/backend/tests/SharedResources.Tests/SharedResources.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFramework>net8.0</TargetFramework>
       <IsPackable>false</IsPackable>
     </PropertyGroup>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
One of the projects wasn't updated to net8.0.
Centralized version in the Directory.Build.props added.

<!--- Describe your changes in detail -->

## Related Issue(s)
Pr itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
