### PR TITLE
Remove key from Canvas component

### DIFF
--- a/frontend/packages/process-editor/src/components/Canvas/Canvas.tsx
+++ b/frontend/packages/process-editor/src/components/Canvas/Canvas.tsx
@@ -11,14 +11,12 @@ import { BPMNEditor } from './BPMNEditor';
 import { VersionHelpText } from './VersionHelpText';
 
 export const Canvas = (): React.ReactElement => {
-  const { isEditAllowed, bpmnXml } = useBpmnContext();
+  const { isEditAllowed } = useBpmnContext();
 
   return (
     <>
       {!isEditAllowed && <VersionHelpText />}
-      <div className={classes.wrapper} key={bpmnXml}>
-        {isEditAllowed ? <BPMNEditor /> : <BPMNViewer />}
-      </div>
+      <div className={classes.wrapper}>{isEditAllowed ? <BPMNEditor /> : <BPMNViewer />}</div>
     </>
   );
 };


### PR DESCRIPTION
## Description

Remove key from Canvas component to prevent rerendering of the BPMN editor

## Related Issue(s)

- #12969

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
