### PR TITLE
resourceadm: handle user not found in gitea

### DIFF
--- a/backend/src/Designer/Services/Implementation/GiteaAPIWrapper/GiteaAPIWrapper.cs
+++ b/backend/src/Designer/Services/Implementation/GiteaAPIWrapper/GiteaAPIWrapper.cs
@@ -734,7 +734,8 @@ namespace Altinn.Studio.Designer.Services.Implementation
                     var cacheEntryOptions = new MemoryCacheEntryOptions();
                     _cache.Set(cacheKey, giteaUser, cacheEntryOptions);
                 }
-                catch (Exception) {
+                catch (Exception)
+                {
                     // User not found in Gitea
                 }
             }

--- a/backend/src/Designer/Services/Implementation/GiteaAPIWrapper/GiteaAPIWrapper.cs
+++ b/backend/src/Designer/Services/Implementation/GiteaAPIWrapper/GiteaAPIWrapper.cs
@@ -727,12 +727,16 @@ namespace Altinn.Studio.Designer.Services.Implementation
             string cacheKey = $"giteauser:{username}";
             if (!_cache.TryGetValue(cacheKey, out GiteaUser giteaUser))
             {
-                HttpResponseMessage response = await _httpClient.GetAsync($"users/{username}/");
-                response.EnsureSuccessStatusCode();
-                giteaUser = await response.Content.ReadAsAsync<GiteaUser>();
-                var cacheEntryOptions = new MemoryCacheEntryOptions();
-
-                _cache.Set(cacheKey, giteaUser, cacheEntryOptions);
+                try
+                {
+                    HttpResponseMessage response = await _httpClient.GetAsync($"users/{username}/");
+                    giteaUser = await response.Content.ReadAsAsync<GiteaUser>();
+                    var cacheEntryOptions = new MemoryCacheEntryOptions();
+                    _cache.Set(cacheKey, giteaUser, cacheEntryOptions);
+                }
+                catch (Exception) {
+                    // User not found in Gitea
+                }
             }
 
             return giteaUser;


### PR DESCRIPTION
## Description

In the cases where the call to get a user (to get the full name of the user) fails, the error is handled and the username is used instead of the full name. This can happen for example when a user has been deleted.

## Related Issue(s)

- None

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
