### PR TITLE
revert navikt/aksel-icons to 5.6.1

### DIFF
--- a/frontend/libs/studio-icons/package.json
+++ b/frontend/libs/studio-icons/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@navikt/aksel-icons": "6.6.1",
+    "@navikt/aksel-icons": "^5.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4678,13 +4678,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@npm:6.6.1":
-  version: 6.6.1
-  resolution: "@navikt/aksel-icons@npm:6.6.1"
-  checksum: 10/5a3da787c6787d66184b0dae32a2458d314ec1812567f0fe75db96a84175b636a5083bd46fc8e1635b0ef3b53d6f66bc7443f912d6eba5d5fe649a8850ded06e
-  languageName: node
-  linkType: hard
-
 "@navikt/aksel-icons@npm:^3.2.4":
   version: 3.4.2
   resolution: "@navikt/aksel-icons@npm:3.4.2"
@@ -4692,7 +4685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@npm:^5.12.2":
+"@navikt/aksel-icons@npm:^5.12.2, @navikt/aksel-icons@npm:^5.6.1":
   version: 5.18.3
   resolution: "@navikt/aksel-icons@npm:5.18.3"
   checksum: 10/de01c59ade08d8c4dc54db77131eff8f29f6a1d25e9dfb031bb6280dc853d51a686ae78b845ff2a7d3dc0291f568ec3714076325ccbd65ed829041e300bbd65b
@@ -6209,7 +6202,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@studio/icons@workspace:frontend/libs/studio-icons"
   dependencies:
-    "@navikt/aksel-icons": "npm:6.6.1"
+    "@navikt/aksel-icons": "npm:^5.6.1"
     "@testing-library/jest-dom": "npm:^6.1.3"
     "@testing-library/react": "npm:^15.0.0"
     "@types/jest": "npm:^29.5.5"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After updating to version 6.6.1 or above of the @navikt/aksel-icons dependency, there are path resolution problems due to the removal of the src folder in the newer version.

Rolling it back to the older version for now.
An issue addressing this problem has been created: https://github.com/Altinn/altinn-studio/issues/12728




<!--- Describe your changes in detail -->

## Related Issue(s)

- itself

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
