### PR TITLE
use command stack changes to trigger add/delete layout set

### DIFF
--- a/frontend/packages/process-editor/src/hooks/useBpmnEditor.test.tsx
+++ b/frontend/packages/process-editor/src/hooks/useBpmnEditor.test.tsx
@@ -113,8 +113,8 @@ describe('useBpmnEditor', () => {
     await waitFor(() => expect(saveBpmnMock).toHaveBeenCalledTimes(1));
   });
 
-  it('should call saveBpmn when "shape.add" event is triggered on modelerInstance and taskType is data', () => {
-    const currentEventName = 'shape.add';
+  it('should call saveBpmn when "commandStack.elements.create.postExecuted" event is triggered on modelerInstance and taskType is data', () => {
+    const currentEventName = 'commandStack.elements.create.postExecuted';
     renderUseBpmnEditor(true, currentEventName);
 
     expect(addLayoutSetMock).toHaveBeenCalledTimes(1);
@@ -127,16 +127,14 @@ describe('useBpmnEditor', () => {
   });
 
   it.each(['confirmation', 'signing', 'feedback', 'endEvent'])(
-    'should not call saveBpmn when "shape.add" event is triggered on modelerInstance when taskType is not data',
+    'should not call saveBpmn when "commandStack.elements.create.postExecuted" event is triggered on modelerInstance when taskType is not data',
     (taskType: BpmnTaskType) => {
       const mockBpmnDetailsConfirm: BpmnDetails = {
-        id: 'otherTestId',
-        name: 'mockName',
-        type: BpmnTypeEnum.Task,
+        ...bpmnDetailsMock,
         taskType: taskType,
       };
       (getBpmnEditorDetailsFromBusinessObject as jest.Mock).mockReturnValue(mockBpmnDetailsConfirm);
-      const currentEventName = 'shape.add';
+      const currentEventName = 'commandStack.elements.create.postExecuted';
       renderUseBpmnEditor(true, currentEventName);
 
       expect(addLayoutSetMock).not.toHaveBeenCalled();
@@ -145,9 +143,9 @@ describe('useBpmnEditor', () => {
     },
   );
 
-  it('should call deleteLayoutSet when "shape.remove" event is triggered on modelerInstance', () => {
+  it('should call deleteLayoutSet when "commandStack.elements.delete.postExecuted" event is triggered on modelerInstance', () => {
     (getBpmnEditorDetailsFromBusinessObject as jest.Mock).mockReturnValue(bpmnDetailsMock);
-    const currentEventName = 'shape.remove';
+    const currentEventName = 'commandStack.elements.delete.postExecuted';
     renderUseBpmnEditor(true, currentEventName);
 
     expect(deleteLayoutSetMock).toHaveBeenCalledTimes(1);

--- a/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
@@ -87,11 +87,11 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
         await handleCommandStackChanged();
       });
 
-      modelerInstance.on('shape.add', (e) => {
+      modelerInstance.on('commandStack.elements.create.postExecuted', (e) => {
         handleShapeAdd(e);
       });
 
-      modelerInstance.on('shape.remove', (e) => {
+      modelerInstance.on('commandStack.elements.delete.postExecuted', (e) => {
         handleShapeRemove(e);
       });
     };


### PR DESCRIPTION
## Description
use event from bpmn modeler that is fired only on user interactions to trigger add/delete layout set instead of shape.add and shape.remove since these events are triggered on every new bpmn-mount.

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

