### PR TITLE
Improve data model generation

### DIFF
--- a/backend/src/DataModeling/Converter/Csharp/CSharpGenerationSettings.cs
+++ b/backend/src/DataModeling/Converter/Csharp/CSharpGenerationSettings.cs
@@ -5,5 +5,20 @@
         public int IndentSize { get; set; } = 2;
 
         public string ModelNamespace { get; set; } = "Altinn.App.Models";
+
+        /// <summary>
+        /// Create two properties on [XmlText] elements
+        /// one called value that is used by xml serialization
+        /// and one called valueNullable for json serialization.
+        ///
+        /// The valueNullable property also used in a `ShouldSerialize` method
+        /// on the parent element
+        /// </summary>
+        public bool XmlTextValueNullableHack { get; set; } = false;
+
+        /// <summary>
+        /// Add a ShouldSerialize method for to the parent property for [XmlText] elements when all attibutes are fixed
+        /// </summary>
+        public bool AddShouldSerializeForTagContent { get; set; } = false;
     }
 }

--- a/backend/src/DataModeling/Converter/Csharp/CSharpGenerationSettings.cs
+++ b/backend/src/DataModeling/Converter/Csharp/CSharpGenerationSettings.cs
@@ -14,11 +14,11 @@
         /// The valueNullable property also used in a `ShouldSerialize` method
         /// on the parent element
         /// </summary>
-        public bool XmlTextValueNullableHack { get; set; } = false;
+        public bool XmlTextValueNullableHack { get; set; } = true;
 
         /// <summary>
         /// Add a ShouldSerialize method for to the parent property for [XmlText] elements when all attibutes are fixed
         /// </summary>
-        public bool AddShouldSerializeForTagContent { get; set; } = false;
+        public bool AddShouldSerializeForTagContent { get; set; } = true;
     }
 }

--- a/backend/src/DataModeling/Converter/Csharp/Compiler.cs
+++ b/backend/src/DataModeling/Converter/Csharp/Compiler.cs
@@ -41,7 +41,6 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
                 var ignoredDiagnostics = new[]
                 {
                     "CS8019", // CS8019: Unnecessary using directive.
-
                 };
                 var diagnostics = result.Diagnostics.Where(d => !ignoredDiagnostics.Contains(d.Descriptor.Id)).ToArray();
                 if (diagnostics.Any())

--- a/backend/src/DataModeling/Converter/Csharp/Compiler.cs
+++ b/backend/src/DataModeling/Converter/Csharp/Compiler.cs
@@ -38,16 +38,18 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             {
                 EmitResult result = compilation.Emit(ms);
 
-                if (!result.Success)
+                var ignoredDiagnostics = new[]
                 {
-                    IEnumerable<Diagnostic> failures = result.Diagnostics.Where(diagnostic =>
-                        diagnostic.IsWarningAsError ||
-                        diagnostic.Severity == DiagnosticSeverity.Error);
+                    "CS8019", // CS8019: Unnecessary using directive.
 
+                };
+                var diagnostics = result.Diagnostics.Where(d => !ignoredDiagnostics.Contains(d.Descriptor.Id)).ToArray();
+                if (diagnostics.Any())
+                {
                     List<string> customErrorMessages = new();
-                    foreach (Diagnostic diagnostic in failures)
+                    foreach (Diagnostic diagnostic in diagnostics)
                     {
-                        customErrorMessages.Add(diagnostic.GetMessage());
+                        customErrorMessages.Add(diagnostic.Id + "" + diagnostic.GetMessage() + csharpCode[(diagnostic.Location.SourceSpan.Start - 10)..(diagnostic.Location.SourceSpan.End + 10)]);
                     }
 
                     throw new CsharpCompilationException("Csharp compilation failed.", customErrorMessages);

--- a/backend/src/DataModeling/Converter/Csharp/CsharpCompilationException.cs
+++ b/backend/src/DataModeling/Converter/Csharp/CsharpCompilationException.cs
@@ -9,7 +9,7 @@ public class CsharpCompilationException : Exception
     public List<string> CustomErrorMessages { get; }
 
     /// <inheritdoc/>
-    public CsharpCompilationException(string message, List<string> customErrorMessages) : base(message)
+    public CsharpCompilationException(string message, List<string> customErrorMessages) : base(message + "\n\n" + string.Join("\n", customErrorMessages))
     {
         CustomErrorMessages = customErrorMessages;
     }

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -524,10 +524,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
         /// </summary>
         private void WriteShouldSerializeMethod(StringBuilder classBuilder, string propName)
         {
-            classBuilder.AppendLine(Indent(2) + $"public bool ShouldSerialize{propName}()");
-            classBuilder.AppendLine(Indent(2) + "{");
-            classBuilder.AppendLine(Indent(3) + $"return {propName}.HasValue;");
-            classBuilder.AppendLine(Indent(2) + "}");
+            classBuilder.AppendLine(Indent(2) + $"public bool ShouldSerialize{propName}() => {propName}.HasValue;");
             classBuilder.AppendLine();
         }
 
@@ -544,10 +541,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             classBuilder.AppendLine(Indent(2) + "[Newtonsoft.Json.JsonIgnore]");
             classBuilder.AppendLine(Indent(2) + "public Guid AltinnRowId { get; set; }");
             classBuilder.AppendLine("");
-            classBuilder.AppendLine(Indent(2) + "public bool ShouldSerializeAltinnRowId()");
-            classBuilder.AppendLine(Indent(2) + "{");
-            classBuilder.AppendLine(Indent(3) + "return AltinnRowId != default;");
-            classBuilder.AppendLine(Indent(2) + "}");
+            classBuilder.AppendLine(Indent(2) + "public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;");
             classBuilder.AppendLine();
         }
     }

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -34,6 +34,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             CreateModelFromMetadataRecursive(classes, rootElementType, serviceMetadata, serviceMetadata.TargetNamespace);
 
             StringBuilder writer = new StringBuilder()
+                .AppendLine("#nullable disable")
                 .AppendLine("using System;")
                 .AppendLine("using System.Collections.Generic;")
                 .AppendLine("using System.ComponentModel.DataAnnotations;")

--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -284,7 +284,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
 
         private void ParseAttributeProperty(ElementMetadata element, StringBuilder classBuilder, bool required, bool useNullableReferenceTypes)
         {
-            string nullableReference = useNullableReferenceTypes ? "?": string.Empty;
+            string nullableReference = useNullableReferenceTypes ? "?" : string.Empty;
             string dataType = "string";
             bool isValueType = false;
             if (element.XsdValueType != null)

--- a/backend/src/DataModeling/Converter/Interfaces/IModelMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Interfaces/IModelMetadataToCsharpConverter.cs
@@ -9,7 +9,8 @@ namespace Altinn.Studio.DataModeling.Converter.Interfaces
         /// </summary>
         /// <param name="serviceMetadata">ServiceMetadata object</param>
         /// <param name="separateNamespaces">Indicates if models should be stored in the separate namespace.</param>
+        /// <param name="useNullableReferenceTypes">Whether to add nullable? to reference types</param>
         /// <returns>The model code in C#</returns>
-        public string CreateModelFromMetadata(ModelMetadata serviceMetadata, bool separateNamespaces = false);
+        public string CreateModelFromMetadata(ModelMetadata serviceMetadata, bool separateNamespaces, bool useNullableReferenceTypes);
     }
 }

--- a/backend/src/Designer/Services/Implementation/ModelNameValidator.cs
+++ b/backend/src/Designer/Services/Implementation/ModelNameValidator.cs
@@ -78,7 +78,7 @@ public class ModelNameValidator : IModelNameValidator
         var jsonSchemaConverterStrategy = JsonSchemaConverterStrategyFactory.SelectStrategy(jsonSchema);
         var metamodelConverter = new JsonSchemaToMetamodelConverter(jsonSchemaConverterStrategy.GetAnalyzer());
         var modelMetadata = metamodelConverter.Convert(SerializeJsonSchema(jsonSchema));
-        _modelMetadataToCsharpConverter.CreateModelFromMetadata(modelMetadata);
+        _modelMetadataToCsharpConverter.CreateModelFromMetadata(modelMetadata, separateNamespaces: false, useNullableReferenceTypes: false);
         return modelMetadata;
     }
 

--- a/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -310,7 +310,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             string modelName = modelMetadata.GetRootElement().TypeName;
             bool separateNamespace = !application.DataTypes.Any(d => d.AppLogic?.ClassRef == $"Altinn.App.Models.{modelName}");
 
-            string csharpClasses = _modelMetadataToCsharpConverter.CreateModelFromMetadata(modelMetadata, separateNamespace);
+            string csharpClasses = _modelMetadataToCsharpConverter.CreateModelFromMetadata(modelMetadata, separateNamespace, useNullableReferenceTypes: false);
             await altinnAppGitRepository.SaveCSharpClasses(csharpClasses, schemaName);
             return separateNamespace ? $"Altinn.App.Models.{modelName}.{modelName}" : $"Altinn.App.Models.{modelName}";
         }

--- a/backend/tests/DataModeling.Tests/Assertions/TypeAssertions.cs
+++ b/backend/tests/DataModeling.Tests/Assertions/TypeAssertions.cs
@@ -83,12 +83,9 @@ public static class TypeAssertions
 
     private static void IsEquivalentTo(IEnumerable<CustomAttributeData> expected, IEnumerable<CustomAttributeData> actual)
     {
-        expected.Count().Should().Be(actual.Count());
-
-        foreach (var item in expected)
-        {
-            Assert.Single(actual.Where(x => x.ToString() == item.ToString()));
-        }
+        var expectedStrings = expected.Select(e => e.ToString());
+        var actualStrings = actual.Select(a => a.ToString());
+        expectedStrings.Should().BeEquivalentTo(actualStrings);
     }
 
     private static void IsEquivalentTo(TypeAttributes expected, TypeAttributes actual)

--- a/backend/tests/DataModeling.Tests/BaseClasses/CsharpModelConversionTestsBase.cs
+++ b/backend/tests/DataModeling.Tests/BaseClasses/CsharpModelConversionTestsBase.cs
@@ -65,7 +65,7 @@ namespace DataModeling.Tests.BaseClasses
 
         protected TTestType ModelMetadataConvertedToCsharpClass()
         {
-            CSharpClasses = new JsonMetadataToCsharpConverter(new CSharpGenerationSettings()).CreateModelFromMetadata(ModelMetadata);
+            CSharpClasses = new JsonMetadataToCsharpConverter(new CSharpGenerationSettings()).CreateModelFromMetadata(ModelMetadata, separateNamespaces: false, useNullableReferenceTypes: false);
             return this as TTestType;
         }
 

--- a/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
+++ b/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
 using System.Xml.Serialization;
 using Altinn.Studio.DataModeling.Converter.Csharp;
 using DataModeling.Tests.Assertions;
@@ -8,11 +9,19 @@ using Designer.Tests.Factories.ModelFactory.DataClasses;
 using FluentAssertions;
 using SharedResources.Tests;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DataModeling.Tests
 {
     public class CsharpEnd2EndGenerationTests : CsharpModelConversionTestsBase<CsharpEnd2EndGenerationTests>
     {
+        private readonly ITestOutputHelper _testOutput;
+
+        public CsharpEnd2EndGenerationTests(ITestOutputHelper testOutput)
+        {
+            _testOutput = testOutput;
+        }
+        
         [Theory]
         [ClassData(typeof(CSharpEnd2EndTestData))]
         public void Convert_FromXsd_Should_EqualExpected(string xsdSchemaPath, string expectedCsharpClassPath)
@@ -61,6 +70,15 @@ namespace DataModeling.Tests
         private void GeneratedClassesShouldBeEquivalentToExpected(string expectedCsharpClassPath)
         {
             string expectedClasses = SharedResourcesHelper.LoadTestDataAsString(expectedCsharpClassPath);
+
+            _testOutput.WriteLine("Expected classes");
+            _testOutput.WriteLine(expectedClasses);
+            _testOutput.WriteLine("Generated classes");
+            _testOutput.WriteLine(CSharpClasses);
+
+            // Save the current generated classes to the expected file so they can be compared with git diff.
+            SharedResourcesHelper.WriteUpdatedTestData(expectedCsharpClassPath, CSharpClasses);
+
             var expectedAssembly = Compiler.CompileToAssembly(expectedClasses);
 
             // Compare root types.

--- a/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
+++ b/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
@@ -21,7 +21,7 @@ namespace DataModeling.Tests
         {
             _testOutput = testOutput;
         }
-        
+
         [Theory]
         [ClassData(typeof(CSharpEnd2EndTestData))]
         public void Convert_FromXsd_Should_EqualExpected(string xsdSchemaPath, string expectedCsharpClassPath)

--- a/backend/tests/DataModeling.Tests/TestDataClasses/CSharpEnd2EndTestData.cs
+++ b/backend/tests/DataModeling.Tests/TestDataClasses/CSharpEnd2EndTestData.cs
@@ -33,6 +33,8 @@ public class CSharpEnd2EndTestData : IEnumerable<object[]>
         yield return new object[] { "Model/XmlSchema/Gitea/skd-formueinntekt-skattemelding-v2.xsd", "Model/CSharp/Gitea/skd-formueinntekt-skattemelding-v2.cs" };
         yield return new object[] { "Model/XmlSchema/Gitea/aal-vedlegg.xsd", "Model/CSharp/Gitea/aal-vedlegg.cs" };
         yield return new object[] { "Model/XmlSchema/Gitea/krt-1188a-1.xsd", "Model/CSharp/Gitea/krt-1188a-1.cs" };
+        yield return new object[] { "Model/XmlSchema/Gitea/3422-39646.xsd", "Model/CSharp/Gitea/3422-39646.cs" };
+        yield return new object[] { "Model/XmlSchema/Gitea/3430-39615.xsd", "Model/CSharp/Gitea/3430-39615.cs" };
         yield return new object[] { "Model/XmlSchema/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.xsd", "Model/CSharp/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.cs" };
         yield return new object[] { "Model/XmlSchema/Gitea/dev-nill-test.xsd", "Model/CSharp/Gitea/dev-nill-test.cs" };
     }

--- a/backend/tests/DataModeling.Tests/TestDataClasses/ValidationTestData.cs
+++ b/backend/tests/DataModeling.Tests/TestDataClasses/ValidationTestData.cs
@@ -19,6 +19,7 @@ public class ValidationTestData : IEnumerable<object[]>
         yield return new object[] { "Model/XmlSchema/Gitea/stami-atid-databehandler-2022.xsd" };
         yield return new object[] { "Model/XmlSchema/Gitea/stami-mu-databehandler-2021.xsd" };
         yield return new object[] { "Model/XmlSchema/Gitea/skd-formueinntekt-skattemelding-v2.xsd" };
+        yield return new object[] { "Model/XmlSchema/Gitea/krt-1188a-1.xsd" };
 
         // Can generate non valid date string from regex
         // yield return new object[] { "Model/XmlSchema/Gitea/hi-algeskjema.xsd" };

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
@@ -92,7 +92,7 @@ public class PutDatamodelTests : DisagnerEndpointsTestsBase<PutDatamodelTests>, 
         customErrorMessages.Should().NotBeNull();
         var customErrorMessagesElement = (JsonElement)customErrorMessages;
         var firstErrorMessage = customErrorMessagesElement.EnumerateArray().FirstOrDefault().GetString();
-        firstErrorMessage.Should().Be("'root': member names cannot be the same as their enclosing type");
+        firstErrorMessage.Should().Contain("'root': member names cannot be the same as their enclosing type");
     }
 
     [Theory]

--- a/backend/tests/Designer.Tests/Services/SchemaModelServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/SchemaModelServiceTests.cs
@@ -229,7 +229,7 @@ namespace Designer.Tests.Services
             });
 
             Assert.NotNull(exception.CustomErrorMessages);
-            Assert.Equal(new List<string>() { "'root': member names cannot be the same as their enclosing type" }, exception.CustomErrorMessages);
+            exception.CustomErrorMessages.Should().ContainSingle(c => c.Contains("root': member names cannot be the same as their enclosing type"));
         }
 
         [Theory]

--- a/backend/tests/SharedResources.Tests/SharedResourcesHelper.cs
+++ b/backend/tests/SharedResources.Tests/SharedResourcesHelper.cs
@@ -43,4 +43,9 @@ public static class SharedResourcesHelper
 
         return xmlSchema;
     }
+
+    public static void WriteUpdatedTestData(string resourceName, string cSharpClasses)
+    {
+        File.WriteAllText(Path.Join("..", "..", "..", "..", "..", "..", "testdata", resourceName), cSharpClasses);
+    }
 }

--- a/testdata/Model/CSharp/Gitea/3422-39646.cs
+++ b/testdata/Model/CSharp/Gitea/3422-39646.cs
@@ -1,0 +1,6417 @@
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
+namespace Altinn.App.Models
+{
+  [XmlRoot(ElementName="melding")]
+  public class RR0010U_M
+  {
+    [XmlAttribute("dataFormatProvider")]
+    [BindNever]
+    public string dataFormatProvider { get; set; } = "SERES";
+
+    [XmlAttribute("dataFormatId")]
+    [BindNever]
+    public string dataFormatId { get; set; } = "3422";
+
+    [XmlAttribute("dataFormatVersion")]
+    [BindNever]
+    public string dataFormatVersion { get; set; } = "48706";
+
+    [XmlElement("Rapport-RR0010U", Order = 1)]
+    [JsonProperty("Rapport-RR0010U")]
+    [JsonPropertyName("Rapport-RR0010U")]
+    public RapportRR0010U RapportRR0010U { get; set; }
+
+    [XmlElement("Skjemainnhold", Order = 2)]
+    [JsonProperty("Skjemainnhold")]
+    [JsonPropertyName("Skjemainnhold")]
+    public Skjemainnhold Skjemainnhold { get; set; }
+
+  }
+
+  public class RapportRR0010U
+  {
+    [XmlElement("aarsregnskap", Order = 1)]
+    [JsonProperty("aarsregnskap")]
+    [JsonPropertyName("aarsregnskap")]
+    public Aarsregnskap aarsregnskap { get; set; }
+
+  }
+
+  public class Aarsregnskap
+  {
+    [XmlElement("type", Order = 1)]
+    [JsonProperty("type")]
+    [JsonPropertyName("type")]
+    public ArsregnskapType25942 type { get; set; }
+
+    [XmlElement("valuta", Order = 2)]
+    [JsonProperty("valuta")]
+    [JsonPropertyName("valuta")]
+    public ArsregnskapValutakode34984 valuta { get; set; }
+
+    [XmlElement("valoer", Order = 3)]
+    [JsonProperty("valoer")]
+    [JsonPropertyName("valoer")]
+    public ArsregnskapValor28974 valoer { get; set; }
+
+  }
+
+  public class ArsregnskapType25942
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "25942";
+
+  }
+
+  public class ArsregnskapValutakode34984
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "34984";
+
+  }
+
+  public class ArsregnskapValor28974
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "28974";
+
+  }
+
+  public class Skjemainnhold
+  {
+    [XmlElement("resultatregnskapAktivitetsbasert", Order = 1)]
+    [JsonProperty("resultatregnskapAktivitetsbasert")]
+    [JsonPropertyName("resultatregnskapAktivitetsbasert")]
+    public ResultatregnskapAktivitetsbasert resultatregnskapAktivitetsbasert { get; set; }
+
+    [XmlElement("balanseEiendelerAnleggsmidler", Order = 2)]
+    [JsonProperty("balanseEiendelerAnleggsmidler")]
+    [JsonPropertyName("balanseEiendelerAnleggsmidler")]
+    public BalanseEiendelerAnleggsmidler balanseEiendelerAnleggsmidler { get; set; }
+
+    [XmlElement("balanseEiendelerOmloepsmidler", Order = 3)]
+    [JsonProperty("balanseEiendelerOmloepsmidler")]
+    [JsonPropertyName("balanseEiendelerOmloepsmidler")]
+    public BalanseEiendelerOmloepsmidler balanseEiendelerOmloepsmidler { get; set; }
+
+    [XmlElement("balanseFormaalskapital", Order = 4)]
+    [JsonProperty("balanseFormaalskapital")]
+    [JsonPropertyName("balanseFormaalskapital")]
+    public BalanseFormaalskapital balanseFormaalskapital { get; set; }
+
+    [XmlElement("balanseGjeld", Order = 5)]
+    [JsonProperty("balanseGjeld")]
+    [JsonPropertyName("balanseGjeld")]
+    public BalanseGjeld balanseGjeld { get; set; }
+
+    [XmlElement("posterUtenomBalansen", Order = 6)]
+    [JsonProperty("posterUtenomBalansen")]
+    [JsonPropertyName("posterUtenomBalansen")]
+    public PosterUtenomBalansen posterUtenomBalansen { get; set; }
+
+  }
+
+  public class ResultatregnskapAktivitetsbasert
+  {
+    [XmlElement("anskaffedeMidler", Order = 1)]
+    [JsonProperty("anskaffedeMidler")]
+    [JsonPropertyName("anskaffedeMidler")]
+    public AnskaffedeMidler anskaffedeMidler { get; set; }
+
+    [XmlElement("forbrukteMidler", Order = 2)]
+    [JsonProperty("forbrukteMidler")]
+    [JsonPropertyName("forbrukteMidler")]
+    public ForbrukteMidler forbrukteMidler { get; set; }
+
+    [XmlElement("aarsresultat", Order = 3)]
+    [JsonProperty("aarsresultat")]
+    [JsonPropertyName("aarsresultat")]
+    public Aarsresultat aarsresultat { get; set; }
+
+    [XmlElement("tilleggReduksjonEgenkapital", Order = 4)]
+    [JsonProperty("tilleggReduksjonEgenkapital")]
+    [JsonPropertyName("tilleggReduksjonEgenkapital")]
+    public TilleggReduksjonEgenkapital tilleggReduksjonEgenkapital { get; set; }
+
+  }
+
+  public class AnskaffedeMidler
+  {
+    [XmlElement("medlemsinntekter", Order = 1)]
+    [JsonProperty("medlemsinntekter")]
+    [JsonPropertyName("medlemsinntekter")]
+    public Medlemsinntekter medlemsinntekter { get; set; }
+
+    [XmlElement("offentligeTilskudd", Order = 2)]
+    [JsonProperty("offentligeTilskudd")]
+    [JsonPropertyName("offentligeTilskudd")]
+    public OffentligeTilskudd offentligeTilskudd { get; set; }
+
+    [XmlElement("andreTilskudd", Order = 3)]
+    [JsonProperty("andreTilskudd")]
+    [JsonPropertyName("andreTilskudd")]
+    public AndreTilskudd andreTilskudd { get; set; }
+
+    [XmlElement("sumTilskudd", Order = 4)]
+    [JsonProperty("sumTilskudd")]
+    [JsonPropertyName("sumTilskudd")]
+    public SumTilskudd sumTilskudd { get; set; }
+
+    [XmlElement("innsamledeMidlerGaverMv", Order = 5)]
+    [JsonProperty("innsamledeMidlerGaverMv")]
+    [JsonPropertyName("innsamledeMidlerGaverMv")]
+    public InnsamledeMidlerGaverMv innsamledeMidlerGaverMv { get; set; }
+
+    [XmlElement("aktiviteterOppfyllerOrgFormaal", Order = 6)]
+    [JsonProperty("aktiviteterOppfyllerOrgFormaal")]
+    [JsonPropertyName("aktiviteterOppfyllerOrgFormaal")]
+    public AktiviteterOppfyllerOrgFormaal aktiviteterOppfyllerOrgFormaal { get; set; }
+
+    [XmlElement("aktiviteterSkaperInntekt", Order = 7)]
+    [JsonProperty("aktiviteterSkaperInntekt")]
+    [JsonPropertyName("aktiviteterSkaperInntekt")]
+    public AktiviteterSkaperInntekt aktiviteterSkaperInntekt { get; set; }
+
+    [XmlElement("opptjenteInntekterOperasjonelleAktiviteter", Order = 8)]
+    [JsonProperty("opptjenteInntekterOperasjonelleAktiviteter")]
+    [JsonPropertyName("opptjenteInntekterOperasjonelleAktiviteter")]
+    public OpptjenteInntekterOperasjonelleAktiviteter opptjenteInntekterOperasjonelleAktiviteter { get; set; }
+
+    [XmlElement("annenDriftsinntekt", Order = 9)]
+    [JsonProperty("annenDriftsinntekt")]
+    [JsonPropertyName("annenDriftsinntekt")]
+    public AnnenDriftsinntekt annenDriftsinntekt { get; set; }
+
+    [XmlElement("finansOgInvesteringsinntekter", Order = 10)]
+    [JsonProperty("finansOgInvesteringsinntekter")]
+    [JsonPropertyName("finansOgInvesteringsinntekter")]
+    public FinansOgInvesteringsinntekter finansOgInvesteringsinntekter { get; set; }
+
+    [XmlElement("andreInntekter", Order = 11)]
+    [JsonProperty("andreInntekter")]
+    [JsonPropertyName("andreInntekter")]
+    public AndreInntekter andreInntekter { get; set; }
+
+    [XmlElement("sumAnskaffedeMidler", Order = 12)]
+    [JsonProperty("sumAnskaffedeMidler")]
+    [JsonPropertyName("sumAnskaffedeMidler")]
+    public SumAnskaffedeMidler sumAnskaffedeMidler { get; set; }
+
+  }
+
+  public class Medlemsinntekter
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteMedlemsinntekter30319 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Medlemsinntekter30320 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public MedlemsinntekterFjoraret30321 fjoraarets { get; set; }
+
+  }
+
+  public class NoteMedlemsinntekter30319
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30319";
+
+  }
+
+  public class Medlemsinntekter30320
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30320";
+
+  }
+
+  public class MedlemsinntekterFjoraret30321
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30321";
+
+  }
+
+  public class OffentligeTilskudd
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteTilskuddOffentlig33418 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public TilskuddOffentlig33419 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public TilskuddOffentligFjoraret33420 fjoraarets { get; set; }
+
+  }
+
+  public class NoteTilskuddOffentlig33418
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33418";
+
+  }
+
+  public class TilskuddOffentlig33419
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33419";
+
+  }
+
+  public class TilskuddOffentligFjoraret33420
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33420";
+
+  }
+
+  public class AndreTilskudd
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteTilskuddAndre33421 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public TilskuddAndre33422 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public TilskuddAndreFjoraret33423 fjoraarets { get; set; }
+
+  }
+
+  public class NoteTilskuddAndre33421
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33421";
+
+  }
+
+  public class TilskuddAndre33422
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33422";
+
+  }
+
+  public class TilskuddAndreFjoraret33423
+  {
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33423";
+
+  }
+
+  public class SumTilskudd
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteTilskudd30310 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public TilskuddOffentlig30311 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public TilskuddOffentligFjoraret30312 fjoraarets { get; set; }
+
+  }
+
+  public class NoteTilskudd30310
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30310";
+
+  }
+
+  public class TilskuddOffentlig30311
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30311";
+
+  }
+
+  public class TilskuddOffentligFjoraret30312
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30312";
+
+  }
+
+  public class InnsamledeMidlerGaverMv
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteMidlerGaverInnsamlede30313 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public MidlerGaverInnsamlede30314 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public MidlerGaverInnsamledeFjoraret30315 fjoraarets { get; set; }
+
+  }
+
+  public class NoteMidlerGaverInnsamlede30313
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30313";
+
+  }
+
+  public class MidlerGaverInnsamlede30314
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30314";
+
+  }
+
+  public class MidlerGaverInnsamledeFjoraret30315
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30315";
+
+  }
+
+  public class AktiviteterOppfyllerOrgFormaal
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteAktiviteterOppfyllerOrganisasjonensFormal33424 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public AktiviteterOppfyllerOrganisasjonensFormal33425 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public AktiviteterOppfyllerOrganisasjonensFormalFjoraret33426 fjoraarets { get; set; }
+
+  }
+
+  public class NoteAktiviteterOppfyllerOrganisasjonensFormal33424
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33424";
+
+  }
+
+  public class AktiviteterOppfyllerOrganisasjonensFormal33425
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33425";
+
+  }
+
+  public class AktiviteterOppfyllerOrganisasjonensFormalFjoraret33426
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33426";
+
+  }
+
+  public class AktiviteterSkaperInntekt
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteAktiviteterSkaperInntekt33427 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public AktiviteterSkaperInntekt33428 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public AktiviteterSkaperInntektFjoraret33429 fjoraarets { get; set; }
+
+  }
+
+  public class NoteAktiviteterSkaperInntekt33427
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33427";
+
+  }
+
+  public class AktiviteterSkaperInntekt33428
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33428";
+
+  }
+
+  public class AktiviteterSkaperInntektFjoraret33429
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33429";
+
+  }
+
+  public class OpptjenteInntekterOperasjonelleAktiviteter
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteAktiviteterOperasjonelle33430 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public AktiviteterOperasjonelle33431 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public AktiviteterOperasjonelleFjoraret33432 fjoraarets { get; set; }
+
+  }
+
+  public class NoteAktiviteterOperasjonelle33430
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33430";
+
+  }
+
+  public class AktiviteterOperasjonelle33431
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33431";
+
+  }
+
+  public class AktiviteterOperasjonelleFjoraret33432
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33432";
+
+  }
+
+  public class AnnenDriftsinntekt
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteDriftsinntekterAndreSum18238 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public DriftsinntekterAndreSum7709 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public DriftsinntekterAndreFjoraretSum7966 fjoraarets { get; set; }
+
+  }
+
+  public class NoteDriftsinntekterAndreSum18238
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18238";
+
+  }
+
+  public class DriftsinntekterAndreSum7709
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7709";
+
+  }
+
+  public class DriftsinntekterAndreFjoraretSum7966
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7966";
+
+  }
+
+  public class FinansOgInvesteringsinntekter
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFinansinntekterInvesteringsinntekter33433 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FinansinntekterInvesteringsinntekter33434 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FinansinntekterInvesteringsinntekterFjoraret33435 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFinansinntekterInvesteringsinntekter33433
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33433";
+
+  }
+
+  public class FinansinntekterInvesteringsinntekter33434
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33434";
+
+  }
+
+  public class FinansinntekterInvesteringsinntekterFjoraret33435
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33435";
+
+  }
+
+  public class AndreInntekter
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteInntektAnnen30307 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public InntektAnnen30308 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public InntektAnnenFjoraret30309 fjoraarets { get; set; }
+
+  }
+
+  public class NoteInntektAnnen30307
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30307";
+
+  }
+
+  public class InntektAnnen30308
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30308";
+
+  }
+
+  public class InntektAnnenFjoraret30309
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30309";
+
+  }
+
+  public class SumAnskaffedeMidler
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteMidlerAnskaffede30316 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public MidlerAnskaffede30317 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public MidlerAnskaffedeFjoraret30318 fjoraarets { get; set; }
+
+  }
+
+  public class NoteMidlerAnskaffede30316
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30316";
+
+  }
+
+  public class MidlerAnskaffede30317
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30317";
+
+  }
+
+  public class MidlerAnskaffedeFjoraret30318
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30318";
+
+  }
+
+  public class ForbrukteMidler
+  {
+    [XmlElement("kostnadAnskaffelseMidler", Order = 1)]
+    [JsonProperty("kostnadAnskaffelseMidler")]
+    [JsonPropertyName("kostnadAnskaffelseMidler")]
+    public KostnadAnskaffelseMidler kostnadAnskaffelseMidler { get; set; }
+
+    [XmlElement("tilskuddBevilningOppfyllelseOrgFormaal", Order = 2)]
+    [JsonProperty("tilskuddBevilningOppfyllelseOrgFormaal")]
+    [JsonPropertyName("tilskuddBevilningOppfyllelseOrgFormaal")]
+    public TilskuddBevilningOppfyllelseOrgFormaal tilskuddBevilningOppfyllelseOrgFormaal { get; set; }
+
+    [XmlElement("kostnaderOppfyllelseOrgFormaal", Order = 3)]
+    [JsonProperty("kostnaderOppfyllelseOrgFormaal")]
+    [JsonPropertyName("kostnaderOppfyllelseOrgFormaal")]
+    public KostnaderOppfyllelseOrgFormaal kostnaderOppfyllelseOrgFormaal { get; set; }
+
+    [XmlElement("kostnaderOrgFormaal", Order = 4)]
+    [JsonProperty("kostnaderOrgFormaal")]
+    [JsonPropertyName("kostnaderOrgFormaal")]
+    public KostnaderOrgFormaal kostnaderOrgFormaal { get; set; }
+
+    [XmlElement("annenRentekostnad", Order = 5)]
+    [JsonProperty("annenRentekostnad")]
+    [JsonPropertyName("annenRentekostnad")]
+    public AnnenRentekostnad annenRentekostnad { get; set; }
+
+    [XmlElement("annenFinanskostnad", Order = 6)]
+    [JsonProperty("annenFinanskostnad")]
+    [JsonPropertyName("annenFinanskostnad")]
+    public AnnenFinanskostnad annenFinanskostnad { get; set; }
+
+    [XmlElement("administrasjonskostnader", Order = 7)]
+    [JsonProperty("administrasjonskostnader")]
+    [JsonPropertyName("administrasjonskostnader")]
+    public Administrasjonskostnader administrasjonskostnader { get; set; }
+
+    [XmlElement("annenDriftskostnad", Order = 8)]
+    [JsonProperty("annenDriftskostnad")]
+    [JsonPropertyName("annenDriftskostnad")]
+    public AnnenDriftskostnad annenDriftskostnad { get; set; }
+
+    [XmlElement("sumForbrukteMidler", Order = 9)]
+    [JsonProperty("sumForbrukteMidler")]
+    [JsonPropertyName("sumForbrukteMidler")]
+    public SumForbrukteMidler sumForbrukteMidler { get; set; }
+
+  }
+
+  public class KostnadAnskaffelseMidler
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteKostnadAnskaffelseAvMidler30806 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public KostnadAnskaffelseAvMidler30807 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public KostnadAnskaffelseAvMidlerFjoraret30808 fjoraarets { get; set; }
+
+  }
+
+  public class NoteKostnadAnskaffelseAvMidler30806
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30806";
+
+  }
+
+  public class KostnadAnskaffelseAvMidler30807
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30807";
+
+  }
+
+  public class KostnadAnskaffelseAvMidlerFjoraret30808
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30808";
+
+  }
+
+  public class TilskuddBevilningOppfyllelseOrgFormaal
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteTilskuddBevilningOppfyllelseOrganisasjonensFormal33436 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public TilskuddBevilningOppfyllelseOrganisasjonensFormal33437 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public TilskuddBevilningOppfyllelseOrganisasjonensFormalFjoraret33438 fjoraarets { get; set; }
+
+  }
+
+  public class NoteTilskuddBevilningOppfyllelseOrganisasjonensFormal33436
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33436";
+
+  }
+
+  public class TilskuddBevilningOppfyllelseOrganisasjonensFormal33437
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33437";
+
+  }
+
+  public class TilskuddBevilningOppfyllelseOrganisasjonensFormalFjoraret33438
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33438";
+
+  }
+
+  public class KostnaderOppfyllelseOrgFormaal
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteKostnaderOppfyllelseOrganisasjonensFormal33439 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public KostnaderOppfyllelseOrganisasjonensFormal33440 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public KostnaderOppfyllelseOrganisasjonensFormalFjoraret33441 fjoraarets { get; set; }
+
+  }
+
+  public class NoteKostnaderOppfyllelseOrganisasjonensFormal33439
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33439";
+
+  }
+
+  public class KostnaderOppfyllelseOrganisasjonensFormal33440
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33440";
+
+  }
+
+  public class KostnaderOppfyllelseOrganisasjonensFormalFjoraret33441
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33441";
+
+  }
+
+  public class KostnaderOrgFormaal
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteKostnadOrganisasjonensFormal30809 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public KostnadOrganisasjonensFormal30810 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public KostnadOrganisasjonensFormalFjoraret30811 fjoraarets { get; set; }
+
+  }
+
+  public class NoteKostnadOrganisasjonensFormal30809
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30809";
+
+  }
+
+  public class KostnadOrganisasjonensFormal30810
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30810";
+
+  }
+
+  public class KostnadOrganisasjonensFormalFjoraret30811
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30811";
+
+  }
+
+  public class AnnenRentekostnad
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteRentekostnaderAndre18550 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public RentekostnaderAndre2216 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public RentekostnaderAndreFjoraret7039 fjoraarets { get; set; }
+
+  }
+
+  public class NoteRentekostnaderAndre18550
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18550";
+
+  }
+
+  public class RentekostnaderAndre2216
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "2216";
+
+  }
+
+  public class RentekostnaderAndreFjoraret7039
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7039";
+
+  }
+
+  public class AnnenFinanskostnad
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFinanskostnaderAndre18337 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FinanskostnaderAndre156 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FinanskostnaderAndreFjoraret7041 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFinanskostnaderAndre18337
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18337";
+
+  }
+
+  public class FinanskostnaderAndre156
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "156";
+
+  }
+
+  public class FinanskostnaderAndreFjoraret7041
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7041";
+
+  }
+
+  public class Administrasjonskostnader
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteKostnaderAdministrative27924 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public KostnaderAdministrative27926 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public KostnaderAdministrativeFjoraret27928 fjoraarets { get; set; }
+
+  }
+
+  public class NoteKostnaderAdministrative27924
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "27924";
+
+  }
+
+  public class KostnaderAdministrative27926
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "27926";
+
+  }
+
+  public class KostnaderAdministrativeFjoraret27928
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "27928";
+
+  }
+
+  public class AnnenDriftskostnad
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteDriftskostnaderAndre18249 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public DriftskostnaderAndre82 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public DriftskostnaderAndreFjoraret7023 fjoraarets { get; set; }
+
+  }
+
+  public class NoteDriftskostnaderAndre18249
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18249";
+
+  }
+
+  public class DriftskostnaderAndre82
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "82";
+
+  }
+
+  public class DriftskostnaderAndreFjoraret7023
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7023";
+
+  }
+
+  public class SumForbrukteMidler
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteMidlerForbrukte30812 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public MidlerForbrukte30813 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public MidlerForbrukteFjoraret30814 fjoraarets { get; set; }
+
+  }
+
+  public class NoteMidlerForbrukte30812
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30812";
+
+  }
+
+  public class MidlerForbrukte30813
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30813";
+
+  }
+
+  public class MidlerForbrukteFjoraret30814
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30814";
+
+  }
+
+  public class Aarsresultat
+  {
+    [XmlElement("ordinaertResultatFoerSkattekostnad", Order = 1)]
+    [JsonProperty("ordinaertResultatFoerSkattekostnad")]
+    [JsonPropertyName("ordinaertResultatFoerSkattekostnad")]
+    public OrdinaertResultatFoerSkattekostnaO ordinaertResultatFoerSkattekostnad { get; set; }
+
+    [XmlElement("skattekostnadOrdinaertResultat", Order = 2)]
+    [JsonProperty("skattekostnadOrdinaertResultat")]
+    [JsonPropertyName("skattekostnadOrdinaertResultat")]
+    public SkattekostnadOrdinaertResultat skattekostnadOrdinaertResultat { get; set; }
+
+    [XmlElement("ordinaertResultatEtterSkattekostnad", Order = 3)]
+    [JsonProperty("ordinaertResultatEtterSkattekostnad")]
+    [JsonPropertyName("ordinaertResultatEtterSkattekostnad")]
+    public OrdinaertResultatEtterSkattekostnad ordinaertResultatEtterSkattekostnad { get; set; }
+
+    [XmlElement("ekstraordinaerePoster", Order = 4)]
+    [JsonProperty("ekstraordinaerePoster")]
+    [JsonPropertyName("ekstraordinaerePoster")]
+    public EkstraordinaerePoster ekstraordinaerePoster { get; set; }
+
+    [XmlElement("skattekostnadPaaEkstraordinaertResultat", Order = 5)]
+    [JsonProperty("skattekostnadPaaEkstraordinaertResultat")]
+    [JsonPropertyName("skattekostnadPaaEkstraordinaertResultat")]
+    public SkattekostnadPaaEkstraordinaertResultat skattekostnadPaaEkstraordinaertResultat { get; set; }
+
+    [XmlElement("aarsresultat", Order = 6)]
+    [JsonProperty("aarsresultat")]
+    [JsonPropertyName("aarsresultat")]
+    public AarsresultatPoster aarsresultat { get; set; }
+
+    [XmlElement("minoritetsinteresser", Order = 7)]
+    [JsonProperty("minoritetsinteresser")]
+    [JsonPropertyName("minoritetsinteresser")]
+    public Minoritetsinteresser minoritetsinteresser { get; set; }
+
+    [XmlElement("aarsresultatEtterMinoritetsinteresser", Order = 8)]
+    [JsonProperty("aarsresultatEtterMinoritetsinteresser")]
+    [JsonPropertyName("aarsresultatEtterMinoritetsinteresser")]
+    public AarsresultatEtterMinoritetsinteresser aarsresultatEtterMinoritetsinteresser { get; set; }
+
+    [XmlElement("andreResultatkomponenterIfrs", Order = 9)]
+    [JsonProperty("andreResultatkomponenterIfrs")]
+    [JsonPropertyName("andreResultatkomponenterIfrs")]
+    public AndreResultatkomponenterIfrs andreResultatkomponenterIfrs { get; set; }
+
+    [XmlElement("totalresultatIfrs", Order = 10)]
+    [JsonProperty("totalresultatIfrs")]
+    [JsonPropertyName("totalresultatIfrs")]
+    public TotalresultatIfrs totalresultatIfrs { get; set; }
+
+  }
+
+  public class OrdinaertResultatFoerSkattekostnaO
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteResultatForSkattekostnad18355 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public ResultatForSkattekostnad167 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public ResultatForSkattekostnadFjoraret7042 fjoraarets { get; set; }
+
+  }
+
+  public class NoteResultatForSkattekostnad18355
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18355";
+
+  }
+
+  public class ResultatForSkattekostnad167
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "167";
+
+  }
+
+  public class ResultatForSkattekostnadFjoraret7042
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7042";
+
+  }
+
+  public class SkattekostnadOrdinaertResultat
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteSkattekostnadOrdinartResultat18259 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public SkattekostnadOrdinartResultat11835 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public SkattekostnadOrdinartResultatFjoraret11836 fjoraarets { get; set; }
+
+  }
+
+  public class NoteSkattekostnadOrdinartResultat18259
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18259";
+
+  }
+
+  public class SkattekostnadOrdinartResultat11835
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "11835";
+
+  }
+
+  public class SkattekostnadOrdinartResultatFjoraret11836
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "11836";
+
+  }
+
+  public class OrdinaertResultatEtterSkattekostnad
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteResultatOrdinart18258 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public ResultatOrdinart7048 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public ResultatOrdinartFjordaret7049 fjoraarets { get; set; }
+
+  }
+
+  public class NoteResultatOrdinart18258
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18258";
+
+  }
+
+  public class ResultatOrdinart7048
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7048";
+
+  }
+
+  public class ResultatOrdinartFjordaret7049
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7049";
+
+  }
+
+  public class EkstraordinaerePoster
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteResultatEkstraordinarePoster29047 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public ResultatEkstraordinarePoster29048 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public ResultatEkstraordinarePosterFjoraret29049 fjoraarets { get; set; }
+
+  }
+
+  public class NoteResultatEkstraordinarePoster29047
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "29047";
+
+  }
+
+  public class ResultatEkstraordinarePoster29048
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "29048";
+
+  }
+
+  public class ResultatEkstraordinarePosterFjoraret29049
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "29049";
+
+  }
+
+  public class SkattekostnadPaaEkstraordinaertResultat
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteSkattekostnadEkstraordinartResultat18263 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public SkattekostnadEkstraordinartResultat2821 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public SkattekostnadEkstraordinartResultatFjoraret8002 fjoraarets { get; set; }
+
+  }
+
+  public class NoteSkattekostnadEkstraordinartResultat18263
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18263";
+
+  }
+
+  public class SkattekostnadEkstraordinartResultat2821
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "2821";
+
+  }
+
+  public class SkattekostnadEkstraordinartResultatFjoraret8002
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "8002";
+
+  }
+
+  public class AarsresultatPoster
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteArsresultat18265 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Arsresultat172 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public ArsresultatFjoraret7054 fjoraarets { get; set; }
+
+  }
+
+  public class NoteArsresultat18265
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18265";
+
+  }
+
+  public class Arsresultat172
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "172";
+
+  }
+
+  public class ArsresultatFjoraret7054
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7054";
+
+  }
+
+  public class Minoritetsinteresser
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteMinoritetsinteresser18264 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Minoritetsinteresser7717 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public MinoritetsinteresserFjoraret8004 fjoraarets { get; set; }
+
+  }
+
+  public class NoteMinoritetsinteresser18264
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18264";
+
+  }
+
+  public class Minoritetsinteresser7717
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7717";
+
+  }
+
+  public class MinoritetsinteresserFjoraret8004
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "8004";
+
+  }
+
+  public class AarsresultatEtterMinoritetsinteresser
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteArsresultatEtterMinoritetsinteresser33417 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public ArsresultatEtterMinoritetsinteresser33415 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public ArsresultatEtterMinoritetsinteresserFjoraret33416 fjoraarets { get; set; }
+
+  }
+
+  public class NoteArsresultatEtterMinoritetsinteresser33417
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33417";
+
+  }
+
+  public class ArsresultatEtterMinoritetsinteresser33415
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33415";
+
+  }
+
+  public class ArsresultatEtterMinoritetsinteresserFjoraret33416
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33416";
+
+  }
+
+  public class AndreResultatkomponenterIfrs
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteResultatkomponenterAndreIFRS35536 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public ResultatkomponenterAndreIFRS32929 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public ResultatkomponenterAndreIFRSFjoraret32930 fjoraarets { get; set; }
+
+  }
+
+  public class NoteResultatkomponenterAndreIFRS35536
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "35536";
+
+  }
+
+  public class ResultatkomponenterAndreIFRS32929
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "32929";
+
+  }
+
+  public class ResultatkomponenterAndreIFRSFjoraret32930
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "32930";
+
+  }
+
+  public class TotalresultatIfrs
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteTotalresultatIFRS36635 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public TotalresultatIFRS36633 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public TotalresultatIFRSFjoraaret36634 fjoraarets { get; set; }
+
+  }
+
+  public class NoteTotalresultatIFRS36635
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "36635";
+
+  }
+
+  public class TotalresultatIFRS36633
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "36633";
+
+  }
+
+  public class TotalresultatIFRSFjoraaret36634
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "36634";
+
+  }
+
+  public class TilleggReduksjonEgenkapital
+  {
+    [XmlElement("grunnkapital", Order = 1)]
+    [JsonProperty("grunnkapital")]
+    [JsonPropertyName("grunnkapital")]
+    public GrunnkapitalTilleggReduksjonEgenkapital grunnkapital { get; set; }
+
+    [XmlElement("formaalskapitalLovpaalagteRestriksjoner", Order = 2)]
+    [JsonProperty("formaalskapitalLovpaalagteRestriksjoner")]
+    [JsonPropertyName("formaalskapitalLovpaalagteRestriksjoner")]
+    public FormaalskapitalLovpaalagteRestriksjonerPoster formaalskapitalLovpaalagteRestriksjoner { get; set; }
+
+    [XmlElement("formaalskapitalEksterntPaalagteRestriksjoner", Order = 3)]
+    [JsonProperty("formaalskapitalEksterntPaalagteRestriksjoner")]
+    [JsonPropertyName("formaalskapitalEksterntPaalagteRestriksjoner")]
+    public FormaalskapitalEksterntPaalagteRestriksjonerTilleggReduksjonEgenkapital formaalskapitalEksterntPaalagteRestriksjoner { get; set; }
+
+    [XmlElement("formaalskapitalSelvpaalagteRestriksjoner", Order = 4)]
+    [JsonProperty("formaalskapitalSelvpaalagteRestriksjoner")]
+    [JsonPropertyName("formaalskapitalSelvpaalagteRestriksjoner")]
+    public FormaalskapitalSelvpaalagteRestriksjonerPoster formaalskapitalSelvpaalagteRestriksjoner { get; set; }
+
+    [XmlElement("annenFormaalskapital", Order = 5)]
+    [JsonProperty("annenFormaalskapital")]
+    [JsonPropertyName("annenFormaalskapital")]
+    public AnnenFormaalskapitalTilleggReduksjonEgenkapital annenFormaalskapital { get; set; }
+
+  }
+
+  public class GrunnkapitalTilleggReduksjonEgenkapital
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteGrunnkapital30815 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Grunnkapital30816 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public GrunnkapitalFjoraret30817 fjoraarets { get; set; }
+
+  }
+
+  public class NoteGrunnkapital30815
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30815";
+
+  }
+
+  public class Grunnkapital30816
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30816";
+
+  }
+
+  public class GrunnkapitalFjoraret30817
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30817";
+
+  }
+
+  public class FormaalskapitalLovpaalagteRestriksjonerPoster
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalRestriksjonerLovpalagte33445 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalRestriksjonerLovpalagte33446 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalRestriksjonerLovpalagteFjoraret33447 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalRestriksjonerLovpalagte33445
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33445";
+
+  }
+
+  public class FormalskapitalRestriksjonerLovpalagte33446
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33446";
+
+  }
+
+  public class FormalskapitalRestriksjonerLovpalagteFjoraret33447
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33447";
+
+  }
+
+  public class FormaalskapitalEksterntPaalagteRestriksjonerTilleggReduksjonEgenkapital
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalRestriksjonerEksterntPalagt33448 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalRestriksjonerEksterntPalagt33449 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalRestriksjonerEksterntPalagtFjoraret33450 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalRestriksjonerEksterntPalagt33448
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33448";
+
+  }
+
+  public class FormalskapitalRestriksjonerEksterntPalagt33449
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33449";
+
+  }
+
+  public class FormalskapitalRestriksjonerEksterntPalagtFjoraret33450
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33450";
+
+  }
+
+  public class FormaalskapitalSelvpaalagteRestriksjonerPoster
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalRestriksjonerSelvpalagte33451 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalRestriksjonerSelvpalagte33452 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalRestriksjonerSelvpalagteFjoraret33453 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalRestriksjonerSelvpalagte33451
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33451";
+
+  }
+
+  public class FormalskapitalRestriksjonerSelvpalagte33452
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33452";
+
+  }
+
+  public class FormalskapitalRestriksjonerSelvpalagteFjoraret33453
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33453";
+
+  }
+
+  public class AnnenFormaalskapitalTilleggReduksjonEgenkapital
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalAnnen33454 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalAnnen33455 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalAnnenFjoraret33456 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalAnnen33454
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33454";
+
+  }
+
+  public class FormalskapitalAnnen33455
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33455";
+
+  }
+
+  public class FormalskapitalAnnenFjoraret33456
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33456";
+
+  }
+
+  public class BalanseEiendelerAnleggsmidler
+  {
+    [XmlElement("immaterielleEiendeler", Order = 1)]
+    [JsonProperty("immaterielleEiendeler")]
+    [JsonPropertyName("immaterielleEiendeler")]
+    public ImmaterielleEiendeler immaterielleEiendeler { get; set; }
+
+    [XmlElement("bevaringsverdigeEiendeler", Order = 2)]
+    [JsonProperty("bevaringsverdigeEiendeler")]
+    [JsonPropertyName("bevaringsverdigeEiendeler")]
+    public BevaringsverdigeEiendeler bevaringsverdigeEiendeler { get; set; }
+
+    [XmlElement("andreDriftsmidler", Order = 3)]
+    [JsonProperty("andreDriftsmidler")]
+    [JsonPropertyName("andreDriftsmidler")]
+    public AndreDriftsmidler andreDriftsmidler { get; set; }
+
+    [XmlElement("finansielleAnleggsmidler", Order = 4)]
+    [JsonProperty("finansielleAnleggsmidler")]
+    [JsonPropertyName("finansielleAnleggsmidler")]
+    public FinansielleAnleggsmidler finansielleAnleggsmidler { get; set; }
+
+  }
+
+  public class ImmaterielleEiendeler
+  {
+    [XmlElement("konsesjonerPatenterLisenserVaremerkerRettigheter", Order = 1)]
+    [JsonProperty("konsesjonerPatenterLisenserVaremerkerRettigheter")]
+    [JsonPropertyName("konsesjonerPatenterLisenserVaremerkerRettigheter")]
+    public KonsesjonerPatenterLisenserVaremerkerRettigheter konsesjonerPatenterLisenserVaremerkerRettigheter { get; set; }
+
+    [XmlElement("utsattSkattefordel", Order = 2)]
+    [JsonProperty("utsattSkattefordel")]
+    [JsonPropertyName("utsattSkattefordel")]
+    public UtsattSkattefordel utsattSkattefordel { get; set; }
+
+    [XmlElement("goodwill", Order = 3)]
+    [JsonProperty("goodwill")]
+    [JsonPropertyName("goodwill")]
+    public Goodwill goodwill { get; set; }
+
+    [XmlElement("sumImmaterielleEiendeler", Order = 4)]
+    [JsonProperty("sumImmaterielleEiendeler")]
+    [JsonPropertyName("sumImmaterielleEiendeler")]
+    public SumImmaterielleEiendeler sumImmaterielleEiendeler { get; set; }
+
+  }
+
+  public class KonsesjonerPatenterLisenserVaremerkerRettigheter
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NotePatenterRettigheter18560 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public PatenterRettigheter205 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public PatenterRettigheterFjoraret7075 fjoraarets { get; set; }
+
+  }
+
+  public class NotePatenterRettigheter18560
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18560";
+
+  }
+
+  public class PatenterRettigheter205
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "205";
+
+  }
+
+  public class PatenterRettigheterFjoraret7075
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7075";
+
+  }
+
+  public class UtsattSkattefordel
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteSkattefordelUtsatt18182 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public SkattefordelUtsatt202 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public SkattefordelUtsattFjoraret7076 fjoraarets { get; set; }
+
+  }
+
+  public class NoteSkattefordelUtsatt18182
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18182";
+
+  }
+
+  public class SkattefordelUtsatt202
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "202";
+
+  }
+
+  public class SkattefordelUtsattFjoraret7076
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7076";
+
+  }
+
+  public class Goodwill
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteForretningsverdiGoodwill18183 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public ForretningsverdiGoodwill206 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public ForretningsverdiGoodwillFjoraret7077 fjoraarets { get; set; }
+
+  }
+
+  public class NoteForretningsverdiGoodwill18183
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18183";
+
+  }
+
+  public class ForretningsverdiGoodwill206
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "206";
+
+  }
+
+  public class ForretningsverdiGoodwillFjoraret7077
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7077";
+
+  }
+
+  public class SumImmaterielleEiendeler
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteEiendelerImmaterielle18180 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public EiendelerImmaterielle2400 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public EiendelerImmaterielleFjoraret8006 fjoraarets { get; set; }
+
+  }
+
+  public class NoteEiendelerImmaterielle18180
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18180";
+
+  }
+
+  public class EiendelerImmaterielle2400
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "2400";
+
+  }
+
+  public class EiendelerImmaterielleFjoraret8006
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "8006";
+
+  }
+
+  public class BevaringsverdigeEiendeler
+  {
+    [XmlElement("tomterBygningerAnnenFastEiendom", Order = 1)]
+    [JsonProperty("tomterBygningerAnnenFastEiendom")]
+    [JsonPropertyName("tomterBygningerAnnenFastEiendom")]
+    public TomterBygningerAnnenFastEiendom tomterBygningerAnnenFastEiendom { get; set; }
+
+    [XmlElement("driftsloesoereInventarVerktoeyKontormaskiner", Order = 2)]
+    [JsonProperty("driftsloesoereInventarVerktoeyKontormaskiner")]
+    [JsonPropertyName("driftsloesoereInventarVerktoeyKontormaskiner")]
+    public DriftsloesoereInventarVerktoeyKontormaskiner driftsloesoereInventarVerktoeyKontormaskiner { get; set; }
+
+    [XmlElement("sumBevaringsverdigeEiendeler", Order = 3)]
+    [JsonProperty("sumBevaringsverdigeEiendeler")]
+    [JsonPropertyName("sumBevaringsverdigeEiendeler")]
+    public SumBevaringsverdigeEiendeler sumBevaringsverdigeEiendeler { get; set; }
+
+  }
+
+  public class TomterBygningerAnnenFastEiendom
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFastEiendom18178 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FastEiendom1976 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FastEiendomFjoraret8007 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFastEiendom18178
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18178";
+
+  }
+
+  public class FastEiendom1976
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "1976";
+
+  }
+
+  public class FastEiendomFjoraret8007
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "8007";
+
+  }
+
+  public class DriftsloesoereInventarVerktoeyKontormaskiner
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteKjoretoyInventarVerktoyMv18562 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public KjoretoyInventarVerktoyMv7725 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public KjoretoyInventarVerktoyMvFjoraret8009 fjoraarets { get; set; }
+
+  }
+
+  public class NoteKjoretoyInventarVerktoyMv18562
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18562";
+
+  }
+
+  public class KjoretoyInventarVerktoyMv7725
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7725";
+
+  }
+
+  public class KjoretoyInventarVerktoyMvFjoraret8009
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "8009";
+
+  }
+
+  public class SumBevaringsverdigeEiendeler
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteDriftsmidlerVarige18176 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public DriftsmidlerVarige47 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public DriftsmidlerVarigeFjoraret8010 fjoraarets { get; set; }
+
+  }
+
+  public class NoteDriftsmidlerVarige18176
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18176";
+
+  }
+
+  public class DriftsmidlerVarige47
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "47";
+
+  }
+
+  public class DriftsmidlerVarigeFjoraret8010
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "8010";
+
+  }
+
+  public class AndreDriftsmidler
+  {
+    [XmlElement("andreDriftsmidler", Order = 1)]
+    [JsonProperty("andreDriftsmidler")]
+    [JsonPropertyName("andreDriftsmidler")]
+    public AndreDriftsmidlerPoster andreDriftsmidler { get; set; }
+
+    [XmlElement("sumAndreDriftsmidler", Order = 2)]
+    [JsonProperty("sumAndreDriftsmidler")]
+    [JsonPropertyName("sumAndreDriftsmidler")]
+    public SumAndreDriftsmidler sumAndreDriftsmidler { get; set; }
+
+  }
+
+  public class AndreDriftsmidlerPoster
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteDriftsmidlerAndre18177 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public DriftsmidlerAndre2836 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public DriftsmidlerAndreFjoraret7088 fjoraarets { get; set; }
+
+  }
+
+  public class NoteDriftsmidlerAndre18177
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18177";
+
+  }
+
+  public class DriftsmidlerAndre2836
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "2836";
+
+  }
+
+  public class DriftsmidlerAndreFjoraret7088
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7088";
+
+  }
+
+  public class SumAndreDriftsmidler
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteDriftsmidlerAndre30979 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public DriftsmidlerAndre30980 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public DriftsmidlerAndreFjoraret30981 fjoraarets { get; set; }
+
+  }
+
+  public class NoteDriftsmidlerAndre30979
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30979";
+
+  }
+
+  public class DriftsmidlerAndre30980
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30980";
+
+  }
+
+  public class DriftsmidlerAndreFjoraret30981
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30981";
+
+  }
+
+  public class FinansielleAnleggsmidler
+  {
+    [XmlElement("investeringDatterselskap", Order = 1)]
+    [JsonProperty("investeringDatterselskap")]
+    [JsonPropertyName("investeringDatterselskap")]
+    public InvesteringDatterselskap investeringDatterselskap { get; set; }
+
+    [XmlElement("investeringAksjerAndeler", Order = 2)]
+    [JsonProperty("investeringAksjerAndeler")]
+    [JsonPropertyName("investeringAksjerAndeler")]
+    public InvesteringAksjerAndeler investeringAksjerAndeler { get; set; }
+
+    [XmlElement("obligasjoner", Order = 3)]
+    [JsonProperty("obligasjoner")]
+    [JsonPropertyName("obligasjoner")]
+    public Obligasjoner obligasjoner { get; set; }
+
+    [XmlElement("andreFordringer", Order = 4)]
+    [JsonProperty("andreFordringer")]
+    [JsonPropertyName("andreFordringer")]
+    public AndreFordringerFinansielleAnleggsmidler andreFordringer { get; set; }
+
+    [XmlElement("sumFinansielleAnleggsmidler", Order = 5)]
+    [JsonProperty("sumFinansielleAnleggsmidler")]
+    [JsonPropertyName("sumFinansielleAnleggsmidler")]
+    public SumFinansielleAnleggsmidler sumFinansielleAnleggsmidler { get; set; }
+
+    [XmlElement("sumAnleggsmidler", Order = 6)]
+    [JsonProperty("sumAnleggsmidler")]
+    [JsonPropertyName("sumAnleggsmidler")]
+    public SumAnleggsmidler sumAnleggsmidler { get; set; }
+
+  }
+
+  public class InvesteringDatterselskap
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteInvesteringerDatterselskap18563 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public InvesteringerDatterselskap9686 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public InvesteringerDatterselskapFjoraret10289 fjoraarets { get; set; }
+
+  }
+
+  public class NoteInvesteringerDatterselskap18563
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18563";
+
+  }
+
+  public class InvesteringerDatterselskap9686
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "9686";
+
+  }
+
+  public class InvesteringerDatterselskapFjoraret10289
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "10289";
+
+  }
+
+  public class InvesteringAksjerAndeler
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteInvesteringerAksjerAndeler18568 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public InvesteringerAksjerAndeler7100 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public InvesteringerAksjerAndelerFjoraret7101 fjoraarets { get; set; }
+
+  }
+
+  public class NoteInvesteringerAksjerAndeler18568
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18568";
+
+  }
+
+  public class InvesteringerAksjerAndeler7100
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7100";
+
+  }
+
+  public class InvesteringerAksjerAndelerFjoraret7101
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7101";
+
+  }
+
+  public class Obligasjoner
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteObligasjonerLangsiktige27582 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public ObligasjonerLangsiktige27583 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public ObligasjonerLangsiktigeFjoraret27584 fjoraarets { get; set; }
+
+  }
+
+  public class NoteObligasjonerLangsiktige27582
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "27582";
+
+  }
+
+  public class ObligasjonerLangsiktige27583
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "27583";
+
+  }
+
+  public class ObligasjonerLangsiktigeFjoraret27584
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "27584";
+
+  }
+
+  public class AndreFordringerFinansielleAnleggsmidler
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFordringerAndreLangsiktige27578 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FordringerAndreLangsiktige203 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FordringerAndreLangsiktigeFjoraret27585 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFordringerAndreLangsiktige27578
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "27578";
+
+  }
+
+  public class FordringerAndreLangsiktige203
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "203";
+
+  }
+
+  public class FordringerAndreLangsiktigeFjoraret27585
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "27585";
+
+  }
+
+  public class SumFinansielleAnleggsmidler
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteAnleggsmidlerFinansielle18372 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public AnleggsmidlerFinansielle5267 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public AnleggsmidlerFinansielleFjoraret8014 fjoraarets { get; set; }
+
+  }
+
+  public class NoteAnleggsmidlerFinansielle18372
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18372";
+
+  }
+
+  public class AnleggsmidlerFinansielle5267
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "5267";
+
+  }
+
+  public class AnleggsmidlerFinansielleFjoraret8014
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "8014";
+
+  }
+
+  public class SumAnleggsmidler
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteAnleggsmidler18570 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Anleggsmidler217 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public AnleggsmidlerFjoraret7108 fjoraarets { get; set; }
+
+  }
+
+  public class NoteAnleggsmidler18570
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18570";
+
+  }
+
+  public class Anleggsmidler217
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "217";
+
+  }
+
+  public class AnleggsmidlerFjoraret7108
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7108";
+
+  }
+
+  public class BalanseEiendelerOmloepsmidler
+  {
+    [XmlElement("beholdninger", Order = 1)]
+    [JsonProperty("beholdninger")]
+    [JsonPropertyName("beholdninger")]
+    public Beholdninger beholdninger { get; set; }
+
+    [XmlElement("fordringer", Order = 2)]
+    [JsonProperty("fordringer")]
+    [JsonPropertyName("fordringer")]
+    public Fordringer fordringer { get; set; }
+
+    [XmlElement("investeringer", Order = 3)]
+    [JsonProperty("investeringer")]
+    [JsonPropertyName("investeringer")]
+    public Investeringer investeringer { get; set; }
+
+    [XmlElement("bankinnskuddKontanter", Order = 4)]
+    [JsonProperty("bankinnskuddKontanter")]
+    [JsonPropertyName("bankinnskuddKontanter")]
+    public BankinnskuddKontanter bankinnskuddKontanter { get; set; }
+
+  }
+
+  public class Beholdninger
+  {
+    [XmlElement("lagerbeholdning", Order = 1)]
+    [JsonProperty("lagerbeholdning")]
+    [JsonPropertyName("lagerbeholdning")]
+    public Lagerbeholdning lagerbeholdning { get; set; }
+
+    [XmlElement("sumBeholdninger", Order = 2)]
+    [JsonProperty("sumBeholdninger")]
+    [JsonPropertyName("sumBeholdninger")]
+    public SumBeholdninger sumBeholdninger { get; set; }
+
+  }
+
+  public class Lagerbeholdning
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteLagerbeholdning30822 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Lagerbeholdning30823 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public LagerbeholdningFjoraret30824 fjoraarets { get; set; }
+
+  }
+
+  public class NoteLagerbeholdning30822
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30822";
+
+  }
+
+  public class Lagerbeholdning30823
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30823";
+
+  }
+
+  public class LagerbeholdningFjoraret30824
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30824";
+
+  }
+
+  public class SumBeholdninger
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteLagerbeholdning18571 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Lagerbeholdning326 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public LagerbeholdningFjoraret797 fjoraarets { get; set; }
+
+  }
+
+  public class NoteLagerbeholdning18571
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18571";
+
+  }
+
+  public class Lagerbeholdning326
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "326";
+
+  }
+
+  public class LagerbeholdningFjoraret797
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "797";
+
+  }
+
+  public class Fordringer
+  {
+    [XmlElement("kundefordringer", Order = 1)]
+    [JsonProperty("kundefordringer")]
+    [JsonPropertyName("kundefordringer")]
+    public Kundefordringer kundefordringer { get; set; }
+
+    [XmlElement("andreFordringer", Order = 2)]
+    [JsonProperty("andreFordringer")]
+    [JsonPropertyName("andreFordringer")]
+    public AndreFordringer andreFordringer { get; set; }
+
+    [XmlElement("sumFordringer", Order = 3)]
+    [JsonProperty("sumFordringer")]
+    [JsonPropertyName("sumFordringer")]
+    public SumFordringer sumFordringer { get; set; }
+
+  }
+
+  public class Kundefordringer
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFordringerKunder18384 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FordringerKunder116 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FordringerKunderFjoraret6921 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFordringerKunder18384
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18384";
+
+  }
+
+  public class FordringerKunder116
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "116";
+
+  }
+
+  public class FordringerKunderFjoraret6921
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "6921";
+
+  }
+
+  public class AndreFordringer
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFordringerAndreKortsiktig18572 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FordringerAndreKortsiktig282 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FordringerAndreKortsiktigFjoraret7112 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFordringerAndreKortsiktig18572
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18572";
+
+  }
+
+  public class FordringerAndreKortsiktig282
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "282";
+
+  }
+
+  public class FordringerAndreKortsiktigFjoraret7112
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7112";
+
+  }
+
+  public class SumFordringer
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFordringer18389 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Fordringer80 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FordringerFjoraret8015 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFordringer18389
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18389";
+
+  }
+
+  public class Fordringer80
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "80";
+
+  }
+
+  public class FordringerFjoraret8015
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "8015";
+
+  }
+
+  public class Investeringer
+  {
+    [XmlElement("markedsbaserteAksjer", Order = 1)]
+    [JsonProperty("markedsbaserteAksjer")]
+    [JsonPropertyName("markedsbaserteAksjer")]
+    public MarkedsbaserteAksjer markedsbaserteAksjer { get; set; }
+
+    [XmlElement("andreMarkedsbaserteFinansielleInstrumenter", Order = 2)]
+    [JsonProperty("andreMarkedsbaserteFinansielleInstrumenter")]
+    [JsonPropertyName("andreMarkedsbaserteFinansielleInstrumenter")]
+    public AndreMarkedsbaserteFinansielleInstrumenter andreMarkedsbaserteFinansielleInstrumenter { get; set; }
+
+    [XmlElement("andreFinansielleInstrumenter", Order = 3)]
+    [JsonProperty("andreFinansielleInstrumenter")]
+    [JsonPropertyName("andreFinansielleInstrumenter")]
+    public AndreFinansielleInstrumenter andreFinansielleInstrumenter { get; set; }
+
+    [XmlElement("sumInvesteringer", Order = 4)]
+    [JsonProperty("sumInvesteringer")]
+    [JsonPropertyName("sumInvesteringer")]
+    public SumInvesteringer sumInvesteringer { get; set; }
+
+  }
+
+  public class MarkedsbaserteAksjer
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteAksjerMvMarkedsbaserte18575 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public AksjerMvMarkedsbaserte7117 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public AksjerMvMarkedsbaserteFjoraret7118 fjoraarets { get; set; }
+
+  }
+
+  public class NoteAksjerMvMarkedsbaserte18575
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18575";
+
+  }
+
+  public class AksjerMvMarkedsbaserte7117
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7117";
+
+  }
+
+  public class AksjerMvMarkedsbaserteFjoraret7118
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7118";
+
+  }
+
+  public class AndreMarkedsbaserteFinansielleInstrumenter
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFinansielleInstrumenterMarkedsbaserteAndre18577 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FinansielleInstrumenterMarkedsbaserteAndre7731 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FinansielleInstrumenterMarkedsbaserteAndreFjoraret8017 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFinansielleInstrumenterMarkedsbaserteAndre18577
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18577";
+
+  }
+
+  public class FinansielleInstrumenterMarkedsbaserteAndre7731
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7731";
+
+  }
+
+  public class FinansielleInstrumenterMarkedsbaserteAndreFjoraret8017
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "8017";
+
+  }
+
+  public class AndreFinansielleInstrumenter
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFinansielleInstrumenterAndre18578 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FinansielleInstrumenterAndre6429 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FinansielleInstrumenterAndreFjoraret7123 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFinansielleInstrumenterAndre18578
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18578";
+
+  }
+
+  public class FinansielleInstrumenterAndre6429
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "6429";
+
+  }
+
+  public class FinansielleInstrumenterAndreFjoraret7123
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7123";
+
+  }
+
+  public class SumInvesteringer
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteInvesteringer18579 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Investeringer6601 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public InvesteringerFjoraret8018 fjoraarets { get; set; }
+
+  }
+
+  public class NoteInvesteringer18579
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18579";
+
+  }
+
+  public class Investeringer6601
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "6601";
+
+  }
+
+  public class InvesteringerFjoraret8018
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "8018";
+
+  }
+
+  public class BankinnskuddKontanter
+  {
+    [XmlElement("bankinnskuddKontanter", Order = 1)]
+    [JsonProperty("bankinnskuddKontanter")]
+    [JsonPropertyName("bankinnskuddKontanter")]
+    public BankinnskuddKontanterPoster bankinnskuddKontanter { get; set; }
+
+    [XmlElement("sumBankinnskuddKontanter", Order = 2)]
+    [JsonProperty("sumBankinnskuddKontanter")]
+    [JsonPropertyName("sumBankinnskuddKontanter")]
+    public SumBankinnskuddKontanter sumBankinnskuddKontanter { get; set; }
+
+    [XmlElement("sumOmloepsmidler", Order = 3)]
+    [JsonProperty("sumOmloepsmidler")]
+    [JsonPropertyName("sumOmloepsmidler")]
+    public SumOmloepsmidler sumOmloepsmidler { get; set; }
+
+    [XmlElement("sumEiendeler", Order = 4)]
+    [JsonProperty("sumEiendeler")]
+    [JsonPropertyName("sumEiendeler")]
+    public SumEiendeler sumEiendeler { get; set; }
+
+  }
+
+  public class BankinnskuddKontanterPoster
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteKontanterBankinnskudd18390 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public KontanterBankinnskudd786 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public KontanterBankinnskuddFjoraret8019 fjoraarets { get; set; }
+
+  }
+
+  public class NoteKontanterBankinnskudd18390
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18390";
+
+  }
+
+  public class KontanterBankinnskudd786
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "786";
+
+  }
+
+  public class KontanterBankinnskuddFjoraret8019
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "8019";
+
+  }
+
+  public class SumBankinnskuddKontanter
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteKontanterBankinnskuddSum29041 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public KontanterBankinnskuddSum29042 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public KontanterBankinnskuddSumFjoraret29043 fjoraarets { get; set; }
+
+  }
+
+  public class NoteKontanterBankinnskuddSum29041
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "29041";
+
+  }
+
+  public class KontanterBankinnskuddSum29042
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "29042";
+
+  }
+
+  public class KontanterBankinnskuddSumFjoraret29043
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "29043";
+
+  }
+
+  public class SumOmloepsmidler
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteOmlopsmidler18580 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Omlopsmidler194 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public OmlopsmidlerFjoraret7126 fjoraarets { get; set; }
+
+  }
+
+  public class NoteOmlopsmidler18580
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18580";
+
+  }
+
+  public class Omlopsmidler194
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "194";
+
+  }
+
+  public class OmlopsmidlerFjoraret7126
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7126";
+
+  }
+
+  public class SumEiendeler
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteEiendeler18167 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Eiendeler219 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public EiendelerFjoraret7127 fjoraarets { get; set; }
+
+  }
+
+  public class NoteEiendeler18167
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18167";
+
+  }
+
+  public class Eiendeler219
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "219";
+
+  }
+
+  public class EiendelerFjoraret7127
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7127";
+
+  }
+
+  public class BalanseFormaalskapital
+  {
+    [XmlElement("grunnkapital", Order = 1)]
+    [JsonProperty("grunnkapital")]
+    [JsonPropertyName("grunnkapital")]
+    public Grunnkapital grunnkapital { get; set; }
+
+    [XmlElement("formaalskapitalLovpaalagteRestriksjoner", Order = 2)]
+    [JsonProperty("formaalskapitalLovpaalagteRestriksjoner")]
+    [JsonPropertyName("formaalskapitalLovpaalagteRestriksjoner")]
+    public FormaalskapitalLovpaalagteRestriksjoner formaalskapitalLovpaalagteRestriksjoner { get; set; }
+
+    [XmlElement("formaalskapitalEksterntPaalagteRestriksjoner", Order = 3)]
+    [JsonProperty("formaalskapitalEksterntPaalagteRestriksjoner")]
+    [JsonPropertyName("formaalskapitalEksterntPaalagteRestriksjoner")]
+    public FormaalskapitalEksterntPaalagteRestriksjoner formaalskapitalEksterntPaalagteRestriksjoner { get; set; }
+
+    [XmlElement("formaalskapitalSelvpaalagteRestriksjoner", Order = 4)]
+    [JsonProperty("formaalskapitalSelvpaalagteRestriksjoner")]
+    [JsonPropertyName("formaalskapitalSelvpaalagteRestriksjoner")]
+    public FormaalskapitalSelvpaalagteRestriksjoner formaalskapitalSelvpaalagteRestriksjoner { get; set; }
+
+  }
+
+  public class Grunnkapital
+  {
+    [XmlElement("grunnkapital", Order = 1)]
+    [JsonProperty("grunnkapital")]
+    [JsonPropertyName("grunnkapital")]
+    public GrunnkapitalPoster grunnkapital { get; set; }
+
+    [XmlElement("annenInnskuttFormaalskapital", Order = 2)]
+    [JsonProperty("annenInnskuttFormaalskapital")]
+    [JsonPropertyName("annenInnskuttFormaalskapital")]
+    public AnnenInnskuttFormaalskapital annenInnskuttFormaalskapital { get; set; }
+
+    [XmlElement("sumInnskuttFormaalskapital", Order = 3)]
+    [JsonProperty("sumInnskuttFormaalskapital")]
+    [JsonPropertyName("sumInnskuttFormaalskapital")]
+    public SumInnskuttFormaalskapital sumInnskuttFormaalskapital { get; set; }
+
+  }
+
+  public class GrunnkapitalPoster
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteGrunnkapital30819 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Grunnkapital30820 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public GrunnkapitalFjoraret30821 fjoraarets { get; set; }
+
+  }
+
+  public class NoteGrunnkapital30819
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30819";
+
+  }
+
+  public class Grunnkapital30820
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30820";
+
+  }
+
+  public class GrunnkapitalFjoraret30821
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "30821";
+
+  }
+
+  public class AnnenInnskuttFormaalskapital
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalInnskuttAnnen33457 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalInnskuttAnnen33458 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalInnskuttAnnenFjoraret33459 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalInnskuttAnnen33457
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33457";
+
+  }
+
+  public class FormalskapitalInnskuttAnnen33458
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33458";
+
+  }
+
+  public class FormalskapitalInnskuttAnnenFjoraret33459
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33459";
+
+  }
+
+  public class SumInnskuttFormaalskapital
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalInnskuttSum33460 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalInnskuttSum33461 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public AktiviteterOppfyllerOrganisasjonensFormalFjoraret33426 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalInnskuttSum33460
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33460";
+
+  }
+
+  public class FormalskapitalInnskuttSum33461
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33461";
+
+  }
+
+  public class FormaalskapitalLovpaalagteRestriksjoner
+  {
+    [XmlElement("annenFormaalskapitalLovpaalagteRestriksjoner", Order = 1)]
+    [JsonProperty("annenFormaalskapitalLovpaalagteRestriksjoner")]
+    [JsonPropertyName("annenFormaalskapitalLovpaalagteRestriksjoner")]
+    public AnnenFormaalskapitalLovpaalagteRestriksjoner annenFormaalskapitalLovpaalagteRestriksjoner { get; set; }
+
+    [XmlElement("sumOpptjentFormaalskapitalLovpaalagteRestriksjoner", Order = 2)]
+    [JsonProperty("sumOpptjentFormaalskapitalLovpaalagteRestriksjoner")]
+    [JsonPropertyName("sumOpptjentFormaalskapitalLovpaalagteRestriksjoner")]
+    public SumOpptjentFormaalskapitalLovpaalagteRestriksjoner sumOpptjentFormaalskapitalLovpaalagteRestriksjoner { get; set; }
+
+  }
+
+  public class AnnenFormaalskapitalLovpaalagteRestriksjoner
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalAnnenRestriksjonerLovpalagte33463 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalAnnenRestriksjonerLovpalagte33464 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalAnnenRestriksjonerLovpalagteFjoraret33465 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalAnnenRestriksjonerLovpalagte33463
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33463";
+
+  }
+
+  public class FormalskapitalAnnenRestriksjonerLovpalagte33464
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33464";
+
+  }
+
+  public class FormalskapitalAnnenRestriksjonerLovpalagteFjoraret33465
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33465";
+
+  }
+
+  public class SumOpptjentFormaalskapitalLovpaalagteRestriksjoner
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalOpptjentSumRestriksjonerLovpalagte33466 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalOpptjentSumRestriksjonerLovpalagte33467 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalOpptjentSumRestriksjonerLovpalagteFjoraret33468 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalOpptjentSumRestriksjonerLovpalagte33466
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33466";
+
+  }
+
+  public class FormalskapitalOpptjentSumRestriksjonerLovpalagte33467
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33467";
+
+  }
+
+  public class FormalskapitalOpptjentSumRestriksjonerLovpalagteFjoraret33468
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33468";
+
+  }
+
+  public class FormaalskapitalEksterntPaalagteRestriksjoner
+  {
+    [XmlElement("annenFormaalskapitalEksterntPaalagteRestriksjoner", Order = 1)]
+    [JsonProperty("annenFormaalskapitalEksterntPaalagteRestriksjoner")]
+    [JsonPropertyName("annenFormaalskapitalEksterntPaalagteRestriksjoner")]
+    public AnnenFormaalskapitalEksterntPaalagteRestriksjoner annenFormaalskapitalEksterntPaalagteRestriksjoner { get; set; }
+
+    [XmlElement("sumFormaalskapitalEksterntPaalagteRestriksjoner", Order = 2)]
+    [JsonProperty("sumFormaalskapitalEksterntPaalagteRestriksjoner")]
+    [JsonPropertyName("sumFormaalskapitalEksterntPaalagteRestriksjoner")]
+    public SumFormaalskapitalEksterntPaalagteRestriksjoner sumFormaalskapitalEksterntPaalagteRestriksjoner { get; set; }
+
+  }
+
+  public class AnnenFormaalskapitalEksterntPaalagteRestriksjoner
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalAnnenRestriksjonerEksterntPalagte33469 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalAnnenRestriksjonerEksterntPalagte33470 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalAnnenRestriksjonerEksterntPalagteFjoraret33471 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalAnnenRestriksjonerEksterntPalagte33469
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33469";
+
+  }
+
+  public class FormalskapitalAnnenRestriksjonerEksterntPalagte33470
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33470";
+
+  }
+
+  public class FormalskapitalAnnenRestriksjonerEksterntPalagteFjoraret33471
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33471";
+
+  }
+
+  public class SumFormaalskapitalEksterntPaalagteRestriksjoner
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalSumRestriksjonerEksterntPalagte33472 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalSumRestriksjonerEksterntPalagte33473 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalSumRestriksjonerEksterntPalagteFjoraret33474 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalSumRestriksjonerEksterntPalagte33472
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33472";
+
+  }
+
+  public class FormalskapitalSumRestriksjonerEksterntPalagte33473
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33473";
+
+  }
+
+  public class FormalskapitalSumRestriksjonerEksterntPalagteFjoraret33474
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33474";
+
+  }
+
+  public class FormaalskapitalSelvpaalagteRestriksjoner
+  {
+    [XmlElement("annenFormaalskapitalSelvpaalagteRestriksjoner", Order = 1)]
+    [JsonProperty("annenFormaalskapitalSelvpaalagteRestriksjoner")]
+    [JsonPropertyName("annenFormaalskapitalSelvpaalagteRestriksjoner")]
+    public AnnenFormaalskapitalSelvpaalagteRestriksjoner annenFormaalskapitalSelvpaalagteRestriksjoner { get; set; }
+
+    [XmlElement("sumFormaalskapitalSelvpaalagteRestriksjoner", Order = 2)]
+    [JsonProperty("sumFormaalskapitalSelvpaalagteRestriksjoner")]
+    [JsonPropertyName("sumFormaalskapitalSelvpaalagteRestriksjoner")]
+    public SumFormaalskapitalSelvpaalagteRestriksjoner sumFormaalskapitalSelvpaalagteRestriksjoner { get; set; }
+
+    [XmlElement("annenFormaalskapital", Order = 3)]
+    [JsonProperty("annenFormaalskapital")]
+    [JsonPropertyName("annenFormaalskapital")]
+    public AnnenFormaalskapital annenFormaalskapital { get; set; }
+
+    [XmlElement("minoritetsinteresser", Order = 4)]
+    [JsonProperty("minoritetsinteresser")]
+    [JsonPropertyName("minoritetsinteresser")]
+    public MinoritetsinteresserFormaalskapitalSelvpaalagteRestriksjoner minoritetsinteresser { get; set; }
+
+    [XmlElement("sumFormaalskapital", Order = 5)]
+    [JsonProperty("sumFormaalskapital")]
+    [JsonPropertyName("sumFormaalskapital")]
+    public SumFormaalskapital sumFormaalskapital { get; set; }
+
+  }
+
+  public class AnnenFormaalskapitalSelvpaalagteRestriksjoner
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalAnnenRestriksjonerSelpalagte33475 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalAnnenRestriksjonerSelvpalagte33476 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalAnnenRestriksjonerSelvpalagteFjoraret33477 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalAnnenRestriksjonerSelpalagte33475
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33475";
+
+  }
+
+  public class FormalskapitalAnnenRestriksjonerSelvpalagte33476
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33476";
+
+  }
+
+  public class FormalskapitalAnnenRestriksjonerSelvpalagteFjoraret33477
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33477";
+
+  }
+
+  public class SumFormaalskapitalSelvpaalagteRestriksjoner
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalSumRestriksjonerSelvpalagte33478 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalSumRestriksjonerSelvpalagte33479 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalSumRestriksjonerSelvpalagteFjoraret33480 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalSumRestriksjonerSelvpalagte33478
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33478";
+
+  }
+
+  public class FormalskapitalSumRestriksjonerSelvpalagte33479
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33479";
+
+  }
+
+  public class FormalskapitalSumRestriksjonerSelvpalagteFjoraret33480
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33480";
+
+  }
+
+  public class AnnenFormaalskapital
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalAnnen33481 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalAnnen33482 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalAnnenFjoraret33483 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalAnnen33481
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33481";
+
+  }
+
+  public class FormalskapitalAnnen33482
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33482";
+
+  }
+
+  public class FormalskapitalAnnenFjoraret33483
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33483";
+
+  }
+
+  public class MinoritetsinteresserFormaalskapitalSelvpaalagteRestriksjoner
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteMinoritetsinteresser29044 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Minoritetsinteresser29045 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public MinoritetsinteresserFjoraret29046 fjoraarets { get; set; }
+
+  }
+
+  public class NoteMinoritetsinteresser29044
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "29044";
+
+  }
+
+  public class Minoritetsinteresser29045
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "29045";
+
+  }
+
+  public class MinoritetsinteresserFjoraret29046
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "29046";
+
+  }
+
+  public class SumFormaalskapital
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteFormalskapitalSum33484 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public FormalskapitalSum33485 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public FormalskapitalSumFjoraret33486 fjoraarets { get; set; }
+
+  }
+
+  public class NoteFormalskapitalSum33484
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33484";
+
+  }
+
+  public class FormalskapitalSum33485
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33485";
+
+  }
+
+  public class FormalskapitalSumFjoraret33486
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "33486";
+
+  }
+
+  public class BalanseGjeld
+  {
+    [XmlElement("avsetningerForForpliktelser", Order = 1)]
+    [JsonProperty("avsetningerForForpliktelser")]
+    [JsonPropertyName("avsetningerForForpliktelser")]
+    public AvsetningerForForpliktelser avsetningerForForpliktelser { get; set; }
+
+    [XmlElement("annenLangsiktigGjeld", Order = 2)]
+    [JsonProperty("annenLangsiktigGjeld")]
+    [JsonPropertyName("annenLangsiktigGjeld")]
+    public AnnenLangsiktigGjeld annenLangsiktigGjeld { get; set; }
+
+    [XmlElement("kortsiktigGjeld", Order = 3)]
+    [JsonProperty("kortsiktigGjeld")]
+    [JsonPropertyName("kortsiktigGjeld")]
+    public KortsiktigGjeld kortsiktigGjeld { get; set; }
+
+  }
+
+  public class AvsetningerForForpliktelser
+  {
+    [XmlElement("pensjonsforpliktelser", Order = 1)]
+    [JsonProperty("pensjonsforpliktelser")]
+    [JsonPropertyName("pensjonsforpliktelser")]
+    public Pensjonsforpliktelser pensjonsforpliktelser { get; set; }
+
+    [XmlElement("utsattSkatt", Order = 2)]
+    [JsonProperty("utsattSkatt")]
+    [JsonPropertyName("utsattSkatt")]
+    public UtsattSkatt utsattSkatt { get; set; }
+
+    [XmlElement("andreAvsetningerForpliktelser", Order = 3)]
+    [JsonProperty("andreAvsetningerForpliktelser")]
+    [JsonPropertyName("andreAvsetningerForpliktelser")]
+    public AndreAvsetningerForpliktelser andreAvsetningerForpliktelser { get; set; }
+
+    [XmlElement("sumAvsetningerForpliktelser", Order = 4)]
+    [JsonProperty("sumAvsetningerForpliktelser")]
+    [JsonPropertyName("sumAvsetningerForpliktelser")]
+    public SumAvsetningerForpliktelser sumAvsetningerForpliktelser { get; set; }
+
+  }
+
+  public class Pensjonsforpliktelser
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NotePensjonsforpliktelser18149 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Pensjonsforpliktelser238 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public PensjonsforpliktelserFjoraret6685 fjoraarets { get; set; }
+
+  }
+
+  public class NotePensjonsforpliktelser18149
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18149";
+
+  }
+
+  public class Pensjonsforpliktelser238
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "238";
+
+  }
+
+  public class PensjonsforpliktelserFjoraret6685
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "6685";
+
+  }
+
+  public class UtsattSkatt
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteSkattUtsatt18148 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public SkattUtsatt237 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public SkattUtsattFjoraret7143 fjoraarets { get; set; }
+
+  }
+
+  public class NoteSkattUtsatt18148
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18148";
+
+  }
+
+  public class SkattUtsatt237
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "237";
+
+  }
+
+  public class SkattUtsattFjoraret7143
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7143";
+
+  }
+
+  public class AndreAvsetningerForpliktelser
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteAvsetningerForpliktelserLangsiktig18582 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public AvsetningerForpliktelserLangsiktig7157 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public AvsetningerForpliktelserLangsiktigFjoraret7146 fjoraarets { get; set; }
+
+  }
+
+  public class NoteAvsetningerForpliktelserLangsiktig18582
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18582";
+
+  }
+
+  public class AvsetningerForpliktelserLangsiktig7157
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7157";
+
+  }
+
+  public class AvsetningerForpliktelserLangsiktigFjoraret7146
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7146";
+
+  }
+
+  public class SumAvsetningerForpliktelser
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteAvsetningerForpliktelser18144 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public AvsetningerForpliktelser7231 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public AvsetningerForpliktelserFjoraret7230 fjoraarets { get; set; }
+
+  }
+
+  public class NoteAvsetningerForpliktelser18144
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18144";
+
+  }
+
+  public class AvsetningerForpliktelser7231
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7231";
+
+  }
+
+  public class AvsetningerForpliktelserFjoraret7230
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7230";
+
+  }
+
+  public class AnnenLangsiktigGjeld
+  {
+    [XmlElement("gjeldKredittinstitusjoner", Order = 1)]
+    [JsonProperty("gjeldKredittinstitusjoner")]
+    [JsonPropertyName("gjeldKredittinstitusjoner")]
+    public GjeldKredittinstitusjoner gjeldKredittinstitusjoner { get; set; }
+
+    [XmlElement("oevrigLangsiktigGjeld", Order = 2)]
+    [JsonProperty("oevrigLangsiktigGjeld")]
+    [JsonPropertyName("oevrigLangsiktigGjeld")]
+    public OevrigLangsiktigGjeld oevrigLangsiktigGjeld { get; set; }
+
+    [XmlElement("sumAnnenLangsiktigGjeld", Order = 3)]
+    [JsonProperty("sumAnnenLangsiktigGjeld")]
+    [JsonPropertyName("sumAnnenLangsiktigGjeld")]
+    public SumAnnenLangsiktigGjeld sumAnnenLangsiktigGjeld { get; set; }
+
+    [XmlElement("sumLangsiktigGjeld", Order = 4)]
+    [JsonProperty("sumLangsiktigGjeld")]
+    [JsonPropertyName("sumLangsiktigGjeld")]
+    public SumLangsiktigGjeld sumLangsiktigGjeld { get; set; }
+
+  }
+
+  public class GjeldKredittinstitusjoner
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteGjeldKredittinstitusjoner18164 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public GjeldKredittinstitusjoner7150 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public GjeldKredittinstitusjonerFjoraret7151 fjoraarets { get; set; }
+
+  }
+
+  public class NoteGjeldKredittinstitusjoner18164
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18164";
+
+  }
+
+  public class GjeldKredittinstitusjoner7150
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7150";
+
+  }
+
+  public class GjeldKredittinstitusjonerFjoraret7151
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7151";
+
+  }
+
+  public class OevrigLangsiktigGjeld
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteGjeldAnnenLangsiktig18584 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public GjeldAnnenLangsiktig242 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public GjeldAnnenLangsiktigFjoraret7155 fjoraarets { get; set; }
+
+  }
+
+  public class NoteGjeldAnnenLangsiktig18584
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18584";
+
+  }
+
+  public class GjeldAnnenLangsiktig242
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "242";
+
+  }
+
+  public class GjeldAnnenLangsiktigFjoraret7155
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7155";
+
+  }
+
+  public class SumAnnenLangsiktigGjeld
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteGjeldAnnenLangsiktigSum25018 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public GjeldAnnenLangsiktigSum25019 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public GjeldAnnenLangsiktigSumFjoraret25020 fjoraarets { get; set; }
+
+  }
+
+  public class NoteGjeldAnnenLangsiktigSum25018
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "25018";
+
+  }
+
+  public class GjeldAnnenLangsiktigSum25019
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "25019";
+
+  }
+
+  public class GjeldAnnenLangsiktigSumFjoraret25020
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "25020";
+
+  }
+
+  public class SumLangsiktigGjeld
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteGjeldLangsiktig18585 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public GjeldLangsiktig86 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public GjeldLangsiktigFjoraret7156 fjoraarets { get; set; }
+
+  }
+
+  public class NoteGjeldLangsiktig18585
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18585";
+
+  }
+
+  public class GjeldLangsiktig86
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "86";
+
+  }
+
+  public class GjeldLangsiktigFjoraret7156
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7156";
+
+  }
+
+  public class KortsiktigGjeld
+  {
+    [XmlElement("gjeldKredittinstitusjoner", Order = 1)]
+    [JsonProperty("gjeldKredittinstitusjoner")]
+    [JsonPropertyName("gjeldKredittinstitusjoner")]
+    public GjeldKredittinstitusjonerPoster gjeldKredittinstitusjoner { get; set; }
+
+    [XmlElement("leverandoergjeld", Order = 2)]
+    [JsonProperty("leverandoergjeld")]
+    [JsonPropertyName("leverandoergjeld")]
+    public Leverandoergjeld leverandoergjeld { get; set; }
+
+    [XmlElement("betalbarSkatt", Order = 3)]
+    [JsonProperty("betalbarSkatt")]
+    [JsonPropertyName("betalbarSkatt")]
+    public BetalbarSkatt betalbarSkatt { get; set; }
+
+    [XmlElement("skyldigeOffentligeAvgifter", Order = 4)]
+    [JsonProperty("skyldigeOffentligeAvgifter")]
+    [JsonPropertyName("skyldigeOffentligeAvgifter")]
+    public SkyldigeOffentligeAvgifter skyldigeOffentligeAvgifter { get; set; }
+
+    [XmlElement("annenKortsiktigGjeld", Order = 5)]
+    [JsonProperty("annenKortsiktigGjeld")]
+    [JsonPropertyName("annenKortsiktigGjeld")]
+    public AnnenKortsiktigGjeld annenKortsiktigGjeld { get; set; }
+
+    [XmlElement("sumKortsiktigGjeld", Order = 6)]
+    [JsonProperty("sumKortsiktigGjeld")]
+    [JsonPropertyName("sumKortsiktigGjeld")]
+    public SumKortsiktigGjeld sumKortsiktigGjeld { get; set; }
+
+    [XmlElement("sumGjeld", Order = 7)]
+    [JsonProperty("sumGjeld")]
+    [JsonPropertyName("sumGjeld")]
+    public SumGjeld sumGjeld { get; set; }
+
+    [XmlElement("sumFormaalskapitalGjeld", Order = 8)]
+    [JsonProperty("sumFormaalskapitalGjeld")]
+    [JsonPropertyName("sumFormaalskapitalGjeld")]
+    public SumFormaalskapitalGjeldS sumFormaalskapitalGjeld { get; set; }
+
+  }
+
+  public class GjeldKredittinstitusjonerPoster
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteGjeldKredittinstitusjonerKortsiktig18587 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public GjeldKredittinstitusjonerKortsiktig10926 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public GjeldKredittinstitusjonerKortsiktigFjoraret13203 fjoraarets { get; set; }
+
+  }
+
+  public class NoteGjeldKredittinstitusjonerKortsiktig18587
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18587";
+
+  }
+
+  public class GjeldKredittinstitusjonerKortsiktig10926
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "10926";
+
+  }
+
+  public class GjeldKredittinstitusjonerKortsiktigFjoraret13203
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "13203";
+
+  }
+
+  public class Leverandoergjeld
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteLeverandorgjeld18588 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Leverandorgjeld220 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public LeverandorgjeldFjoraret7162 fjoraarets { get; set; }
+
+  }
+
+  public class NoteLeverandorgjeld18588
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18588";
+
+  }
+
+  public class Leverandorgjeld220
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "220";
+
+  }
+
+  public class LeverandorgjeldFjoraret7162
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7162";
+
+  }
+
+  public class BetalbarSkatt
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteSkattBetalbar18589 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public SkattBetalbar2483 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public SkattBetalbarFjoraret10293 fjoraarets { get; set; }
+
+  }
+
+  public class NoteSkattBetalbar18589
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18589";
+
+  }
+
+  public class SkattBetalbar2483
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "2483";
+
+  }
+
+  public class SkattBetalbarFjoraret10293
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "10293";
+
+  }
+
+  public class SkyldigeOffentligeAvgifter
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteAvgifterOffentligeSkyldig18590 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public AvgifterOffentligeSkyldig225 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public AvgifterOffentligeSkyldigFjoraret7170 fjoraarets { get; set; }
+
+  }
+
+  public class NoteAvgifterOffentligeSkyldig18590
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18590";
+
+  }
+
+  public class AvgifterOffentligeSkyldig225
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "225";
+
+  }
+
+  public class AvgifterOffentligeSkyldigFjoraret7170
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7170";
+
+  }
+
+  public class AnnenKortsiktigGjeld
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteGjeldAnnenKortsiktig18592 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public GjeldAnnenKortsiktig236 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public GjeldAnnenKortsiktigFjoraret7182 fjoraarets { get; set; }
+
+  }
+
+  public class NoteGjeldAnnenKortsiktig18592
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18592";
+
+  }
+
+  public class GjeldAnnenKortsiktig236
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "236";
+
+  }
+
+  public class GjeldAnnenKortsiktigFjoraret7182
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7182";
+
+  }
+
+  public class SumKortsiktigGjeld
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteGjeldKortsiktig18593 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public GjeldKortsiktig85 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public GjeldKortsiktigFjoraret7183 fjoraarets { get; set; }
+
+  }
+
+  public class NoteGjeldKortsiktig18593
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18593";
+
+  }
+
+  public class GjeldKortsiktig85
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "85";
+
+  }
+
+  public class GjeldKortsiktigFjoraret7183
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7183";
+
+  }
+
+  public class SumGjeld
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteGjeld18138 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Gjeld1119 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public GjeldFjoraret7184 fjoraarets { get; set; }
+
+  }
+
+  public class NoteGjeld18138
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18138";
+
+  }
+
+  public class Gjeld1119
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "1119";
+
+  }
+
+  public class GjeldFjoraret7184
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7184";
+
+  }
+
+  public class SumFormaalskapitalGjeldS
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteGjeldEgenkapital18122 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public GjeldEgenkapital251 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public GjeldEgenkapitalFjoraret7185 fjoraarets { get; set; }
+
+  }
+
+  public class NoteGjeldEgenkapital18122
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18122";
+
+  }
+
+  public class GjeldEgenkapital251
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "251";
+
+  }
+
+  public class GjeldEgenkapitalFjoraret7185
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7185";
+
+  }
+
+  public class PosterUtenomBalansen
+  {
+    [XmlElement("garantistillelser", Order = 1)]
+    [JsonProperty("garantistillelser")]
+    [JsonPropertyName("garantistillelser")]
+    public Garantistillelser garantistillelser { get; set; }
+
+    [XmlElement("pantstillelser", Order = 2)]
+    [JsonProperty("pantstillelser")]
+    [JsonPropertyName("pantstillelser")]
+    public Pantstillelser pantstillelser { get; set; }
+
+  }
+
+  public class Garantistillelser
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NoteGarantistillelse18594 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Garantistillelse16920 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public GarantistillelseFjoraret16921 fjoraarets { get; set; }
+
+  }
+
+  public class NoteGarantistillelse18594
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18594";
+
+  }
+
+  public class Garantistillelse16920
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "16920";
+
+  }
+
+  public class GarantistillelseFjoraret16921
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "16921";
+
+  }
+
+  public class Pantstillelser
+  {
+    [XmlElement("note", Order = 1)]
+    [JsonProperty("note")]
+    [JsonPropertyName("note")]
+    public NotePantstillelser18595 note { get; set; }
+
+    [XmlElement("aarets", Order = 2)]
+    [JsonProperty("aarets")]
+    [JsonPropertyName("aarets")]
+    public Pantstillelser16922 aarets { get; set; }
+
+    [XmlElement("fjoraarets", Order = 3)]
+    [JsonProperty("fjoraarets")]
+    [JsonPropertyName("fjoraarets")]
+    public PantstillelserFjoraret16923 fjoraarets { get; set; }
+
+  }
+
+  public class NotePantstillelser18595
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18595";
+
+  }
+
+  public class Pantstillelser16922
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "16922";
+
+  }
+
+  public class PantstillelserFjoraret16923
+  {
+    [RegularExpression(@"^-?[0-9]{0,15}$")]
+    [Range(Double.MinValue,Double.MaxValue)]
+    [XmlText()]
+    [Required]
+    public decimal value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "16923";
+
+  }
+}

--- a/testdata/Model/CSharp/Gitea/3422-39646.cs
+++ b/testdata/Model/CSharp/Gitea/3422-39646.cs
@@ -52,15 +52,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("type")]
     public ArsregnskapType25942 type { get; set; }
 
+    public bool ShouldSerializetype() => type?.value is not null;
+
     [XmlElement("valuta", Order = 2)]
     [JsonProperty("valuta")]
     [JsonPropertyName("valuta")]
     public ArsregnskapValutakode34984 valuta { get; set; }
 
+    public bool ShouldSerializevaluta() => valuta?.value is not null;
+
     [XmlElement("valoer", Order = 3)]
     [JsonProperty("valoer")]
     [JsonPropertyName("valoer")]
     public ArsregnskapValor28974 valoer { get; set; }
+
+    public bool ShouldSerializevaloer() => valoer?.value is not null;
 
   }
 
@@ -226,15 +232,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteMedlemsinntekter30319 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Medlemsinntekter30320 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public MedlemsinntekterFjoraret30321 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -255,9 +267,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -269,9 +295,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -286,15 +326,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteTilskuddOffentlig33418 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public TilskuddOffentlig33419 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public TilskuddOffentligFjoraret33420 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -315,9 +361,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -329,9 +389,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -346,15 +420,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteTilskuddAndre33421 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public TilskuddAndre33422 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public TilskuddAndreFjoraret33423 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -373,9 +453,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -386,9 +480,23 @@ namespace Altinn.App.Models
   public class TilskuddAndreFjoraret33423
   {
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -403,15 +511,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteTilskudd30310 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public TilskuddOffentlig30311 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public TilskuddOffentligFjoraret30312 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -432,9 +546,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -446,9 +574,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -463,15 +605,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteMidlerGaverInnsamlede30313 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public MidlerGaverInnsamlede30314 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public MidlerGaverInnsamledeFjoraret30315 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -492,9 +640,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -506,9 +668,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -523,15 +699,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteAktiviteterOppfyllerOrganisasjonensFormal33424 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public AktiviteterOppfyllerOrganisasjonensFormal33425 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public AktiviteterOppfyllerOrganisasjonensFormalFjoraret33426 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -552,9 +734,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -566,9 +762,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -583,15 +793,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteAktiviteterSkaperInntekt33427 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public AktiviteterSkaperInntekt33428 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public AktiviteterSkaperInntektFjoraret33429 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -612,9 +828,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -626,9 +856,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -643,15 +887,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteAktiviteterOperasjonelle33430 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public AktiviteterOperasjonelle33431 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public AktiviteterOperasjonelleFjoraret33432 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -672,9 +922,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -686,9 +950,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -703,15 +981,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteDriftsinntekterAndreSum18238 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public DriftsinntekterAndreSum7709 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public DriftsinntekterAndreFjoraretSum7966 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -732,9 +1016,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -746,9 +1044,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -763,15 +1075,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFinansinntekterInvesteringsinntekter33433 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FinansinntekterInvesteringsinntekter33434 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FinansinntekterInvesteringsinntekterFjoraret33435 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -792,9 +1110,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -806,9 +1138,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -823,15 +1169,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteInntektAnnen30307 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public InntektAnnen30308 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public InntektAnnenFjoraret30309 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -852,9 +1204,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -866,9 +1232,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -883,15 +1263,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteMidlerAnskaffede30316 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public MidlerAnskaffede30317 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public MidlerAnskaffedeFjoraret30318 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -912,9 +1298,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -926,9 +1326,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -992,15 +1406,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteKostnadAnskaffelseAvMidler30806 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public KostnadAnskaffelseAvMidler30807 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public KostnadAnskaffelseAvMidlerFjoraret30808 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1021,9 +1441,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1035,9 +1469,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1052,15 +1500,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteTilskuddBevilningOppfyllelseOrganisasjonensFormal33436 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public TilskuddBevilningOppfyllelseOrganisasjonensFormal33437 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public TilskuddBevilningOppfyllelseOrganisasjonensFormalFjoraret33438 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1081,9 +1535,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1095,9 +1563,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1112,15 +1594,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteKostnaderOppfyllelseOrganisasjonensFormal33439 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public KostnaderOppfyllelseOrganisasjonensFormal33440 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public KostnaderOppfyllelseOrganisasjonensFormalFjoraret33441 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1141,9 +1629,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1155,9 +1657,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1172,15 +1688,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteKostnadOrganisasjonensFormal30809 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public KostnadOrganisasjonensFormal30810 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public KostnadOrganisasjonensFormalFjoraret30811 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1201,9 +1723,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1215,9 +1751,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1232,15 +1782,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteRentekostnaderAndre18550 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public RentekostnaderAndre2216 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public RentekostnaderAndreFjoraret7039 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1261,9 +1817,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1275,9 +1845,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1292,15 +1876,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFinanskostnaderAndre18337 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FinanskostnaderAndre156 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FinanskostnaderAndreFjoraret7041 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1321,9 +1911,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1335,9 +1939,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1352,15 +1970,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteKostnaderAdministrative27924 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public KostnaderAdministrative27926 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public KostnaderAdministrativeFjoraret27928 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1381,9 +2005,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1395,9 +2033,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1412,15 +2064,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteDriftskostnaderAndre18249 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public DriftskostnaderAndre82 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public DriftskostnaderAndreFjoraret7023 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1441,9 +2099,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1455,9 +2127,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1472,15 +2158,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteMidlerForbrukte30812 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public MidlerForbrukte30813 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public MidlerForbrukteFjoraret30814 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1501,9 +2193,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1515,9 +2221,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1586,15 +2306,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteResultatForSkattekostnad18355 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public ResultatForSkattekostnad167 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public ResultatForSkattekostnadFjoraret7042 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1615,9 +2341,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1629,9 +2369,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1646,15 +2400,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteSkattekostnadOrdinartResultat18259 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public SkattekostnadOrdinartResultat11835 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public SkattekostnadOrdinartResultatFjoraret11836 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1675,9 +2435,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1689,9 +2463,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1706,15 +2494,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteResultatOrdinart18258 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public ResultatOrdinart7048 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public ResultatOrdinartFjordaret7049 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1735,9 +2529,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1749,9 +2557,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1766,15 +2588,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteResultatEkstraordinarePoster29047 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public ResultatEkstraordinarePoster29048 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public ResultatEkstraordinarePosterFjoraret29049 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1795,9 +2623,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1809,9 +2651,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1826,15 +2682,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteSkattekostnadEkstraordinartResultat18263 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public SkattekostnadEkstraordinartResultat2821 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public SkattekostnadEkstraordinartResultatFjoraret8002 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1855,9 +2717,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1869,9 +2745,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1886,15 +2776,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteArsresultat18265 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Arsresultat172 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public ArsresultatFjoraret7054 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1915,9 +2811,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1929,9 +2839,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1946,15 +2870,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteMinoritetsinteresser18264 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Minoritetsinteresser7717 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public MinoritetsinteresserFjoraret8004 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -1975,9 +2905,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -1989,9 +2933,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2006,15 +2964,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteArsresultatEtterMinoritetsinteresser33417 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public ArsresultatEtterMinoritetsinteresser33415 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public ArsresultatEtterMinoritetsinteresserFjoraret33416 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2035,9 +2999,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2049,9 +3027,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2066,15 +3058,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteResultatkomponenterAndreIFRS35536 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public ResultatkomponenterAndreIFRS32929 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public ResultatkomponenterAndreIFRSFjoraret32930 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2093,9 +3091,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2107,9 +3119,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2124,15 +3150,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteTotalresultatIFRS36635 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public TotalresultatIFRS36633 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public TotalresultatIFRSFjoraaret36634 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2153,9 +3185,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2167,9 +3213,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2213,15 +3273,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteGrunnkapital30815 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Grunnkapital30816 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public GrunnkapitalFjoraret30817 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2242,9 +3308,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2256,9 +3336,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2273,15 +3367,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalRestriksjonerLovpalagte33445 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalRestriksjonerLovpalagte33446 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalRestriksjonerLovpalagteFjoraret33447 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2302,9 +3402,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2316,9 +3430,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2333,15 +3461,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalRestriksjonerEksterntPalagt33448 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalRestriksjonerEksterntPalagt33449 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalRestriksjonerEksterntPalagtFjoraret33450 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2362,9 +3496,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2376,9 +3524,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2393,15 +3555,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalRestriksjonerSelvpalagte33451 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalRestriksjonerSelvpalagte33452 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalRestriksjonerSelvpalagteFjoraret33453 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2422,9 +3590,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2436,9 +3618,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2453,15 +3649,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalAnnen33454 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalAnnen33455 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalAnnenFjoraret33456 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2482,9 +3684,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2496,9 +3712,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2561,15 +3791,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NotePatenterRettigheter18560 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public PatenterRettigheter205 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public PatenterRettigheterFjoraret7075 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2588,9 +3824,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2602,9 +3852,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2619,15 +3883,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteSkattefordelUtsatt18182 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public SkattefordelUtsatt202 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public SkattefordelUtsattFjoraret7076 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2648,9 +3918,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2662,9 +3946,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2679,15 +3977,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteForretningsverdiGoodwill18183 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public ForretningsverdiGoodwill206 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public ForretningsverdiGoodwillFjoraret7077 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2708,9 +4012,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2722,9 +4040,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2739,15 +4071,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteEiendelerImmaterielle18180 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public EiendelerImmaterielle2400 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public EiendelerImmaterielleFjoraret8006 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2768,9 +4106,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2782,9 +4134,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2818,15 +4184,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFastEiendom18178 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FastEiendom1976 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FastEiendomFjoraret8007 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2847,9 +4219,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2861,9 +4247,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2878,15 +4278,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteKjoretoyInventarVerktoyMv18562 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public KjoretoyInventarVerktoyMv7725 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public KjoretoyInventarVerktoyMvFjoraret8009 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2907,9 +4313,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2921,9 +4341,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2938,15 +4372,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteDriftsmidlerVarige18176 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public DriftsmidlerVarige47 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public DriftsmidlerVarigeFjoraret8010 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -2967,9 +4407,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -2981,9 +4435,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3012,15 +4480,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteDriftsmidlerAndre18177 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public DriftsmidlerAndre2836 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public DriftsmidlerAndreFjoraret7088 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3041,9 +4515,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3055,9 +4543,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3072,15 +4574,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteDriftsmidlerAndre30979 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public DriftsmidlerAndre30980 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public DriftsmidlerAndreFjoraret30981 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3101,9 +4609,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3115,9 +4637,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3166,15 +4702,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteInvesteringerDatterselskap18563 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public InvesteringerDatterselskap9686 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public InvesteringerDatterselskapFjoraret10289 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3195,9 +4737,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3209,9 +4765,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3226,15 +4796,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteInvesteringerAksjerAndeler18568 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public InvesteringerAksjerAndeler7100 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public InvesteringerAksjerAndelerFjoraret7101 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3255,9 +4831,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3269,9 +4859,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3286,15 +4890,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteObligasjonerLangsiktige27582 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public ObligasjonerLangsiktige27583 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public ObligasjonerLangsiktigeFjoraret27584 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3315,9 +4925,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3329,9 +4953,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3346,15 +4984,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFordringerAndreLangsiktige27578 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FordringerAndreLangsiktige203 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FordringerAndreLangsiktigeFjoraret27585 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3375,9 +5019,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3389,9 +5047,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3406,15 +5078,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteAnleggsmidlerFinansielle18372 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public AnleggsmidlerFinansielle5267 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public AnleggsmidlerFinansielleFjoraret8014 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3435,9 +5113,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3449,9 +5141,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3466,15 +5172,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteAnleggsmidler18570 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Anleggsmidler217 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public AnleggsmidlerFjoraret7108 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3495,9 +5207,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3509,9 +5235,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3564,15 +5304,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteLagerbeholdning30822 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Lagerbeholdning30823 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public LagerbeholdningFjoraret30824 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3593,9 +5339,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3607,9 +5367,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3624,15 +5398,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteLagerbeholdning18571 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Lagerbeholdning326 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public LagerbeholdningFjoraret797 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3653,9 +5433,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3667,9 +5461,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3703,15 +5511,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFordringerKunder18384 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FordringerKunder116 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FordringerKunderFjoraret6921 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3732,9 +5546,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3746,9 +5574,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3763,15 +5605,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFordringerAndreKortsiktig18572 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FordringerAndreKortsiktig282 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FordringerAndreKortsiktigFjoraret7112 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3792,9 +5640,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3806,9 +5668,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3823,15 +5699,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFordringer18389 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Fordringer80 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FordringerFjoraret8015 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3852,9 +5734,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3866,9 +5762,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3907,15 +5817,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteAksjerMvMarkedsbaserte18575 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public AksjerMvMarkedsbaserte7117 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public AksjerMvMarkedsbaserteFjoraret7118 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3936,9 +5852,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3950,9 +5880,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -3967,15 +5911,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFinansielleInstrumenterMarkedsbaserteAndre18577 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FinansielleInstrumenterMarkedsbaserteAndre7731 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FinansielleInstrumenterMarkedsbaserteAndreFjoraret8017 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -3996,9 +5946,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4010,9 +5974,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4027,15 +6005,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFinansielleInstrumenterAndre18578 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FinansielleInstrumenterAndre6429 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FinansielleInstrumenterAndreFjoraret7123 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4056,9 +6040,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4070,9 +6068,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4087,15 +6099,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteInvesteringer18579 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Investeringer6601 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public InvesteringerFjoraret8018 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4116,9 +6134,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4130,9 +6162,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4171,15 +6217,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteKontanterBankinnskudd18390 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public KontanterBankinnskudd786 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public KontanterBankinnskuddFjoraret8019 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4200,9 +6252,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4214,9 +6280,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4231,15 +6311,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteKontanterBankinnskuddSum29041 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public KontanterBankinnskuddSum29042 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public KontanterBankinnskuddSumFjoraret29043 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4260,9 +6346,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4274,9 +6374,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4291,15 +6405,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteOmlopsmidler18580 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Omlopsmidler194 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public OmlopsmidlerFjoraret7126 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4320,9 +6440,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4334,9 +6468,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4351,15 +6499,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteEiendeler18167 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Eiendeler219 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public EiendelerFjoraret7127 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4380,9 +6534,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4394,9 +6562,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4454,15 +6636,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteGrunnkapital30819 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Grunnkapital30820 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public GrunnkapitalFjoraret30821 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4483,9 +6671,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4497,9 +6699,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4514,15 +6730,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalInnskuttAnnen33457 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalInnskuttAnnen33458 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalInnskuttAnnenFjoraret33459 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4543,9 +6765,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4557,9 +6793,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4574,15 +6824,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalInnskuttSum33460 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalInnskuttSum33461 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public AktiviteterOppfyllerOrganisasjonensFormalFjoraret33426 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4603,9 +6859,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4634,15 +6904,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalAnnenRestriksjonerLovpalagte33463 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalAnnenRestriksjonerLovpalagte33464 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalAnnenRestriksjonerLovpalagteFjoraret33465 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4663,9 +6939,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4677,9 +6967,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4694,15 +6998,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalOpptjentSumRestriksjonerLovpalagte33466 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalOpptjentSumRestriksjonerLovpalagte33467 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalOpptjentSumRestriksjonerLovpalagteFjoraret33468 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4723,9 +7033,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4737,9 +7061,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4768,15 +7106,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalAnnenRestriksjonerEksterntPalagte33469 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalAnnenRestriksjonerEksterntPalagte33470 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalAnnenRestriksjonerEksterntPalagteFjoraret33471 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4797,9 +7141,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4811,9 +7169,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4828,15 +7200,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalSumRestriksjonerEksterntPalagte33472 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalSumRestriksjonerEksterntPalagte33473 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalSumRestriksjonerEksterntPalagteFjoraret33474 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4857,9 +7235,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4871,9 +7263,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4917,15 +7323,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalAnnenRestriksjonerSelpalagte33475 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalAnnenRestriksjonerSelvpalagte33476 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalAnnenRestriksjonerSelvpalagteFjoraret33477 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -4946,9 +7358,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4960,9 +7386,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -4977,15 +7417,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalSumRestriksjonerSelvpalagte33478 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalSumRestriksjonerSelvpalagte33479 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalSumRestriksjonerSelvpalagteFjoraret33480 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5006,9 +7452,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5020,9 +7480,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5037,15 +7511,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalAnnen33481 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalAnnen33482 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalAnnenFjoraret33483 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5066,9 +7546,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5080,9 +7574,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5097,15 +7605,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteMinoritetsinteresser29044 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Minoritetsinteresser29045 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public MinoritetsinteresserFjoraret29046 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5126,9 +7640,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5140,9 +7668,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5157,15 +7699,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteFormalskapitalSum33484 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public FormalskapitalSum33485 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public FormalskapitalSumFjoraret33486 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5186,9 +7734,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5200,9 +7762,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5260,15 +7836,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NotePensjonsforpliktelser18149 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Pensjonsforpliktelser238 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public PensjonsforpliktelserFjoraret6685 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5289,9 +7871,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5303,9 +7899,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5320,15 +7930,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteSkattUtsatt18148 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public SkattUtsatt237 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public SkattUtsattFjoraret7143 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5349,9 +7965,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5363,9 +7993,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5380,15 +8024,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteAvsetningerForpliktelserLangsiktig18582 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public AvsetningerForpliktelserLangsiktig7157 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public AvsetningerForpliktelserLangsiktigFjoraret7146 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5409,9 +8059,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5423,9 +8087,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5440,15 +8118,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteAvsetningerForpliktelser18144 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public AvsetningerForpliktelser7231 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public AvsetningerForpliktelserFjoraret7230 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5469,9 +8153,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5483,9 +8181,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5524,15 +8236,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteGjeldKredittinstitusjoner18164 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public GjeldKredittinstitusjoner7150 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public GjeldKredittinstitusjonerFjoraret7151 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5553,9 +8271,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5567,9 +8299,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5584,15 +8330,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteGjeldAnnenLangsiktig18584 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public GjeldAnnenLangsiktig242 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public GjeldAnnenLangsiktigFjoraret7155 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5613,9 +8365,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5627,9 +8393,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5644,15 +8424,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteGjeldAnnenLangsiktigSum25018 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public GjeldAnnenLangsiktigSum25019 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public GjeldAnnenLangsiktigSumFjoraret25020 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5673,9 +8459,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5687,9 +8487,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5704,15 +8518,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteGjeldLangsiktig18585 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public GjeldLangsiktig86 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public GjeldLangsiktigFjoraret7156 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5733,9 +8553,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5747,9 +8581,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5808,15 +8656,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteGjeldKredittinstitusjonerKortsiktig18587 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public GjeldKredittinstitusjonerKortsiktig10926 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public GjeldKredittinstitusjonerKortsiktigFjoraret13203 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5837,9 +8691,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5851,9 +8719,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5868,15 +8750,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteLeverandorgjeld18588 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Leverandorgjeld220 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public LeverandorgjeldFjoraret7162 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5897,9 +8785,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5911,9 +8813,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5928,15 +8844,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteSkattBetalbar18589 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public SkattBetalbar2483 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public SkattBetalbarFjoraret10293 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -5957,9 +8879,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5971,9 +8907,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -5988,15 +8938,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteAvgifterOffentligeSkyldig18590 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public AvgifterOffentligeSkyldig225 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public AvgifterOffentligeSkyldigFjoraret7170 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -6017,9 +8973,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6031,9 +9001,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6048,15 +9032,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteGjeldAnnenKortsiktig18592 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public GjeldAnnenKortsiktig236 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public GjeldAnnenKortsiktigFjoraret7182 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -6077,9 +9067,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6091,9 +9095,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6108,15 +9126,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteGjeldKortsiktig18593 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public GjeldKortsiktig85 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public GjeldKortsiktigFjoraret7183 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -6137,9 +9161,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6151,9 +9189,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6168,15 +9220,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteGjeld18138 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Gjeld1119 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public GjeldFjoraret7184 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -6197,9 +9255,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6211,9 +9283,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6228,15 +9314,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteGjeldEgenkapital18122 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public GjeldEgenkapital251 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public GjeldEgenkapitalFjoraret7185 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -6257,9 +9349,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6271,9 +9377,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6302,15 +9422,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NoteGarantistillelse18594 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Garantistillelse16920 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public GarantistillelseFjoraret16921 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -6331,9 +9457,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6345,9 +9485,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6362,15 +9516,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("note")]
     public NotePantstillelser18595 note { get; set; }
 
+    public bool ShouldSerializenote() => note?.value is not null;
+
     [XmlElement("aarets", Order = 2)]
     [JsonProperty("aarets")]
     [JsonPropertyName("aarets")]
     public Pantstillelser16922 aarets { get; set; }
 
+    public bool ShouldSerializeaarets() => aarets?.valueNullable is not null;
+
     [XmlElement("fjoraarets", Order = 3)]
     [JsonProperty("fjoraarets")]
     [JsonPropertyName("fjoraarets")]
     public PantstillelserFjoraret16923 fjoraarets { get; set; }
+
+    public bool ShouldSerializefjoraarets() => fjoraarets?.valueNullable is not null;
 
   }
 
@@ -6391,9 +9551,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -6405,9 +9579,23 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^-?[0-9]{0,15}$")]
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]

--- a/testdata/Model/CSharp/Gitea/3430-39615.cs
+++ b/testdata/Model/CSharp/Gitea/3430-39615.cs
@@ -1,0 +1,487 @@
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
+namespace Altinn.App.Models
+{
+  [XmlRoot(ElementName="melding")]
+  public class RR0010H_M
+  {
+    [XmlAttribute("dataFormatProvider")]
+    [BindNever]
+    public string dataFormatProvider { get; set; } = "SERES";
+
+    [XmlAttribute("dataFormatId")]
+    [BindNever]
+    public string dataFormatId { get; set; } = "3430";
+
+    [XmlAttribute("dataFormatVersion")]
+    [BindNever]
+    public string dataFormatVersion { get; set; } = "48617";
+
+    [XmlElement("Innsender", Order = 1)]
+    [JsonProperty("Innsender")]
+    [JsonPropertyName("Innsender")]
+    public Innsender Innsender { get; set; }
+
+    [XmlElement("Skjemainnhold", Order = 2)]
+    [JsonProperty("Skjemainnhold")]
+    [JsonPropertyName("Skjemainnhold")]
+    public Skjemainnhold Skjemainnhold { get; set; }
+
+  }
+
+  public class Innsender
+  {
+    [XmlElement("enhet", Order = 1)]
+    [JsonProperty("enhet")]
+    [JsonPropertyName("enhet")]
+    public Enhet enhet { get; set; }
+
+    [XmlElement("kontaktperson", Order = 2)]
+    [JsonProperty("kontaktperson")]
+    [JsonPropertyName("kontaktperson")]
+    public List<Kontaktperson> kontaktperson { get; set; }
+
+    [XmlElement("opplysningerInnsending", Order = 3)]
+    [JsonProperty("opplysningerInnsending")]
+    [JsonPropertyName("opplysningerInnsending")]
+    public OpplysningerInnsending opplysningerInnsending { get; set; }
+
+  }
+
+  public class Enhet
+  {
+    [XmlElement("organisasjonsnummer", Order = 1)]
+    [JsonProperty("organisasjonsnummer")]
+    [JsonPropertyName("organisasjonsnummer")]
+    public EnhetOrganisasjonsnummer18 organisasjonsnummer { get; set; }
+
+    [XmlElement("organisasjonsform", Order = 2)]
+    [JsonProperty("organisasjonsform")]
+    [JsonPropertyName("organisasjonsform")]
+    public EnhetOrganisasjonsform756 organisasjonsform { get; set; }
+
+    [XmlElement("navn", Order = 3)]
+    [JsonProperty("navn")]
+    [JsonPropertyName("navn")]
+    public EnhetNavn1 navn { get; set; }
+
+  }
+
+  public class EnhetOrganisasjonsnummer18
+  {
+    [MinLength(9)]
+    [MaxLength(9)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "18";
+
+  }
+
+  public class EnhetOrganisasjonsform756
+  {
+    [MinLength(1)]
+    [MaxLength(35)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "756";
+
+  }
+
+  public class EnhetNavn1
+  {
+    [MinLength(1)]
+    [MaxLength(175)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "1";
+
+  }
+
+  public class Kontaktperson
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
+    [XmlElement("e-post", Order = 1)]
+    [JsonProperty("e-post")]
+    [JsonPropertyName("e-post")]
+    public KontaktpersonEPost19022 epost { get; set; }
+
+  }
+
+  public class KontaktpersonEPost19022
+  {
+    [MinLength(1)]
+    [MaxLength(70)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "19022";
+
+  }
+
+  public class OpplysningerInnsending
+  {
+    [XmlElement("fraSluttbrukersystem", Order = 1)]
+    [JsonProperty("fraSluttbrukersystem")]
+    [JsonPropertyName("fraSluttbrukersystem")]
+    public ArsregnskapSysteminnsending35139 fraSluttbrukersystem { get; set; }
+
+    [XmlElement("landTilLand", Order = 2)]
+    [JsonProperty("landTilLand")]
+    [JsonPropertyName("landTilLand")]
+    public ArsregnskapLandTilLand35172 landTilLand { get; set; }
+
+  }
+
+  public class ArsregnskapSysteminnsending35139
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "35139";
+
+  }
+
+  public class ArsregnskapLandTilLand35172
+  {
+    [XmlText()]
+    [Required]
+    public bool value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "35172";
+
+  }
+
+  public class Skjemainnhold
+  {
+    [XmlElement("regnskapsperiode", Order = 1)]
+    [JsonProperty("regnskapsperiode")]
+    [JsonPropertyName("regnskapsperiode")]
+    public Regnskapsperiode regnskapsperiode { get; set; }
+
+    [XmlElement("konsern", Order = 2)]
+    [JsonProperty("konsern")]
+    [JsonPropertyName("konsern")]
+    public Konsern konsern { get; set; }
+
+    [XmlElement("regnskapsprinsipper", Order = 3)]
+    [JsonProperty("regnskapsprinsipper")]
+    [JsonPropertyName("regnskapsprinsipper")]
+    public Regnskapsprinsipper regnskapsprinsipper { get; set; }
+
+    [XmlElement("fastsettelse", Order = 4)]
+    [JsonProperty("fastsettelse")]
+    [JsonPropertyName("fastsettelse")]
+    public Fastsettelse fastsettelse { get; set; }
+
+  }
+
+  public class Regnskapsperiode
+  {
+    [XmlElement("regnskapsstart", Order = 1)]
+    [JsonProperty("regnskapsstart")]
+    [JsonPropertyName("regnskapsstart")]
+    public RegnskapStartdato17103 regnskapsstart { get; set; }
+
+    [XmlElement("regnskapsslutt", Order = 2)]
+    [JsonProperty("regnskapsslutt")]
+    [JsonPropertyName("regnskapsslutt")]
+    public RegnskapAvslutningsdato17104 regnskapsslutt { get; set; }
+
+    [XmlElement("regnskapsaar", Order = 3)]
+    [JsonProperty("regnskapsaar")]
+    [JsonPropertyName("regnskapsaar")]
+    public RegnskapAr17102 regnskapsaar { get; set; }
+
+  }
+
+  public class RegnskapStartdato17103
+  {
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "17103";
+
+  }
+
+  public class RegnskapAvslutningsdato17104
+  {
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "17104";
+
+  }
+
+  public class RegnskapAr17102
+  {
+    [RegularExpression(@"^[0-9]{4}$")]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "17102";
+
+  }
+
+  public class Konsern
+  {
+    [XmlElement("morselskap", Order = 1)]
+    [JsonProperty("morselskap")]
+    [JsonPropertyName("morselskap")]
+    public Morselskap4168 morselskap { get; set; }
+
+    [XmlElement("konsernregnskap", Order = 2)]
+    [JsonProperty("konsernregnskap")]
+    [JsonPropertyName("konsernregnskap")]
+    public KonsernregnskapVedlegg25943 konsernregnskap { get; set; }
+
+    [XmlElement("utenlandskKonsern", Order = 3)]
+    [JsonProperty("utenlandskKonsern")]
+    [JsonPropertyName("utenlandskKonsern")]
+    public UtenlandskKonsern36640 utenlandskKonsern { get; set; }
+
+  }
+
+  public class Morselskap4168
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "4168";
+
+  }
+
+  public class KonsernregnskapVedlegg25943
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "25943";
+
+  }
+
+  public class UtenlandskKonsern36640
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "36640";
+
+  }
+
+  public class Regnskapsprinsipper
+  {
+    [XmlElement("smaaForetak", Order = 1)]
+    [JsonProperty("smaaForetak")]
+    [JsonPropertyName("smaaForetak")]
+    public RegnskapsreglerSmaForetak8079 smaaForetak { get; set; }
+
+    [XmlElement("regnskapsreglerSelskap", Order = 2)]
+    [JsonProperty("regnskapsreglerSelskap")]
+    [JsonPropertyName("regnskapsreglerSelskap")]
+    public RegnskapsoppsettIFRS25021 regnskapsreglerSelskap { get; set; }
+
+    [XmlElement("forenkletIfrs", Order = 3)]
+    [JsonProperty("forenkletIfrs")]
+    [JsonPropertyName("forenkletIfrs")]
+    public ForenkletIFRS36639 forenkletIfrs { get; set; }
+
+    [XmlElement("regnskapsreglerKonsern", Order = 4)]
+    [JsonProperty("regnskapsreglerKonsern")]
+    [JsonPropertyName("regnskapsreglerKonsern")]
+    public RegnskapsoppsettKonsernIFRS25944 regnskapsreglerKonsern { get; set; }
+
+    [XmlElement("forenkletIfrsKonsern", Order = 5)]
+    [JsonProperty("forenkletIfrsKonsern")]
+    [JsonPropertyName("forenkletIfrsKonsern")]
+    public ForenkletIFRSKonsern36641 forenkletIfrsKonsern { get; set; }
+
+    [XmlElement("aarsregnskapIkkeRevideres", Order = 6)]
+    [JsonProperty("aarsregnskapIkkeRevideres")]
+    [JsonPropertyName("aarsregnskapIkkeRevideres")]
+    public ArsregnskapIkkeRevisjonBesluttet34669 aarsregnskapIkkeRevideres { get; set; }
+
+    [XmlElement("aarsregnskapUtarbeidetAutorisertRegnskapsfoerer", Order = 7)]
+    [JsonProperty("aarsregnskapUtarbeidetAutorisertRegnskapsfoerer")]
+    [JsonPropertyName("aarsregnskapUtarbeidetAutorisertRegnskapsfoerer")]
+    public ArsregnskapUtarbeidelseAvAutorisertRegnskapsforer34670 aarsregnskapUtarbeidetAutorisertRegnskapsfoerer { get; set; }
+
+    [XmlElement("tjenestebistandEksternAutorisertRegnskapsfoerer", Order = 8)]
+    [JsonProperty("tjenestebistandEksternAutorisertRegnskapsfoerer")]
+    [JsonPropertyName("tjenestebistandEksternAutorisertRegnskapsfoerer")]
+    public TjenestebistandEksternAutorisertRegnskapsforer34671 tjenestebistandEksternAutorisertRegnskapsfoerer { get; set; }
+
+  }
+
+  public class RegnskapsreglerSmaForetak8079
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "8079";
+
+  }
+
+  public class RegnskapsoppsettIFRS25021
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "25021";
+
+  }
+
+  public class ForenkletIFRS36639
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "36639";
+
+  }
+
+  public class RegnskapsoppsettKonsernIFRS25944
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "25944";
+
+  }
+
+  public class ForenkletIFRSKonsern36641
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "36641";
+
+  }
+
+  public class ArsregnskapIkkeRevisjonBesluttet34669
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "34669";
+
+  }
+
+  public class ArsregnskapUtarbeidelseAvAutorisertRegnskapsforer34670
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "34670";
+
+  }
+
+  public class TjenestebistandEksternAutorisertRegnskapsforer34671
+  {
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "34671";
+
+  }
+
+  public class Fastsettelse
+  {
+    [XmlElement("fastsettelsesdato", Order = 1)]
+    [JsonProperty("fastsettelsesdato")]
+    [JsonPropertyName("fastsettelsesdato")]
+    public RegnskapFastsettelseDato17105 fastsettelsesdato { get; set; }
+
+    [XmlElement("bekreftendeSelskapsrepresentant", Order = 2)]
+    [JsonProperty("bekreftendeSelskapsrepresentant")]
+    [JsonPropertyName("bekreftendeSelskapsrepresentant")]
+    public StyremedlemNavnSpesifisertStyremedlem19023 bekreftendeSelskapsrepresentant { get; set; }
+
+  }
+
+  public class RegnskapFastsettelseDato17105
+  {
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "17105";
+
+  }
+
+  public class StyremedlemNavnSpesifisertStyremedlem19023
+  {
+    [MinLength(1)]
+    [MaxLength(70)]
+    [XmlText()]
+    public string value { get; set; }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "19023";
+
+  }
+}

--- a/testdata/Model/CSharp/Gitea/3430-39615.cs
+++ b/testdata/Model/CSharp/Gitea/3430-39615.cs
@@ -127,10 +127,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("e-post", Order = 1)]
     [JsonProperty("e-post")]

--- a/testdata/Model/CSharp/Gitea/3430-39615.cs
+++ b/testdata/Model/CSharp/Gitea/3430-39615.cs
@@ -62,15 +62,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("organisasjonsnummer")]
     public EnhetOrganisasjonsnummer18 organisasjonsnummer { get; set; }
 
+    public bool ShouldSerializeorganisasjonsnummer() => organisasjonsnummer?.value is not null;
+
     [XmlElement("organisasjonsform", Order = 2)]
     [JsonProperty("organisasjonsform")]
     [JsonPropertyName("organisasjonsform")]
     public EnhetOrganisasjonsform756 organisasjonsform { get; set; }
 
+    public bool ShouldSerializeorganisasjonsform() => organisasjonsform?.value is not null;
+
     [XmlElement("navn", Order = 3)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public EnhetNavn1 navn { get; set; }
+
+    public bool ShouldSerializenavn() => navn?.value is not null;
 
   }
 
@@ -131,6 +137,8 @@ namespace Altinn.App.Models
     [JsonPropertyName("e-post")]
     public KontaktpersonEPost19022 epost { get; set; }
 
+    public bool ShouldSerializeepost() => epost?.value is not null;
+
   }
 
   public class KontaktpersonEPost19022
@@ -153,10 +161,14 @@ namespace Altinn.App.Models
     [JsonPropertyName("fraSluttbrukersystem")]
     public ArsregnskapSysteminnsending35139 fraSluttbrukersystem { get; set; }
 
+    public bool ShouldSerializefraSluttbrukersystem() => fraSluttbrukersystem?.value is not null;
+
     [XmlElement("landTilLand", Order = 2)]
     [JsonProperty("landTilLand")]
     [JsonPropertyName("landTilLand")]
     public ArsregnskapLandTilLand35172 landTilLand { get; set; }
+
+    public bool ShouldSerializelandTilLand() => landTilLand?.valueNullable is not null;
 
   }
 
@@ -173,9 +185,23 @@ namespace Altinn.App.Models
 
   public class ArsregnskapLandTilLand35172
   {
-    [XmlText()]
     [Required]
-    public bool value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public bool? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public bool value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("orid")]
     [BindNever]
@@ -214,15 +240,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("regnskapsstart")]
     public RegnskapStartdato17103 regnskapsstart { get; set; }
 
+    public bool ShouldSerializeregnskapsstart() => regnskapsstart?.value is not null;
+
     [XmlElement("regnskapsslutt", Order = 2)]
     [JsonProperty("regnskapsslutt")]
     [JsonPropertyName("regnskapsslutt")]
     public RegnskapAvslutningsdato17104 regnskapsslutt { get; set; }
 
+    public bool ShouldSerializeregnskapsslutt() => regnskapsslutt?.value is not null;
+
     [XmlElement("regnskapsaar", Order = 3)]
     [JsonProperty("regnskapsaar")]
     [JsonPropertyName("regnskapsaar")]
     public RegnskapAr17102 regnskapsaar { get; set; }
+
+    public bool ShouldSerializeregnskapsaar() => regnskapsaar?.value is not null;
 
   }
 
@@ -269,15 +301,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("morselskap")]
     public Morselskap4168 morselskap { get; set; }
 
+    public bool ShouldSerializemorselskap() => morselskap?.value is not null;
+
     [XmlElement("konsernregnskap", Order = 2)]
     [JsonProperty("konsernregnskap")]
     [JsonPropertyName("konsernregnskap")]
     public KonsernregnskapVedlegg25943 konsernregnskap { get; set; }
 
+    public bool ShouldSerializekonsernregnskap() => konsernregnskap?.value is not null;
+
     [XmlElement("utenlandskKonsern", Order = 3)]
     [JsonProperty("utenlandskKonsern")]
     [JsonPropertyName("utenlandskKonsern")]
     public UtenlandskKonsern36640 utenlandskKonsern { get; set; }
+
+    public bool ShouldSerializeutenlandskKonsern() => utenlandskKonsern?.value is not null;
 
   }
 
@@ -321,40 +359,56 @@ namespace Altinn.App.Models
     [JsonPropertyName("smaaForetak")]
     public RegnskapsreglerSmaForetak8079 smaaForetak { get; set; }
 
+    public bool ShouldSerializesmaaForetak() => smaaForetak?.value is not null;
+
     [XmlElement("regnskapsreglerSelskap", Order = 2)]
     [JsonProperty("regnskapsreglerSelskap")]
     [JsonPropertyName("regnskapsreglerSelskap")]
     public RegnskapsoppsettIFRS25021 regnskapsreglerSelskap { get; set; }
+
+    public bool ShouldSerializeregnskapsreglerSelskap() => regnskapsreglerSelskap?.value is not null;
 
     [XmlElement("forenkletIfrs", Order = 3)]
     [JsonProperty("forenkletIfrs")]
     [JsonPropertyName("forenkletIfrs")]
     public ForenkletIFRS36639 forenkletIfrs { get; set; }
 
+    public bool ShouldSerializeforenkletIfrs() => forenkletIfrs?.value is not null;
+
     [XmlElement("regnskapsreglerKonsern", Order = 4)]
     [JsonProperty("regnskapsreglerKonsern")]
     [JsonPropertyName("regnskapsreglerKonsern")]
     public RegnskapsoppsettKonsernIFRS25944 regnskapsreglerKonsern { get; set; }
+
+    public bool ShouldSerializeregnskapsreglerKonsern() => regnskapsreglerKonsern?.value is not null;
 
     [XmlElement("forenkletIfrsKonsern", Order = 5)]
     [JsonProperty("forenkletIfrsKonsern")]
     [JsonPropertyName("forenkletIfrsKonsern")]
     public ForenkletIFRSKonsern36641 forenkletIfrsKonsern { get; set; }
 
+    public bool ShouldSerializeforenkletIfrsKonsern() => forenkletIfrsKonsern?.value is not null;
+
     [XmlElement("aarsregnskapIkkeRevideres", Order = 6)]
     [JsonProperty("aarsregnskapIkkeRevideres")]
     [JsonPropertyName("aarsregnskapIkkeRevideres")]
     public ArsregnskapIkkeRevisjonBesluttet34669 aarsregnskapIkkeRevideres { get; set; }
+
+    public bool ShouldSerializeaarsregnskapIkkeRevideres() => aarsregnskapIkkeRevideres?.value is not null;
 
     [XmlElement("aarsregnskapUtarbeidetAutorisertRegnskapsfoerer", Order = 7)]
     [JsonProperty("aarsregnskapUtarbeidetAutorisertRegnskapsfoerer")]
     [JsonPropertyName("aarsregnskapUtarbeidetAutorisertRegnskapsfoerer")]
     public ArsregnskapUtarbeidelseAvAutorisertRegnskapsforer34670 aarsregnskapUtarbeidetAutorisertRegnskapsfoerer { get; set; }
 
+    public bool ShouldSerializeaarsregnskapUtarbeidetAutorisertRegnskapsfoerer() => aarsregnskapUtarbeidetAutorisertRegnskapsfoerer?.value is not null;
+
     [XmlElement("tjenestebistandEksternAutorisertRegnskapsfoerer", Order = 8)]
     [JsonProperty("tjenestebistandEksternAutorisertRegnskapsfoerer")]
     [JsonPropertyName("tjenestebistandEksternAutorisertRegnskapsfoerer")]
     public TjenestebistandEksternAutorisertRegnskapsforer34671 tjenestebistandEksternAutorisertRegnskapsfoerer { get; set; }
+
+    public bool ShouldSerializetjenestebistandEksternAutorisertRegnskapsfoerer() => tjenestebistandEksternAutorisertRegnskapsfoerer?.value is not null;
 
   }
 
@@ -453,10 +507,14 @@ namespace Altinn.App.Models
     [JsonPropertyName("fastsettelsesdato")]
     public RegnskapFastsettelseDato17105 fastsettelsesdato { get; set; }
 
+    public bool ShouldSerializefastsettelsesdato() => fastsettelsesdato?.value is not null;
+
     [XmlElement("bekreftendeSelskapsrepresentant", Order = 2)]
     [JsonProperty("bekreftendeSelskapsrepresentant")]
     [JsonPropertyName("bekreftendeSelskapsrepresentant")]
     public StyremedlemNavnSpesifisertStyremedlem19023 bekreftendeSelskapsrepresentant { get; set; }
+
+    public bool ShouldSerializebekreftendeSelskapsrepresentant() => bekreftendeSelskapsrepresentant?.value is not null;
 
   }
 

--- a/testdata/Model/CSharp/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.cs
+++ b/testdata/Model/CSharp/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.cs
+++ b/testdata/Model/CSharp/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.cs
@@ -67,20 +67,14 @@ namespace Altinn.App.Models
     [JsonPropertyName("hfHentPreutfyllingFeilet")]
     public bool? hfHentPreutfyllingFeilet { get; set; }
 
-    public bool ShouldSerializehfHentPreutfyllingFeilet()
-    {
-      return hfHentPreutfyllingFeilet.HasValue;
-    }
+    public bool ShouldSerializehfHentPreutfyllingFeilet() => hfHentPreutfyllingFeilet.HasValue;
 
     [XmlElement("hfHentRollerFeilet", Order = 2)]
     [JsonProperty("hfHentRollerFeilet")]
     [JsonPropertyName("hfHentRollerFeilet")]
     public bool? hfHentRollerFeilet { get; set; }
 
-    public bool ShouldSerializehfHentRollerFeilet()
-    {
-      return hfHentRollerFeilet.HasValue;
-    }
+    public bool ShouldSerializehfHentRollerFeilet() => hfHentRollerFeilet.HasValue;
 
   }
 
@@ -121,10 +115,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("finnesDetReelleRettighetshavereITilleggTilRolleinnehavereForStiftelse")]
     public bool? finnesDetReelleRettighetshavereITilleggTilRolleinnehavereForStiftelse { get; set; }
 
-    public bool ShouldSerializefinnesDetReelleRettighetshavereITilleggTilRolleinnehavereForStiftelse()
-    {
-      return finnesDetReelleRettighetshavereITilleggTilRolleinnehavereForStiftelse.HasValue;
-    }
+    public bool ShouldSerializefinnesDetReelleRettighetshavereITilleggTilRolleinnehavereForStiftelse() => finnesDetReelleRettighetshavereITilleggTilRolleinnehavereForStiftelse.HasValue;
 
     [XmlElement("reellRettighetshaver", Order = 8)]
     [JsonProperty("reellRettighetshaver")]
@@ -136,20 +127,14 @@ namespace Altinn.App.Models
     [JsonPropertyName("kanIkkeIdentifisereFlereReelleRettighetshavere")]
     public bool? kanIkkeIdentifisereFlereReelleRettighetshavere { get; set; }
 
-    public bool ShouldSerializekanIkkeIdentifisereFlereReelleRettighetshavere()
-    {
-      return kanIkkeIdentifisereFlereReelleRettighetshavere.HasValue;
-    }
+    public bool ShouldSerializekanIkkeIdentifisereFlereReelleRettighetshavere() => kanIkkeIdentifisereFlereReelleRettighetshavere.HasValue;
 
     [XmlElement("erVirksomhetRegistrertPaaRegulertMarked", Order = 10)]
     [JsonProperty("erVirksomhetRegistrertPaaRegulertMarked")]
     [JsonPropertyName("erVirksomhetRegistrertPaaRegulertMarked")]
     public bool? erVirksomhetRegistrertPaaRegulertMarked { get; set; }
 
-    public bool ShouldSerializeerVirksomhetRegistrertPaaRegulertMarked()
-    {
-      return erVirksomhetRegistrertPaaRegulertMarked.HasValue;
-    }
+    public bool ShouldSerializeerVirksomhetRegistrertPaaRegulertMarked() => erVirksomhetRegistrertPaaRegulertMarked.HasValue;
 
     [XmlElement("regulertMarked", Order = 11)]
     [JsonProperty("regulertMarked")]
@@ -161,10 +146,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("erReelleRettighetshavereRegistrertIUtenlandskRegister")]
     public bool? erReelleRettighetshavereRegistrertIUtenlandskRegister { get; set; }
 
-    public bool ShouldSerializeerReelleRettighetshavereRegistrertIUtenlandskRegister()
-    {
-      return erReelleRettighetshavereRegistrertIUtenlandskRegister.HasValue;
-    }
+    public bool ShouldSerializeerReelleRettighetshavereRegistrertIUtenlandskRegister() => erReelleRettighetshavereRegistrertIUtenlandskRegister.HasValue;
 
     [XmlElement("utenlandskRegister", Order = 13)]
     [JsonProperty("utenlandskRegister")]
@@ -230,10 +212,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("erOffentligVirksomhetUtenlandsk")]
     public bool? erOffentligVirksomhetUtenlandsk { get; set; }
 
-    public bool ShouldSerializeerOffentligVirksomhetUtenlandsk()
-    {
-      return erOffentligVirksomhetUtenlandsk.HasValue;
-    }
+    public bool ShouldSerializeerOffentligVirksomhetUtenlandsk() => erOffentligVirksomhetUtenlandsk.HasValue;
 
   }
 
@@ -245,10 +224,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("erRegistrertIFolkeregisteret", Order = 1)]
     [JsonProperty("erRegistrertIFolkeregisteret")]
@@ -261,10 +237,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("hfErPreutfylt")]
     public bool? hfErPreutfylt { get; set; }
 
-    public bool ShouldSerializehfErPreutfylt()
-    {
-      return hfErPreutfylt.HasValue;
-    }
+    public bool ShouldSerializehfErPreutfylt() => hfErPreutfylt.HasValue;
 
     [XmlElement("foedselsEllerDNummer", Order = 3)]
     [JsonProperty("foedselsEllerDNummer")]
@@ -293,10 +266,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("hfSoekFolkeregistrertPersonFeilkode")]
     public long? hfSoekFolkeregistrertPersonFeilkode { get; set; }
 
-    public bool ShouldSerializehfSoekFolkeregistrertPersonFeilkode()
-    {
-      return hfSoekFolkeregistrertPersonFeilkode.HasValue;
-    }
+    public bool ShouldSerializehfSoekFolkeregistrertPersonFeilkode() => hfSoekFolkeregistrertPersonFeilkode.HasValue;
 
     [XmlElement("statsborgerskap", Order = 8)]
     [JsonProperty("statsborgerskap")]
@@ -313,10 +283,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("harPosisjonEierskap")]
     public bool? harPosisjonEierskap { get; set; }
 
-    public bool ShouldSerializeharPosisjonEierskap()
-    {
-      return harPosisjonEierskap.HasValue;
-    }
+    public bool ShouldSerializeharPosisjonEierskap() => harPosisjonEierskap.HasValue;
 
     [XmlElement("posisjonEierskap", Order = 11)]
     [JsonProperty("posisjonEierskap")]
@@ -328,10 +295,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("harPosisjonKontrollOverStemmerettigheter")]
     public bool? harPosisjonKontrollOverStemmerettigheter { get; set; }
 
-    public bool ShouldSerializeharPosisjonKontrollOverStemmerettigheter()
-    {
-      return harPosisjonKontrollOverStemmerettigheter.HasValue;
-    }
+    public bool ShouldSerializeharPosisjonKontrollOverStemmerettigheter() => harPosisjonKontrollOverStemmerettigheter.HasValue;
 
     [XmlElement("posisjonKontrollOverStemmerettigheter", Order = 13)]
     [JsonProperty("posisjonKontrollOverStemmerettigheter")]
@@ -343,10 +307,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("harPosisjonRettTilAaUtpekeEllerAvsetteMinstHalvpartenAvStyremedlemmene")]
     public bool? harPosisjonRettTilAaUtpekeEllerAvsetteMinstHalvpartenAvStyremedlemmene { get; set; }
 
-    public bool ShouldSerializeharPosisjonRettTilAaUtpekeEllerAvsetteMinstHalvpartenAvStyremedlemmene()
-    {
-      return harPosisjonRettTilAaUtpekeEllerAvsetteMinstHalvpartenAvStyremedlemmene.HasValue;
-    }
+    public bool ShouldSerializeharPosisjonRettTilAaUtpekeEllerAvsetteMinstHalvpartenAvStyremedlemmene() => harPosisjonRettTilAaUtpekeEllerAvsetteMinstHalvpartenAvStyremedlemmene.HasValue;
 
     [XmlElement("grunnlagForPosisjonenRettTilAaUtpekeEllerAvsetteMinstHalvpartenAvStyremedlemmene", Order = 15)]
     [JsonProperty("grunnlagForPosisjonenRettTilAaUtpekeEllerAvsetteMinstHalvpartenAvStyremedlemmene")]
@@ -358,10 +319,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("harPosisjonKontrollPaaAnnenMaate")]
     public bool? harPosisjonKontrollPaaAnnenMaate { get; set; }
 
-    public bool ShouldSerializeharPosisjonKontrollPaaAnnenMaate()
-    {
-      return harPosisjonKontrollPaaAnnenMaate.HasValue;
-    }
+    public bool ShouldSerializeharPosisjonKontrollPaaAnnenMaate() => harPosisjonKontrollPaaAnnenMaate.HasValue;
 
     [XmlElement("beskrivelseAvPosisjonenKontrollPaaAnnenMaate", Order = 17)]
     [JsonProperty("beskrivelseAvPosisjonenKontrollPaaAnnenMaate")]
@@ -373,10 +331,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("harPosisjonAvgittGrunnkapital")]
     public bool? harPosisjonAvgittGrunnkapital { get; set; }
 
-    public bool ShouldSerializeharPosisjonAvgittGrunnkapital()
-    {
-      return harPosisjonAvgittGrunnkapital.HasValue;
-    }
+    public bool ShouldSerializeharPosisjonAvgittGrunnkapital() => harPosisjonAvgittGrunnkapital.HasValue;
 
     [XmlElement("posisjonAvgittGrunnkapital", Order = 19)]
     [JsonProperty("posisjonAvgittGrunnkapital")]
@@ -388,10 +343,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("harPosisjonRettTilAaUtpekeEtFlertallAvStyremedlemmene")]
     public bool? harPosisjonRettTilAaUtpekeEtFlertallAvStyremedlemmene { get; set; }
 
-    public bool ShouldSerializeharPosisjonRettTilAaUtpekeEtFlertallAvStyremedlemmene()
-    {
-      return harPosisjonRettTilAaUtpekeEtFlertallAvStyremedlemmene.HasValue;
-    }
+    public bool ShouldSerializeharPosisjonRettTilAaUtpekeEtFlertallAvStyremedlemmene() => harPosisjonRettTilAaUtpekeEtFlertallAvStyremedlemmene.HasValue;
 
     [XmlElement("posisjonRettTilAaUtpekeEtFlertallAvStyremedlemmene", Order = 21)]
     [JsonProperty("posisjonRettTilAaUtpekeEtFlertallAvStyremedlemmene")]
@@ -403,10 +355,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("harPosisjonSaerligeRettigheter")]
     public bool? harPosisjonSaerligeRettigheter { get; set; }
 
-    public bool ShouldSerializeharPosisjonSaerligeRettigheter()
-    {
-      return harPosisjonSaerligeRettigheter.HasValue;
-    }
+    public bool ShouldSerializeharPosisjonSaerligeRettigheter() => harPosisjonSaerligeRettigheter.HasValue;
 
     [XmlElement("posisjonSaerligeRettigheter", Order = 23)]
     [JsonProperty("posisjonSaerligeRettigheter")]
@@ -418,10 +367,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("harPosisjonDestinatar")]
     public bool? harPosisjonDestinatar { get; set; }
 
-    public bool ShouldSerializeharPosisjonDestinatar()
-    {
-      return harPosisjonDestinatar.HasValue;
-    }
+    public bool ShouldSerializeharPosisjonDestinatar() => harPosisjonDestinatar.HasValue;
 
     [XmlElement("posisjonDestinatar", Order = 25)]
     [JsonProperty("posisjonDestinatar")]
@@ -462,10 +408,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("erUtenlandskVirksomhet", Order = 1)]
     [JsonProperty("erUtenlandskVirksomhet")]
@@ -622,10 +565,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
     [XmlElement("foedselsdato", Order = 1)]

--- a/testdata/Model/CSharp/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.cs
+++ b/testdata/Model/CSharp/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.cs
@@ -238,6 +238,17 @@ namespace Altinn.App.Models
 
   public class ReellRettighetshaver
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("erRegistrertIFolkeregisteret", Order = 1)]
     [JsonProperty("erRegistrertIFolkeregisteret")]
     [JsonPropertyName("erRegistrertIFolkeregisteret")]
@@ -421,16 +432,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("hfPosisjonsbeskrivelse")]
     public string hfPosisjonsbeskrivelse { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class Posisjon
@@ -454,6 +455,17 @@ namespace Altinn.App.Models
 
   public class MellomliggendeVirksomhet
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("erUtenlandskVirksomhet", Order = 1)]
     [JsonProperty("erUtenlandskVirksomhet")]
     [JsonPropertyName("erUtenlandskVirksomhet")]
@@ -485,16 +497,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("hfLandnavn")]
     public string hfLandnavn { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class UtenlandskVirksomhet
@@ -613,6 +615,17 @@ namespace Altinn.App.Models
 
   public class Rolleinnehaver
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
     [XmlElement("foedselsdato", Order = 1)]
     [JsonProperty("foedselsdato")]
@@ -629,15 +642,5 @@ namespace Altinn.App.Models
     [JsonPropertyName("rolle")]
     public string rolle { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 }

--- a/testdata/Model/CSharp/Gitea/Kursdomene_APINøkkel_M_2020-05-26_5702_34556_SERES.cs
+++ b/testdata/Model/CSharp/Gitea/Kursdomene_APINøkkel_M_2020-05-26_5702_34556_SERES.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/Kursdomene_APINøkkel_M_2020-05-26_5702_34556_SERES.cs
+++ b/testdata/Model/CSharp/Gitea/Kursdomene_APINøkkel_M_2020-05-26_5702_34556_SERES.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;
@@ -14,15 +13,15 @@ namespace Altinn.App.Models
   {
     [XmlAttribute("dataFormatProvider")]
     [BindNever]
-    public string dataFormatProvider {get; set; } = "SERES";
+    public string dataFormatProvider { get; set; } = "SERES";
 
     [XmlAttribute("dataFormatId")]
     [BindNever]
-    public string dataFormatId {get; set; } = "5702";
+    public string dataFormatId { get; set; } = "5702";
 
     [XmlAttribute("dataFormatVersion")]
     [BindNever]
-    public string dataFormatVersion {get; set; } = "34556";
+    public string dataFormatVersion { get; set; } = "34556";
 
     [XmlElement("Applikasjon", Order = 1)]
     [JsonProperty("Applikasjon")]

--- a/testdata/Model/CSharp/Gitea/Kursdomene_BekrefteBruksvilkår_M_2020-05-25_5704_34554_SERES.cs
+++ b/testdata/Model/CSharp/Gitea/Kursdomene_BekrefteBruksvilkår_M_2020-05-25_5704_34554_SERES.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/Kursdomene_BekrefteBruksvilkår_M_2020-05-25_5704_34554_SERES.cs
+++ b/testdata/Model/CSharp/Gitea/Kursdomene_BekrefteBruksvilkår_M_2020-05-25_5704_34554_SERES.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;
@@ -14,15 +13,15 @@ namespace Altinn.App.Models
   {
     [XmlAttribute("dataFormatProvider")]
     [BindNever]
-    public string dataFormatProvider {get; set; } = "SERES";
+    public string dataFormatProvider { get; set; } = "SERES";
 
     [XmlAttribute("dataFormatId")]
     [BindNever]
-    public string dataFormatId {get; set; } = "5704";
+    public string dataFormatId { get; set; } = "5704";
 
     [XmlAttribute("dataFormatVersion")]
     [BindNever]
-    public string dataFormatVersion {get; set; } = "34554";
+    public string dataFormatVersion { get; set; } = "34554";
 
     [XmlElement("Tjenesteeier", Order = 1)]
     [JsonProperty("Tjenesteeier")]

--- a/testdata/Model/CSharp/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.cs
+++ b/testdata/Model/CSharp/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.cs
+++ b/testdata/Model/CSharp/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;
@@ -14,15 +13,15 @@ namespace Altinn.App.Models
   {
     [XmlAttribute("dataFormatProvider")]
     [BindNever]
-    public string dataFormatProvider {get; set; } = "SERES";
+    public string dataFormatProvider { get; set; } = "SERES";
 
     [XmlAttribute("dataFormatId")]
     [BindNever]
-    public string dataFormatId {get; set; } = "5703";
+    public string dataFormatId { get; set; } = "5703";
 
     [XmlAttribute("dataFormatVersion")]
     [BindNever]
-    public string dataFormatVersion {get; set; } = "34553";
+    public string dataFormatVersion { get; set; } = "34553";
 
     [XmlElement("Tjenesteeier", Order = 1)]
     [JsonProperty("Tjenesteeier")]

--- a/testdata/Model/CSharp/Gitea/aal-vedlegg.cs
+++ b/testdata/Model/CSharp/Gitea/aal-vedlegg.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/aal-vedlegg.cs
+++ b/testdata/Model/CSharp/Gitea/aal-vedlegg.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/CSharp/Gitea/bokskjema.cs
+++ b/testdata/Model/CSharp/Gitea/bokskjema.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/bokskjema.cs
+++ b/testdata/Model/CSharp/Gitea/bokskjema.cs
@@ -63,10 +63,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("meantForPress")]
     public bool? meantForPress { get; set; }
 
-    public bool ShouldSerializemeantForPress()
-    {
-      return meantForPress.HasValue;
-    }
+    public bool ShouldSerializemeantForPress() => meantForPress.HasValue;
 
     [XmlElement("language", Order = 11)]
     [JsonProperty("language")]
@@ -98,10 +95,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("hasISBN")]
     public bool? hasISBN { get; set; }
 
-    public bool ShouldSerializehasISBN()
-    {
-      return hasISBN.HasValue;
-    }
+    public bool ShouldSerializehasISBN() => hasISBN.HasValue;
 
     [RegularExpression(@"(?=[\S\s]{13}$|[\S\s]{17}$)[\S\s]*^(978([\-]?)[0-9]{2}([\-]?)([0-1][0-9]|[2-6][0-9]{2}|[78][0-9]{3}|9[0-8][0-9]{3}|99[0-9]{4}|69[0-9]{4})([\-]?)[0-9]{1,5}([\-]?)[xX0-9])$")]
     [XmlElement("isbn", Order = 17)]
@@ -119,10 +113,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("isSeries")]
     public bool? isSeries { get; set; }
 
-    public bool ShouldSerializeisSeries()
-    {
-      return isSeries.HasValue;
-    }
+    public bool ShouldSerializeisSeries() => isSeries.HasValue;
 
     [RegularExpression(@"(?=[\S\s]{8}$|[\S\s]{9}$)[\S\s]*^([0-9]{4}([\-]?)[0-9]{3}[xX0-9])$")]
     [XmlElement("issn", Order = 20)]
@@ -170,10 +161,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("hasISMN")]
     public bool? hasISMN { get; set; }
 
-    public bool ShouldSerializehasISMN()
-    {
-      return hasISMN.HasValue;
-    }
+    public bool ShouldSerializehasISMN() => hasISMN.HasValue;
 
     [RegularExpression(@"(?=[\S\s]{13}$|[\S\s]{17}$)[\S\s]*^(979([\-]?)0([\-]?)(0[0-9]{2}|[1-3][0-9]{3}|[4-6][0-9]{4}|[78][0-9]{5}|9[0-9]{6})([\-]?)[0-9]{1,5}([\-]?)[xX0-9])$")]
     [XmlElement("ismn", Order = 29)]
@@ -187,20 +175,14 @@ namespace Altinn.App.Models
     [JsonPropertyName("orgNumber")]
     public decimal? orgNumber { get; set; }
 
-    public bool ShouldSerializeorgNumber()
-    {
-      return orgNumber.HasValue;
-    }
+    public bool ShouldSerializeorgNumber() => orgNumber.HasValue;
 
     [XmlElement("access", Order = 31)]
     [JsonProperty("access")]
     [JsonPropertyName("access")]
     public bool? access { get; set; }
 
-    public bool ShouldSerializeaccess()
-    {
-      return access.HasValue;
-    }
+    public bool ShouldSerializeaccess() => access.HasValue;
 
     [XmlElement("comment", Order = 32)]
     [JsonProperty("comment")]
@@ -222,10 +204,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("role", Order = 1)]
     [JsonProperty("role")]
@@ -252,10 +231,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("orgName", Order = 1)]
     [JsonProperty("orgName")]
@@ -277,10 +253,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("publisherName", Order = 1)]
     [JsonProperty("publisherName")]

--- a/testdata/Model/CSharp/Gitea/bokskjema.cs
+++ b/testdata/Model/CSharp/Gitea/bokskjema.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;
@@ -216,6 +215,17 @@ namespace Altinn.App.Models
 
   public class personOfResponsibility
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("role", Order = 1)]
     [JsonProperty("role")]
     [JsonPropertyName("role")]
@@ -231,6 +241,10 @@ namespace Altinn.App.Models
     [JsonPropertyName("lastname")]
     public string lastname { get; set; }
 
+  }
+
+  public class organizationOfResponsibility
+  {
     [XmlAttribute("altinnRowId")]
     [JsonPropertyName("altinnRowId")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -239,13 +253,9 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId()
     {
-        return AltinnRowId != default;
+      return AltinnRowId != default;
     }
 
-  }
-
-  public class organizationOfResponsibility
-  {
     [XmlElement("orgName", Order = 1)]
     [JsonProperty("orgName")]
     [JsonPropertyName("orgName")]
@@ -256,6 +266,10 @@ namespace Altinn.App.Models
     [JsonPropertyName("orgRole")]
     public string orgRole { get; set; }
 
+  }
+
+  public class publisherObject
+  {
     [XmlAttribute("altinnRowId")]
     [JsonPropertyName("altinnRowId")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -264,26 +278,13 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId()
     {
-        return AltinnRowId != default;
+      return AltinnRowId != default;
     }
-  }
 
-  public class publisherObject
-  {
     [XmlElement("publisherName", Order = 1)]
     [JsonProperty("publisherName")]
     [JsonPropertyName("publisherName")]
     public string publisherName { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-        return AltinnRowId != default;
-    }
   }
 }

--- a/testdata/Model/CSharp/Gitea/dat-aarligmelding-bemanning.cs
+++ b/testdata/Model/CSharp/Gitea/dat-aarligmelding-bemanning.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/dat-aarligmelding-bemanning.cs
+++ b/testdata/Model/CSharp/Gitea/dat-aarligmelding-bemanning.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/CSharp/Gitea/dat-bilpleie-soknad.cs
+++ b/testdata/Model/CSharp/Gitea/dat-bilpleie-soknad.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/dat-bilpleie-soknad.cs
+++ b/testdata/Model/CSharp/Gitea/dat-bilpleie-soknad.cs
@@ -145,10 +145,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("AntallAnsatte")]
     public decimal? AntallAnsatte { get; set; }
 
-    public bool ShouldSerializeAntallAnsatte()
-    {
-      return AntallAnsatte.HasValue;
-    }
+    public bool ShouldSerializeAntallAnsatte() => AntallAnsatte.HasValue;
 
     [XmlElement("Underenheter", Order = 6)]
     [JsonProperty("Underenheter")]
@@ -174,10 +171,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [MinLength(0)]
     [MaxLength(255)]
@@ -207,20 +201,14 @@ namespace Altinn.App.Models
     [JsonPropertyName("ErIStatensVegvesen")]
     public bool? ErIStatensVegvesen { get; set; }
 
-    public bool ShouldSerializeErIStatensVegvesen()
-    {
-      return ErIStatensVegvesen.HasValue;
-    }
+    public bool ShouldSerializeErIStatensVegvesen() => ErIStatensVegvesen.HasValue;
 
     [XmlElement("KunAnsvarligSkalArbeide", Order = 2)]
     [JsonProperty("KunAnsvarligSkalArbeide")]
     [JsonPropertyName("KunAnsvarligSkalArbeide")]
     public bool? KunAnsvarligSkalArbeide { get; set; }
 
-    public bool ShouldSerializeKunAnsvarligSkalArbeide()
-    {
-      return KunAnsvarligSkalArbeide.HasValue;
-    }
+    public bool ShouldSerializeKunAnsvarligSkalArbeide() => KunAnsvarligSkalArbeide.HasValue;
 
     [Range(0,Double.MaxValue)]
     [XmlElement("AntallAnsatteEgenUtfylt", Order = 3)]
@@ -228,10 +216,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("AntallAnsatteEgenUtfylt")]
     public decimal? AntallAnsatteEgenUtfylt { get; set; }
 
-    public bool ShouldSerializeAntallAnsatteEgenUtfylt()
-    {
-      return AntallAnsatteEgenUtfylt.HasValue;
-    }
+    public bool ShouldSerializeAntallAnsatteEgenUtfylt() => AntallAnsatteEgenUtfylt.HasValue;
 
     [Range(0,Double.MaxValue)]
     [XmlElement("AntallHMSKort", Order = 4)]
@@ -239,20 +224,14 @@ namespace Altinn.App.Models
     [JsonPropertyName("AntallHMSKort")]
     public decimal? AntallHMSKort { get; set; }
 
-    public bool ShouldSerializeAntallHMSKort()
-    {
-      return AntallHMSKort.HasValue;
-    }
+    public bool ShouldSerializeAntallHMSKort() => AntallHMSKort.HasValue;
 
     [XmlElement("SkalUnderenheterJobbeMedBilpleie", Order = 5)]
     [JsonProperty("SkalUnderenheterJobbeMedBilpleie")]
     [JsonPropertyName("SkalUnderenheterJobbeMedBilpleie")]
     public bool? SkalUnderenheterJobbeMedBilpleie { get; set; }
 
-    public bool ShouldSerializeSkalUnderenheterJobbeMedBilpleie()
-    {
-      return SkalUnderenheterJobbeMedBilpleie.HasValue;
-    }
+    public bool ShouldSerializeSkalUnderenheterJobbeMedBilpleie() => SkalUnderenheterJobbeMedBilpleie.HasValue;
 
     [XmlElement("UnderenheterSomSkalBilpleie", Order = 6)]
     [JsonProperty("UnderenheterSomSkalBilpleie")]
@@ -264,10 +243,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("OmfattetAvForurensingsforskriften")]
     public bool? OmfattetAvForurensingsforskriften { get; set; }
 
-    public bool ShouldSerializeOmfattetAvForurensingsforskriften()
-    {
-      return OmfattetAvForurensingsforskriften.HasValue;
-    }
+    public bool ShouldSerializeOmfattetAvForurensingsforskriften() => OmfattetAvForurensingsforskriften.HasValue;
 
     [XmlElement("UnderenheterOmfattetAvForurensingsforskriften", Order = 8)]
     [JsonProperty("UnderenheterOmfattetAvForurensingsforskriften")]
@@ -279,10 +255,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("HarVerneombud")]
     public bool? HarVerneombud { get; set; }
 
-    public bool ShouldSerializeHarVerneombud()
-    {
-      return HarVerneombud.HasValue;
-    }
+    public bool ShouldSerializeHarVerneombud() => HarVerneombud.HasValue;
 
     [MinLength(0)]
     [MaxLength(255)]
@@ -303,20 +276,14 @@ namespace Altinn.App.Models
     [JsonPropertyName("AlternativOrdning")]
     public bool? AlternativOrdning { get; set; }
 
-    public bool ShouldSerializeAlternativOrdning()
-    {
-      return AlternativOrdning.HasValue;
-    }
+    public bool ShouldSerializeAlternativOrdning() => AlternativOrdning.HasValue;
 
     [XmlElement("HarAMU", Order = 13)]
     [JsonProperty("HarAMU")]
     [JsonPropertyName("HarAMU")]
     public bool? HarAMU { get; set; }
 
-    public bool ShouldSerializeHarAMU()
-    {
-      return HarAMU.HasValue;
-    }
+    public bool ShouldSerializeHarAMU() => HarAMU.HasValue;
 
     [Range(Double.MinValue,Double.MaxValue)]
     [XmlElement("BHTorgnr", Order = 14)]
@@ -324,10 +291,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("BHTorgnr")]
     public decimal? BHTorgnr { get; set; }
 
-    public bool ShouldSerializeBHTorgnr()
-    {
-      return BHTorgnr.HasValue;
-    }
+    public bool ShouldSerializeBHTorgnr() => BHTorgnr.HasValue;
 
     [XmlElement("Arbeidsavtaler", Order = 15)]
     [JsonProperty("Arbeidsavtaler")]
@@ -339,10 +303,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("ErUtfyllerKontaktPerson")]
     public bool? ErUtfyllerKontaktPerson { get; set; }
 
-    public bool ShouldSerializeErUtfyllerKontaktPerson()
-    {
-      return ErUtfyllerKontaktPerson.HasValue;
-    }
+    public bool ShouldSerializeErUtfyllerKontaktPerson() => ErUtfyllerKontaktPerson.HasValue;
 
     [MinLength(0)]
     [MaxLength(255)]
@@ -370,20 +331,14 @@ namespace Altinn.App.Models
     [JsonPropertyName("BekreftOpplysninger")]
     public bool? BekreftOpplysninger { get; set; }
 
-    public bool ShouldSerializeBekreftOpplysninger()
-    {
-      return BekreftOpplysninger.HasValue;
-    }
+    public bool ShouldSerializeBekreftOpplysninger() => BekreftOpplysninger.HasValue;
 
     [XmlElement("BekreftStraff", Order = 21)]
     [JsonProperty("BekreftStraff")]
     [JsonPropertyName("BekreftStraff")]
     public bool? BekreftStraff { get; set; }
 
-    public bool ShouldSerializeBekreftStraff()
-    {
-      return BekreftStraff.HasValue;
-    }
+    public bool ShouldSerializeBekreftStraff() => BekreftStraff.HasValue;
 
   }
 }

--- a/testdata/Model/CSharp/Gitea/dat-bilpleie-soknad.cs
+++ b/testdata/Model/CSharp/Gitea/dat-bilpleie-soknad.cs
@@ -167,6 +167,17 @@ namespace Altinn.App.Models
 
   public class Underenhet
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [MinLength(0)]
     [MaxLength(255)]
     [XmlElement("Organisasjonsnummer", Order = 1)]
@@ -186,16 +197,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("Adresse")]
     public Adresse Adresse { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class InnholdSkjema

--- a/testdata/Model/CSharp/Gitea/dat-skjema.cs
+++ b/testdata/Model/CSharp/Gitea/dat-skjema.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/dat-skjema.cs
+++ b/testdata/Model/CSharp/Gitea/dat-skjema.cs
@@ -163,10 +163,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [MinLength(0)]
     [MaxLength(255)]
@@ -197,10 +194,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("AntallAnsatte")]
     public decimal? AntallAnsatte { get; set; }
 
-    public bool ShouldSerializeAntallAnsatte()
-    {
-      return AntallAnsatte.HasValue;
-    }
+    public bool ShouldSerializeAntallAnsatte() => AntallAnsatte.HasValue;
 
     [XmlElement("ASellerASAiHjemland", Order = 2)]
     [JsonProperty("ASellerASAiHjemland")]

--- a/testdata/Model/CSharp/Gitea/dat-skjema.cs
+++ b/testdata/Model/CSharp/Gitea/dat-skjema.cs
@@ -156,6 +156,17 @@ namespace Altinn.App.Models
 
   public class Underenhet
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [MinLength(0)]
     [MaxLength(255)]
     [XmlElement("Organisasjonsnummer", Order = 1)]
@@ -175,16 +186,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("Adresse")]
     public Adresse Adresse { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class InnholdSkjema

--- a/testdata/Model/CSharp/Gitea/dev-nill-test.cs
+++ b/testdata/Model/CSharp/Gitea/dev-nill-test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/dev-nill-test.cs
+++ b/testdata/Model/CSharp/Gitea/dev-nill-test.cs
@@ -26,10 +26,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("nonNillableRef")]
     public bool? nonNillableRef { get; set; }
 
-    public bool ShouldSerializenonNillableRef()
-    {
-      return nonNillableRef.HasValue;
-    }
+    public bool ShouldSerializenonNillableRef() => nonNillableRef.HasValue;
 
     [XmlElement("nillableRef", Order = 2)]
     [JsonProperty("nillableRef")]
@@ -41,10 +38,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("nonNillableBoolean")]
     public bool? nonNillableBoolean { get; set; }
 
-    public bool ShouldSerializenonNillableBoolean()
-    {
-      return nonNillableBoolean.HasValue;
-    }
+    public bool ShouldSerializenonNillableBoolean() => nonNillableBoolean.HasValue;
 
     [XmlElement("nillableBoolean", Order = 4)]
     [JsonProperty("nillableBoolean")]

--- a/testdata/Model/CSharp/Gitea/dev-nill-test.cs
+++ b/testdata/Model/CSharp/Gitea/dev-nill-test.cs
@@ -3,58 +3,57 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;
 namespace Altinn.App.Models
 {
-    [XmlRoot(ElementName="modell")]
-    public class modell
-    {
-        [XmlElement("element", Order = 1)]
-        [JsonProperty("element")]
-        [JsonPropertyName("element")]
-        public ModelType element { get; set; }
+  [XmlRoot(ElementName="modell")]
+  public class modell
+  {
+    [XmlElement("element", Order = 1)]
+    [JsonProperty("element")]
+    [JsonPropertyName("element")]
+    public ModelType element { get; set; }
 
+  }
+
+  public class ModelType
+  {
+    [XmlElement("nonNillableRef", Order = 1)]
+    [JsonProperty("nonNillableRef")]
+    [JsonPropertyName("nonNillableRef")]
+    public bool? nonNillableRef { get; set; }
+
+    public bool ShouldSerializenonNillableRef()
+    {
+      return nonNillableRef.HasValue;
     }
 
-    public class ModelType
+    [XmlElement("nillableRef", Order = 2)]
+    [JsonProperty("nillableRef")]
+    [JsonPropertyName("nillableRef")]
+    public bool? nillableRef { get; set; }
+
+    [XmlElement("nonNillableBoolean", Order = 3)]
+    [JsonProperty("nonNillableBoolean")]
+    [JsonPropertyName("nonNillableBoolean")]
+    public bool? nonNillableBoolean { get; set; }
+
+    public bool ShouldSerializenonNillableBoolean()
     {
-        [XmlElement("nonNillableRef", Order = 1)]
-        [JsonProperty("nonNillableRef")]
-        [JsonPropertyName("nonNillableRef")]
-        public bool? nonNillableRef { get; set; }
-
-        public bool ShouldSerializenonNillableRef()
-        {
-            return nonNillableRef.HasValue;
-        }
-
-        [XmlElement("nillableRef", Order = 2)]
-        [JsonProperty("nillableRef")]
-        [JsonPropertyName("nillableRef")]
-        public bool? nillableRef { get; set; }
-
-        [XmlElement("nonNillableBoolean", Order = 3)]
-        [JsonProperty("nonNillableBoolean")]
-        [JsonPropertyName("nonNillableBoolean")]
-        public bool? nonNillableBoolean { get; set; }
-
-        public bool ShouldSerializenonNillableBoolean()
-        {
-            return nonNillableBoolean.HasValue;
-        }
-
-        [XmlElement("nillableBoolean", Order = 4)]
-        [JsonProperty("nillableBoolean")]
-        [JsonPropertyName("nillableBoolean")]
-        public bool? nillableBoolean { get; set; }
-
-        [XmlElement("s1", Order = 5)]
-        [JsonProperty("s1")]
-        [JsonPropertyName("s1")]
-        public string s1 { get; set; }
-
+      return nonNillableBoolean.HasValue;
     }
+
+    [XmlElement("nillableBoolean", Order = 4)]
+    [JsonProperty("nillableBoolean")]
+    [JsonPropertyName("nillableBoolean")]
+    public bool? nillableBoolean { get; set; }
+
+    [XmlElement("s1", Order = 5)]
+    [JsonProperty("s1")]
+    [JsonPropertyName("s1")]
+    public string s1 { get; set; }
+
+  }
 }

--- a/testdata/Model/CSharp/Gitea/dihe-redusert-foreldrebetaling-bhg.cs
+++ b/testdata/Model/CSharp/Gitea/dihe-redusert-foreldrebetaling-bhg.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/dihe-redusert-foreldrebetaling-bhg.cs
+++ b/testdata/Model/CSharp/Gitea/dihe-redusert-foreldrebetaling-bhg.cs
@@ -141,10 +141,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("DL_DOKID_DB", Order = 1)]
     [JsonProperty("DL_DOKID_DB")]
@@ -166,10 +163,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("DB_DOKID", Order = 1)]
     [JsonProperty("DB_DOKID")]
@@ -191,10 +185,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("VE_DOKID_DB", Order = 1)]
     [JsonProperty("VE_DOKID_DB")]
@@ -321,10 +312,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("navn", Order = 1)]
     [JsonProperty("navn")]
@@ -361,10 +349,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("grunnlagNavn", Order = 1)]
     [JsonProperty("grunnlagNavn")]

--- a/testdata/Model/CSharp/Gitea/dihe-redusert-foreldrebetaling-bhg.cs
+++ b/testdata/Model/CSharp/Gitea/dihe-redusert-foreldrebetaling-bhg.cs
@@ -134,6 +134,17 @@ namespace Altinn.App.Models
 
   public class DOKLINK
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("DL_DOKID_DB", Order = 1)]
     [JsonProperty("DL_DOKID_DB")]
     [JsonPropertyName("DL_DOKID_DB")]
@@ -144,6 +155,10 @@ namespace Altinn.App.Models
     [JsonPropertyName("DL_TYPE_DT")]
     public string DL_TYPE_DT { get; set; }
 
+  }
+
+  public class DOKBESKRIV
+  {
     [XmlAttribute("altinnRowId")]
     [JsonPropertyName("altinnRowId")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -154,10 +169,7 @@ namespace Altinn.App.Models
     {
       return AltinnRowId != default;
     }
-  }
 
-  public class DOKBESKRIV
-  {
     [XmlElement("DB_DOKID", Order = 1)]
     [JsonProperty("DB_DOKID")]
     [JsonPropertyName("DB_DOKID")]
@@ -168,6 +180,10 @@ namespace Altinn.App.Models
     [JsonPropertyName("DB_TITTEL")]
     public string DB_TITTEL { get; set; }
 
+  }
+
+  public class DOKVERSJON
+  {
     [XmlAttribute("altinnRowId")]
     [JsonPropertyName("altinnRowId")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -178,10 +194,7 @@ namespace Altinn.App.Models
     {
       return AltinnRowId != default;
     }
-  }
 
-  public class DOKVERSJON
-  {
     [XmlElement("VE_DOKID_DB", Order = 1)]
     [JsonProperty("VE_DOKID_DB")]
     [JsonPropertyName("VE_DOKID_DB")]
@@ -197,16 +210,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("VE_FILREF")]
     public string VE_FILREF { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class FlatData
@@ -311,6 +314,17 @@ namespace Altinn.App.Models
 
   public class Barn
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("navn", Order = 1)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
@@ -336,6 +350,10 @@ namespace Altinn.App.Models
     [JsonPropertyName("bhgEllerSfo")]
     public string bhgEllerSfo { get; set; }
 
+  }
+
+  public class Skattegrunnlag
+  {
     [XmlAttribute("altinnRowId")]
     [JsonPropertyName("altinnRowId")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -346,10 +364,7 @@ namespace Altinn.App.Models
     {
       return AltinnRowId != default;
     }
-  }
 
-  public class Skattegrunnlag
-  {
     [XmlElement("grunnlagNavn", Order = 1)]
     [JsonProperty("grunnlagNavn")]
     [JsonPropertyName("grunnlagNavn")]
@@ -362,16 +377,6 @@ namespace Altinn.App.Models
     [Required]
     public decimal? beloep { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class AppLogikk

--- a/testdata/Model/CSharp/Gitea/hi-algeskjema.cs
+++ b/testdata/Model/CSharp/Gitea/hi-algeskjema.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/hi-algeskjema.cs
+++ b/testdata/Model/CSharp/Gitea/hi-algeskjema.cs
@@ -37,20 +37,14 @@ namespace Altinn.App.Models
     [JsonPropertyName("longitude")]
     public decimal? longitude { get; set; }
 
-    public bool ShouldSerializelongitude()
-    {
-      return longitude.HasValue;
-    }
+    public bool ShouldSerializelongitude() => longitude.HasValue;
 
     [XmlElement("latitude", Order = 6)]
     [JsonProperty("latitude")]
     [JsonPropertyName("latitude")]
     public decimal? latitude { get; set; }
 
-    public bool ShouldSerializelatitude()
-    {
-      return latitude.HasValue;
-    }
+    public bool ShouldSerializelatitude() => latitude.HasValue;
 
     [Range(Double.MinValue,Double.MaxValue)]
     [XmlElement("depth", Order = 7)]
@@ -58,10 +52,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("depth")]
     public decimal? depth { get; set; }
 
-    public bool ShouldSerializedepth()
-    {
-      return depth.HasValue;
-    }
+    public bool ShouldSerializedepth() => depth.HasValue;
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
     [XmlElement("sampledate", Order = 8)]
@@ -75,10 +66,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("hour")]
     public decimal? hour { get; set; }
 
-    public bool ShouldSerializehour()
-    {
-      return hour.HasValue;
-    }
+    public bool ShouldSerializehour() => hour.HasValue;
 
     [Range(Double.MinValue,Double.MaxValue)]
     [XmlElement("minute", Order = 10)]
@@ -86,10 +74,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("minute")]
     public decimal? minute { get; set; }
 
-    public bool ShouldSerializeminute()
-    {
-      return minute.HasValue;
-    }
+    public bool ShouldSerializeminute() => minute.HasValue;
 
     [XmlElement("productionarea", Order = 11)]
     [JsonProperty("productionarea")]
@@ -116,30 +101,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("harmfulalgae")]
     public bool? harmfulalgae { get; set; }
 
-    public bool ShouldSerializeharmfulalgae()
-    {
-      return harmfulalgae.HasValue;
-    }
+    public bool ShouldSerializeharmfulalgae() => harmfulalgae.HasValue;
 
     [XmlElement("reportedmortality", Order = 16)]
     [JsonProperty("reportedmortality")]
     [JsonPropertyName("reportedmortality")]
     public bool? reportedmortality { get; set; }
 
-    public bool ShouldSerializereportedmortality()
-    {
-      return reportedmortality.HasValue;
-    }
+    public bool ShouldSerializereportedmortality() => reportedmortality.HasValue;
 
     [XmlElement("behaviourchanges", Order = 17)]
     [JsonProperty("behaviourchanges")]
     [JsonPropertyName("behaviourchanges")]
     public bool? behaviourchanges { get; set; }
 
-    public bool ShouldSerializebehaviourchanges()
-    {
-      return behaviourchanges.HasValue;
-    }
+    public bool ShouldSerializebehaviourchanges() => behaviourchanges.HasValue;
 
     [Range(Double.MinValue,Double.MaxValue)]
     [XmlElement("diatomcount", Order = 18)]
@@ -147,10 +123,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("diatomcount")]
     public decimal? diatomcount { get; set; }
 
-    public bool ShouldSerializediatomcount()
-    {
-      return diatomcount.HasValue;
-    }
+    public bool ShouldSerializediatomcount() => diatomcount.HasValue;
 
     [Range(Double.MinValue,Double.MaxValue)]
     [XmlElement("dinoflagellatecount", Order = 19)]
@@ -158,10 +131,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("dinoflagellatecount")]
     public decimal? dinoflagellatecount { get; set; }
 
-    public bool ShouldSerializedinoflagellatecount()
-    {
-      return dinoflagellatecount.HasValue;
-    }
+    public bool ShouldSerializedinoflagellatecount() => dinoflagellatecount.HasValue;
 
     [Range(Double.MinValue,Double.MaxValue)]
     [XmlElement("flagellatecount", Order = 20)]
@@ -169,10 +139,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("flagellatecount")]
     public decimal? flagellatecount { get; set; }
 
-    public bool ShouldSerializeflagellatecount()
-    {
-      return flagellatecount.HasValue;
-    }
+    public bool ShouldSerializeflagellatecount() => flagellatecount.HasValue;
 
     [XmlElement("comments", Order = 21)]
     [JsonProperty("comments")]
@@ -199,10 +166,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("scientificname", Order = 1)]
     [JsonProperty("scientificname")]
@@ -215,10 +179,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("density")]
     public decimal? density { get; set; }
 
-    public bool ShouldSerializedensity()
-    {
-      return density.HasValue;
-    }
+    public bool ShouldSerializedensity() => density.HasValue;
 
   }
 
@@ -230,10 +191,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("organisationid", Order = 1)]
     [JsonProperty("organisationid")]

--- a/testdata/Model/CSharp/Gitea/hi-algeskjema.cs
+++ b/testdata/Model/CSharp/Gitea/hi-algeskjema.cs
@@ -192,6 +192,17 @@ namespace Altinn.App.Models
 
   public class AltinnAlgae
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("scientificname", Order = 1)]
     [JsonProperty("scientificname")]
     [JsonPropertyName("scientificname")]
@@ -208,6 +219,10 @@ namespace Altinn.App.Models
       return density.HasValue;
     }
 
+  }
+
+  public class AltinnOwner
+  {
     [XmlAttribute("altinnRowId")]
     [JsonPropertyName("altinnRowId")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -218,10 +233,7 @@ namespace Altinn.App.Models
     {
       return AltinnRowId != default;
     }
-  }
 
-  public class AltinnOwner
-  {
     [XmlElement("organisationid", Order = 1)]
     [JsonProperty("organisationid")]
     [JsonPropertyName("organisationid")]
@@ -232,15 +244,5 @@ namespace Altinn.App.Models
     [JsonPropertyName("organisationname")]
     public string organisationname { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 }

--- a/testdata/Model/CSharp/Gitea/krt-1188a-1.cs
+++ b/testdata/Model/CSharp/Gitea/krt-1188a-1.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/krt-1188a-1.cs
+++ b/testdata/Model/CSharp/Gitea/krt-1188a-1.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;
@@ -14,15 +13,15 @@ namespace Altinn.App.Models
   {
     [XmlAttribute("dataFormatProvider")]
     [BindNever]
-    public string dataFormatProvider {get; set; } = "SERES";
+    public string dataFormatProvider { get; set; } = "SERES";
 
     [XmlAttribute("dataFormatId")]
     [BindNever]
-    public string dataFormatId {get; set; } = "6946";
+    public string dataFormatId { get; set; } = "6946";
 
     [XmlAttribute("dataFormatVersion")]
     [BindNever]
-    public string dataFormatVersion {get; set; } = "46317";
+    public string dataFormatVersion { get; set; } = "46317";
 
     [XmlElement("rapport", Order = 1)]
     [JsonProperty("rapport")]
@@ -91,7 +90,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Postnummer/660288";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Postnummer/660288";
 
   }
 
@@ -103,7 +102,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Adresselinje1/660286";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Adresselinje1/660286";
 
   }
 
@@ -115,7 +114,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Poststed/660287";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Poststed/660287";
 
   }
 
@@ -142,7 +141,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Organisasjonsnummer/472763";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Organisasjonsnummer/472763";
 
   }
 
@@ -154,7 +153,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Foretaksnavn/639250";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Foretaksnavn/639250";
 
   }
 
@@ -167,7 +166,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Målform/660674";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Målform/660674";
 
   }
 
@@ -241,7 +240,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Arkivkode/660676";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Arkivkode/660676";
 
   }
 
@@ -276,7 +275,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Epost_S01/637664";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Epost_S01/637664";
 
   }
 
@@ -288,7 +287,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Navn_S01/637662";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Navn_S01/637662";
 
   }
 
@@ -300,7 +299,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/TelefonNummer_S01/637660";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/TelefonNummer_S01/637660";
 
   }
 
@@ -312,7 +311,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/TelefonPrefiks_S01/637658";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/TelefonPrefiks_S01/637658";
 
   }
 
@@ -347,7 +346,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Epost_S02/637663";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Epost_S02/637663";
 
   }
 
@@ -359,7 +358,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Navn_S02/637661";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Navn_S02/637661";
 
   }
 
@@ -371,7 +370,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/TelefonNummer_S02/637659";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/TelefonNummer_S02/637659";
 
   }
 
@@ -383,7 +382,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/TelefonPrefiks_S02/637657";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/TelefonPrefiks_S02/637657";
 
   }
 
@@ -409,7 +408,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/År/660276";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/År/660276";
 
   }
 
@@ -420,7 +419,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Periodetype/660275";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Periodetype/660275";
 
   }
 
@@ -441,7 +440,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/RapporteringsId/636854";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/RapporteringsId/636854";
 
   }
 
@@ -454,7 +453,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Tekst_60_S1/488638";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Tekst_60_S1/488638";
 
   }
 
@@ -466,7 +465,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Tekst_120_S01/619866";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Tekst_120_S01/619866";
 
   }
 
@@ -477,7 +476,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Avdeling/664243";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Avdeling/664243";
 
   }
 
@@ -490,7 +489,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Tekst_255_S10/600714";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/Tekst_255_S10/600714";
 
   }
 
@@ -502,7 +501,7 @@ namespace Altinn.App.Models
 
     [XmlAttribute("guid")]
     [BindNever]
-    public string guid {get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/År_S01/602291";
+    public string guid { get; set; } = "http://seres.no/guid/Finanstilsynet/Dataenkeltype/År_S01/602291";
 
   }
 }

--- a/testdata/Model/CSharp/Gitea/krt-1188a-1.cs
+++ b/testdata/Model/CSharp/Gitea/krt-1188a-1.cs
@@ -62,6 +62,8 @@ namespace Altinn.App.Models
     [JsonPropertyName("maalform")]
     public Maalform maalform { get; set; }
 
+    public bool ShouldSerializemaalform() => maalform?.valueNullable is not null;
+
   }
 
   public class Adresse
@@ -71,15 +73,21 @@ namespace Altinn.App.Models
     [JsonPropertyName("postnummer")]
     public Postnummer postnummer { get; set; }
 
+    public bool ShouldSerializepostnummer() => postnummer?.value is not null;
+
     [XmlElement("adresselinje1", Order = 2)]
     [JsonProperty("adresselinje1")]
     [JsonPropertyName("adresselinje1")]
     public Adresselinje1 adresselinje1 { get; set; }
 
+    public bool ShouldSerializeadresselinje1() => adresselinje1?.value is not null;
+
     [XmlElement("poststed", Order = 3)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
     public Poststed poststed { get; set; }
+
+    public bool ShouldSerializepoststed() => poststed?.value is not null;
 
   }
 
@@ -126,10 +134,14 @@ namespace Altinn.App.Models
     [JsonPropertyName("organisasjonsnummer")]
     public Organisasjonsnummer organisasjonsnummer { get; set; }
 
+    public bool ShouldSerializeorganisasjonsnummer() => organisasjonsnummer?.value is not null;
+
     [XmlElement("navn", Order = 2)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public Foretaksnavn navn { get; set; }
+
+    public bool ShouldSerializenavn() => navn?.value is not null;
 
   }
 
@@ -161,9 +173,23 @@ namespace Altinn.App.Models
   public class Maalform
   {
     [Range(Double.MinValue,Double.MaxValue)]
-    [XmlText()]
     [Required]
-    public decimal value { get; set; }
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    [JsonProperty(PropertyName = "value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public decimal value
+    {
+      get => valueNullable ?? default;
+      set
+      {
+        this.valueNullable = value;
+      }
+    }
 
     [XmlAttribute("guid")]
     [BindNever]
@@ -203,25 +229,35 @@ namespace Altinn.App.Models
     [JsonPropertyName("sporvalgrappreg")]
     public Tekst_60_S1 sporvalgrappreg { get; set; }
 
+    public bool ShouldSerializesporvalgrappreg() => sporvalgrappreg?.value is not null;
+
     [XmlElement("hjelpefelt", Order = 7)]
     [JsonProperty("hjelpefelt")]
     [JsonPropertyName("hjelpefelt")]
     public Tekst_120_S01 hjelpefelt { get; set; }
+
+    public bool ShouldSerializehjelpefelt() => hjelpefelt?.value is not null;
 
     [XmlElement("avdeling", Order = 8)]
     [JsonProperty("avdeling")]
     [JsonPropertyName("avdeling")]
     public Avdeling avdeling { get; set; }
 
+    public bool ShouldSerializeavdeling() => avdeling?.value is not null;
+
     [XmlElement("beskrivelse", Order = 9)]
     [JsonProperty("beskrivelse")]
     [JsonPropertyName("beskrivelse")]
     public Tekst_255_S10 beskrivelse { get; set; }
 
+    public bool ShouldSerializebeskrivelse() => beskrivelse?.value is not null;
+
     [XmlElement("periodeaarstall", Order = 10)]
     [JsonProperty("periodeaarstall")]
     [JsonPropertyName("periodeaarstall")]
     public AAr_S01 periodeaarstall { get; set; }
+
+    public bool ShouldSerializeperiodeaarstall() => periodeaarstall?.value is not null;
 
   }
 
@@ -231,6 +267,8 @@ namespace Altinn.App.Models
     [JsonProperty("arkivkode")]
     [JsonPropertyName("arkivkode")]
     public Arkivkode arkivkode { get; set; }
+
+    public bool ShouldSerializearkivkode() => arkivkode?.value is not null;
 
   }
 
@@ -252,20 +290,28 @@ namespace Altinn.App.Models
     [JsonPropertyName("epost")]
     public Epost_S01 epost { get; set; }
 
+    public bool ShouldSerializeepost() => epost?.value is not null;
+
     [XmlElement("navn", Order = 2)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public Navn_S01 navn { get; set; }
+
+    public bool ShouldSerializenavn() => navn?.value is not null;
 
     [XmlElement("telefonnummer", Order = 3)]
     [JsonProperty("telefonnummer")]
     [JsonPropertyName("telefonnummer")]
     public TelefonNummer_S01 telefonnummer { get; set; }
 
+    public bool ShouldSerializetelefonnummer() => telefonnummer?.value is not null;
+
     [XmlElement("telefonprefiks", Order = 4)]
     [JsonProperty("telefonprefiks")]
     [JsonPropertyName("telefonprefiks")]
     public TelefonPrefiks_S01 telefonprefiks { get; set; }
+
+    public bool ShouldSerializetelefonprefiks() => telefonprefiks?.value is not null;
 
   }
 
@@ -323,20 +369,28 @@ namespace Altinn.App.Models
     [JsonPropertyName("epost")]
     public Epost_S02 epost { get; set; }
 
+    public bool ShouldSerializeepost() => epost?.value is not null;
+
     [XmlElement("navn", Order = 2)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public Navn_S02 navn { get; set; }
+
+    public bool ShouldSerializenavn() => navn?.value is not null;
 
     [XmlElement("telefonnummer", Order = 3)]
     [JsonProperty("telefonnummer")]
     [JsonPropertyName("telefonnummer")]
     public TelefonNummer_S02 telefonnummer { get; set; }
 
+    public bool ShouldSerializetelefonnummer() => telefonnummer?.value is not null;
+
     [XmlElement("telefonprefiks", Order = 4)]
     [JsonProperty("telefonprefiks")]
     [JsonPropertyName("telefonprefiks")]
     public TelefonPrefiks_S02 telefonprefiks { get; set; }
+
+    public bool ShouldSerializetelefonprefiks() => telefonprefiks?.value is not null;
 
   }
 
@@ -394,10 +448,14 @@ namespace Altinn.App.Models
     [JsonPropertyName("aar")]
     public AAr aar { get; set; }
 
+    public bool ShouldSerializeaar() => aar?.value is not null;
+
     [XmlElement("periodetype", Order = 2)]
     [JsonProperty("periodetype")]
     [JsonPropertyName("periodetype")]
     public Periodetype periodetype { get; set; }
+
+    public bool ShouldSerializeperiodetype() => periodetype?.value is not null;
 
   }
 
@@ -430,6 +488,8 @@ namespace Altinn.App.Models
     [JsonProperty("rapporteringsid")]
     [JsonPropertyName("rapporteringsid")]
     public Rapporteringsid rapporteringsid { get; set; }
+
+    public bool ShouldSerializerapporteringsid() => rapporteringsid?.value is not null;
 
   }
 

--- a/testdata/Model/CSharp/Gitea/nbib-melding.cs
+++ b/testdata/Model/CSharp/Gitea/nbib-melding.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/nbib-melding.cs
+++ b/testdata/Model/CSharp/Gitea/nbib-melding.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/CSharp/Gitea/nsm-klareringsportalen.cs
+++ b/testdata/Model/CSharp/Gitea/nsm-klareringsportalen.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/nsm-klareringsportalen.cs
+++ b/testdata/Model/CSharp/Gitea/nsm-klareringsportalen.cs
@@ -95,6 +95,17 @@ namespace Altinn.App.Models
 
   public class Arbeidserfaringer
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("fraaar", Order = 1)]
     [JsonProperty("fraaar")]
     [JsonPropertyName("fraaar")]
@@ -165,16 +176,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("tilmaaned")]
     public string tilmaaned { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class Personalia
@@ -283,6 +284,17 @@ namespace Altinn.App.Models
 
   public class Adresse
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("adressebeskrivelse", Order = 1)]
     [JsonProperty("adressebeskrivelse")]
     [JsonPropertyName("adressebeskrivelse")]
@@ -303,6 +315,10 @@ namespace Altinn.App.Models
     [JsonPropertyName("land")]
     public string land { get; set; }
 
+  }
+
+  public class Iddokumenter
+  {
     [XmlAttribute("altinnRowId")]
     [JsonPropertyName("altinnRowId")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -313,10 +329,7 @@ namespace Altinn.App.Models
     {
       return AltinnRowId != default;
     }
-  }
 
-  public class Iddokumenter
-  {
     [XmlElement("typedokument", Order = 1)]
     [JsonProperty("typedokument")]
     [JsonPropertyName("typedokument")]
@@ -332,6 +345,10 @@ namespace Altinn.App.Models
     [JsonPropertyName("land")]
     public string land { get; set; }
 
+  }
+
+  public class Person
+  {
     [XmlAttribute("altinnRowId")]
     [JsonPropertyName("altinnRowId")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -342,10 +359,7 @@ namespace Altinn.App.Models
     {
       return AltinnRowId != default;
     }
-  }
 
-  public class Person
-  {
     [XmlElement("foedselsnummer", Order = 1)]
     [JsonProperty("foedselsnummer")]
     [JsonPropertyName("foedselsnummer")]
@@ -381,16 +395,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("utenlandsadresse")]
     public List<Adresse> utenlandsadresse { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class Personnavn
@@ -419,6 +423,17 @@ namespace Altinn.App.Models
 
   public class Statsborgerskap
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("fraDato", Order = 1)]
     [JsonProperty("fraDato")]
     [JsonPropertyName("fraDato")]
@@ -454,16 +469,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("land")]
     public string land { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class Relasjoner
@@ -572,6 +577,17 @@ namespace Altinn.App.Models
 
   public class Naerstaaende
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("personinfo", Order = 1)]
     [JsonProperty("personinfo")]
     [JsonPropertyName("personinfo")]
@@ -617,16 +633,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("relasjonmedperson")]
     public string relasjonmedperson { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class Samboerektefelle
@@ -690,6 +696,17 @@ namespace Altinn.App.Models
 
   public class Bostedhistorikkutland
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("land", Order = 1)]
     [JsonProperty("land")]
     [JsonPropertyName("land")]
@@ -740,6 +757,10 @@ namespace Altinn.App.Models
     [JsonPropertyName("spesifikasjon")]
     public string spesifikasjon { get; set; }
 
+  }
+
+  public class Bostedhistorikkeu
+  {
     [XmlAttribute("altinnRowId")]
     [JsonPropertyName("altinnRowId")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -750,10 +771,7 @@ namespace Altinn.App.Models
     {
       return AltinnRowId != default;
     }
-  }
 
-  public class Bostedhistorikkeu
-  {
     [XmlElement("land", Order = 1)]
     [JsonProperty("land")]
     [JsonPropertyName("land")]
@@ -774,16 +792,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("antallganger")]
     public string antallganger { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class OEkonomi
@@ -862,6 +870,17 @@ namespace Altinn.App.Models
 
   public class Investering
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("type", Order = 1)]
     [JsonProperty("type")]
     [JsonPropertyName("type")]
@@ -877,6 +896,10 @@ namespace Altinn.App.Models
     [JsonPropertyName("land")]
     public string land { get; set; }
 
+  }
+
+  public class Transaksjonutland
+  {
     [XmlAttribute("altinnRowId")]
     [JsonPropertyName("altinnRowId")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -887,10 +910,7 @@ namespace Altinn.App.Models
     {
       return AltinnRowId != default;
     }
-  }
 
-  public class Transaksjonutland
-  {
     [XmlElement("antallganger", Order = 1)]
     [JsonProperty("antallganger")]
     [JsonPropertyName("antallganger")]
@@ -911,16 +931,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("belop")]
     public string belop { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class Strafferettslig
@@ -959,6 +969,17 @@ namespace Altinn.App.Models
 
   public class Straffforhold
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("aar", Order = 1)]
     [JsonProperty("aar")]
     [JsonPropertyName("aar")]
@@ -979,16 +1000,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("type")]
     public string type { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class Rusmidler
@@ -1145,6 +1156,17 @@ namespace Altinn.App.Models
 
   public class Tilknytningtilfelle
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [XmlElement("beskrivelse", Order = 1)]
     [JsonProperty("beskrivelse")]
     [JsonPropertyName("beskrivelse")]
@@ -1165,6 +1187,10 @@ namespace Altinn.App.Models
     [JsonPropertyName("til")]
     public string til { get; set; }
 
+  }
+
+  public class Utdanningssted
+  {
     [XmlAttribute("altinnRowId")]
     [JsonPropertyName("altinnRowId")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -1175,10 +1201,7 @@ namespace Altinn.App.Models
     {
       return AltinnRowId != default;
     }
-  }
 
-  public class Utdanningssted
-  {
     [XmlElement("utdanningsted", Order = 1)]
     [JsonProperty("utdanningsted")]
     [JsonPropertyName("utdanningsted")]
@@ -1199,16 +1222,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("til")]
     public string til { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class Helse

--- a/testdata/Model/CSharp/Gitea/nsm-klareringsportalen.cs
+++ b/testdata/Model/CSharp/Gitea/nsm-klareringsportalen.cs
@@ -102,10 +102,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("fraaar", Order = 1)]
     [JsonProperty("fraaar")]
@@ -216,10 +213,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("ishatttidligerenavn")]
     public bool? ishatttidligerenavn { get; set; }
 
-    public bool ShouldSerializeishatttidligerenavn()
-    {
-      return ishatttidligerenavn.HasValue;
-    }
+    public bool ShouldSerializeishatttidligerenavn() => ishatttidligerenavn.HasValue;
 
     [XmlElement("hatttidligerenavn", Order = 8)]
     [JsonProperty("hatttidligerenavn")]
@@ -291,10 +285,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("adressebeskrivelse", Order = 1)]
     [JsonProperty("adressebeskrivelse")]
@@ -326,10 +317,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("typedokument", Order = 1)]
     [JsonProperty("typedokument")]
@@ -356,10 +344,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("foedselsnummer", Order = 1)]
     [JsonProperty("foedselsnummer")]
@@ -430,10 +415,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("fraDato", Order = 1)]
     [JsonProperty("fraDato")]
@@ -584,10 +566,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("personinfo", Order = 1)]
     [JsonProperty("personinfo")]
@@ -703,10 +682,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("land", Order = 1)]
     [JsonProperty("land")]
@@ -768,10 +744,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("land", Order = 1)]
     [JsonProperty("land")]
@@ -877,10 +850,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("type", Order = 1)]
     [JsonProperty("type")]
@@ -907,10 +877,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("antallganger", Order = 1)]
     [JsonProperty("antallganger")]
@@ -976,10 +943,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("aar", Order = 1)]
     [JsonProperty("aar")]
@@ -1163,10 +1127,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("beskrivelse", Order = 1)]
     [JsonProperty("beskrivelse")]
@@ -1198,10 +1159,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [XmlElement("utdanningsted", Order = 1)]
     [JsonProperty("utdanningsted")]

--- a/testdata/Model/CSharp/Gitea/skd-formueinntekt-skattemelding-v2.cs
+++ b/testdata/Model/CSharp/Gitea/skd-formueinntekt-skattemelding-v2.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/skd-formueinntekt-skattemelding-v2.cs
+++ b/testdata/Model/CSharp/Gitea/skd-formueinntekt-skattemelding-v2.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/CSharp/Gitea/skjema.cs
+++ b/testdata/Model/CSharp/Gitea/skjema.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/skjema.cs
+++ b/testdata/Model/CSharp/Gitea/skjema.cs
@@ -203,10 +203,7 @@ namespace Altinn.App.Models
     [Newtonsoft.Json.JsonIgnore]
     public Guid AltinnRowId { get; set; }
 
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
     [MinLength(0)]
     [MaxLength(50)]
@@ -268,10 +265,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("AntallEnerom")]
     public decimal? AntallEnerom { get; set; }
 
-    public bool ShouldSerializeAntallEnerom()
-    {
-      return AntallEnerom.HasValue;
-    }
+    public bool ShouldSerializeAntallEnerom() => AntallEnerom.HasValue;
 
     [XmlElement("AlleRomHarBadOgToalett", Order = 5)]
     [JsonProperty("AlleRomHarBadOgToalett")]
@@ -289,10 +283,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("AntallRomMedKjokken")]
     public decimal? AntallRomMedKjokken { get; set; }
 
-    public bool ShouldSerializeAntallRomMedKjokken()
-    {
-      return AntallRomMedKjokken.HasValue;
-    }
+    public bool ShouldSerializeAntallRomMedKjokken() => AntallRomMedKjokken.HasValue;
 
     [XmlElement("TilbysMatservering", Order = 8)]
     [JsonProperty("TilbysMatservering")]
@@ -350,10 +341,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("BekreftetRiktig")]
     public bool? BekreftetRiktig { get; set; }
 
-    public bool ShouldSerializeBekreftetRiktig()
-    {
-      return BekreftetRiktig.HasValue;
-    }
+    public bool ShouldSerializeBekreftetRiktig() => BekreftetRiktig.HasValue;
 
     [MinLength(0)]
     [MaxLength(255)]

--- a/testdata/Model/CSharp/Gitea/skjema.cs
+++ b/testdata/Model/CSharp/Gitea/skjema.cs
@@ -196,6 +196,17 @@ namespace Altinn.App.Models
 
   public class Underenhet
   {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId()
+    {
+      return AltinnRowId != default;
+    }
+
     [MinLength(0)]
     [MaxLength(50)]
     [XmlElement("Organisasjonsnummer", Order = 1)]
@@ -215,16 +226,6 @@ namespace Altinn.App.Models
     [JsonPropertyName("Adresse")]
     public Adresse Adresse { get; set; }
 
-    [XmlAttribute("altinnRowId")]
-    [JsonPropertyName("altinnRowId")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [Newtonsoft.Json.JsonIgnore]
-    public Guid AltinnRowId { get; set; }
-
-    public bool ShouldSerializeAltinnRowId()
-    {
-      return AltinnRowId != default;
-    }
   }
 
   public class NorskRepresentant

--- a/testdata/Model/CSharp/Gitea/srf-fufinn-behovsendring.cs
+++ b/testdata/Model/CSharp/Gitea/srf-fufinn-behovsendring.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/srf-fufinn-behovsendring.cs
+++ b/testdata/Model/CSharp/Gitea/srf-fufinn-behovsendring.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/CSharp/Gitea/srf-fufinn-behovskartleggin.cs
+++ b/testdata/Model/CSharp/Gitea/srf-fufinn-behovskartleggin.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/srf-fufinn-behovskartleggin.cs
+++ b/testdata/Model/CSharp/Gitea/srf-fufinn-behovskartleggin.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/CSharp/Gitea/srf-melding-til-statsforvalteren.cs
+++ b/testdata/Model/CSharp/Gitea/srf-melding-til-statsforvalteren.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/srf-melding-til-statsforvalteren.cs
+++ b/testdata/Model/CSharp/Gitea/srf-melding-til-statsforvalteren.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/CSharp/Gitea/stami-atid-databehandler-2022.cs
+++ b/testdata/Model/CSharp/Gitea/stami-atid-databehandler-2022.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/stami-atid-databehandler-2022.cs
+++ b/testdata/Model/CSharp/Gitea/stami-atid-databehandler-2022.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/CSharp/Gitea/stami-mu-bestilling-2021.cs
+++ b/testdata/Model/CSharp/Gitea/stami-mu-bestilling-2021.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/stami-mu-bestilling-2021.cs
+++ b/testdata/Model/CSharp/Gitea/stami-mu-bestilling-2021.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/CSharp/Gitea/stami-mu-databehandler-2021.cs
+++ b/testdata/Model/CSharp/Gitea/stami-mu-databehandler-2021.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/stami-mu-databehandler-2021.cs
+++ b/testdata/Model/CSharp/Gitea/stami-mu-databehandler-2021.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/CSharp/Gitea/udi-unntak-karantenehotell-velferd.cs
+++ b/testdata/Model/CSharp/Gitea/udi-unntak-karantenehotell-velferd.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/udi-unntak-karantenehotell-velferd.cs
+++ b/testdata/Model/CSharp/Gitea/udi-unntak-karantenehotell-velferd.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/CSharp/Gitea/udir-invitasjon-vfkl.cs
+++ b/testdata/Model/CSharp/Gitea/udir-invitasjon-vfkl.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/udir-invitasjon-vfkl.cs
+++ b/testdata/Model/CSharp/Gitea/udir-invitasjon-vfkl.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/CSharp/Gitea/udir-vfkl.cs
+++ b/testdata/Model/CSharp/Gitea/udir-vfkl.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/testdata/Model/CSharp/Gitea/udir-vfkl.cs
+++ b/testdata/Model/CSharp/Gitea/udir-vfkl.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;

--- a/testdata/Model/XmlSchema/Gitea/3422-39646.xsd
+++ b/testdata/Model/XmlSchema/Gitea/3422-39646.xsd
@@ -1,0 +1,5095 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:seres="http://seres.no/xsd/forvaltningsdata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified"
+           elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsd:annotation>
+    <xsd:documentation>
+      <xs:attribute name="XSLT-skriptnavn" fixed="SERES_XSD_GEN"/>
+      <xs:attribute name="XSD-generatorversjon" fixed="2.0.13"/>
+      <xs:attribute name="XSLT-prosessor" fixed="SAXON versjon 9.1.0.7"/>
+      <xs:attribute name="generert" fixed="2015-11-19T09:57:37.819+01:00"/>
+      <xs:attribute name="navneromprefix" fixed="http://seres.no/xsd"/>
+      <xs:attribute name="namespace" fixed="http://seres.no/xsd/Regnskapsregisteret/RR-0010U_M/2015"/>
+      <xs:attribute name="meldingsnavn" fixed="melding"/>
+      <xs:attribute name="domenenavn" fixed="Regnskapsregisteret"/>
+      <xs:attribute name="modellnavn" fixed="RR-0010U_M"/>
+      <xs:attribute name="metamodellversjon" fixed="1.2"/>
+      <xs:attribute name="guid" fixed="true"/>
+      <xs:attribute name="orid" fixed="true"/>
+      <xs:attribute name="nillable" fixed="true"/>
+      <xs:attribute name="tillat-gjenbruk" fixed="false"/>
+      <xs:attribute name="elementtype" fixed="true"/>
+      <xs:attribute name="forvaltningsdata" fixed="true"/>
+      <xs:attribute name="forvaltningsdata-navnerom" fixed="http://seres.no/xsd/forvaltningsdata"/>
+      <xs:attribute name="særnorske-bokstaver-i-navn" fixed="false"/>
+      <xs:attribute name="ft_guid_som_attributt" fixed="false"/>
+      <xs:attribute name="sem-ref" fixed="false"/>
+      <xs:attribute name="kodebibliotek" fixed="false"/>
+      <xs:attribute name="språk" fixed=""/>
+      <xs:attribute name="XSD-variant" fixed="Altinn 1.3"/>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:element name="melding" type="RR-0010U_M"/>
+  <xsd:complexType seres:elementtype="Meldingsmodell"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/Meldingsmodell/RR-0010U_M/479323"
+                   name="RR-0010U_M">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="Rapport-RR0010U" type="Rapport-RR0010U"/>
+      <xsd:element minOccurs="0" name="Skjemainnhold" type="Skjemainnhold"/>
+    </xsd:sequence>
+    <xsd:attribute fixed="SERES" name="dataFormatProvider" type="xsd:string" use="required"/>
+    <xsd:attribute fixed="3422" name="dataFormatId" type="xsd:string" use="required"/>
+    <xsd:attribute fixed="48706" name="dataFormatVersion" type="xsd:string" use="required"/>
+    <xsd:anyAttribute namespace="##any"/>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/ORDatakodeutvalg/ArsregnskapType-25942/396760" seres:orid="25942"
+                   name="ArsregnskapType-25942">
+    <xsd:simpleContent>
+      <xsd:extension base="ArsregnskapType-25942_Verdirestriksjon">
+        <xsd:attribute fixed="25942" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/ArsregnskapValutakode-34984/489375"
+                   seres:orid="34984" name="ArsregnskapValutakode-34984">
+    <xsd:simpleContent>
+      <xsd:extension base="ArsregnskapValutakode-34984_Verdirestriksjon">
+        <xsd:attribute fixed="34984" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/ORDatakodeutvalg/ArsregnskapValor-28974/396326" seres:orid="28974"
+                   name="ArsregnskapValor-28974">
+    <xsd:simpleContent>
+      <xsd:extension base="ArsregnskapValor-28974_Verdirestriksjon">
+        <xsd:attribute fixed="28974" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteMedlemsinntekter-30319/450511"
+                   seres:orid="30319" name="NoteMedlemsinntekter-30319">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteMedlemsinntekter-30319_Verdirestriksjon">
+        <xsd:attribute fixed="30319" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/Medlemsinntekter-30320/450583"
+                   seres:orid="30320" name="Medlemsinntekter-30320">
+    <xsd:simpleContent>
+      <xsd:extension base="Medlemsinntekter-30320_Verdirestriksjon">
+        <xsd:attribute fixed="30320" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/MedlemsinntekterFjoraret-30321/450451"
+                   seres:orid="30321" name="MedlemsinntekterFjoraret-30321">
+    <xsd:simpleContent>
+      <xsd:extension base="MedlemsinntekterFjoraret-30321_Verdirestriksjon">
+        <xsd:attribute fixed="30321" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteTilskuddOffentlig-33418/479383"
+                   seres:orid="33418" name="NoteTilskuddOffentlig-33418">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteTilskuddOffentlig-33418_Verdirestriksjon">
+        <xsd:attribute fixed="33418" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/TilskuddOffentlig-33419/479382"
+                   seres:orid="33419" name="TilskuddOffentlig-33419">
+    <xsd:simpleContent>
+      <xsd:extension base="TilskuddOffentlig-33419_Verdirestriksjon">
+        <xsd:attribute fixed="33419" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/TilskuddOffentligFjoraret-33420/479381"
+                   seres:orid="33420" name="TilskuddOffentligFjoraret-33420">
+    <xsd:simpleContent>
+      <xsd:extension base="TilskuddOffentligFjoraret-33420_Verdirestriksjon">
+        <xsd:attribute fixed="33420" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteTilskuddAndre-33421/479480"
+                   seres:orid="33421" name="NoteTilskuddAndre-33421">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteTilskuddAndre-33421_Verdirestriksjon">
+        <xsd:attribute fixed="33421" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/TilskuddAndre-33422/479479"
+                   seres:orid="33422" name="TilskuddAndre-33422">
+    <xsd:simpleContent>
+      <xsd:extension base="TilskuddAndre-33422_Verdirestriksjon">
+        <xsd:attribute fixed="33422" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/TilskuddAndreFjoraret-33423/479482"
+                   seres:orid="33423" name="TilskuddAndreFjoraret-33423">
+    <xsd:simpleContent>
+      <xsd:extension base="TilskuddAndreFjoraret-33423_Verdirestriksjon">
+        <xsd:attribute fixed="33423" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteTilskudd-30310/450471"
+                   seres:orid="30310" name="NoteTilskudd-30310">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteTilskudd-30310_Verdirestriksjon">
+        <xsd:attribute fixed="30310" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/TilskuddOffentlig-30311/450559"
+                   seres:orid="30311" name="TilskuddOffentlig-30311">
+    <xsd:simpleContent>
+      <xsd:extension base="TilskuddOffentlig-30311_Verdirestriksjon">
+        <xsd:attribute fixed="30311" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/TilskuddOffentligFjoraret-30312/450545"
+                   seres:orid="30312" name="TilskuddOffentligFjoraret-30312">
+    <xsd:simpleContent>
+      <xsd:extension base="TilskuddOffentligFjoraret-30312_Verdirestriksjon">
+        <xsd:attribute fixed="30312" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteMidlerGaverInnsamlede-30313/450496"
+                   seres:orid="30313" name="NoteMidlerGaverInnsamlede-30313">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteMidlerGaverInnsamlede-30313_Verdirestriksjon">
+        <xsd:attribute fixed="30313" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/MidlerGaverInnsamlede-30314/450501"
+                   seres:orid="30314" name="MidlerGaverInnsamlede-30314">
+    <xsd:simpleContent>
+      <xsd:extension base="MidlerGaverInnsamlede-30314_Verdirestriksjon">
+        <xsd:attribute fixed="30314" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/MidlerGaverInnsamledeFjoraret-30315/450522"
+                   seres:orid="30315" name="MidlerGaverInnsamledeFjoraret-30315">
+    <xsd:simpleContent>
+      <xsd:extension base="MidlerGaverInnsamledeFjoraret-30315_Verdirestriksjon">
+        <xsd:attribute fixed="30315" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteAktiviteterOppfyllerOrganisasjonensFormal-33424/479478"
+                   seres:orid="33424" name="NoteAktiviteterOppfyllerOrganisasjonensFormal-33424">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteAktiviteterOppfyllerOrganisasjonensFormal-33424_Verdirestriksjon">
+        <xsd:attribute fixed="33424" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/AktiviteterOppfyllerOrganisasjonensFormal-33425/479484"
+                   seres:orid="33425" name="AktiviteterOppfyllerOrganisasjonensFormal-33425">
+    <xsd:simpleContent>
+      <xsd:extension base="AktiviteterOppfyllerOrganisasjonensFormal-33425_Verdirestriksjon">
+        <xsd:attribute fixed="33425" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/AktiviteterOppfyllerOrganisasjonensFormalFjoraret-33426/479483"
+                   seres:orid="33426" name="AktiviteterOppfyllerOrganisasjonensFormalFjoraret-33426">
+    <xsd:simpleContent>
+      <xsd:extension base="AktiviteterOppfyllerOrganisasjonensFormalFjoraret-33426_Verdirestriksjon">
+        <xsd:attribute fixed="33426" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteAktiviteterSkaperInntekt-33427/479477"
+                   seres:orid="33427" name="NoteAktiviteterSkaperInntekt-33427">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteAktiviteterSkaperInntekt-33427_Verdirestriksjon">
+        <xsd:attribute fixed="33427" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/AktiviteterSkaperInntekt-33428/479485"
+                   seres:orid="33428" name="AktiviteterSkaperInntekt-33428">
+    <xsd:simpleContent>
+      <xsd:extension base="AktiviteterSkaperInntekt-33428_Verdirestriksjon">
+        <xsd:attribute fixed="33428" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/AktiviteterSkaperInntektFjoraret-33429/479481"
+                   seres:orid="33429" name="AktiviteterSkaperInntektFjoraret-33429">
+    <xsd:simpleContent>
+      <xsd:extension base="AktiviteterSkaperInntektFjoraret-33429_Verdirestriksjon">
+        <xsd:attribute fixed="33429" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteAktiviteterOperasjonelle-33430/479526"
+                   seres:orid="33430" name="NoteAktiviteterOperasjonelle-33430">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteAktiviteterOperasjonelle-33430_Verdirestriksjon">
+        <xsd:attribute fixed="33430" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/AktiviteterOperasjonelleFjoraret-33432/479527"
+                   seres:orid="33432" name="AktiviteterOperasjonelleFjoraret-33432">
+    <xsd:simpleContent>
+      <xsd:extension base="AktiviteterOperasjonelleFjoraret-33432_Verdirestriksjon">
+        <xsd:attribute fixed="33432" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/AktiviteterOperasjonelle-33431/479525"
+                   seres:orid="33431" name="AktiviteterOperasjonelle-33431">
+    <xsd:simpleContent>
+      <xsd:extension base="AktiviteterOperasjonelle-33431_Verdirestriksjon">
+        <xsd:attribute fixed="33431" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteDriftsinntekterAndreSum-18238/399465"
+                   seres:orid="18238" name="NoteDriftsinntekterAndreSum-18238">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteDriftsinntekterAndreSum-18238_Verdirestriksjon">
+        <xsd:attribute fixed="18238" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/DriftsinntekterAndreSum-7709/400350"
+                   seres:orid="7709" name="DriftsinntekterAndreSum-7709">
+    <xsd:simpleContent>
+      <xsd:extension base="DriftsinntekterAndreSum-7709_Verdirestriksjon">
+        <xsd:attribute fixed="7709" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/DriftsinntekterAndreFjoraretSum-7966/399380"
+                   seres:orid="7966" name="DriftsinntekterAndreFjoraretSum-7966">
+    <xsd:simpleContent>
+      <xsd:extension base="DriftsinntekterAndreFjoraretSum-7966_Verdirestriksjon">
+        <xsd:attribute fixed="7966" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFinansinntekterInvesteringsinntekter-33433/479533"
+                   seres:orid="33433" name="NoteFinansinntekterInvesteringsinntekter-33433">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFinansinntekterInvesteringsinntekter-33433_Verdirestriksjon">
+        <xsd:attribute fixed="33433" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FinansinntekterInvesteringsinntekter-33434/479534"
+                   seres:orid="33434" name="FinansinntekterInvesteringsinntekter-33434">
+    <xsd:simpleContent>
+      <xsd:extension base="FinansinntekterInvesteringsinntekter-33434_Verdirestriksjon">
+        <xsd:attribute fixed="33434" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FinansinntekterInvesteringsinntekterFjoraret-33435/479535"
+                   seres:orid="33435" name="FinansinntekterInvesteringsinntekterFjoraret-33435">
+    <xsd:simpleContent>
+      <xsd:extension base="FinansinntekterInvesteringsinntekterFjoraret-33435_Verdirestriksjon">
+        <xsd:attribute fixed="33435" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteInntektAnnen-30307/450489"
+                   seres:orid="30307" name="NoteInntektAnnen-30307">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteInntektAnnen-30307_Verdirestriksjon">
+        <xsd:attribute fixed="30307" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/InntektAnnen-30308/450468"
+                   seres:orid="30308" name="InntektAnnen-30308">
+    <xsd:simpleContent>
+      <xsd:extension base="InntektAnnen-30308_Verdirestriksjon">
+        <xsd:attribute fixed="30308" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/InntektAnnenFjoraret-30309/450548"
+                   seres:orid="30309" name="InntektAnnenFjoraret-30309">
+    <xsd:simpleContent>
+      <xsd:extension base="InntektAnnenFjoraret-30309_Verdirestriksjon">
+        <xsd:attribute fixed="30309" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteMidlerAnskaffede-30316/450580"
+                   seres:orid="30316" name="NoteMidlerAnskaffede-30316">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteMidlerAnskaffede-30316_Verdirestriksjon">
+        <xsd:attribute fixed="30316" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/MidlerAnskaffede-30317/450453"
+                   seres:orid="30317" name="MidlerAnskaffede-30317">
+    <xsd:simpleContent>
+      <xsd:extension base="MidlerAnskaffede-30317_Verdirestriksjon">
+        <xsd:attribute fixed="30317" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/MidlerAnskaffedeFjoraret-30318/450542"
+                   seres:orid="30318" name="MidlerAnskaffedeFjoraret-30318">
+    <xsd:simpleContent>
+      <xsd:extension base="MidlerAnskaffedeFjoraret-30318_Verdirestriksjon">
+        <xsd:attribute fixed="30318" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteKostnadAnskaffelseAvMidler-30806/450563"
+                   seres:orid="30806" name="NoteKostnadAnskaffelseAvMidler-30806">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteKostnadAnskaffelseAvMidler-30806_Verdirestriksjon">
+        <xsd:attribute fixed="30806" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/KostnadAnskaffelseAvMidler-30807/450455"
+                   seres:orid="30807" name="KostnadAnskaffelseAvMidler-30807">
+    <xsd:simpleContent>
+      <xsd:extension base="KostnadAnskaffelseAvMidler-30807_Verdirestriksjon">
+        <xsd:attribute fixed="30807" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/KostnadAnskaffelseAvMidlerFjoraret-30808/450456"
+                   seres:orid="30808" name="KostnadAnskaffelseAvMidlerFjoraret-30808">
+    <xsd:simpleContent>
+      <xsd:extension base="KostnadAnskaffelseAvMidlerFjoraret-30808_Verdirestriksjon">
+        <xsd:attribute fixed="30808" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteTilskuddBevilningOppfyllelseOrganisasjonensFormal-33436/479568"
+                   seres:orid="33436" name="NoteTilskuddBevilningOppfyllelseOrganisasjonensFormal-33436">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteTilskuddBevilningOppfyllelseOrganisasjonensFormal-33436_Verdirestriksjon">
+        <xsd:attribute fixed="33436" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/TilskuddBevilningOppfyllelseOrganisasjonensFormal-33437/479567"
+                   seres:orid="33437" name="TilskuddBevilningOppfyllelseOrganisasjonensFormal-33437">
+    <xsd:simpleContent>
+      <xsd:extension base="TilskuddBevilningOppfyllelseOrganisasjonensFormal-33437_Verdirestriksjon">
+        <xsd:attribute fixed="33437" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/TilskuddBevilningOppfyllelseOrganisasjonensFormalFjoraret-33438/479566"
+                   seres:orid="33438" name="TilskuddBevilningOppfyllelseOrganisasjonensFormalFjoraret-33438">
+    <xsd:simpleContent>
+      <xsd:extension base="TilskuddBevilningOppfyllelseOrganisasjonensFormalFjoraret-33438_Verdirestriksjon">
+        <xsd:attribute fixed="33438" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteKostnaderOppfyllelseOrganisasjonensFormal-33439/479575"
+                   seres:orid="33439" name="NoteKostnaderOppfyllelseOrganisasjonensFormal-33439">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteKostnaderOppfyllelseOrganisasjonensFormal-33439_Verdirestriksjon">
+        <xsd:attribute fixed="33439" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/KostnaderOppfyllelseOrganisasjonensFormal-33440/479574"
+                   seres:orid="33440" name="KostnaderOppfyllelseOrganisasjonensFormal-33440">
+    <xsd:simpleContent>
+      <xsd:extension base="KostnaderOppfyllelseOrganisasjonensFormal-33440_Verdirestriksjon">
+        <xsd:attribute fixed="33440" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/KostnaderOppfyllelseOrganisasjonensFormalFjoraret-33441/479576"
+                   seres:orid="33441" name="KostnaderOppfyllelseOrganisasjonensFormalFjoraret-33441">
+    <xsd:simpleContent>
+      <xsd:extension base="KostnaderOppfyllelseOrganisasjonensFormalFjoraret-33441_Verdirestriksjon">
+        <xsd:attribute fixed="33441" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteKostnadOrganisasjonensFormal-30809/450560"
+                   seres:orid="30809" name="NoteKostnadOrganisasjonensFormal-30809">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteKostnadOrganisasjonensFormal-30809_Verdirestriksjon">
+        <xsd:attribute fixed="30809" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/KostnadOrganisasjonensFormal-30810/450434"
+                   seres:orid="30810" name="KostnadOrganisasjonensFormal-30810">
+    <xsd:simpleContent>
+      <xsd:extension base="KostnadOrganisasjonensFormal-30810_Verdirestriksjon">
+        <xsd:attribute fixed="30810" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/KostnadOrganisasjonensFormalFjoraret-30811/450550"
+                   seres:orid="30811" name="KostnadOrganisasjonensFormalFjoraret-30811">
+    <xsd:simpleContent>
+      <xsd:extension base="KostnadOrganisasjonensFormalFjoraret-30811_Verdirestriksjon">
+        <xsd:attribute fixed="30811" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteRentekostnaderAndre-18550/399887"
+                   seres:orid="18550" name="NoteRentekostnaderAndre-18550">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteRentekostnaderAndre-18550_Verdirestriksjon">
+        <xsd:attribute fixed="18550" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/RentekostnaderAndre-2216/399252" seres:orid="2216"
+                   name="RentekostnaderAndre-2216">
+    <xsd:simpleContent>
+      <xsd:extension base="RentekostnaderAndre-2216_Verdirestriksjon">
+        <xsd:attribute fixed="2216" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/RentekostnaderAndreFjoraret-7039/400055"
+                   seres:orid="7039" name="RentekostnaderAndreFjoraret-7039">
+    <xsd:simpleContent>
+      <xsd:extension base="RentekostnaderAndreFjoraret-7039_Verdirestriksjon">
+        <xsd:attribute fixed="7039" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteFinanskostnaderAndre-18337/400258"
+                   seres:orid="18337" name="NoteFinanskostnaderAndre-18337">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFinanskostnaderAndre-18337_Verdirestriksjon">
+        <xsd:attribute fixed="18337" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FinanskostnaderAndre-156/399276" seres:orid="156"
+                   name="FinanskostnaderAndre-156">
+    <xsd:simpleContent>
+      <xsd:extension base="FinanskostnaderAndre-156_Verdirestriksjon">
+        <xsd:attribute fixed="156" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FinanskostnaderAndreFjoraret-7041/399402"
+                   seres:orid="7041" name="FinanskostnaderAndreFjoraret-7041">
+    <xsd:simpleContent>
+      <xsd:extension base="FinanskostnaderAndreFjoraret-7041_Verdirestriksjon">
+        <xsd:attribute fixed="7041" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteKostnaderAdministrative-27924/450567"
+                   seres:orid="27924" name="NoteKostnaderAdministrative-27924">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteKostnaderAdministrative-27924_Verdirestriksjon">
+        <xsd:attribute fixed="27924" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/KostnaderAdministrative-27926/450467"
+                   seres:orid="27926" name="KostnaderAdministrative-27926">
+    <xsd:simpleContent>
+      <xsd:extension base="KostnaderAdministrative-27926_Verdirestriksjon">
+        <xsd:attribute fixed="27926" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/KostnaderAdministrativeFjoraret-27928/450484"
+                   seres:orid="27928" name="KostnaderAdministrativeFjoraret-27928">
+    <xsd:simpleContent>
+      <xsd:extension base="KostnaderAdministrativeFjoraret-27928_Verdirestriksjon">
+        <xsd:attribute fixed="27928" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteDriftskostnaderAndre-18249/400317"
+                   seres:orid="18249" name="NoteDriftskostnaderAndre-18249">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteDriftskostnaderAndre-18249_Verdirestriksjon">
+        <xsd:attribute fixed="18249" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/DriftskostnaderAndre-82/399777" seres:orid="82"
+                   name="DriftskostnaderAndre-82">
+    <xsd:simpleContent>
+      <xsd:extension base="DriftskostnaderAndre-82_Verdirestriksjon">
+        <xsd:attribute fixed="82" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/DriftskostnaderAndreFjoraret-7023/400163"
+                   seres:orid="7023" name="DriftskostnaderAndreFjoraret-7023">
+    <xsd:simpleContent>
+      <xsd:extension base="DriftskostnaderAndreFjoraret-7023_Verdirestriksjon">
+        <xsd:attribute fixed="7023" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteMidlerForbrukte-30812/450459"
+                   seres:orid="30812" name="NoteMidlerForbrukte-30812">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteMidlerForbrukte-30812_Verdirestriksjon">
+        <xsd:attribute fixed="30812" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/MidlerForbrukte-30813/450513"
+                   seres:orid="30813" name="MidlerForbrukte-30813">
+    <xsd:simpleContent>
+      <xsd:extension base="MidlerForbrukte-30813_Verdirestriksjon">
+        <xsd:attribute fixed="30813" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/MidlerForbrukteFjoraret-30814/450571"
+                   seres:orid="30814" name="MidlerForbrukteFjoraret-30814">
+    <xsd:simpleContent>
+      <xsd:extension base="MidlerForbrukteFjoraret-30814_Verdirestriksjon">
+        <xsd:attribute fixed="30814" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteResultatForSkattekostnad-18355/399817"
+                   seres:orid="18355" name="NoteResultatForSkattekostnad-18355">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteResultatForSkattekostnad-18355_Verdirestriksjon">
+        <xsd:attribute fixed="18355" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/ResultatForSkattekostnad-167/399432"
+                   seres:orid="167" name="ResultatForSkattekostnad-167">
+    <xsd:simpleContent>
+      <xsd:extension base="ResultatForSkattekostnad-167_Verdirestriksjon">
+        <xsd:attribute fixed="167" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/ResultatForSkattekostnadFjoraret-7042/399369"
+                   seres:orid="7042" name="ResultatForSkattekostnadFjoraret-7042">
+    <xsd:simpleContent>
+      <xsd:extension base="ResultatForSkattekostnadFjoraret-7042_Verdirestriksjon">
+        <xsd:attribute fixed="7042" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteSkattekostnadOrdinartResultat-18259/399917"
+                   seres:orid="18259" name="NoteSkattekostnadOrdinartResultat-18259">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteSkattekostnadOrdinartResultat-18259_Verdirestriksjon">
+        <xsd:attribute fixed="18259" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/SkattekostnadOrdinartResultat-11835/400096"
+                   seres:orid="11835" name="SkattekostnadOrdinartResultat-11835">
+    <xsd:simpleContent>
+      <xsd:extension base="SkattekostnadOrdinartResultat-11835_Verdirestriksjon">
+        <xsd:attribute fixed="11835" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/SkattekostnadOrdinartResultatFjoraret-11836/400142"
+                   seres:orid="11836" name="SkattekostnadOrdinartResultatFjoraret-11836">
+    <xsd:simpleContent>
+      <xsd:extension base="SkattekostnadOrdinartResultatFjoraret-11836_Verdirestriksjon">
+        <xsd:attribute fixed="11836" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteResultatOrdinart-18258/399229"
+                   seres:orid="18258" name="NoteResultatOrdinart-18258">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteResultatOrdinart-18258_Verdirestriksjon">
+        <xsd:attribute fixed="18258" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/ResultatOrdinart-7048/399781" seres:orid="7048"
+                   name="ResultatOrdinart-7048">
+    <xsd:simpleContent>
+      <xsd:extension base="ResultatOrdinart-7048_Verdirestriksjon">
+        <xsd:attribute fixed="7048" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/ResultatOrdinartFjordaret-7049/399621"
+                   seres:orid="7049" name="ResultatOrdinartFjordaret-7049">
+    <xsd:simpleContent>
+      <xsd:extension base="ResultatOrdinartFjordaret-7049_Verdirestriksjon">
+        <xsd:attribute fixed="7049" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteResultatEkstraordinarePoster-29047/399823"
+                   seres:orid="29047" name="NoteResultatEkstraordinarePoster-29047">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteResultatEkstraordinarePoster-29047_Verdirestriksjon">
+        <xsd:attribute fixed="29047" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/ResultatEkstraordinarePoster-29048/400030"
+                   seres:orid="29048" name="ResultatEkstraordinarePoster-29048">
+    <xsd:simpleContent>
+      <xsd:extension base="ResultatEkstraordinarePoster-29048_Verdirestriksjon">
+        <xsd:attribute fixed="29048" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/ResultatEkstraordinarePosterFjoraret-29049/399693"
+                   seres:orid="29049" name="ResultatEkstraordinarePosterFjoraret-29049">
+    <xsd:simpleContent>
+      <xsd:extension base="ResultatEkstraordinarePosterFjoraret-29049_Verdirestriksjon">
+        <xsd:attribute fixed="29049" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteSkattekostnadEkstraordinartResultat-18263/400299"
+                   seres:orid="18263" name="NoteSkattekostnadEkstraordinartResultat-18263">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteSkattekostnadEkstraordinartResultat-18263_Verdirestriksjon">
+        <xsd:attribute fixed="18263" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/SkattekostnadEkstraordinartResultat-2821/399659"
+                   seres:orid="2821" name="SkattekostnadEkstraordinartResultat-2821">
+    <xsd:simpleContent>
+      <xsd:extension base="SkattekostnadEkstraordinartResultat-2821_Verdirestriksjon">
+        <xsd:attribute fixed="2821" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/SkattekostnadEkstraordinartResultatFjoraret-8002/399767"
+                   seres:orid="8002" name="SkattekostnadEkstraordinartResultatFjoraret-8002">
+    <xsd:simpleContent>
+      <xsd:extension base="SkattekostnadEkstraordinartResultatFjoraret-8002_Verdirestriksjon">
+        <xsd:attribute fixed="8002" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteArsresultat-18265/399871" seres:orid="18265"
+                   name="NoteArsresultat-18265">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteArsresultat-18265_Verdirestriksjon">
+        <xsd:attribute fixed="18265" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Arsresultat-172/399198" seres:orid="172"
+                   name="Arsresultat-172">
+    <xsd:simpleContent>
+      <xsd:extension base="Arsresultat-172_Verdirestriksjon">
+        <xsd:attribute fixed="172" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/ArsresultatFjoraret-7054/399995" seres:orid="7054"
+                   name="ArsresultatFjoraret-7054">
+    <xsd:simpleContent>
+      <xsd:extension base="ArsresultatFjoraret-7054_Verdirestriksjon">
+        <xsd:attribute fixed="7054" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteMinoritetsinteresser-18264/400080"
+                   seres:orid="18264" name="NoteMinoritetsinteresser-18264">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteMinoritetsinteresser-18264_Verdirestriksjon">
+        <xsd:attribute fixed="18264" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Minoritetsinteresser-7717/399533" seres:orid="7717"
+                   name="Minoritetsinteresser-7717">
+    <xsd:simpleContent>
+      <xsd:extension base="Minoritetsinteresser-7717_Verdirestriksjon">
+        <xsd:attribute fixed="7717" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/MinoritetsinteresserFjoraret-8004/399379"
+                   seres:orid="8004" name="MinoritetsinteresserFjoraret-8004">
+    <xsd:simpleContent>
+      <xsd:extension base="MinoritetsinteresserFjoraret-8004_Verdirestriksjon">
+        <xsd:attribute fixed="8004" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteArsresultatEtterMinoritetsinteresser-33417/474292"
+                   seres:orid="33417" name="NoteArsresultatEtterMinoritetsinteresser-33417">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteArsresultatEtterMinoritetsinteresser-33417_Verdirestriksjon">
+        <xsd:attribute fixed="33417" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/ArsresultatEtterMinoritetsinteresser-33415/474294"
+                   seres:orid="33415" name="ArsresultatEtterMinoritetsinteresser-33415">
+    <xsd:simpleContent>
+      <xsd:extension base="ArsresultatEtterMinoritetsinteresser-33415_Verdirestriksjon">
+        <xsd:attribute fixed="33415" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/ArsresultatEtterMinoritetsinteresserFjoraret-33416/474293"
+                   seres:orid="33416" name="ArsresultatEtterMinoritetsinteresserFjoraret-33416">
+    <xsd:simpleContent>
+      <xsd:extension base="ArsresultatEtterMinoritetsinteresserFjoraret-33416_Verdirestriksjon">
+        <xsd:attribute fixed="33416" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteResultatkomponenterAndreIFRS-35536/592945"
+                   seres:orid="35536" name="NoteResultatkomponenterAndreIFRS-35536">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteResultatkomponenterAndreIFRS-35536_Verdirestriksjon">
+        <xsd:attribute fixed="35536" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/ResultatkomponenterAndreIFRS-32929/592944"
+                   seres:orid="32929" name="ResultatkomponenterAndreIFRS-32929">
+    <xsd:simpleContent>
+      <xsd:extension base="ResultatkomponenterAndreIFRS-32929_Verdirestriksjon">
+        <xsd:attribute fixed="32929" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/ResultatkomponenterAndreIFRSFjoraret-32930/592943"
+                   seres:orid="32930" name="ResultatkomponenterAndreIFRSFjoraret-32930">
+    <xsd:simpleContent>
+      <xsd:extension base="ResultatkomponenterAndreIFRSFjoraret-32930_Verdirestriksjon">
+        <xsd:attribute fixed="32930" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteTotalresultatIFRS-36635/613253"
+                   seres:orid="36635" name="NoteTotalresultatIFRS-36635">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteTotalresultatIFRS-36635_Verdirestriksjon">
+        <xsd:attribute fixed="36635" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/TotalresultatIFRS-36633/613249"
+                   seres:orid="36633" name="TotalresultatIFRS-36633">
+    <xsd:simpleContent>
+      <xsd:extension base="TotalresultatIFRS-36633_Verdirestriksjon">
+        <xsd:attribute fixed="36633" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/TotalresultatIFRSFjoråret-36634/613248"
+                   seres:orid="36634" name="TotalresultatIFRSFjoraaret-36634">
+    <xsd:simpleContent>
+      <xsd:extension base="TotalresultatIFRSFjoraaret-36634_Verdirestriksjon">
+        <xsd:attribute fixed="36634" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteGrunnkapital-30815/450436"
+                   seres:orid="30815" name="NoteGrunnkapital-30815">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteGrunnkapital-30815_Verdirestriksjon">
+        <xsd:attribute fixed="30815" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/Grunnkapital-30816/450449"
+                   seres:orid="30816" name="Grunnkapital-30816">
+    <xsd:simpleContent>
+      <xsd:extension base="Grunnkapital-30816_Verdirestriksjon">
+        <xsd:attribute fixed="30816" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/GrunnkapitalFjoraret-30817/450485"
+                   seres:orid="30817" name="GrunnkapitalFjoraret-30817">
+    <xsd:simpleContent>
+      <xsd:extension base="GrunnkapitalFjoraret-30817_Verdirestriksjon">
+        <xsd:attribute fixed="30817" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalRestriksjonerLovpalagte-33445/479717"
+                   seres:orid="33445" name="NoteFormalskapitalRestriksjonerLovpalagte-33445">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalRestriksjonerLovpalagte-33445_Verdirestriksjon">
+        <xsd:attribute fixed="33445" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalRestriksjonerLovpalagte-33446/479721"
+                   seres:orid="33446" name="FormalskapitalRestriksjonerLovpalagte-33446">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalRestriksjonerLovpalagte-33446_Verdirestriksjon">
+        <xsd:attribute fixed="33446" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalRestriksjonerLovpalagteFjoraret-33447/479724"
+                   seres:orid="33447" name="FormalskapitalRestriksjonerLovpalagteFjoraret-33447">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalRestriksjonerLovpalagteFjoraret-33447_Verdirestriksjon">
+        <xsd:attribute fixed="33447" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalRestriksjonerEksterntPalagt-33448/479719"
+                   seres:orid="33448" name="NoteFormalskapitalRestriksjonerEksterntPalagt-33448">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalRestriksjonerEksterntPalagt-33448_Verdirestriksjon">
+        <xsd:attribute fixed="33448" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalRestriksjonerEksterntPalagt-33449/479725"
+                   seres:orid="33449" name="FormalskapitalRestriksjonerEksterntPalagt-33449">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalRestriksjonerEksterntPalagt-33449_Verdirestriksjon">
+        <xsd:attribute fixed="33449" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalRestriksjonerEksterntPalagtFjoraret-33450/479722"
+                   seres:orid="33450" name="FormalskapitalRestriksjonerEksterntPalagtFjoraret-33450">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalRestriksjonerEksterntPalagtFjoraret-33450_Verdirestriksjon">
+        <xsd:attribute fixed="33450" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalRestriksjonerSelvpalagte-33451/479720"
+                   seres:orid="33451" name="NoteFormalskapitalRestriksjonerSelvpalagte-33451">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalRestriksjonerSelvpalagte-33451_Verdirestriksjon">
+        <xsd:attribute fixed="33451" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalRestriksjonerSelvpalagte-33452/479718"
+                   seres:orid="33452" name="FormalskapitalRestriksjonerSelvpalagte-33452">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalRestriksjonerSelvpalagte-33452_Verdirestriksjon">
+        <xsd:attribute fixed="33452" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalRestriksjonerSelvpalagteFjoraret-33453/479723"
+                   seres:orid="33453" name="FormalskapitalRestriksjonerSelvpalagteFjoraret-33453">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalRestriksjonerSelvpalagteFjoraret-33453_Verdirestriksjon">
+        <xsd:attribute fixed="33453" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalAnnen-33454/479756"
+                   seres:orid="33454" name="NoteFormalskapitalAnnen-33454">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalAnnen-33454_Verdirestriksjon">
+        <xsd:attribute fixed="33454" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalAnnen-33455/479761"
+                   seres:orid="33455" name="FormalskapitalAnnen-33455">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalAnnen-33455_Verdirestriksjon">
+        <xsd:attribute fixed="33455" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalAnnenFjoraret-33456/479762"
+                   seres:orid="33456" name="FormalskapitalAnnenFjoraret-33456">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalAnnenFjoraret-33456_Verdirestriksjon">
+        <xsd:attribute fixed="33456" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NotePatenterRettigheter-18560/399617"
+                   seres:orid="18560" name="NotePatenterRettigheter-18560">
+    <xsd:simpleContent>
+      <xsd:extension base="NotePatenterRettigheter-18560_Verdirestriksjon">
+        <xsd:attribute fixed="18560" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/PatenterRettigheter-205/400050" seres:orid="205"
+                   name="PatenterRettigheter-205">
+    <xsd:simpleContent>
+      <xsd:extension base="PatenterRettigheter-205_Verdirestriksjon">
+        <xsd:attribute fixed="205" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/PatenterRettigheterFjoraret-7075/400126"
+                   seres:orid="7075" name="PatenterRettigheterFjoraret-7075">
+    <xsd:simpleContent>
+      <xsd:extension base="PatenterRettigheterFjoraret-7075_Verdirestriksjon">
+        <xsd:attribute fixed="7075" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteSkattefordelUtsatt-18182/400352"
+                   seres:orid="18182" name="NoteSkattefordelUtsatt-18182">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteSkattefordelUtsatt-18182_Verdirestriksjon">
+        <xsd:attribute fixed="18182" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/SkattefordelUtsatt-202/399371" seres:orid="202"
+                   name="SkattefordelUtsatt-202">
+    <xsd:simpleContent>
+      <xsd:extension base="SkattefordelUtsatt-202_Verdirestriksjon">
+        <xsd:attribute fixed="202" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/SkattefordelUtsattFjoraret-7076/399801"
+                   seres:orid="7076" name="SkattefordelUtsattFjoraret-7076">
+    <xsd:simpleContent>
+      <xsd:extension base="SkattefordelUtsattFjoraret-7076_Verdirestriksjon">
+        <xsd:attribute fixed="7076" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteForretningsverdiGoodwill-18183/400203"
+                   seres:orid="18183" name="NoteForretningsverdiGoodwill-18183">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteForretningsverdiGoodwill-18183_Verdirestriksjon">
+        <xsd:attribute fixed="18183" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/ForretningsverdiGoodwill-206/400340"
+                   seres:orid="206" name="ForretningsverdiGoodwill-206">
+    <xsd:simpleContent>
+      <xsd:extension base="ForretningsverdiGoodwill-206_Verdirestriksjon">
+        <xsd:attribute fixed="206" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/ForretningsverdiGoodwillFjoraret-7077/400267"
+                   seres:orid="7077" name="ForretningsverdiGoodwillFjoraret-7077">
+    <xsd:simpleContent>
+      <xsd:extension base="ForretningsverdiGoodwillFjoraret-7077_Verdirestriksjon">
+        <xsd:attribute fixed="7077" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteEiendelerImmaterielle-18180/399689"
+                   seres:orid="18180" name="NoteEiendelerImmaterielle-18180">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteEiendelerImmaterielle-18180_Verdirestriksjon">
+        <xsd:attribute fixed="18180" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/EiendelerImmaterielle-2400/400118" seres:orid="2400"
+                   name="EiendelerImmaterielle-2400">
+    <xsd:simpleContent>
+      <xsd:extension base="EiendelerImmaterielle-2400_Verdirestriksjon">
+        <xsd:attribute fixed="2400" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/EiendelerImmaterielleFjoraret-8006/399713"
+                   seres:orid="8006" name="EiendelerImmaterielleFjoraret-8006">
+    <xsd:simpleContent>
+      <xsd:extension base="EiendelerImmaterielleFjoraret-8006_Verdirestriksjon">
+        <xsd:attribute fixed="8006" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteFastEiendom-18178/399513" seres:orid="18178"
+                   name="NoteFastEiendom-18178">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFastEiendom-18178_Verdirestriksjon">
+        <xsd:attribute fixed="18178" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FastEiendom-1976/400113" seres:orid="1976"
+                   name="FastEiendom-1976">
+    <xsd:simpleContent>
+      <xsd:extension base="FastEiendom-1976_Verdirestriksjon">
+        <xsd:attribute fixed="1976" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FastEiendomFjoraret-8007/400130" seres:orid="8007"
+                   name="FastEiendomFjoraret-8007">
+    <xsd:simpleContent>
+      <xsd:extension base="FastEiendomFjoraret-8007_Verdirestriksjon">
+        <xsd:attribute fixed="8007" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteKjoretoyInventarVerktoyMv-18562/400273"
+                   seres:orid="18562" name="NoteKjoretoyInventarVerktoyMv-18562">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteKjoretoyInventarVerktoyMv-18562_Verdirestriksjon">
+        <xsd:attribute fixed="18562" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/KjoretoyInventarVerktoyMv-7725/399980"
+                   seres:orid="7725" name="KjoretoyInventarVerktoyMv-7725">
+    <xsd:simpleContent>
+      <xsd:extension base="KjoretoyInventarVerktoyMv-7725_Verdirestriksjon">
+        <xsd:attribute fixed="7725" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/KjoretoyInventarVerktoyMvFjoraret-8009/399206"
+                   seres:orid="8009" name="KjoretoyInventarVerktoyMvFjoraret-8009">
+    <xsd:simpleContent>
+      <xsd:extension base="KjoretoyInventarVerktoyMvFjoraret-8009_Verdirestriksjon">
+        <xsd:attribute fixed="8009" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteDriftsmidlerVarige-18176/400071"
+                   seres:orid="18176" name="NoteDriftsmidlerVarige-18176">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteDriftsmidlerVarige-18176_Verdirestriksjon">
+        <xsd:attribute fixed="18176" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/DriftsmidlerVarige-47/400217" seres:orid="47"
+                   name="DriftsmidlerVarige-47">
+    <xsd:simpleContent>
+      <xsd:extension base="DriftsmidlerVarige-47_Verdirestriksjon">
+        <xsd:attribute fixed="47" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/DriftsmidlerVarigeFjoraret-8010/399394"
+                   seres:orid="8010" name="DriftsmidlerVarigeFjoraret-8010">
+    <xsd:simpleContent>
+      <xsd:extension base="DriftsmidlerVarigeFjoraret-8010_Verdirestriksjon">
+        <xsd:attribute fixed="8010" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteDriftsmidlerAndre-18177/399792"
+                   seres:orid="18177" name="NoteDriftsmidlerAndre-18177">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteDriftsmidlerAndre-18177_Verdirestriksjon">
+        <xsd:attribute fixed="18177" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/DriftsmidlerAndre-2836/399459" seres:orid="2836"
+                   name="DriftsmidlerAndre-2836">
+    <xsd:simpleContent>
+      <xsd:extension base="DriftsmidlerAndre-2836_Verdirestriksjon">
+        <xsd:attribute fixed="2836" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/DriftsmidlerAndreFjoraret-7088/400185"
+                   seres:orid="7088" name="DriftsmidlerAndreFjoraret-7088">
+    <xsd:simpleContent>
+      <xsd:extension base="DriftsmidlerAndreFjoraret-7088_Verdirestriksjon">
+        <xsd:attribute fixed="7088" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteDriftsmidlerAndre-30979/450531"
+                   seres:orid="30979" name="NoteDriftsmidlerAndre-30979">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteDriftsmidlerAndre-30979_Verdirestriksjon">
+        <xsd:attribute fixed="30979" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/DriftsmidlerAndre-30980/450512"
+                   seres:orid="30980" name="DriftsmidlerAndre-30980">
+    <xsd:simpleContent>
+      <xsd:extension base="DriftsmidlerAndre-30980_Verdirestriksjon">
+        <xsd:attribute fixed="30980" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/DriftsmidlerAndreFjoraret-30981/450586"
+                   seres:orid="30981" name="DriftsmidlerAndreFjoraret-30981">
+    <xsd:simpleContent>
+      <xsd:extension base="DriftsmidlerAndreFjoraret-30981_Verdirestriksjon">
+        <xsd:attribute fixed="30981" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteInvesteringerDatterselskap-18563/399966"
+                   seres:orid="18563" name="NoteInvesteringerDatterselskap-18563">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteInvesteringerDatterselskap-18563_Verdirestriksjon">
+        <xsd:attribute fixed="18563" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/InvesteringerDatterselskap-9686/399780"
+                   seres:orid="9686" name="InvesteringerDatterselskap-9686">
+    <xsd:simpleContent>
+      <xsd:extension base="InvesteringerDatterselskap-9686_Verdirestriksjon">
+        <xsd:attribute fixed="9686" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/InvesteringerDatterselskapFjoraret-10289/399308"
+                   seres:orid="10289" name="InvesteringerDatterselskapFjoraret-10289">
+    <xsd:simpleContent>
+      <xsd:extension base="InvesteringerDatterselskapFjoraret-10289_Verdirestriksjon">
+        <xsd:attribute fixed="10289" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteInvesteringerAksjerAndeler-18568/399456"
+                   seres:orid="18568" name="NoteInvesteringerAksjerAndeler-18568">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteInvesteringerAksjerAndeler-18568_Verdirestriksjon">
+        <xsd:attribute fixed="18568" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/InvesteringerAksjerAndeler-7100/400216"
+                   seres:orid="7100" name="InvesteringerAksjerAndeler-7100">
+    <xsd:simpleContent>
+      <xsd:extension base="InvesteringerAksjerAndeler-7100_Verdirestriksjon">
+        <xsd:attribute fixed="7100" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/InvesteringerAksjerAndelerFjoraret-7101/400331"
+                   seres:orid="7101" name="InvesteringerAksjerAndelerFjoraret-7101">
+    <xsd:simpleContent>
+      <xsd:extension base="InvesteringerAksjerAndelerFjoraret-7101_Verdirestriksjon">
+        <xsd:attribute fixed="7101" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteObligasjonerLangsiktige-27582/400173"
+                   seres:orid="27582" name="NoteObligasjonerLangsiktige-27582">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteObligasjonerLangsiktige-27582_Verdirestriksjon">
+        <xsd:attribute fixed="27582" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/ObligasjonerLangsiktige-27583/400095"
+                   seres:orid="27583" name="ObligasjonerLangsiktige-27583">
+    <xsd:simpleContent>
+      <xsd:extension base="ObligasjonerLangsiktige-27583_Verdirestriksjon">
+        <xsd:attribute fixed="27583" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/ObligasjonerLangsiktigeFjoraret-27584/400277"
+                   seres:orid="27584" name="ObligasjonerLangsiktigeFjoraret-27584">
+    <xsd:simpleContent>
+      <xsd:extension base="ObligasjonerLangsiktigeFjoraret-27584_Verdirestriksjon">
+        <xsd:attribute fixed="27584" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteFordringerAndreLangsiktige-27578/399320"
+                   seres:orid="27578" name="NoteFordringerAndreLangsiktige-27578">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFordringerAndreLangsiktige-27578_Verdirestriksjon">
+        <xsd:attribute fixed="27578" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FordringerAndreLangsiktige-203/399850"
+                   seres:orid="203" name="FordringerAndreLangsiktige-203">
+    <xsd:simpleContent>
+      <xsd:extension base="FordringerAndreLangsiktige-203_Verdirestriksjon">
+        <xsd:attribute fixed="203" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FordringerAndreLangsiktigeFjoraret-27585/399614"
+                   seres:orid="27585" name="FordringerAndreLangsiktigeFjoraret-27585">
+    <xsd:simpleContent>
+      <xsd:extension base="FordringerAndreLangsiktigeFjoraret-27585_Verdirestriksjon">
+        <xsd:attribute fixed="27585" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteAnleggsmidlerFinansielle-18372/399224"
+                   seres:orid="18372" name="NoteAnleggsmidlerFinansielle-18372">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteAnleggsmidlerFinansielle-18372_Verdirestriksjon">
+        <xsd:attribute fixed="18372" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/AnleggsmidlerFinansielle-5267/399245"
+                   seres:orid="5267" name="AnleggsmidlerFinansielle-5267">
+    <xsd:simpleContent>
+      <xsd:extension base="AnleggsmidlerFinansielle-5267_Verdirestriksjon">
+        <xsd:attribute fixed="5267" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/AnleggsmidlerFinansielleFjoraret-8014/400202"
+                   seres:orid="8014" name="AnleggsmidlerFinansielleFjoraret-8014">
+    <xsd:simpleContent>
+      <xsd:extension base="AnleggsmidlerFinansielleFjoraret-8014_Verdirestriksjon">
+        <xsd:attribute fixed="8014" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteAnleggsmidler-18570/399377" seres:orid="18570"
+                   name="NoteAnleggsmidler-18570">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteAnleggsmidler-18570_Verdirestriksjon">
+        <xsd:attribute fixed="18570" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Anleggsmidler-217/400312" seres:orid="217"
+                   name="Anleggsmidler-217">
+    <xsd:simpleContent>
+      <xsd:extension base="Anleggsmidler-217_Verdirestriksjon">
+        <xsd:attribute fixed="217" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/AnleggsmidlerFjoraret-7108/399593" seres:orid="7108"
+                   name="AnleggsmidlerFjoraret-7108">
+    <xsd:simpleContent>
+      <xsd:extension base="AnleggsmidlerFjoraret-7108_Verdirestriksjon">
+        <xsd:attribute fixed="7108" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteLagerbeholdning-30822/450500"
+                   seres:orid="30822" name="NoteLagerbeholdning-30822">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteLagerbeholdning-30822_Verdirestriksjon">
+        <xsd:attribute fixed="30822" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/Lagerbeholdning-30823/450574"
+                   seres:orid="30823" name="Lagerbeholdning-30823">
+    <xsd:simpleContent>
+      <xsd:extension base="Lagerbeholdning-30823_Verdirestriksjon">
+        <xsd:attribute fixed="30823" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/LagerbeholdningFjoraret-30824/450575"
+                   seres:orid="30824" name="LagerbeholdningFjoraret-30824">
+    <xsd:simpleContent>
+      <xsd:extension base="LagerbeholdningFjoraret-30824_Verdirestriksjon">
+        <xsd:attribute fixed="30824" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteLagerbeholdning-18571/400208" seres:orid="18571"
+                   name="NoteLagerbeholdning-18571">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteLagerbeholdning-18571_Verdirestriksjon">
+        <xsd:attribute fixed="18571" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Lagerbeholdning-326/400252" seres:orid="326"
+                   name="Lagerbeholdning-326">
+    <xsd:simpleContent>
+      <xsd:extension base="Lagerbeholdning-326_Verdirestriksjon">
+        <xsd:attribute fixed="326" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/LagerbeholdningFjoraret-797/400170" seres:orid="797"
+                   name="LagerbeholdningFjoraret-797">
+    <xsd:simpleContent>
+      <xsd:extension base="LagerbeholdningFjoraret-797_Verdirestriksjon">
+        <xsd:attribute fixed="797" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteFordringerKunder-18384/399470"
+                   seres:orid="18384" name="NoteFordringerKunder-18384">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFordringerKunder-18384_Verdirestriksjon">
+        <xsd:attribute fixed="18384" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FordringerKunder-116/399863" seres:orid="116"
+                   name="FordringerKunder-116">
+    <xsd:simpleContent>
+      <xsd:extension base="FordringerKunder-116_Verdirestriksjon">
+        <xsd:attribute fixed="116" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FordringerKunderFjoraret-6921/399695"
+                   seres:orid="6921" name="FordringerKunderFjoraret-6921">
+    <xsd:simpleContent>
+      <xsd:extension base="FordringerKunderFjoraret-6921_Verdirestriksjon">
+        <xsd:attribute fixed="6921" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteFordringerAndreKortsiktig-18572/400000"
+                   seres:orid="18572" name="NoteFordringerAndreKortsiktig-18572">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFordringerAndreKortsiktig-18572_Verdirestriksjon">
+        <xsd:attribute fixed="18572" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FordringerAndreKortsiktig-282/399435"
+                   seres:orid="282" name="FordringerAndreKortsiktig-282">
+    <xsd:simpleContent>
+      <xsd:extension base="FordringerAndreKortsiktig-282_Verdirestriksjon">
+        <xsd:attribute fixed="282" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FordringerAndreKortsiktigFjoraret-7112/399272"
+                   seres:orid="7112" name="FordringerAndreKortsiktigFjoraret-7112">
+    <xsd:simpleContent>
+      <xsd:extension base="FordringerAndreKortsiktigFjoraret-7112_Verdirestriksjon">
+        <xsd:attribute fixed="7112" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteFordringer-18389/399983" seres:orid="18389"
+                   name="NoteFordringer-18389">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFordringer-18389_Verdirestriksjon">
+        <xsd:attribute fixed="18389" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Fordringer-80/399290" seres:orid="80"
+                   name="Fordringer-80">
+    <xsd:simpleContent>
+      <xsd:extension base="Fordringer-80_Verdirestriksjon">
+        <xsd:attribute fixed="80" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FordringerFjoraret-8015/399644" seres:orid="8015"
+                   name="FordringerFjoraret-8015">
+    <xsd:simpleContent>
+      <xsd:extension base="FordringerFjoraret-8015_Verdirestriksjon">
+        <xsd:attribute fixed="8015" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteAksjerMvMarkedsbaserte-18575/399672"
+                   seres:orid="18575" name="NoteAksjerMvMarkedsbaserte-18575">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteAksjerMvMarkedsbaserte-18575_Verdirestriksjon">
+        <xsd:attribute fixed="18575" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/AksjerMvMarkedsbaserte-7117/400338"
+                   seres:orid="7117" name="AksjerMvMarkedsbaserte-7117">
+    <xsd:simpleContent>
+      <xsd:extension base="AksjerMvMarkedsbaserte-7117_Verdirestriksjon">
+        <xsd:attribute fixed="7117" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/AksjerMvMarkedsbaserteFjoraret-7118/399453"
+                   seres:orid="7118" name="AksjerMvMarkedsbaserteFjoraret-7118">
+    <xsd:simpleContent>
+      <xsd:extension base="AksjerMvMarkedsbaserteFjoraret-7118_Verdirestriksjon">
+        <xsd:attribute fixed="7118" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteFinansielleInstrumenterMarkedsbaserteAndre-18577/400337"
+                   seres:orid="18577" name="NoteFinansielleInstrumenterMarkedsbaserteAndre-18577">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFinansielleInstrumenterMarkedsbaserteAndre-18577_Verdirestriksjon">
+        <xsd:attribute fixed="18577" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FinansielleInstrumenterMarkedsbaserteAndre-7731/399303"
+                   seres:orid="7731" name="FinansielleInstrumenterMarkedsbaserteAndre-7731">
+    <xsd:simpleContent>
+      <xsd:extension base="FinansielleInstrumenterMarkedsbaserteAndre-7731_Verdirestriksjon">
+        <xsd:attribute fixed="7731" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FinansielleInstrumenterMarkedsbaserteAndreFjoraret-8017/400022"
+                   seres:orid="8017" name="FinansielleInstrumenterMarkedsbaserteAndreFjoraret-8017">
+    <xsd:simpleContent>
+      <xsd:extension base="FinansielleInstrumenterMarkedsbaserteAndreFjoraret-8017_Verdirestriksjon">
+        <xsd:attribute fixed="8017" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteFinansielleInstrumenterAndre-18578/399391"
+                   seres:orid="18578" name="NoteFinansielleInstrumenterAndre-18578">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFinansielleInstrumenterAndre-18578_Verdirestriksjon">
+        <xsd:attribute fixed="18578" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FinansielleInstrumenterAndre-6429/399427"
+                   seres:orid="6429" name="FinansielleInstrumenterAndre-6429">
+    <xsd:simpleContent>
+      <xsd:extension base="FinansielleInstrumenterAndre-6429_Verdirestriksjon">
+        <xsd:attribute fixed="6429" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/FinansielleInstrumenterAndreFjoraret-7123/399424"
+                   seres:orid="7123" name="FinansielleInstrumenterAndreFjoraret-7123">
+    <xsd:simpleContent>
+      <xsd:extension base="FinansielleInstrumenterAndreFjoraret-7123_Verdirestriksjon">
+        <xsd:attribute fixed="7123" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteInvesteringer-18579/399352" seres:orid="18579"
+                   name="NoteInvesteringer-18579">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteInvesteringer-18579_Verdirestriksjon">
+        <xsd:attribute fixed="18579" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Investeringer-6601/400300" seres:orid="6601"
+                   name="Investeringer-6601">
+    <xsd:simpleContent>
+      <xsd:extension base="Investeringer-6601_Verdirestriksjon">
+        <xsd:attribute fixed="6601" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/InvesteringerFjoraret-8018/399227" seres:orid="8018"
+                   name="InvesteringerFjoraret-8018">
+    <xsd:simpleContent>
+      <xsd:extension base="InvesteringerFjoraret-8018_Verdirestriksjon">
+        <xsd:attribute fixed="8018" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteKontanterBankinnskudd-18390/399248"
+                   seres:orid="18390" name="NoteKontanterBankinnskudd-18390">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteKontanterBankinnskudd-18390_Verdirestriksjon">
+        <xsd:attribute fixed="18390" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/KontanterBankinnskudd-786/399719" seres:orid="786"
+                   name="KontanterBankinnskudd-786">
+    <xsd:simpleContent>
+      <xsd:extension base="KontanterBankinnskudd-786_Verdirestriksjon">
+        <xsd:attribute fixed="786" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/KontanterBankinnskuddFjoraret-8019/399515"
+                   seres:orid="8019" name="KontanterBankinnskuddFjoraret-8019">
+    <xsd:simpleContent>
+      <xsd:extension base="KontanterBankinnskuddFjoraret-8019_Verdirestriksjon">
+        <xsd:attribute fixed="8019" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteKontanterBankinnskuddSum-29041/399718"
+                   seres:orid="29041" name="NoteKontanterBankinnskuddSum-29041">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteKontanterBankinnskuddSum-29041_Verdirestriksjon">
+        <xsd:attribute fixed="29041" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/KontanterBankinnskuddSum-29042/399763"
+                   seres:orid="29042" name="KontanterBankinnskuddSum-29042">
+    <xsd:simpleContent>
+      <xsd:extension base="KontanterBankinnskuddSum-29042_Verdirestriksjon">
+        <xsd:attribute fixed="29042" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/KontanterBankinnskuddSumFjoraret-29043/399867"
+                   seres:orid="29043" name="KontanterBankinnskuddSumFjoraret-29043">
+    <xsd:simpleContent>
+      <xsd:extension base="KontanterBankinnskuddSumFjoraret-29043_Verdirestriksjon">
+        <xsd:attribute fixed="29043" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteOmlopsmidler-18580/399764" seres:orid="18580"
+                   name="NoteOmlopsmidler-18580">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteOmlopsmidler-18580_Verdirestriksjon">
+        <xsd:attribute fixed="18580" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Omlopsmidler-194/399376" seres:orid="194"
+                   name="Omlopsmidler-194">
+    <xsd:simpleContent>
+      <xsd:extension base="Omlopsmidler-194_Verdirestriksjon">
+        <xsd:attribute fixed="194" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/OmlopsmidlerFjoraret-7126/399643" seres:orid="7126"
+                   name="OmlopsmidlerFjoraret-7126">
+    <xsd:simpleContent>
+      <xsd:extension base="OmlopsmidlerFjoraret-7126_Verdirestriksjon">
+        <xsd:attribute fixed="7126" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteEiendeler-18167/399653" seres:orid="18167"
+                   name="NoteEiendeler-18167">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteEiendeler-18167_Verdirestriksjon">
+        <xsd:attribute fixed="18167" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Eiendeler-219/399753" seres:orid="219"
+                   name="Eiendeler-219">
+    <xsd:simpleContent>
+      <xsd:extension base="Eiendeler-219_Verdirestriksjon">
+        <xsd:attribute fixed="219" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/EiendelerFjoraret-7127/399909" seres:orid="7127"
+                   name="EiendelerFjoraret-7127">
+    <xsd:simpleContent>
+      <xsd:extension base="EiendelerFjoraret-7127_Verdirestriksjon">
+        <xsd:attribute fixed="7127" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteGrunnkapital-30819/450498"
+                   seres:orid="30819" name="NoteGrunnkapital-30819">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteGrunnkapital-30819_Verdirestriksjon">
+        <xsd:attribute fixed="30819" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/Grunnkapital-30820/450438"
+                   seres:orid="30820" name="Grunnkapital-30820">
+    <xsd:simpleContent>
+      <xsd:extension base="Grunnkapital-30820_Verdirestriksjon">
+        <xsd:attribute fixed="30820" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/GrunnkapitalFjoraret-30821/450440"
+                   seres:orid="30821" name="GrunnkapitalFjoraret-30821">
+    <xsd:simpleContent>
+      <xsd:extension base="GrunnkapitalFjoraret-30821_Verdirestriksjon">
+        <xsd:attribute fixed="30821" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalInnskuttAnnen-33457/479952"
+                   seres:orid="33457" name="NoteFormalskapitalInnskuttAnnen-33457">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalInnskuttAnnen-33457_Verdirestriksjon">
+        <xsd:attribute fixed="33457" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalInnskuttAnnen-33458/479951"
+                   seres:orid="33458" name="FormalskapitalInnskuttAnnen-33458">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalInnskuttAnnen-33458_Verdirestriksjon">
+        <xsd:attribute fixed="33458" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalInnskuttAnnenFjoraret-33459/480209"
+                   seres:orid="33459" name="FormalskapitalInnskuttAnnenFjoraret-33459">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalInnskuttAnnenFjoraret-33459_Verdirestriksjon">
+        <xsd:attribute fixed="33459" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalInnskuttSum-33460/480216"
+                   seres:orid="33460" name="NoteFormalskapitalInnskuttSum-33460">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalInnskuttSum-33460_Verdirestriksjon">
+        <xsd:attribute fixed="33460" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalInnskuttSum-33461/480217"
+                   seres:orid="33461" name="FormalskapitalInnskuttSum-33461">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalInnskuttSum-33461_Verdirestriksjon">
+        <xsd:attribute fixed="33461" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalInnskuttSumFjoraret-33462/480215"
+                   seres:orid="33462" name="FormalskapitalInnskuttSumFjoraret-33462">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalInnskuttSumFjoraret-33462_Verdirestriksjon">
+        <xsd:attribute fixed="33462" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalAnnenRestriksjonerLovpalagte-33463/480254"
+                   seres:orid="33463" name="NoteFormalskapitalAnnenRestriksjonerLovpalagte-33463">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalAnnenRestriksjonerLovpalagte-33463_Verdirestriksjon">
+        <xsd:attribute fixed="33463" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalAnnenRestriksjonerLovpalagte-33464/480255"
+                   seres:orid="33464" name="FormalskapitalAnnenRestriksjonerLovpalagte-33464">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalAnnenRestriksjonerLovpalagte-33464_Verdirestriksjon">
+        <xsd:attribute fixed="33464" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalAnnenRestriksjonerLovpalagteFjoraret-33465/480256"
+                   seres:orid="33465" name="FormalskapitalAnnenRestriksjonerLovpalagteFjoraret-33465">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalAnnenRestriksjonerLovpalagteFjoraret-33465_Verdirestriksjon">
+        <xsd:attribute fixed="33465" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalOpptjentSumRestriksjonerLovpalagte-33466/480264"
+                   seres:orid="33466" name="NoteFormalskapitalOpptjentSumRestriksjonerLovpalagte-33466">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalOpptjentSumRestriksjonerLovpalagte-33466_Verdirestriksjon">
+        <xsd:attribute fixed="33466" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalOpptjentSumRestriksjonerLovpalagte-33467/480262"
+                   seres:orid="33467" name="FormalskapitalOpptjentSumRestriksjonerLovpalagte-33467">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalOpptjentSumRestriksjonerLovpalagte-33467_Verdirestriksjon">
+        <xsd:attribute fixed="33467" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalOpptjentSumRestriksjonerLovpalagteFjoraret-33468/480263"
+                   seres:orid="33468" name="FormalskapitalOpptjentSumRestriksjonerLovpalagteFjoraret-33468">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalOpptjentSumRestriksjonerLovpalagteFjoraret-33468_Verdirestriksjon">
+        <xsd:attribute fixed="33468" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalAnnenRestriksjonerEksterntPalagte-33469/482341"
+                   seres:orid="33469" name="NoteFormalskapitalAnnenRestriksjonerEksterntPalagte-33469">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalAnnenRestriksjonerEksterntPalagte-33469_Verdirestriksjon">
+        <xsd:attribute fixed="33469" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalAnnenRestriksjonerEksterntPalagte-33470/482346"
+                   seres:orid="33470" name="FormalskapitalAnnenRestriksjonerEksterntPalagte-33470">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalAnnenRestriksjonerEksterntPalagte-33470_Verdirestriksjon">
+        <xsd:attribute fixed="33470" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalAnnenRestriksjonerEksterntPalagteFjoraret-33471/482347"
+                   seres:orid="33471" name="FormalskapitalAnnenRestriksjonerEksterntPalagteFjoraret-33471">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalAnnenRestriksjonerEksterntPalagteFjoraret-33471_Verdirestriksjon">
+        <xsd:attribute fixed="33471" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalSumRestriksjonerEksterntPalagte-33472/480404"
+                   seres:orid="33472" name="NoteFormalskapitalSumRestriksjonerEksterntPalagte-33472">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalSumRestriksjonerEksterntPalagte-33472_Verdirestriksjon">
+        <xsd:attribute fixed="33472" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalSumRestriksjonerEksterntPalagte-33473/480407"
+                   seres:orid="33473" name="FormalskapitalSumRestriksjonerEksterntPalagte-33473">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalSumRestriksjonerEksterntPalagte-33473_Verdirestriksjon">
+        <xsd:attribute fixed="33473" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalSumRestriksjonerEksterntPalagteFjoraret-33474/480405"
+                   seres:orid="33474" name="FormalskapitalSumRestriksjonerEksterntPalagteFjoraret-33474">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalSumRestriksjonerEksterntPalagteFjoraret-33474_Verdirestriksjon">
+        <xsd:attribute fixed="33474" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalAnnenRestriksjonerSelpalagte-33475/480403"
+                   seres:orid="33475" name="NoteFormalskapitalAnnenRestriksjonerSelpalagte-33475">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalAnnenRestriksjonerSelpalagte-33475_Verdirestriksjon">
+        <xsd:attribute fixed="33475" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalAnnenRestriksjonerSelvpalagte-33476/480409"
+                   seres:orid="33476" name="FormalskapitalAnnenRestriksjonerSelvpalagte-33476">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalAnnenRestriksjonerSelvpalagte-33476_Verdirestriksjon">
+        <xsd:attribute fixed="33476" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalAnnenRestriksjonerSelvpalagteFjoraret-33477/480406"
+                   seres:orid="33477" name="FormalskapitalAnnenRestriksjonerSelvpalagteFjoraret-33477">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalAnnenRestriksjonerSelvpalagteFjoraret-33477_Verdirestriksjon">
+        <xsd:attribute fixed="33477" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalSumRestriksjonerSelvpalagte-33478/480408"
+                   seres:orid="33478" name="NoteFormalskapitalSumRestriksjonerSelvpalagte-33478">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalSumRestriksjonerSelvpalagte-33478_Verdirestriksjon">
+        <xsd:attribute fixed="33478" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalSumRestriksjonerSelvpalagte-33479/480424"
+                   seres:orid="33479" name="FormalskapitalSumRestriksjonerSelvpalagte-33479">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalSumRestriksjonerSelvpalagte-33479_Verdirestriksjon">
+        <xsd:attribute fixed="33479" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalSumRestriksjonerSelvpalagteFjoraret-33480/480425"
+                   seres:orid="33480" name="FormalskapitalSumRestriksjonerSelvpalagteFjoraret-33480">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalSumRestriksjonerSelvpalagteFjoraret-33480_Verdirestriksjon">
+        <xsd:attribute fixed="33480" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalAnnen-33481/480423"
+                   seres:orid="33481" name="NoteFormalskapitalAnnen-33481">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalAnnen-33481_Verdirestriksjon">
+        <xsd:attribute fixed="33481" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalAnnen-33482/480422"
+                   seres:orid="33482" name="FormalskapitalAnnen-33482">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalAnnen-33482_Verdirestriksjon">
+        <xsd:attribute fixed="33482" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalAnnenFjoraret-33483/480421"
+                   seres:orid="33483" name="FormalskapitalAnnenFjoraret-33483">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalAnnenFjoraret-33483_Verdirestriksjon">
+        <xsd:attribute fixed="33483" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteMinoritetsinteresser-29044/400329"
+                   seres:orid="29044" name="NoteMinoritetsinteresser-29044">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteMinoritetsinteresser-29044_Verdirestriksjon">
+        <xsd:attribute fixed="29044" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Minoritetsinteresser-29045/400241"
+                   seres:orid="29045" name="Minoritetsinteresser-29045">
+    <xsd:simpleContent>
+      <xsd:extension base="Minoritetsinteresser-29045_Verdirestriksjon">
+        <xsd:attribute fixed="29045" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/MinoritetsinteresserFjoraret-29046/399450"
+                   seres:orid="29046" name="MinoritetsinteresserFjoraret-29046">
+    <xsd:simpleContent>
+      <xsd:extension base="MinoritetsinteresserFjoraret-29046_Verdirestriksjon">
+        <xsd:attribute fixed="29046" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/NoteFormalskapitalSum-33484/480432"
+                   seres:orid="33484" name="NoteFormalskapitalSum-33484">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteFormalskapitalSum-33484_Verdirestriksjon">
+        <xsd:attribute fixed="33484" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalSum-33485/480433"
+                   seres:orid="33485" name="FormalskapitalSum-33485">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalSum-33485_Verdirestriksjon">
+        <xsd:attribute fixed="33485" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/FormalskapitalSumFjoraret-33486/480434"
+                   seres:orid="33486" name="FormalskapitalSumFjoraret-33486">
+    <xsd:simpleContent>
+      <xsd:extension base="FormalskapitalSumFjoraret-33486_Verdirestriksjon">
+        <xsd:attribute fixed="33486" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NotePensjonsforpliktelser-18149/399601"
+                   seres:orid="18149" name="NotePensjonsforpliktelser-18149">
+    <xsd:simpleContent>
+      <xsd:extension base="NotePensjonsforpliktelser-18149_Verdirestriksjon">
+        <xsd:attribute fixed="18149" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Pensjonsforpliktelser-238/399803" seres:orid="238"
+                   name="Pensjonsforpliktelser-238">
+    <xsd:simpleContent>
+      <xsd:extension base="Pensjonsforpliktelser-238_Verdirestriksjon">
+        <xsd:attribute fixed="238" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/PensjonsforpliktelserFjoraret-6685/399230"
+                   seres:orid="6685" name="PensjonsforpliktelserFjoraret-6685">
+    <xsd:simpleContent>
+      <xsd:extension base="PensjonsforpliktelserFjoraret-6685_Verdirestriksjon">
+        <xsd:attribute fixed="6685" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteSkattUtsatt-18148/400036" seres:orid="18148"
+                   name="NoteSkattUtsatt-18148">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteSkattUtsatt-18148_Verdirestriksjon">
+        <xsd:attribute fixed="18148" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/SkattUtsatt-237/399699" seres:orid="237"
+                   name="SkattUtsatt-237">
+    <xsd:simpleContent>
+      <xsd:extension base="SkattUtsatt-237_Verdirestriksjon">
+        <xsd:attribute fixed="237" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/SkattUtsattFjoraret-7143/399361" seres:orid="7143"
+                   name="SkattUtsattFjoraret-7143">
+    <xsd:simpleContent>
+      <xsd:extension base="SkattUtsattFjoraret-7143_Verdirestriksjon">
+        <xsd:attribute fixed="7143" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteAvsetningerForpliktelserLangsiktig-18582/399438"
+                   seres:orid="18582" name="NoteAvsetningerForpliktelserLangsiktig-18582">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteAvsetningerForpliktelserLangsiktig-18582_Verdirestriksjon">
+        <xsd:attribute fixed="18582" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/AvsetningerForpliktelserLangsiktig-7157/399428"
+                   seres:orid="7157" name="AvsetningerForpliktelserLangsiktig-7157">
+    <xsd:simpleContent>
+      <xsd:extension base="AvsetningerForpliktelserLangsiktig-7157_Verdirestriksjon">
+        <xsd:attribute fixed="7157" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/AvsetningerForpliktelserLangsiktigFjoraret-7146/399890"
+                   seres:orid="7146" name="AvsetningerForpliktelserLangsiktigFjoraret-7146">
+    <xsd:simpleContent>
+      <xsd:extension base="AvsetningerForpliktelserLangsiktigFjoraret-7146_Verdirestriksjon">
+        <xsd:attribute fixed="7146" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteAvsetningerForpliktelser-18144/400179"
+                   seres:orid="18144" name="NoteAvsetningerForpliktelser-18144">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteAvsetningerForpliktelser-18144_Verdirestriksjon">
+        <xsd:attribute fixed="18144" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/AvsetningerForpliktelser-7231/400351"
+                   seres:orid="7231" name="AvsetningerForpliktelser-7231">
+    <xsd:simpleContent>
+      <xsd:extension base="AvsetningerForpliktelser-7231_Verdirestriksjon">
+        <xsd:attribute fixed="7231" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/AvsetningerForpliktelserFjoraret-7230/400294"
+                   seres:orid="7230" name="AvsetningerForpliktelserFjoraret-7230">
+    <xsd:simpleContent>
+      <xsd:extension base="AvsetningerForpliktelserFjoraret-7230_Verdirestriksjon">
+        <xsd:attribute fixed="7230" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteGjeldKredittinstitusjoner-18164/399866"
+                   seres:orid="18164" name="NoteGjeldKredittinstitusjoner-18164">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteGjeldKredittinstitusjoner-18164_Verdirestriksjon">
+        <xsd:attribute fixed="18164" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldKredittinstitusjoner-7150/399461"
+                   seres:orid="7150" name="GjeldKredittinstitusjoner-7150">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldKredittinstitusjoner-7150_Verdirestriksjon">
+        <xsd:attribute fixed="7150" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldKredittinstitusjonerFjoraret-7151/400293"
+                   seres:orid="7151" name="GjeldKredittinstitusjonerFjoraret-7151">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldKredittinstitusjonerFjoraret-7151_Verdirestriksjon">
+        <xsd:attribute fixed="7151" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteGjeldAnnenLangsiktig-18584/399638"
+                   seres:orid="18584" name="NoteGjeldAnnenLangsiktig-18584">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteGjeldAnnenLangsiktig-18584_Verdirestriksjon">
+        <xsd:attribute fixed="18584" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldAnnenLangsiktig-242/400321" seres:orid="242"
+                   name="GjeldAnnenLangsiktig-242">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldAnnenLangsiktig-242_Verdirestriksjon">
+        <xsd:attribute fixed="242" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldAnnenLangsiktigFjoraret-7155/399383"
+                   seres:orid="7155" name="GjeldAnnenLangsiktigFjoraret-7155">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldAnnenLangsiktigFjoraret-7155_Verdirestriksjon">
+        <xsd:attribute fixed="7155" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteGjeldAnnenLangsiktigSum-25018/399658"
+                   seres:orid="25018" name="NoteGjeldAnnenLangsiktigSum-25018">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteGjeldAnnenLangsiktigSum-25018_Verdirestriksjon">
+        <xsd:attribute fixed="25018" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldAnnenLangsiktigSum-25019/399511"
+                   seres:orid="25019" name="GjeldAnnenLangsiktigSum-25019">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldAnnenLangsiktigSum-25019_Verdirestriksjon">
+        <xsd:attribute fixed="25019" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldAnnenLangsiktigSumFjoraret-25020/399671"
+                   seres:orid="25020" name="GjeldAnnenLangsiktigSumFjoraret-25020">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldAnnenLangsiktigSumFjoraret-25020_Verdirestriksjon">
+        <xsd:attribute fixed="25020" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteGjeldLangsiktig-18585/399226" seres:orid="18585"
+                   name="NoteGjeldLangsiktig-18585">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteGjeldLangsiktig-18585_Verdirestriksjon">
+        <xsd:attribute fixed="18585" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldLangsiktig-86/400027" seres:orid="86"
+                   name="GjeldLangsiktig-86">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldLangsiktig-86_Verdirestriksjon">
+        <xsd:attribute fixed="86" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldLangsiktigFjoraret-7156/400129"
+                   seres:orid="7156" name="GjeldLangsiktigFjoraret-7156">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldLangsiktigFjoraret-7156_Verdirestriksjon">
+        <xsd:attribute fixed="7156" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteGjeldKredittinstitusjonerKortsiktig-18587/399752"
+                   seres:orid="18587" name="NoteGjeldKredittinstitusjonerKortsiktig-18587">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteGjeldKredittinstitusjonerKortsiktig-18587_Verdirestriksjon">
+        <xsd:attribute fixed="18587" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldKredittinstitusjonerKortsiktig-10926/399247"
+                   seres:orid="10926" name="GjeldKredittinstitusjonerKortsiktig-10926">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldKredittinstitusjonerKortsiktig-10926_Verdirestriksjon">
+        <xsd:attribute fixed="10926" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldKredittinstitusjonerKortsiktigFjoraret-13203/399325"
+                   seres:orid="13203" name="GjeldKredittinstitusjonerKortsiktigFjoraret-13203">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldKredittinstitusjonerKortsiktigFjoraret-13203_Verdirestriksjon">
+        <xsd:attribute fixed="13203" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteLeverandorgjeld-18588/399773" seres:orid="18588"
+                   name="NoteLeverandorgjeld-18588">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteLeverandorgjeld-18588_Verdirestriksjon">
+        <xsd:attribute fixed="18588" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Leverandorgjeld-220/399415" seres:orid="220"
+                   name="Leverandorgjeld-220">
+    <xsd:simpleContent>
+      <xsd:extension base="Leverandorgjeld-220_Verdirestriksjon">
+        <xsd:attribute fixed="220" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/LeverandorgjeldFjoraret-7162/399945"
+                   seres:orid="7162" name="LeverandorgjeldFjoraret-7162">
+    <xsd:simpleContent>
+      <xsd:extension base="LeverandorgjeldFjoraret-7162_Verdirestriksjon">
+        <xsd:attribute fixed="7162" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteSkattBetalbar-18589/400085" seres:orid="18589"
+                   name="NoteSkattBetalbar-18589">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteSkattBetalbar-18589_Verdirestriksjon">
+        <xsd:attribute fixed="18589" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/SkattBetalbar-2483/399403" seres:orid="2483"
+                   name="SkattBetalbar-2483">
+    <xsd:simpleContent>
+      <xsd:extension base="SkattBetalbar-2483_Verdirestriksjon">
+        <xsd:attribute fixed="2483" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/SkattBetalbarFjoraret-10293/400161"
+                   seres:orid="10293" name="SkattBetalbarFjoraret-10293">
+    <xsd:simpleContent>
+      <xsd:extension base="SkattBetalbarFjoraret-10293_Verdirestriksjon">
+        <xsd:attribute fixed="10293" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteAvgifterOffentligeSkyldig-18590/399259"
+                   seres:orid="18590" name="NoteAvgifterOffentligeSkyldig-18590">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteAvgifterOffentligeSkyldig-18590_Verdirestriksjon">
+        <xsd:attribute fixed="18590" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/AvgifterOffentligeSkyldig-225/399209"
+                   seres:orid="225" name="AvgifterOffentligeSkyldig-225">
+    <xsd:simpleContent>
+      <xsd:extension base="AvgifterOffentligeSkyldig-225_Verdirestriksjon">
+        <xsd:attribute fixed="225" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/AvgifterOffentligeSkyldigFjoraret-7170/399648"
+                   seres:orid="7170" name="AvgifterOffentligeSkyldigFjoraret-7170">
+    <xsd:simpleContent>
+      <xsd:extension base="AvgifterOffentligeSkyldigFjoraret-7170_Verdirestriksjon">
+        <xsd:attribute fixed="7170" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteGjeldAnnenKortsiktig-18592/399750"
+                   seres:orid="18592" name="NoteGjeldAnnenKortsiktig-18592">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteGjeldAnnenKortsiktig-18592_Verdirestriksjon">
+        <xsd:attribute fixed="18592" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldAnnenKortsiktig-236/399833" seres:orid="236"
+                   name="GjeldAnnenKortsiktig-236">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldAnnenKortsiktig-236_Verdirestriksjon">
+        <xsd:attribute fixed="236" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldAnnenKortsiktigFjoraret-7182/399544"
+                   seres:orid="7182" name="GjeldAnnenKortsiktigFjoraret-7182">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldAnnenKortsiktigFjoraret-7182_Verdirestriksjon">
+        <xsd:attribute fixed="7182" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteGjeldKortsiktig-18593/400120" seres:orid="18593"
+                   name="NoteGjeldKortsiktig-18593">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteGjeldKortsiktig-18593_Verdirestriksjon">
+        <xsd:attribute fixed="18593" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldKortsiktig-85/400132" seres:orid="85"
+                   name="GjeldKortsiktig-85">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldKortsiktig-85_Verdirestriksjon">
+        <xsd:attribute fixed="85" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldKortsiktigFjoraret-7183/400270"
+                   seres:orid="7183" name="GjeldKortsiktigFjoraret-7183">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldKortsiktigFjoraret-7183_Verdirestriksjon">
+        <xsd:attribute fixed="7183" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteGjeld-18138/400345" seres:orid="18138"
+                   name="NoteGjeld-18138">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteGjeld-18138_Verdirestriksjon">
+        <xsd:attribute fixed="18138" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Gjeld-1119/400059" seres:orid="1119"
+                   name="Gjeld-1119">
+    <xsd:simpleContent>
+      <xsd:extension base="Gjeld-1119_Verdirestriksjon">
+        <xsd:attribute fixed="1119" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldFjoraret-7184/400215" seres:orid="7184"
+                   name="GjeldFjoraret-7184">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldFjoraret-7184_Verdirestriksjon">
+        <xsd:attribute fixed="7184" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteGjeldEgenkapital-18122/399816"
+                   seres:orid="18122" name="NoteGjeldEgenkapital-18122">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteGjeldEgenkapital-18122_Verdirestriksjon">
+        <xsd:attribute fixed="18122" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldEgenkapital-251/399626" seres:orid="251"
+                   name="GjeldEgenkapital-251">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldEgenkapital-251_Verdirestriksjon">
+        <xsd:attribute fixed="251" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GjeldEgenkapitalFjoraret-7185/399285"
+                   seres:orid="7185" name="GjeldEgenkapitalFjoraret-7185">
+    <xsd:simpleContent>
+      <xsd:extension base="GjeldEgenkapitalFjoraret-7185_Verdirestriksjon">
+        <xsd:attribute fixed="7185" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NoteGarantistillelse-18594/399317"
+                   seres:orid="18594" name="NoteGarantistillelse-18594">
+    <xsd:simpleContent>
+      <xsd:extension base="NoteGarantistillelse-18594_Verdirestriksjon">
+        <xsd:attribute fixed="18594" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Garantistillelse-16920/399457" seres:orid="16920"
+                   name="Garantistillelse-16920">
+    <xsd:simpleContent>
+      <xsd:extension base="Garantistillelse-16920_Verdirestriksjon">
+        <xsd:attribute fixed="16920" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/GarantistillelseFjoraret-16921/399929"
+                   seres:orid="16921" name="GarantistillelseFjoraret-16921">
+    <xsd:simpleContent>
+      <xsd:extension base="GarantistillelseFjoraret-16921_Verdirestriksjon">
+        <xsd:attribute fixed="16921" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/NotePantstillelser-18595/399464" seres:orid="18595"
+                   name="NotePantstillelser-18595">
+    <xsd:simpleContent>
+      <xsd:extension base="NotePantstillelser-18595_Verdirestriksjon">
+        <xsd:attribute fixed="18595" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/Pantstillelser-16922/400155" seres:orid="16922"
+                   name="Pantstillelser-16922">
+    <xsd:simpleContent>
+      <xsd:extension base="Pantstillelser-16922_Verdirestriksjon">
+        <xsd:attribute fixed="16922" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/PantstillelserFjoraret-16923/400167"
+                   seres:orid="16923" name="PantstillelserFjoraret-16923">
+    <xsd:simpleContent>
+      <xsd:extension base="PantstillelserFjoraret-16923_Verdirestriksjon">
+        <xsd:attribute fixed="16923" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:simpleType name="ArsregnskapType-25942_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/S/500693" value="S"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/K/500692" value="K"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ArsregnskapValutakode-34984_Verdirestriksjon">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ArsregnskapValor-28974_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/H/500673" value="H"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/T/500672" value="T"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/M/500671" value="M"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteMedlemsinntekter-30319_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Medlemsinntekter-30320_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="MedlemsinntekterFjoraret-30321_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteTilskuddOffentlig-33418_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="TilskuddOffentlig-33419_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="TilskuddOffentligFjoraret-33420_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="NoteTilskuddAndre-33421_Verdirestriksjon">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="TilskuddAndre-33422_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="TilskuddAndreFjoraret-33423_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer"/>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteTilskudd-30310_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="TilskuddOffentlig-30311_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="TilskuddOffentligFjoraret-30312_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteMidlerGaverInnsamlede-30313_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="MidlerGaverInnsamlede-30314_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="MidlerGaverInnsamledeFjoraret-30315_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteAktiviteterOppfyllerOrganisasjonensFormal-33424_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="AktiviteterOppfyllerOrganisasjonensFormal-33425_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="AktiviteterOppfyllerOrganisasjonensFormalFjoraret-33426_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteAktiviteterSkaperInntekt-33427_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AktiviteterSkaperInntekt-33428_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AktiviteterSkaperInntektFjoraret-33429_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteAktiviteterOperasjonelle-33430_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AktiviteterOperasjonelleFjoraret-33432_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AktiviteterOperasjonelle-33431_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteDriftsinntekterAndreSum-18238_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="DriftsinntekterAndreSum-7709_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="DriftsinntekterAndreFjoraretSum-7966_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteFinansinntekterInvesteringsinntekter-33433_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FinansinntekterInvesteringsinntekter-33434_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FinansinntekterInvesteringsinntekterFjoraret-33435_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteInntektAnnen-30307_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="InntektAnnen-30308_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="InntektAnnenFjoraret-30309_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteMidlerAnskaffede-30316_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="MidlerAnskaffede-30317_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="MidlerAnskaffedeFjoraret-30318_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteKostnadAnskaffelseAvMidler-30806_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="KostnadAnskaffelseAvMidler-30807_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="KostnadAnskaffelseAvMidlerFjoraret-30808_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteTilskuddBevilningOppfyllelseOrganisasjonensFormal-33436_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="TilskuddBevilningOppfyllelseOrganisasjonensFormal-33437_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="TilskuddBevilningOppfyllelseOrganisasjonensFormalFjoraret-33438_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteKostnaderOppfyllelseOrganisasjonensFormal-33439_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="KostnaderOppfyllelseOrganisasjonensFormal-33440_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="KostnaderOppfyllelseOrganisasjonensFormalFjoraret-33441_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteKostnadOrganisasjonensFormal-30809_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="KostnadOrganisasjonensFormal-30810_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="KostnadOrganisasjonensFormalFjoraret-30811_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteRentekostnaderAndre-18550_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="RentekostnaderAndre-2216_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="RentekostnaderAndreFjoraret-7039_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteFinanskostnaderAndre-18337_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FinanskostnaderAndre-156_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FinanskostnaderAndreFjoraret-7041_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteKostnaderAdministrative-27924_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="KostnaderAdministrative-27926_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="KostnaderAdministrativeFjoraret-27928_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteDriftskostnaderAndre-18249_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="DriftskostnaderAndre-82_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="DriftskostnaderAndreFjoraret-7023_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteMidlerForbrukte-30812_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="MidlerForbrukte-30813_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="MidlerForbrukteFjoraret-30814_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteResultatForSkattekostnad-18355_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="ResultatForSkattekostnad-167_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="ResultatForSkattekostnadFjoraret-7042_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteSkattekostnadOrdinartResultat-18259_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="SkattekostnadOrdinartResultat-11835_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="SkattekostnadOrdinartResultatFjoraret-11836_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteResultatOrdinart-18258_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="ResultatOrdinart-7048_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="ResultatOrdinartFjordaret-7049_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteResultatEkstraordinarePoster-29047_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="ResultatEkstraordinarePoster-29048_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="ResultatEkstraordinarePosterFjoraret-29049_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteSkattekostnadEkstraordinartResultat-18263_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="SkattekostnadEkstraordinartResultat-2821_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="SkattekostnadEkstraordinartResultatFjoraret-8002_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteArsresultat-18265_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Arsresultat-172_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="ArsresultatFjoraret-7054_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteMinoritetsinteresser-18264_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Minoritetsinteresser-7717_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="MinoritetsinteresserFjoraret-8004_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteArsresultatEtterMinoritetsinteresser-33417_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="ArsresultatEtterMinoritetsinteresser-33415_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="ArsresultatEtterMinoritetsinteresserFjoraret-33416_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="NoteResultatkomponenterAndreIFRS-35536_Verdirestriksjon">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="ResultatkomponenterAndreIFRS-32929_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="ResultatkomponenterAndreIFRSFjoraret-32930_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteTotalresultatIFRS-36635_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="TotalresultatIFRS-36633_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="TotalresultatIFRSFjoraaret-36634_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteGrunnkapital-30815_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Grunnkapital-30816_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GrunnkapitalFjoraret-30817_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteFormalskapitalRestriksjonerLovpalagte-33445_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalRestriksjonerLovpalagte-33446_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalRestriksjonerLovpalagteFjoraret-33447_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteFormalskapitalRestriksjonerEksterntPalagt-33448_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalRestriksjonerEksterntPalagt-33449_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalRestriksjonerEksterntPalagtFjoraret-33450_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteFormalskapitalRestriksjonerSelvpalagte-33451_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalRestriksjonerSelvpalagte-33452_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalRestriksjonerSelvpalagteFjoraret-33453_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteFormalskapitalAnnen-33454_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FormalskapitalAnnen-33455_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FormalskapitalAnnenFjoraret-33456_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="NotePatenterRettigheter-18560_Verdirestriksjon">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="PatenterRettigheter-205_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="PatenterRettigheterFjoraret-7075_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteSkattefordelUtsatt-18182_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="SkattefordelUtsatt-202_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="SkattefordelUtsattFjoraret-7076_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteForretningsverdiGoodwill-18183_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="ForretningsverdiGoodwill-206_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="ForretningsverdiGoodwillFjoraret-7077_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteEiendelerImmaterielle-18180_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="EiendelerImmaterielle-2400_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="EiendelerImmaterielleFjoraret-8006_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteFastEiendom-18178_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FastEiendom-1976_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FastEiendomFjoraret-8007_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteKjoretoyInventarVerktoyMv-18562_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="KjoretoyInventarVerktoyMv-7725_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="KjoretoyInventarVerktoyMvFjoraret-8009_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteDriftsmidlerVarige-18176_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="DriftsmidlerVarige-47_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="DriftsmidlerVarigeFjoraret-8010_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteDriftsmidlerAndre-18177_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="DriftsmidlerAndre-2836_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="DriftsmidlerAndreFjoraret-7088_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteDriftsmidlerAndre-30979_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="DriftsmidlerAndre-30980_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="DriftsmidlerAndreFjoraret-30981_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteInvesteringerDatterselskap-18563_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="InvesteringerDatterselskap-9686_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="InvesteringerDatterselskapFjoraret-10289_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteInvesteringerAksjerAndeler-18568_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="InvesteringerAksjerAndeler-7100_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="InvesteringerAksjerAndelerFjoraret-7101_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteObligasjonerLangsiktige-27582_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="ObligasjonerLangsiktige-27583_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="ObligasjonerLangsiktigeFjoraret-27584_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteFordringerAndreLangsiktige-27578_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FordringerAndreLangsiktige-203_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FordringerAndreLangsiktigeFjoraret-27585_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteAnleggsmidlerFinansielle-18372_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AnleggsmidlerFinansielle-5267_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AnleggsmidlerFinansielleFjoraret-8014_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteAnleggsmidler-18570_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Anleggsmidler-217_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AnleggsmidlerFjoraret-7108_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteLagerbeholdning-30822_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Lagerbeholdning-30823_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="LagerbeholdningFjoraret-30824_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteLagerbeholdning-18571_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Lagerbeholdning-326_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="LagerbeholdningFjoraret-797_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteFordringerKunder-18384_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FordringerKunder-116_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FordringerKunderFjoraret-6921_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteFordringerAndreKortsiktig-18572_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FordringerAndreKortsiktig-282_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FordringerAndreKortsiktigFjoraret-7112_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteFordringer-18389_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Fordringer-80_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FordringerFjoraret-8015_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteAksjerMvMarkedsbaserte-18575_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AksjerMvMarkedsbaserte-7117_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AksjerMvMarkedsbaserteFjoraret-7118_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteFinansielleInstrumenterMarkedsbaserteAndre-18577_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FinansielleInstrumenterMarkedsbaserteAndre-7731_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FinansielleInstrumenterMarkedsbaserteAndreFjoraret-8017_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteFinansielleInstrumenterAndre-18578_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FinansielleInstrumenterAndre-6429_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FinansielleInstrumenterAndreFjoraret-7123_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteInvesteringer-18579_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Investeringer-6601_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="InvesteringerFjoraret-8018_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteKontanterBankinnskudd-18390_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="KontanterBankinnskudd-786_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="KontanterBankinnskuddFjoraret-8019_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteKontanterBankinnskuddSum-29041_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="KontanterBankinnskuddSum-29042_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="KontanterBankinnskuddSumFjoraret-29043_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteOmlopsmidler-18580_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Omlopsmidler-194_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="OmlopsmidlerFjoraret-7126_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteEiendeler-18167_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Eiendeler-219_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="EiendelerFjoraret-7127_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteGrunnkapital-30819_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Grunnkapital-30820_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GrunnkapitalFjoraret-30821_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteFormalskapitalInnskuttAnnen-33457_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FormalskapitalInnskuttAnnen-33458_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FormalskapitalInnskuttAnnenFjoraret-33459_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteFormalskapitalInnskuttSum-33460_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FormalskapitalInnskuttSum-33461_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FormalskapitalInnskuttSumFjoraret-33462_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteFormalskapitalAnnenRestriksjonerLovpalagte-33463_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalAnnenRestriksjonerLovpalagte-33464_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalAnnenRestriksjonerLovpalagteFjoraret-33465_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteFormalskapitalOpptjentSumRestriksjonerLovpalagte-33466_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalOpptjentSumRestriksjonerLovpalagte-33467_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalOpptjentSumRestriksjonerLovpalagteFjoraret-33468_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteFormalskapitalAnnenRestriksjonerEksterntPalagte-33469_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalAnnenRestriksjonerEksterntPalagte-33470_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalAnnenRestriksjonerEksterntPalagteFjoraret-33471_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteFormalskapitalSumRestriksjonerEksterntPalagte-33472_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalSumRestriksjonerEksterntPalagte-33473_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalSumRestriksjonerEksterntPalagteFjoraret-33474_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteFormalskapitalAnnenRestriksjonerSelpalagte-33475_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalAnnenRestriksjonerSelvpalagte-33476_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalAnnenRestriksjonerSelvpalagteFjoraret-33477_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteFormalskapitalSumRestriksjonerSelvpalagte-33478_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalSumRestriksjonerSelvpalagte-33479_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="FormalskapitalSumRestriksjonerSelvpalagteFjoraret-33480_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteFormalskapitalAnnen-33481_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FormalskapitalAnnen-33482_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FormalskapitalAnnenFjoraret-33483_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteMinoritetsinteresser-29044_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Minoritetsinteresser-29045_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="MinoritetsinteresserFjoraret-29046_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteFormalskapitalSum-33484_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FormalskapitalSum-33485_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="FormalskapitalSumFjoraret-33486_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NotePensjonsforpliktelser-18149_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Pensjonsforpliktelser-238_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="PensjonsforpliktelserFjoraret-6685_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteSkattUtsatt-18148_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="SkattUtsatt-237_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="SkattUtsattFjoraret-7143_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteAvsetningerForpliktelserLangsiktig-18582_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AvsetningerForpliktelserLangsiktig-7157_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="AvsetningerForpliktelserLangsiktigFjoraret-7146_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteAvsetningerForpliktelser-18144_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AvsetningerForpliktelser-7231_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AvsetningerForpliktelserFjoraret-7230_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteGjeldKredittinstitusjoner-18164_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldKredittinstitusjoner-7150_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldKredittinstitusjonerFjoraret-7151_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteGjeldAnnenLangsiktig-18584_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldAnnenLangsiktig-242_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldAnnenLangsiktigFjoraret-7155_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteGjeldAnnenLangsiktigSum-25018_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldAnnenLangsiktigSum-25019_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldAnnenLangsiktigSumFjoraret-25020_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteGjeldLangsiktig-18585_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldLangsiktig-86_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldLangsiktigFjoraret-7156_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="NoteGjeldKredittinstitusjonerKortsiktig-18587_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldKredittinstitusjonerKortsiktig-10926_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon"
+                  name="GjeldKredittinstitusjonerKortsiktigFjoraret-13203_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteLeverandorgjeld-18588_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Leverandorgjeld-220_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="LeverandorgjeldFjoraret-7162_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteSkattBetalbar-18589_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="SkattBetalbar-2483_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="SkattBetalbarFjoraret-10293_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteAvgifterOffentligeSkyldig-18590_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AvgifterOffentligeSkyldig-225_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="AvgifterOffentligeSkyldigFjoraret-7170_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteGjeldAnnenKortsiktig-18592_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldAnnenKortsiktig-236_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldAnnenKortsiktigFjoraret-7182_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteGjeldKortsiktig-18593_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldKortsiktig-85_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldKortsiktigFjoraret-7183_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteGjeld-18138_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Gjeld-1119_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldFjoraret-7184_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteGjeldEgenkapital-18122_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldEgenkapital-251_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GjeldEgenkapitalFjoraret-7185_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NoteGarantistillelse-18594_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Garantistillelse-16920_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="GarantistillelseFjoraret-16921_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="NotePantstillelser-18595_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="35"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="Pantstillelser-16922_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="PantstillelserFjoraret-16923_Verdirestriksjon">
+    <xsd:restriction base="xsd:integer">
+      <xsd:totalDigits value="15"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="Rapport-RR0010U">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="aarsregnskap" type="Aarsregnskap"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Skjemainnhold">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="resultatregnskapAktivitetsbasert" type="ResultatregnskapAktivitetsbasert"/>
+      <xsd:element minOccurs="0" name="balanseEiendelerAnleggsmidler" type="BalanseEiendelerAnleggsmidler"/>
+      <xsd:element minOccurs="0" name="balanseEiendelerOmloepsmidler" type="BalanseEiendelerOmloepsmidler"/>
+      <xsd:element minOccurs="0" name="balanseFormaalskapital" type="BalanseFormaalskapital"/>
+      <xsd:element minOccurs="0" name="balanseGjeld" type="BalanseGjeld"/>
+      <xsd:element minOccurs="0" name="posterUtenomBalansen" type="PosterUtenomBalansen"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Aarsregnskap">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="type" type="ArsregnskapType-25942"/>
+      <xsd:element minOccurs="0" name="valuta" type="ArsregnskapValutakode-34984"/>
+      <xsd:element minOccurs="0" name="valoer" type="ArsregnskapValor-28974"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="ResultatregnskapAktivitetsbasert">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="anskaffedeMidler" type="AnskaffedeMidler"/>
+      <xsd:element minOccurs="0" name="forbrukteMidler" type="ForbrukteMidler"/>
+      <xsd:element minOccurs="0" name="aarsresultat" type="Aarsresultat"/>
+      <xsd:element minOccurs="0" name="tilleggReduksjonEgenkapital" type="TilleggReduksjonEgenkapital"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="TilleggReduksjonEgenkapital">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="grunnkapital" type="GrunnkapitalTilleggReduksjonEgenkapital"/>
+      <xsd:element minOccurs="0" name="formaalskapitalLovpaalagteRestriksjoner"
+                   type="FormaalskapitalLovpaalagteRestriksjonerPoster"/>
+      <xsd:element minOccurs="0" name="formaalskapitalEksterntPaalagteRestriksjoner"
+                   type="FormaalskapitalEksterntPaalagteRestriksjonerTilleggReduksjonEgenkapital"/>
+      <xsd:element minOccurs="0" name="formaalskapitalSelvpaalagteRestriksjoner"
+                   type="FormaalskapitalSelvpaalagteRestriksjonerPoster"/>
+      <xsd:element minOccurs="0" name="annenFormaalskapital" type="AnnenFormaalskapitalTilleggReduksjonEgenkapital"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Aarsresultat">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="ordinaertResultatFoerSkattekostnad" type="OrdinaertResultatFoerSkattekostnaO"/>
+      <xsd:element minOccurs="0" name="skattekostnadOrdinaertResultat" type="SkattekostnadOrdinaertResultat"/>
+      <xsd:element minOccurs="0" name="ordinaertResultatEtterSkattekostnad" type="OrdinaertResultatEtterSkattekostnad"/>
+      <xsd:element minOccurs="0" name="ekstraordinaerePoster" type="EkstraordinaerePoster"/>
+      <xsd:element minOccurs="0" name="skattekostnadPaaEkstraordinaertResultat"
+                   type="SkattekostnadPaaEkstraordinaertResultat"/>
+      <xsd:element minOccurs="0" name="aarsresultat" type="AarsresultatPoster"/>
+      <xsd:element minOccurs="0" name="minoritetsinteresser" type="Minoritetsinteresser"/>
+      <xsd:element minOccurs="0" name="aarsresultatEtterMinoritetsinteresser"
+                   type="AarsresultatEtterMinoritetsinteresser"/>
+      <xsd:element minOccurs="0" name="andreResultatkomponenterIfrs" type="AndreResultatkomponenterIfrs"/>
+      <xsd:element minOccurs="0" name="totalresultatIfrs" type="TotalresultatIfrs"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="ForbrukteMidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="kostnadAnskaffelseMidler" type="KostnadAnskaffelseMidler"/>
+      <xsd:element minOccurs="0" name="tilskuddBevilningOppfyllelseOrgFormaal"
+                   type="TilskuddBevilningOppfyllelseOrgFormaal"/>
+      <xsd:element minOccurs="0" name="kostnaderOppfyllelseOrgFormaal" type="KostnaderOppfyllelseOrgFormaal"/>
+      <xsd:element minOccurs="0" name="kostnaderOrgFormaal" type="KostnaderOrgFormaal"/>
+      <xsd:element minOccurs="0" name="annenRentekostnad" type="AnnenRentekostnad"/>
+      <xsd:element minOccurs="0" name="annenFinanskostnad" type="AnnenFinanskostnad"/>
+      <xsd:element minOccurs="0" name="administrasjonskostnader" type="Administrasjonskostnader"/>
+      <xsd:element minOccurs="0" name="annenDriftskostnad" type="AnnenDriftskostnad"/>
+      <xsd:element minOccurs="0" name="sumForbrukteMidler" type="SumForbrukteMidler"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnskaffedeMidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="medlemsinntekter" type="Medlemsinntekter"/>
+      <xsd:element minOccurs="0" name="offentligeTilskudd" type="OffentligeTilskudd"/>
+      <xsd:element minOccurs="0" name="andreTilskudd" type="AndreTilskudd"/>
+      <xsd:element minOccurs="0" name="sumTilskudd" type="SumTilskudd"/>
+      <xsd:element minOccurs="0" name="innsamledeMidlerGaverMv" type="InnsamledeMidlerGaverMv"/>
+      <xsd:element minOccurs="0" name="aktiviteterOppfyllerOrgFormaal" type="AktiviteterOppfyllerOrgFormaal"/>
+      <xsd:element minOccurs="0" name="aktiviteterSkaperInntekt" type="AktiviteterSkaperInntekt"/>
+      <xsd:element minOccurs="0" name="opptjenteInntekterOperasjonelleAktiviteter"
+                   type="OpptjenteInntekterOperasjonelleAktiviteter"/>
+      <xsd:element minOccurs="0" name="annenDriftsinntekt" type="AnnenDriftsinntekt"/>
+      <xsd:element minOccurs="0" name="finansOgInvesteringsinntekter" type="FinansOgInvesteringsinntekter"/>
+      <xsd:element minOccurs="0" name="andreInntekter" type="AndreInntekter"/>
+      <xsd:element minOccurs="0" name="sumAnskaffedeMidler" type="SumAnskaffedeMidler"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumAnskaffedeMidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteMidlerAnskaffede-30316"/>
+      <xsd:element minOccurs="0" name="aarets" type="MidlerAnskaffede-30317"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="MidlerAnskaffedeFjoraret-30318"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AndreInntekter">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteInntektAnnen-30307"/>
+      <xsd:element minOccurs="0" name="aarets" type="InntektAnnen-30308"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="InntektAnnenFjoraret-30309"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="FinansOgInvesteringsinntekter">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFinansinntekterInvesteringsinntekter-33433"/>
+      <xsd:element minOccurs="0" name="aarets" type="FinansinntekterInvesteringsinntekter-33434"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FinansinntekterInvesteringsinntekterFjoraret-33435"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnnenDriftsinntekt">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteDriftsinntekterAndreSum-18238"/>
+      <xsd:element minOccurs="0" name="aarets" type="DriftsinntekterAndreSum-7709"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="DriftsinntekterAndreFjoraretSum-7966"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="OpptjenteInntekterOperasjonelleAktiviteter">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteAktiviteterOperasjonelle-33430"/>
+      <xsd:element minOccurs="0" name="aarets" type="AktiviteterOperasjonelle-33431"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="AktiviteterOperasjonelleFjoraret-33432"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AktiviteterSkaperInntekt">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteAktiviteterSkaperInntekt-33427"/>
+      <xsd:element minOccurs="0" name="aarets" type="AktiviteterSkaperInntekt-33428"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="AktiviteterSkaperInntektFjoraret-33429"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AktiviteterOppfyllerOrgFormaal">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteAktiviteterOppfyllerOrganisasjonensFormal-33424"/>
+      <xsd:element minOccurs="0" name="aarets" type="AktiviteterOppfyllerOrganisasjonensFormal-33425"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="AktiviteterOppfyllerOrganisasjonensFormalFjoraret-33426"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="InnsamledeMidlerGaverMv">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteMidlerGaverInnsamlede-30313"/>
+      <xsd:element minOccurs="0" name="aarets" type="MidlerGaverInnsamlede-30314"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="MidlerGaverInnsamledeFjoraret-30315"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumTilskudd">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteTilskudd-30310"/>
+      <xsd:element minOccurs="0" name="aarets" type="TilskuddOffentlig-30311"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="TilskuddOffentligFjoraret-30312"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AndreTilskudd">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteTilskuddAndre-33421"/>
+      <xsd:element minOccurs="0" name="aarets" type="TilskuddAndre-33422"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="TilskuddAndreFjoraret-33423"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="OffentligeTilskudd">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteTilskuddOffentlig-33418"/>
+      <xsd:element minOccurs="0" name="aarets" type="TilskuddOffentlig-33419"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="TilskuddOffentligFjoraret-33420"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Medlemsinntekter">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteMedlemsinntekter-30319"/>
+      <xsd:element minOccurs="0" name="aarets" type="Medlemsinntekter-30320"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="MedlemsinntekterFjoraret-30321"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumForbrukteMidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteMidlerForbrukte-30812"/>
+      <xsd:element minOccurs="0" name="aarets" type="MidlerForbrukte-30813"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="MidlerForbrukteFjoraret-30814"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnnenDriftskostnad">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteDriftskostnaderAndre-18249"/>
+      <xsd:element minOccurs="0" name="aarets" type="DriftskostnaderAndre-82"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="DriftskostnaderAndreFjoraret-7023"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Administrasjonskostnader">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteKostnaderAdministrative-27924"/>
+      <xsd:element minOccurs="0" name="aarets" type="KostnaderAdministrative-27926"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="KostnaderAdministrativeFjoraret-27928"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnnenFinanskostnad">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFinanskostnaderAndre-18337"/>
+      <xsd:element minOccurs="0" name="aarets" type="FinanskostnaderAndre-156"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FinanskostnaderAndreFjoraret-7041"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnnenRentekostnad">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteRentekostnaderAndre-18550"/>
+      <xsd:element minOccurs="0" name="aarets" type="RentekostnaderAndre-2216"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="RentekostnaderAndreFjoraret-7039"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="KostnaderOrgFormaal">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteKostnadOrganisasjonensFormal-30809"/>
+      <xsd:element minOccurs="0" name="aarets" type="KostnadOrganisasjonensFormal-30810"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="KostnadOrganisasjonensFormalFjoraret-30811"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="KostnaderOppfyllelseOrgFormaal">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteKostnaderOppfyllelseOrganisasjonensFormal-33439"/>
+      <xsd:element minOccurs="0" name="aarets" type="KostnaderOppfyllelseOrganisasjonensFormal-33440"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="KostnaderOppfyllelseOrganisasjonensFormalFjoraret-33441"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="TilskuddBevilningOppfyllelseOrgFormaal">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteTilskuddBevilningOppfyllelseOrganisasjonensFormal-33436"/>
+      <xsd:element minOccurs="0" name="aarets" type="TilskuddBevilningOppfyllelseOrganisasjonensFormal-33437"/>
+      <xsd:element minOccurs="0" name="fjoraarets"
+                   type="TilskuddBevilningOppfyllelseOrganisasjonensFormalFjoraret-33438"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="KostnadAnskaffelseMidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteKostnadAnskaffelseAvMidler-30806"/>
+      <xsd:element minOccurs="0" name="aarets" type="KostnadAnskaffelseAvMidler-30807"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="KostnadAnskaffelseAvMidlerFjoraret-30808"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="TotalresultatIfrs">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteTotalresultatIFRS-36635"/>
+      <xsd:element minOccurs="0" name="aarets" type="TotalresultatIFRS-36633"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="TotalresultatIFRSFjoraaret-36634"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AndreResultatkomponenterIfrs">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteResultatkomponenterAndreIFRS-35536"/>
+      <xsd:element minOccurs="0" name="aarets" type="ResultatkomponenterAndreIFRS-32929"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="ResultatkomponenterAndreIFRSFjoraret-32930"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AarsresultatEtterMinoritetsinteresser">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteArsresultatEtterMinoritetsinteresser-33417"/>
+      <xsd:element minOccurs="0" name="aarets" type="ArsresultatEtterMinoritetsinteresser-33415"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="ArsresultatEtterMinoritetsinteresserFjoraret-33416"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Minoritetsinteresser">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteMinoritetsinteresser-18264"/>
+      <xsd:element minOccurs="0" name="aarets" type="Minoritetsinteresser-7717"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="MinoritetsinteresserFjoraret-8004"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AarsresultatPoster">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteArsresultat-18265"/>
+      <xsd:element minOccurs="0" name="aarets" type="Arsresultat-172"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="ArsresultatFjoraret-7054"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SkattekostnadPaaEkstraordinaertResultat">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteSkattekostnadEkstraordinartResultat-18263"/>
+      <xsd:element minOccurs="0" name="aarets" type="SkattekostnadEkstraordinartResultat-2821"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="SkattekostnadEkstraordinartResultatFjoraret-8002"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="EkstraordinaerePoster">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteResultatEkstraordinarePoster-29047"/>
+      <xsd:element minOccurs="0" name="aarets" type="ResultatEkstraordinarePoster-29048"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="ResultatEkstraordinarePosterFjoraret-29049"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="OrdinaertResultatEtterSkattekostnad">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteResultatOrdinart-18258"/>
+      <xsd:element minOccurs="0" name="aarets" type="ResultatOrdinart-7048"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="ResultatOrdinartFjordaret-7049"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SkattekostnadOrdinaertResultat">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteSkattekostnadOrdinartResultat-18259"/>
+      <xsd:element minOccurs="0" name="aarets" type="SkattekostnadOrdinartResultat-11835"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="SkattekostnadOrdinartResultatFjoraret-11836"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="OrdinaertResultatFoerSkattekostnaO">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteResultatForSkattekostnad-18355"/>
+      <xsd:element minOccurs="0" name="aarets" type="ResultatForSkattekostnad-167"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="ResultatForSkattekostnadFjoraret-7042"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnnenFormaalskapitalTilleggReduksjonEgenkapital">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalAnnen-33454"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalAnnen-33455"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FormalskapitalAnnenFjoraret-33456"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="FormaalskapitalSelvpaalagteRestriksjoner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="annenFormaalskapitalSelvpaalagteRestriksjoner"
+                   type="AnnenFormaalskapitalSelvpaalagteRestriksjoner"/>
+      <xsd:element minOccurs="0" name="sumFormaalskapitalSelvpaalagteRestriksjoner"
+                   type="SumFormaalskapitalSelvpaalagteRestriksjoner"/>
+      <xsd:element minOccurs="0" name="annenFormaalskapital" type="AnnenFormaalskapital"/>
+      <xsd:element minOccurs="0" name="minoritetsinteresser"
+                   type="MinoritetsinteresserFormaalskapitalSelvpaalagteRestriksjoner"/>
+      <xsd:element minOccurs="0" name="sumFormaalskapital" type="SumFormaalskapital"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="FormaalskapitalEksterntPaalagteRestriksjoner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="annenFormaalskapitalEksterntPaalagteRestriksjoner"
+                   type="AnnenFormaalskapitalEksterntPaalagteRestriksjoner"/>
+      <xsd:element minOccurs="0" name="sumFormaalskapitalEksterntPaalagteRestriksjoner"
+                   type="SumFormaalskapitalEksterntPaalagteRestriksjoner"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="FormaalskapitalLovpaalagteRestriksjoner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="annenFormaalskapitalLovpaalagteRestriksjoner"
+                   type="AnnenFormaalskapitalLovpaalagteRestriksjoner"/>
+      <xsd:element minOccurs="0" name="sumOpptjentFormaalskapitalLovpaalagteRestriksjoner"
+                   type="SumOpptjentFormaalskapitalLovpaalagteRestriksjoner"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="GrunnkapitalTilleggReduksjonEgenkapital">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteGrunnkapital-30815"/>
+      <xsd:element minOccurs="0" name="aarets" type="Grunnkapital-30816"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="GrunnkapitalFjoraret-30817"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="PosterUtenomBalansen">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="garantistillelser" type="Garantistillelser"/>
+      <xsd:element minOccurs="0" name="pantstillelser" type="Pantstillelser"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="BalanseGjeld">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="avsetningerForForpliktelser" type="AvsetningerForForpliktelser"/>
+      <xsd:element minOccurs="0" name="annenLangsiktigGjeld" type="AnnenLangsiktigGjeld"/>
+      <xsd:element minOccurs="0" name="kortsiktigGjeld" type="KortsiktigGjeld"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="BalanseFormaalskapital">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="grunnkapital" type="Grunnkapital"/>
+      <xsd:element minOccurs="0" name="formaalskapitalLovpaalagteRestriksjoner"
+                   type="FormaalskapitalLovpaalagteRestriksjoner"/>
+      <xsd:element minOccurs="0" name="formaalskapitalEksterntPaalagteRestriksjoner"
+                   type="FormaalskapitalEksterntPaalagteRestriksjoner"/>
+      <xsd:element minOccurs="0" name="formaalskapitalSelvpaalagteRestriksjoner"
+                   type="FormaalskapitalSelvpaalagteRestriksjoner"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="BalanseEiendelerOmloepsmidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="beholdninger" type="Beholdninger"/>
+      <xsd:element minOccurs="0" name="fordringer" type="Fordringer"/>
+      <xsd:element minOccurs="0" name="investeringer" type="Investeringer"/>
+      <xsd:element minOccurs="0" name="bankinnskuddKontanter" type="BankinnskuddKontanter"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="BalanseEiendelerAnleggsmidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="immaterielleEiendeler" type="ImmaterielleEiendeler"/>
+      <xsd:element minOccurs="0" name="bevaringsverdigeEiendeler" type="BevaringsverdigeEiendeler"/>
+      <xsd:element minOccurs="0" name="andreDriftsmidler" type="AndreDriftsmidler"/>
+      <xsd:element minOccurs="0" name="finansielleAnleggsmidler" type="FinansielleAnleggsmidler"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="FinansielleAnleggsmidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="investeringDatterselskap" type="InvesteringDatterselskap"/>
+      <xsd:element minOccurs="0" name="investeringAksjerAndeler" type="InvesteringAksjerAndeler"/>
+      <xsd:element minOccurs="0" name="obligasjoner" type="Obligasjoner"/>
+      <xsd:element minOccurs="0" name="andreFordringer" type="AndreFordringerFinansielleAnleggsmidler"/>
+      <xsd:element minOccurs="0" name="sumFinansielleAnleggsmidler" type="SumFinansielleAnleggsmidler"/>
+      <xsd:element minOccurs="0" name="sumAnleggsmidler" type="SumAnleggsmidler"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AndreDriftsmidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="andreDriftsmidler" type="AndreDriftsmidlerPoster"/>
+      <xsd:element minOccurs="0" name="sumAndreDriftsmidler" type="SumAndreDriftsmidler"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="BevaringsverdigeEiendeler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="tomterBygningerAnnenFastEiendom" type="TomterBygningerAnnenFastEiendom"/>
+      <xsd:element minOccurs="0" name="driftsloesoereInventarVerktoeyKontormaskiner"
+                   type="DriftsloesoereInventarVerktoeyKontormaskiner"/>
+      <xsd:element minOccurs="0" name="sumBevaringsverdigeEiendeler" type="SumBevaringsverdigeEiendeler"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="ImmaterielleEiendeler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="konsesjonerPatenterLisenserVaremerkerRettigheter"
+                   type="KonsesjonerPatenterLisenserVaremerkerRettigheter"/>
+      <xsd:element minOccurs="0" name="utsattSkattefordel" type="UtsattSkattefordel"/>
+      <xsd:element minOccurs="0" name="goodwill" type="Goodwill"/>
+      <xsd:element minOccurs="0" name="sumImmaterielleEiendeler" type="SumImmaterielleEiendeler"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="BankinnskuddKontanter">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="bankinnskuddKontanter" type="BankinnskuddKontanterPoster"/>
+      <xsd:element minOccurs="0" name="sumBankinnskuddKontanter" type="SumBankinnskuddKontanter"/>
+      <xsd:element minOccurs="0" name="sumOmloepsmidler" type="SumOmloepsmidler"/>
+      <xsd:element minOccurs="0" name="sumEiendeler" type="SumEiendeler"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Investeringer">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="markedsbaserteAksjer" type="MarkedsbaserteAksjer"/>
+      <xsd:element minOccurs="0" name="andreMarkedsbaserteFinansielleInstrumenter"
+                   type="AndreMarkedsbaserteFinansielleInstrumenter"/>
+      <xsd:element minOccurs="0" name="andreFinansielleInstrumenter" type="AndreFinansielleInstrumenter"/>
+      <xsd:element minOccurs="0" name="sumInvesteringer" type="SumInvesteringer"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Fordringer">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="kundefordringer" type="Kundefordringer"/>
+      <xsd:element minOccurs="0" name="andreFordringer" type="AndreFordringer"/>
+      <xsd:element minOccurs="0" name="sumFordringer" type="SumFordringer"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Beholdninger">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="lagerbeholdning" type="Lagerbeholdning"/>
+      <xsd:element minOccurs="0" name="sumBeholdninger" type="SumBeholdninger"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Grunnkapital">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="grunnkapital" type="GrunnkapitalPoster"/>
+      <xsd:element minOccurs="0" name="annenInnskuttFormaalskapital" type="AnnenInnskuttFormaalskapital"/>
+      <xsd:element minOccurs="0" name="sumInnskuttFormaalskapital" type="SumInnskuttFormaalskapital"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="KortsiktigGjeld">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="gjeldKredittinstitusjoner" type="GjeldKredittinstitusjonerPoster"/>
+      <xsd:element minOccurs="0" name="leverandoergjeld" type="Leverandoergjeld"/>
+      <xsd:element minOccurs="0" name="betalbarSkatt" type="BetalbarSkatt"/>
+      <xsd:element minOccurs="0" name="skyldigeOffentligeAvgifter" type="SkyldigeOffentligeAvgifter"/>
+      <xsd:element minOccurs="0" name="annenKortsiktigGjeld" type="AnnenKortsiktigGjeld"/>
+      <xsd:element minOccurs="0" name="sumKortsiktigGjeld" type="SumKortsiktigGjeld"/>
+      <xsd:element minOccurs="0" name="sumGjeld" type="SumGjeld"/>
+      <xsd:element minOccurs="0" name="sumFormaalskapitalGjeld" type="SumFormaalskapitalGjeldS"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnnenLangsiktigGjeld">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="gjeldKredittinstitusjoner" type="GjeldKredittinstitusjoner"/>
+      <xsd:element minOccurs="0" name="oevrigLangsiktigGjeld" type="OevrigLangsiktigGjeld"/>
+      <xsd:element minOccurs="0" name="sumAnnenLangsiktigGjeld" type="SumAnnenLangsiktigGjeld"/>
+      <xsd:element minOccurs="0" name="sumLangsiktigGjeld" type="SumLangsiktigGjeld"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AvsetningerForForpliktelser">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="pensjonsforpliktelser" type="Pensjonsforpliktelser"/>
+      <xsd:element minOccurs="0" name="utsattSkatt" type="UtsattSkatt"/>
+      <xsd:element minOccurs="0" name="andreAvsetningerForpliktelser" type="AndreAvsetningerForpliktelser"/>
+      <xsd:element minOccurs="0" name="sumAvsetningerForpliktelser" type="SumAvsetningerForpliktelser"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumImmaterielleEiendeler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteEiendelerImmaterielle-18180"/>
+      <xsd:element minOccurs="0" name="aarets" type="EiendelerImmaterielle-2400"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="EiendelerImmaterielleFjoraret-8006"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Goodwill">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteForretningsverdiGoodwill-18183"/>
+      <xsd:element minOccurs="0" name="aarets" type="ForretningsverdiGoodwill-206"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="ForretningsverdiGoodwillFjoraret-7077"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="UtsattSkattefordel">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteSkattefordelUtsatt-18182"/>
+      <xsd:element minOccurs="0" name="aarets" type="SkattefordelUtsatt-202"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="SkattefordelUtsattFjoraret-7076"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="KonsesjonerPatenterLisenserVaremerkerRettigheter">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NotePatenterRettigheter-18560"/>
+      <xsd:element minOccurs="0" name="aarets" type="PatenterRettigheter-205"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="PatenterRettigheterFjoraret-7075"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumBevaringsverdigeEiendeler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteDriftsmidlerVarige-18176"/>
+      <xsd:element minOccurs="0" name="aarets" type="DriftsmidlerVarige-47"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="DriftsmidlerVarigeFjoraret-8010"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="DriftsloesoereInventarVerktoeyKontormaskiner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteKjoretoyInventarVerktoyMv-18562"/>
+      <xsd:element minOccurs="0" name="aarets" type="KjoretoyInventarVerktoyMv-7725"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="KjoretoyInventarVerktoyMvFjoraret-8009"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="TomterBygningerAnnenFastEiendom">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFastEiendom-18178"/>
+      <xsd:element minOccurs="0" name="aarets" type="FastEiendom-1976"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FastEiendomFjoraret-8007"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumAndreDriftsmidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteDriftsmidlerAndre-30979"/>
+      <xsd:element minOccurs="0" name="aarets" type="DriftsmidlerAndre-30980"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="DriftsmidlerAndreFjoraret-30981"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AndreDriftsmidlerPoster">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteDriftsmidlerAndre-18177"/>
+      <xsd:element minOccurs="0" name="aarets" type="DriftsmidlerAndre-2836"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="DriftsmidlerAndreFjoraret-7088"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumAnleggsmidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteAnleggsmidler-18570"/>
+      <xsd:element minOccurs="0" name="aarets" type="Anleggsmidler-217"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="AnleggsmidlerFjoraret-7108"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumFinansielleAnleggsmidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteAnleggsmidlerFinansielle-18372"/>
+      <xsd:element minOccurs="0" name="aarets" type="AnleggsmidlerFinansielle-5267"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="AnleggsmidlerFinansielleFjoraret-8014"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AndreFordringerFinansielleAnleggsmidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFordringerAndreLangsiktige-27578"/>
+      <xsd:element minOccurs="0" name="aarets" type="FordringerAndreLangsiktige-203"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FordringerAndreLangsiktigeFjoraret-27585"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Obligasjoner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteObligasjonerLangsiktige-27582"/>
+      <xsd:element minOccurs="0" name="aarets" type="ObligasjonerLangsiktige-27583"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="ObligasjonerLangsiktigeFjoraret-27584"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="InvesteringAksjerAndeler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteInvesteringerAksjerAndeler-18568"/>
+      <xsd:element minOccurs="0" name="aarets" type="InvesteringerAksjerAndeler-7100"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="InvesteringerAksjerAndelerFjoraret-7101"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="InvesteringDatterselskap">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteInvesteringerDatterselskap-18563"/>
+      <xsd:element minOccurs="0" name="aarets" type="InvesteringerDatterselskap-9686"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="InvesteringerDatterselskapFjoraret-10289"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumBeholdninger">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteLagerbeholdning-18571"/>
+      <xsd:element minOccurs="0" name="aarets" type="Lagerbeholdning-326"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="LagerbeholdningFjoraret-797"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Lagerbeholdning">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteLagerbeholdning-30822"/>
+      <xsd:element minOccurs="0" name="aarets" type="Lagerbeholdning-30823"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="LagerbeholdningFjoraret-30824"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumFordringer">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFordringer-18389"/>
+      <xsd:element minOccurs="0" name="aarets" type="Fordringer-80"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FordringerFjoraret-8015"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AndreFordringer">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFordringerAndreKortsiktig-18572"/>
+      <xsd:element minOccurs="0" name="aarets" type="FordringerAndreKortsiktig-282"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FordringerAndreKortsiktigFjoraret-7112"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Kundefordringer">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFordringerKunder-18384"/>
+      <xsd:element minOccurs="0" name="aarets" type="FordringerKunder-116"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FordringerKunderFjoraret-6921"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumInvesteringer">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteInvesteringer-18579"/>
+      <xsd:element minOccurs="0" name="aarets" type="Investeringer-6601"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="InvesteringerFjoraret-8018"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AndreFinansielleInstrumenter">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFinansielleInstrumenterAndre-18578"/>
+      <xsd:element minOccurs="0" name="aarets" type="FinansielleInstrumenterAndre-6429"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FinansielleInstrumenterAndreFjoraret-7123"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="MarkedsbaserteAksjer">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteAksjerMvMarkedsbaserte-18575"/>
+      <xsd:element minOccurs="0" name="aarets" type="AksjerMvMarkedsbaserte-7117"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="AksjerMvMarkedsbaserteFjoraret-7118"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AndreMarkedsbaserteFinansielleInstrumenter">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFinansielleInstrumenterMarkedsbaserteAndre-18577"/>
+      <xsd:element minOccurs="0" name="aarets" type="FinansielleInstrumenterMarkedsbaserteAndre-7731"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FinansielleInstrumenterMarkedsbaserteAndreFjoraret-8017"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumEiendeler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteEiendeler-18167"/>
+      <xsd:element minOccurs="0" name="aarets" type="Eiendeler-219"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="EiendelerFjoraret-7127"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumOmloepsmidler">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteOmlopsmidler-18580"/>
+      <xsd:element minOccurs="0" name="aarets" type="Omlopsmidler-194"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="OmlopsmidlerFjoraret-7126"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumBankinnskuddKontanter">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteKontanterBankinnskuddSum-29041"/>
+      <xsd:element minOccurs="0" name="aarets" type="KontanterBankinnskuddSum-29042"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="KontanterBankinnskuddSumFjoraret-29043"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="BankinnskuddKontanterPoster">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteKontanterBankinnskudd-18390"/>
+      <xsd:element minOccurs="0" name="aarets" type="KontanterBankinnskudd-786"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="KontanterBankinnskuddFjoraret-8019"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumInnskuttFormaalskapital">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalInnskuttSum-33460"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalInnskuttSum-33461"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="AktiviteterOppfyllerOrganisasjonensFormalFjoraret-33426"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnnenInnskuttFormaalskapital">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalInnskuttAnnen-33457"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalInnskuttAnnen-33458"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FormalskapitalInnskuttAnnenFjoraret-33459"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="GrunnkapitalPoster">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteGrunnkapital-30819"/>
+      <xsd:element minOccurs="0" name="aarets" type="Grunnkapital-30820"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="GrunnkapitalFjoraret-30821"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumAvsetningerForpliktelser">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteAvsetningerForpliktelser-18144"/>
+      <xsd:element minOccurs="0" name="aarets" type="AvsetningerForpliktelser-7231"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="AvsetningerForpliktelserFjoraret-7230"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AndreAvsetningerForpliktelser">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteAvsetningerForpliktelserLangsiktig-18582"/>
+      <xsd:element minOccurs="0" name="aarets" type="AvsetningerForpliktelserLangsiktig-7157"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="AvsetningerForpliktelserLangsiktigFjoraret-7146"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="UtsattSkatt">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteSkattUtsatt-18148"/>
+      <xsd:element minOccurs="0" name="aarets" type="SkattUtsatt-237"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="SkattUtsattFjoraret-7143"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Pensjonsforpliktelser">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NotePensjonsforpliktelser-18149"/>
+      <xsd:element minOccurs="0" name="aarets" type="Pensjonsforpliktelser-238"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="PensjonsforpliktelserFjoraret-6685"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumLangsiktigGjeld">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteGjeldLangsiktig-18585"/>
+      <xsd:element minOccurs="0" name="aarets" type="GjeldLangsiktig-86"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="GjeldLangsiktigFjoraret-7156"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumAnnenLangsiktigGjeld">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteGjeldAnnenLangsiktigSum-25018"/>
+      <xsd:element minOccurs="0" name="aarets" type="GjeldAnnenLangsiktigSum-25019"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="GjeldAnnenLangsiktigSumFjoraret-25020"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="OevrigLangsiktigGjeld">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteGjeldAnnenLangsiktig-18584"/>
+      <xsd:element minOccurs="0" name="aarets" type="GjeldAnnenLangsiktig-242"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="GjeldAnnenLangsiktigFjoraret-7155"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="GjeldKredittinstitusjoner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteGjeldKredittinstitusjoner-18164"/>
+      <xsd:element minOccurs="0" name="aarets" type="GjeldKredittinstitusjoner-7150"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="GjeldKredittinstitusjonerFjoraret-7151"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumFormaalskapitalGjeldS">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteGjeldEgenkapital-18122"/>
+      <xsd:element minOccurs="0" name="aarets" type="GjeldEgenkapital-251"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="GjeldEgenkapitalFjoraret-7185"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumGjeld">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteGjeld-18138"/>
+      <xsd:element minOccurs="0" name="aarets" type="Gjeld-1119"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="GjeldFjoraret-7184"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumKortsiktigGjeld">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteGjeldKortsiktig-18593"/>
+      <xsd:element minOccurs="0" name="aarets" type="GjeldKortsiktig-85"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="GjeldKortsiktigFjoraret-7183"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnnenKortsiktigGjeld">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteGjeldAnnenKortsiktig-18592"/>
+      <xsd:element minOccurs="0" name="aarets" type="GjeldAnnenKortsiktig-236"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="GjeldAnnenKortsiktigFjoraret-7182"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SkyldigeOffentligeAvgifter">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteAvgifterOffentligeSkyldig-18590"/>
+      <xsd:element minOccurs="0" name="aarets" type="AvgifterOffentligeSkyldig-225"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="AvgifterOffentligeSkyldigFjoraret-7170"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="BetalbarSkatt">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteSkattBetalbar-18589"/>
+      <xsd:element minOccurs="0" name="aarets" type="SkattBetalbar-2483"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="SkattBetalbarFjoraret-10293"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Leverandoergjeld">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteLeverandorgjeld-18588"/>
+      <xsd:element minOccurs="0" name="aarets" type="Leverandorgjeld-220"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="LeverandorgjeldFjoraret-7162"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="GjeldKredittinstitusjonerPoster">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteGjeldKredittinstitusjonerKortsiktig-18587"/>
+      <xsd:element minOccurs="0" name="aarets" type="GjeldKredittinstitusjonerKortsiktig-10926"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="GjeldKredittinstitusjonerKortsiktigFjoraret-13203"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Pantstillelser">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NotePantstillelser-18595"/>
+      <xsd:element minOccurs="0" name="aarets" type="Pantstillelser-16922"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="PantstillelserFjoraret-16923"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Garantistillelser">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteGarantistillelse-18594"/>
+      <xsd:element minOccurs="0" name="aarets" type="Garantistillelse-16920"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="GarantistillelseFjoraret-16921"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnnenFormaalskapitalLovpaalagteRestriksjoner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalAnnenRestriksjonerLovpalagte-33463"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalAnnenRestriksjonerLovpalagte-33464"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FormalskapitalAnnenRestriksjonerLovpalagteFjoraret-33465"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumOpptjentFormaalskapitalLovpaalagteRestriksjoner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalOpptjentSumRestriksjonerLovpalagte-33466"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalOpptjentSumRestriksjonerLovpalagte-33467"/>
+      <xsd:element minOccurs="0" name="fjoraarets"
+                   type="FormalskapitalOpptjentSumRestriksjonerLovpalagteFjoraret-33468"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnnenFormaalskapitalEksterntPaalagteRestriksjoner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalAnnenRestriksjonerEksterntPalagte-33469"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalAnnenRestriksjonerEksterntPalagte-33470"/>
+      <xsd:element minOccurs="0" name="fjoraarets"
+                   type="FormalskapitalAnnenRestriksjonerEksterntPalagteFjoraret-33471"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumFormaalskapitalEksterntPaalagteRestriksjoner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalSumRestriksjonerEksterntPalagte-33472"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalSumRestriksjonerEksterntPalagte-33473"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FormalskapitalSumRestriksjonerEksterntPalagteFjoraret-33474"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnnenFormaalskapitalSelvpaalagteRestriksjoner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalAnnenRestriksjonerSelpalagte-33475"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalAnnenRestriksjonerSelvpalagte-33476"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FormalskapitalAnnenRestriksjonerSelvpalagteFjoraret-33477"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumFormaalskapitalSelvpaalagteRestriksjoner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalSumRestriksjonerSelvpalagte-33478"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalSumRestriksjonerSelvpalagte-33479"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FormalskapitalSumRestriksjonerSelvpalagteFjoraret-33480"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="AnnenFormaalskapital">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalAnnen-33481"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalAnnen-33482"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FormalskapitalAnnenFjoraret-33483"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="MinoritetsinteresserFormaalskapitalSelvpaalagteRestriksjoner">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteMinoritetsinteresser-29044"/>
+      <xsd:element minOccurs="0" name="aarets" type="Minoritetsinteresser-29045"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="MinoritetsinteresserFjoraret-29046"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="SumFormaalskapital">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalSum-33484"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalSum-33485"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FormalskapitalSumFjoraret-33486"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="FormaalskapitalLovpaalagteRestriksjonerPoster">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalRestriksjonerLovpalagte-33445"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalRestriksjonerLovpalagte-33446"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FormalskapitalRestriksjonerLovpalagteFjoraret-33447"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="FormaalskapitalEksterntPaalagteRestriksjonerTilleggReduksjonEgenkapital">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalRestriksjonerEksterntPalagt-33448"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalRestriksjonerEksterntPalagt-33449"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FormalskapitalRestriksjonerEksterntPalagtFjoraret-33450"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="FormaalskapitalSelvpaalagteRestriksjonerPoster">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="note" type="NoteFormalskapitalRestriksjonerSelvpalagte-33451"/>
+      <xsd:element minOccurs="0" name="aarets" type="FormalskapitalRestriksjonerSelvpalagte-33452"/>
+      <xsd:element minOccurs="0" name="fjoraarets" type="FormalskapitalRestriksjonerSelvpalagteFjoraret-33453"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xs:schema>

--- a/testdata/Model/XmlSchema/Gitea/3430-39615.xsd
+++ b/testdata/Model/XmlSchema/Gitea/3430-39615.xsd
@@ -1,0 +1,456 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:seres="http://seres.no/xsd/forvaltningsdata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified"
+           elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsd:annotation>
+    <xsd:documentation>
+      <xs:attribute name="XSLT-skriptnavn" fixed="SERES_XSD_GEN"/>
+      <xs:attribute name="XSD-generatorversjon" fixed="2.0.13"/>
+      <xs:attribute name="XSLT-prosessor" fixed="SAXON versjon 9.1.0.7"/>
+      <xs:attribute name="generert" fixed="2015-11-16T15:02:03.256+01:00"/>
+      <xs:attribute name="navneromprefix" fixed="http://seres.no/xsd"/>
+      <xs:attribute name="namespace" fixed="http://seres.no/xsd/Regnskapsregisteret/RR-0010H_M/2015"/>
+      <xs:attribute name="meldingsnavn" fixed="melding"/>
+      <xs:attribute name="domenenavn" fixed="Regnskapsregisteret"/>
+      <xs:attribute name="modellnavn" fixed="RR-0010H_M"/>
+      <xs:attribute name="metamodellversjon" fixed="1.2"/>
+      <xs:attribute name="guid" fixed="true"/>
+      <xs:attribute name="orid" fixed="true"/>
+      <xs:attribute name="nillable" fixed="true"/>
+      <xs:attribute name="tillat-gjenbruk" fixed="false"/>
+      <xs:attribute name="elementtype" fixed="true"/>
+      <xs:attribute name="forvaltningsdata" fixed="true"/>
+      <xs:attribute name="forvaltningsdata-navnerom" fixed="http://seres.no/xsd/forvaltningsdata"/>
+      <xs:attribute name="særnorske-bokstaver-i-navn" fixed="false"/>
+      <xs:attribute name="ft_guid_som_attributt" fixed="false"/>
+      <xs:attribute name="sem-ref" fixed="false"/>
+      <xs:attribute name="kodebibliotek" fixed="false"/>
+      <xs:attribute name="språk" fixed=""/>
+      <xs:attribute name="XSD-variant" fixed="Altinn 1.3"/>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:element name="melding" type="RR-0010H_M"/>
+  <xsd:complexType seres:elementtype="Meldingsmodell"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/Meldingsmodell/RR-0010H_M/450423"
+                   name="RR-0010H_M">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="Innsender" type="Innsender"/>
+      <xsd:element minOccurs="0" name="Skjemainnhold" type="Skjemainnhold"/>
+    </xsd:sequence>
+    <xsd:attribute fixed="SERES" name="dataFormatProvider" type="xsd:string" use="required"/>
+    <xsd:attribute fixed="3430" name="dataFormatId" type="xsd:string" use="required"/>
+    <xsd:attribute fixed="48617" name="dataFormatVersion" type="xsd:string" use="required"/>
+    <xsd:anyAttribute namespace="##any"/>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/EnhetOrganisasjonsnummer-18/400536" seres:orid="18"
+                   name="EnhetOrganisasjonsnummer-18">
+    <xsd:simpleContent>
+      <xsd:extension base="EnhetOrganisasjonsnummer-18_Verdirestriksjon">
+        <xsd:attribute fixed="18" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/EnhetOrganisasjonsform-756/399934" seres:orid="756"
+                   name="EnhetOrganisasjonsform-756">
+    <xsd:simpleContent>
+      <xsd:extension base="EnhetOrganisasjonsform-756_Verdirestriksjon">
+        <xsd:attribute fixed="756" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/EnhetNavn-1/400376" seres:orid="1"
+                   name="EnhetNavn-1">
+    <xsd:simpleContent>
+      <xsd:extension base="EnhetNavn-1_Verdirestriksjon">
+        <xsd:attribute fixed="1" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/KontaktpersonEPost-19022/399576" seres:orid="19022"
+                   name="KontaktpersonEPost-19022">
+    <xsd:simpleContent>
+      <xsd:extension base="KontaktpersonEPost-19022_Verdirestriksjon">
+        <xsd:attribute fixed="19022" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/ArsregnskapSysteminnsending-35139/555499"
+                   seres:orid="35139" name="ArsregnskapSysteminnsending-35139">
+    <xsd:simpleContent>
+      <xsd:extension base="ArsregnskapSysteminnsending-35139_Verdirestriksjon">
+        <xsd:attribute fixed="35139" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDataenkeltype/ArsregnskapLandTilLand-35172/566229"
+                   seres:orid="35172" name="ArsregnskapLandTilLand-35172">
+    <xsd:simpleContent>
+      <xsd:extension base="ArsregnskapLandTilLand-35172_Verdirestriksjon">
+        <xsd:attribute fixed="35172" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/RegnskapAr-17102/400287" seres:orid="17102"
+                   name="RegnskapAr-17102">
+    <xsd:simpleContent>
+      <xsd:extension base="RegnskapAr-17102_Verdirestriksjon">
+        <xsd:attribute fixed="17102" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/RegnskapStartdato-17103/399965" seres:orid="17103"
+                   name="RegnskapStartdato-17103">
+    <xsd:simpleContent>
+      <xsd:extension base="RegnskapStartdato-17103_Verdirestriksjon">
+        <xsd:attribute fixed="17103" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/RegnskapAvslutningsdato-17104/399700"
+                   seres:orid="17104" name="RegnskapAvslutningsdato-17104">
+    <xsd:simpleContent>
+      <xsd:extension base="RegnskapAvslutningsdato-17104_Verdirestriksjon">
+        <xsd:attribute fixed="17104" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/ORDatakodeutvalg/Morselskap-4168/397351" seres:orid="4168"
+                   name="Morselskap-4168">
+    <xsd:simpleContent>
+      <xsd:extension base="Morselskap-4168_Verdirestriksjon">
+        <xsd:attribute fixed="4168" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/ORDatakodeutvalg/KonsernregnskapVedlegg-25943/397353"
+                   seres:orid="25943" name="KonsernregnskapVedlegg-25943">
+    <xsd:simpleContent>
+      <xsd:extension base="KonsernregnskapVedlegg-25943_Verdirestriksjon">
+        <xsd:attribute fixed="25943" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDatakodeliste/UtenlandskKonsern-36640/613242"
+                   seres:orid="36640" name="UtenlandskKonsern-36640">
+    <xsd:simpleContent>
+      <xsd:extension base="UtenlandskKonsern-36640_Verdirestriksjon">
+        <xsd:attribute fixed="36640" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/ORDatakodeutvalg/RegnskapsreglerSmaForetak-8079/397350"
+                   seres:orid="8079" name="RegnskapsreglerSmaForetak-8079">
+    <xsd:simpleContent>
+      <xsd:extension base="RegnskapsreglerSmaForetak-8079_Verdirestriksjon">
+        <xsd:attribute fixed="8079" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/ORDatakodeutvalg/RegnskapsoppsettIFRS-25021/397352"
+                   seres:orid="25021" name="RegnskapsoppsettIFRS-25021">
+    <xsd:simpleContent>
+      <xsd:extension base="RegnskapsoppsettIFRS-25021_Verdirestriksjon">
+        <xsd:attribute fixed="25021" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDatakodeliste/ForenkletIFRS-36639/613245"
+                   seres:orid="36639" name="ForenkletIFRS-36639">
+    <xsd:simpleContent>
+      <xsd:extension base="ForenkletIFRS-36639_Verdirestriksjon">
+        <xsd:attribute fixed="36639" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/ORDatakodeutvalg/RegnskapsoppsettKonsernIFRS-25944/397354"
+                   seres:orid="25944" name="RegnskapsoppsettKonsernIFRS-25944">
+    <xsd:simpleContent>
+      <xsd:extension base="RegnskapsoppsettKonsernIFRS-25944_Verdirestriksjon">
+        <xsd:attribute fixed="25944" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDatakodeliste/ForenkletIFRSKonsern-36641/613239"
+                   seres:orid="36641" name="ForenkletIFRSKonsern-36641">
+    <xsd:simpleContent>
+      <xsd:extension base="ForenkletIFRSKonsern-36641_Verdirestriksjon">
+        <xsd:attribute fixed="36641" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDatakodeutvalg/ArsregnskapIkkeRevisjonBesluttet-34669/477715"
+                   seres:orid="34669" name="ArsregnskapIkkeRevisjonBesluttet-34669">
+    <xsd:simpleContent>
+      <xsd:extension base="ArsregnskapIkkeRevisjonBesluttet-34669_Verdirestriksjon">
+        <xsd:attribute fixed="34669" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDatakodeutvalg/ArsregnskapUtarbeidelseAvAutorisertRegnskapsforer-34670/477714"
+                   seres:orid="34670" name="ArsregnskapUtarbeidelseAvAutorisertRegnskapsforer-34670">
+    <xsd:simpleContent>
+      <xsd:extension base="ArsregnskapUtarbeidelseAvAutorisertRegnskapsforer-34670_Verdirestriksjon">
+        <xsd:attribute fixed="34670" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDatakodeliste"
+                   seres:guid="http://seres.no/guid/Regnskapsregisteret/ORDatakodeutvalg/TjenestebistandEksternAutorisertRegnskapsforer-34671/477713"
+                   seres:orid="34671" name="TjenestebistandEksternAutorisertRegnskapsforer-34671">
+    <xsd:simpleContent>
+      <xsd:extension base="TjenestebistandEksternAutorisertRegnskapsforer-34671_Verdirestriksjon">
+        <xsd:attribute fixed="34671" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/RegnskapFastsettelseDato-17105/399637"
+                   seres:orid="17105" name="RegnskapFastsettelseDato-17105">
+    <xsd:simpleContent>
+      <xsd:extension base="RegnskapFastsettelseDato-17105_Verdirestriksjon">
+        <xsd:attribute fixed="17105" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType seres:elementtype="ORDataenkeltype"
+                   seres:guid="http://seres.no/guid/ORDataenkeltype/StyremedlemNavnSpesifisertStyremedlem-19023/399857"
+                   seres:orid="19023" name="StyremedlemNavnSpesifisertStyremedlem-19023">
+    <xsd:simpleContent>
+      <xsd:extension base="StyremedlemNavnSpesifisertStyremedlem-19023_Verdirestriksjon">
+        <xsd:attribute fixed="19023" name="orid" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="EnhetOrganisasjonsnummer-18_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:length value="9"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="EnhetOrganisasjonsform-756_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:minLength value="1"/>
+      <xsd:maxLength value="35"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="EnhetNavn-1_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:minLength value="1"/>
+      <xsd:maxLength value="175"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon" name="KontaktpersonEPost-19022_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:minLength value="1"/>
+      <xsd:maxLength value="70"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ArsregnskapSysteminnsending-35139_Verdirestriksjon">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ArsregnskapLandTilLand-35172_Verdirestriksjon">
+    <xsd:restriction base="xsd:boolean"/>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="RegnskapAr-17102_Verdirestriksjon">
+    <xsd:restriction base="xsd:gYear">
+      <xsd:minInclusive value="1980"/>
+      <xsd:maxInclusive value="9999"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="RegnskapStartdato-17103_Verdirestriksjon">
+    <xsd:restriction base="xsd:date">
+      <xsd:minInclusive value="1980-01-01"/>
+      <xsd:maxInclusive value="9999-12-31"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="RegnskapAvslutningsdato-17104_Verdirestriksjon">
+    <xsd:restriction base="xsd:date">
+      <xsd:minInclusive value="1980-01-01"/>
+      <xsd:maxInclusive value="9999-12-31"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="Morselskap-4168_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/ja/500664" value="ja"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/nei/500663" value="nei"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="KonsernregnskapVedlegg-25943_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/ja/500668" value="ja"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/nei/500667" value="nei"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="UtenlandskKonsern-36640_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/ja/613241" value="ja"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/nei/613240" value="nei"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="RegnskapsreglerSmaForetak-8079_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/ja/500662" value="ja"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/nei/500661" value="nei"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="RegnskapsoppsettIFRS-25021_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/nei/500666" value="nei"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/ja/500665" value="ja"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ForenkletIFRS-36639_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/ja/613244" value="ja"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/nei/613243" value="nei"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="RegnskapsoppsettKonsernIFRS-25944_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/nei/500670" value="nei"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/ja/500669" value="ja"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ForenkletIFRSKonsern-36641_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/ja/613238" value="ja"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/nei/613237" value="nei"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ArsregnskapIkkeRevisjonBesluttet-34669_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/ja/500660" value="ja"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/nei/500659" value="nei"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ArsregnskapUtarbeidelseAvAutorisertRegnskapsforer-34670_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/ja/500658" value="ja"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/nei/500657" value="nei"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="TjenestebistandEksternAutorisertRegnskapsforer-34671_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/ja/500656" value="ja"/>
+      <xsd:enumeration seres:elementtype="Datakodeelement"
+                       seres:guid="http://seres.no/guid/Regnskapsregisteret/Datakodeelement/nei/500655" value="nei"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tallrestriksjon" name="RegnskapFastsettelseDato-17105_Verdirestriksjon">
+    <xsd:restriction base="xsd:date"/>
+  </xsd:simpleType>
+  <xsd:simpleType seres:elementtype="Tegnrestriksjon"
+                  name="StyremedlemNavnSpesifisertStyremedlem-19023_Verdirestriksjon">
+    <xsd:restriction base="xsd:string">
+      <xsd:minLength value="1"/>
+      <xsd:maxLength value="70"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="Skjemainnhold">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="regnskapsperiode" type="Regnskapsperiode"/>
+      <xsd:element minOccurs="0" name="konsern" type="Konsern"/>
+      <xsd:element minOccurs="0" name="regnskapsprinsipper" type="Regnskapsprinsipper"/>
+      <xsd:element minOccurs="0" name="fastsettelse" type="Fastsettelse"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Innsender">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="enhet" type="Enhet"/>
+      <xsd:element minOccurs="0" maxOccurs="unbounded" name="kontaktperson" type="Kontaktperson"/>
+      <xsd:element minOccurs="0" name="opplysningerInnsending" type="OpplysningerInnsending"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="OpplysningerInnsending">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="fraSluttbrukersystem" type="ArsregnskapSysteminnsending-35139"/>
+      <xsd:element minOccurs="0" name="landTilLand" type="ArsregnskapLandTilLand-35172"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Kontaktperson">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="e-post" type="KontaktpersonEPost-19022"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Enhet">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="organisasjonsnummer" type="EnhetOrganisasjonsnummer-18"/>
+      <xsd:element minOccurs="0" name="organisasjonsform" type="EnhetOrganisasjonsform-756"/>
+      <xsd:element minOccurs="0" name="navn" type="EnhetNavn-1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Fastsettelse">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="fastsettelsesdato" type="RegnskapFastsettelseDato-17105"/>
+      <xsd:element minOccurs="0" name="bekreftendeSelskapsrepresentant"
+                   type="StyremedlemNavnSpesifisertStyremedlem-19023"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Regnskapsprinsipper">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="smaaForetak" type="RegnskapsreglerSmaForetak-8079"/>
+      <xsd:element minOccurs="0" name="regnskapsreglerSelskap" type="RegnskapsoppsettIFRS-25021"/>
+      <xsd:element minOccurs="0" name="forenkletIfrs" type="ForenkletIFRS-36639"/>
+      <xsd:element minOccurs="0" name="regnskapsreglerKonsern" type="RegnskapsoppsettKonsernIFRS-25944"/>
+      <xsd:element minOccurs="0" name="forenkletIfrsKonsern" type="ForenkletIFRSKonsern-36641"/>
+      <xsd:element minOccurs="0" name="aarsregnskapIkkeRevideres" type="ArsregnskapIkkeRevisjonBesluttet-34669"/>
+      <xsd:element minOccurs="0" name="aarsregnskapUtarbeidetAutorisertRegnskapsfoerer"
+                   type="ArsregnskapUtarbeidelseAvAutorisertRegnskapsforer-34670"/>
+      <xsd:element minOccurs="0" name="tjenestebistandEksternAutorisertRegnskapsfoerer"
+                   type="TjenestebistandEksternAutorisertRegnskapsforer-34671"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Konsern">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="morselskap" type="Morselskap-4168"/>
+      <xsd:element minOccurs="0" name="konsernregnskap" type="KonsernregnskapVedlegg-25943"/>
+      <xsd:element minOccurs="0" name="utenlandskKonsern" type="UtenlandskKonsern-36640"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Regnskapsperiode">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="regnskapsstart" type="RegnskapStartdato-17103"/>
+      <xsd:element minOccurs="0" name="regnskapsslutt" type="RegnskapAvslutningsdato-17104"/>
+      <xsd:element minOccurs="0" name="regnskapsaar" type="RegnskapAr-17102"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xs:schema>


### PR DESCRIPTION
See commit log. It is likely that the review is easier if you look at individual commits. 

#### Update test infrastructure
* Automatically write the changed classes to disk when tests fails (this ensures they work the second time and you can easily review and check in the updated good state of the classes)
* Be explicit about specific warnings to ignore. The code should be warning free, but tracking what namespaces we use is hard.
* Use `ITestOutputHelper` to log the generated models for easier to read test failures without having to debug.
#### Update baseline for datamodels to what they actually equals.
* Move AltinnRowId to the top of classes and remove `using System.Threading.Tasks;`
#### Add #nullable dissable to generated models
* Just make the tests work
#### Rewrite model codegen without changing output
* Preparation for the next commit.
#### Add support for generating classes with nullable reference types.
* Currently disabled. Not sure how and when to make this available, (but tests indicate that I do it correctly).
#### Add code for generating a hack with [XmlText] and nullable properties
* The requested functionality from #12674
* Add a few more xsd files that uses [XmlText]
#### Activate XmlTextValueNullableHack and AddShouldSerializeForTagContent
* Toggle the switch to activate the functionality and update the test files


## Related Issue(s)
- Fixes #12674
- Fix half of https://github.com/Altinn/altinn-studio/issues/10550 by adding `#nullable disable`, but with a switch to add `#nullable enable` instead.

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
