### PR TITLE
Rename useStudioParams to useStudioEnvironmentParams

### DIFF
--- a/frontend/app-development/features/appPublish/components/CreateRelease.tsx
+++ b/frontend/app-development/features/appPublish/components/CreateRelease.tsx
@@ -6,12 +6,12 @@ import { versionNameValid } from './utils';
 import { useBranchStatusQuery, useAppReleasesQuery } from '../../../hooks/queries';
 import { useCreateReleaseMutation } from '../../../hooks/mutations';
 import { useTranslation } from 'react-i18next';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { FormField } from 'app-shared/components/FormField';
 import { StudioButton } from '@studio/components';
 
 export function CreateRelease() {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const [tagName, setTagName] = useState<string>('');
   const [body, setBody] = useState<string>('');
   const { data: releases = [] } = useAppReleasesQuery(org, app);

--- a/frontend/app-development/features/appPublish/components/Deploy.tsx
+++ b/frontend/app-development/features/appPublish/components/Deploy.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { DeployDropdown } from './DeployDropdown';
 import { useCreateDeploymentMutation } from '../../../hooks/mutations';
 import { Trans, useTranslation } from 'react-i18next';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { toast } from 'react-toastify';
 import { Alert, Link } from '@digdir/design-system-react';
 import { useDeployPermissionsQuery } from 'app-development/hooks/queries';
@@ -28,7 +28,7 @@ export const Deploy = ({
   const [selectedImageTag, setSelectedImageTag] = useState(null);
   const { t } = useTranslation();
 
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const {
     data: permissions,
     isPending: permissionsIsPending,

--- a/frontend/app-development/features/appPublish/components/DeployDropdown.tsx
+++ b/frontend/app-development/features/appPublish/components/DeployDropdown.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppReleasesQuery } from 'app-development/hooks/queries';
 import { BuildResult } from 'app-shared/types/Build';
 import { DateUtils } from '@studio/pure-functions';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export interface DeployDropdownProps {
   appDeployedVersion: string;
@@ -27,7 +27,7 @@ export const DeployDropdown = ({
   startDeploy,
   isPending,
 }: DeployDropdownProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const [isConfirmDeployDialogOpen, setIsConfirmDeployDialogOpen] = useState<boolean>();
   const { t } = useTranslation();
 

--- a/frontend/app-development/features/appPublish/components/Release.tsx
+++ b/frontend/app-development/features/appPublish/components/Release.tsx
@@ -8,7 +8,7 @@ import { StudioSpinner } from '@studio/components';
 import type { Build } from 'app-shared/types/Build';
 import { BuildResult, BuildStatus } from 'app-shared/types/Build';
 import type { AppRelease } from 'app-shared/types/AppRelease';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 interface IReleaseComponent {
   release: AppRelease;
@@ -50,7 +50,7 @@ export function Release(props: IReleaseComponent) {
     }
     return release.body;
   }
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   return (
     <div className={classes.releaseWrapper}>
       <div className={classes.releaseRow}>

--- a/frontend/app-development/features/appPublish/containers/DeploymentContainer.tsx
+++ b/frontend/app-development/features/appPublish/containers/DeploymentContainer.tsx
@@ -7,7 +7,7 @@ import {
   useAppDeploymentsQuery,
 } from '../../../hooks/queries';
 import type { Environment } from 'app-shared/types/Environment';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { DeploymentEnvironment } from '../components/DeploymentEnvironment';
 import { getAppLink } from 'app-shared/ext-urls';
 import { useTranslation } from 'react-i18next';
@@ -15,7 +15,7 @@ import { Alert } from '@digdir/design-system-react';
 import { PROD_ENV_TYPE } from 'app-shared/constants';
 
 export const DeploymentContainer = () => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { t } = useTranslation();
 
   const {

--- a/frontend/app-development/features/appPublish/containers/ReleaseContainer.tsx
+++ b/frontend/app-development/features/appPublish/containers/ReleaseContainer.tsx
@@ -15,11 +15,11 @@ import { useQueryClient } from '@tanstack/react-query';
 import { QueryKey } from 'app-shared/types/QueryKey';
 
 import { useRepoStatusQuery } from 'app-shared/hooks/queries';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export function ReleaseContainer() {
   const hiddenMdDown = useMediaQuery('(max-width: 1025px)');
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const [popoverOpenClick, setPopoverOpenClick] = useState<boolean>(false);
   const [popoverOpenHover, setPopoverOpenHover] = useState<boolean>(false);
 

--- a/frontend/app-development/features/appPublish/pages/DeployPage.tsx
+++ b/frontend/app-development/features/appPublish/pages/DeployPage.tsx
@@ -7,11 +7,11 @@ import { useDeployPermissionsQuery, useOrgListQuery } from '../../../hooks/queri
 import { Trans, useTranslation } from 'react-i18next';
 import { AltinnContentLoader } from 'app-shared/components/molecules/AltinnContentLoader';
 import { useInvalidator } from '../../../hooks/useInvalidator';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { Alert } from '@digdir/design-system-react';
 
 export function DeployPage() {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { t } = useTranslation();
   const { data: orgs, isPending: orgsIsPending, isError: orgsIsError } = useOrgListQuery();
   const {

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
@@ -14,7 +14,7 @@ import type {
 } from 'app-shared/types/DatamodelMetadata';
 import { useQueryClient } from '@tanstack/react-query';
 import { QueryKey } from 'app-shared/types/QueryKey';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { mergeJsonAndXsdData } from 'app-development/utils/metadataUtils';
 import { extractFilename, removeSchemaExtension } from 'app-shared/utils/filenameUtils';
 export interface SelectedSchemaEditorProps {
@@ -58,7 +58,7 @@ interface SchemaEditorWithDebounceProps {
 }
 
 const SchemaEditorWithDebounce = ({ jsonSchema, modelPath }: SchemaEditorWithDebounceProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { mutate } = useSchemaMutation();
   const queryClient = useQueryClient();
   const [model, setModel] = useState<JsonSchema>(jsonSchema);

--- a/frontend/app-development/features/overview/components/DeploymentContainer.tsx
+++ b/frontend/app-development/features/overview/components/DeploymentContainer.tsx
@@ -5,7 +5,7 @@ import {
   useEnvironmentsQuery,
   useOrgListQuery,
 } from 'app-development/hooks/queries';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { Alert } from '@digdir/design-system-react';
 import { useTranslation } from 'react-i18next';
 import { DeploymentStatusList } from './DeploymentStatusList';
@@ -16,7 +16,7 @@ import type { Environment } from 'app-shared/types/Environment';
 type DeploymentContainerProps = Pick<HTMLAttributes<HTMLDivElement>, 'className'>;
 
 export const DeploymentContainer = ({ className }: DeploymentContainerProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { t } = useTranslation();
 
   const {

--- a/frontend/app-development/features/overview/components/DeploymentStatus.tsx
+++ b/frontend/app-development/features/overview/components/DeploymentStatus.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classes from './DeploymentStatus.module.css';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { Trans, useTranslation } from 'react-i18next';
 import { Alert, Heading, Paragraph, Spinner, Link } from '@digdir/design-system-react';
 import { DateUtils } from '@studio/pure-functions';
@@ -24,7 +24,7 @@ export const DeploymentStatus = ({
   isProduction,
   urlToApp,
 }: DeploymentStatusProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { t } = useTranslation();
 
   const formatDateTime = (dateAsString: string): string => {

--- a/frontend/app-development/features/overview/components/DeploymentStatusList.tsx
+++ b/frontend/app-development/features/overview/components/DeploymentStatusList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import type { Environment } from 'app-shared/types/Environment';
 import { DeploymentStatus } from './DeploymentStatus';
 import classes from './DeploymentStatusList.module.css';
@@ -20,7 +20,7 @@ export const DeploymentStatusList = ({
   kubernetesDeploymentList,
   pipelineDeploymentList,
 }: DeploymentStatusListProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
 
   return (
     <div className={classes.container}>

--- a/frontend/app-development/features/overview/components/Deployments.tsx
+++ b/frontend/app-development/features/overview/components/Deployments.tsx
@@ -1,7 +1,7 @@
 import type { HTMLAttributes } from 'react';
 import React from 'react';
 import { useOrgListQuery } from 'app-development/hooks/queries';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { Alert } from '@digdir/design-system-react';
 import { useTranslation } from 'react-i18next';
 import { StudioSpinner } from '@studio/components';
@@ -13,7 +13,7 @@ import { DeploymentContainer } from './DeploymentContainer';
 type DeploymentsProps = Pick<HTMLAttributes<HTMLDivElement>, 'className'>;
 
 export const Deployments = ({ className }: DeploymentsProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
 
   const {
     data: orgs,

--- a/frontend/app-development/features/overview/components/Header.tsx
+++ b/frontend/app-development/features/overview/components/Header.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect } from 'react';
 import { useAppConfigQuery } from 'app-development/hooks/queries';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { Heading } from '@digdir/design-system-react';
 import { toast } from 'react-toastify';
 import { useTranslation } from 'react-i18next';
 import { StudioSpinner } from '@studio/components';
 
 export const Header = () => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
 
   const {
     data: appConfigData,

--- a/frontend/app-development/features/processEditor/ProcessEditor.tsx
+++ b/frontend/app-development/features/processEditor/ProcessEditor.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ProcessEditor as ProcessEditorImpl } from '@altinn/process-editor';
 import { useAppPolicyMutation, useBpmnMutation } from '../../hooks/mutations';
 import { useBpmnQuery } from '../../hooks/queries/useBpmnQuery';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { toast } from 'react-toastify';
 import { StudioPageSpinner } from '@studio/components';
 import { useTranslation } from 'react-i18next';
@@ -36,7 +36,7 @@ enum SyncClientsName {
 
 export const ProcessEditor = (): React.ReactElement => {
   const { t } = useTranslation();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const queryClient = useQueryClient();
   const { data: currentPolicy, isPending: isPendingCurrentPolicy } = useAppPolicyQuery(org, app);
   const { mutate: mutateApplicationPolicy } = useAppPolicyMutation(org, app);

--- a/frontend/app-development/features/textEditor/TextEditor.tsx
+++ b/frontend/app-development/features/textEditor/TextEditor.tsx
@@ -11,13 +11,13 @@ import {
   useDeleteLanguageMutation,
   useTextIdMutation,
 } from '../../hooks/mutations';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useTranslation } from 'react-i18next';
 import { useUpsertTextResourceMutation } from 'app-shared/hooks/mutations/useUpsertTextResourceMutation';
 
 export const TextEditor = () => {
   const { t } = useTranslation();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const [searchParams, setSearchParams] = useSearchParams({ lang: '', search: '' });
 
   const selectedLanguagesStorageKey = `${org}:${app}:selectedLanguages`;

--- a/frontend/app-development/hooks/mutations/useCreateDatamodelMutation.ts
+++ b/frontend/app-development/hooks/mutations/useCreateDatamodelMutation.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import type { CreateDatamodelPayload } from 'app-shared/types/api';
 import { QueryKey } from 'app-shared/types/QueryKey';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export interface CreateDatamodelMutationArgs {
   name: string;
@@ -11,7 +11,7 @@ export interface CreateDatamodelMutationArgs {
 
 export const useCreateDatamodelMutation = () => {
   const { createDatamodel } = useServicesContext();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({ name, relativePath }: CreateDatamodelMutationArgs) => {

--- a/frontend/app-development/hooks/mutations/useDeleteDatamodelMutation.ts
+++ b/frontend/app-development/hooks/mutations/useDeleteDatamodelMutation.ts
@@ -1,13 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { isXsdFile } from 'app-shared/utils/filenameUtils';
 import type { DatamodelMetadata } from 'app-shared/types/DatamodelMetadata';
 
 export const useDeleteDatamodelMutation = () => {
   const { deleteDatamodel } = useServicesContext();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (modelPath: string) => {

--- a/frontend/app-development/hooks/mutations/useGenerateModelsMutation.ts
+++ b/frontend/app-development/hooks/mutations/useGenerateModelsMutation.ts
@@ -4,7 +4,7 @@ import { QueryKey } from 'app-shared/types/QueryKey';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import type { AxiosError } from 'axios';
 import type { JsonSchema } from 'app-shared/types/JsonSchema';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import type { ApiError } from 'app-shared/types/api/ApiError';
 
 export const useGenerateModelsMutation = (
@@ -12,7 +12,7 @@ export const useGenerateModelsMutation = (
   meta?: QueryMeta,
 ): UseMutationResult<void, AxiosError<ApiError>> => {
   const queryClient = useQueryClient();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { generateModels } = useServicesContext();
   return useMutation({
     mutationFn: (payload: JsonSchema) => generateModels(org, app, modelPath, payload),

--- a/frontend/app-development/hooks/mutations/useSchemaMutation.ts
+++ b/frontend/app-development/hooks/mutations/useSchemaMutation.ts
@@ -2,11 +2,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import type { JsonSchema } from 'app-shared/types/JsonSchema';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export const useSchemaMutation = () => {
   const queryClient = useQueryClient();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { saveDatamodel } = useServicesContext();
   return useMutation({
     mutationFn: async (args: { modelPath: string; model: JsonSchema }) => {

--- a/frontend/app-development/hooks/mutations/useUploadDatamodelMutation.ts
+++ b/frontend/app-development/hooks/mutations/useUploadDatamodelMutation.ts
@@ -2,11 +2,11 @@ import type { MutationMeta } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export const useUploadDatamodelMutation = (meta?: MutationMeta) => {
   const { uploadDatamodel } = useServicesContext();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (file: FormData) => uploadDatamodel(org, app, file),

--- a/frontend/app-development/hooks/queries/useSchemaQuery.ts
+++ b/frontend/app-development/hooks/queries/useSchemaQuery.ts
@@ -6,13 +6,13 @@ import type { AxiosError } from 'axios';
 import type { JsonSchema } from 'app-shared/types/JsonSchema';
 import { isXsdFile } from 'app-shared/utils/filenameUtils';
 import { StringUtils } from '@studio/pure-functions';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import type { ApiError } from 'app-shared/types/api/ApiError';
 
 export const useSchemaQuery = (
   modelPath: string,
 ): UseQueryResult<JsonSchema | null, AxiosError<ApiError, any>> => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { getDatamodel, addXsdFromRepo } = useServicesContext();
   return useQuery<JsonSchema | null, AxiosError<ApiError, any>>({
     queryKey: [QueryKey.JsonSchema, org, app, modelPath],

--- a/frontend/app-development/router/routes.tsx
+++ b/frontend/app-development/router/routes.tsx
@@ -7,7 +7,7 @@ import { DeployPage } from '../features/appPublish/pages/DeployPage';
 import { ProcessEditor } from 'app-development/features/processEditor';
 import { RoutePaths } from 'app-development/enums/RoutePaths';
 import type { AppVersion } from 'app-shared/types/AppVersion';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppVersionQuery } from 'app-shared/hooks/queries';
 import React from 'react';
 
@@ -35,7 +35,7 @@ const isLatestFrontendVersion = (version: AppVersion): boolean =>
   version?.frontendVersion?.startsWith(latestFrontendVersion);
 
 const UiEditor = () => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: version } = useAppVersionQuery(org, app);
   if (!version) return null;
   return isLatestFrontendVersion(version) ? <UiEditorLatest /> : <UiEditorV3 />;

--- a/frontend/app-preview/src/components/AppBarConfig/AppPreviewBarConfig.tsx
+++ b/frontend/app-preview/src/components/AppBarConfig/AppPreviewBarConfig.tsx
@@ -8,7 +8,7 @@ import { ArrowCirclepathIcon, EyeIcon, LinkIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
 import type { AppPreviewSubMenuProps } from '../AppPreviewSubMenu';
 import { useLayoutSetsQuery } from 'app-shared/hooks/queries/useLayoutSetsQuery';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { TopBarMenu } from 'app-shared/enums/TopBarMenu';
 import type { TopBarMenuItem } from 'app-shared/types/TopBarMenuItem';
 import { PackagesRouter } from 'app-shared/navigation/PackagesRouter';
@@ -43,7 +43,7 @@ export const SubPreviewMenuLeftContent = ({
   handleChangeLayoutSet,
 }: AppPreviewSubMenuProps) => {
   const { t } = useTranslation();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: layoutSets } = useLayoutSetsQuery(org, app);
 
   return (

--- a/frontend/app-preview/src/views/LandingPage.tsx
+++ b/frontend/app-preview/src/views/LandingPage.tsx
@@ -13,7 +13,7 @@ import {
 } from '../components/AppBarConfig/AppPreviewBarConfig';
 
 import { AppPreviewSubMenu } from '../components/AppPreviewSubMenu';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { previewPage } from 'app-shared/api/paths';
 import type { TopBarMenuItem } from 'app-shared/types/TopBarMenuItem';
 import { PreviewLimitationsInfo } from 'app-shared/components/PreviewLimitationsInfo/PreviewLimitationsInfo';
@@ -30,7 +30,7 @@ export interface LandingPageProps {
 export type PreviewAsViewSize = 'desktop' | 'mobile';
 
 export const LandingPage = ({ variant = 'preview' }: LandingPageProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { t } = useTranslation();
   const previewConnection = usePreviewConnection();
   const { data: user } = useUserQuery();

--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigEndEvent/CustomReceiptContent/RedirectToCreatePageButton/RedirectToCreatePageButton.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigEndEvent/CustomReceiptContent/RedirectToCreatePageButton/RedirectToCreatePageButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classes from './RedirectToCreatePageButton.module.css';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { PackagesRouter } from 'app-shared/navigation/PackagesRouter';
 import { PencilWritingIcon } from '@studio/icons';
 import { StudioButton } from '@studio/components';
@@ -11,7 +11,7 @@ import { RedirectBox } from '../../../../RedirectBox';
 
 export const RedirectToCreatePageButton = (): React.ReactElement => {
   const { t } = useTranslation();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const packagesRouter = new PackagesRouter({ org, app });
   const { existingCustomReceiptLayoutSetId } = useBpmnApiContext();
 

--- a/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/CloneModal/CloneModal.tsx
+++ b/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/CloneModal/CloneModal.tsx
@@ -7,7 +7,7 @@ import classes from './CloneModal.module.css';
 import { LegacyTextField } from '@digdir/design-system-react';
 import { useTranslation } from 'react-i18next';
 import { useDatamodelsXsdQuery } from 'app-shared/hooks/queries';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { InformationSquareFillIcon } from '@studio/icons';
 import { StudioButton } from '@studio/components';
 
@@ -17,7 +17,7 @@ export interface ICloneModalProps {
 }
 
 export const CloneModal = (props: ICloneModalProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const gitUrl = window.location.origin.toString() + repositoryGitPath(org, app);
   const copyGitUrl = () => navigator.clipboard.writeText(gitUrl);
   const canCopy = document.queryCommandSupported ? document.queryCommandSupported('copy') : false;

--- a/frontend/packages/shared/src/hooks/useStudioEnvironmentParams.test.ts
+++ b/frontend/packages/shared/src/hooks/useStudioEnvironmentParams.test.ts
@@ -1,10 +1,10 @@
 import { app, org } from '@studio/testing/testids';
 import { renderHook } from '@testing-library/react';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
-describe('useStudioUrlParams', () => {
+describe('useStudioEnvironmentParams', () => {
   it('Returns the org and app names from the URL', () => {
-    const { result } = renderHook(() => useStudioUrlParams());
+    const { result } = renderHook(() => useStudioEnvironmentParams());
     expect(result.current).toEqual({ org, app });
   });
 });

--- a/frontend/packages/shared/src/hooks/useStudioEnvironmentParams.ts
+++ b/frontend/packages/shared/src/hooks/useStudioEnvironmentParams.ts
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 
-interface StudioUrlParams {
+interface StudioEnvironmentParams {
   org: string;
   app: string;
 }
@@ -9,7 +9,7 @@ interface StudioUrlParams {
  * Retrieves the org and app names from the URL.
  * @returns {StudioUrlParams} The org and app names.
  */
-export const useStudioUrlParams = (): StudioUrlParams => {
-  const { org, app } = useParams<Partial<StudioUrlParams>>();
+export const useStudioEnvironmentParams = (): StudioEnvironmentParams => {
+  const { org, app } = useParams<Partial<StudioEnvironmentParams>>();
   return { org, app };
 };

--- a/frontend/packages/shared/src/navigation/main-header/ProfileMenu/ProfileMenu.tsx
+++ b/frontend/packages/shared/src/navigation/main-header/ProfileMenu/ProfileMenu.tsx
@@ -7,7 +7,7 @@ import { post } from '../../../utils/networking';
 import { repositoryPath, userLogoutAfterPath, userLogoutPath } from '../../../api/paths';
 import { useTranslation } from 'react-i18next';
 import type { User } from 'app-shared/types/Repository';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { StudioButton } from '@studio/components';
 import { profileButtonId } from '@studio/testing/testids';
 
@@ -37,7 +37,7 @@ export const ProfileMenu = ({
   const menuRef = useRef(null);
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
 
   const handleClick = (event: any) => setMenuOpen(true);
   const handleClose = () => setMenuOpen(false);

--- a/frontend/packages/text-editor/src/TextList.tsx
+++ b/frontend/packages/text-editor/src/TextList.tsx
@@ -14,7 +14,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { APP_NAME } from 'app-shared/constants';
 import { useLayoutNamesQuery } from './hooks/useLayoutNamesQuery';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export type TextListProps = {
   resourceRows: TextTableRow[];
@@ -30,7 +30,7 @@ export const TextList = ({
   selectedLanguages,
   ...rest
 }: TextListProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { t } = useTranslation();
   const { data: layoutNames, isPending: layoutNamesPending } = useLayoutNamesQuery(org, app);
 

--- a/frontend/packages/ux-editor-v3/src/App.tsx
+++ b/frontend/packages/ux-editor-v3/src/App.tsx
@@ -9,7 +9,7 @@ import { selectedLayoutNameSelector } from './selectors/formLayoutSelectors';
 import { useWidgetsQuery } from './hooks/queries/useWidgetsQuery';
 import { useTextResourcesQuery } from 'app-shared/hooks/queries/useTextResourcesQuery';
 import { useLayoutSetsQuery } from 'app-shared/hooks/queries/useLayoutSetsQuery';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from './hooks/useAppContext';
 import { FormItemContextProvider } from './containers/FormItemContext';
 
@@ -21,7 +21,7 @@ import { FormItemContextProvider } from './containers/FormItemContext';
 
 export function App() {
   const t = useText();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const selectedLayout = useSelector(selectedLayoutNameSelector);
   const { selectedLayoutSet, setSelectedLayoutSet, removeSelectedLayoutSet } = useAppContext();
   const { data: layoutSets, isSuccess: areLayoutSetsFetched } = useLayoutSetsQuery(org, app);

--- a/frontend/packages/ux-editor-v3/src/SubApp.tsx
+++ b/frontend/packages/ux-editor-v3/src/SubApp.tsx
@@ -5,13 +5,13 @@ import { setupStore } from './store';
 import './styles/index.css';
 import { AppContext } from './AppContext';
 import { useReactiveLocalStorage } from 'app-shared/hooks/useReactiveLocalStorage';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 const store = setupStore();
 
 export const SubApp = () => {
   const previewIframeRef = useRef<HTMLIFrameElement>(null);
-  const { app } = useStudioUrlParams();
+  const { app } = useStudioEnvironmentParams();
   const [selectedLayoutSet, setSelectedLayoutSet, removeSelectedLayoutSet] =
     useReactiveLocalStorage('layoutSet/' + app, null);
 

--- a/frontend/packages/ux-editor-v3/src/components/Elements/Elements.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/Elements/Elements.tsx
@@ -9,12 +9,12 @@ import { useFormLayoutSettingsQuery } from '../../hooks/queries/useFormLayoutSet
 import { useLayoutSetsQuery } from 'app-shared/hooks/queries/useLayoutSetsQuery';
 import { LayoutSetsContainer } from './LayoutSetsContainer';
 
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import classes from './Elements.module.css';
 import { useAppContext } from '../../hooks/useAppContext';
 
 export const Elements = () => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const selectedLayout: string = useSelector(selectedLayoutNameSelector);
   const { selectedLayoutSet } = useAppContext();
   const layoutSetsQuery = useLayoutSetsQuery(org, app);

--- a/frontend/packages/ux-editor-v3/src/components/Elements/LayoutSetsContainer.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/Elements/LayoutSetsContainer.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { useLayoutSetsQuery } from 'app-shared/hooks/queries/useLayoutSetsQuery';
 import { NativeSelect } from '@digdir/design-system-react';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useText } from '../../hooks';
 import classes from './LayoutSetsContainer.module.css';
 import { useAppContext } from '../../hooks/useAppContext';
 
 export function LayoutSetsContainer() {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const layoutSetsQuery = useLayoutSetsQuery(org, app);
   const layoutSetNames = layoutSetsQuery.data?.sets?.map((set) => set.id);
   const t = useText();

--- a/frontend/packages/ux-editor-v3/src/components/FormComponent/FormComponent.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/FormComponent/FormComponent.tsx
@@ -16,7 +16,7 @@ import { useDeleteFormComponentMutation } from '../../hooks/mutations/useDeleteF
 import { useTextResourcesSelector } from '../../hooks';
 import { useTranslation } from 'react-i18next';
 import { AltinnConfirmDialog } from 'app-shared/components';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../hooks/useAppContext';
 
 export interface IFormComponentProps {
@@ -40,7 +40,7 @@ export const FormComponent = memo(function FormComponent({
   isEditMode,
 }: IFormComponentProps) {
   const { t } = useTranslation();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
 
   const textResources: ITextResource[] = useTextResourcesSelector<ITextResource[]>(
     textResourcesByLanguageSelector(DEFAULT_LANGUAGE),

--- a/frontend/packages/ux-editor-v3/src/components/Preview/Preview.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/Preview/Preview.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import classes from './Preview.module.css';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useSelector } from 'react-redux';
 import cn from 'classnames';
 import { selectedLayoutNameSelector } from '../../selectors/formLayoutSelectors';
@@ -60,7 +60,7 @@ const NoSelectedPageMessage = () => {
 
 // The actual preview frame that displays the selected page
 const PreviewFrame = () => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const [viewportToSimulate, setViewportToSimulate] = useState<SupportedView>('desktop');
   const { t } = useTranslation();
   const { previewIframeRef, selectedLayoutSet } = useAppContext();

--- a/frontend/packages/ux-editor-v3/src/components/Properties/OldDynamicsInfo.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/Properties/OldDynamicsInfo.tsx
@@ -3,14 +3,14 @@ import classes from './OldDynamicsInfo.module.css';
 import { ExternalLinkIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
 import { giteaEditLink, altinnDocsUrl } from 'app-shared/ext-urls';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../hooks/useAppContext';
 import { Link } from '@digdir/design-system-react';
 
 export const OldDynamicsInfo = () => {
   const { t } = useTranslation();
   const { selectedLayoutSet } = useAppContext();
-  const { app, org } = useStudioUrlParams();
+  const { app, org } = useStudioEnvironmentParams();
   const dynamicLocation = selectedLayoutSet
     ? `App/ui/${selectedLayoutSet}/RuleHandler.js`
     : 'App/ui/RuleHandler.js';

--- a/frontend/packages/ux-editor-v3/src/components/TextResourceEdit.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/TextResourceEdit.tsx
@@ -10,14 +10,14 @@ import { useTextResourcesSelector } from '../hooks';
 import { useUpsertTextResourcesMutation } from 'app-shared/hooks/mutations';
 import { useTranslation } from 'react-i18next';
 import { useTextResourcesQuery } from 'app-shared/hooks/queries';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../hooks/useAppContext';
 import { StudioButton } from '@studio/components';
 
 export const TextResourceEdit = () => {
   const dispatch = useDispatch();
   const editId = useSelector(getCurrentEditId);
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: textResources } = useTextResourcesQuery(org, app);
   const languages: string[] = useTextResourcesSelector<string[]>(getAllLanguages);
   const setEditId = (id: string) => dispatch(setCurrentEditId(id));
@@ -64,7 +64,7 @@ export interface TextBoxProps {
 }
 
 const TextBox = ({ language, t, textResource, textResourceId }: TextBoxProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { mutate } = useUpsertTextResourcesMutation(org, app);
 
   const { previewIframeRef } = useAppContext();

--- a/frontend/packages/ux-editor-v3/src/components/config/EditFormContainer.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/config/EditFormContainer.tsx
@@ -25,7 +25,7 @@ import { selectedLayoutNameSelector } from '../../selectors/formLayoutSelectors'
 import { useFormLayoutsQuery } from '../../hooks/queries/useFormLayoutsQuery';
 import { FormField } from '../FormField';
 import type { FormContainer } from '../../types/FormContainer';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../hooks/useAppContext';
 import { ComponentTypeV3 } from 'app-shared/types/ComponentTypeV3';
 
@@ -42,7 +42,7 @@ export const EditFormContainer = ({
 }: IEditFormContainerProps) => {
   const t = useText();
 
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
 
   const { selectedLayoutSet } = useAppContext();
   const { data: formLayouts } = useFormLayoutsQuery(org, app, selectedLayoutSet);

--- a/frontend/packages/ux-editor-v3/src/components/config/Expressions/ExpressionContent/ExpressionEditMode/SimpleExpression/DataSourceValue.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/config/Expressions/ExpressionContent/ExpressionEditMode/SimpleExpression/DataSourceValue.tsx
@@ -15,7 +15,7 @@ import {
   getDataModelElementNames,
 } from '../../../../../../utils/expressionsUtils';
 import { useText } from '../../../../../../hooks';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../../../../../hooks/useAppContext';
 
 export interface DataSourceValueProps {
@@ -31,7 +31,7 @@ export const DataSourceValue = ({
   specifyDataSourceValue,
   isComparableValue,
 }: DataSourceValueProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedLayoutSet } = useAppContext();
   // TODO: Show spinner when isLoading
   const datamodelQuery = useDatamodelMetadataQuery(org, app, selectedLayoutSet, undefined);

--- a/frontend/packages/ux-editor-v3/src/components/config/SelectDataModelComponent.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/config/SelectDataModelComponent.tsx
@@ -3,7 +3,7 @@ import { LegacySelect } from '@digdir/design-system-react';
 import { useDatamodelMetadataQuery } from '../../hooks/queries/useDatamodelMetadataQuery';
 import { FormField } from '../FormField';
 import type { Option } from '@altinn/text-editor/types';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../hooks/useAppContext';
 
 export interface ISelectDataModelProps {
@@ -30,7 +30,7 @@ export const SelectDataModelComponent = ({
   helpText,
   propertyPath,
 }: ISelectDataModelProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedLayoutSet } = useAppContext();
   const { data } = useDatamodelMetadataQuery(org, app, selectedLayoutSet, undefined);
   const [dataModelElementNames, setDataModelElementNames] = React.useState<Option[]>([]);

--- a/frontend/packages/ux-editor-v3/src/components/config/editModal/EditCodeList.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/config/editModal/EditCodeList.tsx
@@ -7,11 +7,11 @@ import { StudioButton, StudioSpinner } from '@studio/components';
 
 import { altinnDocsUrl } from 'app-shared/ext-urls';
 import { FormField } from '../../FormField';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export function EditCodeList({ component, handleComponentChange }: IGenericEditComponent) {
   const { t } = useTranslation();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
 
   const { data: optionListIds, isPending, isError, error } = useOptionListIdsQuery(org, app);
   const [useCustomCodeList, setUseCustomCodeList] = useState<boolean>(optionListIds?.length === 0);

--- a/frontend/packages/ux-editor-v3/src/components/config/editModal/EditDataModelBindings.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/config/editModal/EditDataModelBindings.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { useText } from '../../../hooks';
 import { SelectDataModelComponent } from '../SelectDataModelComponent';
 import { useDatamodelMetadataQuery } from '../../../hooks/queries/useDatamodelMetadataQuery';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { LinkIcon } from '@studio/icons';
 import { StudioButton } from '@studio/components';
 import classes from './EditDataModelBindings.module.css';
@@ -28,7 +28,7 @@ export const EditDataModelBindings = ({
   renderOptions,
   helpText,
 }: EditDataModelBindingsProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedLayoutSet } = useAppContext();
   const { data } = useDatamodelMetadataQuery(org, app, selectedLayoutSet, undefined);
   const t = useText();

--- a/frontend/packages/ux-editor-v3/src/components/toolbar/ConditionalRenderingModal.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/toolbar/ConditionalRenderingModal.tsx
@@ -18,7 +18,7 @@ import {
   addConditionalRenderingConnection,
   deleteConditionalRenderingConnection,
 } from '../../utils/ruleConfigUtils';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useFormLayoutsQuery } from '../../hooks/queries/useFormLayoutsQuery';
 import { useAppContext } from '../../hooks/useAppContext';
 
@@ -29,7 +29,7 @@ export interface IConditionalRenderingModalProps {
 }
 
 export function ConditionalRenderingModal(props: IConditionalRenderingModalProps) {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const [selectedConnectionId, setSelectedConnectionId] = React.useState<string>(null);
   const { selectedLayoutSet } = useAppContext();
   const { data: ruleModel } = useRuleModelQuery(org, app, selectedLayoutSet);

--- a/frontend/packages/ux-editor-v3/src/components/toolbar/RuleModal.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/toolbar/RuleModal.tsx
@@ -9,7 +9,7 @@ import type { RuleConnection } from 'app-shared/types/RuleConfig';
 import { useRuleConfigQuery } from '../../hooks/queries/useRuleConfigQuery';
 import { useRuleConfigMutation } from '../../hooks/mutations/useRuleConfigMutation';
 import { addRuleConnection, deleteRuleConnection } from '../../utils/ruleConfigUtils';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../hooks/useAppContext';
 
 export interface IRuleModalProps {
@@ -19,7 +19,7 @@ export interface IRuleModalProps {
 }
 
 export function RuleModal(props: IRuleModalProps) {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const [selectedConnectionId, setSelectedConnectionId] = React.useState<string>(null);
   const { selectedLayoutSet } = useAppContext();
   const { data: ruleConfig } = useRuleConfigQuery(org, app, selectedLayoutSet);

--- a/frontend/packages/ux-editor-v3/src/containers/DesignView/DesignView.tsx
+++ b/frontend/packages/ux-editor-v3/src/containers/DesignView/DesignView.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 import { useFormLayoutsQuery } from '../../hooks/queries/useFormLayoutsQuery';
 import classes from './DesignView.module.css';
 import { useTranslation } from 'react-i18next';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { Accordion } from '@digdir/design-system-react';
 import type { IFormLayouts } from '../../types/global';
 import type { FormLayoutPage } from '../../types/FormLayoutPage';
@@ -39,7 +39,7 @@ const mapFormLayoutsToFormLayoutPages = (formLayouts: IFormLayouts): FormLayoutP
  */
 export const DesignView = (): ReactNode => {
   const dispatch = useDispatch();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedLayoutSet } = useAppContext();
   const { mutate: addLayoutMutation, isPending } = useAddLayoutMutation(
     org,

--- a/frontend/packages/ux-editor-v3/src/containers/DesignView/FormTree/FormItem/FormItemTitle/useDeleteItem.ts
+++ b/frontend/packages/ux-editor-v3/src/containers/DesignView/FormTree/FormItem/FormItemTitle/useDeleteItem.ts
@@ -1,4 +1,4 @@
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useDeleteFormContainerMutation } from '../../../../../hooks/mutations/useDeleteFormContainerMutation';
 import { useDeleteFormComponentMutation } from '../../../../../hooks/mutations/useDeleteFormComponentMutation';
 import { useMemo } from 'react';
@@ -8,7 +8,7 @@ import type { FormContainer } from '../../../../../types/FormContainer';
 import { useAppContext } from '../../../../../hooks/useAppContext';
 
 export const useDeleteItem = (formItem: FormComponent | FormContainer) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedLayoutSet } = useAppContext();
   const { mutate: deleteContainer } = useDeleteFormContainerMutation(org, app, selectedLayoutSet);
   const { mutate: deleteComponent } = useDeleteFormComponentMutation(org, app, selectedLayoutSet);

--- a/frontend/packages/ux-editor-v3/src/containers/DesignView/FormTree/UnknownReferencedItem/useDeleteUnknownComponentReference.ts
+++ b/frontend/packages/ux-editor-v3/src/containers/DesignView/FormTree/UnknownReferencedItem/useDeleteUnknownComponentReference.ts
@@ -1,4 +1,4 @@
-﻿import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+﻿import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../../../hooks/useAppContext';
 import { useSelectedFormLayoutWithName } from '../../../../hooks';
 import { useFormLayoutMutation } from '../../../../hooks/mutations/useFormLayoutMutation';
@@ -6,7 +6,7 @@ import { removeComponent } from '../../../../utils/formLayoutUtils';
 import type { IInternalLayout } from '../../../../types/global';
 
 export const useDeleteUnknownComponentReference = () => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedLayoutSet } = useAppContext();
   const { layoutName } = useSelectedFormLayoutWithName();
   const { mutateAsync: updateFormLayoutMutation } = useFormLayoutMutation(

--- a/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
+++ b/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
@@ -5,7 +5,7 @@ import { MenuElipsisVerticalIcon, ArrowUpIcon, ArrowDownIcon } from '@studio/ico
 import { useFormLayoutSettingsQuery } from '../../../../hooks/queries/useFormLayoutSettingsQuery';
 import { useUpdateLayoutOrderMutation } from '../../../../hooks/mutations/useUpdateLayoutOrderMutation';
 import { useUpdateLayoutNameMutation } from '../../../../hooks/mutations/useUpdateLayoutNameMutation';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useSelector } from 'react-redux';
 import type { IAppState } from '../../../../types/global';
 import { useSearchParams } from 'react-router-dom';
@@ -31,7 +31,7 @@ export type NavigationMenuProps = {
 export const NavigationMenu = ({ pageName, pageIsReceipt }: NavigationMenuProps): JSX.Element => {
   const { t } = useTranslation();
 
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
 
   const { selectedLayoutSet } = useAppContext();
   const invalidLayouts: string[] = useSelector(

--- a/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -8,7 +8,7 @@ import { pageAccordionContentId } from '@studio/testing/testids';
 import { TrashIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../../hooks/useAppContext';
 import { firstAvailableLayout } from '../../../utils/formLayoutsUtils';
 import { useFormLayoutSettingsQuery } from '../../../hooks/queries/useFormLayoutSettingsQuery';
@@ -44,7 +44,7 @@ export const PageAccordion = ({
   pageIsReceipt,
 }: PageAccordionProps): ReactNode => {
   const { t } = useTranslation();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedLayoutSet } = useAppContext();
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedLayout = searchParams.get('layout');

--- a/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/useDeleteLayout.ts
+++ b/frontend/packages/ux-editor-v3/src/containers/DesignView/PageAccordion/useDeleteLayout.ts
@@ -1,9 +1,9 @@
 import { useDeleteLayoutMutation } from '../../../hooks/mutations/useDeleteLayoutMutation';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../../hooks/useAppContext';
 
 export const useDeleteLayout = () => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedLayoutSet } = useAppContext();
   return useDeleteLayoutMutation(org, app, selectedLayoutSet);
 };

--- a/frontend/packages/ux-editor-v3/src/containers/FormDesigner.tsx
+++ b/frontend/packages/ux-editor-v3/src/containers/FormDesigner.tsx
@@ -14,7 +14,7 @@ import { StudioPageSpinner } from '@studio/components';
 import { BASE_CONTAINER_ID } from 'app-shared/constants';
 import { useRuleConfigQuery } from '../hooks/queries/useRuleConfigQuery';
 import { useInstanceIdQuery } from 'app-shared/hooks/queries';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import type { HandleAdd, HandleMove } from 'app-shared/types/dndTypes';
 import type { ComponentTypeV3 } from 'app-shared/types/ComponentTypeV3';
 import { generateComponentId } from '../utils/generateId';
@@ -43,7 +43,7 @@ export const FormDesigner = ({
   selectedLayoutSet,
 }: FormDesignerProps): JSX.Element => {
   const dispatch = useDispatch();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: instanceId } = useInstanceIdQuery(org, app);
   const { data: formLayouts, isError: layoutFetchedError } = useFormLayoutsQuery(
     org,

--- a/frontend/packages/ux-editor-v3/src/containers/FormItemContext.tsx
+++ b/frontend/packages/ux-editor-v3/src/containers/FormItemContext.tsx
@@ -16,7 +16,7 @@ import { useUpdateFormComponentMutation } from '../hooks/mutations/useUpdateForm
 import { selectedLayoutNameSelector } from '../selectors/formLayoutSelectors';
 import { AUTOSAVE_DEBOUNCE_INTERVAL_MILLISECONDS } from 'app-shared/constants';
 import { LayoutItemType } from '../types/global';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../hooks/useAppContext';
 
 export type FormItemContext = {
@@ -55,7 +55,7 @@ export const FormItemContextProvider = ({
   children,
 }: FormItemContextProviderProps): JSX.Element => {
   const dispatch = useDispatch();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedLayoutSet } = useAppContext();
   const selectedLayoutName = useSelector(selectedLayoutNameSelector);
   const prevSelectedLayoutSetNameRef = useRef(selectedLayoutSet);

--- a/frontend/packages/ux-editor-v3/src/hooks/useFormLayoutsSelector.ts
+++ b/frontend/packages/ux-editor-v3/src/hooks/useFormLayoutsSelector.ts
@@ -3,11 +3,11 @@ import { useSelector } from 'react-redux';
 import type { IFormLayouts, IInternalLayout, IInternalLayoutWithName } from '../types/global';
 import { selectedLayoutNameSelector } from '../selectors/formLayoutSelectors';
 import { createEmptyLayout } from '../utils/formLayoutUtils';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from './useAppContext';
 
 export const useFormLayouts = (): IFormLayouts => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedLayoutSet } = useAppContext();
   const formLayoutsQuery = useFormLayoutsQuery(org, app, selectedLayoutSet);
   const { data } = formLayoutsQuery;

--- a/frontend/packages/ux-editor-v3/src/hooks/useTextResourcesSelector.ts
+++ b/frontend/packages/ux-editor-v3/src/hooks/useTextResourcesSelector.ts
@@ -1,9 +1,9 @@
 import type { TextResourcesSelector } from '../types/global';
 import { useTextResourcesQuery } from 'app-shared/hooks/queries';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export const useTextResourcesSelector = <T>(selector: TextResourcesSelector<T>): T => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: textResources } = useTextResourcesQuery(org, app);
   return selector(textResources);
 };

--- a/frontend/packages/ux-editor-v3/src/hooks/useValidateComponent.ts
+++ b/frontend/packages/ux-editor-v3/src/hooks/useValidateComponent.ts
@@ -6,7 +6,7 @@ import type {
   FormRadioButtonsComponent,
 } from '../types/FormComponent';
 import { useOptionListIdsQuery } from './queries/useOptionListIdsQuery';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export enum ErrorCode {
   NoOptions = 'NoOptions',
@@ -48,7 +48,7 @@ const validateOptionGroup = (
 };
 
 export const useValidateComponent = (component: FormComponent): ComponentValidationResult => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: optionListIds } = useOptionListIdsQuery(org, app);
 
   switch (component.type) {

--- a/frontend/packages/ux-editor/src/App.tsx
+++ b/frontend/packages/ux-editor/src/App.tsx
@@ -6,7 +6,7 @@ import { ErrorPage } from './components/ErrorPage';
 import { useDatamodelMetadataQuery } from './hooks/queries/useDatamodelMetadataQuery';
 import { useWidgetsQuery } from './hooks/queries/useWidgetsQuery';
 import { useTextResourcesQuery } from 'app-shared/hooks/queries/useTextResourcesQuery';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { FormItemContextProvider } from './containers/FormItemContext';
 
 /**
@@ -17,7 +17,7 @@ import { FormItemContextProvider } from './containers/FormItemContext';
 
 export function App() {
   const t = useText();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName } = useAppContext();
   const { isSuccess: areWidgetsFetched, isError: widgetFetchedError } = useWidgetsQuery(org, app);
   const { isSuccess: isDatamodelFetched, isError: dataModelFetchedError } =

--- a/frontend/packages/ux-editor/src/components/Elements/Elements.tsx
+++ b/frontend/packages/ux-editor/src/components/Elements/Elements.tsx
@@ -5,13 +5,13 @@ import { Heading, Paragraph } from '@digdir/design-system-react';
 import { useText, useAppContext } from '../../hooks';
 import { LayoutSetsContainer } from './LayoutSetsContainer';
 
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import classes from './Elements.module.css';
 
 import { useCustomReceiptLayoutSetName } from 'app-shared/hooks/useCustomReceiptLayoutSetName';
 
 export const Elements = () => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName, selectedFormLayoutName } = useAppContext();
   const existingCustomReceiptName: string | undefined = useCustomReceiptLayoutSetName(org, app);
 

--- a/frontend/packages/ux-editor/src/components/Elements/LayoutSetsContainer.tsx
+++ b/frontend/packages/ux-editor/src/components/Elements/LayoutSetsContainer.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { useLayoutSetsQuery } from 'app-shared/hooks/queries/useLayoutSetsQuery';
 import { NativeSelect } from '@digdir/design-system-react';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useText, useAppContext } from '../../hooks';
 import classes from './LayoutSetsContainer.module.css';
 
 export function LayoutSetsContainer() {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const layoutSetsQuery = useLayoutSetsQuery(org, app);
   const layoutSetNames = layoutSetsQuery.data?.sets?.map((set) => set.id);
   const t = useText();

--- a/frontend/packages/ux-editor/src/components/FormComponent/FormComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/FormComponent/FormComponent.tsx
@@ -16,7 +16,7 @@ import { useDeleteFormComponentMutation } from '../../hooks/mutations/useDeleteF
 import { useTextResourcesSelector, useAppContext } from '../../hooks';
 import { useTranslation } from 'react-i18next';
 import { AltinnConfirmDialog } from 'app-shared/components';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export interface IFormComponentProps {
   component: IFormComponent;
@@ -39,7 +39,7 @@ export const FormComponent = memo(function FormComponent({
   isEditMode,
 }: IFormComponentProps) {
   const { t } = useTranslation();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
 
   const textResources: ITextResource[] = useTextResourcesSelector<ITextResource[]>(
     textResourcesByLanguageSelector(DEFAULT_LANGUAGE),

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import classes from './Preview.module.css';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import cn from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useAppContext, useSelectedTaskId } from '../../hooks';
@@ -58,7 +58,7 @@ const NoSelectedPageMessage = () => {
 
 // The actual preview frame that displays the selected page
 const PreviewFrame = () => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const [viewportToSimulate, setViewportToSimulate] = useState<SupportedView>('desktop');
   const { previewIframeRef, selectedFormLayoutSetName, selectedFormLayoutName } = useAppContext();
   const taskId = useSelectedTaskId(selectedFormLayoutSetName);

--- a/frontend/packages/ux-editor/src/components/Properties/OldDynamicsInfo.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/OldDynamicsInfo.tsx
@@ -3,14 +3,14 @@ import classes from './OldDynamicsInfo.module.css';
 import { ExternalLinkIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
 import { giteaEditLink, altinnDocsUrl } from 'app-shared/ext-urls';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../hooks';
 import { Link } from '@digdir/design-system-react';
 
 export const OldDynamicsInfo = () => {
   const { t } = useTranslation();
   const { selectedFormLayoutSetName } = useAppContext();
-  const { app, org } = useStudioUrlParams();
+  const { app, org } = useStudioEnvironmentParams();
   const dynamicLocation = selectedFormLayoutSetName
     ? `App/ui/${selectedFormLayoutSetName}/RuleHandler.js`
     : 'App/ui/RuleHandler.js';

--- a/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/EditPageId.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/EditPageId.tsx
@@ -5,7 +5,7 @@ import { getPageNameErrorKey } from '../../../utils/designViewUtils';
 import { useUpdateLayoutNameMutation } from '../../../hooks/mutations/useUpdateLayoutNameMutation';
 import { StudioToggleableTextfield } from '@studio/components';
 import { useTextIdMutation } from 'app-development/hooks/mutations';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useText, useAppContext } from '../../../hooks';
 import { useFormLayoutSettingsQuery } from '../../../hooks/queries/useFormLayoutSettingsQuery';
 import { Trans } from 'react-i18next';
@@ -14,7 +14,7 @@ export interface EditPageIdProps {
   layoutName: string;
 }
 export const EditPageId = ({ layoutName }: EditPageIdProps) => {
-  const { app, org } = useStudioUrlParams();
+  const { app, org } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName, refetchLayouts } = useAppContext();
   const { mutate: mutateTextId } = useTextIdMutation(org, app);
   const { mutate: updateLayoutName } = useUpdateLayoutNameMutation(

--- a/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/HiddenExpressionOnLayout.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/HiddenExpressionOnLayout.tsx
@@ -4,14 +4,14 @@ import type { Expression } from '@studio/components';
 import type { IInternalLayout } from '../../../types/global';
 import { ObjectUtils } from '@studio/pure-functions';
 import { useFormLayoutMutation } from '../../../hooks/mutations/useFormLayoutMutation';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useSelectedFormLayoutWithName, useAppContext } from '../../../hooks';
 import { Trans } from 'react-i18next';
 import { AUTOSAVE_DEBOUNCE_INTERVAL_MILLISECONDS } from 'app-shared/constants';
 import { useDebounce } from 'app-shared/hooks/useDebounce';
 
 export const HiddenExpressionOnLayout = () => {
-  const { app, org } = useStudioUrlParams();
+  const { app, org } = useStudioEnvironmentParams();
   const { layout, layoutName } = useSelectedFormLayoutWithName();
   const { selectedFormLayoutSetName, refetchLayouts } = useAppContext();
   const { mutate: saveLayout } = useFormLayoutMutation(

--- a/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigWarning.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigWarning.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { List, Link, Heading } from '@digdir/design-system-react';
 import { repositoryLayoutPath } from 'app-shared/api/paths';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { getDuplicatedIds } from '../../../utils/formLayoutUtils';
 import type { IInternalLayout } from '../../../types/global';
 import { useTranslation } from 'react-i18next';
@@ -15,7 +15,7 @@ type PageConfigWarningProps = {
 };
 
 export const PageConfigWarning = ({ layout, selectedFormLayoutName }: PageConfigWarningProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { t } = useTranslation();
   const duplicatedIds = getDuplicatedIds(layout)
     .map((id) => `<${id}>`)

--- a/frontend/packages/ux-editor/src/components/TextResource/TextResourceEditor/TextResourceValueEditor/TextResourceValueEditor.tsx
+++ b/frontend/packages/ux-editor/src/components/TextResource/TextResourceEditor/TextResourceValueEditor/TextResourceValueEditor.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent } from 'react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { StudioCodeFragment, StudioTextarea } from '@studio/components';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useTextResourcesQuery } from 'app-shared/hooks/queries';
 import { DEFAULT_LANGUAGE } from 'app-shared/constants';
 import type { ITextResources } from 'app-shared/types/global';
@@ -22,7 +22,7 @@ const getTextResourceValue = (textResources: ITextResources, id: string) =>
   findTextResource(textResources, id)?.value || '';
 
 export const TextResourceValueEditor = ({ textResourceId }: TextResourceValueEditorProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: textResources } = useTextResourcesQuery(org, app);
   const { mutate } = useUpsertTextResourceMutation(org, app);
   const value = getTextResourceValue(textResources, textResourceId);

--- a/frontend/packages/ux-editor/src/components/config/ExpressionContent/ExpressionContent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/ExpressionContent/ExpressionContent.tsx
@@ -4,7 +4,7 @@ import { getComponentIds, getDataModelElementNames } from '../../../utils/expres
 import type { Expression, DataLookupOptions } from '@studio/components';
 import { DataLookupFuncName, StudioDeleteButton } from '@studio/components';
 import { useFormLayoutsQuery } from '../../../hooks/queries/useFormLayoutsQuery';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useDatamodelMetadataQuery } from '../../../hooks/queries/useDatamodelMetadataQuery';
 import { Paragraph } from '@digdir/design-system-react';
 import classes from './ExpressionContent.module.css';
@@ -25,7 +25,7 @@ export const ExpressionContent = ({
   heading,
 }: ExpressionContentProps) => {
   const t = useText();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName } = useAppContext();
   const { data: formLayoutsData } = useFormLayoutsQuery(org, app, selectedFormLayoutSetName);
   const { data: datamodelMetadata } = useDatamodelMetadataQuery(

--- a/frontend/packages/ux-editor/src/components/config/SelectDataModelComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/SelectDataModelComponent.tsx
@@ -3,7 +3,7 @@ import { LegacySelect } from '@digdir/design-system-react';
 import { useDatamodelMetadataQuery } from '../../hooks/queries/useDatamodelMetadataQuery';
 import { FormField } from '../FormField';
 import type { Option } from '@altinn/text-editor/types';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import type { DatamodelFieldElement } from 'app-shared/types/DatamodelFieldElement';
 import { useAppContext } from '../../hooks';
 
@@ -31,7 +31,7 @@ export const SelectDataModelComponent = ({
   helpText,
   propertyPath,
 }: ISelectDataModelProps) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName } = useAppContext();
   const { data } = useDatamodelMetadataQuery(org, app, selectedFormLayoutSetName, undefined);
   const [dataModelElementNames, setDataModelElementNames] = React.useState<Option[]>([]);

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/AttachmentList/AttachmentListComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/AttachmentList/AttachmentListComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { IGenericEditComponent } from '../../componentConfig';
 import { useAppMetadataQuery } from 'app-development/hooks/queries';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useLayoutSetsQuery } from 'app-shared/hooks/queries/useLayoutSetsQuery';
 import { useAppContext } from '../../../../hooks/useAppContext';
 import type { ComponentType } from 'app-shared/types/ComponentType';
@@ -20,7 +20,7 @@ export const AttachmentListComponent = ({
   handleComponentChange,
 }: IGenericEditComponent<ComponentType.AttachmentList>) => {
   const { t } = useTranslation();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: layoutSets } = useLayoutSetsQuery(org, app);
   const { data: appMetadata, isPending: appMetadataPending } = useAppMetadataQuery(org, app);
   const { selectedFormLayoutSetName } = useAppContext();

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/RepeatingGroup/RepeatingGroupComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/RepeatingGroup/RepeatingGroupComponent.tsx
@@ -9,7 +9,7 @@ import {
   useTextResourcesSelector,
   useAppContext,
 } from '../../../../hooks';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useFormLayoutsQuery } from '../../../../hooks/queries/useFormLayoutsQuery';
 import type { ITextResource } from 'app-shared/types/global';
 import { textResourcesByLanguageSelector } from '../../../../selectors/textResourceSelectors';
@@ -23,7 +23,7 @@ export const RepeatingGroupComponent = ({
 }: IEditFormComponentProps<ComponentType.RepeatingGroup>) => {
   const t = useText();
 
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
 
   const { selectedFormLayoutSetName, selectedFormLayoutName } = useAppContext();
   const { data: formLayouts } = useFormLayoutsQuery(org, app, selectedFormLayoutSetName);

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditCodeList/EditCodeList.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditCodeList/EditCodeList.tsx
@@ -7,7 +7,7 @@ import { StudioButton, StudioSpinner } from '@studio/components';
 
 import { altinnDocsUrl } from 'app-shared/ext-urls';
 import { FormField } from '../../../FormField';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import classes from './EditCodeList.module.css';
 import type { ComponentType } from 'app-shared/types/ComponentType';
 
@@ -15,7 +15,7 @@ export function EditCodeList<
   T extends ComponentType.Checkboxes | ComponentType.RadioButtons | ComponentType.Dropdown,
 >({ component, handleComponentChange }: IGenericEditComponent<T>) {
   const { t } = useTranslation();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
 
   const { data: optionListIds, isPending, isError, error } = useOptionListIdsQuery(org, app);
   const [useCustomCodeList, setUseCustomCodeList] = useState<boolean>(optionListIds?.length === 0);

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings/EditDataModelBindings.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditDataModelBindings/EditDataModelBindings.tsx
@@ -7,7 +7,7 @@ import {
 import { ComponentType } from 'app-shared/types/ComponentType';
 import React, { useEffect, useState } from 'react';
 import { useDatamodelMetadataQuery } from '../../../../hooks/queries/useDatamodelMetadataQuery';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import classes from './EditDataModelBindings.module.css';
 import { useTranslation } from 'react-i18next';
 import { UndefinedBinding } from './UndefinedBinding';
@@ -33,7 +33,7 @@ export const EditDataModelBindings = <T extends ComponentType>({
   renderOptions,
   helpText,
 }: EditDataModelBindingsProps<T>) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName } = useAppContext();
   const { data } = useDatamodelMetadataQuery(org, app, selectedFormLayoutSetName, undefined);
   const { t } = useTranslation();

--- a/frontend/packages/ux-editor/src/components/toolbar/ConditionalRenderingModal.tsx
+++ b/frontend/packages/ux-editor/src/components/toolbar/ConditionalRenderingModal.tsx
@@ -18,7 +18,7 @@ import {
   addConditionalRenderingConnection,
   deleteConditionalRenderingConnection,
 } from '../../utils/ruleConfigUtils';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useFormLayoutsQuery } from '../../hooks/queries/useFormLayoutsQuery';
 import { useAppContext } from '../../hooks';
 
@@ -29,7 +29,7 @@ export interface IConditionalRenderingModalProps {
 }
 
 export function ConditionalRenderingModal(props: IConditionalRenderingModalProps) {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const [selectedConnectionId, setSelectedConnectionId] = React.useState<string>(null);
   const { selectedFormLayoutSetName } = useAppContext();
   const { data: ruleModel } = useRuleModelQuery(org, app, selectedFormLayoutSetName);

--- a/frontend/packages/ux-editor/src/components/toolbar/RuleModal.tsx
+++ b/frontend/packages/ux-editor/src/components/toolbar/RuleModal.tsx
@@ -9,7 +9,7 @@ import type { RuleConnection } from 'app-shared/types/RuleConfig';
 import { useRuleConfigQuery } from '../../hooks/queries/useRuleConfigQuery';
 import { useRuleConfigMutation } from '../../hooks/mutations/useRuleConfigMutation';
 import { addRuleConnection, deleteRuleConnection } from '../../utils/ruleConfigUtils';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../hooks';
 
 export interface IRuleModalProps {
@@ -19,7 +19,7 @@ export interface IRuleModalProps {
 }
 
 export function RuleModal(props: IRuleModalProps) {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const [selectedConnectionId, setSelectedConnectionId] = React.useState<string>(null);
   const { selectedFormLayoutSetName } = useAppContext();
   const { data: ruleConfig } = useRuleConfigQuery(org, app, selectedFormLayoutSetName);

--- a/frontend/packages/ux-editor/src/containers/DesignView/DesignView.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/DesignView.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import React from 'react';
 import classes from './DesignView.module.css';
 import { useTranslation } from 'react-i18next';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { Accordion } from '@digdir/design-system-react';
 import type { IFormLayouts } from '../../types/global';
 import type { FormLayoutPage } from '../../types/FormLayoutPage';
@@ -33,7 +33,7 @@ const mapFormLayoutsToFormLayoutPages = (formLayouts: IFormLayouts): FormLayoutP
  * @returns {ReactNode} - The rendered component
  */
 export const DesignView = (): ReactNode => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const {
     selectedFormLayoutSetName,
     selectedFormLayoutName,

--- a/frontend/packages/ux-editor/src/containers/DesignView/FormTree/FormItem/FormItemTitle/useDeleteItem.ts
+++ b/frontend/packages/ux-editor/src/containers/DesignView/FormTree/FormItem/FormItemTitle/useDeleteItem.ts
@@ -1,4 +1,4 @@
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useDeleteFormContainerMutation } from '../../../../../hooks/mutations/useDeleteFormContainerMutation';
 import { useDeleteFormComponentMutation } from '../../../../../hooks/mutations/useDeleteFormComponentMutation';
 import { useMemo } from 'react';
@@ -8,7 +8,7 @@ import type { FormContainer } from '../../../../../types/FormContainer';
 import { useAppContext } from '../../../../../hooks';
 
 export const useDeleteItem = (formItem: FormComponent | FormContainer) => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName } = useAppContext();
   const { mutate: deleteContainer } = useDeleteFormContainerMutation(
     org,

--- a/frontend/packages/ux-editor/src/containers/DesignView/FormTree/UnknownReferencedItem/useDeleteUnknownComponentReference.ts
+++ b/frontend/packages/ux-editor/src/containers/DesignView/FormTree/UnknownReferencedItem/useDeleteUnknownComponentReference.ts
@@ -1,11 +1,11 @@
-﻿import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+﻿import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useSelectedFormLayoutWithName, useAppContext } from '../../../../hooks';
 import { useFormLayoutMutation } from '../../../../hooks/mutations/useFormLayoutMutation';
 import { removeComponent } from '../../../../utils/formLayoutUtils';
 import type { IInternalLayout } from '../../../../types/global';
 
 export const useDeleteUnknownComponentReference = () => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName, refetchLayouts } = useAppContext();
   const { layoutName } = useSelectedFormLayoutWithName();
   const { mutateAsync: updateFormLayoutMutation } = useFormLayoutMutation(

--- a/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
@@ -4,7 +4,7 @@ import { DropdownMenu } from '@digdir/design-system-react';
 import { MenuElipsisVerticalIcon, ArrowUpIcon, ArrowDownIcon } from '@studio/icons';
 import { useFormLayoutSettingsQuery } from '../../../../hooks/queries/useFormLayoutSettingsQuery';
 import { useUpdateLayoutOrderMutation } from '../../../../hooks/mutations/useUpdateLayoutOrderMutation';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../../../hooks';
 import { StudioButton } from '@studio/components';
 
@@ -25,7 +25,7 @@ export type NavigationMenuProps = {
 export const NavigationMenu = ({ pageName, pageIsReceipt }: NavigationMenuProps): JSX.Element => {
   const { t } = useTranslation();
 
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
 
   const { selectedFormLayoutSetName } = useAppContext();
 

--- a/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.tsx
@@ -7,7 +7,7 @@ import { NavigationMenu } from './NavigationMenu';
 import { pageAccordionContentId } from '@studio/testing/testids';
 import { TrashIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../../hooks';
 import { StudioButton } from '@studio/components';
 import { useDeleteLayoutMutation } from '../../../hooks/mutations/useDeleteLayoutMutation';
@@ -43,7 +43,7 @@ export const PageAccordion = ({
   isValid,
 }: PageAccordionProps): ReactNode => {
   const { t } = useTranslation();
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName, refetchLayouts } = useAppContext();
 
   const { mutate: deleteLayout, isPending } = useDeleteLayoutMutation(

--- a/frontend/packages/ux-editor/src/containers/FormDesigner.tsx
+++ b/frontend/packages/ux-editor/src/containers/FormDesigner.tsx
@@ -13,7 +13,7 @@ import { StudioPageSpinner } from '@studio/components';
 import { BASE_CONTAINER_ID } from 'app-shared/constants';
 import { useRuleConfigQuery } from '../hooks/queries/useRuleConfigQuery';
 import { useInstanceIdQuery } from 'app-shared/hooks/queries';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import type { HandleAdd, HandleMove } from 'app-shared/types/dndTypes';
 import type { ComponentType } from 'app-shared/types/ComponentType';
 import { generateComponentId } from '../utils/generateId';
@@ -30,7 +30,7 @@ import { Preview } from '../components/Preview';
 import { DragAndDropTree } from 'app-shared/components/DragAndDropTree';
 
 export const FormDesigner = (): JSX.Element => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: instanceId } = useInstanceIdQuery(org, app);
   const { selectedFormLayoutSetName, selectedFormLayoutName, refetchLayouts } = useAppContext();
   const { data: formLayouts, isError: layoutFetchedError } = useFormLayoutsQuery(

--- a/frontend/packages/ux-editor/src/containers/FormItemContext.tsx
+++ b/frontend/packages/ux-editor/src/containers/FormItemContext.tsx
@@ -15,7 +15,7 @@ import type { UpdateFormComponentMutationArgs } from '../hooks/mutations/useUpda
 import { useUpdateFormComponentMutation } from '../hooks/mutations/useUpdateFormComponentMutation';
 import { AUTOSAVE_DEBOUNCE_INTERVAL_MILLISECONDS } from 'app-shared/constants';
 import { LayoutItemType } from '../types/global';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../hooks';
 import type { MutateOptions } from '@tanstack/react-query';
 
@@ -69,7 +69,7 @@ type FormItemContextProviderProps = {
 export const FormItemContextProvider = ({
   children,
 }: FormItemContextProviderProps): React.JSX.Element => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName, selectedFormLayoutName, refetchLayouts } = useAppContext();
   const prevSelectedFormLayoutSetNameRef = useRef(selectedFormLayoutSetName);
   const prevSelectedFormLayoutNameRef = useRef(selectedFormLayoutName);

--- a/frontend/packages/ux-editor/src/hooks/useFormLayouts.ts
+++ b/frontend/packages/ux-editor/src/hooks/useFormLayouts.ts
@@ -1,10 +1,10 @@
 import { useFormLayoutsQuery } from './queries/useFormLayoutsQuery';
 import type { IFormLayouts } from '../types/global';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from './';
 
 export const useFormLayouts = (): IFormLayouts => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName } = useAppContext();
   const formLayoutsQuery = useFormLayoutsQuery(org, app, selectedFormLayoutSetName);
   const { data } = formLayoutsQuery;

--- a/frontend/packages/ux-editor/src/hooks/useSelectedFormLayoutName.ts
+++ b/frontend/packages/ux-editor/src/hooks/useSelectedFormLayoutName.ts
@@ -1,6 +1,6 @@
 import { useSearchParamsState } from 'app-shared/hooks/useSearchParamsState';
 import { useFormLayoutSettingsQuery } from './queries/useFormLayoutSettingsQuery';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export type UseSelectedFormLayoutNameResult = {
   selectedFormLayoutName: string;
@@ -10,7 +10,7 @@ export type UseSelectedFormLayoutNameResult = {
 export const useSelectedFormLayoutName = (
   selectedFormLayoutSetName: string,
 ): UseSelectedFormLayoutNameResult => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: formLayoutSettings } = useFormLayoutSettingsQuery(
     org,
     app,

--- a/frontend/packages/ux-editor/src/hooks/useSelectedFormLayoutSetName.ts
+++ b/frontend/packages/ux-editor/src/hooks/useSelectedFormLayoutSetName.ts
@@ -1,4 +1,4 @@
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useLayoutSetsQuery } from 'app-shared/hooks/queries/useLayoutSetsQuery';
 import { useEffect, useState } from 'react';
 import { typedLocalStorage } from 'app-shared/utils/webStorage';
@@ -9,7 +9,7 @@ export type UseSelectedFormLayoutSetNameResult = {
 };
 
 export const useSelectedFormLayoutSetName = (): UseSelectedFormLayoutSetNameResult => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: layoutSets } = useLayoutSetsQuery(org, app);
 
   const storageKey: string = 'selectedFormLayoutSetName';

--- a/frontend/packages/ux-editor/src/hooks/useSelectedTaskId.ts
+++ b/frontend/packages/ux-editor/src/hooks/useSelectedTaskId.ts
@@ -1,9 +1,9 @@
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useLayoutSetsQuery } from 'app-shared/hooks/queries/useLayoutSetsQuery';
 import { TASKID_FOR_STATELESS_APPS } from 'app-shared/constants';
 
 export const useSelectedTaskId = (selectedFormLayoutSetName: string): string => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: layoutSets } = useLayoutSetsQuery(org, app);
 
   return (

--- a/frontend/packages/ux-editor/src/hooks/useTextResourcesSelector.ts
+++ b/frontend/packages/ux-editor/src/hooks/useTextResourcesSelector.ts
@@ -1,9 +1,9 @@
 import type { TextResourcesSelector } from '../types/global';
 import { useTextResourcesQuery } from 'app-shared/hooks/queries';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export const useTextResourcesSelector = <T>(selector: TextResourcesSelector<T>): T => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: textResources } = useTextResourcesQuery(org, app);
   return selector(textResources);
 };

--- a/frontend/packages/ux-editor/src/hooks/useValidateComponent.ts
+++ b/frontend/packages/ux-editor/src/hooks/useValidateComponent.ts
@@ -6,7 +6,7 @@ import type {
   FormRadioButtonsComponent,
 } from '../types/FormComponent';
 import { useOptionListIdsQuery } from './queries/useOptionListIdsQuery';
-import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export enum ErrorCode {
   NoOptions = 'NoOptions',
@@ -48,7 +48,7 @@ const validateOptionGroup = (
 };
 
 export const useValidateComponent = (component: FormComponent): ComponentValidationResult => {
-  const { org, app } = useStudioUrlParams();
+  const { org, app } = useStudioEnvironmentParams();
   const { data: optionListIds } = useOptionListIdsQuery(org, app);
 
   switch (component.type) {


### PR DESCRIPTION
## Description
As the name `useStudioParams` does not reflect what the hook actually does, it has been renamed to `useStudioEnvironmentParams` as it only returns `org` and `app` from the params 

## Related Issue(s)
- The PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)