### PR TITLE
12568 mock receipt for preview

### DIFF
--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -526,8 +526,7 @@ namespace Altinn.Studio.Designer.Controllers
             AppProcessState processState = new AppProcessState(mockInstance.Process)
             {
                 ProcessTasks = tasks != null
-                    ? new List<AppProcessTaskTypeInfo>(tasks?.ConvertAll(task => new AppProcessTaskTypeInfo { ElementId = task, AltinnTaskType = task == "CustomReceipt" ? "EndEvent_1" : "data" }
-                    ))
+                    ? new List<AppProcessTaskTypeInfo>(tasks?.ConvertAll(task => new AppProcessTaskTypeInfo { ElementId = task, AltinnTaskType = "data" }))
                     : null
             };
 

--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -526,7 +526,8 @@ namespace Altinn.Studio.Designer.Controllers
             AppProcessState processState = new AppProcessState(mockInstance.Process)
             {
                 ProcessTasks = tasks != null
-                    ? new List<AppProcessTaskTypeInfo>(tasks?.ConvertAll(task => new AppProcessTaskTypeInfo { ElementId = task, AltinnTaskType = "data" }))
+                    ? new List<AppProcessTaskTypeInfo>(tasks?.ConvertAll(task => new AppProcessTaskTypeInfo { ElementId = task, AltinnTaskType = task == "CustomReceipt" ? "EndEvent_1" : "data" }
+                    ))
                     : null
             };
 

--- a/backend/src/Designer/Services/Implementation/PreviewService.cs
+++ b/backend/src/Designer/Services/Implementation/PreviewService.cs
@@ -35,11 +35,11 @@ public class PreviewService : IPreviewService
         Application applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata(cancellationToken);
         DataType dataType = await GetDataTypeForLayoutSetName(org, app, developer, layoutSetName, cancellationToken);
         string task = await GetTaskForLayoutSetName(org, app, developer, layoutSetName, cancellationToken);
-        bool processShouldActAsReceipt = task == "CustomReceipt";
+        bool shouldProcessActAsReceipt = task == "CustomReceipt";
         // RegEx for instance guid in app-frontend: [\da-f]{8}-[\da-f]{4}-[1-5][\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}
         string instanceGuid = "f1e23d45-6789-1bcd-8c34-56789abcdef0";
-        string dataTypeForDataElement = processShouldActAsReceipt ? await GetDataTypeForCustomReceipt(org, app, developer, cancellationToken) : dataType?.Id;
-        ProcessState processState = processShouldActAsReceipt
+        string dataTypeForDataElement = shouldProcessActAsReceipt ? await GetDataTypeForCustomReceipt(org, app, developer, cancellationToken) : dataType?.Id;
+        ProcessState processState = shouldProcessActAsReceipt
             ? new()
             {
                 CurrentTask = null,

--- a/backend/src/Designer/Services/Implementation/PreviewService.cs
+++ b/backend/src/Designer/Services/Implementation/PreviewService.cs
@@ -145,6 +145,7 @@ public class PreviewService : IPreviewService
         cancellationToken.ThrowIfCancellationRequested();
         AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
         LayoutSets layoutSets = await altinnAppGitRepository.GetLayoutSetsFile(cancellationToken);
-        return layoutSets?.Sets?.Find(set => set.Tasks[0] == "CustomReceipt")?.DataType;
+        string dataType = layoutSets?.Sets?.Find(set => set.Tasks[0] == "CustomReceipt")?.DataType;
+        return dataType ?? string.Empty;
     }
 }

--- a/backend/src/Designer/Services/Implementation/PreviewService.cs
+++ b/backend/src/Designer/Services/Implementation/PreviewService.cs
@@ -55,6 +55,18 @@ public class PreviewService : IPreviewService
                     ElementId = task
                 }
             };
+        InstanceStatus status = processShouldActAsReceipt
+            ? new()
+            {
+                Archived = DateTime.Now,
+                IsArchived = true,
+                ReadStatus = ReadStatus.Read,
+            }
+            : new()
+            {
+                Archived = null,
+                IsArchived = false
+            };
         Instance instance = new()
         {
             InstanceOwner = new InstanceOwner { PartyId = instanceOwnerPartyId == null ? "undefined" : instanceOwnerPartyId.Value.ToString() },
@@ -70,6 +82,7 @@ public class PreviewService : IPreviewService
                 },
             Org = applicationMetadata.Org == developer ? "ttd" : applicationMetadata.Org,
             Process = processState,
+            Status = status
         };
         return instance;
     }
@@ -101,6 +114,11 @@ public class PreviewService : IPreviewService
             {
                 foreach (LayoutSetConfig layoutSet in layoutSets.Sets.Where(ls => !tasks.Contains(ls.Tasks[0])))
                 {
+                    if (layoutSet.Tasks[0] == "CustomReceipt")
+                    {
+                        continue;
+                    }
+
                     tasks.Add(layoutSet.Tasks[0]);
                 }
             }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/AddLayoutSetTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/AddLayoutSetTests.cs
@@ -10,6 +10,7 @@ using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Npgsql.Replication.PgOutput.Messages;
 using Xunit;
 
 namespace Designer.Tests.Controllers.AppDevelopmentController
@@ -43,10 +44,9 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             LayoutSets layoutSetsAfter = await GetLayoutSetsFile(org, targetRepository, developer);
 
             layoutSetsBefore.Schema.Should().NotBeNull();
-            layoutSetsBefore.Sets.Should().HaveCount(3);
             Assert.False(layoutSetsBefore.Sets.Exists(set => set.Id == newLayoutSetConfig.Id));
+            layoutSetsBefore.Sets.Count.Should().Be(layoutSetsAfter.Sets.Count - 1);
             layoutSetsAfter.Schema.Should().NotBeNull();
-            layoutSetsAfter.Sets.Should().HaveCount(4);
             Assert.True(layoutSetsAfter.Sets.Exists(set => set.Id == newLayoutSetConfig.Id));
         }
 

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/DeleteLayoutSetTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/DeleteLayoutSetTests.cs
@@ -39,9 +39,8 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
 
             LayoutSets layoutSetsAfter = await GetLayoutSetsFile(org, targetRepository, developer);
 
-            layoutSetsBefore.Sets.Should().HaveCount(3);
             Assert.True(layoutSetsBefore.Sets.Exists(set => set.Id == layoutSetToDeleteId));
-            layoutSetsAfter.Sets.Should().HaveCount(2);
+            layoutSetsAfter.Sets.Should().HaveCount(layoutSetsBefore.Sets.Count - 1);
             Assert.False(layoutSetsAfter.Sets.Exists(set => set.Id == layoutSetToDeleteId));
         }
 
@@ -67,11 +66,10 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             LayoutSets layoutSetsAfter = await GetLayoutSetsFile(org, targetRepository, developer);
             Application appMetadataAfter = await GetApplicationMetadataFile(org, targetRepository, developer);
 
-            layoutSetsBefore.Sets.Should().HaveCount(3);
             appMetadataBefore.DataTypes.Find(dataType => dataType.Id == connectedDataType).TaskId.Should()
                 .Be(connectedTaskId);
             Assert.True(layoutSetsBefore.Sets.Exists(set => set.Id == layoutSetToDeleteId));
-            layoutSetsAfter.Sets.Should().HaveCount(2);
+            layoutSetsAfter.Sets.Should().HaveCount(layoutSetsBefore.Sets.Count - 1);
             appMetadataAfter.DataTypes.Find(dataType => dataType.Id == connectedDataType).TaskId.Should().BeNull();
             Assert.False(layoutSetsAfter.Sets.Exists(set => set.Id == layoutSetToDeleteId));
         }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateLayoutSetTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateLayoutSetTests.cs
@@ -47,7 +47,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             layoutSetsBefore.Schema.Should().NotBeNull();
             Assert.False(layoutSetsBefore.Sets.Exists(set => set.DataType == newLayoutSetConfig.DataType));
             layoutSetsAfter.Schema.Should().NotBeNull();
-            layoutSetsBefore.Sets.Count.Should().Be(layoutSetsAfter.Sets.Count);
+            layoutSetsBefore.Sets.Should().HaveCount(layoutSetsAfter.Sets.Count);
             Assert.True(layoutSetsAfter.Sets.Exists(set => set.DataType == newLayoutSetConfig.DataType));
         }
 
@@ -75,7 +75,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
 
             layoutSetsBefore.Schema.Should().NotBeNull();
             Assert.False(layoutSetsBefore.Sets.Exists(set => set.Id == newLayoutSetConfig.Id));
-            layoutSetsBefore.Sets.Count.Should().Be(layoutSetsAfter.Sets.Count);
+            layoutSetsBefore.Sets.Should().HaveCount(layoutSetsAfter.Sets.Count);
             layoutSetsAfter.Schema.Should().NotBeNull();
             Assert.True(layoutSetsAfter.Sets.Exists(set => set.Id == newLayoutSetConfig.Id));
         }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateLayoutSetTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateLayoutSetTests.cs
@@ -45,10 +45,9 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             LayoutSets layoutSetsAfter = await GetLayoutSetsFile(org, targetRepository, developer);
 
             layoutSetsBefore.Schema.Should().NotBeNull();
-            layoutSetsBefore.Sets.Should().HaveCount(3);
             Assert.False(layoutSetsBefore.Sets.Exists(set => set.DataType == newLayoutSetConfig.DataType));
             layoutSetsAfter.Schema.Should().NotBeNull();
-            layoutSetsAfter.Sets.Should().HaveCount(3);
+            layoutSetsBefore.Sets.Count.Should().Be(layoutSetsAfter.Sets.Count);
             Assert.True(layoutSetsAfter.Sets.Exists(set => set.DataType == newLayoutSetConfig.DataType));
         }
 
@@ -75,10 +74,9 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             LayoutSets layoutSetsAfter = await GetLayoutSetsFile(org, targetRepository, developer);
 
             layoutSetsBefore.Schema.Should().NotBeNull();
-            layoutSetsBefore.Sets.Should().HaveCount(3);
             Assert.False(layoutSetsBefore.Sets.Exists(set => set.Id == newLayoutSetConfig.Id));
+            layoutSetsBefore.Sets.Count.Should().Be(layoutSetsAfter.Sets.Count);
             layoutSetsAfter.Schema.Should().NotBeNull();
-            layoutSetsAfter.Sets.Should().HaveCount(3);
             Assert.True(layoutSetsAfter.Sets.Exists(set => set.Id == newLayoutSetConfig.Id));
         }
 

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/InstancesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/InstancesTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 using Designer.Tests.Utils;
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Newtonsoft.Json;
 using Xunit;
@@ -56,6 +57,27 @@ namespace Designer.Tests.Controllers.PreviewController
             Instance instance = JsonConvert.DeserializeObject<Instance>(responseDocument.RootElement.ToString());
             Assert.Equal("test-datatask-id", instance.Data[0].Id);
             Assert.Equal("Task_1", instance.Process.CurrentTask.ElementId);
+        }
+
+        [Fact]
+        public async Task Post_InstanceForCustomReceipt_Ok()
+        {
+            string targetRepository = TestDataHelper.GenerateTestRepoName();
+            await CopyRepositoryForTest(Org, StatefulApp, Developer, targetRepository);
+
+            string dataPathWithData = $"{Org}/{targetRepository}/instances?instanceOwnerPartyId=51001";
+            using HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, dataPathWithData);
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={StatefulApp}&selectedLayoutSet={CustomReceiptLayoutSetName2}");
+
+            using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonDocument responseDocument = JsonDocument.Parse(responseBody);
+            Instance instance = JsonConvert.DeserializeObject<Instance>(responseDocument.RootElement.ToString());
+            Assert.Equal(DataTypeForCustomReceipt, instance.Data[0].DataType);
+            Assert.Equal("EndEvent_1", instance.Process.EndEvent);
+            instance.Process.CurrentTask.Should().BeNull();
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTestsBase.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTestsBase.cs
@@ -15,6 +15,8 @@ namespace Designer.Tests.Controllers.PreviewController
         protected const string Developer = "testUser";
         protected const string LayoutSetName = "layoutSet1";
         protected const string LayoutSetName2 = "layoutSet2";
+        protected const string CustomReceiptLayoutSetName2 = "receipt";
+        protected const string DataTypeForCustomReceipt = "receiptDataType";
         protected const string PartyId = "51001";
         protected const string InstanceGuId = "f1e23d45-6789-1bcd-8c34-56789abcdef0";
         protected const string AttachmentGuId = "f47ac10b-58cc-4372-a567-0e02b2c3d479";

--- a/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
+++ b/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
@@ -119,7 +119,7 @@ public class AppDevelopmentServiceTest : IDisposable
 
         // Assert
         updatedLayoutSets.Should().NotBeNull();
-        updatedLayoutSets.Sets.Should().HaveCount(3);
+        updatedLayoutSets.Sets.Should().HaveCount(4);
         updatedLayoutSets.Sets.Should().Contain(newLayoutSet);
     }
 
@@ -161,7 +161,7 @@ public class AppDevelopmentServiceTest : IDisposable
 
         // Assert
         updatedLayoutSets.Should().NotBeNull();
-        updatedLayoutSets.Sets.Should().HaveCount(3);
+        updatedLayoutSets.Sets.Should().HaveCount(4);
         updatedLayoutSets.Sets.Should().Contain(newLayoutSet);
         layoutSetFileNamesBeforeUpdate.Should().BeEquivalentTo(layoutSetFileNamesAfterUpdate);
     }
@@ -180,7 +180,7 @@ public class AppDevelopmentServiceTest : IDisposable
 
         // Assert
         updatedLayoutSets.Should().NotBeNull();
-        updatedLayoutSets.Sets.Should().HaveCount(4);
+        updatedLayoutSets.Sets.Should().HaveCount(5);
         updatedLayoutSets.Sets.Should().Contain(newLayoutSet);
     }
 

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layout-sets.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layout-sets.json
@@ -21,6 +21,13 @@
             "tasks": [
                 "Task_3"
             ]
+        },
+        {
+            "id": "receipt",
+            "dataType": "receiptDataType",
+            "tasks": [
+                "CustomReceipt"
+            ]
         }
     ],
     "uiSettings": {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Preview was origianlly failing since the layout-sets file did not contain a datType by default for the custom receipt layout set when added from proces-editor. To make sure the app-developer is forced to add a dataType when adding a custom receipt from process-editor should be solved in another issue. But given that the dataType reference is present in the layoutsets file this PR will make sure that app-frontend gets a response similar to the end event process task when we preview. custom receipt _and_ it will make sure that the dataType is fetched directly from the layoutsets file and not through appmetadata (since that is based on the task-ref and the custom receipt task-id is not present in appmetadata)

**If you add a dataType in layout-sets for the custom receipt set today you will get this view:**
<img width="1512" alt="Skjermbilde 2024-03-28 kl  10 32 20" src="https://github.com/Altinn/altinn-studio/assets/71079896/ddd8db67-4264-4e89-8462-bd6f835aaa0f">

**On this branch you will get this after adding a dataType:**
<img width="1512" alt="Skjermbilde 2024-03-28 kl  10 34 09" src="https://github.com/Altinn/altinn-studio/assets/71079896/9b48a0ea-f726-4c0f-b89d-1fa102f75dc4">

**If referring to an unexisting dataType you get this:**
<img width="1512" alt="Skjermbilde 2024-03-28 kl  10 35 00" src="https://github.com/Altinn/altinn-studio/assets/71079896/25261dd9-18a5-4e90-bd97-77d9e2b6c676">

**Also added a fallback to an empty dataType reference if the reference does not exist in the layoutsets file so the preview will not fail, but only fallback to the standard Altinn receipt**

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

