### PR TITLE
create new modeler instance always, but only call getModeler once in useBpmnEditor hook

### DIFF
--- a/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
@@ -1,5 +1,5 @@
 import type { MutableRefObject } from 'react';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type BpmnModeler from 'bpmn-js/lib/Modeler';
 import { useBpmnContext } from '../contexts/BpmnContext';
 import { useBpmnModeler } from './useBpmnModeler';
@@ -7,6 +7,7 @@ import { getBpmnEditorDetailsFromBusinessObject } from '../utils/hookUtils';
 import { useBpmnConfigPanelFormContext } from '../contexts/BpmnConfigPanelContext';
 import { useBpmnApiContext } from '../contexts/BpmnApiContext';
 import { BpmnTypeEnum } from '../enum/BpmnTypeEnum';
+import { getLayoutSetIdFromTaskId } from '../utils/hookUtils/hookUtils';
 
 // Wrapper around bpmn-js to Reactify it
 
@@ -20,21 +21,12 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
   const canvasRef = useRef<HTMLDivElement | null>(null);
   const { metaDataFormRef, resetForm } = useBpmnConfigPanelFormContext();
   const { getModeler } = useBpmnModeler();
-  const { addLayoutSet, deleteLayoutSet, saveBpmn } = useBpmnApiContext();
+  const { addLayoutSet, deleteLayoutSet, saveBpmn, layoutSets } = useBpmnApiContext();
+  //let modelerRef: BpmnModeler | null = null;
 
   const handleCommandStackChanged = async () => {
     saveBpmn(await getUpdatedXml(), metaDataFormRef.current || null);
     resetForm();
-  };
-
-  const handleShapeRemove = (e) => {
-    const bpmnDetails = getBpmnEditorDetailsFromBusinessObject(e?.element?.businessObject);
-    if (bpmnDetails.type === BpmnTypeEnum.Task) {
-      deleteLayoutSet({
-        layoutSetIdToUpdate: bpmnDetails.id,
-      });
-    }
-    setBpmnDetails(null);
   };
 
   const handleShapeAdd = (e) => {
@@ -48,62 +40,68 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
     }
   };
 
-  const handleSetBpmnDetails = (e) => {
-    const bpmnDetails = {
-      ...getBpmnEditorDetailsFromBusinessObject(e.element?.businessObject),
-      element: e.element,
-    };
-    setBpmnDetails(bpmnDetails);
+  const handleShapeRemove = (e) => {
+    const bpmnDetails = getBpmnEditorDetailsFromBusinessObject(e?.element?.businessObject);
+    if (bpmnDetails.type === BpmnTypeEnum.Task) {
+      const layoutSetId = getLayoutSetIdFromTaskId(bpmnDetails, layoutSets);
+      if (layoutSetId) {
+        deleteLayoutSet({
+          layoutSetIdToUpdate: layoutSetId,
+        });
+      }
+    }
+    setBpmnDetails(null);
+  };
+
+  const handleSetBpmnDetails = useCallback(
+    (e) => {
+      const bpmnDetails = {
+        ...getBpmnEditorDetailsFromBusinessObject(e.element?.businessObject),
+        element: e.element,
+      };
+      setBpmnDetails(bpmnDetails);
+    },
+    [setBpmnDetails],
+  );
+
+  const initializeEditor = async () => {
+    try {
+      await modelerRef.current.importXML(bpmnXml);
+      const canvas: any = modelerRef.current.get('canvas');
+      canvas.zoom('fit-viewport');
+    } catch (exception) {
+      console.log('An error occurred while rendering the viewer:', exception);
+    }
+  };
+
+  const initializeBpmnChanges = () => {
+    modelerRef.current.on('commandStack.changed', async () => {
+      await handleCommandStackChanged();
+    });
+    modelerRef.current.on('shape.add', (e) => {
+      handleShapeAdd(e);
+    });
+    modelerRef.current.on('shape.remove', (e) => {
+      handleShapeRemove(e);
+    });
   };
 
   useEffect(() => {
     if (!canvasRef.current) {
       console.log('Canvas reference is not yet available in the DOM.');
-      return;
     }
-    const modelerInstance: BpmnModeler = getModeler(canvasRef.current);
-
-    // set modelerRef.current to the Context so that it can be used in other components
-    modelerRef.current = modelerInstance;
-
-    const initializeEditor = async () => {
-      try {
-        await modelerInstance.importXML(bpmnXml);
-        const canvas: any = modelerInstance.get('canvas');
-        canvas.zoom('fit-viewport');
-      } catch (exception) {
-        console.log('An error occurred while rendering the viewer:', exception);
-      }
-    };
-
+    // GetModeler can only be fetched from this hook once since the modeler creates a
+    // new instance and will attach the same canvasRef container to all instances it fetches
+    modelerRef.current = getModeler(canvasRef.current);
     initializeEditor();
-  }, [modelerRef]); // Missing dependencies are not added due to resulting wierd behaviour in the process editor
-
-  useEffect(() => {
-    const initializeBpmnChanges = () => {
-      const modelerInstance = getModeler(canvasRef.current);
-
-      modelerInstance.on('commandStack.changed', async () => {
-        await handleCommandStackChanged();
-      });
-
-      modelerInstance.on('shape.add', (e) => {
-        handleShapeAdd(e);
-      });
-
-      modelerInstance.on('shape.remove', (e) => {
-        handleShapeRemove(e);
-      });
-    };
-
     initializeBpmnChanges();
-  }, []); // Missing dependencies are not added due to resulting wierd behaviour in the process editor
+    // set modelerRef.current to the Context so that it can be used in other components
+  }, []); // Missing dependencies are not added to avoid getModeler to be called multiple times
 
   useEffect(() => {
-    const modelerInstance: BpmnModeler = getModeler(canvasRef.current);
-    const eventBus: BpmnModeler = modelerInstance.get('eventBus');
+    const eventBus: BpmnModeler = modelerRef.current.get('eventBus');
     eventBus.on('element.click', handleSetBpmnDetails);
-  }, [getModeler, handleSetBpmnDetails]);
+  }, [modelerRef, handleSetBpmnDetails]);
 
   return { canvasRef, modelerRef };
 };

--- a/frontend/packages/process-editor/src/hooks/useBpmnModeler/useBpmnModeler.test.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnModeler/useBpmnModeler.test.ts
@@ -17,7 +17,6 @@ jest.mock(
 );
 
 const mockedCanvasHTMLDivElement = `<div>MockedHtml</div>` as unknown as HTMLDivElement;
-const mockedCanvasHTMLDivElement2 = `<div>MockedHtml2</div>` as unknown as HTMLDivElement;
 
 describe('useBpmnModeler', () => {
   it('should create instance of the BpmnModeler when calling getModeler', () => {
@@ -26,17 +25,5 @@ describe('useBpmnModeler', () => {
 
     const modelerInstance = getModeler(mockedCanvasHTMLDivElement) as ModelerMock;
     expect(modelerInstance.container.container).toBe(mockedCanvasHTMLDivElement);
-  });
-
-  it('should avoid creating a new instance of the class if it already has an instance', () => {
-    const { result } = renderHook(() => useBpmnModeler());
-    const { getModeler } = result.current;
-
-    const modelerInstance = getModeler(mockedCanvasHTMLDivElement) as ModelerMock;
-    expect(modelerInstance.container.container).toBe(mockedCanvasHTMLDivElement);
-
-    const modelerInstance2 = getModeler(mockedCanvasHTMLDivElement2) as ModelerMock;
-    expect(modelerInstance2.container.container).not.toBe(mockedCanvasHTMLDivElement2);
-    expect(modelerInstance2.container.container).toBe(mockedCanvasHTMLDivElement);
   });
 });

--- a/frontend/packages/process-editor/src/utils/StudioBpmnModeler.ts
+++ b/frontend/packages/process-editor/src/utils/StudioBpmnModeler.ts
@@ -6,20 +6,19 @@ import { altinnCustomTasks } from '../extensions/altinnCustomTasks';
 export class StudioBpmnModeler {
   private static instance: BpmnModeler | null = null;
 
-  // Singleton pattern to ensure only one instance of the StudioBpmnModeler is created
+  // Need to create a new modelerInstance in order to get the updated
+  // canvasContainer when switching between tabs in Studio
   public static getInstance(canvasContainer: HTMLDivElement): BpmnModeler {
-    if (!StudioBpmnModeler.instance) {
-      StudioBpmnModeler.instance = new BpmnModeler({
-        container: canvasContainer,
-        keyboard: {
-          bindTo: document,
-        },
-        additionalModules: [SupportedPaletteProvider, SupportedContextPadProvider],
-        moddleExtensions: {
-          altinn: altinnCustomTasks,
-        },
-      });
-    }
+    StudioBpmnModeler.instance = new BpmnModeler({
+      container: canvasContainer,
+      keyboard: {
+        bindTo: document,
+      },
+      additionalModules: [SupportedPaletteProvider, SupportedContextPadProvider],
+      moddleExtensions: {
+        altinn: altinnCustomTasks,
+      },
+    });
     return StudioBpmnModeler.instance;
   }
 }

--- a/frontend/packages/process-editor/src/utils/hookUtils/hookUtils.test.ts
+++ b/frontend/packages/process-editor/src/utils/hookUtils/hookUtils.test.ts
@@ -9,6 +9,7 @@ import type { BpmnTaskType } from '../../types/BpmnTaskType';
 import {
   getBpmnEditorDetailsFromBusinessObject,
   getBpmnViewerDetailsFromBusinessObject,
+  getLayoutSetIdFromTaskId,
 } from './hookUtils';
 
 describe('hookUtils', () => {
@@ -107,6 +108,39 @@ describe('hookUtils', () => {
       expect(bpmnDetails.name).toEqual(mockName);
       expect(bpmnDetails.type).toEqual(mockTypeTask);
       expect(bpmnDetails.taskType).toBeNull();
+    });
+  });
+
+  const mockTaskId = 'mockId';
+  const bpmnDetailsMock: BpmnDetails = {
+    id: mockTaskId,
+    name: 'mockName',
+    type: BpmnTypeEnum.Task,
+    taskType: 'data',
+  };
+
+  const layoutSets = {
+    sets: [
+      { id: 'layoutSet1', tasks: ['task1'] },
+      { id: 'layoutSet2', tasks: ['task2'] },
+    ],
+  };
+
+  describe('getLayoutSetIdFromTaskId', () => {
+    it('should return the layout set id corresponding to the task id', () => {
+      const result = getLayoutSetIdFromTaskId({ ...bpmnDetailsMock, id: 'task1' }, layoutSets);
+      expect(result).toBe('layoutSet1');
+    });
+
+    it('should return undefined if task id does not exist in any layout set', () => {
+      const result = getLayoutSetIdFromTaskId(bpmnDetailsMock, layoutSets);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined if layout sets are empty', () => {
+      const layoutSets = { sets: [] };
+      const result = getLayoutSetIdFromTaskId(bpmnDetailsMock, layoutSets);
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/frontend/packages/process-editor/src/utils/hookUtils/hookUtils.ts
+++ b/frontend/packages/process-editor/src/utils/hookUtils/hookUtils.ts
@@ -1,6 +1,7 @@
 import type { BpmnDetails } from '../../types/BpmnDetails';
 import type { BpmnBusinessObjectViewer } from '../../types/BpmnBusinessObjectViewer';
 import type { BpmnBusinessObjectEditor } from '../../types/BpmnBusinessObjectEditor';
+import type { LayoutSets } from 'app-shared/types/api/LayoutSetsResponse';
 
 /**
  * Gets the bpmn details from the business object in viewer mode
@@ -43,4 +44,9 @@ export const getBpmnEditorDetailsFromBusinessObject = (
     type: businessObject?.$type,
   };
   return bpmnDetails;
+};
+
+export const getLayoutSetIdFromTaskId = (bpmnDetails: BpmnDetails, layoutSets: LayoutSets) => {
+  const layoutSet = layoutSets.sets.find((set) => set.tasks[0] === bpmnDetails.id);
+  return layoutSet?.id;
 };


### PR DESCRIPTION
## Description
- Remove singleton modeler instance usage to avoid mismatch in container property and canvasRef when switching tabs in Studio
- Make sure only fetching modeler instance once from useBpmnEditor hook to avoid attaching multiple instances in the same canvas
- Get the corresponding layoutSetId connected to the task when deleting a task with the `deleteLayoutSet` endpoint

This PR fixes an issue with getting an empty canvas in process-editor when moving between tabs

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

