### PR TITLE
feat(Bpmnjs): Ensure that the user is fully informed about the consequences when deleting a task

### DIFF
--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedContextPadProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedContextPadProvider.js
@@ -4,9 +4,33 @@ class SupportedContextPadProvider {
   }
 
   getContextPadEntries() {
+    const overrideDeleteEntry = (entries) => {
+      const deleteEntry = entries['delete'];
+      entries['delete'] = {
+        ...deleteEntry,
+        action: {
+          click: function (event, element) {
+            if (element.type !== 'bpmn:Task') {
+              deleteEntry.action.click(event, element);
+              return;
+            }
+
+            const isConfirmed = confirm(
+              'Prosessteget du ønsker å slette er knyttet til en sidegruppe, som kan inneholde konfigureringer du selv har lagt til. Hvis du sletter dette prosessteget, sletter du også tilhørende sidegruppe.',
+            );
+
+            if (isConfirmed) {
+              deleteEntry.action.click(event, element);
+            }
+          },
+        },
+      };
+    };
+
     return function (entries) {
       // Should not be able to replace the entry
       delete entries['replace'];
+      overrideDeleteEntry(entries);
       return entries;
     };
   }

--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedContextPadProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedContextPadProvider.js
@@ -16,7 +16,7 @@ class SupportedContextPadProvider {
             }
 
             const isConfirmed = confirm(
-              'Prosess-steget du vil slette kan være knyttet til en sidegruppe. Den kan inneholde konfigurasjoner du har satt opp. Hvis du sletter steget, sletter du også hele sidegruppen og alt som ligger under den.',
+              'Prosess-steget du vil slette kan være knyttet til en sidegruppe. Den kan inneholde visningsoppsett eller skjema du har satt opp. Hvis du sletter steget, sletter du også hele sidegruppen og alt som hører til.',
             );
 
             if (isConfirmed) {

--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedContextPadProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedContextPadProvider.js
@@ -16,7 +16,7 @@ class SupportedContextPadProvider {
             }
 
             const isConfirmed = confirm(
-              'Prosessteget du ønsker å slette er knyttet til en sidegruppe, som kan inneholde konfigureringer du selv har lagt til. Hvis du sletter dette prosessteget, sletter du også tilhørende sidegruppe.',
+              'Prosess-steget du vil slette kan være knyttet til en sidegruppe. Den kan inneholde konfigurasjoner du har satt opp. Hvis du sletter steget, sletter du også hele sidegruppen og alt som ligger under den.',
             );
 
             if (isConfirmed) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Before proceeding with deleting the task, we want to ensure that the user is fully informed about the consequences. Continuing will permanently remove the task  including any associated layoutset from local changes.

## Related Issue(s)

- #12660 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
