### PR TITLE
return false if parentId is undefined

### DIFF
--- a/frontend/packages/ux-editor/src/utils/formLayoutUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/formLayoutUtils.ts
@@ -392,7 +392,7 @@ export const isItemChildOfContainer = (
   containerType?: ContainerComponentType,
 ): boolean => {
   const parentId = findParentId(layout, itemId);
-  if (parentId === BASE_CONTAINER_ID) return false;
+  if (parentId === BASE_CONTAINER_ID || !parentId) return false;
   const parent = getItem(layout, parentId);
   return !containerType || parent.type === containerType;
 };


### PR DESCRIPTION
## Description
Return `false` from `isItemChildOfContainer` if `parentId` is undefined. This will happen if the given Id of the item does not exist in the layout that is selected. This should not happen in real execution, but it can result in failing tests if the tests are provided with inconsistent test-data that might not be relevant for the given test so it is acceptable. 

In this particular case we had some testdata for the layout put directly on the cache while we are using different test data for the rendering components with different components as input. 

Might be an idea to do this in a more consistent way in the future so the tests are more realistic? 
