### PR TITLE
Delete dataType connection in LayoutSets based on dataTypeId directly when deleting a data model

### DIFF
--- a/backend/src/Designer/Services/Implementation/SchemaModelService.cs
+++ b/backend/src/Designer/Services/Implementation/SchemaModelService.cs
@@ -412,18 +412,18 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
             if (applicationMetadata.DataTypes != null)
             {
-                DataType removeForm = applicationMetadata.DataTypes.Find(m => m.Id == id);
+                DataType dataTypeToDelete = applicationMetadata.DataTypes.Find(m => m.Id == id);
                 if (altinnAppGitRepository.AppUsesLayoutSets())
                 {
                     var layoutSets = await altinnAppGitRepository.GetLayoutSetsFile();
-                    var layoutSet = layoutSets.Sets.Find(set => set.Tasks[0] == removeForm.TaskId);
-                    if (layoutSet is not null)
+                    List<LayoutSetConfig> layoutSetsWithDeletedDataType = layoutSets.Sets.FindAll(set => set.DataType == dataTypeToDelete.Id);
+                    foreach (LayoutSetConfig layoutSet in layoutSetsWithDeletedDataType)
                     {
                         layoutSet.DataType = null;
-                        await altinnAppGitRepository.SaveLayoutSets(layoutSets);
                     }
+                    await altinnAppGitRepository.SaveLayoutSets(layoutSets);
                 }
-                applicationMetadata.DataTypes.Remove(removeForm);
+                applicationMetadata.DataTypes.Remove(dataTypeToDelete);
                 await altinnAppGitRepository.SaveApplicationMetadata(applicationMetadata);
             }
         }

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/DeleteDatamodelTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/DeleteDatamodelTests.cs
@@ -1,10 +1,13 @@
 ﻿using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Altinn.App.Core.Models;
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Mocks;
+using Designer.Tests.Utils;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,7 +36,7 @@ public class DeleteDatamodelTests : DisagnerEndpointsTestsBase<DeleteDatamodelTe
 
     [Theory]
     [InlineData("ttd", "ttd-datamodels", "/App/models/41111.schema.json")]
-    public async Task Delete_Datamodel_Ok(string org, string repo, string modelPath)
+    public async Task Delete_Datamodel_FromDataModelRepo_Ok(string org, string repo, string modelPath)
     {
         string dataPathWithData = $"{VersionPrefix(org, repo)}/datamodel?modelPath={modelPath}";
 
@@ -41,5 +44,29 @@ public class DeleteDatamodelTests : DisagnerEndpointsTestsBase<DeleteDatamodelTe
 
         using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Theory]
+    [InlineData("ttd", "app-with-layoutsets", "testUser", "/App/models/datamodel.schema.json")]
+    public async Task Delete_Datamodel_FromAppWhereDataModelHasMultipleLayoutSetConnections_Ok(string org, string repo, string developer, string modelPath)
+    {
+        string targetRepository = TestDataHelper.GenerateTestRepoName();
+        await CopyRepositoryForTest(org, repo, developer, targetRepository);
+        string dataPathWithData = $"{VersionPrefix(org, targetRepository)}/datamodel?modelPath={modelPath}";
+        string applicationMetadataFromRepoBefore = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
+        string layoutSetsFromRepoBefore = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/ui/layout-sets.json");
+        applicationMetadataFromRepoBefore.Should().Contain("datamodel");
+        LayoutSets layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsFromRepoBefore, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        layoutSets.Sets.FindAll(set => set.DataType == "datamodel").Count.Should().Be(2);
+
+        using HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, dataPathWithData);
+
+        using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        string applicationMetadataFromRepoAfter = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
+        string layoutSetsFromRepoAfter = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/ui/layout-sets.json");
+        applicationMetadataFromRepoAfter.Should().NotContain("datamodel");
+        layoutSetsFromRepoAfter.Should().NotContain("datamodel");
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTestsBase.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/PreviewControllerTestsBase.cs
@@ -16,7 +16,7 @@ namespace Designer.Tests.Controllers.PreviewController
         protected const string LayoutSetName = "layoutSet1";
         protected const string LayoutSetName2 = "layoutSet2";
         protected const string CustomReceiptLayoutSetName = "receipt";
-        protected const string CustomReceiptDataType = "receiptDataType";
+        protected const string CustomReceiptDataType = "datamodel";
         protected const string PartyId = "51001";
         protected const string InstanceGuId = "f1e23d45-6789-1bcd-8c34-56789abcdef0";
         protected const string AttachmentGuId = "f47ac10b-58cc-4372-a567-0e02b2c3d479";

--- a/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layout-sets.json
+++ b/backend/tests/Designer.Tests/_TestData/Repositories/testUser/ttd/app-with-layoutsets/App/ui/layout-sets.json
@@ -24,7 +24,7 @@
         },
         {
             "id": "receipt",
-            "dataType": "receiptDataType",
+            "dataType": "datamodel",
             "tasks": [
                 "CustomReceipt"
             ]


### PR DESCRIPTION
## Description
Delete dataType connection in LayoutSets based on dataTypeId directly when deleting a data model
Add test

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
