### PR TITLE
Ensure autosave on layoutset switch is done for correct layoutset.

### DIFF
--- a/frontend/packages/ux-editor/src/containers/FormItemContext.tsx
+++ b/frontend/packages/ux-editor/src/containers/FormItemContext.tsx
@@ -67,13 +67,13 @@ export const FormItemContextProvider = ({
     org,
     app,
     prevSelectedFormLayoutNameRef.current,
-    selectedFormLayoutSetName,
+    prevSelectedFormLayoutSetNameRef.current,
   );
   const { mutateAsync: updateFormComponent } = useUpdateFormComponentMutation(
     org,
     app,
     prevSelectedFormLayoutNameRef.current,
-    selectedFormLayoutSetName,
+    prevSelectedFormLayoutSetNameRef.current,
   );
 
   useEffect(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Seems like the issue was caused by the setup in FormItemContext. 
There was an autosave set up for the "previous" layout/layoutset when changing layoutset. This was triggered when switching layoutsets, but the save was done for the newly selected layoutset, with context from the old layoutset. 

## Related Issue(s)

- #12497 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
