### PR TITLE
Add actions to confirmation task as default

### DIFF
--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
@@ -47,12 +47,48 @@ class SupportedPaletteProvider {
             bpmnFactory.create('altinn:TaskExtension', {
               taskType: taskType,
               actions: bpmnFactory.create('altinn:Actions', {
-                action: ['sign', 'reject'],
+                action: [
+                  bpmnFactory.create('altinn:Action', {
+                    action: 'sign',
+                  }),
+                  bpmnFactory.create('altinn:Action', {
+                    action: 'reject',
+                  }),
+                ],
               }),
               signatureConfig: bpmnFactory.create('altinn:SignatureConfig', {
                 dataTypesToSign: bpmnFactory.create('altinn:DataTypesToSign', {
                   dataType: ['Model'],
                 }),
+              }),
+            }),
+          ],
+        });
+
+        modeling.updateProperties(task, {
+          extensionElements,
+        });
+
+        create.start(event, task);
+      };
+    }
+
+    function createCustomConfirmationTask() {
+      const taskType = 'confirmation';
+
+      return function (event) {
+        const task = buildAltinnTask(taskType);
+
+        const extensionElements = bpmnFactory.create('bpmn:ExtensionElements', {
+          values: [
+            bpmnFactory.create('altinn:TaskExtension', {
+              taskType: taskType,
+              actions: bpmnFactory.create('altinn:Actions', {
+                action: [
+                  bpmnFactory.create('altinn:Action', {
+                    action: 'confirm',
+                  }),
+                ],
               }),
             }),
           ],
@@ -120,14 +156,6 @@ class SupportedPaletteProvider {
             dragstart: createCustomTask('data'),
           },
         },
-        'create.altinn-confirmation-task': {
-          group: 'activity',
-          title: translate('Create Altinn Confirm Task'),
-          className: 'bpmn-icon-task-generic bpmn-icon-confirmation-task',
-          action: {
-            dragstart: createCustomTask('confirmation'),
-          },
-        },
         'create.altinn-feedback-task': {
           group: 'activity',
           title: translate('Create Altinn Feedback Task'),
@@ -142,6 +170,14 @@ class SupportedPaletteProvider {
           title: translate('Create Altinn signing Task'),
           action: {
             dragstart: createCustomSigningTask(),
+          },
+        },
+        'create.altinn-confirmation-task': {
+          group: 'activity',
+          title: translate('Create Altinn Confirm Task'),
+          className: 'bpmn-icon-task-generic bpmn-icon-confirmation-task',
+          action: {
+            dragstart: createCustomConfirmationTask('confirmation'),
           },
         },
         'create.altinn-payment-task': {

--- a/frontend/packages/process-editor/src/extensions/altinnCustomTasks.ts
+++ b/frontend/packages/process-editor/src/extensions/altinnCustomTasks.ts
@@ -39,6 +39,23 @@ export const altinnCustomTasks = {
           name: 'action',
           isMany: true,
           isAttr: false,
+          type: 'Action',
+        },
+      ],
+    },
+    {
+      name: 'Action',
+      properties: [
+        {
+          name: 'action',
+          isMany: false,
+          isBody: true,
+          type: 'String',
+        },
+        {
+          name: 'type',
+          isMany: false,
+          isAttr: true,
           type: 'String',
         },
       ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change the template that is used to create the custom altinn confirm task in process editor so a `confirm action` is included in the bpmn task element by default

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
