### PR TITLE
10699 organization should remain selected on dashboard

### DIFF
--- a/frontend/dashboard/app/App.test.tsx
+++ b/frontend/dashboard/app/App.test.tsx
@@ -45,7 +45,7 @@ describe('App', () => {
     renderWithMockServices();
     await waitForElementToBeRemoved(screen.queryByText(textMock('dashboard.loading')));
     expect(screen.getByRole('heading', { level: 2, name: textMock('dashboard.favourites') }));
-    expect(screen.getByRole('heading', { level: 2, name: textMock('dashboard.my_apps') }));
+    expect(screen.getByRole('heading', { level: 2, name: textMock('dashboard.apps') }));
     expect(screen.getByRole('heading', { level: 2, name: textMock('dashboard.resources') }));
   });
 });

--- a/frontend/dashboard/hooks/guards/useContextRedirectionGuard.ts
+++ b/frontend/dashboard/hooks/guards/useContextRedirectionGuard.ts
@@ -1,0 +1,75 @@
+import type { Organization } from 'app-shared/types/Organization';
+import { useEffect, useState } from 'react';
+import { useSelectedContext } from '../useSelectedContext';
+import type { NavigateFunction } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import { SelectedContextType } from 'app-shared/navigation/main-header/Header';
+import { typedSessionStorage } from 'app-shared/utils/webStorage';
+import { userHasAccessToSelectedContext } from 'dashboard/utils/userUtils';
+
+export type UseRedirectionGuardResult = {
+  isRedirectionComplete: boolean;
+};
+
+export const useContextRedirectionGuard = (
+  organizations: Organization[],
+): UseRedirectionGuardResult => {
+  const selectedContext = useSelectedContext();
+  const navigate = useNavigate();
+  const [isContextRedirectionComplete, setIsContextRedirectionComplete] = useState<boolean>(false);
+
+  if (selectedContext !== SelectedContextType.None) {
+    typedSessionStorage.setItem('dashboard::selectedContext', selectedContext);
+  }
+
+  useEffect(() => {
+    handleContextRedirection(selectedContext, organizations, navigate);
+    setIsContextRedirectionComplete(true);
+  }, [selectedContext, organizations, navigate]);
+
+  return {
+    isRedirectionComplete: isContextRedirectionComplete,
+  };
+};
+
+function handleContextRedirection(
+  currentContext: SelectedContextType | string,
+  organizations: Organization[],
+  navigate: NavigateFunction,
+) {
+  const targetContext = getTargetContext(currentContext);
+
+  if (!hasAccessToContext(targetContext, organizations)) {
+    navigateToContext(SelectedContextType.Self, navigate);
+    return;
+  }
+
+  if (targetContext === currentContext) return;
+  navigateToContext(targetContext, navigate);
+}
+
+function getTargetContext(
+  currentContext: SelectedContextType | string,
+): SelectedContextType | string {
+  if (currentContext === SelectedContextType.None) {
+    return typedSessionStorage.getItem('dashboard::selectedContext') || SelectedContextType.Self;
+  }
+  return currentContext;
+}
+
+function hasAccessToContext(
+  targetContext: SelectedContextType | string,
+  organizations: Organization[],
+): boolean {
+  return (
+    organizations &&
+    userHasAccessToSelectedContext({ selectedContext: targetContext, orgs: organizations })
+  );
+}
+
+function navigateToContext(
+  targetContext: SelectedContextType | string,
+  navigate: NavigateFunction,
+) {
+  navigate(targetContext + location.search, { replace: true });
+}

--- a/frontend/dashboard/hooks/guards/useContextRedirectionGuard.ts
+++ b/frontend/dashboard/hooks/guards/useContextRedirectionGuard.ts
@@ -32,11 +32,11 @@ export const useContextRedirectionGuard = (
   };
 };
 
-function handleContextRedirection(
+const handleContextRedirection = (
   currentContext: SelectedContextType | string,
   organizations: Organization[],
   navigate: NavigateFunction,
-) {
+): void => {
   const targetContext = getTargetContext(currentContext);
 
   if (!hasAccessToContext(targetContext, organizations)) {
@@ -46,30 +46,30 @@ function handleContextRedirection(
 
   if (targetContext === currentContext) return;
   navigateToContext(targetContext, navigate);
-}
+};
 
-function getTargetContext(
+const getTargetContext = (
   currentContext: SelectedContextType | string,
-): SelectedContextType | string {
+): SelectedContextType | string => {
   if (currentContext === SelectedContextType.None) {
     return typedSessionStorage.getItem('dashboard::selectedContext') || SelectedContextType.Self;
   }
   return currentContext;
-}
+};
 
-function hasAccessToContext(
+const hasAccessToContext = (
   targetContext: SelectedContextType | string,
   organizations: Organization[],
-): boolean {
+): boolean => {
   return (
     organizations &&
     userHasAccessToSelectedContext({ selectedContext: targetContext, orgs: organizations })
   );
-}
+};
 
-function navigateToContext(
+const navigateToContext = (
   targetContext: SelectedContextType | string,
   navigate: NavigateFunction,
-) {
+): void => {
   navigate(targetContext + location.search, { replace: true });
-}
+};

--- a/frontend/dashboard/hooks/useSelectedContext/useSelectedContext.ts
+++ b/frontend/dashboard/hooks/useSelectedContext/useSelectedContext.ts
@@ -2,6 +2,6 @@ import { useParams } from 'react-router-dom';
 import { SelectedContextType } from 'app-shared/navigation/main-header/Header';
 
 export const useSelectedContext = () => {
-  const { selectedContext = SelectedContextType.Self } = useParams();
+  const { selectedContext = SelectedContextType.None } = useParams();
   return selectedContext;
 };

--- a/frontend/dashboard/pages/PageLayout/PageLayout.test.tsx
+++ b/frontend/dashboard/pages/PageLayout/PageLayout.test.tsx
@@ -37,7 +37,7 @@ const renderWithMockServices = (services?: Partial<ServicesContextProps>) => {
 };
 
 describe('PageLayout', () => {
-  test('should not redirect to root if context is self', async () => {
+  it('should not redirect to root if context is self', async () => {
     (useParams as jest.Mock).mockReturnValue({
       selectedContext: SelectedContextType.Self,
     });
@@ -45,7 +45,7 @@ describe('PageLayout', () => {
     expect(mockedNavigate).not.toHaveBeenCalled();
   });
 
-  test('should not redirect to root if context is all', async () => {
+  it('should not redirect to root if context is all', async () => {
     (useParams as jest.Mock).mockReturnValue({
       selectedContext: SelectedContextType.All,
     });
@@ -53,7 +53,7 @@ describe('PageLayout', () => {
     expect(mockedNavigate).not.toHaveBeenCalled();
   });
 
-  test('should not redirect to root if user have access to selected context', async () => {
+  it('should not redirect to root if user have access to selected context', async () => {
     (useParams as jest.Mock).mockReturnValue({
       selectedContext: 'ttd',
     });
@@ -61,7 +61,7 @@ describe('PageLayout', () => {
     expect(mockedNavigate).not.toHaveBeenCalled();
   });
 
-  test('should redirect to root if user does not have access to selected context', async () => {
+  it('should redirect to root if user does not have access to selected context', async () => {
     (useParams as jest.Mock).mockReturnValue({
       selectedContext: 'testinvalidcontext',
     });
@@ -70,13 +70,13 @@ describe('PageLayout', () => {
     expect(mockedNavigate).toHaveBeenCalledWith(SelectedContextType.Self, expect.anything());
   });
 
-  test('should redirect to self context if none is defined', async () => {
+  it('should redirect to self context if none is defined', async () => {
     renderWithMockServices();
     expect(mockedNavigate).toHaveBeenCalledTimes(1);
     expect(mockedNavigate).toHaveBeenCalledWith(SelectedContextType.Self, expect.anything());
   });
 
-  test.each([
+  it.each([
     ['"self"', 'self'],
     ['"all"', 'all'],
     ['"ttd"', 'ttd'],
@@ -92,7 +92,7 @@ describe('PageLayout', () => {
     },
   );
 
-  test('should redirect to self if user does not have access to session stored context', async () => {
+  it('should redirect to self if user does not have access to session stored context', async () => {
     (useParams as jest.Mock).mockReturnValue({});
     sessionStorage.setItem('dashboard::selectedContext', '"testinvalidcontext"');
     renderWithMockServices();

--- a/frontend/dashboard/pages/PageLayout/PageLayout.test.tsx
+++ b/frontend/dashboard/pages/PageLayout/PageLayout.test.tsx
@@ -37,6 +37,11 @@ const renderWithMockServices = (services?: Partial<ServicesContextProps>) => {
 };
 
 describe('PageLayout', () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    mockedNavigate.mockReset();
+  });
+
   it('should not redirect to root if context is self', async () => {
     (useParams as jest.Mock).mockReturnValue({
       selectedContext: SelectedContextType.Self,
@@ -94,10 +99,5 @@ describe('PageLayout', () => {
     renderWithMockServices();
     expect(mockedNavigate).toHaveBeenCalledTimes(1);
     expect(mockedNavigate).toHaveBeenCalledWith(SelectedContextType.Self, expect.anything());
-  });
-
-  afterEach(() => {
-    sessionStorage.clear();
-    mockedNavigate.mockReset();
   });
 });

--- a/frontend/dashboard/pages/PageLayout/PageLayout.test.tsx
+++ b/frontend/dashboard/pages/PageLayout/PageLayout.test.tsx
@@ -76,19 +76,15 @@ describe('PageLayout', () => {
     expect(mockedNavigate).toHaveBeenCalledWith(SelectedContextType.Self, expect.anything());
   });
 
-  it.each([
-    ['"self"', 'self'],
-    ['"all"', 'all'],
-    ['"ttd"', 'ttd'],
-  ])(
+  it.each([['self', 'all', 'ttd']])(
     'should redirect to last selected context if none is selected, selected: %s',
-    async (context, navparam) => {
+    async (context) => {
       (useParams as jest.Mock).mockReturnValue({
         selectedContext: SelectedContextType.None,
       });
-      sessionStorage.setItem('dashboard::selectedContext', context);
+      sessionStorage.setItem('dashboard::selectedContext', `"${context}"`);
       renderWithMockServices();
-      expect(mockedNavigate).toHaveBeenCalledWith(navparam, expect.anything());
+      expect(mockedNavigate).toHaveBeenCalledWith(context, expect.anything());
     },
   );
 

--- a/frontend/dashboard/pages/PageLayout/PageLayout.tsx
+++ b/frontend/dashboard/pages/PageLayout/PageLayout.tsx
@@ -1,38 +1,19 @@
-import AppHeader, {
-  HeaderContext,
-  SelectedContextType,
-} from 'app-shared/navigation/main-header/Header';
-import { Outlet, useNavigate } from 'react-router-dom';
-import type { NavigateFunction } from 'react-router-dom';
+import AppHeader, { HeaderContext } from 'app-shared/navigation/main-header/Header';
+import { Outlet } from 'react-router-dom';
 import { useOrganizationsQuery } from 'dashboard/hooks/queries';
 import { useUserQuery } from 'app-shared/hooks/queries';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import type { IHeaderContext } from 'app-shared/navigation/main-header/Header';
 import { useTranslation } from 'react-i18next';
 
-import { useSelectedContext } from 'dashboard/hooks/useSelectedContext';
-import { typedSessionStorage } from 'app-shared/utils/webStorage';
 import { StudioPageSpinner } from '@studio/components';
-import type { Organization } from 'app-shared/types/Organization';
-import { userHasAccessToSelectedContext } from 'dashboard/utils/userUtils';
+import { useContextRedirectionGuard } from 'dashboard/hooks/guards/useContextRedirectionGuard';
 
 export const PageLayout = () => {
   const { t } = useTranslation();
   const { data: user } = useUserQuery();
   const { data: organizations } = useOrganizationsQuery();
-
-  const selectedContext = useSelectedContext();
-  const navigate = useNavigate();
-  const [isReady, setIsReady] = useState<boolean>(false);
-
-  if (selectedContext !== SelectedContextType.None) {
-    typedSessionStorage.setItem('dashboard::selectedContext', selectedContext);
-  }
-
-  useEffect(() => {
-    handleRedirection(selectedContext, organizations, navigate);
-    setIsReady(true);
-  }, [selectedContext, organizations, navigate]);
+  const { isRedirectionComplete } = useContextRedirectionGuard(organizations);
 
   const headerContextValue: IHeaderContext = useMemo(
     () => ({
@@ -42,7 +23,7 @@ export const PageLayout = () => {
     [organizations, user],
   );
 
-  if (!isReady) return <StudioPageSpinner spinnerTitle={t('dashboard.loading')} />;
+  if (!isRedirectionComplete) return <StudioPageSpinner spinnerTitle={t('dashboard.loading')} />;
   return (
     <>
       <HeaderContext.Provider value={headerContextValue}>
@@ -52,27 +33,3 @@ export const PageLayout = () => {
     </>
   );
 };
-
-function handleRedirection(
-  selectedContext: string,
-  organizations: Organization[],
-  navigate: NavigateFunction,
-) {
-  let navigateToContext = selectedContext;
-
-  if (selectedContext === SelectedContextType.None) {
-    navigateToContext =
-      typedSessionStorage.getItem('dashboard::selectedContext') || SelectedContextType.Self;
-  }
-
-  if (
-    organizations &&
-    userHasAccessToSelectedContext({ selectedContext: navigateToContext, orgs: organizations })
-  ) {
-    if (navigateToContext !== selectedContext) {
-      navigate(navigateToContext + location.search, { replace: true });
-    }
-  } else {
-    navigate(SelectedContextType.Self, { replace: true });
-  }
-}

--- a/frontend/dashboard/utils/repoUtils/repoUtils.ts
+++ b/frontend/dashboard/utils/repoUtils/repoUtils.ts
@@ -24,18 +24,21 @@ const appsTranslationMap: TranslationMap = {
   all: 'dashboard.all_apps',
   self: 'dashboard.my_apps',
   org: 'dashboard.apps',
+  none: 'undefined',
   named_org: 'dashboard.org_apps',
 };
 const dataModelsTranslationMap: TranslationMap = {
   all: 'dashboard.all_data_models',
   self: 'dashboard.my_data_models',
   org: 'dashboard.data_models',
+  none: 'undefined',
   named_org: 'dashboard.org_data_models',
 };
 const resourcesTranslationMap: TranslationMap = {
   all: 'dashboard.all_resources',
   self: 'dashboard.my_resources',
   org: 'dashboard.resources',
+  none: 'undefined',
   named_org: 'dashboard.org_resources',
 };
 

--- a/frontend/dashboard/utils/userUtils/userUtils.ts
+++ b/frontend/dashboard/utils/userUtils/userUtils.ts
@@ -8,7 +8,11 @@ export const userHasAccessToSelectedContext = ({
   selectedContext: string | SelectedContextType;
   orgs: Organization[];
 }): boolean => {
-  if (selectedContext == SelectedContextType.Self || selectedContext == SelectedContextType.All) {
+  if (
+    selectedContext == SelectedContextType.Self ||
+    selectedContext == SelectedContextType.All ||
+    selectedContext == SelectedContextType.None
+  ) {
     return true;
   }
 

--- a/frontend/packages/shared/src/components/altinnHeader/AltinnHeader.tsx
+++ b/frontend/packages/shared/src/components/altinnHeader/AltinnHeader.tsx
@@ -43,12 +43,13 @@ export const AltinnHeader = ({
   const { t } = useTranslation();
 
   const repositoryType = getRepositoryType(org, app);
+  const isOrgRepo = user.login !== org;
 
   return (
     <div role='banner'>
       <div className={classnames(classes.altinnHeaderBar, classes[variant])}>
         <div className={classes.leftContent}>
-          <a href='/' aria-label={t('top_menu.dashboard')}>
+          <a href={`/dashboard/${isOrgRepo ? org : ''}`} aria-label={t('top_menu.dashboard')}>
             <AltinnStudioLogo />
           </a>
           {app && (

--- a/frontend/packages/shared/src/components/altinnHeader/AltinnHeader.tsx
+++ b/frontend/packages/shared/src/components/altinnHeader/AltinnHeader.tsx
@@ -43,13 +43,12 @@ export const AltinnHeader = ({
   const { t } = useTranslation();
 
   const repositoryType = getRepositoryType(org, app);
-  const isOrgRepo = user.login !== org;
 
   return (
     <div role='banner'>
       <div className={classnames(classes.altinnHeaderBar, classes[variant])}>
         <div className={classes.leftContent}>
-          <a href={`/dashboard/${isOrgRepo ? org : ''}`} aria-label={t('top_menu.dashboard')}>
+          <a href='/' aria-label={t('top_menu.dashboard')}>
             <AltinnStudioLogo />
           </a>
           {app && (

--- a/frontend/packages/shared/src/navigation/main-header/Header.tsx
+++ b/frontend/packages/shared/src/navigation/main-header/Header.tsx
@@ -10,6 +10,7 @@ import { useSelectedContext } from 'dashboard/hooks/useSelectedContext';
 export enum SelectedContextType {
   All = 'all',
   Self = 'self',
+  None = 'none',
 }
 
 export interface IHeaderContext {

--- a/frontend/packages/shared/src/navigation/main-header/HeaderMenu.test.tsx
+++ b/frontend/packages/shared/src/navigation/main-header/HeaderMenu.test.tsx
@@ -74,7 +74,7 @@ describe('HeaderMenu', () => {
 
     await userEvent.click(selfItem); // eslint-disable-line testing-library/no-unnecessary-act
 
-    expect(mockedNavigate).toHaveBeenCalledWith('/');
+    expect(mockedNavigate).toHaveBeenCalledWith('/self');
   });
 
   it('should call setSelectedContext with org-id when selecting org as context', async () => {

--- a/frontend/packages/shared/src/navigation/main-header/HeaderMenu.tsx
+++ b/frontend/packages/shared/src/navigation/main-header/HeaderMenu.tsx
@@ -39,6 +39,7 @@ export function HeaderMenu({ org, repo }: HeaderMenuProps) {
     post(url).then(() => {
       window.location.assign(`${altinnWindow.location.origin}/Home/Logout`);
     });
+    sessionStorage.clear();
     return true;
   };
 
@@ -106,7 +107,7 @@ export function HeaderMenu({ org, repo }: HeaderMenuProps) {
         <MenuItem
           data-testid={userMenuItemId}
           selected={selectedContext === SelectedContextType.Self}
-          onClick={() => handleSetSelectedContext('')}
+          onClick={() => handleSetSelectedContext(SelectedContextType.Self)}
         >
           {user?.full_name || user?.login}
         </MenuItem>


### PR DESCRIPTION
Redirect the user to last selected context when navigating to dashboard root, e.g. clicking header-logo from app editor.

## Description

* Add new context type `SelectedContextType.None` to identify navigation to the dashboard without specified context
* Store dashboard context on session storage key `dashboard::selectedContext`
* If user navigates to dashboard root url `/dashboard`, redirect user to last selected context if it is defined in session storage and user has access to it
* Clear session storage on logout

## Related Issue(s)

- #10699 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
