### PR TITLE
Only tryChange appMetadata if connected task from dataTypeChange is NOT customReceipt

### DIFF
--- a/backend/src/Designer/Constants/General.cs
+++ b/backend/src/Designer/Constants/General.cs
@@ -14,5 +14,10 @@ namespace Altinn.Studio.Designer.Constants
         /// The name of the cookie used for asp authentication in designer application
         /// </summary>
         public const string DesignerCookieName = "AltinnStudioDesigner";
+
+        /// <summary>
+        /// The identifying name for a custom receipt at process end in the application
+        /// </summary>
+        public const string CustomReceiptId = "CustomReceipt";
     }
 }

--- a/backend/src/Designer/Controllers/PreviewController.cs
+++ b/backend/src/Designer/Controllers/PreviewController.cs
@@ -1002,6 +1002,11 @@ namespace Altinn.Studio.Designer.Controllers
             LayoutSets layoutSetsWithMockedDataTypesIfMissing = AddDataTypesToReturnedLayoutSetsIfMissing(layoutSets);
             layoutSetsWithMockedDataTypesIfMissing.Sets.ForEach(set =>
             {
+                if (set.Tasks[0] == Constants.General.CustomReceiptId)
+                {
+                    return;
+                }
+
                 if (!applicationMetadata.DataTypes.Any(dataType => dataType.Id == set.DataType))
                 {
                     applicationMetadata.DataTypes.Add(new DataType()

--- a/backend/src/Designer/EventHandlers/ProcessDataTypeChanged/ProcessDataTypeChangedApplicationMetadataHandler.cs
+++ b/backend/src/Designer/EventHandlers/ProcessDataTypeChanged/ProcessDataTypeChangedApplicationMetadataHandler.cs
@@ -34,7 +34,7 @@ public class ProcessDataTypeChangedApplicationMetadataHandler : INotificationHan
 
                 var applicationMetadata = await repository.GetApplicationMetadata(cancellationToken);
 
-                if (TryChangeDataType(applicationMetadata, notification.NewDataType, notification.ConnectedTaskId))
+                if (notification.ConnectedTaskId != Constants.General.CustomReceiptId && TryChangeDataType(applicationMetadata, notification.NewDataType, notification.ConnectedTaskId))
                 {
                     await repository.SaveApplicationMetadata(applicationMetadata);
                 }

--- a/backend/src/Designer/Services/Implementation/PreviewService.cs
+++ b/backend/src/Designer/Services/Implementation/PreviewService.cs
@@ -19,7 +19,6 @@ public class PreviewService : IPreviewService
     private readonly IAltinnGitRepositoryFactory _altinnGitRepositoryFactory;
     public const string MockDataModelIdPrefix = "MockDataModel";
     public const string MockDataTaskId = "test-datatask-id";
-    private const string CustomReceiptTaskId = "CustomReceipt";
 
     /// <summary>
     /// Constructor
@@ -37,7 +36,7 @@ public class PreviewService : IPreviewService
         AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, app, developer);
         Application applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata(cancellationToken);
         string task = await GetTaskForLayoutSetName(org, app, developer, layoutSetName, cancellationToken);
-        bool shouldProcessActAsReceipt = task == CustomReceiptTaskId;
+        bool shouldProcessActAsReceipt = task == Constants.General.CustomReceiptId;
         // RegEx for instance guid in app-frontend: [\da-f]{8}-[\da-f]{4}-[1-5][\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}
         string instanceGuid = "f1e23d45-6789-1bcd-8c34-56789abcdef0";
         ProcessState processState = shouldProcessActAsReceipt
@@ -97,7 +96,7 @@ public class PreviewService : IPreviewService
             {
                 foreach (LayoutSetConfig layoutSet in layoutSets.Sets.Where(ls => !tasks.Contains(ls.Tasks[0])))
                 {
-                    if (layoutSet.Tasks[0] == CustomReceiptTaskId)
+                    if (layoutSet.Tasks[0] == Constants.General.CustomReceiptId)
                     {
                         continue;
                     }
@@ -158,7 +157,7 @@ public class PreviewService : IPreviewService
     private async Task<string> GetDataTypeForCustomReceipt(AltinnAppGitRepository altinnAppGitRepository)
     {
         LayoutSets layoutSets = await altinnAppGitRepository.GetLayoutSetsFile();
-        string dataType = layoutSets?.Sets?.Find(set => set.Tasks[0] == CustomReceiptTaskId)?.DataType;
+        string dataType = layoutSets?.Sets?.Find(set => set.Tasks[0] == Constants.General.CustomReceiptId)?.DataType;
         return dataType ?? string.Empty;
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetAppMetadataModelIdsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetAppMetadataModelIdsTests.cs
@@ -34,7 +34,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
 
             string responseContent = await response.Content.ReadAsStringAsync();
 
-            responseContent.Should().Be("[\"datamodel\",\"unUsedDatamodel\",\"HvemErHvem_M\",\"receiptDataType\"]");
+            responseContent.Should().Be("[\"datamodel\",\"unUsedDatamodel\",\"HvemErHvem_M\"]");
         }
 
         [Theory]

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/InstancesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/InstancesTests.cs
@@ -67,7 +67,7 @@ namespace Designer.Tests.Controllers.PreviewController
 
             string dataPathWithData = $"{Org}/{targetRepository}/instances?instanceOwnerPartyId=51001";
             using HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, dataPathWithData);
-            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV4}&selectedLayoutSet={CustomReceiptLayoutSetName2}");
+            httpRequestMessage.Headers.Referrer = new Uri($"{MockedReferrerUrl}?org={Org}&app={AppV4}&selectedLayoutSet={CustomReceiptLayoutSetName}");
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -75,7 +75,7 @@ namespace Designer.Tests.Controllers.PreviewController
             string responseBody = await response.Content.ReadAsStringAsync();
             JsonDocument responseDocument = JsonDocument.Parse(responseBody);
             Instance instance = JsonConvert.DeserializeObject<Instance>(responseDocument.RootElement.ToString());
-            Assert.Equal(DataTypeForCustomReceipt, instance.Data[0].DataType);
+            Assert.Equal(CustomReceiptDataType, instance.Data[0].DataType);
             Assert.Equal("EndEvent_1", instance.Process.EndEvent);
             instance.Process.CurrentTask.Should().BeNull();
         }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTestsBase.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTestsBase.cs
@@ -15,8 +15,8 @@ namespace Designer.Tests.Controllers.PreviewController
         protected const string Developer = "testUser";
         protected const string LayoutSetName = "layoutSet1";
         protected const string LayoutSetName2 = "layoutSet2";
-        protected const string CustomReceiptLayoutSetName2 = "receipt";
-        protected const string DataTypeForCustomReceipt = "receiptDataType";
+        protected const string CustomReceiptLayoutSetName = "receipt";
+        protected const string CustomReceiptDataType = "receiptDataType";
         protected const string PartyId = "51001";
         protected const string InstanceGuId = "f1e23d45-6789-1bcd-8c34-56789abcdef0";
         protected const string AttachmentGuId = "f47ac10b-58cc-4372-a567-0e02b2c3d479";

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/config/applicationmetadata.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/config/applicationmetadata.json
@@ -56,19 +56,6 @@
             "taskId": "Task_3",
             "maxCount": 1,
             "minCount": 1
-        },
-        {
-            "id": "receiptDataType",
-            "allowedContentTypes": [
-                "application/xml"
-            ],
-            "appLogic": {
-                "autoCreate": true,
-                "classRef": "Altinn.App.Models.receiptDataType"
-            },
-            "taskId": "CustomReceipt",
-            "maxCount": 1,
-            "minCount": 1
         }
     ],
     "partyTypesAllowed": {

--- a/testdata/App/ui/layout-sets.json
+++ b/testdata/App/ui/layout-sets.json
@@ -34,6 +34,13 @@
       "tasks": [
         "Task_5"
       ]
+    },
+    {
+      "id": "receipt",
+      "dataType": "receiptDataType",
+      "tasks": [
+        "CustomReceipt"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description
In order to be able to only modify the dataType in layout-sets and NOT applicationMetadata when changing dataType for CustomReceipt we need to check in the event handler for appmetadata that the task is NOT customReceipt before going on with the change. If connectedTask is CustomReceipt --> do nothing in this handler. 

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
