### PR TITLE
Resourceadm: return resources from all environments in resource list

### DIFF
--- a/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -13,7 +13,6 @@ using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.ModelBinding.Constants;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Interfaces;
-using Altinn.Studio.Designer.TypedHttpClients.Altinn2Metadata;
 using Altinn.Studio.Designer.TypedHttpClients.ResourceRegistryOptions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -32,20 +31,18 @@ namespace Altinn.Studio.Designer.Controllers
         private readonly IResourceRegistryOptions _resourceRegistryOptions;
         private readonly IMemoryCache _memoryCache;
         private readonly CacheSettings _cacheSettings;
-        private readonly IAltinn2MetadataClient _altinn2MetadataClient;
         private readonly IOrgService _orgService;
         private readonly IResourceRegistry _resourceRegistry;
         private readonly ResourceRegistryIntegrationSettings _resourceRegistrySettings;
         private readonly IUserRequestsSynchronizationService _userRequestsSynchronizationService;
 
-        public ResourceAdminController(IGitea gitea, IRepository repository, IResourceRegistryOptions resourceRegistryOptions, IMemoryCache memoryCache, IOptions<CacheSettings> cacheSettings, IAltinn2MetadataClient altinn2MetadataClient, IOrgService orgService, IOptions<ResourceRegistryIntegrationSettings> resourceRegistryEnvironment, IResourceRegistry resourceRegistry, IUserRequestsSynchronizationService userRequestsSynchronizationService)
+        public ResourceAdminController(IGitea gitea, IRepository repository, IResourceRegistryOptions resourceRegistryOptions, IMemoryCache memoryCache, IOptions<CacheSettings> cacheSettings, IOrgService orgService, IOptions<ResourceRegistryIntegrationSettings> resourceRegistryEnvironment, IResourceRegistry resourceRegistry, IUserRequestsSynchronizationService userRequestsSynchronizationService)
         {
             _giteaApi = gitea;
             _repository = repository;
             _resourceRegistryOptions = resourceRegistryOptions;
             _memoryCache = memoryCache;
             _cacheSettings = cacheSettings.Value;
-            _altinn2MetadataClient = altinn2MetadataClient;
             _orgService = orgService;
             _resourceRegistrySettings = resourceRegistryEnvironment.Value;
             _resourceRegistry = resourceRegistry;

--- a/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -166,7 +166,7 @@ namespace Altinn.Studio.Designer.Controllers
             foreach (ServiceResource resource in repositoryResourceList)
             {
                 ListviewServiceResource listviewResource = await _giteaApi.MapServiceResourceToListViewResource(org, string.Format("{0}-resources", org), resource);
-                listviewResource.HasPolicy = _repository.ResourceHasPolicy(org, repository, resource);
+                listviewResource.HasPolicy = true;
                 listviewResource.Environments = ["gitea"];
                 listviewServiceResources.Add(listviewResource);
             }

--- a/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -168,7 +168,7 @@ namespace Altinn.Studio.Designer.Controllers
                 listviewServiceResources.Add(listviewResource);
             }
 
-            if (includeEnvResources == true)
+            if (includeEnvResources)
             {
                 foreach (string environment in _resourceRegistrySettings.Keys)
                 {

--- a/backend/src/Designer/Models/ListviewServiceResource.cs
+++ b/backend/src/Designer/Models/ListviewServiceResource.cs
@@ -24,11 +24,16 @@ namespace Altinn.Studio.Designer.Models
         /// <summary>
         /// Timestamp for when the resourcefile was last changed
         /// </summary>
-        public DateTime LastChanged { get; set; }
+        public DateTime? LastChanged { get; set; }
 
         /// <summary>
         /// A bool indicating if the resource has a policy or not
         /// </summary>
         public bool? HasPolicy { get; set; }
+
+        /// <summary>
+        /// A list of environments the resource is deployed in
+        /// </summary>
+        public IList<string> Environments { get; set; }
     }
 }

--- a/backend/src/Designer/Services/Implementation/GiteaAPIWrapper/GiteaAPIWrapper.cs
+++ b/backend/src/Designer/Services/Implementation/GiteaAPIWrapper/GiteaAPIWrapper.cs
@@ -247,7 +247,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 listviewResource.CreatedBy = userFullName;
             }
 
-            if (listviewResource.LastChanged.Year.Equals(1))
+            if (listviewResource.LastChanged == null)
             {
                 listviewResource.LastChanged = DateTime.Now;
             }

--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -538,35 +538,6 @@ namespace Altinn.Studio.Designer.Services.Implementation
             return await _resourceRegistryService.PublishServiceResource(resource, env, policy);
         }
 
-        public bool ResourceHasPolicy(string org, string repository, ServiceResource resource)
-        {
-            List<FileSystemObject> contents = new();
-            string repositoryPath = _settings.GetServicePath(org, repository, AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext));
-
-            if (Directory.Exists(repositoryPath))
-            {
-                string[] dirs = Directory.GetDirectories(repositoryPath);
-                foreach (string directoryPath in dirs)
-                {
-                    FileSystemObject d = GetFileSystemObjectForDirectory(directoryPath);
-                    if (!d.Name.StartsWith(".") && d.Name.ToLower().Contains(resource.Identifier.ToLower()))
-                    {
-                        contents.Add(d);
-                        string[] files = Directory.GetFiles(d.Path);
-                        foreach (string file in files)
-                        {
-                            if (file.EndsWith("policy.xml"))
-                            {
-                                return true;
-                            }
-                        }
-                    }
-                }
-            }
-
-            return false;
-        }
-
         private List<FileSystemObject> GetResourceFiles(string org, string repository, string path = "")
         {
             List<FileSystemObject> contents = GetContents(org, repository, path);

--- a/backend/src/Designer/Services/Implementation/ResourceRegistryService.cs
+++ b/backend/src/Designer/Services/Implementation/ResourceRegistryService.cs
@@ -191,6 +191,23 @@ namespace Altinn.Studio.Designer.Services.Implementation
             return null;
         }
 
+        public async Task<XacmlPolicy> GetResourcePolicy(string id, string env)
+        {
+            string policyUrl = $"{GetResourceRegistryBaseUrl(env)}{_platformSettings.ResourceRegistryUrl}/{id}/policy";
+
+            HttpResponseMessage response = await _httpClient.GetAsync(policyUrl);
+            response.EnsureSuccessStatusCode();
+
+            string contentString = await response.Content.ReadAsStringAsync();
+            XacmlPolicy policy;
+            using (XmlReader reader = XmlReader.Create(new StringReader(contentString)))
+            {
+                policy = XacmlParser.ParseXacmlPolicy(reader);
+            }
+
+            return policy;
+        }
+
         public async Task<List<ServiceResource>> GetResources(string env)
         {
             string resourceUrl;
@@ -218,7 +235,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
         ///     Get resource list
         /// </summary>
         /// <returns>List of all resources</returns>
-        public async Task<List<ServiceResource>> GetResourceList(string env)
+        public async Task<List<ServiceResource>> GetResourceList(string env, bool includeAltinn2)
         {
 
             string endpointUrl;
@@ -226,11 +243,11 @@ namespace Altinn.Studio.Designer.Services.Implementation
             //Checks if not tested locally by passing dev as env parameter
             if (!env.ToLower().Equals("dev"))
             {
-                endpointUrl = $"{GetResourceRegistryBaseUrl(env)}{_platformSettings.ResourceRegistryUrl}/resourcelist/";
+                endpointUrl = $"{GetResourceRegistryBaseUrl(env)}{_platformSettings.ResourceRegistryUrl}/resourcelist/?includeApps=false&includeAltinn2={includeAltinn2}";
             }
             else
             {
-                endpointUrl = $"{_platformSettings.ResourceRegistryDefaultBaseUrl}{_platformSettings.ResourceRegistryUrl}/resourcelist/";
+                endpointUrl = $"{_platformSettings.ResourceRegistryDefaultBaseUrl}{_platformSettings.ResourceRegistryUrl}/resourcelist/?includeApps=false&includeAltinn2={includeAltinn2}";
             }
 
             JsonSerializerOptions options = new JsonSerializerOptions

--- a/backend/src/Designer/Services/Implementation/ResourceRegistryService.cs
+++ b/backend/src/Designer/Services/Implementation/ResourceRegistryService.cs
@@ -21,7 +21,6 @@ using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.Dto;
 using Altinn.Studio.Designer.Services.Interfaces;
-using Altinn.Studio.PolicyAdmin.Constants;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -293,7 +292,6 @@ namespace Altinn.Studio.Designer.Services.Implementation
             response.EnsureSuccessStatusCode();
 
             string contentString = await response.Content.ReadAsStringAsync();
-            contentString = contentString.Replace("urn:altinn:resourceregistry", AltinnXacmlConstants.MatchAttributeIdentifiers.ResourceRegistryResource);
             XacmlPolicy policy;
             using (XmlReader reader = XmlReader.Create(new StringReader(contentString)))
             {

--- a/backend/src/Designer/Services/Interfaces/IRepository.cs
+++ b/backend/src/Designer/Services/Interfaces/IRepository.cs
@@ -128,15 +128,6 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         StatusCodeResult AddServiceResource(string org, ServiceResource newResource);
 
         /// <summary>
-        /// Checks a resource if it has a policy by checking if a policyfile exists in the same folder as the resourcefile.
-        /// </summary>
-        /// <param name="org">The organisation which owns the repository</param>
-        /// <param name="repository">The repository</param>
-        /// <param name="resource">The resource which is to be checked for policy</param>
-        /// <returns>Returns true if resourcefile has a policyfile along with it. If not, returns false</returns>
-        bool ResourceHasPolicy(string org, string repository, ServiceResource resource);
-
-        /// <summary>
         /// Publishes a specific resource to the ResourceRegistry
         /// </summary>
         /// <param name="org">The organisation that owns the repository</param>

--- a/backend/src/Designer/Services/Interfaces/IResourceRegistry.cs
+++ b/backend/src/Designer/Services/Interfaces/IResourceRegistry.cs
@@ -52,7 +52,7 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// Get Policy from Altinn 3 resource
         /// </summary>
         Task<XacmlPolicy> GetResourcePolicy(string resourceId, string environment);
-        
+
         /// <summary>
         /// Create a new access list for an organization in a given environment
         /// </summary>

--- a/backend/src/Designer/Services/Interfaces/IResourceRegistry.cs
+++ b/backend/src/Designer/Services/Interfaces/IResourceRegistry.cs
@@ -36,7 +36,7 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// Integration point for retrieving the full list of resources
         /// </summary>
         /// <returns>The resource full list of all resources if exists</returns>
-        Task<List<ServiceResource>> GetResourceList(string env);
+        Task<List<ServiceResource>> GetResourceList(string env, bool includeAltinn2);
 
         /// <summary>
         /// Get Resource from Altinn 2 service
@@ -48,6 +48,11 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// </summary>
         Task<XacmlPolicy> GetXacmlPolicy(string serviceCode, int serviceEditionCode, string identifier, string environment);
 
+        /// <summary>
+        /// Get Policy from Altinn 3 resource
+        /// </summary>
+        Task<XacmlPolicy> GetResourcePolicy(string resourceId, string environment);
+        
         /// <summary>
         /// Create a new access list for an organization in a given environment
         /// </summary>

--- a/backend/tests/Designer.Tests/Controllers/ResourceAdminController/GetAltinn2LinkServicesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ResourceAdminController/GetAltinn2LinkServicesTests.cs
@@ -37,7 +37,7 @@ namespace Designer.Tests.Controllers.ResourceAdminController
                     ExternalServiceCode = "Test2",
                     ExternalServiceEditionCode = 123
                 });
-                ResourceRegistryMock.Setup(r => r.GetResourceList(It.IsAny<string>())).ReturnsAsync(new List<ServiceResource>());
+                ResourceRegistryMock.Setup(r => r.GetResourceList(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(new List<ServiceResource>());
                 Altinn2MetadataClientMock.Setup(r => r.AvailableServices(It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(services);
 
                 // Act


### PR DESCRIPTION
## Description

- Return resources from all environments in resource list
- Add service to import resource and Xacml policy from environment to Gitea
- Add function to get Xacml policy for resource from resource registry
- Remove hasPolicy calculation for resource list
- Allow resourcelist last changed date to be null
- Remove temporary fix replacing `urn:altinn:resourceregistry` in xacml policy file on import from Altinn 2 (already fixed in Altinn 2 export policy code)
- Whitespace changes

## Related Issue(s)

- #12732 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
