### PR TITLE
Remove prop drilling of app and org in SettingsModal

### DIFF
--- a/frontend/app-development/layout/PageHeader.tsx
+++ b/frontend/app-development/layout/PageHeader.tsx
@@ -25,9 +25,7 @@ export const subMenuContent = ({ org, app, hasRepoError }: SubMenuContentProps) 
       org={org}
       app={app}
       hasCloneModal
-      leftComponent={
-        repositoryType !== RepositoryType.DataModels && <SettingsModalButton org={org} app={app} />
-      }
+      leftComponent={repositoryType !== RepositoryType.DataModels && <SettingsModalButton />}
       hasRepoError={hasRepoError}
     />
   );

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.test.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.test.tsx
@@ -11,7 +11,6 @@ import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import type { AppConfig } from 'app-shared/types/AppConfig';
 import { useAppConfigMutation } from 'app-development/hooks/mutations';
 import { MemoryRouter } from 'react-router-dom';
-import { app, org } from '@studio/testing/testids';
 
 jest.mock('../../../hooks/mutations/useAppConfigMutation');
 const updateAppConfigMutation = jest.fn();
@@ -33,8 +32,6 @@ describe('SettingsModal', () => {
   const defaultProps: SettingsModalProps = {
     isOpen: true,
     onClose: mockOnClose,
-    org,
-    app,
   };
 
   it('closes the modal when the close button is clicked', async () => {

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/SettingsModal.tsx
@@ -23,42 +23,19 @@ import { SetupTab } from './components/Tabs/SetupTab';
 export type SettingsModalProps = {
   isOpen: boolean;
   onClose: () => void;
-  org: string;
-  app: string;
   defaultTab?: SettingsModalTab;
 };
 
-/**
- * @component
- *    Displays the settings modal
- *
- * @property {boolean}[isOpen] - Flag for if the modal is open
- * @property {function}[onClose] - Function to be executed on close
- *
- * @returns {ReactNode} - The rendered component
- */
-export const SettingsModal = ({
-  isOpen,
-  onClose,
-  org,
-  app,
-  defaultTab,
-}: SettingsModalProps): ReactNode => {
+export const SettingsModal = ({ isOpen, onClose, defaultTab }: SettingsModalProps): ReactNode => {
   const { t } = useTranslation();
 
   const [currentTab, setCurrentTab] = useState<SettingsModalTab>(defaultTab || 'about');
 
-  /**
-   * Ids for the navigation tabs
-   */
   const aboutTabId: SettingsModalTab = 'about';
   const setupTabId: SettingsModalTab = 'setup';
   const policyTabId: SettingsModalTab = 'policy';
   const accessControlTabId: SettingsModalTab = 'access_control';
 
-  /**
-   * The tabs to display in the navigation bar
-   */
   const leftNavigationTabs: LeftNavigationTab[] = [
     createNavigationTab(
       <InformationSquareIcon className={classes.icon} />,
@@ -86,31 +63,23 @@ export const SettingsModal = ({
     ),
   ];
 
-  /**
-   * Changes the active tab
-   * @param tabId
-   */
   const changeTabTo = (tabId: SettingsModalTab) => {
     setCurrentTab(tabId);
   };
 
-  /**
-   * Displays the currently selected tab and its content
-   * @returns
-   */
   const displayTabs = () => {
     switch (currentTab) {
       case 'about': {
-        return <AboutTab org={org} app={app} />;
+        return <AboutTab />;
       }
       case 'setup': {
-        return <SetupTab org={org} app={app} />;
+        return <SetupTab />;
       }
       case 'policy': {
-        return <PolicyTab org={org} app={app} />;
+        return <PolicyTab />;
       }
       case 'access_control': {
-        return <AccessControlTab org={org} app={app} />;
+        return <AccessControlTab />;
       }
     }
   };

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/TabHeader/TabHeader.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/TabHeader/TabHeader.tsx
@@ -4,9 +4,6 @@ import classes from './TabHeader.module.css';
 import { Heading } from '@digdir/design-system-react';
 
 export type TabHeaderProps = {
-  /**
-   * The text in the header
-   */
   text: string;
 };
 

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/AboutTab/AboutTab.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/AboutTab/AboutTab.tsx
@@ -15,23 +15,11 @@ import { TabDataError } from '../../TabDataError';
 import { InputFields } from './InputFields';
 import { CreatedFor } from './CreatedFor';
 import { TabContent } from '../../TabContent';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
-export type AboutTabProps = {
-  org: string;
-  app: string;
-};
-
-/**
- * @component
- *    Displays the tab rendering the config for an app
- *
- * @property {string}[org] - The org
- * @property {string}[app] - The app
- *
- * @returns {ReactNode} - The rendered component
- */
-export const AboutTab = ({ org, app }: AboutTabProps): ReactNode => {
+export const AboutTab = (): ReactNode => {
   const { t } = useTranslation();
+  const { org, app } = useStudioEnvironmentParams();
 
   const repositoryType = getRepositoryType(org, app);
 

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/AboutTab/InputFields/InputFields.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/AboutTab/InputFields/InputFields.tsx
@@ -8,15 +8,7 @@ import { Textfield } from '@digdir/design-system-react';
 type AppConfigForm = Pick<AppConfig, 'serviceName' | 'serviceId'>;
 
 export type InputFieldsProps = {
-  /**
-   * The app configuration data
-   */
   appConfig: AppConfig;
-  /**
-   * Function to save the updated data
-   * @param appConfig the new app config
-   * @returns void
-   */
   onSave: (appConfig: AppConfig) => void;
 };
 

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/AccessControlTab/AccessControlTab.test.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/AccessControlTab/AccessControlTab.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render as rtlRender, screen, waitForElementToBeRemoved } from '@testing-library/react';
-import type { AccessControlTabProps } from './AccessControlTab';
 import { AccessControlTab } from './AccessControlTab';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
@@ -10,13 +9,16 @@ import type { QueryClient } from '@tanstack/react-query';
 import { mockAppMetadata } from '../../../mocks/applicationMetadataMock';
 import userEvent from '@testing-library/user-event';
 import { app, org } from '@studio/testing/testids';
+import { MemoryRouter } from 'react-router-dom';
 
 const getAppMetadata = jest.fn().mockImplementation(() => Promise.resolve({}));
 
-const defaultProps: AccessControlTabProps = {
-  org,
-  app,
-};
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => {
+    return { org, app };
+  },
+}));
 
 describe('AccessControlTab', () => {
   afterEach(jest.clearAllMocks);
@@ -88,8 +90,10 @@ const render = (
   };
 
   return rtlRender(
-    <ServicesContextProvider {...allQueries} client={queryClient}>
-      <AccessControlTab {...defaultProps}></AccessControlTab>
-    </ServicesContextProvider>,
+    <MemoryRouter>
+      <ServicesContextProvider {...allQueries} client={queryClient}>
+        <AccessControlTab />
+      </ServicesContextProvider>
+    </MemoryRouter>,
   );
 };

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/AccessControlTab/AccessControlTab.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/AccessControlTab/AccessControlTab.tsx
@@ -9,23 +9,11 @@ import { LoadingTabData } from '../../LoadingTabData';
 import { TabDataError } from '../../TabDataError';
 import { TabContent } from '../../TabContent';
 import { SelectAllowedPartyTypes } from './SelectAllowedPartyTypes';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
-export type AccessControlTabProps = {
-  org: string;
-  app: string;
-};
-
-/**
- * @component
- *    Displays the tab rendering the access control for an app
- *
- * @property {string}[org] - The org
- * @property {string}[app] - The app
- *
- * @returns {ReactNode} - The rendered component
- */
-export const AccessControlTab = ({ org, app }: AccessControlTabProps): ReactNode => {
+export const AccessControlTab = (): ReactNode => {
   const { t } = useTranslation();
+  const { org, app } = useStudioEnvironmentParams();
 
   const {
     data: appMetadata,
@@ -52,7 +40,7 @@ export const AccessControlTab = ({ org, app }: AccessControlTabProps): ReactNode
             <Paragraph size='medium'>
               {t('settings_modal.access_control_tab_checkbox_description')}
             </Paragraph>
-            <SelectAllowedPartyTypes org={org} app={app} appMetadata={appMetadata} />
+            <SelectAllowedPartyTypes appMetadata={appMetadata} />
           </>
         );
       }

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/AccessControlTab/SelectAllowedPartyTypes/SelectAllowedPartyTypes.test.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/AccessControlTab/SelectAllowedPartyTypes/SelectAllowedPartyTypes.test.tsx
@@ -12,10 +12,16 @@ import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { app, org } from '@studio/testing/testids';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => {
+    return { org, app };
+  },
+}));
 
 const defaultProps: SelectAllowedPartyTypesProps = {
-  org,
-  app,
   appMetadata: mockAppMetadata,
 };
 
@@ -140,8 +146,10 @@ describe('SelectAllowedPartyTypes', () => {
 const renderSelectAllowedPartyTypes = (props: Partial<SelectAllowedPartyTypesProps> = {}) => {
   const queryClient: QueryClient = createQueryClientMock();
   return rtlRender(
-    <ServicesContextProvider {...queriesMock} client={queryClient}>
-      <SelectAllowedPartyTypes {...defaultProps} {...props}></SelectAllowedPartyTypes>
-    </ServicesContextProvider>,
+    <MemoryRouter>
+      <ServicesContextProvider {...queriesMock} client={queryClient}>
+        <SelectAllowedPartyTypes {...defaultProps} {...props}></SelectAllowedPartyTypes>
+      </ServicesContextProvider>
+    </MemoryRouter>,
   );
 };

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/AccessControlTab/SelectAllowedPartyTypes/SelectAllowedPartyTypes.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/AccessControlTab/SelectAllowedPartyTypes/SelectAllowedPartyTypes.tsx
@@ -6,19 +6,16 @@ import { useTranslation } from 'react-i18next';
 import { getPartyTypesAllowedOptions } from '../../../../utils/tabUtils/accessControlTabUtils';
 import { useAppMetadataMutation } from 'app-development/hooks/mutations';
 import { AccessControlWarningModal } from '../AccessControWarningModal';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export interface SelectAllowedPartyTypesProps {
-  org: string;
-  app: string;
   appMetadata: ApplicationMetadata;
 }
 
-export const SelectAllowedPartyTypes = ({
-  org,
-  app,
-  appMetadata,
-}: SelectAllowedPartyTypesProps) => {
+export const SelectAllowedPartyTypes = ({ appMetadata }: SelectAllowedPartyTypesProps) => {
   const { t } = useTranslation();
+  const { org, app } = useStudioEnvironmentParams();
+
   const modalRef = useRef<HTMLDialogElement>(null);
 
   const partyTypesAllowed = appMetadata.partyTypesAllowed;

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/PolicyTab/PolicyTab.test.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/PolicyTab/PolicyTab.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render as rtlRender, screen, waitForElementToBeRemoved } from '@testing-library/react';
-import type { PolicyTabProps } from './PolicyTab';
 import { PolicyTab } from './PolicyTab';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
@@ -13,6 +12,7 @@ import userEvent from '@testing-library/user-event';
 import { useAppPolicyMutation } from 'app-development/hooks/mutations';
 import { mockPolicy } from '../../../mocks/policyMock';
 import { app, org } from '@studio/testing/testids';
+import { MemoryRouter } from 'react-router-dom';
 
 const mockActions: PolicyAction[] = [
   { actionId: 'a1', actionTitle: 'Action 1', actionDescription: 'The first action' },
@@ -54,10 +54,12 @@ const getAppPolicy = jest.fn().mockImplementation(() => Promise.resolve({}));
 const getPolicyActions = jest.fn().mockImplementation(() => Promise.resolve({}));
 const getPolicySubjects = jest.fn().mockImplementation(() => Promise.resolve({}));
 
-const defaultProps: PolicyTabProps = {
-  org,
-  app,
-};
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => {
+    return { org, app };
+  },
+}));
 
 describe('PolicyTab', () => {
   afterEach(jest.clearAllMocks);
@@ -151,8 +153,10 @@ const render = (
   };
 
   return rtlRender(
-    <ServicesContextProvider {...allQueries} client={queryClient}>
-      <PolicyTab {...defaultProps} />
-    </ServicesContextProvider>,
+    <MemoryRouter>
+      <ServicesContextProvider {...allQueries} client={queryClient}>
+        <PolicyTab />
+      </ServicesContextProvider>
+    </MemoryRouter>,
   );
 };

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/PolicyTab/PolicyTab.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/PolicyTab/PolicyTab.tsx
@@ -18,23 +18,11 @@ import {
 } from 'app-shared/hooks/queries';
 import { mergeQueryStatuses } from 'app-shared/utils/tanstackQueryUtils';
 import { TabContent } from '../../TabContent';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
-export type PolicyTabProps = {
-  org: string;
-  app: string;
-};
-
-/**
- * @component
- *    Displays the tab rendering the polciy for an app
- *
- * @property {string}[org] - The org
- * @property {string}[app] - The app
- *
- * @returns {ReactNode} - The rendered component
- */
-export const PolicyTab = ({ org, app }: PolicyTabProps): ReactNode => {
+export const PolicyTab = (): ReactNode => {
   const { t } = useTranslation();
+  const { org, app } = useStudioEnvironmentParams();
 
   const {
     status: policyStatus,

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/SetupTab/SetupTab.test.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/SetupTab/SetupTab.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render as rtlRender, screen, waitForElementToBeRemoved } from '@testing-library/react';
-import type { SetupTabProps } from './SetupTab';
 import { SetupTab } from './SetupTab';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import type { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
@@ -10,16 +9,16 @@ import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { MemoryRouter } from 'react-router-dom';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { mockAppMetadata } from '../../../mocks/applicationMetadataMock';
-
-const mockOrg: string = 'testOrg';
-const mockApp: string = 'testApp';
+import { app, org } from '@studio/testing/testids';
 
 const getAppMetadata = jest.fn().mockImplementation(() => Promise.resolve({}));
 
-const defaultProps: SetupTabProps = {
-  org: mockOrg,
-  app: mockApp,
-};
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => {
+    return { org, app };
+  },
+}));
 
 describe('SetupTab Component', () => {
   afterEach(() => {
@@ -70,7 +69,6 @@ describe('SetupTab Component', () => {
 
 const render = (
   queries: Partial<ServicesContextProps> = {},
-  props: Partial<SetupTabProps> = {},
   queryClient: QueryClient = createQueryClientMock(),
 ) => {
   const allQueries: ServicesContextProps = {
@@ -81,7 +79,7 @@ const render = (
   return rtlRender(
     <MemoryRouter>
       <ServicesContextProvider {...allQueries} client={queryClient}>
-        <SetupTab {...defaultProps} {...props} />
+        <SetupTab />
       </ServicesContextProvider>
     </MemoryRouter>,
   );

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/SetupTab/SetupTab.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/SetupTab/SetupTab.tsx
@@ -8,23 +8,11 @@ import { ErrorMessage } from '@digdir/design-system-react';
 import { TabHeader } from '../../TabHeader';
 import { SetupTabContent } from './SetupTabContent';
 import { TabContent } from '../../TabContent';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
-export type SetupTabProps = {
-  org: string;
-  app: string;
-};
-
-/**
- * @component
- *    Displays the tab rendering the setup tab for an app
- *
- * @property {string}[org] - The org
- * @property {string}[app] - The app
- *
- * @returns {ReactNode} - The rendered component
- */
-export const SetupTab = ({ org, app }: SetupTabProps): ReactNode => {
+export const SetupTab = (): ReactNode => {
   const { t } = useTranslation();
+  const { org, app } = useStudioEnvironmentParams();
 
   const {
     status: appMetadataStatus,
@@ -43,7 +31,7 @@ export const SetupTab = ({ org, app }: SetupTabProps): ReactNode => {
           </TabDataError>
         );
       case 'success':
-        return <SetupTabContent appMetadata={appMetadata} org={org} app={app} />;
+        return <SetupTabContent appMetadata={appMetadata} />;
     }
   };
 

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/SetupTab/SetupTabContent/SetupTabContent.test.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/SetupTab/SetupTabContent/SetupTabContent.test.tsx
@@ -12,9 +12,14 @@ import { queriesMock } from 'app-shared/mocks/queriesMock';
 import type { ApplicationMetadata } from 'app-shared/types/ApplicationMetadata';
 import { mockAppMetadata } from '../../../../mocks/applicationMetadataMock';
 import userEvent from '@testing-library/user-event';
+import { app, org } from '@studio/testing/testids';
 
-const mockOrg: string = 'testOrg';
-const mockApp: string = 'testApp';
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => {
+    return { org, app };
+  },
+}));
 
 jest.mock('../../../../../../../hooks/mutations/useAppMetadataMutation');
 const updateAppMetadataMutation = jest.fn();
@@ -27,8 +32,6 @@ mockUpdateAppMetadataMutation.mockReturnValue({
 
 const defaultProps: SetupTabContentProps = {
   appMetadata: mockAppMetadata,
-  org: mockOrg,
-  app: mockApp,
 };
 
 describe('SetupTabContent', () => {

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/SetupTab/SetupTabContent/SetupTabContent.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModal/components/Tabs/SetupTab/SetupTabContent/SetupTabContent.tsx
@@ -5,25 +5,15 @@ import type { ApplicationMetadata } from 'app-shared/types/ApplicationMetadata';
 import { useTranslation } from 'react-i18next';
 import { useAppMetadataMutation } from 'app-development/hooks/mutations';
 import { Paragraph, Switch } from '@digdir/design-system-react';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
 export type SetupTabContentProps = {
   appMetadata: ApplicationMetadata;
-  org: string;
-  app: string;
 };
 
-/**
- * @component
- *    The content of the Setup Tab
- *
- * @property {ApplicationMetadata}[appMetadata] - The application metadata
- * @property {string}[org] - The org
- * @property {string}[app] - The app
- *
- * @returns {ReactNode} - The rendered component
- */
-export const SetupTabContent = ({ appMetadata, org, app }: SetupTabContentProps): ReactNode => {
+export const SetupTabContent = ({ appMetadata }: SetupTabContentProps): ReactNode => {
   const { t } = useTranslation();
+  const { org, app } = useStudioEnvironmentParams();
 
   const { mutate: updateAppMetadataMutation } = useAppMetadataMutation(org, app);
 

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModalButton.test.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModalButton.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { SettingsModalButtonProps } from './SettingsModalButton';
 import { SettingsModalButton } from './SettingsModalButton';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import type { QueryClient } from '@tanstack/react-query';
@@ -11,12 +10,6 @@ import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { MemoryRouter } from 'react-router-dom';
 import { AppDevelopmentContextProvider } from '../../contexts/AppDevelopmentContext';
-import { app, org } from '@studio/testing/testids';
-
-const defaultProps: SettingsModalButtonProps = {
-  org,
-  app,
-};
 
 describe('SettingsModal', () => {
   const user = userEvent.setup();
@@ -88,7 +81,7 @@ const renderSettingsModalButton = (
     <MemoryRouter>
       <ServicesContextProvider {...allQueries} client={queryClient}>
         <AppDevelopmentContextProvider>
-          <SettingsModalButton {...defaultProps} />
+          <SettingsModalButton />
         </AppDevelopmentContextProvider>
       </ServicesContextProvider>
     </MemoryRouter>,

--- a/frontend/app-development/layout/SettingsModalButton/SettingsModalButton.tsx
+++ b/frontend/app-development/layout/SettingsModalButton/SettingsModalButton.tsx
@@ -6,16 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { SettingsModal } from './SettingsModal';
 import { useSettingsModalContext } from '../../contexts/SettingsModalContext';
 
-export type SettingsModalButtonProps = {
-  org: string;
-  app: string;
-};
-
-/**
- * @component
- *    Displays a button to open the Settings modal
- */
-export const SettingsModalButton = ({ org, app }: SettingsModalButtonProps): ReactNode => {
+export const SettingsModalButton = (): ReactNode => {
   const { t } = useTranslation();
   const { settingsModalOpen, setSettingsModalOpen, settingsModalSelectedTab } =
     useSettingsModalContext();
@@ -37,8 +28,6 @@ export const SettingsModalButton = ({ org, app }: SettingsModalButtonProps): Rea
           <SettingsModal
             isOpen={settingsModalOpen}
             onClose={() => setSettingsModalOpen(false)}
-            org={org}
-            app={app}
             defaultTab={settingsModalSelectedTab}
           />
         )


### PR DESCRIPTION
## Description
- Removing prop drilling og `org` and `app` in `SettingsModal` as it can be retrieved from `useStudioEnvironmentParams`

## Related Issue(s)
- The PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)