### PR TITLE
Add esling-disable-next-line on missing dependencies useBpmnEditor

### DIFF
--- a/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
@@ -123,6 +123,8 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
     modelerRef.current = getModeler(canvasRef.current);
     initializeEditor();
     initializeBpmnChanges();
+
+    // eslint-disable-next-line
   }, []); // Missing dependencies are not added to avoid getModeler to be called multiple times
 
   useEffect(() => {


### PR DESCRIPTION
## Description
- Adding `eslint-disable-next-line` to the array of missing dependencies in `useBpmnEditor.ts` to avoid GithubActions to comment on every PR. 

## Related Issue(s)

- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)