### PR TITLE
added serialization value to icon enum properties

### DIFF
--- a/backend/src/Designer/Models/FooterFile.cs
+++ b/backend/src/Designer/Models/FooterFile.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
@@ -40,7 +41,10 @@ public enum ComponentType
 
 public enum IconType
 {
+    [EnumMember(Value = "information")]
     Information,
+    [EnumMember(Value = "email")]
     Email,
+    [EnumMember(Value = "phone")]
     Phone
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Icon property expects a lowercase property. However, the enum for IconType defines the icon types with uppercase. A `[EnumMember(value =...)]` annotation is needed so that the enum properties serialize with the correct case.

## Related Issue(s)

- #10469

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
