### PR TITLE
Only add feature flag to session storage if present in url

### DIFF
--- a/frontend/packages/shared/src/utils/featureToggleUtils.test.ts
+++ b/frontend/packages/shared/src/utils/featureToggleUtils.test.ts
@@ -6,45 +6,51 @@ import {
 } from './featureToggleUtils';
 
 describe('featureToggle localStorage', () => {
+  beforeEach(() => typedLocalStorage.removeItem('featureFlags'));
+
   it('should return true if feature is enabled in the localStorage', () => {
     typedLocalStorage.setItem<string[]>('featureFlags', ['shouldOverrideAppLibCheck']);
-    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBe(true);
+    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBeTruthy();
   });
 
   it('should return true if featureFlag includes in feature params', () => {
     typedLocalStorage.setItem<string[]>('featureFlags', ['demo', 'shouldOverrideAppLibCheck']);
-    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBe(true);
+    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBeTruthy();
   });
 
   it('should return false if feature is not enabled in the localStorage', () => {
     typedLocalStorage.setItem<string[]>('featureFlags', ['demo']);
-    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBe(false);
+    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBeFalsy();
   });
 
   it('should return false if feature is not enabled in the localStorage', () => {
-    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBe(false);
+    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBeFalsy();
   });
 });
 
 describe('featureToggle url', () => {
+  beforeEach(() => {
+    typedLocalStorage.removeItem('featureFlags');
+    typedSessionStorage.removeItem('featureFlags');
+  });
   it('should return true if feature is enabled in the url', () => {
     window.history.pushState({}, 'PageUrl', '/?featureFlags=shouldOverrideAppLibCheck');
-    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBe(true);
+    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBeTruthy();
   });
 
   it('should return true if featureFlag includes in feature params', () => {
     window.history.pushState({}, 'PageUrl', '/?featureFlags=demo,shouldOverrideAppLibCheck');
-    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBe(true);
+    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBeTruthy();
   });
 
   it('should return false if feature is not included in the url', () => {
     window.history.pushState({}, 'PageUrl', '/?featureFlags=demo');
-    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBe(false);
+    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBeFalsy();
   });
 
   it('should return false if feature is not included in the url', () => {
     window.history.pushState({}, 'PageUrl', '/');
-    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBe(false);
+    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBeFalsy();
   });
 
   it('should persist features in sessionStorage when persistFeatureFlag is set in url', () => {
@@ -53,9 +59,9 @@ describe('featureToggle url', () => {
       'PageUrl',
       '/?featureFlags=customizeEndEvent,shouldOverrideAppLibCheck&persistFeatureFlag=true',
     );
-    expect(shouldDisplayFeature('componentConfigBeta')).toBe(false);
-    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBe(true);
-    expect(shouldDisplayFeature('customizeEndEvent')).toBe(true);
+    expect(shouldDisplayFeature('componentConfigBeta')).toBeFalsy();
+    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBeTruthy();
+    expect(shouldDisplayFeature('customizeEndEvent')).toBeTruthy();
     expect(typedSessionStorage.getItem<string[]>('featureFlags')).toEqual([
       'shouldOverrideAppLibCheck',
       'customizeEndEvent',

--- a/frontend/packages/shared/src/utils/featureToggleUtils.test.ts
+++ b/frontend/packages/shared/src/utils/featureToggleUtils.test.ts
@@ -1,4 +1,4 @@
-import { typedLocalStorage } from 'app-shared/utils/webStorage';
+import { typedLocalStorage, typedSessionStorage } from 'app-shared/utils/webStorage';
 import {
   addFeatureFlagToLocalStorage,
   removeFeatureFlagFromLocalStorage,
@@ -45,6 +45,22 @@ describe('featureToggle url', () => {
   it('should return false if feature is not included in the url', () => {
     window.history.pushState({}, 'PageUrl', '/');
     expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBe(false);
+  });
+
+  it('should persist features in sessionStorage when persistFeatureFlag is set in url', () => {
+    window.history.pushState(
+      {},
+      'PageUrl',
+      '/?featureFlags=customizeEndEvent,shouldOverrideAppLibCheck&persistFeatureFlag=true',
+    );
+    expect(shouldDisplayFeature('componentConfigBeta')).toBe(false);
+    expect(shouldDisplayFeature('shouldOverrideAppLibCheck')).toBe(true);
+    expect(shouldDisplayFeature('customizeEndEvent')).toBe(true);
+    expect(typedSessionStorage.getItem<string[]>('featureFlags')).toEqual([
+      'shouldOverrideAppLibCheck',
+      'customizeEndEvent',
+    ]);
+    expect(typedLocalStorage.getItem<string[]>('featureFlags')).toBeUndefined();
   });
 });
 

--- a/frontend/packages/shared/src/utils/featureToggleUtils.ts
+++ b/frontend/packages/shared/src/utils/featureToggleUtils.ts
@@ -28,7 +28,7 @@ const defaultActiveFeatures: SupportedFeatureFlags[] = [];
  */
 export const shouldDisplayFeature = (featureFlag: SupportedFeatureFlags): boolean => {
   // Check if feature should be persisted in session storage, (url)?persistFeatureFlag=true
-  if (shouldPersistInSession()) {
+  if (shouldPersistInSession() && isFeatureActivatedByUrl(featureFlag)) {
     addFeatureFlagToSessionStorage(featureFlag);
   }
 


### PR DESCRIPTION
## Description
Check if featureFlag is included in url before adding to sessionStorage to avoid all featureFlags that is checked with `shouldDisplayFeature()` during current render is added. 
Add test that checks that a flag _not_ listed in the url is not added to sessionStorage and does not return true from `shouldDisplayFeature()`

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

