### PR TITLE
12696 automatically add payment data type to applicationmetadata when adding payment task

### DIFF
--- a/backend/src/Designer/Controllers/ProcessModelingController.cs
+++ b/backend/src/Designer/Controllers/ProcessModelingController.cs
@@ -146,5 +146,23 @@ namespace Altinn.Studio.Designer.Controllers
             Stream processDefinitionStream = _processModelingService.GetProcessDefinitionStream(editingContext);
             return new FileStreamResult(processDefinitionStream, MediaTypeNames.Text.Plain);
         }
+
+        [HttpPost("data-type/{dataTypeId}")]
+        public async Task<ActionResult> AddDataTypeToApplicationMetadata(string org, string repo, [FromRoute] string dataTypeId, CancellationToken cancellationToken)
+        {
+            string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
+            var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, repo, developer);
+            await _processModelingService.AddDataTypeToApplicationMetadataAsync(editingContext, dataTypeId, cancellationToken);
+            return Ok();
+        }
+
+        [HttpDelete("data-type/{dataTypeId}")]
+        public async Task<ActionResult> DeleteDataTypeFromApplicationMetadata(string org, string repo, [FromRoute] string dataTypeId, CancellationToken cancellationToken)
+        {
+            string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
+            var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, repo, developer);
+            await _processModelingService.DeleteDataTypeFromApplicationMetadataAsync(editingContext, dataTypeId, cancellationToken);
+            return Ok();
+        }
     }
 }

--- a/backend/src/Designer/Services/Implementation/ProcessModeling/ProcessModelingService.cs
+++ b/backend/src/Designer/Services/Implementation/ProcessModeling/ProcessModelingService.cs
@@ -4,8 +4,10 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Models.App;
 using Altinn.Studio.Designer.Services.Interfaces;
 using NuGet.Versioning;
 
@@ -51,6 +53,30 @@ namespace Altinn.Studio.Designer.Services.Implementation.ProcessModeling
         {
             AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(altinnRepoEditingContext.Org, altinnRepoEditingContext.Repo, altinnRepoEditingContext.Developer);
             return altinnAppGitRepository.GetProcessDefinitionFile();
+        }
+
+        public async Task AddDataTypeToApplicationMetadataAsync(AltinnRepoEditingContext altinnRepoEditingContext, string dataTypeId, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(altinnRepoEditingContext.Org, altinnRepoEditingContext.Repo, altinnRepoEditingContext.Developer);
+            ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
+            applicationMetadata.DataTypes.Add(new DataType
+            {
+                Id = dataTypeId,
+                AllowedContentTypes = ["application/json"],
+                MaxCount = 1,
+                EnablePdfCreation = false
+            });
+            await altinnAppGitRepository.SaveApplicationMetadata(applicationMetadata);
+        }
+
+        public async Task DeleteDataTypeFromApplicationMetadataAsync(AltinnRepoEditingContext altinnRepoEditingContext, string dataTypeId, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(altinnRepoEditingContext.Org, altinnRepoEditingContext.Repo, altinnRepoEditingContext.Developer);
+            ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
+            applicationMetadata.DataTypes.RemoveAll(dataType => dataType.Id == dataTypeId);
+            await altinnAppGitRepository.SaveApplicationMetadata(applicationMetadata);
         }
 
         private IEnumerable<string> EnumerateTemplateResources(SemanticVersion version)

--- a/backend/src/Designer/Services/Implementation/ProcessModeling/ProcessModelingService.cs
+++ b/backend/src/Designer/Services/Implementation/ProcessModeling/ProcessModelingService.cs
@@ -59,22 +59,25 @@ namespace Altinn.Studio.Designer.Services.Implementation.ProcessModeling
         {
             cancellationToken.ThrowIfCancellationRequested();
             AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(altinnRepoEditingContext.Org, altinnRepoEditingContext.Repo, altinnRepoEditingContext.Developer);
-            ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
-            applicationMetadata.DataTypes.Add(new DataType
+            ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata(cancellationToken);
+            if (!applicationMetadata.DataTypes.Exists(dataType => dataType.Id == dataTypeId))
             {
-                Id = dataTypeId,
-                AllowedContentTypes = ["application/json"],
-                MaxCount = 1,
-                EnablePdfCreation = false
-            });
-            await altinnAppGitRepository.SaveApplicationMetadata(applicationMetadata);
+                applicationMetadata.DataTypes.Add(new DataType
+                {
+                    Id = dataTypeId,
+                    AllowedContentTypes = ["application/json"],
+                    MaxCount = 1,
+                    EnablePdfCreation = false
+                });
+                await altinnAppGitRepository.SaveApplicationMetadata(applicationMetadata);
+            }
         }
 
         public async Task DeleteDataTypeFromApplicationMetadataAsync(AltinnRepoEditingContext altinnRepoEditingContext, string dataTypeId, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(altinnRepoEditingContext.Org, altinnRepoEditingContext.Repo, altinnRepoEditingContext.Developer);
-            ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
+            ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata(cancellationToken);
             applicationMetadata.DataTypes.RemoveAll(dataType => dataType.Id == dataTypeId);
             await altinnAppGitRepository.SaveApplicationMetadata(applicationMetadata);
         }

--- a/backend/src/Designer/Services/Interfaces/IProcessModelingService.cs
+++ b/backend/src/Designer/Services/Interfaces/IProcessModelingService.cs
@@ -39,5 +39,25 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// <param name="altinnRepoEditingContext">An <see cref="AltinnRepoEditingContext"/>.</param>
         /// <returns>A <see cref="Stream"/> of a process definition file.</returns>
         Stream GetProcessDefinitionStream(AltinnRepoEditingContext altinnRepoEditingContext);
+
+        /// <summary>
+        /// Adds a simple dataType to applicationMetadata.
+        /// Used for adding a dataType when signing and payment tasks are added to the process.
+        /// </summary>
+        /// <param name="altinnRepoEditingContext">An <see cref="AltinnRepoEditingContext"/>.</param>
+        /// <param name="dataTypeId">Id for the added data type</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
+        Task AddDataTypeToApplicationMetadataAsync(AltinnRepoEditingContext altinnRepoEditingContext,
+            string dataTypeId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes a simple dataType from applicationMetadata.
+        /// Used for deleting a dataType when signing and payment tasks are removed from the process.
+        /// </summary>
+        /// <param name="altinnRepoEditingContext">An <see cref="AltinnRepoEditingContext"/>.</param>
+        /// <param name="dataTypeId">Id for the data type to remove</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
+        Task DeleteDataTypeFromApplicationMetadataAsync(AltinnRepoEditingContext altinnRepoEditingContext,
+            string dataTypeId, CancellationToken cancellationToken = default);
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/AddDataTypeToApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/AddDataTypeToApplicationMetadataTests.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Altinn.Platform.Storage.Interface.Models;
+using Designer.Tests.Controllers.ApiTests;
+using Designer.Tests.Utils;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Designer.Tests.Controllers.ProcessModelingController
+{
+    public class AddDataTypeToApplicationMetadataTests : DisagnerEndpointsTestsBase<AddDataTypeToApplicationMetadataTests>, IClassFixture<WebApplicationFactory<Program>>
+    {
+        private static string VersionPrefix(string org, string repository, string dataTypeId) => $"/designer/api/{org}/{repository}/process-modelling/data-type/{dataTypeId}";
+
+        public AddDataTypeToApplicationMetadataTests(WebApplicationFactory<Program> factory) : base(factory)
+        {
+        }
+
+        [Theory]
+        [InlineData("ttd", "empty-app", "testUser", "paymentInformation-1234")]
+        public async Task AddDataTypeToApplicationMetadata_ShouldAddDataTypeAndReturnOK(string org, string app, string developer, string dataTypeId)
+        {
+            string targetRepository = TestDataHelper.GenerateTestRepoName();
+            await CopyRepositoryForTest(org, app, developer, targetRepository);
+            string url = VersionPrefix(org, targetRepository, dataTypeId);
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, url);
+            using var response = await HttpClient.SendAsync(request);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            string appMetadataString = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
+            Application appMetadata = JsonSerializer.Deserialize<Application>(appMetadataString, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+            DataType expectedDataType = new()
+            {
+                Id = dataTypeId,
+                AllowedContentTypes = new List<string>() { "application/json" },
+                MaxCount = 1,
+                MinCount = 0,
+                EnablePdfCreation = false,
+                EnableFileScan = false,
+                ValidationErrorOnPendingFileScan = false,
+                EnabledFileAnalysers = new List<string>(),
+                EnabledFileValidators = new List<string>()
+            };
+
+            appMetadata.DataTypes.Count.Should().Be(2);
+            appMetadata.DataTypes.Find(dataType => dataType.Id == dataTypeId).Should().BeEquivalentTo(expectedDataType);
+        }
+
+        [Theory]
+        [InlineData("ttd", "empty-app", "testUser", "ref-data-as-pdf")]
+        public async Task AddDataTypeToApplicationMetadataWhenExists_ShouldNotAddDataTypeAndReturnOK(string org, string app, string developer, string dataTypeId)
+        {
+            string targetRepository = TestDataHelper.GenerateTestRepoName();
+            await CopyRepositoryForTest(org, app, developer, targetRepository);
+            string url = VersionPrefix(org, targetRepository, dataTypeId);
+            using var request = new HttpRequestMessage(HttpMethod.Post, url);
+            using var response = await HttpClient.SendAsync(request);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            string appMetadataString = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
+            Application appMetadata = JsonSerializer.Deserialize<Application>(appMetadataString, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            appMetadata.DataTypes.Count.Should().Be(1);
+        }
+    }
+}

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/DeleteDataTypeFromApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/DeleteDataTypeFromApplicationMetadataTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Altinn.Platform.Storage.Interface.Models;
+using Designer.Tests.Controllers.ApiTests;
+using Designer.Tests.Utils;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Designer.Tests.Controllers.ProcessModelingController
+{
+    public class DeleteDataTypeFromApplicationMetadataTests : DisagnerEndpointsTestsBase<DeleteDataTypeFromApplicationMetadataTests>, IClassFixture<WebApplicationFactory<Program>>
+    {
+        private static string VersionPrefix(string org, string repository, string dataTypeId) => $"/designer/api/{org}/{repository}/process-modelling/data-type/{dataTypeId}";
+
+        public DeleteDataTypeFromApplicationMetadataTests(WebApplicationFactory<Program> factory) : base(factory)
+        {
+        }
+
+        [Theory]
+        [InlineData("ttd", "empty-app", "testUser", "ref-data-as-pdf")]
+        public async Task DeleteDataTypeFromApplicationMetadata_ShouldDeleteDataTypeAndReturnOK(string org, string app, string developer, string dataTypeId)
+        {
+            string targetRepository = TestDataHelper.GenerateTestRepoName();
+            await CopyRepositoryForTest(org, app, developer, targetRepository);
+            string url = VersionPrefix(org, targetRepository, dataTypeId);
+
+            using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+            using var response = await HttpClient.SendAsync(request);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            string appMetadataString = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
+            Application appMetadata = JsonSerializer.Deserialize<Application>(appMetadataString, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            appMetadata.DataTypes.Count.Should().Be(0);
+        }
+    }
+}

--- a/frontend/app-development/features/processEditor/ProcessEditor.tsx
+++ b/frontend/app-development/features/processEditor/ProcessEditor.tsx
@@ -19,6 +19,8 @@ import { useDeleteLayoutSetMutation } from '../../hooks/mutations/useDeleteLayou
 import { useAppMetadataModelIdsQuery } from 'app-shared/hooks/queries/useAppMetadataModelIdsQuery';
 import { useUpdateProcessDataTypeMutation } from '../../hooks/mutations/useUpdateProcessDataTypeMutation';
 import type { MetaDataForm } from 'app-shared/types/BpmnMetaDataForm';
+import { useAddDataTypeToAppMetadata } from '../../hooks/mutations/useAddDataTypeToAppMetadata';
+import { useDeleteDataTypeFromAppMetadata } from '../../hooks/mutations/useDeleteDataTypeFromAppMetadata';
 
 enum SyncClientsName {
   FileSyncSuccess = 'FileSyncSuccess',
@@ -45,6 +47,8 @@ export const ProcessEditor = (): React.ReactElement => {
   );
   const { mutate: mutateDataType, isPending: updateDataTypePending } =
     useUpdateProcessDataTypeMutation(org, app);
+  const { mutate: addDataTypeToAppMetadata } = useAddDataTypeToAppMetadata(org, app);
+  const { mutate: deleteDataTypeFromAppMetadata } = useDeleteDataTypeFromAppMetadata(org, app);
   const existingCustomReceiptName: string | undefined = useCustomReceiptLayoutSetName(org, app);
   const { data: availableDataModelIds, isPending: availableDataModelIdsPending } =
     useAppMetadataModelIdsQuery(org, app);
@@ -109,6 +113,8 @@ export const ProcessEditor = (): React.ReactElement => {
       appLibVersion={appLibData.backendVersion}
       bpmnXml={hasBpmnQueryError ? null : bpmnXml}
       mutateDataType={mutateDataType}
+      addDataTypeToAppMetadata={addDataTypeToAppMetadata}
+      deleteDataTypeFromAppMetadata={deleteDataTypeFromAppMetadata}
       saveBpmn={saveBpmnXml}
     />
   );

--- a/frontend/app-development/hooks/mutations/useAddDataTypeToAppMetadata.test.ts
+++ b/frontend/app-development/hooks/mutations/useAddDataTypeToAppMetadata.test.ts
@@ -1,0 +1,23 @@
+import { renderHookWithMockStore } from '../../test/mocks';
+import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { waitFor } from '@testing-library/react';
+import { useAddDataTypeToAppMetadata } from './useAddDataTypeToAppMetadata';
+
+const org = 'org';
+const app = 'app';
+const dataTypeId = 'paymentInformation-1234';
+
+describe('useAddDataTypeToAppMetadata', () => {
+  it('Calls addDataTypeToAppMetadata with correct arguments and payload', async () => {
+    const addDataTypeToAppMetadata = renderHookWithMockStore()(() =>
+      useAddDataTypeToAppMetadata(org, app),
+    ).renderHookResult.result;
+    await addDataTypeToAppMetadata.current.mutateAsync({
+      dataTypeId,
+    });
+    await waitFor(() => expect(addDataTypeToAppMetadata.current.isSuccess).toBe(true));
+
+    expect(queriesMock.addDataTypeToAppMetadata).toHaveBeenCalledTimes(1);
+    expect(queriesMock.addDataTypeToAppMetadata).toHaveBeenCalledWith(org, app, dataTypeId);
+  });
+});

--- a/frontend/app-development/hooks/mutations/useAddDataTypeToAppMetadata.ts
+++ b/frontend/app-development/hooks/mutations/useAddDataTypeToAppMetadata.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
+
+export const useAddDataTypeToAppMetadata = (org: string, app: string) => {
+  const { addDataTypeToAppMetadata } = useServicesContext();
+
+  return useMutation({
+    mutationFn: ({ dataTypeId }: { dataTypeId: string }) =>
+      addDataTypeToAppMetadata(org, app, dataTypeId),
+  });
+};

--- a/frontend/app-development/hooks/mutations/useDeleteDataTypeFromAppMetadata.test.ts
+++ b/frontend/app-development/hooks/mutations/useDeleteDataTypeFromAppMetadata.test.ts
@@ -1,0 +1,23 @@
+import { renderHookWithMockStore } from '../../test/mocks';
+import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { useDeleteDataTypeFromAppMetadata } from './useDeleteDataTypeFromAppMetadata';
+import { waitFor } from '@testing-library/react';
+
+const org = 'org';
+const app = 'app';
+const dataTypeId = 'paymentInformation-1234';
+
+describe('useDeleteDataTypeFromAppMetadata', () => {
+  it('Calls deleteDataTypeFromAppMetadata with correct arguments and payload', async () => {
+    const deleteDataTypeFromAppMetadata = renderHookWithMockStore()(() =>
+      useDeleteDataTypeFromAppMetadata(org, app),
+    ).renderHookResult.result;
+    await deleteDataTypeFromAppMetadata.current.mutateAsync({
+      dataTypeId,
+    });
+    await waitFor(() => expect(deleteDataTypeFromAppMetadata.current.isSuccess).toBe(true));
+
+    expect(queriesMock.deleteDataTypeFromAppMetadata).toHaveBeenCalledTimes(1);
+    expect(queriesMock.deleteDataTypeFromAppMetadata).toHaveBeenCalledWith(org, app, dataTypeId);
+  });
+});

--- a/frontend/app-development/hooks/mutations/useDeleteDataTypeFromAppMetadata.ts
+++ b/frontend/app-development/hooks/mutations/useDeleteDataTypeFromAppMetadata.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
+
+export const useDeleteDataTypeFromAppMetadata = (org: string, app: string) => {
+  const { deleteDataTypeFromAppMetadata } = useServicesContext();
+
+  return useMutation({
+    mutationFn: ({ dataTypeId }: { dataTypeId: string }) =>
+      deleteDataTypeFromAppMetadata(org, app, dataTypeId),
+  });
+};

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -776,6 +776,7 @@
   "process_editor.configuration_panel_name_label": "Navn: ",
   "process_editor.configuration_panel_no_task_message": "Velg en oppgave i diagrammet til venstre for å se detaljer om valgt oppgave.",
   "process_editor.configuration_panel_no_task_title": "Ingen oppgave er valgt",
+  "process_editor.configuration_panel_payment_task": "Oppgave: Betaling",
   "process_editor.configuration_panel_select_datamodel": "Velg en datamodell",
   "process_editor.configuration_panel_set_datamodel": "Datamodell:",
   "process_editor.configuration_panel_set_datamodel_link": "Legg til datamodell",

--- a/frontend/packages/process-editor/src/ProcessEditor.test.tsx
+++ b/frontend/packages/process-editor/src/ProcessEditor.test.tsx
@@ -22,6 +22,8 @@ const defaultProps: ProcessEditorProps = {
   deleteLayoutSet: jest.fn(),
   mutateLayoutSet: jest.fn(),
   mutateDataType: jest.fn(),
+  addDataTypeToAppMetadata: jest.fn(),
+  deleteDataTypeFromAppMetadata: jest.fn(),
 };
 
 const renderProcessEditor = (bpmnXml: string) => {

--- a/frontend/packages/process-editor/src/ProcessEditor.tsx
+++ b/frontend/packages/process-editor/src/ProcessEditor.tsx
@@ -24,6 +24,8 @@ export type ProcessEditorProps = {
   deleteLayoutSet: BpmnApiContextProps['deleteLayoutSet'];
   mutateLayoutSet: BpmnApiContextProps['mutateLayoutSet'];
   mutateDataType: BpmnApiContextProps['mutateDataType'];
+  addDataTypeToAppMetadata: BpmnApiContextProps['addDataTypeToAppMetadata'];
+  deleteDataTypeFromAppMetadata: BpmnApiContextProps['deleteDataTypeFromAppMetadata'];
   saveBpmn: (bpmnXml: string, metaData?: MetaDataForm) => void;
 };
 
@@ -38,6 +40,8 @@ export const ProcessEditor = ({
   deleteLayoutSet,
   mutateLayoutSet,
   mutateDataType,
+  addDataTypeToAppMetadata,
+  deleteDataTypeFromAppMetadata,
   saveBpmn,
 }: ProcessEditorProps): JSX.Element => {
   const { t } = useTranslation();
@@ -61,6 +65,8 @@ export const ProcessEditor = ({
         deleteLayoutSet={deleteLayoutSet}
         mutateLayoutSet={mutateLayoutSet}
         mutateDataType={mutateDataType}
+        addDataTypeToAppMetadata={addDataTypeToAppMetadata}
+        deleteDataTypeFromAppMetadata={deleteDataTypeFromAppMetadata}
         saveBpmn={saveBpmn}
       >
         <BpmnConfigPanelFormContextProvider>

--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
@@ -1,4 +1,5 @@
 import { shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
+import { generateRandomId } from 'app-shared/utils/generateRandomId';
 
 const supportedEntries = ['create.exclusive-gateway', 'create.start-event', 'create.end-event'];
 
@@ -58,8 +59,16 @@ class SupportedPaletteProvider {
               }),
               signatureConfig: bpmnFactory.create('altinn:SignatureConfig', {
                 dataTypesToSign: bpmnFactory.create('altinn:DataTypesToSign', {
-                  dataType: ['Model'],
+                  dataTypes: [],
                 }),
+                signatureDataType: bpmnFactory.create(
+                  'altinn:SignatureDataType',
+                  {
+                    dataType: bpmnFactory.create('altinn:DataType', {
+                      dataType: `signatureInformation-${generateRandomId(4)}`,
+                    }),
+                  }, // What about uniqueFromSignaturesInDataTypes
+                ),
               }),
             }),
           ],
@@ -127,7 +136,9 @@ class SupportedPaletteProvider {
               }),
               paymentConfig: bpmnFactory.create('altinn:PaymentConfig', {
                 paymentDataType: bpmnFactory.create('altinn:PaymentDataType', {
-                  dataType: ['paymentInformation'],
+                  dataType: bpmnFactory.create('altinn:DataType', {
+                    dataType: `paymentInformation-${generateRandomId(4)}`,
+                  }),
                 }),
               }),
             }),

--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/ConfigIcon/ConfigIcon.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/ConfigIcon/ConfigIcon.tsx
@@ -5,6 +5,7 @@ import {
   ConfirmationTaskIcon,
   DataTaskIcon,
   FeedbackTaskIcon,
+  PaymentTaskIcon,
   ReceiptIcon,
   SignTaskIcon,
 } from '@studio/icons';
@@ -23,6 +24,8 @@ export const ConfigIcon = ({ taskType }: ConfigIconProps): React.ReactElement =>
       return <FeedbackTaskIcon className={classes.icon} />;
     case 'signing':
       return <SignTaskIcon className={classes.icon} />;
+    case 'payment':
+      return <PaymentTaskIcon className={classes.icon} />;
     case 'endEvent':
       return <ReceiptIcon className={classes.icon} />;
   }

--- a/frontend/packages/process-editor/src/contexts/BpmnApiContext.tsx
+++ b/frontend/packages/process-editor/src/contexts/BpmnApiContext.tsx
@@ -11,7 +11,9 @@ export type BpmnApiContextProps = {
   addLayoutSet: (data: { layoutSetIdToUpdate: string; layoutSetConfig: LayoutSetConfig }) => void;
   deleteLayoutSet: (data: { layoutSetIdToUpdate: string }) => void;
   mutateLayoutSet: (data: { layoutSetIdToUpdate: string; newLayoutSetId: string }) => void;
-  mutateDataType: (dataTypeChange: DataTypeChange) => void;
+  mutateDataType: (dataTypeId: DataTypeChange) => void;
+  addDataTypeToAppMetadata: (data: { dataTypeId: string }) => void;
+  deleteDataTypeFromAppMetadata: (data: { dataTypeId: string }) => void;
   saveBpmn: (bpmnXml: string, metaData?: MetaDataForm) => void;
 };
 
@@ -27,6 +29,8 @@ export type BpmnApiContextProviderProps = {
   deleteLayoutSet: (data: { layoutSetIdToUpdate: string }) => void;
   mutateLayoutSet: (data: { layoutSetIdToUpdate: string; newLayoutSetId: string }) => void;
   mutateDataType: (data: DataTypeChange) => void;
+  addDataTypeToAppMetadata: (data: { dataTypeId: string }) => void;
+  deleteDataTypeFromAppMetadata: (data: { dataTypeId: string }) => void;
   saveBpmn: (bpmnXml: string, metaData?: MetaDataForm) => void;
 };
 export const BpmnApiContextProvider = ({
@@ -39,6 +43,8 @@ export const BpmnApiContextProvider = ({
   deleteLayoutSet,
   mutateLayoutSet,
   mutateDataType,
+  addDataTypeToAppMetadata,
+  deleteDataTypeFromAppMetadata,
   saveBpmn,
 }: Partial<BpmnApiContextProviderProps>) => {
   return (
@@ -52,6 +58,8 @@ export const BpmnApiContextProvider = ({
         deleteLayoutSet,
         mutateLayoutSet,
         mutateDataType,
+        addDataTypeToAppMetadata,
+        deleteDataTypeFromAppMetadata,
         saveBpmn,
       }}
     >

--- a/frontend/packages/process-editor/src/extensions/altinnCustomTasks.ts
+++ b/frontend/packages/process-editor/src/extensions/altinnCustomTasks.ts
@@ -72,7 +72,7 @@ export const altinnCustomTasks = {
         {
           name: 'signatureDataType',
           isMany: false,
-          type: 'String',
+          type: 'SignatureDataType',
         },
       ],
     },
@@ -90,10 +90,21 @@ export const altinnCustomTasks = {
       name: 'PaymentDataType',
       properties: [
         {
-          name: 'paymentType',
+          name: 'dataType',
           isMany: false,
           isAttr: false,
-          type: 'String',
+          type: 'DataType',
+        },
+      ],
+    },
+    {
+      name: 'SignatureDataType',
+      properties: [
+        {
+          name: 'dataType',
+          isMany: false,
+          isAttr: false,
+          type: 'DataType',
         },
       ],
     },
@@ -101,9 +112,20 @@ export const altinnCustomTasks = {
       name: 'DataTypesToSign',
       properties: [
         {
-          name: 'dataType',
+          name: 'dataTypes',
           isMany: true,
           isAttr: false,
+          type: 'DataType',
+        },
+      ],
+    },
+    {
+      name: 'DataType',
+      properties: [
+        {
+          name: 'dataType',
+          isMany: false,
+          isBody: true,
           type: 'String',
         },
       ],

--- a/frontend/packages/process-editor/src/hooks/useBpmnEditor.test.tsx
+++ b/frontend/packages/process-editor/src/hooks/useBpmnEditor.test.tsx
@@ -6,75 +6,17 @@ import { BpmnApiContextProvider } from '../contexts/BpmnApiContext';
 import { useBpmnModeler } from './useBpmnModeler';
 import { getBpmnEditorDetailsFromBusinessObject } from '../utils/hookUtils';
 import type { BpmnDetails } from '../types/BpmnDetails';
-import { BpmnTypeEnum } from '../enum/BpmnTypeEnum';
 import type { BpmnTaskType } from '../types/BpmnTaskType';
 import type { LayoutSets } from 'app-shared/types/api/LayoutSetsResponse';
+import { getMockBpmnElementForTask, mockBpmnDetails } from '../../test/mocks/bpmnDetailsMock';
+import { mockModelerRef } from '../../test/mocks/bpmnModelerMock';
 
-// This should be moved to test-folder which is created in Actions PR
-const getMockBpmnElementForTask = (taskType: BpmnTaskType) => {
-  switch (taskType) {
-    case 'data':
-      return {
-        businessObject: {
-          extensionElements: {
-            values: [],
-          },
-        },
-      };
-    case 'signing':
-      return {
-        businessObject: {
-          extensionElements: {
-            values: [
-              {
-                signatureConfig: {
-                  signatureDataType: {
-                    dataType: {
-                      dataType: 'signatureInformation-1234',
-                    },
-                  },
-                },
-              },
-            ],
-          },
-        },
-      };
-    case 'payment':
-      return {
-        businessObject: {
-          extensionElements: {
-            values: [
-              {
-                paymentConfig: {
-                  paymentDataType: {
-                    dataType: {
-                      dataType: 'paymentInformation-1234',
-                    },
-                  },
-                },
-              },
-            ],
-          },
-        },
-      };
-  }
-};
-
-const taskId = 'testId';
 const layoutSetId = 'someLayoutSetId';
-const bpmnDetailsMock: BpmnDetails = {
-  id: taskId,
-  name: 'mockName',
-  type: BpmnTypeEnum.Task,
-  taskType: 'data',
-  element: getMockBpmnElementForTask('data'),
-};
-
 const layoutSetsMock: LayoutSets = {
   sets: [
     {
       id: layoutSetId,
-      tasks: [taskId],
+      tasks: [mockBpmnDetails.id],
     },
   ],
 };
@@ -129,7 +71,7 @@ const setBpmnDetailsMock = jest.fn();
 const overrideUseBpmnContext = () => {
   (useBpmnContext as jest.Mock).mockReturnValue({
     getUpdatedXml: jest.fn(),
-    modelerRef: { current: null },
+    modelerRef: mockModelerRef,
     setBpmnDetails: setBpmnDetailsMock,
   });
 };
@@ -187,18 +129,18 @@ describe('useBpmnEditor', () => {
 
     expect(addLayoutSetMock).toHaveBeenCalledTimes(1);
     expect(addLayoutSetMock).toHaveBeenCalledWith({
-      layoutSetIdToUpdate: bpmnDetailsMock.id,
-      layoutSetConfig: { id: bpmnDetailsMock.id, tasks: [bpmnDetailsMock.id] },
+      layoutSetIdToUpdate: mockBpmnDetails.id,
+      layoutSetConfig: { id: mockBpmnDetails.id, tasks: [mockBpmnDetails.id] },
     });
     expect(setBpmnDetailsMock).toHaveBeenCalledTimes(1);
-    expect(setBpmnDetailsMock).toHaveBeenCalledWith(bpmnDetailsMock);
+    expect(setBpmnDetailsMock).toHaveBeenCalledWith(mockBpmnDetails);
   });
 
   it.each(['confirmation', 'signing', 'payment', 'feedback', 'endEvent'])(
     'should not call addLayoutSet when "shape.add" event is triggered on modelerInstance when taskType is %s',
     (taskType: BpmnTaskType) => {
       const mockBpmnDetailsNotData: BpmnDetails = {
-        ...bpmnDetailsMock,
+        ...mockBpmnDetails,
         taskType,
         element: getMockBpmnElementForTask(taskType),
       };
@@ -215,7 +157,7 @@ describe('useBpmnEditor', () => {
     'should call deleteLayoutSet when "shape.remove" event is triggered on modelerInstance and the task has a connected layout set for taskType %s',
     (taskType: BpmnTaskType) => {
       const mockBpmnDetailsWithConnectedLayoutSet: BpmnDetails = {
-        ...bpmnDetailsMock,
+        ...mockBpmnDetails,
         taskType,
         element: getMockBpmnElementForTask(taskType),
       };
@@ -233,7 +175,7 @@ describe('useBpmnEditor', () => {
     'should not call addDataTypeToApplicationMetadata when "shape.add" event is triggered on modelerInstance and taskType is %s',
     (taskType: BpmnTaskType) => {
       const mockBpmnDetailsNotPayOrSign: BpmnDetails = {
-        ...bpmnDetailsMock,
+        ...mockBpmnDetails,
         taskType,
         element: getMockBpmnElementForTask(taskType),
       };
@@ -248,7 +190,7 @@ describe('useBpmnEditor', () => {
   it('should call addDataTypeToApplicationMetadata when "shape.add" event is triggered on modelerInstance and taskType is signing', () => {
     const taskType: BpmnTaskType = 'signing';
     const mockBpmnDetailsSigningTask: BpmnDetails = {
-      ...bpmnDetailsMock,
+      ...mockBpmnDetails,
       taskType,
       element: getMockBpmnElementForTask(taskType),
     };
@@ -265,7 +207,7 @@ describe('useBpmnEditor', () => {
   it('should call addDataTypeToApplicationMetadata when "shape.add" event is triggered on modelerInstance and taskType is payment', () => {
     const taskType: BpmnTaskType = 'payment';
     const mockBpmnDetailsPaymentTask: BpmnDetails = {
-      ...bpmnDetailsMock,
+      ...mockBpmnDetails,
       taskType,
       element: getMockBpmnElementForTask(taskType),
     };
@@ -283,7 +225,7 @@ describe('useBpmnEditor', () => {
     'should not call deleteDataTypeFromAppMetadata when "shape.remove" event is triggered on modelerInstance and taskType is %s',
     (taskType: BpmnTaskType) => {
       const mockBpmnDetailsNotPayOrSign: BpmnDetails = {
-        ...bpmnDetailsMock,
+        ...mockBpmnDetails,
         taskType,
         element: getMockBpmnElementForTask(taskType),
       };
@@ -298,7 +240,7 @@ describe('useBpmnEditor', () => {
   it('should call deleteDataTypeFromAppMetadata when "shape.remove" event is triggered on modelerInstance and taskType is signing', () => {
     const taskType: BpmnTaskType = 'signing';
     const mockBpmnDetailsSigningTask: BpmnDetails = {
-      ...bpmnDetailsMock,
+      ...mockBpmnDetails,
       taskType,
       element: getMockBpmnElementForTask(taskType),
     };
@@ -315,7 +257,7 @@ describe('useBpmnEditor', () => {
   it('should call deleteDataTypeFromAppMetadataMock when "shape.remove" event is triggered on modelerInstance and taskType is payment', () => {
     const taskType: BpmnTaskType = 'payment';
     const mockBpmnDetailsPaymentTask: BpmnDetails = {
-      ...bpmnDetailsMock,
+      ...mockBpmnDetails,
       taskType,
       element: getMockBpmnElementForTask(taskType),
     };
@@ -331,7 +273,7 @@ describe('useBpmnEditor', () => {
 
   it('should not call deleteLayoutSet when "shape.remove" event is triggered on modelerInstance and deleted task has no layoutSet', () => {
     const mockBpmnDetailsWithoutConnectedLayoutSet: BpmnDetails = {
-      ...bpmnDetailsMock,
+      ...mockBpmnDetails,
       id: 'TaskIdNotPresetInLayoutSets',
     };
     const currentEventName = 'shape.remove';
@@ -352,7 +294,7 @@ describe('useBpmnEditor', () => {
     renderUseBpmnEditor(true, currentEventName);
 
     expect(setBpmnDetailsMock).toHaveBeenCalledTimes(1);
-    expect(setBpmnDetailsMock).toHaveBeenCalledWith(bpmnDetailsMock);
+    expect(setBpmnDetailsMock).toHaveBeenCalledWith(mockBpmnDetails);
   });
 });
 
@@ -360,7 +302,7 @@ const renderUseBpmnEditor = (
   overrideBpmnContext: boolean,
   currentEventName: string,
   currentTaskType: BpmnTaskType = 'data',
-  bpmnDetails = bpmnDetailsMock,
+  bpmnDetails = mockBpmnDetails,
 ) => {
   overrideBpmnContext && overrideUseBpmnContext();
   overrideGetBpmnEditorDetailsFromBusinessObject(bpmnDetails);

--- a/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
@@ -21,8 +21,14 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
   const canvasRef = useRef<HTMLDivElement | null>(null);
   const { metaDataFormRef, resetForm } = useBpmnConfigPanelFormContext();
   const { getModeler } = useBpmnModeler();
-  const { addLayoutSet, deleteLayoutSet, saveBpmn, layoutSets } = useBpmnApiContext();
-  //let modelerRef: BpmnModeler | null = null;
+  const {
+    addLayoutSet,
+    deleteLayoutSet,
+    addDataTypeToAppMetadata,
+    deleteDataTypeFromAppMetadata,
+    saveBpmn,
+    layoutSets,
+  } = useBpmnApiContext();
 
   const handleCommandStackChanged = async () => {
     saveBpmn(await getUpdatedXml(), metaDataFormRef.current || null);
@@ -41,6 +47,16 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
         layoutSetConfig: { id: bpmnDetails.id, tasks: [bpmnDetails.id] },
       });
     }
+    if (bpmnDetails.taskType === 'payment') {
+      addDataTypeToAppMetadata({
+        dataTypeId: 'paymentInformation',
+      });
+    }
+    if (bpmnDetails.taskType === 'signing') {
+      addDataTypeToAppMetadata({
+        dataTypeId: 'signingInformation',
+      });
+    }
   };
 
   const handleShapeRemove = (e) => {
@@ -52,6 +68,16 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
           layoutSetIdToUpdate: layoutSetId,
         });
       }
+    }
+    if (bpmnDetails.taskType === 'payment') {
+      deleteDataTypeFromAppMetadata({
+        dataTypeId: 'paymentInformation',
+      });
+    }
+    if (bpmnDetails.taskType === 'signing') {
+      deleteDataTypeFromAppMetadata({
+        dataTypeId: 'signingInformation',
+      });
     }
     setBpmnDetails(null);
   };
@@ -94,11 +120,11 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
       console.log('Canvas reference is not yet available in the DOM.');
     }
     // GetModeler can only be fetched from this hook once since the modeler creates a
-    // new instance and will attach the same canvasRef container to all instances it fetches
+    // new instance and will attach the same canvasRef container to all instances it fetches.
+    // Set modelerRef.current to the Context so that it can be used in other components
     modelerRef.current = getModeler(canvasRef.current);
     initializeEditor();
     initializeBpmnChanges();
-    // set modelerRef.current to the Context so that it can be used in other components
   }, []); // Missing dependencies are not added to avoid getModeler to be called multiple times
 
   useEffect(() => {

--- a/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
@@ -37,26 +37,24 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
 
   const handleShapeAdd = (e) => {
     const bpmnDetails = getBpmnEditorDetailsFromBusinessObject(e?.element?.businessObject);
-    setBpmnDetails({
-      ...bpmnDetails,
-      element: e.element,
-    });
     if (bpmnDetails.taskType === 'data') {
       addLayoutSet({
         layoutSetIdToUpdate: bpmnDetails.id,
         layoutSetConfig: { id: bpmnDetails.id, tasks: [bpmnDetails.id] },
       });
     }
-    if (bpmnDetails.taskType === 'payment') {
+    if (bpmnDetails.taskType === 'payment' || bpmnDetails.taskType === 'signing') {
+      const dataTypeId =
+        bpmnDetails.taskType === 'payment'
+          ? e?.element?.businessObject.extensionElements.values[0].paymentConfig.paymentDataType
+              .dataType.dataType
+          : e?.element?.businessObject.extensionElements.values[0].signatureConfig.signatureDataType
+              .dataType.dataType;
       addDataTypeToAppMetadata({
-        dataTypeId: 'paymentInformation',
+        dataTypeId,
       });
     }
-    if (bpmnDetails.taskType === 'signing') {
-      addDataTypeToAppMetadata({
-        dataTypeId: 'signingInformation',
-      });
-    }
+    handleSetBpmnDetails(e);
   };
 
   const handleShapeRemove = (e) => {
@@ -69,14 +67,15 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
         });
       }
     }
-    if (bpmnDetails.taskType === 'payment') {
+    if (bpmnDetails.taskType === 'payment' || bpmnDetails.taskType === 'signing') {
+      const dataTypeId =
+        bpmnDetails.taskType === 'payment'
+          ? e?.element?.businessObject.extensionElements.values[0].paymentConfig.paymentDataType
+              .dataType.dataType
+          : e?.element?.businessObject.extensionElements.values[0].signatureConfig.signatureDataType
+              .dataType.dataType;
       deleteDataTypeFromAppMetadata({
-        dataTypeId: 'paymentInformation',
-      });
-    }
-    if (bpmnDetails.taskType === 'signing') {
-      deleteDataTypeFromAppMetadata({
-        dataTypeId: 'signingInformation',
+        dataTypeId,
       });
     }
     setBpmnDetails(null);

--- a/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
@@ -7,7 +7,10 @@ import { getBpmnEditorDetailsFromBusinessObject } from '../utils/hookUtils';
 import { useBpmnConfigPanelFormContext } from '../contexts/BpmnConfigPanelContext';
 import { useBpmnApiContext } from '../contexts/BpmnApiContext';
 import { BpmnTypeEnum } from '../enum/BpmnTypeEnum';
-import { getLayoutSetIdFromTaskId } from '../utils/hookUtils/hookUtils';
+import {
+  getDataTypeIdFromBusinessObject,
+  getLayoutSetIdFromTaskId,
+} from '../utils/hookUtils/hookUtils';
 
 // Wrapper around bpmn-js to Reactify it
 
@@ -44,12 +47,10 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
       });
     }
     if (bpmnDetails.taskType === 'payment' || bpmnDetails.taskType === 'signing') {
-      const dataTypeId =
-        bpmnDetails.taskType === 'payment'
-          ? e?.element?.businessObject.extensionElements.values[0].paymentConfig.paymentDataType
-              .dataType.dataType
-          : e?.element?.businessObject.extensionElements.values[0].signatureConfig.signatureDataType
-              .dataType.dataType;
+      const dataTypeId = getDataTypeIdFromBusinessObject(
+        bpmnDetails.taskType,
+        e.element.businessObject,
+      );
       addDataTypeToAppMetadata({
         dataTypeId,
       });
@@ -68,12 +69,10 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
       }
     }
     if (bpmnDetails.taskType === 'payment' || bpmnDetails.taskType === 'signing') {
-      const dataTypeId =
-        bpmnDetails.taskType === 'payment'
-          ? e?.element?.businessObject.extensionElements.values[0].paymentConfig.paymentDataType
-              .dataType.dataType
-          : e?.element?.businessObject.extensionElements.values[0].signatureConfig.signatureDataType
-              .dataType.dataType;
+      const dataTypeId = getDataTypeIdFromBusinessObject(
+        bpmnDetails.taskType,
+        e.element.businessObject,
+      );
       deleteDataTypeFromAppMetadata({
         dataTypeId,
       });

--- a/frontend/packages/process-editor/src/utils/hookUtils/hookUtils.ts
+++ b/frontend/packages/process-editor/src/utils/hookUtils/hookUtils.ts
@@ -2,6 +2,18 @@ import type { BpmnDetails } from '../../types/BpmnDetails';
 import type { BpmnBusinessObjectViewer } from '../../types/BpmnBusinessObjectViewer';
 import type { BpmnBusinessObjectEditor } from '../../types/BpmnBusinessObjectEditor';
 import type { LayoutSets } from 'app-shared/types/api/LayoutSetsResponse';
+import type { BpmnTaskType } from '@altinn/process-editor/types/BpmnTaskType';
+
+export const bpmnTaskConfig = {
+  payment: {
+    configNode: 'paymentConfig',
+    dataTypeName: 'paymentDataType',
+  },
+  signing: {
+    configNode: 'signatureConfig',
+    dataTypeName: 'signatureDataType',
+  },
+};
 
 /**
  * Gets the bpmn details from the business object in viewer mode
@@ -42,6 +54,15 @@ export const getBpmnEditorDetailsFromBusinessObject = (
     taskType: taskTypeFromV8 || taskTypeFromV7,
     type: businessObject?.$type,
   };
+};
+
+export const getDataTypeIdFromBusinessObject = (
+  bpmnTaskType: BpmnTaskType,
+  businessObject: BpmnBusinessObjectEditor,
+): string => {
+  const configNode = bpmnTaskConfig[bpmnTaskType].configNode;
+  const dataTypeName = bpmnTaskConfig[bpmnTaskType].dataTypeName;
+  return businessObject?.extensionElements?.values[0][configNode][dataTypeName]?.dataType?.dataType;
 };
 
 export const getLayoutSetIdFromTaskId = (bpmnDetails: BpmnDetails, layoutSets: LayoutSets) => {

--- a/frontend/packages/process-editor/test/mocks/bpmnContextMock.ts
+++ b/frontend/packages/process-editor/test/mocks/bpmnContextMock.ts
@@ -39,7 +39,9 @@ export const mockBpmnApiContextValue: BpmnApiContextProps = {
   availableDataModelIds: [],
   addLayoutSet: jest.fn(),
   deleteLayoutSet: jest.fn(),
-  mutateDataType: jest.fn(),
   mutateLayoutSet: jest.fn(),
+  mutateDataType: jest.fn(),
+  addDataTypeToAppMetadata: jest.fn(),
+  deleteDataTypeFromAppMetadata: jest.fn(),
   saveBpmn: jest.fn(),
 };

--- a/frontend/packages/process-editor/test/mocks/bpmnDetailsMock.ts
+++ b/frontend/packages/process-editor/test/mocks/bpmnDetailsMock.ts
@@ -1,6 +1,7 @@
 import type { BpmnDetails } from '../../src/types/BpmnDetails';
 import { BpmnTypeEnum } from '../../src/enum/BpmnTypeEnum';
 import type { ModdleElement } from 'bpmn-js/lib/model/Types';
+import type { BpmnTaskType } from '@altinn/process-editor/types/BpmnTaskType';
 
 export const mockBpmnId: string = 'testId';
 export const mockBpmnName: string = 'testName';
@@ -31,12 +32,69 @@ export const mockBpmnElement: ModdleElement = {
   },
 };
 
+export const getMockBpmnElementForTask = (taskType: BpmnTaskType) => {
+  switch (taskType) {
+    case 'data':
+      return mockBpmnElement;
+    case 'confirmation':
+      return {
+        businessObject: {
+          extensionElements: {
+            values: [
+              {
+                actions: confirmationActions,
+              },
+            ],
+          },
+        },
+      };
+    case 'signing':
+      return {
+        businessObject: {
+          extensionElements: {
+            values: [
+              {
+                actions: signingActions,
+                signatureConfig: {
+                  signatureDataType: {
+                    dataType: {
+                      dataType: 'signatureInformation-1234',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      };
+    case 'payment':
+      return {
+        businessObject: {
+          extensionElements: {
+            values: [
+              {
+                actions: paymentActions,
+                paymentConfig: {
+                  paymentDataType: {
+                    dataType: {
+                      dataType: 'paymentInformation-1234',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      };
+  }
+};
+
 export const mockBpmnDetails: BpmnDetails = {
   id: mockBpmnId,
   name: mockBpmnName,
   taskType: 'data',
   type: BpmnTypeEnum.Task,
-  element: mockBpmnElement,
+  element: getMockBpmnElementForTask('data'),
 };
 
 export const confirmationActions = {

--- a/frontend/packages/shared/src/api/mutations.ts
+++ b/frontend/packages/shared/src/api/mutations.ts
@@ -34,6 +34,7 @@ import {
   resourceAccessListPath,
   processEditorPathPut,
   layoutSetPath,
+  processEditorDataTypePath,
   processEditorDataTypeChangePath,
 } from 'app-shared/api/paths';
 import type { AddLanguagePayload } from 'app-shared/types/api/AddLanguagePayload';
@@ -121,6 +122,9 @@ export const updatePolicy = (org: string, repo: string, id: string, payload: Pol
 export const updateResource = (org: string, repo: string, payload: Resource) => put(resourceEditPath(org, repo), payload);
 
 // ProcessEditor
+
+export const addDataTypeToAppMetadata = (org: string, app: string, dataTypeId: string) => post(processEditorDataTypePath(org, app, dataTypeId));
+export const deleteDataTypeFromAppMetadata = (org: string, app: string, dataTypeId: string) => del(processEditorDataTypePath(org, app, dataTypeId));
 export const updateBpmnXml = (org: string, app: string, form: any) =>
   put(processEditorPathPut(org, app), form, {
     headers: {

--- a/frontend/packages/shared/src/api/paths.js
+++ b/frontend/packages/shared/src/api/paths.js
@@ -151,3 +151,4 @@ export const processEditorPath = (org, app) => `${basePath}/${org}/${app}/proces
 export const processEditorWebSocketHub = () => '/sync-hub';
 export const processEditorPathPut = (org, app) => `${basePath}/${org}/${app}/process-modelling/process-definition-latest`;
 export const processEditorDataTypeChangePath = (org, app) => `${basePath}/${org}/${app}/process-modelling/data-type`;
+export const processEditorDataTypePath = (org, app, dataTypeId) => `${basePath}/${org}/${app}/process-modelling/data-type/${dataTypeId}`;

--- a/frontend/packages/shared/src/mocks/queriesMock.ts
+++ b/frontend/packages/shared/src/mocks/queriesMock.ts
@@ -164,6 +164,7 @@ export const queriesMock: ServicesContextProps = {
 
   // Mutations
   addAppAttachmentMetadata: jest.fn().mockImplementation(() => Promise.resolve()),
+  addDataTypeToAppMetadata: jest.fn().mockImplementation(() => Promise.resolve()),
   addLayoutSet: jest.fn().mockImplementation(() => Promise.resolve()),
   addLanguageCode: jest.fn().mockImplementation(() => Promise.resolve()),
   addRepo: jest.fn().mockImplementation(() => Promise.resolve<Repository>(repository)),
@@ -180,6 +181,7 @@ export const queriesMock: ServicesContextProps = {
     .mockImplementation(() => Promise.resolve<CreateRepoCommitPayload>(createRepoCommitPayload)),
   deleteAppAttachmentMetadata: jest.fn().mockImplementation(() => Promise.resolve()),
   deleteDatamodel: jest.fn().mockImplementation(() => Promise.resolve()),
+  deleteDataTypeFromAppMetadata: jest.fn().mockImplementation(() => Promise.resolve()),
   deleteFormLayout: jest.fn().mockImplementation(() => Promise.resolve()),
   deleteLanguageCode: jest.fn().mockImplementation(() => Promise.resolve()),
   deleteLayoutSet: jest.fn().mockImplementation(() => Promise.resolve()),


### PR DESCRIPTION
## Description
Add dataType to appmetadata when adding payment and signing tasks to bpmn process.
Use custom prefix id `paymentInformation-` and `signatureInformation-` and 4 characters random identifier as suffix.
Remove same dataType when deleting using the same dataTypeId as identifier for backend. 

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
