### PR TITLE
Make the icon in StudioTextfieldToggleView only visible when hovering

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioToggleableTextfield/StudioTextfieldToggleView/StudioTextfieldToggleView.module.css
+++ b/frontend/libs/studio-components/src/components/StudioToggleableTextfield/StudioTextfieldToggleView/StudioTextfieldToggleView.module.css
@@ -1,7 +1,25 @@
+.button {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+}
+
 .viewModeIconsContainer {
   display: flex;
   align-items: center;
   color: var(--fds-semantic-text-neutral-default);
+}
+
+.editIconWrapper {
+  flex: 1;
+  text-align: right;
+  display: none;
+}
+
+.button:hover .editIconWrapper,
+.button:focus .editIconWrapper {
+  display: flex;
+  align-items: center;
 }
 
 .editIcon {

--- a/frontend/libs/studio-components/src/components/StudioToggleableTextfield/StudioTextfieldToggleView/StudioTextfieldToggleView.tsx
+++ b/frontend/libs/studio-components/src/components/StudioToggleableTextfield/StudioTextfieldToggleView/StudioTextfieldToggleView.tsx
@@ -2,21 +2,27 @@ import React from 'react';
 import { PencilIcon, KeyVerticalIcon } from '@studio/icons';
 import { StudioButton, type StudioButtonProps } from '@studio/components';
 import classes from './StudioTextfieldToggleView.module.css';
+import cn from 'classnames';
 
 export type StudioTextfieldToggleViewProps = StudioButtonProps;
 
 export const StudioTextfieldToggleView = ({
   onClick,
   children,
+  className: givenClass,
   ...rest
 }: StudioTextfieldToggleViewProps) => {
+  const className = cn(classes.button, givenClass);
+
   return (
-    <StudioButton {...rest} onClick={onClick}>
+    <StudioButton className={className} onClick={onClick} {...rest}>
       <span className={classes.viewModeIconsContainer}>
         <KeyVerticalIcon data-testid='keyIcon' aria-hidden />
         {children}
       </span>
-      <PencilIcon className={classes.editIcon} data-testid='editIcon' aria-hidden />
+      <span className={classes.editIconWrapper}>
+        <PencilIcon className={classes.editIcon} data-testid='editIcon' aria-hidden />
+      </span>
     </StudioButton>
   );
 };


### PR DESCRIPTION
## Description
- Make the icon in ```<StudioTextfieldToggleView />``` only show when the component is hovered. 

## Related Issue(s)
- #12799 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)