### PR TITLE
automatically add layoutset for payment task type

### DIFF
--- a/frontend/packages/process-editor/src/hooks/useBpmnEditor.test.tsx
+++ b/frontend/packages/process-editor/src/hooks/useBpmnEditor.test.tsx
@@ -137,7 +137,31 @@ describe('useBpmnEditor', () => {
     expect(setBpmnDetailsMock).toHaveBeenCalledWith(mockBpmnDetails);
   });
 
-  it.each(['confirmation', 'signing', 'payment', 'feedback', 'endEvent'])(
+  it.each(['data', 'payment'])(
+    'should call addLayoutSet when "shape.add" event is triggered on modelerInstance when taskType is %s',
+    (taskType: BpmnTaskType) => {
+      const mockBpmnDetailsAutomaticLayoutSet: BpmnDetails = {
+        ...mockBpmnDetails,
+        taskType,
+        element: getMockBpmnElementForTask(taskType),
+      };
+      const currentEventName = 'shape.add';
+      renderUseBpmnEditor(true, currentEventName, taskType, mockBpmnDetailsAutomaticLayoutSet);
+
+      expect(addLayoutSetMock).toHaveBeenCalledTimes(1);
+      expect(addLayoutSetMock).toHaveBeenCalledWith({
+        layoutSetIdToUpdate: mockBpmnDetailsAutomaticLayoutSet.id,
+        layoutSetConfig: {
+          id: mockBpmnDetailsAutomaticLayoutSet.id,
+          tasks: [mockBpmnDetailsAutomaticLayoutSet.id],
+        },
+      });
+      expect(setBpmnDetailsMock).toHaveBeenCalledTimes(1);
+      expect(setBpmnDetailsMock).toHaveBeenCalledWith(mockBpmnDetailsAutomaticLayoutSet);
+    },
+  );
+
+  it.each(['confirmation', 'signing', 'feedback', 'endEvent'])(
     'should not call addLayoutSet when "shape.add" event is triggered on modelerInstance when taskType is %s',
     (taskType: BpmnTaskType) => {
       const mockBpmnDetailsNotData: BpmnDetails = {

--- a/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
@@ -39,7 +39,7 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
 
   const handleShapeAdd = (e) => {
     const bpmnDetails = getBpmnEditorDetailsFromBusinessObject(e?.element?.businessObject);
-    if (bpmnDetails.taskType === 'data') {
+    if (bpmnDetails.taskType === 'data' || bpmnDetails.taskType === 'payment') {
       addLayoutSet({
         layoutSetIdToUpdate: bpmnDetails.id,
         layoutSetConfig: { id: bpmnDetails.id, tasks: [bpmnDetails.id] },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
First part of #12809, which automatically adds layoutset when adding payment task. 
Setting up default layout for payment will come as a separate PR.

## Related Issue(s)

- #12809

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
