### PR TITLE
resourceam: do not allow resource identifier to start with 'app_'

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -893,6 +893,7 @@
   "resourceadm.dashboard_num_resources": "Alle ressurser ({{num}})",
   "resourceadm.dashboard_organizationdata_error_body": "Vi beklager, men en feil oppstod ved henting av organisasjoner som kreves for å kjøre applikasjonen.",
   "resourceadm.dashboard_organizationdata_error_header": "Feil oppstod ved innlasting av organisasjoner",
+  "resourceadm.dashboard_resource_id_cannot_be_app": "Ressurs id kan ikke starte med \"app_\".",
   "resourceadm.dashboard_resource_name_and_id_checkmark_icon": "Bruk ny ressurs-id",
   "resourceadm.dashboard_resource_name_and_id_delete_icon": "Slett ny ressurs-id",
   "resourceadm.dashboard_resource_name_and_id_error": "Ressurs med valgt id eksisterer allerede.",

--- a/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.test.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.test.tsx
@@ -39,7 +39,7 @@ describe('ImportResourceModal', () => {
 
     const importButtonText = textMock('resourceadm.dashboard_import_modal_import_button');
     const importButton = screen.queryByRole('button', { name: importButtonText });
-    expect(importButton).toBeDisabled();
+    expect(importButton).toHaveAttribute('aria-disabled', 'true');
 
     const environmentSelect = screen.getByLabelText(
       textMock('resourceadm.dashboard_import_modal_select_env'),
@@ -48,7 +48,7 @@ describe('ImportResourceModal', () => {
     await act(() => user.click(screen.getByRole('option', { name: 'AT21' })));
 
     await waitFor(() => expect(environmentSelect).toHaveValue('AT21'));
-    expect(importButton).toBeDisabled();
+    expect(importButton).toHaveAttribute('aria-disabled', 'true');
 
     // wait for the second combobox to appear, instead of waiting for the spinner to disappear.
     // (sometimes the spinner disappears) too quick and the test will fail
@@ -65,7 +65,10 @@ describe('ImportResourceModal', () => {
     await act(() => user.click(screen.getByRole('option', { name: mockOption })));
 
     await waitFor(() => expect(serviceSelect).toHaveValue(mockOption));
-    expect(screen.getByRole('button', { name: importButtonText })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: importButtonText })).not.toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
   });
 
   it('should clear service field when environment is changed', async () => {
@@ -210,6 +213,41 @@ describe('ImportResourceModal', () => {
     await act(() => user.type(idField, '?/test'));
 
     expect(idField).toHaveValue(`${mockAltinn2LinkService.serviceName.toLowerCase()}--test`);
+  });
+
+  it('displays error message when resource identifier starts with _app', async () => {
+    const user = userEvent.setup();
+    renderImportResourceModal();
+
+    const environmentSelect = screen.getByLabelText(
+      textMock('resourceadm.dashboard_import_modal_select_env'),
+    );
+    await act(() => user.click(environmentSelect));
+    await act(() => user.click(screen.getByRole('option', { name: 'AT21' })));
+
+    // wait for the second combobox to appear, instead of waiting for the spinner to disappear.
+    // (sometimes the spinner disappears) too quick and the test will fail
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(textMock('resourceadm.dashboard_import_modal_select_service')),
+      ).toBeInTheDocument();
+    });
+
+    const serviceSelect = screen.getByLabelText(
+      textMock('resourceadm.dashboard_import_modal_select_service'),
+    );
+    await act(() => user.click(serviceSelect));
+    await act(() => user.click(screen.getByRole('option', { name: mockOption })));
+
+    const idField = await screen.findByLabelText(
+      textMock('resourceadm.dashboard_resource_name_and_id_resource_id'),
+    );
+    await act(() => user.clear(idField));
+    await act(() => user.type(idField, 'app_'));
+
+    expect(
+      screen.getByText(textMock('resourceadm.dashboard_resource_id_cannot_be_app')),
+    ).toBeInTheDocument();
   });
 
   it('displays conflict message if identifier is in use', async () => {

--- a/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.tsx
@@ -15,6 +15,7 @@ import { ServerCodes } from 'app-shared/enums/ServerCodes';
 import { useUrlParams } from '../../hooks/useSelectedContext';
 import { StudioButton } from '@studio/components';
 import { formatIdString } from '../../utils/stringUtils';
+import { getResourceIdentifierErrorMessage } from 'resourceadm/utils/resourceUtils';
 
 const environmentOptions = ['AT21', 'AT22', 'AT23', 'AT24', 'TT02', 'PROD'];
 
@@ -55,6 +56,8 @@ export const ImportResourceModal = ({
   const { mutate: importResourceFromAltinn2Mutation } =
     useImportResourceFromAltinn2Mutation(selectedContext);
 
+  const idErrorMessage = getResourceIdentifierErrorMessage(id, resourceIdExists);
+  const hasValidValues = selectedEnv && selectedService && id && !idErrorMessage;
   /**
    * Reset fields on close
    */
@@ -133,10 +136,11 @@ export const ImportResourceModal = ({
               <Textfield
                 label={t('resourceadm.dashboard_resource_name_and_id_resource_id')}
                 value={id}
-                onChange={(event) => setId(formatIdString(event.target.value))}
-                error={
-                  resourceIdExists ? t('resourceadm.dashboard_resource_name_and_id_error') : ''
-                }
+                onChange={(event) => {
+                  setResourceIdExists(false);
+                  setId(formatIdString(event.target.value));
+                }}
+                error={idErrorMessage ? t(idErrorMessage) : ''}
               />
             </div>
           )}
@@ -144,10 +148,10 @@ export const ImportResourceModal = ({
       )}
       <div className={classes.buttonWrapper}>
         <StudioButton
-          onClick={handleImportResource}
+          onClick={() => (hasValidValues ? handleImportResource() : undefined)}
           color='first'
           size='small'
-          disabled={!selectedEnv || !selectedService || !id}
+          aria-disabled={!hasValidValues}
         >
           {t('resourceadm.dashboard_import_modal_import_button')}
         </StudioButton>

--- a/frontend/resourceadm/components/NewResourceModal/NewResourceModal.test.tsx
+++ b/frontend/resourceadm/components/NewResourceModal/NewResourceModal.test.tsx
@@ -102,6 +102,24 @@ describe('NewResourceModal', () => {
     expect(mockedNavigate).toHaveBeenCalledWith(`/${org}/${org}-resources/resource/test/about`);
   });
 
+  test('should show error message if resource id starts with app_', async () => {
+    const user = userEvent.setup();
+    await renderAndOpenModal({
+      createResource: jest
+        .fn()
+        .mockImplementation(() => Promise.reject({ response: { status: ServerCodes.Conflict } })),
+    });
+
+    const titleInput = screen.getByLabelText(
+      textMock('resourceadm.dashboard_resource_name_and_id_resource_name'),
+    );
+    await act(() => user.type(titleInput, 'app_test'));
+
+    expect(
+      screen.getByText(textMock('resourceadm.dashboard_resource_id_cannot_be_app')),
+    ).toBeInTheDocument();
+  });
+
   test('should show error message if resource id is already in use', async () => {
     const user = userEvent.setup();
     await renderAndOpenModal({

--- a/frontend/resourceadm/components/NewResourceModal/NewResourceModal.tsx
+++ b/frontend/resourceadm/components/NewResourceModal/NewResourceModal.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { ServerCodes } from 'app-shared/enums/ServerCodes';
 import { useUrlParams } from '../../hooks/useSelectedContext';
 import { StudioButton } from '@studio/components';
+import { getResourceIdentifierErrorMessage } from 'resourceadm/utils/resourceUtils';
 
 export type NewResourceModalProps = {
   onClose: () => void;
@@ -36,6 +37,9 @@ export const NewResourceModal = forwardRef<HTMLDialogElement, NewResourceModalPr
 
     // Mutation function to create new resource
     const { mutate: createNewResource } = useCreateResourceMutation(selectedContext);
+
+    const idErrorMessage = getResourceIdentifierErrorMessage(id, resourceIdExists);
+    const hasValidValues = id.length !== 0 && title.length !== 0 && !idErrorMessage;
 
     /**
      * Creates a new resource in backend, and navigates if success
@@ -88,18 +92,14 @@ export const NewResourceModal = forwardRef<HTMLDialogElement, NewResourceModalPr
               setId(newId);
             }}
             onTitleChange={(newTitle: string) => setTitle(newTitle)}
-            conflictErrorMessage={
-              resourceIdExists ? t('resourceadm.dashboard_resource_name_and_id_error') : ''
-            }
+            conflictErrorMessage={idErrorMessage ? t(idErrorMessage) : ''}
           />
         </Modal.Content>
         <Modal.Footer>
           <StudioButton
-            onClick={() =>
-              !(id.length === 0 || title.length === 0) ? handleCreateNewResource() : undefined
-            }
+            onClick={() => (hasValidValues ? handleCreateNewResource() : undefined)}
             color='first'
-            aria-disabled={id.length === 0 || title.length === 0}
+            aria-disabled={!hasValidValues}
             size='small'
           >
             {t('resourceadm.dashboard_create_modal_create_button')}

--- a/frontend/resourceadm/utils/resourceUtils/index.ts
+++ b/frontend/resourceadm/utils/resourceUtils/index.ts
@@ -4,4 +4,5 @@ export {
   getMissingInputLanguageString,
   getIsActiveTab,
   createNavigationTab,
+  getResourceIdentifierErrorMessage,
 } from './resourceUtils';

--- a/frontend/resourceadm/utils/resourceUtils/resourceUtils.ts
+++ b/frontend/resourceadm/utils/resourceUtils/resourceUtils.ts
@@ -10,6 +10,7 @@ import type {
 } from 'app-shared/types/ResourceAdm';
 import type { ReactNode } from 'react';
 import type { NavigationBarPage } from '../../types/NavigationBarPage';
+import { isAppPrefix } from '../stringUtils';
 
 /**
  * The map of resource type
@@ -194,4 +195,14 @@ export const createNavigationTab = (
     },
     isActiveTab: getIsActiveTab(currentPage, tabId),
   };
+};
+
+export const getResourceIdentifierErrorMessage = (identifier: string, isConflict?: boolean) => {
+  const hasAppPrefix = isAppPrefix(identifier);
+  if (hasAppPrefix) {
+    return 'resourceadm.dashboard_resource_id_cannot_be_app';
+  } else if (isConflict) {
+    return 'resourceadm.dashboard_resource_name_and_id_error';
+  }
+  return '';
 };

--- a/frontend/resourceadm/utils/stringUtils/index.ts
+++ b/frontend/resourceadm/utils/stringUtils/index.ts
@@ -1,1 +1,1 @@
-export { formatIdString } from './stringUtils';
+export { formatIdString, isAppPrefix } from './stringUtils';

--- a/frontend/resourceadm/utils/stringUtils/stringUtils.ts
+++ b/frontend/resourceadm/utils/stringUtils/stringUtils.ts
@@ -7,3 +7,7 @@
 export const formatIdString = (s: string): string => {
   return s.replace(/[^A-Za-z0-9-_.!~*'()%]+/g, '-').toLowerCase();
 };
+
+export const isAppPrefix = (s: string): boolean => {
+  return s.substring(0, 4) === 'app_';
+};


### PR DESCRIPTION
## Description

The "app_" prefix is reserved for apps. Show an error message if user attempts to create a resource with the "app_" prefix.

## Related Issue(s)

- #12490

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
