### PR TITLE
Fix textKey

### DIFF
--- a/frontend/packages/schema-editor/src/components/SchemaInspector/InlineObject.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/InlineObject.tsx
@@ -16,7 +16,7 @@ export function InlineObject({ item }: IInlineObjectProps) {
         {JSON.stringify(item, null, '    ')}
       </pre>
       <div id='information-paper' className={classes.informationPaper}>
-        {t('combination_inline_object_disclaimer')}
+        {t('schema_editor.combination_inline_object_disclaimer')}
       </div>
     </div>
   );

--- a/frontend/packages/schema-editor/src/components/SchemaInspector/ItemPropertiesTab.test.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaInspector/ItemPropertiesTab.test.tsx
@@ -43,7 +43,9 @@ describe('ItemPropertiesTab', () => {
     renderWithProviders({
       appContextProps: { schemaModel: SchemaModel.fromArray(uiSchemaNodes) },
     })(<ItemPropertiesTab selectedItem={uiSchemaNodes[2]} />);
-    expect(screen.getByText(textMock('combination_inline_object_disclaimer'))).toBeDefined();
+    expect(
+      screen.getByText(textMock('schema_editor.combination_inline_object_disclaimer')),
+    ).toBeDefined();
   });
 
   it('Renders a name field when a field node is selected', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When adding a combination in a combination in datamodel, the textkey is broken.

![image](https://github.com/Altinn/altinn-studio/assets/74791975/92b8b961-cdc3-40f3-9e8a-470f65e11b11)

<!--- Describe your changes in detail -->

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
