### PR TITLE
12972 fetching changes should reload preview

### DIFF
--- a/frontend/app-development/layout/PageHeader.tsx
+++ b/frontend/app-development/layout/PageHeader.tsx
@@ -19,7 +19,11 @@ type SubMenuContentProps = {
   hasRepoError?: boolean;
 };
 
-export const subMenuContent = ({ org, app, hasRepoError }: SubMenuContentProps) => {
+export const SubMenuContent = ({
+  org,
+  app,
+  hasRepoError,
+}: SubMenuContentProps): React.ReactElement => {
   const repositoryType = getRepositoryType(org, app);
   const { doReloadPreview } = usePreviewContext();
 
@@ -82,7 +86,7 @@ export const PageHeader = ({
     <AltinnHeader
       menuItems={!isRepoError && menuItems}
       showSubMenu={showSubMenu || !isRepoError}
-      subMenuContent={subMenuContent({ org, app, hasRepoError: isRepoError })}
+      subMenuContent={SubMenuContent({ org, app, hasRepoError: isRepoError })}
       org={org}
       app={!isRepoError && app}
       user={user}

--- a/frontend/app-development/layout/PageHeader.tsx
+++ b/frontend/app-development/layout/PageHeader.tsx
@@ -11,6 +11,7 @@ import type { User } from 'app-shared/types/Repository';
 import { PackagesRouter } from 'app-shared/navigation/PackagesRouter';
 import { RepositoryType } from 'app-shared/types/global';
 import { useSelectedFormLayoutSetName, useSelectedFormLayoutName } from '@altinn/ux-editor/hooks';
+import { usePreviewContext } from 'app-development/contexts/PreviewContext';
 
 type SubMenuContentProps = {
   org: string;
@@ -20,6 +21,8 @@ type SubMenuContentProps = {
 
 export const subMenuContent = ({ org, app, hasRepoError }: SubMenuContentProps) => {
   const repositoryType = getRepositoryType(org, app);
+  const { doReloadPreview } = usePreviewContext();
+
   return (
     <GiteaHeader
       org={org}
@@ -27,6 +30,7 @@ export const subMenuContent = ({ org, app, hasRepoError }: SubMenuContentProps) 
       hasCloneModal
       leftComponent={repositoryType !== RepositoryType.DataModels && <SettingsModalButton />}
       hasRepoError={hasRepoError}
+      onPullSuccess={doReloadPreview}
     />
   );
 };

--- a/frontend/packages/shared/src/components/GiteaHeader/GiteaHeader.tsx
+++ b/frontend/packages/shared/src/components/GiteaHeader/GiteaHeader.tsx
@@ -12,6 +12,7 @@ type GiteaHeaderProps = {
   rightContentClassName?: string;
   leftComponent?: ReactNode;
   hasRepoError?: boolean;
+  onPullSuccess?: () => void;
 };
 
 /**
@@ -43,12 +44,15 @@ export const GiteaHeader = ({
   rightContentClassName,
   leftComponent,
   hasRepoError,
+  onPullSuccess,
 }: GiteaHeaderProps): React.ReactNode => {
   return (
     <div className={classes.wrapper}>
       <div className={classes.leftContentWrapper}>{leftComponent}</div>
       <div className={`${classes.rightContentWrapper} ${rightContentClassName}`}>
-        {!hasRepoError && <VersionControlButtons org={org} app={app} />}
+        {!hasRepoError && (
+          <VersionControlButtons org={org} app={app} onPullSuccess={onPullSuccess} />
+        )}
         <ThreeDotsMenu
           onlyShowRepository={menuOnlyHasRepository}
           hasCloneModal={hasCloneModal}

--- a/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/FetchChangesButton/FetchChangesButton.tsx
+++ b/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/FetchChangesButton/FetchChangesButton.tsx
@@ -20,7 +20,8 @@ export const FetchChangesButton = ({
 }: IFetchChangesButtonProps) => {
   const { t } = useTranslation();
 
-  const fetchChangesHandler = (event: any) => fetchChanges(event.currentTarget);
+  const fetchChangesHandler = ({ currentTarget }: React.MouseEvent<HTMLButtonElement>) =>
+    fetchChanges(currentTarget);
 
   return (
     <StudioButton

--- a/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/VersionControlButtons.test.tsx
+++ b/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/VersionControlButtons.test.tsx
@@ -51,6 +51,7 @@ const defaultQueries: Partial<ServicesContextProps> = {
 const defaultProps: IVersionControlButtonsProps = {
   org,
   app,
+  onPullSuccess: jest.fn(),
 };
 
 describe('Shared > Version Control > VersionControlHeader', () => {
@@ -234,6 +235,13 @@ describe('Shared > Version Control > VersionControlHeader', () => {
       name: textMock('sync_header.changes_to_share'),
     });
     expect(shareButton).toHaveAttribute('title', textMock('sync_header.sharing_changes_no_access'));
+  });
+
+  it('should call onPullSuccess when fetching changes', async () => {
+    renderVersionControlButtons();
+    const fetchButton = screen.getByRole('button', { name: textMock('sync_header.fetch_changes') });
+    await user.click(fetchButton);
+    expect(defaultProps.onPullSuccess).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/VersionControlButtons.tsx
+++ b/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/VersionControlButtons.tsx
@@ -13,7 +13,6 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useRepoCommitAndPushMutation } from 'app-shared/hooks/mutations';
 import { toast } from 'react-toastify';
-import { usePreviewContext } from 'app-development/contexts/PreviewContext';
 
 const initialModalState = {
   header: '',

--- a/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/VersionControlButtons.tsx
+++ b/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/VersionControlButtons.tsx
@@ -13,6 +13,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useRepoCommitAndPushMutation } from 'app-shared/hooks/mutations';
 import { toast } from 'react-toastify';
+import { usePreviewContext } from 'app-development/contexts/PreviewContext';
 
 const initialModalState = {
   header: '',
@@ -33,9 +34,10 @@ function hasLocalChanges(result: IGitStatus) {
 export interface IVersionControlButtonsProps {
   org: string;
   app: string;
+  onPullSuccess?: () => void;
 }
 
-export const VersionControlButtons = ({ org, app }: IVersionControlButtonsProps) => {
+export const VersionControlButtons = ({ org, app, onPullSuccess }: IVersionControlButtonsProps) => {
   const { t } = useTranslation();
   const [hasPushRights, setHasPushRights] = useState(false);
   const [hasMergeConflict, setHasMergeConflict] = useState(false);
@@ -73,6 +75,7 @@ export const VersionControlButtons = ({ org, app }: IVersionControlButtonsProps)
     });
     const { data: result } = await fetchPullData();
     if (result.repositoryStatus === 'Ok') {
+      if (onPullSuccess) onPullSuccess();
       // force reFetch  files
       await queryClient.invalidateQueries(); // Todo: This invalidates ALL queries. Consider providing a list of relevant queries only.
       // if pull was successful, show app is updated message


### PR DESCRIPTION
## Description

* Add `onPullSuccess` prop to `VersionControlButton` that is called when changes are successfully fetched.
* Call `doReloadPreview` when `onPullSuccess` is called from the page header

## Related Issue(s)

- #12972

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
