### PR TITLE
Fixing jest and playwright test type conflict

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -31,5 +31,13 @@
   },
   "files": ["declaration.d.ts"],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "tmp", "./testing/cypress/**", "dist", "**/prettier.config.js"]
+  "exclude": [
+    "node_modules",
+    "tmp",
+    "./testing/cypress/**",
+    "./testing/playwright/**",
+    "./frontend/resourceadm/testing/playwright/**",
+    "dist",
+    "**/prettier.config.js"
+  ]
 }


### PR DESCRIPTION
## Description
- Updating tsconfig.json so that the terminal does not show the errors for the test files. 

## Related Issue(s)

- #12861 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)