### PR TITLE
Mock dataType in preview if missing from current layoutset

### DIFF
--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
@@ -15,13 +16,13 @@ using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.App;
+using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
 using LibGit2Sharp;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ApplicationLanguage = Altinn.Studio.Designer.Models.ApplicationLanguage;
-using LayoutSets = Altinn.Studio.Designer.Models.LayoutSets;
 
 namespace Altinn.Studio.Designer.Controllers
 {
@@ -150,6 +151,11 @@ namespace Altinn.Studio.Designer.Controllers
             string appNugetVersionString = _appDevelopmentService.GetAppLibVersion(AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer)).ToString();
             // This property is populated at runtime by the apps, so we need to mock it here
             applicationMetadata.AltinnNugetVersion = GetMockedAltinnNugetBuildFromVersion(appNugetVersionString);
+            if (altinnAppGitRepository.AppUsesLayoutSets())
+            {
+                LayoutSets layoutSets = await altinnAppGitRepository.GetLayoutSetsFile(cancellationToken);
+                applicationMetadata = SetMockDataTypeIfMissing(applicationMetadata, layoutSets);
+            }
             return Ok(applicationMetadata);
         }
 
@@ -192,7 +198,8 @@ namespace Altinn.Studio.Designer.Controllers
                 string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
                 AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
                 LayoutSets layoutSets = await altinnAppGitRepository.GetLayoutSetsFile(cancellationToken);
-                return Ok(layoutSets);
+                LayoutSets layoutSetsWithMockedDataTypes = AddDataTypesToReturnedLayoutSetsIfMissing(layoutSets);
+                return Ok(layoutSetsWithMockedDataTypes);
             }
             catch (NotFoundException)
             {
@@ -236,7 +243,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>layoutsettings</returns>
         [HttpGet]
         [Route("api/layoutsettings/{layoutSetName}")]
-        public async Task<ActionResult<string>> LayoutSettingsForStatefulApps(string org, string app, [FromRoute] string layoutSetName, CancellationToken cancellationToken)
+        public async Task<ActionResult<string>> LayoutSettingsForV4Apps(string org, string app, [FromRoute] string layoutSetName, CancellationToken cancellationToken)
         {
             try
             {
@@ -436,7 +443,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
         /// <returns>Json schema for datamodel for the current task</returns>
         [HttpGet]
-        [Route("instances/{partyId}/{instanceGuid}/data/test-datatask-id")]
+        [Route("instances/{partyId}/{instanceGuid}/data/" + PreviewService.MockDataTaskId)]
         public async Task<ActionResult> GetFormData(string org, string app, [FromRoute] int partyId, [FromRoute] string instanceGuid, CancellationToken cancellationToken)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
@@ -465,7 +472,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
         /// <returns>Json schema for datamodel for the current data task in the process</returns>
         [HttpPut]
-        [Route("instances/{partyId}/{instanceGuid}/data/test-datatask-id")]
+        [Route("instances/{partyId}/{instanceGuid}/data/" + PreviewService.MockDataTaskId)]
         public async Task<ActionResult> UpdateFormData(string org, string app, [FromRoute] int partyId, [FromRoute] string instanceGuid, CancellationToken cancellationToken)
         {
             return await GetFormData(org, app, partyId, instanceGuid, cancellationToken);
@@ -577,7 +584,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// </summary>
         /// <returns>Ok</returns>
         [HttpGet]
-        [Route("instances/{partyId}/{instanceGuId}/data/test-datatask-id/validate")]
+        [Route("instances/{partyId}/{instanceGuId}/data/" + PreviewService.MockDataTaskId + "/validate")]
         public ActionResult ValidateInstanceForDataTask()
         {
             return Ok(new List<string>());
@@ -648,10 +655,18 @@ namespace Altinn.Studio.Designer.Controllers
         [Route("api/jsonschema/{datamodel}")]
         public async Task<ActionResult<string>> Datamodel(string org, string app, [FromRoute] string datamodel, CancellationToken cancellationToken)
         {
-            string modelPath = $"/App/models/{datamodel}.schema.json";
-            string decodedPath = Uri.UnescapeDataString(modelPath);
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
-            string json = await _schemaModelService.GetSchema(AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer), decodedPath, cancellationToken);
+            string modelPath = $"/App/models/{datamodel}.schema.json";
+            if (datamodel.StartsWith(PreviewService.MockDataModelIdPrefix))
+            {
+                AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
+                ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata(cancellationToken);
+                string existingDataTypeId = applicationMetadata.DataTypes.First(dataType => dataType.AppLogic?.ClassRef is not null).Id;
+                modelPath = $"/App/models/{existingDataTypeId}.schema.json";
+            }
+            string decodedPath = Uri.UnescapeDataString(modelPath);
+            string json = await _schemaModelService.GetSchema(
+                AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer), decodedPath, cancellationToken);
             return Ok(json);
         }
 
@@ -684,7 +699,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>A List of form layouts as byte array</returns>
         [HttpGet]
         [Route("api/layouts/{layoutSetName}")]
-        public async Task<ActionResult<Dictionary<string, JsonNode>>> GetFormLayoutsForStatefulApps(string org, string app, [FromRoute] string layoutSetName, CancellationToken cancellationToken)
+        public async Task<ActionResult<Dictionary<string, JsonNode>>> GetFormLayoutsForV4Apps(string org, string app, [FromRoute] string layoutSetName, CancellationToken cancellationToken)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
             AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
@@ -728,7 +743,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>Rule handler as string or no content if not found</returns>
         [HttpGet]
         [Route("api/rulehandler/{layoutSetName}")]
-        public async Task<ActionResult<string>> GetRuleHandlerStateful(string org, string app, [FromRoute] string layoutSetName, CancellationToken cancellationToken)
+        public async Task<ActionResult<string>> GetRuleHandlerV4(string org, string app, [FromRoute] string layoutSetName, CancellationToken cancellationToken)
         {
             try
             {
@@ -777,7 +792,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>Rule configuration as string or no content if not found</returns>
         [HttpGet]
         [Route("api/ruleconfiguration/{layoutSetName}")]
-        public async Task<ActionResult<string>> GetRuleConfigurationStateful(string org, string app, [FromRoute] string layoutSetName, CancellationToken cancellationToken)
+        public async Task<ActionResult<string>> GetRuleConfigurationV4(string org, string app, [FromRoute] string layoutSetName, CancellationToken cancellationToken)
         {
             try
             {
@@ -887,7 +902,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>The options list if it exists, otherwise nothing</returns>
         [HttpGet]
         [Route("instances/{partyId}/{instanceGuid}/datalists/{dataListId}")]
-        public async Task<ActionResult<List<string>>> GetDatalistsForInstance(string org, string app, string dataListId, [FromQuery] string language, [FromQuery] string size, CancellationToken cancellationToken)
+        public ActionResult<List<string>> GetDataListsForInstance(string org, string app, string dataListId, [FromQuery] string language, [FromQuery] string size, CancellationToken cancellationToken)
         {
             // TODO: Should look into whether we can get some actual data here, or if we can make an "informed" mock based on the setup.
             // For now, we just return an empty list.
@@ -937,7 +952,7 @@ namespace Altinn.Studio.Designer.Controllers
             return Ok();
         }
 
-        private string GetSelectedLayoutSetInEditorFromRefererHeader(string refererHeader)
+        private static string GetSelectedLayoutSetInEditorFromRefererHeader(string refererHeader)
         {
             Uri refererUri = new(refererHeader);
             string layoutSetName = HttpUtility.ParseQueryString(refererUri.Query)["selectedLayoutSet"];
@@ -945,7 +960,7 @@ namespace Altinn.Studio.Designer.Controllers
             return string.IsNullOrEmpty(layoutSetName) ? null : layoutSetName;
         }
 
-        private string ReplaceIndexToFetchCorrectOrgAppInCshtml(string originalContent)
+        private static string ReplaceIndexToFetchCorrectOrgAppInCshtml(string originalContent)
         {
             // Replace the array indexes in the script in the cshtml that retrieves the org and app name since
             // /app-specific-preview/ is added when fetching the cshtml file from endpoint instead of designer wwwroot
@@ -979,6 +994,28 @@ namespace Altinn.Studio.Designer.Controllers
             return MINIMUM_NUGET_VERSION;
         }
 
+        private static ApplicationMetadata SetMockDataTypeIfMissing(ApplicationMetadata applicationMetadata, LayoutSets layoutSets)
+        {
+            LayoutSets layoutSetsWithMockedDataTypesIfMissing = AddDataTypesToReturnedLayoutSetsIfMissing(layoutSets);
+            layoutSetsWithMockedDataTypesIfMissing.Sets.ForEach(set =>
+            {
+                if (!applicationMetadata.DataTypes.Any(dataType => dataType.Id == set.DataType))
+                {
+                    applicationMetadata.DataTypes.Add(new DataType()
+                    {
+                        Id = set.DataType,
+                        AppLogic = new ApplicationLogic()
+                        {
+                            ClassRef = $"Altinn.App.Models.model.{set.DataType}"
+                        },
+                        TaskId = set.Tasks[0]
+                    });
+                }
+            });
+
+            return applicationMetadata;
+        }
+
         private bool IsValidSemVerVersion(string[] versionParts)
         {
             return versionParts.Length >= 3 && Convert.ToInt32(versionParts[0]) >= 8;
@@ -992,6 +1029,18 @@ namespace Altinn.Studio.Designer.Controllers
         private int GetPreviewVersion(string[] versionParts)
         {
             return Convert.ToInt32(versionParts[3]);
+        }
+
+        private static LayoutSets AddDataTypesToReturnedLayoutSetsIfMissing(LayoutSets layoutSets)
+        {
+            int counter = 0;
+            foreach (var set in layoutSets.Sets.Where(set => string.IsNullOrEmpty(set.DataType)))
+            {
+                string mockDataTypeId = $"{PreviewService.MockDataModelIdPrefix}-{counter++}";
+                set.DataType = mockDataTypeId;
+            }
+
+            return layoutSets;
         }
     }
 }

--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -659,6 +659,9 @@ namespace Altinn.Studio.Designer.Controllers
             string modelPath = $"/App/models/{datamodel}.schema.json";
             if (datamodel.StartsWith(PreviewService.MockDataModelIdPrefix))
             {
+                // If app-frontend tries to fetch a datamodel for a mockDataModelId we will return the first
+                // datamodel in appMetadata since our mocked preview will not use this datamodel anyway, but
+                // app-frontend expects an actual datamodel as a response
                 AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
                 ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata(cancellationToken);
                 string existingDataTypeId = applicationMetadata.DataTypes.First(dataType => dataType.AppLogic?.ClassRef is not null).Id;

--- a/backend/tests/Designer.Tests/Controllers/ApiTests/DisagnerEndpointsTestsBase.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApiTests/DisagnerEndpointsTestsBase.cs
@@ -10,6 +10,7 @@ using Designer.Tests.Mocks;
 using Designer.Tests.Utils;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 
 namespace Designer.Tests.Controllers.ApiTests
 {

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetAppMetadataModelIdsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetAppMetadataModelIdsTests.cs
@@ -34,7 +34,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
 
             string responseContent = await response.Content.ReadAsStringAsync();
 
-            responseContent.Should().Be("[\"datamodel\",\"unUsedDatamodel\",\"HvemErHvem_M\"]");
+            responseContent.Should().Be("[\"datamodel\",\"unUsedDatamodel\",\"HvemErHvem_M\",\"receiptDataType\"]");
         }
 
         [Theory]

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/AnonymousTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/AnonymousTests.cs
@@ -17,7 +17,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_Anonymous_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/api/v1/data/anonymous";
+            string dataPathWithData = $"{Org}/{AppV3}/api/v1/data/anonymous";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/ApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/ApplicationMetadataTests.cs
@@ -2,9 +2,11 @@
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.App;
+using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Mocks;
 using Designer.Tests.Utils;
@@ -37,12 +39,12 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_ApplicationMetadata_Ok()
         {
-            string expectedApplicationMetadataString = TestDataHelper.GetFileFromRepo(Org, App, Developer, "App/config/applicationmetadata.json");
+            string expectedApplicationMetadataString = TestDataHelper.GetFileFromRepo(Org, AppV3, Developer, "App/config/applicationmetadata.json");
             _appDevelopmentServiceMock
                 .Setup(rs => rs.GetAppLibVersion(It.IsAny<AltinnRepoEditingContext>()))
                 .Returns(NuGet.Versioning.NuGetVersion.Parse("1.0.0"));
 
-            string dataPathWithData = $"{Org}/{App}/api/v1/applicationmetadata";
+            string dataPathWithData = $"{Org}/{AppV3}/api/v1/applicationmetadata";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
@@ -58,12 +60,12 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_ApplicationMetadata_With_V8_Altinn_Nuget_Version_Ok()
         {
-            string expectedApplicationMetadataString = TestDataHelper.GetFileFromRepo(Org, App, Developer, "App/config/applicationmetadata.json");
+            string expectedApplicationMetadataString = TestDataHelper.GetFileFromRepo(Org, AppV3, Developer, "App/config/applicationmetadata.json");
             _appDevelopmentServiceMock
                 .Setup(rs => rs.GetAppLibVersion(It.IsAny<AltinnRepoEditingContext>()))
                 .Returns(NuGet.Versioning.NuGetVersion.Parse("8.0.0"));
 
-            string dataPathWithData = $"{Org}/{App}/api/v1/applicationmetadata";
+            string dataPathWithData = $"{Org}/{AppV3}/api/v1/applicationmetadata";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
@@ -72,6 +74,38 @@ namespace Designer.Tests.Controllers.PreviewController
             string responseBody = await response.Content.ReadAsStringAsync();
             ApplicationMetadata expectedApplicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(expectedApplicationMetadataString, SerializerOptions);
             expectedApplicationMetadata.AltinnNugetVersion = "8.0.0.0";
+            string expectedJson = JsonSerializer.Serialize(expectedApplicationMetadata, SerializerOptions);
+            JsonUtils.DeepEquals(expectedJson, responseBody).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Get_ApplicationMetadata_WithLessDataTypesThanLayoutSetsFile_OkWithMockedDataTypes()
+        {
+            string expectedApplicationMetadataString = TestDataHelper.GetFileFromRepo(Org, AppV4, Developer, "App/config/applicationmetadata.json");
+            _appDevelopmentServiceMock
+                .Setup(rs => rs.GetAppLibVersion(It.IsAny<AltinnRepoEditingContext>()))
+                .Returns(NuGet.Versioning.NuGetVersion.Parse("8.0.0"));
+
+            string dataPathWithData = $"{Org}/{AppV4}/api/v1/applicationmetadata";
+            using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            ApplicationMetadata expectedApplicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(expectedApplicationMetadataString, SerializerOptions);
+            expectedApplicationMetadata.AltinnNugetVersion = "8.0.0.0";
+            // Add the mocked data type to expected app metadata
+            expectedApplicationMetadata.DataTypes.Add(new DataType()
+            {
+                Id = $"{PreviewService.MockDataModelIdPrefix}-0",
+                AppLogic = new ApplicationLogic()
+                {
+                    ClassRef = $"Altinn.App.Models.model.{PreviewService.MockDataModelIdPrefix}-0"
+                },
+                TaskId = "Task_2"
+            });
+
             string expectedJson = JsonSerializer.Serialize(expectedApplicationMetadata, SerializerOptions);
             JsonUtils.DeepEquals(expectedJson, responseBody).Should().BeTrue();
         }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/ApplicationSettingsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/ApplicationSettingsTests.cs
@@ -19,7 +19,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_ApplicationSettings_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/api/v1/applicationsettings";
+            string dataPathWithData = $"{Org}/{AppV3}/api/v1/applicationsettings";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/CurrentPartyTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/CurrentPartyTests.cs
@@ -19,7 +19,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_CurrentParty_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/api/authorization/parties/current";
+            string dataPathWithData = $"{Org}/{AppV3}/api/authorization/parties/current";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/CurrentUserTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/CurrentUserTests.cs
@@ -19,7 +19,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_CurrentUser_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/api/v1/profile/user";
+            string dataPathWithData = $"{Org}/{AppV3}/api/v1/profile/user";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/DatamodelTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/DatamodelTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Altinn.Studio.Designer.Services.Implementation;
 using Designer.Tests.Utils;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -19,9 +20,25 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_Datamodel_Ok()
         {
-            string expectedDatamodel = TestDataHelper.GetFileFromRepo(Org, App, Developer, "App/models/custom-dm-name.schema.json");
+            string expectedDatamodel = TestDataHelper.GetFileFromRepo(Org, AppV3, Developer, "App/models/custom-dm-name.schema.json");
 
-            string dataPathWithData = $"{Org}/{App}/api/jsonschema/custom-dm-name";
+            string dataPathWithData = $"{Org}/{AppV3}/api/jsonschema/custom-dm-name";
+            using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            JsonUtils.DeepEquals(expectedDatamodel, responseBody).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Get_Datamodel_MockedDataTypeId_OkWithDefaultDataModel()
+        {
+            // Expects to get a response that is a datamodel, but does not matter which, so returns the first data type in app metadata with a classRef
+            string expectedDatamodel = TestDataHelper.GetFileFromRepo(Org, AppV4, Developer, "App/models/datamodel.schema.json");
+
+            string dataPathWithData = $"{Org}/{AppV4}/api/jsonschema/{PreviewService.MockDataModelIdPrefix}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/DeleteAttachmentTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/DeleteAttachmentTests.cs
@@ -17,20 +17,20 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Delete_Attachment_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/data/{AttachmentGuId}";
+            string dataPathWithData = $"{Org}/{AppV3}/instances/{PartyId}/{InstanceGuId}/data/{AttachmentGuId}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Delete, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={App}&selectedLayoutSet=");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV3}&selectedLayoutSet=");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
         [Fact]
-        public async Task Delete_AttachmentForStateFulApp_Ok()
+        public async Task Delete_AttachmentForV4App_Ok()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/data/{AttachmentGuId}";
+            string dataPathWithData = $"{Org}/{AppV4}/instances/{PartyId}/{InstanceGuId}/data/{AttachmentGuId}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Delete, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={StatefulApp}&selectedLayoutSet={LayoutSetName}");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV4}&selectedLayoutSet={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetApplicationLanguagesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetApplicationLanguagesTests.cs
@@ -16,7 +16,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_ApplicationLanguages_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/api/v1/applicationlanguages";
+            string dataPathWithData = $"{Org}/{AppV3}/api/v1/applicationlanguages";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormDataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormDataTests.cs
@@ -20,11 +20,11 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_FormData_Ok()
         {
-            string expectedFormData = TestDataHelper.GetFileFromRepo(Org, App, Developer, "App/models/custom-dm-name.schema.json");
+            string expectedFormData = TestDataHelper.GetFileFromRepo(Org, AppV3, Developer, "App/models/custom-dm-name.schema.json");
 
-            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
+            string dataPathWithData = $"{Org}/{AppV3}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={App}&selectedLayoutSet=");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV3}&selectedLayoutSet=");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -38,7 +38,7 @@ namespace Designer.Tests.Controllers.PreviewController
         {
             string dataPathWithData = $"{Org}/empty-app/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={App}&selectedLayoutSet=");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV3}&selectedLayoutSet=");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -48,13 +48,13 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
-        public async Task Get_FormDataForStatefulApp_Ok()
+        public async Task Get_FormDataForV4App_Ok()
         {
-            string expectedFormData = TestDataHelper.GetFileFromRepo(Org, StatefulApp, Developer, "App/models/datamodel.schema.json");
+            string expectedFormData = TestDataHelper.GetFileFromRepo(Org, AppV4, Developer, "App/models/datamodel.schema.json");
 
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
+            string dataPathWithData = $"{Org}/{AppV4}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={StatefulApp}&selectedLayoutSet={LayoutSetName}");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV4}&selectedLayoutSet={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -64,11 +64,11 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
-        public async Task Get_FormDataForStatefulAppForTaskWithoutDatamodel_Ok()
+        public async Task Get_FormDataForV4AppForTaskWithoutDatamodel_Ok()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
+            string dataPathWithData = $"{Org}/{AppV4}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={StatefulApp}&selectedLayoutSet={LayoutSetName2}");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV4}&selectedLayoutSet={LayoutSetName2}");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormLayoutsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormLayoutsTests.cs
@@ -19,10 +19,10 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_FormLayouts_Ok()
         {
-            string expectedFormLayout = TestDataHelper.GetFileFromRepo(Org, App, Developer, "App/ui/layouts/layout.json");
+            string expectedFormLayout = TestDataHelper.GetFileFromRepo(Org, AppV3, Developer, "App/ui/layouts/layout.json");
             string expectedFormLayouts = @"{""layout"": " + expectedFormLayout + "}";
 
-            string dataPathWithData = $"{Org}/{App}/api/resource/FormLayout.json";
+            string dataPathWithData = $"{Org}/{AppV3}/api/resource/FormLayout.json";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormLayoutsV4Tests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormLayoutsV4Tests.cs
@@ -9,21 +9,21 @@ using Xunit;
 
 namespace Designer.Tests.Controllers.PreviewController
 {
-    public class GetFormLayoutsForStatefulApps : PreviewControllerTestsBase<GetFormLayoutsForStatefulApps>, IClassFixture<WebApplicationFactory<Program>>
+    public class GetFormLayoutsV4Tests : PreviewControllerTestsBase<GetFormLayoutsV4Tests>, IClassFixture<WebApplicationFactory<Program>>
     {
 
-        public GetFormLayoutsForStatefulApps(WebApplicationFactory<Program> factory) : base(factory)
+        public GetFormLayoutsV4Tests(WebApplicationFactory<Program> factory) : base(factory)
         {
         }
 
         [Fact]
-        public async Task Get_FormLayoutsForStatefulApp_Ok()
+        public async Task Get_FormLayoutsForV4App_Ok()
         {
-            string expectedFormLayout1 = TestDataHelper.GetFileFromRepo(Org, StatefulApp, Developer, $"App/ui/{LayoutSetName}/layouts/layoutFile1InSet1.json");
-            string expectedFormLayout2 = TestDataHelper.GetFileFromRepo(Org, StatefulApp, Developer, $"App/ui/{LayoutSetName}/layouts/layoutFile2InSet1.json");
+            string expectedFormLayout1 = TestDataHelper.GetFileFromRepo(Org, AppV4, Developer, $"App/ui/{LayoutSetName}/layouts/layoutFile1InSet1.json");
+            string expectedFormLayout2 = TestDataHelper.GetFileFromRepo(Org, AppV4, Developer, $"App/ui/{LayoutSetName}/layouts/layoutFile2InSet1.json");
             string expectedFormLayouts = "{\"layoutFile1InSet1\":" + expectedFormLayout1 + ",\"layoutFile2InSet1\":" + expectedFormLayout2 + "}";
 
-            string dataPathWithData = $"{Org}/{StatefulApp}/api/layouts/{LayoutSetName}";
+            string dataPathWithData = $"{Org}/{AppV4}/api/layouts/{LayoutSetName}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetImageTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetImageTests.cs
@@ -20,9 +20,9 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_Image_From_Wwww_Root_Folder_Ok()
         {
-            byte[] expectedImageData = TestDataHelper.GetFileAsByteArrayFromRepo(Org, App, Developer, "App/wwwroot/AltinnD-logo.svg");
+            byte[] expectedImageData = TestDataHelper.GetFileAsByteArrayFromRepo(Org, AppV3, Developer, "App/wwwroot/AltinnD-logo.svg");
 
-            string dataPathWithData = $"{Org}/{App}/AltinnD-logo.svg";
+            string dataPathWithData = $"{Org}/{AppV3}/AltinnD-logo.svg";
 
             using HttpResponseMessage response = await HttpClient.GetAsync(dataPathWithData);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -35,9 +35,9 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_Image_From_Sub_Folder_Ok()
         {
-            byte[] expectedImageData = TestDataHelper.GetFileAsByteArrayFromRepo(Org, App, Developer, "App/wwwroot/images/AltinnD-logo.svg");
+            byte[] expectedImageData = TestDataHelper.GetFileAsByteArrayFromRepo(Org, AppV3, Developer, "App/wwwroot/images/AltinnD-logo.svg");
 
-            string dataPathWithData = $"{Org}/{App}/images/AltinnD-logo.svg";
+            string dataPathWithData = $"{Org}/{AppV3}/images/AltinnD-logo.svg";
 
             using HttpResponseMessage response = await HttpClient.GetAsync(dataPathWithData);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -50,9 +50,9 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_Image_From_Sub_Sub_Folder_Ok()
         {
-            byte[] expectedImageData = TestDataHelper.GetFileAsByteArrayFromRepo(Org, App, Developer, "App/wwwroot/images/subImagesFolder/AltinnD-logo.svg");
+            byte[] expectedImageData = TestDataHelper.GetFileAsByteArrayFromRepo(Org, AppV3, Developer, "App/wwwroot/images/subImagesFolder/AltinnD-logo.svg");
 
-            string dataPathWithData = $"{Org}/{App}/images/subImagesFolder/AltinnD-logo.svg";
+            string dataPathWithData = $"{Org}/{AppV3}/images/subImagesFolder/AltinnD-logo.svg";
 
             using HttpResponseMessage response = await HttpClient.GetAsync(dataPathWithData);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -65,7 +65,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_Image_Non_Existing_Folder_Returns_NotFound()
         {
-            string dataPathWithData = $"{Org}/{App}/images/subImagesFolder/SubSubImageFolder/AltinnD-logo.svg";
+            string dataPathWithData = $"{Org}/{AppV3}/images/subImagesFolder/SubSubImageFolder/AltinnD-logo.svg";
 
             using HttpResponseMessage response = await HttpClient.GetAsync(dataPathWithData);
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -74,7 +74,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_Image_Non_Existing_Image_Return_NotFound()
         {
-            string dataPathWithData = $"{Org}/{App}/images/subImagesFolder/non-existing-image.svg";
+            string dataPathWithData = $"{Org}/{AppV3}/images/subImagesFolder/non-existing-image.svg";
 
             using HttpResponseMessage response = await HttpClient.GetAsync(dataPathWithData);
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetOptionsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetOptionsTests.cs
@@ -17,7 +17,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_Options_when_options_exists_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/api/options/test-options";
+            string dataPathWithData = $"{Org}/{AppV3}/api/options/test-options";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
@@ -29,9 +29,9 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
-        public async Task Get_Options_when_options_exists_for_stateful_app_Ok()
+        public async Task Get_Options_when_options_exists_for_v4_app_Ok()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/options/test-options";
+            string dataPathWithData = $"{Org}/{AppV4}/instances/{PartyId}/{InstanceGuId}/options/test-options";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
@@ -45,7 +45,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_Options_when_no_options_exist_returns_Ok_empty_list()
         {
-            string dataPathWithData = $"{Org}/{App}/api/options/non-existing-options";
+            string dataPathWithData = $"{Org}/{AppV3}/api/options/non-existing-options";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleConfigurationTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleConfigurationTests.cs
@@ -35,7 +35,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_RuleConfiguration_NoContent()
         {
-            string dataPathWithData = $"{Org}/{App}/api/resource/RuleConfiguration.json";
+            string dataPathWithData = $"{Org}/{AppV3}/api/resource/RuleConfiguration.json";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleConfigurationV4Tests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleConfigurationV4Tests.cs
@@ -9,17 +9,17 @@ using Xunit;
 
 namespace Designer.Tests.Controllers.PreviewController
 {
-    public class GetRuleConfigurationStatefulTests : PreviewControllerTestsBase<GetRuleConfigurationStatefulTests>, IClassFixture<WebApplicationFactory<Program>>
+    public class GetRuleConfigurationV4Tests : PreviewControllerTestsBase<GetRuleConfigurationV4Tests>, IClassFixture<WebApplicationFactory<Program>>
     {
 
-        public GetRuleConfigurationStatefulTests(WebApplicationFactory<Program> factory) : base(factory)
+        public GetRuleConfigurationV4Tests(WebApplicationFactory<Program> factory) : base(factory)
         {
         }
 
         [Fact]
-        public async Task Get_RuleConfigurationForStatefulAppWithoutRuleConfig_NoContent()
+        public async Task Get_RuleConfigurationForV4AppWithoutRuleConfig_NoContent()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/api/ruleconfiguration/{LayoutSetName}";
+            string dataPathWithData = $"{Org}/{AppV4}/api/ruleconfiguration/{LayoutSetName}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
@@ -27,11 +27,11 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
-        public async Task Get_RuleConfigurationForStatefulAppWithRuleConfig_Ok()
+        public async Task Get_RuleConfigurationForV4AppWithRuleConfig_Ok()
         {
-            string expectedRuleConfig = TestDataHelper.GetFileFromRepo(Org, StatefulApp, Developer, $"App/ui/{LayoutSetName2}/RuleConfiguration.json");
+            string expectedRuleConfig = TestDataHelper.GetFileFromRepo(Org, AppV4, Developer, $"App/ui/{LayoutSetName2}/RuleConfiguration.json");
 
-            string dataPathWithData = $"{Org}/{StatefulApp}/api/ruleconfiguration/{LayoutSetName2}";
+            string dataPathWithData = $"{Org}/{AppV4}/api/ruleconfiguration/{LayoutSetName2}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleHandlerTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleHandlerTests.cs
@@ -16,7 +16,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_RuleHandler_NoContent()
         {
-            string dataPathWithData = $"{Org}/{App}/api/resource/RuleHandler.js";
+            string dataPathWithData = $"{Org}/{AppV3}/api/resource/RuleHandler.js";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleHandlerV4Tests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleHandlerV4Tests.cs
@@ -6,17 +6,17 @@ using Xunit;
 
 namespace Designer.Tests.Controllers.PreviewController
 {
-    public class GetRuleHandlerStatefulTests : PreviewControllerTestsBase<GetRuleHandlerStatefulTests>, IClassFixture<WebApplicationFactory<Program>>
+    public class GetRuleHandlerV4Tests : PreviewControllerTestsBase<GetRuleHandlerV4Tests>, IClassFixture<WebApplicationFactory<Program>>
     {
 
-        public GetRuleHandlerStatefulTests(WebApplicationFactory<Program> factory) : base(factory)
+        public GetRuleHandlerV4Tests(WebApplicationFactory<Program> factory) : base(factory)
         {
         }
 
         [Fact]
-        public async Task Get_RuleHandlerForStatefulAppWithoutRuleHandler_NoContent()
+        public async Task Get_RuleHandlerForV4AppWithoutRuleHandler_NoContent()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/api/rulehandler/{LayoutSetName}";
+            string dataPathWithData = $"{Org}/{AppV4}/api/rulehandler/{LayoutSetName}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
@@ -24,9 +24,9 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
-        public async Task Get_RuleHandlerForStatefulAppWithRuleHandler_Ok()
+        public async Task Get_RuleHandlerForV4AppWithRuleHandler_Ok()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/api/rulehandler/{LayoutSetName2}";
+            string dataPathWithData = $"{Org}/{AppV4}/api/rulehandler/{LayoutSetName2}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/InstanceForNextTaskTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/InstanceForNextTaskTests.cs
@@ -20,9 +20,9 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_InstanceForNextProcess_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}";
+            string dataPathWithData = $"{Org}/{AppV3}/instances/{PartyId}/{InstanceGuId}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={App}&selectedLayoutSet=");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV3}&selectedLayoutSet=");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -35,11 +35,11 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
-        public async Task Get_InstanceForNextTaskForStatefulApp_Ok_TaskIsIncreased()
+        public async Task Get_InstanceForNextTaskForV4App_Ok_TaskIsIncreased()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}";
+            string dataPathWithData = $"{Org}/{AppV4}/instances/{PartyId}/{InstanceGuId}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={StatefulApp}&selectedLayoutSet={LayoutSetName}");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV4}&selectedLayoutSet={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/InstancesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/InstancesTests.cs
@@ -23,11 +23,11 @@ namespace Designer.Tests.Controllers.PreviewController
         public async Task Post_Instance_Ok()
         {
             string targetRepository = TestDataHelper.GenerateTestRepoName();
-            await CopyRepositoryForTest(Org, App, Developer, targetRepository);
+            await CopyRepositoryForTest(Org, AppV3, Developer, targetRepository);
 
             string dataPathWithData = $"{Org}/{targetRepository}/instances?instanceOwnerPartyId=51001";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={App}&selectedLayoutSet=");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV3}&selectedLayoutSet=");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -40,14 +40,14 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
-        public async Task Post_InstanceForStatefulApp_Ok()
+        public async Task Post_InstanceForV4App_Ok()
         {
             string targetRepository = TestDataHelper.GenerateTestRepoName();
-            await CopyRepositoryForTest(Org, StatefulApp, Developer, targetRepository);
+            await CopyRepositoryForTest(Org, AppV4, Developer, targetRepository);
 
             string dataPathWithData = $"{Org}/{targetRepository}/instances?instanceOwnerPartyId=51001";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={StatefulApp}&selectedLayoutSet={LayoutSetName}");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV4}&selectedLayoutSet={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -63,11 +63,11 @@ namespace Designer.Tests.Controllers.PreviewController
         public async Task Post_InstanceForCustomReceipt_Ok()
         {
             string targetRepository = TestDataHelper.GenerateTestRepoName();
-            await CopyRepositoryForTest(Org, StatefulApp, Developer, targetRepository);
+            await CopyRepositoryForTest(Org, AppV4, Developer, targetRepository);
 
             string dataPathWithData = $"{Org}/{targetRepository}/instances?instanceOwnerPartyId=51001";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={StatefulApp}&selectedLayoutSet={CustomReceiptLayoutSetName2}");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV4}&selectedLayoutSet={CustomReceiptLayoutSetName2}");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/KeepAliveTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/KeepAliveTests.cs
@@ -16,7 +16,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_KeepAlive_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/api/authentication/keepAlive";
+            string dataPathWithData = $"{Org}/{AppV3}/api/authentication/keepAlive";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/LanguageTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/LanguageTests.cs
@@ -19,7 +19,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_Text_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/api/v1/texts/nb";
+            string dataPathWithData = $"{Org}/{AppV3}/api/v1/texts/nb";
 
             using HttpResponseMessage response = await HttpClient.GetAsync(dataPathWithData);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSetsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSetsTests.cs
@@ -1,7 +1,12 @@
 ﻿using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Altinn.Studio.Designer.Models;
+using Designer.Tests.Utils;
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
+using SharedResources.Tests;
 using Xunit;
 
 namespace Designer.Tests.Controllers.PreviewController
@@ -13,9 +18,28 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
+        public async Task Get_LayoutSets_ShouldReturnLayoutSetsWithoutAnyUndefinedDataTypes()
+        {
+            string actualLayoutSetsString = TestDataHelper.GetFileFromRepo(Org, AppV4, Developer, "App/ui/layout-sets.json");
+            LayoutSets actualLayoutSets = JsonSerializer.Deserialize<LayoutSets>(actualLayoutSetsString);
+
+            string dataPathWithData = $"{Org}/{AppV4}/api/layoutsets";
+            using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
+
+            using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            LayoutSets responseLayoutSets = JsonSerializer.Deserialize<LayoutSets>(responseBody);
+
+            actualLayoutSets.Sets.Exists(set => set.DataType is null).Should().BeTrue();
+            responseLayoutSets.Sets.Exists(set => set.DataType is null).Should().BeFalse();
+        }
+
+        [Fact]
         public async Task Get_LayoutSets_NotFound()
         {
-            string dataPathWithData = $"{Org}/{App}/api/layoutsets";
+            string dataPathWithData = $"{Org}/{AppV3}/api/layoutsets";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSettingsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSettingsTests.cs
@@ -18,9 +18,9 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_LayoutSettings_Ok()
         {
-            string expectedLayoutSettings = TestDataHelper.GetFileFromRepo(Org, App, Developer, "App/ui/Settings.json");
+            string expectedLayoutSettings = TestDataHelper.GetFileFromRepo(Org, AppV3, Developer, "App/ui/Settings.json");
 
-            string dataPathWithData = $"{Org}/{App}/api/layoutsettings";
+            string dataPathWithData = $"{Org}/{AppV3}/api/layoutsettings";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSettingsV4Tests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSettingsV4Tests.cs
@@ -9,18 +9,18 @@ using Xunit;
 
 namespace Designer.Tests.Controllers.PreviewController
 {
-    public class LayoutSettingsForStatefulAppsTests : PreviewControllerTestsBase<LayoutSettingsForStatefulAppsTests>, IClassFixture<WebApplicationFactory<Program>>
+    public class LayoutSettingsV4Tests : PreviewControllerTestsBase<LayoutSettingsV4Tests>, IClassFixture<WebApplicationFactory<Program>>
     {
-        public LayoutSettingsForStatefulAppsTests(WebApplicationFactory<Program> factory) : base(factory)
+        public LayoutSettingsV4Tests(WebApplicationFactory<Program> factory) : base(factory)
         {
         }
 
         [Fact]
-        public async Task Get_LayoutSettingsForStatefulApps_Ok()
+        public async Task Get_LayoutSettingsForV4Apps_Ok()
         {
-            string expectedLayoutSettings = TestDataHelper.GetFileFromRepo(Org, StatefulApp, Developer, $"App/ui/{LayoutSetName}/Settings.json");
+            string expectedLayoutSettings = TestDataHelper.GetFileFromRepo(Org, AppV4, Developer, $"App/ui/{LayoutSetName}/Settings.json");
 
-            string dataPathWithData = $"{Org}/{StatefulApp}/api/layoutsettings/{LayoutSetName}";
+            string dataPathWithData = $"{Org}/{AppV4}/api/layoutsettings/{LayoutSetName}";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/PostAttachmentTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/PostAttachmentTests.cs
@@ -18,20 +18,20 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Post_Attachment_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/data?dataType=FileUploadId";
+            string dataPathWithData = $"{Org}/{AppV3}/instances/{PartyId}/{InstanceGuId}/data?dataType=FileUploadId";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={App}&selectedLayoutSet=");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV3}&selectedLayoutSet=");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         }
 
         [Fact]
-        public async Task Post_AttachmentForStateFulApp_Ok()
+        public async Task Post_AttachmentForV4App_Ok()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/data?dataType=FileUploadId";
+            string dataPathWithData = $"{Org}/{AppV4}/instances/{PartyId}/{InstanceGuId}/data?dataType=FileUploadId";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={StatefulApp}&selectedLayoutSet={LayoutSetName}");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV4}&selectedLayoutSet={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status201Created, (int)response.StatusCode);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTestsBase.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTestsBase.cs
@@ -10,8 +10,8 @@ namespace Designer.Tests.Controllers.PreviewController
     where TTestClass : class
     {
         protected const string Org = "ttd";
-        protected const string App = "preview-app";
-        protected const string StatefulApp = "app-with-layoutsets";
+        protected const string AppV3 = "preview-app";
+        protected const string AppV4 = "app-with-layoutsets";
         protected const string Developer = "testUser";
         protected const string LayoutSetName = "layoutSet1";
         protected const string LayoutSetName2 = "layoutSet2";

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/ProcessNextTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/ProcessNextTests.cs
@@ -20,9 +20,9 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_ProcessNext_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/process/next";
+            string dataPathWithData = $"{Org}/{AppV3}/instances/{PartyId}/{InstanceGuId}/process/next";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={App}&selectedLayoutSet=");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV3}&selectedLayoutSet=");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -35,11 +35,11 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
-        public async Task Get_ProcessNextForStatefulApp_Ok()
+        public async Task Get_ProcessNextForV4App_Ok()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/process/next";
+            string dataPathWithData = $"{Org}/{AppV4}/instances/{PartyId}/{InstanceGuId}/process/next";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={StatefulApp}&selectedLayoutSet={LayoutSetName}");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV4}&selectedLayoutSet={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/ProcessTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/ProcessTests.cs
@@ -22,9 +22,9 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_Process_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/process";
+            string dataPathWithData = $"{Org}/{AppV3}/instances/{PartyId}/{InstanceGuId}/process";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={App}&selectedLayoutSet=");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV3}&selectedLayoutSet=");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -36,11 +36,11 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
-        public async Task Get_ProcessForStatefulApp_Ok()
+        public async Task Get_ProcessForV4App_Ok()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/process";
+            string dataPathWithData = $"{Org}/{AppV4}/instances/{PartyId}/{InstanceGuId}/process";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={StatefulApp}&selectedLayoutSet={LayoutSetName}");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV4}&selectedLayoutSet={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/TextResourcesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/TextResourcesTests.cs
@@ -19,7 +19,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Get_TextResources_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/api/v1/textresources";
+            string dataPathWithData = $"{Org}/{AppV3}/api/v1/textresources";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/UpdateFormDataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/UpdateFormDataTests.cs
@@ -17,9 +17,9 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Put_UpdateFormData_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
+            string dataPathWithData = $"{Org}/{AppV3}/instances/{PartyId}/{InstanceGuId}/data/test-datatask-id";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Put, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={App}&selectedLayoutSet=");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV3}&selectedLayoutSet=");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/UpdateProcessNextTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/UpdateProcessNextTests.cs
@@ -20,9 +20,9 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Put_ProcessNext_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/instances/{PartyId}/{InstanceGuId}/process/next";
+            string dataPathWithData = $"{Org}/{AppV3}/instances/{PartyId}/{InstanceGuId}/process/next";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Put, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={App}&selectedLayoutSet=");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV3}&selectedLayoutSet=");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -32,11 +32,11 @@ namespace Designer.Tests.Controllers.PreviewController
         }
 
         [Fact]
-        public async Task Put_ProcessNextForStatefulAppForNonExistingTask_Ok()
+        public async Task Put_ProcessNextForV4AppForNonExistingTask_Ok()
         {
-            string dataPathWithData = $"{Org}/{StatefulApp}/instances/{PartyId}/{InstanceGuId}/process/next";
+            string dataPathWithData = $"{Org}/{AppV4}/instances/{PartyId}/{InstanceGuId}/process/next";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Put, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={StatefulApp}&selectedLayoutSet={LayoutSetName}");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV4}&selectedLayoutSet={LayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/ValidateInstantiationTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/ValidateInstantiationTests.cs
@@ -18,7 +18,7 @@ namespace Designer.Tests.Controllers.PreviewController
         [Fact]
         public async Task Post_ValidateInstantiation_Ok()
         {
-            string dataPathWithData = $"{Org}/{App}/api/v1/parties/validateInstantiation";
+            string dataPathWithData = $"{Org}/{AppV3}/api/v1/parties/validateInstantiation";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, dataPathWithData);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/config/applicationmetadata.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/config/applicationmetadata.json
@@ -51,9 +51,22 @@
             ],
             "appLogic": {
                 "autoCreate": true,
-                "classRef": "Altinn.App.Models.datamodel"
+                "classRef": "Altinn.App.Models.HvemErHvem_M"
             },
             "taskId": "Task_3",
+            "maxCount": 1,
+            "minCount": 1
+        },
+        {
+            "id": "receiptDataType",
+            "allowedContentTypes": [
+                "application/xml"
+            ],
+            "appLogic": {
+                "autoCreate": true,
+                "classRef": "Altinn.App.Models.receiptDataType"
+            },
+            "taskId": "CustomReceipt",
             "maxCount": 1,
             "minCount": 1
         }
@@ -65,9 +78,6 @@
         "subUnit": false
     },
     "autoDeleteOnProcessEnd": false,
-    "onEntry": {
-        "show": "select-instance"
-    },
     "created": "2021-02-06T15:18:12.2060944Z",
     "createdBy": "jeeva",
     "lastChanged": "2021-02-06T15:18:12.2062288Z",

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layout-sets.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layout-sets.json
@@ -17,7 +17,7 @@
         },
         {
             "id": "layoutSet3",
-            "dataType": null,
+            "dataType": "HvemErHvem_M",
             "tasks": [
                 "Task_3"
             ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Mock that current layout set/task that is edited in ux-editor has a connected datatype for preview not to crash. Then the app-developer is not presented with the generic "Ukjent feil" in preview when adding a data task from process editor and not adding a datatype immediately. 

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
