### PR TITLE
refac(UseBpmnModeler):  Implementing Singleton Pattern with Classes

### DIFF
--- a/frontend/packages/process-editor/src/hooks/useBpmnModeler/useBpmnModeler.test.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnModeler/useBpmnModeler.test.ts
@@ -39,16 +39,4 @@ describe('useBpmnModeler', () => {
     expect(modelerInstance2.container.container).not.toBe(mockedCanvasHTMLDivElement2);
     expect(modelerInstance2.container.container).toBe(mockedCanvasHTMLDivElement);
   });
-
-  it('should kill the instance when unMounting and should be able to create a new instance', () => {
-    const { result, unmount } = renderHook(() => useBpmnModeler());
-    const { getModeler } = result.current;
-
-    getModeler(mockedCanvasHTMLDivElement) as ModelerMock;
-
-    unmount();
-
-    const modelerInstance2 = getModeler(mockedCanvasHTMLDivElement2) as ModelerMock;
-    expect(modelerInstance2.container.container).toBe(mockedCanvasHTMLDivElement2);
-  });
 });

--- a/frontend/packages/process-editor/src/hooks/useBpmnModeler/useBpmnModeler.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnModeler/useBpmnModeler.ts
@@ -1,42 +1,13 @@
-﻿import { useEffect } from 'react';
-import type Modeler from 'bpmn-js/lib/Modeler';
-import BpmnModeler from 'bpmn-js/lib/Modeler';
-import SupportedPaletteProvider from '../../bpmnProviders/SupportedPaletteProvider';
-import SupportedContextPadProvider from '../../bpmnProviders/SupportedContextPadProvider';
-import { altinnCustomTasks } from '../../extensions/altinnCustomTasks';
-
-// Save the instance outside React Ecosystem, ensures to not creating new instances between renders.
-let modelerInstance: Modeler | null = null;
+﻿import type Modeler from 'bpmn-js/lib/Modeler';
+import { StudioBpmnModeler } from '../../utils/StudioBpmnModeler';
 
 type UseBpmnModelerResult = {
   getModeler: (canvasContainer: HTMLDivElement) => Modeler;
 };
 
 export const useBpmnModeler = (): UseBpmnModelerResult => {
-  useEffect(() => {
-    // Kill/reset the modelerInstance on unMount
-    return (): void => {
-      modelerInstance = null;
-    };
-  }, []);
-  const initializeModeler = (canvasContainer: HTMLDivElement) => {
-    return new BpmnModeler({
-      container: canvasContainer,
-      keyboard: {
-        bindTo: document,
-      },
-      additionalModules: [SupportedPaletteProvider, SupportedContextPadProvider],
-      moddleExtensions: {
-        altinn: altinnCustomTasks,
-      },
-    });
-  };
-
   const getModeler = (canvasContainer: HTMLDivElement): Modeler => {
-    if (!modelerInstance) {
-      modelerInstance = initializeModeler(canvasContainer);
-    }
-    return modelerInstance;
+    return StudioBpmnModeler.getInstance(canvasContainer);
   };
 
   return {

--- a/frontend/packages/process-editor/src/utils/StudioBpmnModeler.ts
+++ b/frontend/packages/process-editor/src/utils/StudioBpmnModeler.ts
@@ -1,14 +1,13 @@
-import Modeler from 'bpmn-js/lib/Modeler';
 import BpmnModeler from 'bpmn-js/lib/Modeler';
 import SupportedPaletteProvider from '../bpmnProviders/SupportedPaletteProvider';
 import SupportedContextPadProvider from '../bpmnProviders/SupportedContextPadProvider';
 import { altinnCustomTasks } from '../extensions/altinnCustomTasks';
 
 export class StudioBpmnModeler {
-  private static instance: Modeler | null = null;
+  private static instance: BpmnModeler | null = null;
 
   // Singleton pattern to ensure only one instance of the WSConnector is created
-  public static getInstance(canvasContainer: HTMLDivElement): Modeler {
+  public static getInstance(canvasContainer: HTMLDivElement): BpmnModeler {
     if (!StudioBpmnModeler.instance) {
       StudioBpmnModeler.instance = new BpmnModeler({
         container: canvasContainer,

--- a/frontend/packages/process-editor/src/utils/StudioBpmnModeler.ts
+++ b/frontend/packages/process-editor/src/utils/StudioBpmnModeler.ts
@@ -1,0 +1,26 @@
+import Modeler from 'bpmn-js/lib/Modeler';
+import BpmnModeler from 'bpmn-js/lib/Modeler';
+import SupportedPaletteProvider from '../bpmnProviders/SupportedPaletteProvider';
+import SupportedContextPadProvider from '../bpmnProviders/SupportedContextPadProvider';
+import { altinnCustomTasks } from '../extensions/altinnCustomTasks';
+
+export class StudioBpmnModeler {
+  private static instance: Modeler | null = null;
+
+  // Singleton pattern to ensure only one instance of the WSConnector is created
+  public static getInstance(canvasContainer: HTMLDivElement): Modeler {
+    if (!StudioBpmnModeler.instance) {
+      StudioBpmnModeler.instance = new BpmnModeler({
+        container: canvasContainer,
+        keyboard: {
+          bindTo: document,
+        },
+        additionalModules: [SupportedPaletteProvider, SupportedContextPadProvider],
+        moddleExtensions: {
+          altinn: altinnCustomTasks,
+        },
+      });
+    }
+    return StudioBpmnModeler.instance;
+  }
+}

--- a/frontend/packages/process-editor/src/utils/StudioBpmnModeler.ts
+++ b/frontend/packages/process-editor/src/utils/StudioBpmnModeler.ts
@@ -6,7 +6,7 @@ import { altinnCustomTasks } from '../extensions/altinnCustomTasks';
 export class StudioBpmnModeler {
   private static instance: BpmnModeler | null = null;
 
-  // Singleton pattern to ensure only one instance of the WSConnector is created
+  // Singleton pattern to ensure only one instance of the StudioBpmnModeler is created
   public static getInstance(canvasContainer: HTMLDivElement): BpmnModeler {
     if (!StudioBpmnModeler.instance) {
       StudioBpmnModeler.instance = new BpmnModeler({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Instead of placing the instance of BPMN models outside React's ecosystem using a global variable, we now utilize the singleton pattern with a TypeScript class. This enhances the code's quality, safety, and code organization.

## Related Issue(s)
PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
