### PR TITLE
fix(ProcessEditor): should re-render the diagram when local changes are deleted

### DIFF
--- a/frontend/packages/process-editor/src/components/Canvas/Canvas.tsx
+++ b/frontend/packages/process-editor/src/components/Canvas/Canvas.tsx
@@ -11,12 +11,14 @@ import { BPMNEditor } from './BPMNEditor';
 import { VersionHelpText } from './VersionHelpText';
 
 export const Canvas = (): React.ReactElement => {
-  const { isEditAllowed } = useBpmnContext();
+  const { isEditAllowed, bpmnXml } = useBpmnContext();
 
   return (
     <>
       {!isEditAllowed && <VersionHelpText />}
-      <div className={classes.wrapper}>{isEditAllowed ? <BPMNEditor /> : <BPMNViewer />}</div>
+      <div className={classes.wrapper} key={bpmnXml}>
+        {isEditAllowed ? <BPMNEditor /> : <BPMNViewer />}
+      </div>
     </>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When deleting local changes, the diagram does not re-render which causes the diagram to display the wrong state. I fixed this by ensuring that React is re-rendering the diagram when bpmn diagram has changed.

## Related Issue(s)

- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)