### PR TITLE
Fix orgEnvironments cache key

### DIFF
--- a/backend/src/Designer/Services/Implementation/EnvironmentsService.cs
+++ b/backend/src/Designer/Services/Implementation/EnvironmentsService.cs
@@ -65,7 +65,7 @@ public class EnvironmentsService : IEnvironmentsService
 
     public async Task<IEnumerable<EnvironmentModel>> GetOrganizationEnvironments(string org)
     {
-        const string cacheKey = $"{nameof(GetOrganizationEnvironments)}_{nameof(org)}";
+        string cacheKey = $"{nameof(GetOrganizationEnvironments)}_{org}";
         if (_cache.TryGetValue(cacheKey, out List<EnvironmentModel> environments))
         {
             return environments;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The cache key is the same for all organizations which mean that they all share the same environment list.
The cache is refreshed every 2 hours with the environment list of the first organization that calls the `GetOrganizationEnvironments` function.

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)