### PR TITLE
Make sure selectedLayoutSet is an existing one in layoutsets before rendering ux-editor

### DIFF
--- a/frontend/packages/ux-editor/src/App.test.tsx
+++ b/frontend/packages/ux-editor/src/App.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import { formLayoutSettingsMock, renderWithProviders } from './testing/mocks';
 import { App } from './App';
 import { textMock } from '../../../testing/mocks/i18nMock';
@@ -46,16 +46,16 @@ describe('App', () => {
     await waitForLoadingToFinish();
   });
 
-  it('Removes the preview layout set from local storage if it does not exist', async () => {
-    const removeSelectedLayoutSetMock = jest.fn();
+  it('Sets a new initial layout set as selected if current does not exist', async () => {
+    const setSelectedLayoutSetMock = jest.fn();
     const layoutSetThatDoesNotExist = 'layout-set-that-does-not-exist';
     typedLocalStorage.setItem('selectedLayoutSet', layoutSetThatDoesNotExist);
     renderApp(mockQueries, {
       selectedLayoutSet: layoutSetThatDoesNotExist,
-      removeSelectedLayoutSet: removeSelectedLayoutSetMock,
+      setSelectedLayoutSet: setSelectedLayoutSetMock,
     });
-    await waitForLoadingToFinish();
-    expect(removeSelectedLayoutSetMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(setSelectedLayoutSetMock).toHaveBeenCalledTimes(1));
+    expect(setSelectedLayoutSetMock).toHaveBeenCalledWith(layoutSetsMock.sets[0].id);
   });
 
   it('Does not remove the preview layout set from local storage if it exists', async () => {

--- a/frontend/packages/ux-editor/src/App.tsx
+++ b/frontend/packages/ux-editor/src/App.tsx
@@ -30,11 +30,15 @@ export function App() {
     useDatamodelMetadataQuery(org, app, selectedLayoutSet);
   const { isSuccess: areTextResourcesFetched } = useTextResourcesQuery(org, app);
 
+  const layoutSetsIncludesSelectedLayout = layoutSets?.sets
+    ?.map((set) => set.id)
+    .includes(selectedLayoutSet);
+
   useEffect(() => {
     if (
       areLayoutSetsFetched &&
       selectedLayoutSet &&
-      (!layoutSets || !layoutSets.sets.map((set) => set.id).includes(selectedLayoutSet))
+      (!layoutSets || !layoutSetsIncludesSelectedLayout)
     )
       removeSelectedLayoutSet();
   }, [
@@ -43,10 +47,14 @@ export function App() {
     selectedLayoutSet,
     setSelectedLayoutSet,
     removeSelectedLayoutSet,
+    layoutSetsIncludesSelectedLayout,
   ]);
 
   const componentIsReady =
-    areWidgetsFetched && isDatamodelFetched && areTextResourcesFetched && areLayoutSetsFetched;
+    areWidgetsFetched &&
+    isDatamodelFetched &&
+    areTextResourcesFetched &&
+    layoutSetsIncludesSelectedLayout;
 
   const componentHasError = dataModelFetchedError || widgetFetchedError;
 
@@ -70,11 +78,11 @@ export function App() {
   };
 
   useEffect(() => {
-    if (selectedLayoutSet === null && layoutSets) {
+    if (layoutSets && (selectedLayoutSet === null || !layoutSetsIncludesSelectedLayout)) {
       // Only set layout set if layout sets exists and there is no layout set selected yet
       setSelectedLayoutSet(layoutSets.sets[0].id);
     }
-  }, [setSelectedLayoutSet, selectedLayoutSet, layoutSets, app]);
+  }, [setSelectedLayoutSet, selectedLayoutSet, layoutSets, layoutSetsIncludesSelectedLayout, app]);
 
   if (componentHasError) {
     const mappedError = mapErrorToDisplayError();

--- a/frontend/packages/ux-editor/src/App.tsx
+++ b/frontend/packages/ux-editor/src/App.tsx
@@ -30,7 +30,7 @@ export function App() {
     useDatamodelMetadataQuery(org, app, selectedLayoutSet);
   const { isSuccess: areTextResourcesFetched } = useTextResourcesQuery(org, app);
 
-  const layoutSetsIncludesSelectedLayout = layoutSets?.sets
+  const layoutSetsIncludesSelectedLayoutSet = layoutSets?.sets
     ?.map((set) => set.id)
     .includes(selectedLayoutSet);
 
@@ -38,7 +38,7 @@ export function App() {
     if (
       areLayoutSetsFetched &&
       selectedLayoutSet &&
-      (!layoutSets || !layoutSetsIncludesSelectedLayout)
+      (!layoutSets || !layoutSetsIncludesSelectedLayoutSet)
     )
       removeSelectedLayoutSet();
   }, [
@@ -47,14 +47,14 @@ export function App() {
     selectedLayoutSet,
     setSelectedLayoutSet,
     removeSelectedLayoutSet,
-    layoutSetsIncludesSelectedLayout,
+    layoutSetsIncludesSelectedLayoutSet,
   ]);
 
   const componentIsReady =
     areWidgetsFetched &&
     isDatamodelFetched &&
     areTextResourcesFetched &&
-    layoutSetsIncludesSelectedLayout;
+    layoutSetsIncludesSelectedLayoutSet;
 
   const componentHasError = dataModelFetchedError || widgetFetchedError;
 
@@ -78,11 +78,17 @@ export function App() {
   };
 
   useEffect(() => {
-    if (layoutSets && (selectedLayoutSet === null || !layoutSetsIncludesSelectedLayout)) {
+    if (layoutSets && (selectedLayoutSet === null || !layoutSetsIncludesSelectedLayoutSet)) {
       // Only set layout set if layout sets exists and there is no layout set selected yet
       setSelectedLayoutSet(layoutSets.sets[0].id);
     }
-  }, [setSelectedLayoutSet, selectedLayoutSet, layoutSets, layoutSetsIncludesSelectedLayout, app]);
+  }, [
+    setSelectedLayoutSet,
+    selectedLayoutSet,
+    layoutSets,
+    layoutSetsIncludesSelectedLayoutSet,
+    app,
+  ]);
 
   if (componentHasError) {
     const mappedError = mapErrorToDisplayError();


### PR DESCRIPTION
## Description
If editing a page in a layoutset that has been deleted we get error in ux-editor.
It can be tested by adding a custom receipt (or any other new layout set in teory), go to app-dev page, and back to process and delete local changes. Going to app-dev page again will result in errors.

This PR updates the selected layout set to the first in the set if the currently selected one does not exist. OBS: only possible to do this change for v4 since these apps require layoutsets. 
## Related Issue(s)

- #12308 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
