### PR TITLE
Fix storage warnings

### DIFF
--- a/frontend/packages/shared/src/hooks/useLocalStorage.test.ts
+++ b/frontend/packages/shared/src/hooks/useLocalStorage.test.ts
@@ -11,6 +11,15 @@ describe('useLocalStorage', () => {
     expect(result.current[0]).toBe(value);
   });
 
+  it('Gets and parses value on first render only', () => {
+    const key = 'someKey';
+    const getItemSpy = jest.spyOn(window.Storage.prototype, 'getItem').mockImplementation();
+    const { rerender } = renderHook(() => useLocalStorage(key));
+    rerender();
+    expect(getItemSpy).toHaveBeenCalledTimes(1);
+    getItemSpy.mockRestore();
+  });
+
   it('Provides a function that sets the stored value', async () => {
     const key = 'keyThatIsNotYetSet';
     const { result } = renderHook(() => useLocalStorage(key));

--- a/frontend/packages/shared/src/hooks/useLocalStorage.ts
+++ b/frontend/packages/shared/src/hooks/useLocalStorage.ts
@@ -7,7 +7,7 @@ const useWebStorage = <T>(
   key: string,
   initialValue?: T,
 ): [T, (newValue: T) => void, () => void] => {
-  const [value, setValue] = useState<T>(typedStorage.getItem(key) || initialValue);
+  const [value, setValue] = useState<T>(() => typedStorage.getItem(key) || initialValue);
 
   const setStorageValue = useCallback(
     (newValue: T) => {

--- a/frontend/packages/shared/src/utils/webStorage.test.ts
+++ b/frontend/packages/shared/src/utils/webStorage.test.ts
@@ -41,6 +41,25 @@ describe('typedLocalStorage', () => {
     typedLocalStorage.removeItem('test');
     expect(typedLocalStorage.getItem<string | undefined>('test')).toBeUndefined();
   });
+
+  it('should not store undefined values', async () => {
+    const key = 'undefinedValueKey';
+    const value = undefined;
+    typedLocalStorage.setItem<string>(key, undefined);
+    expect(typedLocalStorage.getItem(key)).toBe(value);
+    expect(window?.localStorage.getItem(key)).toBe(null);
+  });
+
+  it('should remove invalid values', async () => {
+    const key = 'invalidValueKey';
+    const value = undefined;
+    const warSpy = jest.spyOn(global.console, 'warn').mockImplementation();
+    window?.localStorage.setItem(key, value);
+    expect(typedLocalStorage.getItem(key)).toBe(value);
+    expect(window?.localStorage.getItem(key)).toBe(null);
+    expect(warSpy).toHaveBeenCalledTimes(1);
+    warSpy.mockRestore();
+  });
 });
 
 afterAll(() => {

--- a/frontend/packages/shared/src/utils/webStorage.ts
+++ b/frontend/packages/shared/src/utils/webStorage.ts
@@ -15,8 +15,12 @@ const createWebStorage = (storage: WebStorage): TypedStorage => {
     console.warn('Storage API not available. The browser might not support the provided storage.');
   }
 
+  const removeItem = (key: string): void => storage.removeItem(key);
+
   return {
-    setItem: <T>(key: string, value: T): void => storage.setItem(key, JSON.stringify(value)),
+    setItem: <T>(key: string, value: T): void => {
+      if (value !== undefined) storage.setItem(key, JSON.stringify(value));
+    },
     getItem: <T>(key: string): T | undefined => {
       const storedItem = storage.getItem(key);
       if (!storedItem) {
@@ -29,9 +33,10 @@ const createWebStorage = (storage: WebStorage): TypedStorage => {
         console.warn(
           `Failed to parse stored item with key ${key}. Ensure that the item is a valid JSON string. Error: ${error}`,
         );
+        removeItem(key);
       }
     },
-    removeItem: (key: string): void => storage.removeItem(key),
+    removeItem,
   };
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes the console warnings linked to the webStorage.

- Prevent getting/parsing value from localStorage on each render
- Prevent storing an undefined value, as it is not a valid JSON value and will throw an exception when parsed (e.g to test it : `JSON.parse(JSON.stringify(undefined))`)
- Remove values that can't be parsed

#### BEFORE (buggy version)

https://github.com/Altinn/altinn-studio/assets/24462611/6f92156a-575c-4c84-9595-b1913db4a508

#### AFTER (fixed version)

https://github.com/Altinn/altinn-studio/assets/24462611/55025a9c-07ec-44f5-9722-af53da221ad5

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
