### PR TITLE
Altinn CDN tests allow 304

### DIFF
--- a/src/test/K6/src/tests/app/portalsimulation.js
+++ b/src/test/K6/src/tests/app/portalsimulation.js
@@ -52,7 +52,7 @@ export default function (data) {
   res = altinnCdn.getToolkits();
   for (var i = 0; i < res.length; i++) {
     success = check(res[i], {
-      'Altinn CDN Toolkits': (r) => r.status === 200,
+      'Altinn CDN Toolkits': (r) => r.status === 200 || r.status === 304,
     });
     addErrorCount(success);
   }
@@ -60,7 +60,7 @@ export default function (data) {
   res = altinnCdn.getFonts();
   for (var i = 0; i < res.length; i++) {
     success = check(res[i], {
-      'Altinn CDN Fonts': (r) => r.status === 200,
+      'Altinn CDN Fonts': (r) => r.status === 200 || r.status === 304,
     });
     addErrorCount(success);
   }
@@ -68,7 +68,7 @@ export default function (data) {
   res = altinnCdn.getImg();
   for (var i = 0; i < res.length; i++) {
     success = check(res[i], {
-      'Altinn CDN Images': (r) => r.status === 200,
+      'Altinn CDN Images': (r) => r.status === 200 || r.status === 304,
     });
     addErrorCount(success);
   }


### PR DESCRIPTION
## Description
Updating Altinn CDN tests to allow response code 304. This might fix the unstable tests.
