### PR TITLE
Change function name from formatDateDDMMYY to formatDateDDMMYYYY

### DIFF
--- a/frontend/app-development/features/appPublish/components/DeploymentEnvironmentStatus.tsx
+++ b/frontend/app-development/features/appPublish/components/DeploymentEnvironmentStatus.tsx
@@ -26,7 +26,7 @@ export const DeploymentEnvironmentStatus = ({
 
   const formatDateTime = (dateAsString: string): string => {
     return t('general.date_time_format', {
-      date: DateUtils.formatDateDDMMYY(dateAsString),
+      date: DateUtils.formatDateDDMMYYYY(dateAsString),
       time: DateUtils.formatTimeHHmm(dateAsString),
     });
   };

--- a/frontend/app-development/features/overview/components/DeploymentLogList.tsx
+++ b/frontend/app-development/features/overview/components/DeploymentLogList.tsx
@@ -28,7 +28,7 @@ export const DeploymentLogList = ({
 
   const formatDateTime = (dateAsString: string): string => {
     return t('general.date_time_format', {
-      date: DateUtils.formatDateDDMMYY(dateAsString),
+      date: DateUtils.formatDateDDMMYYYY(dateAsString),
       time: DateUtils.formatTimeHHmm(dateAsString),
     });
   };

--- a/frontend/app-development/features/overview/components/DeploymentStatus.tsx
+++ b/frontend/app-development/features/overview/components/DeploymentStatus.tsx
@@ -29,7 +29,7 @@ export const DeploymentStatus = ({
 
   const formatDateTime = (dateAsString: string): string => {
     return t('general.date_time_format', {
-      date: DateUtils.formatDateDDMMYY(dateAsString),
+      date: DateUtils.formatDateDDMMYYYY(dateAsString),
       time: DateUtils.formatTimeHHmm(dateAsString),
     });
   };

--- a/frontend/libs/studio-pure-functions/src/DateUtils/DateUtils.test.ts
+++ b/frontend/libs/studio-pure-functions/src/DateUtils/DateUtils.test.ts
@@ -11,7 +11,7 @@ test('that formatTimeHHmm works', () => {
 });
 
 test('that formatDateDDMMYY works', () => {
-  const formatted = DateUtils.formatDateDDMMYY(
+  const formatted = DateUtils.formatDateDDMMYYYY(
     'Tue Jan 10 2023 13:23:45 GMT+0100 (Central European Standard Time)',
     'Europe/Oslo',
   );

--- a/frontend/libs/studio-pure-functions/src/DateUtils/DateUtils.ts
+++ b/frontend/libs/studio-pure-functions/src/DateUtils/DateUtils.ts
@@ -7,7 +7,7 @@ export class DateUtils {
       timeZone,
     });
 
-  static formatDateDDMMYY = (dateasstring: string, timeZone?: string) =>
+  static formatDateDDMMYYYY = (dateasstring: string, timeZone?: string) =>
     new Date(dateasstring).toLocaleDateString('no-NB', {
       year: 'numeric',
       month: '2-digit',
@@ -17,7 +17,7 @@ export class DateUtils {
 
   static formatDateTime = (dateasstring: string, timeZone?: string) =>
     [
-      DateUtils.formatDateDDMMYY(dateasstring, timeZone),
+      DateUtils.formatDateDDMMYYYY(dateasstring, timeZone),
       DateUtils.formatTimeHHmm(dateasstring, timeZone),
     ].join(' ');
 


### PR DESCRIPTION
## Description
I was working on the dashboard and needed a function that returned the date format with a 4-digit year (e.g., 30.04.2024). I could only find the function formatDateDDMMYY, so I started creating a new function called formatDateDDMMYYYY.

However, I discovered that formatDateDDMMYY already returns a 4-digit year. To avoid confusion, I updated the function name in this PR.

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
