### PR TITLE
Simplify isItemChildOfContainer

### DIFF
--- a/frontend/packages/ux-editor/src/components/Properties/DataModelBindings.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/DataModelBindings.tsx
@@ -54,7 +54,7 @@ export const DataModelBindings = (): React.JSX.Element => {
       <div className={classes.container}>
         {(formItem.type === ComponentType.FileUploadWithTag ||
           formItem.type === ComponentType.FileUpload) &&
-          isItemChildOfContainer(layout, formItem, ComponentType.RepeatingGroup) && (
+          isItemChildOfContainer(layout, formItem.id, ComponentType.RepeatingGroup) && (
             <Alert severity='warning'>
               {t('ux_editor.modal_properties_data_model_restrictions_attachment_components')}
             </Alert>

--- a/frontend/packages/ux-editor/src/utils/formLayoutUtils.test.tsx
+++ b/frontend/packages/ux-editor/src/utils/formLayoutUtils.test.tsx
@@ -527,27 +527,22 @@ describe('formLayoutUtils', () => {
 
   describe('isItemChildOfContainer', () => {
     it('Returns true if the item is a child of the given container type', () => {
-      expect(
-        isItemChildOfContainer(mockInternal, paragraphInGroupComponent, ComponentType.Group),
-      ).toBe(true);
+      const result = isItemChildOfContainer(mockInternal, paragraphInGroupId, ComponentType.Group);
+      expect(result).toBe(true);
     });
 
     it('Returns true if the item is a child of any container when containerType is not specified', () => {
-      expect(isItemChildOfContainer(mockInternal, paragraphInGroupComponent)).toBe(true);
+      expect(isItemChildOfContainer(mockInternal, paragraphInGroupId)).toBe(true);
     });
 
     it('Returns false if the item is not a child of the given container type', () => {
       expect(
-        isItemChildOfContainer(
-          mockInternal,
-          paragraphInGroupComponent,
-          ComponentType.AccordionGroup,
-        ),
+        isItemChildOfContainer(mockInternal, paragraphInGroupId, ComponentType.AccordionGroup),
       ).toBe(false);
     });
 
     it('Returns false if the item is not a child of any container when containerType is not specified', () => {
-      expect(isItemChildOfContainer(mockInternal, paragraphComponent)).toBe(false);
+      expect(isItemChildOfContainer(mockInternal, paragraphId)).toBe(false);
     });
   });
 

--- a/frontend/packages/ux-editor/src/utils/formLayoutUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/formLayoutUtils.ts
@@ -388,18 +388,15 @@ export const hasMultiPageGroup = (layout: IInternalLayout): boolean =>
 
 export const isItemChildOfContainer = (
   layout: IInternalLayout,
-  item: FormItem,
+  itemId: string,
   containerType?: ContainerComponentType,
 ): boolean => {
-  const containerOfItemId = Object.keys(layout.order).find((containerId) => {
-    return (
-      containerId !== BASE_CONTAINER_ID &&
-      Object.values(layout.order[containerId]).includes(item.id)
-    );
-  });
-  if (!containerOfItemId) return false;
-  return containerType ? layout.containers[containerOfItemId].type === containerType : true;
+  const parentId = findParentId(layout, itemId);
+  if (parentId === BASE_CONTAINER_ID) return false;
+  const parent = getItem(layout, parentId);
+  return !containerType || parent.type === containerType;
 };
+
 /**
  * Checks if a component with the given id exists in the given layout.
  * @param id The id of the component to check for.


### PR DESCRIPTION
## Description
Made the function `isItemChildOfContainer` easier to read by using the `findParentId` function.

## Related Issue(s)
- #12306

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
