### PR TITLE
12716 auto open parent components on drop

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioTreeView/StudioTreeViewItem/StudioTreeViewItem.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioTreeView/StudioTreeViewItem/StudioTreeViewItem.test.tsx
@@ -151,6 +151,22 @@ describe('StudioTreeViewItem', () => {
     expect(getTreeItem({ name: label })).toBe(wrapper.querySelector('[role="treeitem"]')); // eslint-disable-line testing-library/no-node-access
   });
 
+  it('Opens the tree item when a child is selected', async () => {
+    const childLabel = 'directchild';
+    const childId = 'child';
+    renderItem(
+      {
+        label,
+        children: <StudioTreeViewItem nodeId={childId} label={childLabel} />,
+      },
+      { selectedId: childId },
+    );
+    await user.click(getTreeItem({ name: childLabel, hidden: true }));
+    expect(setSelectedId).toHaveBeenCalledTimes(1);
+    expect(setSelectedId).toHaveBeenCalledWith(childId);
+    expect(getTreeItem({ name: label, expanded: true })).toBeInTheDocument();
+  });
+
   const getTreeItem = (options: ByRoleOptions = {}) => {
     const allOptions: ByRoleOptions = { name: label, ...options };
     allOptions.name = RegExp(`^${allOptions.name}( |$)`);

--- a/frontend/libs/studio-components/src/components/StudioTreeView/StudioTreeViewItem/StudioTreeViewItem.tsx
+++ b/frontend/libs/studio-components/src/components/StudioTreeView/StudioTreeViewItem/StudioTreeViewItem.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useTreeViewRootContext } from '../hooks/useTreeViewRootContext';
 import { useTreeViewItemContext } from '../hooks/useTreeViewItemContext';
 import {
-  findDirectChildIds,
   findFirstChildId,
   findFirstNodeId,
   findLastVisibleNodeId,
@@ -19,6 +18,7 @@ import { ChevronDownIcon, ChevronRightIcon } from '@studio/icons';
 import { StudioButton } from '../../StudioButton';
 import classes from './StudioTreeViewItem.module.css';
 import cn from 'classnames';
+import { useTreeViewItemOpenOnHierarchySelect } from '../hooks/useTreeViewItemOpenOnHierarchySelect';
 
 export type StudioTreeViewItemProps = {
   as?: ElementType;
@@ -46,20 +46,7 @@ export const StudioTreeViewItem = ({
   const { level } = useTreeViewItemContext();
   const treeItemRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (nodeId === selectedId) {
-      setOpen(true);
-    }
-    if (children) {
-      const childIds = findDirectChildIds(rootId, nodeId);
-      childIds.forEach((id) => {
-        if (id === selectedId) {
-          setOpen(true);
-          console.log(`Opening ${nodeId} because child ${id} is selected`);
-        }
-      });
-    }
-  }, [children, nodeId, rootId, selectedId]);
+  useTreeViewItemOpenOnHierarchySelect(rootId, nodeId, selectedId, setOpen);
 
   useEffect(() => {
     if (focusedId === nodeId) {

--- a/frontend/libs/studio-components/src/components/StudioTreeView/StudioTreeViewItem/StudioTreeViewItem.tsx
+++ b/frontend/libs/studio-components/src/components/StudioTreeView/StudioTreeViewItem/StudioTreeViewItem.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useTreeViewRootContext } from '../hooks/useTreeViewRootContext';
 import { useTreeViewItemContext } from '../hooks/useTreeViewItemContext';
 import {
+  findDirectChildIds,
   findFirstChildId,
   findFirstNodeId,
   findLastVisibleNodeId,
@@ -44,6 +45,21 @@ export const StudioTreeViewItem = ({
     useTreeViewRootContext();
   const { level } = useTreeViewItemContext();
   const treeItemRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (nodeId === selectedId) {
+      setOpen(true);
+    }
+    if (children) {
+      const childIds = findDirectChildIds(rootId, nodeId);
+      childIds.forEach((id) => {
+        if (id === selectedId) {
+          setOpen(true);
+          console.log(`Opening ${nodeId} because child ${id} is selected`);
+        }
+      });
+    }
+  }, [children, nodeId, rootId, selectedId]);
 
   useEffect(() => {
     if (focusedId === nodeId) {

--- a/frontend/libs/studio-components/src/components/StudioTreeView/hooks/useTreeViewItemOpenOnHierarchySelect.ts
+++ b/frontend/libs/studio-components/src/components/StudioTreeView/hooks/useTreeViewItemOpenOnHierarchySelect.ts
@@ -1,0 +1,18 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { useEffect } from 'react';
+import { isDirectChildOfNode } from '../utils/domUtils';
+
+export const useTreeViewItemOpenOnHierarchySelect = (
+  rootId: string,
+  nodeId: string,
+  selectedId: string,
+  setOpen: Dispatch<SetStateAction<boolean>>,
+) => {
+  useEffect(() => {
+    if (nodeId === selectedId) {
+      setOpen(true);
+    } else if (isDirectChildOfNode(selectedId, rootId, nodeId)) {
+      setOpen(true);
+    }
+  }, [nodeId, rootId, selectedId, setOpen]);
+};

--- a/frontend/libs/studio-components/src/components/StudioTreeView/utils/domUtils.ts
+++ b/frontend/libs/studio-components/src/components/StudioTreeView/utils/domUtils.ts
@@ -19,6 +19,14 @@ export const findGroup = (rootId: string, id: string) =>
 const findItemLevel = (rootId: string, nodeId?: string): number =>
   nodeId ? parseInt(findTreeItem(rootId, nodeId)?.getAttribute('aria-level')) : 0;
 
+export const isDirectChildOfNode = (
+  childId: string,
+  rootId: string,
+  parentId?: string,
+): boolean => {
+  return findDirectChildIds(rootId, parentId).includes(childId);
+};
+
 export const findDirectChildIds = (rootId: string, nodeId?: string): string[] => {
   const list = nodeId ? findGroup(rootId, nodeId) : document.getElementById(rootId);
   if (!list) return [];

--- a/frontend/packages/schema-editor/src/components/SchemaEditor/hooks/useAddReference.ts
+++ b/frontend/packages/schema-editor/src/components/SchemaEditor/hooks/useAddReference.ts
@@ -3,16 +3,19 @@ import { useCallback } from 'react';
 import type { NodePosition } from '@altinn/schema-model';
 import { calculatePositionInFullList } from '../utils';
 import { useSavableSchemaModel } from '../../../hooks/useSavableSchemaModel';
+import { useSchemaEditorAppContext } from '@altinn/schema-editor/hooks/useSchemaEditorAppContext';
 
 export const useAddReference = (): HandleAdd<string> => {
+  const { setSelectedNodePointer } = useSchemaEditorAppContext();
   const savableModel = useSavableSchemaModel();
   return useCallback(
     (reference: string, position: ItemPosition) => {
       const index = calculatePositionInFullList(savableModel, position);
       const target: NodePosition = { parentPointer: position.parentId, index };
       const refName = savableModel.generateUniqueChildName(target.parentPointer, 'ref');
-      savableModel.addReference(refName, reference, target);
+      const ref = savableModel.addReference(refName, reference, target);
+      setSelectedNodePointer(ref.pointer);
     },
-    [savableModel],
+    [savableModel, setSelectedNodePointer],
   );
 };

--- a/frontend/packages/schema-editor/src/components/SchemaTree/SchemaNode/ActionButtons/AddPropertyMenu.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaTree/SchemaNode/ActionButtons/AddPropertyMenu.tsx
@@ -5,12 +5,14 @@ import { ObjectKind } from '@altinn/schema-model';
 import { ActionButton } from './ActionButton';
 import { DropdownMenu } from '@digdir/design-system-react';
 import { CombinationIcon, PropertyIcon, ReferenceIcon, PlusIcon } from '@studio/icons';
+import { useSchemaEditorAppContext } from '@altinn/schema-editor/hooks/useSchemaEditorAppContext';
 
 interface AddPropertyMenuProps {
   pointer: string;
 }
 
 export const AddPropertyMenu = ({ pointer }: AddPropertyMenuProps) => {
+  const { setSelectedNodePointer } = useSchemaEditorAppContext();
   const addButtonRef = useRef<HTMLButtonElement>(null);
   const { t } = useTranslation();
   const [isAddDropdownOpen, setIsAddDropdownOpen] = useState(false);
@@ -21,7 +23,8 @@ export const AddPropertyMenu = ({ pointer }: AddPropertyMenuProps) => {
   const addReference = () => addPropertyAndClose(ObjectKind.Reference);
 
   const addPropertyAndClose = (kind: ObjectKind) => {
-    addProperty(kind, undefined, pointer);
+    const childPointer = addProperty(kind, undefined, pointer);
+    setSelectedNodePointer(childPointer);
     closeDropdown();
   };
 

--- a/frontend/packages/schema-editor/src/components/SchemaTree/SchemaNode/SchemaNode.test.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaTree/SchemaNode/SchemaNode.test.tsx
@@ -163,6 +163,20 @@ describe('SchemaNode', () => {
     expect(setSelectedNodePointer).toHaveBeenCalledTimes(1);
     expect(setSelectedNodePointer).toHaveBeenCalledWith(null);
   });
+
+  it('Marks the node as selected when it is added', async () => {
+    const { pointer } = objectNodeMock;
+    const schemaModel = setupSchemaModel();
+    const save = jest.fn();
+    render({ schemaModel, save, pointer });
+    await user.click(getAddButton());
+    const addFieldButtonName = textMock('schema_editor.add_field');
+    const addFieldButton = screen.getByRole('menuitem', { name: addFieldButtonName });
+    await user.click(addFieldButton);
+    const savedModel = getSavedModel(save);
+    const updatedNode = savedModel.getNode(pointer) as FieldNode;
+    expect(updatedNode.pointer).toEqual(pointer);
+  });
 });
 
 interface RenderProps {


### PR DESCRIPTION
## Description

To make this behaviour feel consistent these are the changes done:
* Mark new nodes as selected when added to the tree view
* Ensure all nodes are expanded/opened when a it or a child tree node is selected

This way, when either a new item is added through drag and drop or by button on the parent element (as described in #12038), the added element should be visible and expanded if applicable.

## Related Issues

- #12716 
- #12038

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
