### PR TITLE
fix(Websockets): ensure to use the correct client names

### DIFF
--- a/frontend/app-development/features/processEditor/ProcessEditor.test.tsx
+++ b/frontend/app-development/features/processEditor/ProcessEditor.test.tsx
@@ -95,6 +95,7 @@ describe('ProcessEditor', () => {
     renderProcessEditor();
 
     expect(useWebSocket).toHaveBeenCalledWith({
+      clientsName: ['FileSyncSuccess', 'FileSyncError'],
       webSocketUrl: processEditorWebSocketHub(),
       webSocketConnector: WSConnector,
     });

--- a/frontend/app-development/features/processEditor/ProcessEditor.tsx
+++ b/frontend/app-development/features/processEditor/ProcessEditor.tsx
@@ -17,6 +17,11 @@ import { type MetaDataForm } from '@altinn/process-editor/src/contexts/BpmnConfi
 import { useCustomReceiptLayoutSetName } from 'app-shared/hooks/useCustomReceiptLayoutSetName';
 import { useLayoutSetsQuery } from 'app-shared/hooks/queries/useLayoutSetsQuery';
 
+enum SyncEventListenersName {
+  FileSyncSuccess = 'FileSyncSuccess',
+  FileSyncError = 'FileSyncError',
+}
+
 export const ProcessEditor = (): React.ReactElement => {
   const { t } = useTranslation();
   const { org, app } = useStudioUrlParams();
@@ -30,7 +35,10 @@ export const ProcessEditor = (): React.ReactElement => {
 
   const { onWSMessageReceived } = useWebSocket({
     webSocketUrl: processEditorWebSocketHub(),
-    socketMessageListeners: ['FileSyncSuccess', 'FileSyncError'],
+    socketMessageListeners: [
+      SyncEventListenersName.FileSyncSuccess,
+      SyncEventListenersName.FileSyncError,
+    ],
     webSocketConnector: WSConnector,
   });
 

--- a/frontend/app-development/features/processEditor/ProcessEditor.tsx
+++ b/frontend/app-development/features/processEditor/ProcessEditor.tsx
@@ -30,6 +30,7 @@ export const ProcessEditor = (): React.ReactElement => {
 
   const { onWSMessageReceived } = useWebSocket({
     webSocketUrl: processEditorWebSocketHub(),
+    socketMessageListeners: ['FileSyncSuccess', 'FileSyncError'],
     webSocketConnector: WSConnector,
   });
 

--- a/frontend/app-development/features/processEditor/ProcessEditor.tsx
+++ b/frontend/app-development/features/processEditor/ProcessEditor.tsx
@@ -17,7 +17,7 @@ import { type MetaDataForm } from '@altinn/process-editor/src/contexts/BpmnConfi
 import { useCustomReceiptLayoutSetName } from 'app-shared/hooks/useCustomReceiptLayoutSetName';
 import { useLayoutSetsQuery } from 'app-shared/hooks/queries/useLayoutSetsQuery';
 
-enum SyncEventListenersName {
+enum SyncClientsName {
   FileSyncSuccess = 'FileSyncSuccess',
   FileSyncError = 'FileSyncError',
 }
@@ -35,10 +35,7 @@ export const ProcessEditor = (): React.ReactElement => {
 
   const { onWSMessageReceived } = useWebSocket({
     webSocketUrl: processEditorWebSocketHub(),
-    socketMessageListeners: [
-      SyncEventListenersName.FileSyncSuccess,
-      SyncEventListenersName.FileSyncError,
-    ],
+    clientsName: [SyncClientsName.FileSyncSuccess, SyncClientsName.FileSyncError],
     webSocketConnector: WSConnector,
   });
 

--- a/frontend/packages/shared/src/hooks/useWebSocket.test.ts
+++ b/frontend/packages/shared/src/hooks/useWebSocket.test.ts
@@ -2,6 +2,8 @@ import { renderHook } from '@testing-library/react';
 import { useWebSocket } from './useWebSocket';
 import { WSConnector } from 'app-shared/websockets/WSConnector';
 
+const socketMessageListenersMock = ['MessageClientOne', 'MessageClientTwo'];
+
 jest.mock('app-shared/websockets/WSConnector', () => ({
   WSConnector: {
     getInstance: jest.fn().mockReturnValue({
@@ -15,23 +17,29 @@ describe('useWebSocket', () => {
     renderHook(() =>
       useWebSocket({
         webSocketUrl: 'ws://jest-test-mocked-url.com',
+        socketMessageListeners: socketMessageListenersMock,
         webSocketConnector: WSConnector,
       }),
     );
-    expect(WSConnector.getInstance).toHaveBeenCalledWith('ws://jest-test-mocked-url.com');
+    expect(WSConnector.getInstance).toHaveBeenCalledWith('ws://jest-test-mocked-url.com', [
+      'MessageClientOne',
+      'MessageClientTwo',
+    ]);
   });
 
   it('should provide a function to listen to messages', () => {
     const { result } = renderHook(() =>
       useWebSocket({
         webSocketUrl: 'ws://jest-test-mocked-url.com',
+        socketMessageListeners: socketMessageListenersMock,
         webSocketConnector: WSConnector,
       }),
     );
     const callback = jest.fn();
     result.current.onWSMessageReceived(callback);
     expect(
-      WSConnector.getInstance('ws://jest-test-mocked-url.com').onMessageReceived,
+      WSConnector.getInstance('ws://jest-test-mocked-url.com', socketMessageListenersMock)
+        .onMessageReceived,
     ).toHaveBeenCalledWith(callback);
   });
 });

--- a/frontend/packages/shared/src/hooks/useWebSocket.test.ts
+++ b/frontend/packages/shared/src/hooks/useWebSocket.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { useWebSocket } from './useWebSocket';
 import { WSConnector } from 'app-shared/websockets/WSConnector';
 
-const socketMessageListenersMock = ['MessageClientOne', 'MessageClientTwo'];
+const clientsNameMock = ['MessageClientOne', 'MessageClientTwo'];
 
 jest.mock('app-shared/websockets/WSConnector', () => ({
   WSConnector: {
@@ -17,7 +17,7 @@ describe('useWebSocket', () => {
     renderHook(() =>
       useWebSocket({
         webSocketUrl: 'ws://jest-test-mocked-url.com',
-        socketMessageListeners: socketMessageListenersMock,
+        clientsName: clientsNameMock,
         webSocketConnector: WSConnector,
       }),
     );
@@ -31,15 +31,14 @@ describe('useWebSocket', () => {
     const { result } = renderHook(() =>
       useWebSocket({
         webSocketUrl: 'ws://jest-test-mocked-url.com',
-        socketMessageListeners: socketMessageListenersMock,
+        clientsName: clientsNameMock,
         webSocketConnector: WSConnector,
       }),
     );
     const callback = jest.fn();
     result.current.onWSMessageReceived(callback);
     expect(
-      WSConnector.getInstance('ws://jest-test-mocked-url.com', socketMessageListenersMock)
-        .onMessageReceived,
+      WSConnector.getInstance('ws://jest-test-mocked-url.com', clientsNameMock).onMessageReceived,
     ).toHaveBeenCalledWith(callback);
   });
 });

--- a/frontend/packages/shared/src/hooks/useWebSocket.ts
+++ b/frontend/packages/shared/src/hooks/useWebSocket.ts
@@ -7,17 +7,19 @@ type UseWebSocketResult = {
 
 type UseWebsocket = {
   webSocketUrl: string;
+  socketMessageListeners: string[];
   webSocketConnector: typeof WSConnector;
 };
 
 export const useWebSocket = ({
   webSocketUrl,
+  socketMessageListeners,
   webSocketConnector,
 }: UseWebsocket): UseWebSocketResult => {
   const wsConnectionRef = useRef(null);
   useEffect(() => {
-    wsConnectionRef.current = webSocketConnector.getInstance(webSocketUrl);
-  }, [webSocketConnector, webSocketUrl]);
+    wsConnectionRef.current = webSocketConnector.getInstance(webSocketUrl, socketMessageListeners);
+  }, [webSocketConnector, webSocketUrl, socketMessageListeners]);
 
   const onWSMessageReceived = <T>(callback: (message: T) => void): void => {
     wsConnectionRef.current?.onMessageReceived(callback);

--- a/frontend/packages/shared/src/hooks/useWebSocket.ts
+++ b/frontend/packages/shared/src/hooks/useWebSocket.ts
@@ -7,19 +7,19 @@ type UseWebSocketResult = {
 
 type UseWebsocket = {
   webSocketUrl: string;
-  socketMessageListeners: string[];
+  clientsName: string[];
   webSocketConnector: typeof WSConnector;
 };
 
 export const useWebSocket = ({
   webSocketUrl,
-  socketMessageListeners,
+  clientsName,
   webSocketConnector,
 }: UseWebsocket): UseWebSocketResult => {
   const wsConnectionRef = useRef(null);
   useEffect(() => {
-    wsConnectionRef.current = webSocketConnector.getInstance(webSocketUrl, socketMessageListeners);
-  }, [webSocketConnector, webSocketUrl, socketMessageListeners]);
+    wsConnectionRef.current = webSocketConnector.getInstance(webSocketUrl, clientsName);
+  }, [webSocketConnector, webSocketUrl, clientsName]);
 
   const onWSMessageReceived = <T>(callback: (message: T) => void): void => {
     wsConnectionRef.current?.onMessageReceived(callback);

--- a/frontend/packages/shared/src/websockets/WSConnector.test.ts
+++ b/frontend/packages/shared/src/websockets/WSConnector.test.ts
@@ -16,13 +16,19 @@ jest.mock('@microsoft/signalr', () => ({
 describe('WSConnector', () => {
   it('should create an instance of WSConnector using singleton pattern', () => {
     const webSocketUrl: string = 'ws://jest-test-mocked-url.com';
-    const result: WSConnector = WSConnector.getInstance(webSocketUrl);
+    const result: WSConnector = WSConnector.getInstance(webSocketUrl, [
+      'MessageClientOne',
+      'MessageClientTwo',
+    ]);
     expect(result).toBeInstanceOf(WSConnector);
   });
 
   it('should be able to create an instance using new keyword', () => {
     const webSocketUrl: string = 'ws://jest-test-mocked-url.com';
-    const result: WSConnector = new WSConnector(webSocketUrl);
+    const result: WSConnector = new WSConnector(webSocketUrl, [
+      'MessageClientOne',
+      'MessageClientTwo',
+    ]);
     expect(result).toBeInstanceOf(WSConnector);
   });
 });

--- a/frontend/packages/shared/src/websockets/WSConnector.ts
+++ b/frontend/packages/shared/src/websockets/WSConnector.ts
@@ -3,28 +3,28 @@ import { type HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
 export class WSConnector {
   private connection: HubConnection;
   private static instance: WSConnector;
-  private socketMessageListeners: string[] = [];
+  private clientsName: string[] = [];
 
   constructor(
     private readonly webSocketUrl: string,
-    socketMessageListeners: string[],
+    clientsName: string[],
   ) {
     this.createConnection(this.webSocketUrl);
     this.startConnection();
-    this.socketMessageListeners = socketMessageListeners;
+    this.clientsName = clientsName;
   }
 
   // Singleton pattern to ensure only one instance of the WSConnector is created
-  public static getInstance(webSocketUrl: string, socketMessageListeners: string[]): WSConnector {
+  public static getInstance(webSocketUrl: string, clientsName: string[]): WSConnector {
     if (!WSConnector.instance) {
-      WSConnector.instance = new WSConnector(webSocketUrl, socketMessageListeners);
+      WSConnector.instance = new WSConnector(webSocketUrl, clientsName);
     }
     return WSConnector.instance;
   }
 
   public onMessageReceived<T>(callback: (message: T) => void): void {
-    this.socketMessageListeners.forEach((listener) => {
-      this.connection.on(listener, (message: T) => callback(message));
+    this.clientsName.forEach((clientName) => {
+      this.connection.on(clientName, (message: T) => callback(message));
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Extended the WSConnector class to get arguments about which event listeners to use.

## Related Issue(s)
PR itself

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
