### PR TITLE
Remove datatype bpmn elements from payment- and signatureconfig in task definitions

### DIFF
--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
@@ -61,14 +61,7 @@ class SupportedPaletteProvider {
                 dataTypesToSign: bpmnFactory.create('altinn:DataTypesToSign', {
                   dataTypes: [],
                 }),
-                signatureDataType: bpmnFactory.create(
-                  'altinn:SignatureDataType',
-                  {
-                    dataType: bpmnFactory.create('altinn:DataType', {
-                      dataType: `signatureInformation-${generateRandomId(4)}`,
-                    }),
-                  }, // What about uniqueFromSignaturesInDataTypes
-                ),
+                signatureDataType: `signatureInformation-${generateRandomId(4)}`,
               }),
             }),
           ],
@@ -135,11 +128,7 @@ class SupportedPaletteProvider {
                 ],
               }),
               paymentConfig: bpmnFactory.create('altinn:PaymentConfig', {
-                paymentDataType: bpmnFactory.create('altinn:PaymentDataType', {
-                  dataType: bpmnFactory.create('altinn:DataType', {
-                    dataType: `paymentInformation-${generateRandomId(4)}`,
-                  }),
-                }),
+                paymentDataType: `paymentInformation-${generateRandomId(4)}`,
               }),
             }),
           ],

--- a/frontend/packages/process-editor/src/extensions/altinnCustomTasks.ts
+++ b/frontend/packages/process-editor/src/extensions/altinnCustomTasks.ts
@@ -72,7 +72,7 @@ export const altinnCustomTasks = {
         {
           name: 'signatureDataType',
           isMany: false,
-          type: 'SignatureDataType',
+          type: 'String',
         },
       ],
     },
@@ -82,29 +82,7 @@ export const altinnCustomTasks = {
         {
           name: 'paymentDataType',
           isMany: false,
-          type: 'PaymentDataType',
-        },
-      ],
-    },
-    {
-      name: 'PaymentDataType',
-      properties: [
-        {
-          name: 'dataType',
-          isMany: false,
-          isAttr: false,
-          type: 'DataType',
-        },
-      ],
-    },
-    {
-      name: 'SignatureDataType',
-      properties: [
-        {
-          name: 'dataType',
-          isMany: false,
-          isAttr: false,
-          type: 'DataType',
+          type: 'String',
         },
       ],
     },

--- a/frontend/packages/process-editor/src/utils/hookUtils/hookUtils.ts
+++ b/frontend/packages/process-editor/src/utils/hookUtils/hookUtils.ts
@@ -62,7 +62,7 @@ export const getDataTypeIdFromBusinessObject = (
 ): string => {
   const configNode = bpmnTaskConfig[bpmnTaskType].configNode;
   const dataTypeName = bpmnTaskConfig[bpmnTaskType].dataTypeName;
-  return businessObject?.extensionElements?.values[0][configNode][dataTypeName]?.dataType?.dataType;
+  return businessObject?.extensionElements?.values[0][configNode][dataTypeName];
 };
 
 export const getLayoutSetIdFromTaskId = (bpmnDetails: BpmnDetails, layoutSets: LayoutSets) => {

--- a/frontend/packages/process-editor/test/mocks/bpmnDetailsMock.ts
+++ b/frontend/packages/process-editor/test/mocks/bpmnDetailsMock.ts
@@ -56,11 +56,7 @@ export const getMockBpmnElementForTask = (taskType: BpmnTaskType) => {
               {
                 actions: signingActions,
                 signatureConfig: {
-                  signatureDataType: {
-                    dataType: {
-                      dataType: 'signatureInformation-1234',
-                    },
-                  },
+                  signatureDataType: 'signatureInformation-1234',
                 },
               },
             ],
@@ -75,11 +71,7 @@ export const getMockBpmnElementForTask = (taskType: BpmnTaskType) => {
               {
                 actions: paymentActions,
                 paymentConfig: {
-                  paymentDataType: {
-                    dataType: {
-                      dataType: 'paymentInformation-1234',
-                    },
-                  },
+                  paymentDataType: 'paymentInformation-1234',
                 },
               },
             ],


### PR DESCRIPTION
## Description
Removes the dataType element from the payment- and signatureConfig elements in the bpmn task definitions

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

