### PR TITLE
add layout sets not found exception to filter

### DIFF
--- a/backend/src/Designer/Controllers/AppDevelopmentController.cs
+++ b/backend/src/Designer/Controllers/AppDevelopmentController.cs
@@ -235,7 +235,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is canceled.</param>
-        /// <returns>The layout-sets.json</returns>
+        /// <returns>A string array of all layout names without file extension in all sets</returns>
         [HttpGet]
         [UseSystemTextJson]
         [Route("layout-names")]
@@ -280,10 +280,6 @@ namespace Altinn.Studio.Designer.Controllers
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
             var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer);
             LayoutSets layoutSets = await _appDevelopmentService.GetLayoutSets(editingContext, cancellationToken);
-            if (layoutSets is null)
-            {
-                return Ok();
-            }
             return Ok(layoutSets);
         }
 
@@ -336,17 +332,10 @@ namespace Altinn.Studio.Designer.Controllers
         [Route("layout-set/{layoutSetIdToUpdate}")]
         public async Task<ActionResult> DeleteLayoutSet(string org, string app, [FromRoute] string layoutSetIdToUpdate, CancellationToken cancellationToken)
         {
-            try
-            {
-                string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
-                var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer);
-                LayoutSets layoutSets = await _appDevelopmentService.DeleteLayoutSet(editingContext, layoutSetIdToUpdate, cancellationToken);
-                return Ok(layoutSets);
-            }
-            catch (FileNotFoundException exception)
-            {
-                return NotFound($"Layout-sets.json not found: {exception}");
-            }
+            string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
+            var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer);
+            LayoutSets layoutSets = await _appDevelopmentService.DeleteLayoutSet(editingContext, layoutSetIdToUpdate, cancellationToken);
+            return Ok(layoutSets);
         }
 
         /// <summary>

--- a/backend/src/Designer/Filters/AppDevelopment/AppDevelopmentExceptionFilterAttribute.cs
+++ b/backend/src/Designer/Filters/AppDevelopment/AppDevelopmentExceptionFilterAttribute.cs
@@ -1,8 +1,10 @@
 using System.Net;
 using Altinn.Studio.Designer.Exceptions;
+using Altinn.Studio.Designer.Exceptions.AppDevelopment;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
+using NonUniqueLayoutSetIdException = Altinn.Studio.Designer.Exceptions.NonUniqueLayoutSetIdException;
 
 namespace Altinn.Studio.Designer.Filters.AppDevelopment
 {
@@ -17,6 +19,10 @@ namespace Altinn.Studio.Designer.Filters.AppDevelopment
                 return;
             }
 
+            if (context.Exception is NoLayoutSetsFileFoundException)
+            {
+                context.Result = new StatusCodeResult((int)HttpStatusCode.OK);
+            }
             if (context.Exception is NonUniqueLayoutSetIdException)
             {
                 context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, AppDevelopmentErrorCodes.NonUniqueLayoutSetIdError, HttpStatusCode.BadRequest)) { StatusCode = (int)HttpStatusCode.BadRequest };

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetLayoutSetsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetLayoutSetsTests.cs
@@ -1,0 +1,69 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Designer.Tests.Controllers.ApiTests;
+using Designer.Tests.Utils;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using SharedResources.Tests;
+using Xunit;
+
+namespace Designer.Tests.Controllers.AppDevelopmentController
+{
+    public class GetLayoutSetsTests : DisagnerEndpointsTestsBase<GetLayoutSetsTests>, IClassFixture<WebApplicationFactory<Program>>
+    {
+        private static string VersionPrefix(string org, string repository) => $"/designer/api/{org}/{repository}/app-development";
+        public GetLayoutSetsTests(WebApplicationFactory<Program> factory) : base(factory)
+        {
+        }
+
+        [Theory]
+        [InlineData("ttd", "app-with-layoutsets", "testUser", "layoutSet1", "TestData/App/ui/layout-sets.json")]
+        [InlineData("ttd", "app-without-layoutsets", "testUser", null, null)]
+        public async Task GetLayoutSets_ShouldReturnLayoutSets(string org, string app, string developer, string layoutSetName, string expectedLayoutPaths)
+        {
+            string targetRepository = TestDataHelper.GenerateTestRepoName();
+            await CopyRepositoryForTest(org, app, developer, targetRepository);
+
+            string expectedLayoutSets = string.IsNullOrEmpty(layoutSetName) ? null : await AddLayoutSetsToRepo(TestRepoPath, expectedLayoutPaths);
+
+            string url = $"{VersionPrefix(org, targetRepository)}/layout-sets";
+            using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
+
+            using var response = await HttpClient.SendAsync(httpRequestMessage);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            string responseContent = string.IsNullOrEmpty(layoutSetName) ? null : await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrEmpty(layoutSetName))
+            {
+                responseContent.Should().BeNull();
+            }
+            else
+            {
+                JsonUtils.DeepEquals(expectedLayoutSets, responseContent).Should().BeTrue();
+            }
+        }
+
+        [Theory(Skip = "If App/ui is not present in repo, the controller returns 500")]
+        [InlineData("ttd", "empty-app", "layoutSet1")]
+        [InlineData("ttd", "empty-app", null)]
+        public async Task GetLayoutSettings_IfNotExists_Should_AndReturnNotFound(string org, string app, string layoutSetName)
+        {
+            string url = $"{VersionPrefix(org, app)}/layout-settings?layoutSetName={layoutSetName}";
+            using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
+
+            using var response = await HttpClient.SendAsync(httpRequestMessage);
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+
+        private async Task<string> AddLayoutSetsToRepo(string createdFolderPath, string expectedLayoutSetsPath)
+        {
+            string layoutSets = SharedResourcesHelper.LoadTestDataAsString(expectedLayoutSetsPath);
+            string filePath = Path.Combine(createdFolderPath, "App", "ui", "layout-sets.json");
+            await File.WriteAllTextAsync(filePath, layoutSets);
+            return layoutSets;
+        }
+
+    }
+}

--- a/testdata/App/ui/layout-sets.json
+++ b/testdata/App/ui/layout-sets.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "",
   "sets": [{
     "id": "message",
     "dataType": "message",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add custom exception that is thrown when layout sets file does not exist in app (case for v3 apps) to filter so statuscode OK is returned.

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

