### PR TITLE
Fix the link to the datamodel page for datamodel repos

### DIFF
--- a/frontend/dashboard/utils/urlUtils/urlUtils.test.ts
+++ b/frontend/dashboard/utils/urlUtils/urlUtils.test.ts
@@ -20,7 +20,7 @@ describe('urlUtils', () => {
         repo: 'org-name-datamodels',
       });
 
-      expect(result).toBe(`${APP_DEVELOPMENT_BASENAME}/org-name/org-name-datamodels/datamodel`);
+      expect(result).toBe(`${APP_DEVELOPMENT_BASENAME}/org-name/org-name-datamodels/data-model`);
     });
 
     it('should not return url to dataModelling when repo name does not match "<org>-dataModels"', () => {

--- a/frontend/dashboard/utils/urlUtils/urlUtils.ts
+++ b/frontend/dashboard/utils/urlUtils/urlUtils.ts
@@ -13,7 +13,7 @@ type GetRepoUrl = {
 
 export const getRepoEditUrl = ({ org, repo }: GetRepoUrl): string => {
   if (getRepositoryType(org, repo) === RepositoryType.DataModels) {
-    return `${APP_DEVELOPMENT_BASENAME}/${org}/${repo}/datamodel`;
+    return `${APP_DEVELOPMENT_BASENAME}/${org}/${repo}/data-model`;
   }
 
   return `${APP_DEVELOPMENT_BASENAME}/${org}/${repo}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The 404 page is displayed when opening a datamodel repository

**BEFORE**

https://github.com/Altinn/altinn-studio/assets/24462611/3e948cc9-72cd-4a1a-b409-9d839d1c7973

**AFTER**

https://github.com/Altinn/altinn-studio/assets/24462611/2bbc6749-fb78-4c3d-896e-b231a3d27f0e

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
