### PR TITLE
Only add layout set for data tasks

### DIFF
--- a/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
@@ -40,7 +40,7 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
   const handleShapeAdd = (e) => {
     const bpmnDetails = getBpmnEditorDetailsFromBusinessObject(e?.element?.businessObject);
     setBpmnDetails(bpmnDetails);
-    if (bpmnDetails.type === BpmnTypeEnum.Task) {
+    if (bpmnDetails.taskType === 'data') {
       addLayoutSet({
         layoutSetIdToUpdate: bpmnDetails.id,
         layoutSetConfig: { id: bpmnDetails.id, tasks: [bpmnDetails.id] },


### PR DESCRIPTION
## Description
Only add layout set when adding bpmn elements in the process editor that have taskType 'data'. This is due to the other taskTypes like `confirmation` and `sign` have default layouts in the apps in the app-developer does not add a layout set. 
So adding and customizing the look of these steps should be optional and triggered by an active choice. 

_This PR does not include adding the possibility to trigger a creation of a related layoutset in the config panel for elements that are not data-tasks_

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

