### PR TITLE
Resourceadm: improve service selection in import link service modal

### DIFF
--- a/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -442,7 +442,8 @@ namespace Altinn.Studio.Designer.Controllers
                 foreach (ServiceResource resource in allResources)
                 {
                     if (resource?.HasCompetentAuthority.Orgcode != null
-                        && resource.ResourceReferences != null && resource.ResourceReferences.Exists(r => r.ReferenceType != null && r.ReferenceType.Equals(ReferenceType.ServiceCode)))
+                        && resource.ResourceReferences != null && resource.ResourceReferences.Exists(r => r.ReferenceType != null && r.ReferenceType.Equals(ReferenceType.ServiceCode)) 
+                        && resource.ResourceType == ResourceType.Altinn2Service)
                     {
                         AvailableService service = new AvailableService();
                         if (resource.Title.ContainsKey("nb"))

--- a/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -442,7 +442,7 @@ namespace Altinn.Studio.Designer.Controllers
                 foreach (ServiceResource resource in allResources)
                 {
                     if (resource?.HasCompetentAuthority.Orgcode != null
-                        && resource.ResourceReferences != null && resource.ResourceReferences.Exists(r => r.ReferenceType != null && r.ReferenceType.Equals(ReferenceType.ServiceCode)) 
+                        && resource.ResourceReferences != null && resource.ResourceReferences.Exists(r => r.ReferenceType != null && r.ReferenceType.Equals(ReferenceType.ServiceCode))
                         && resource.ResourceType == ResourceType.Altinn2Service)
                     {
                         AvailableService service = new AvailableService();

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -986,6 +986,7 @@
   "resourceadm.dashboard_import_environment_header": "Importer ressurs til Altinn Studio",
   "resourceadm.dashboard_import_environment_radio_header": "Velg miljø å importere fra",
   "resourceadm.dashboard_import_modal_import_button": "Importer lenketjeneste",
+  "resourceadm.dashboard_import_modal_no_services_found": "Fant ingen treff",
   "resourceadm.dashboard_import_modal_resource_name_and_id_text": "Ressurs-id er foreslått basert på lenketjenesten du har valgt, og kan redigeres om du ønsker en annen. Id må inneholde minst 4 tegn, og kan ikke endres senere.",
   "resourceadm.dashboard_import_modal_select_env": "Velg miljøet du vil importere fra",
   "resourceadm.dashboard_import_modal_select_service": "Velg lenketjenesten du vil importere",

--- a/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.test.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ImportResourceModal.test.tsx
@@ -10,6 +10,7 @@ import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import type { Altinn2LinkService } from 'app-shared/types/Altinn2LinkService';
 import { ServerCodes } from 'app-shared/enums/ServerCodes';
+import { mapAltinn2LinkServiceToSelectOption } from 'resourceadm/utils/mapperUtils';
 
 const mockAltinn2LinkService: Altinn2LinkService = {
   serviceOwnerCode: 'ttd',
@@ -18,7 +19,7 @@ const mockAltinn2LinkService: Altinn2LinkService = {
   serviceName: 'TestService',
 };
 const mockAltinn2LinkServices: Altinn2LinkService[] = [mockAltinn2LinkService];
-const mockOption: string = `${mockAltinn2LinkService.serviceOwnerCode}: ${mockAltinn2LinkService.externalServiceCode}-${mockAltinn2LinkService.externalServiceEditionCode}-${mockAltinn2LinkService.serviceName}`;
+const mockOption: string = mapAltinn2LinkServiceToSelectOption(mockAltinn2LinkService).label;
 
 const mockOnClose = jest.fn();
 const getAltinn2LinkServices = jest

--- a/frontend/resourceadm/components/ImportResourceModal/ServiceContent/ServiceContent.test.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ServiceContent/ServiceContent.test.tsx
@@ -10,6 +10,7 @@ import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import type { QueryClient } from '@tanstack/react-query';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { mapAltinn2LinkServiceToSelectOption } from 'resourceadm/utils/mapperUtils';
 
 const mockSelectedContext: string = 'selectedContext';
 const mockEnv: string = 'env1';
@@ -30,8 +31,10 @@ const mockAltinn2LinkServices: Altinn2LinkService[] = [
   mockAltinn2LinkService,
   mockAltinn2HyphenLinkService,
 ];
-const mockOption: string = `${mockAltinn2LinkService.serviceOwnerCode}: ${mockAltinn2LinkService.externalServiceCode}-${mockAltinn2LinkService.externalServiceEditionCode}-${mockAltinn2LinkService.serviceName}`;
-const mockHyphenOption: string = `${mockAltinn2HyphenLinkService.serviceOwnerCode}: ${mockAltinn2HyphenLinkService.externalServiceCode}-${mockAltinn2HyphenLinkService.externalServiceEditionCode}-${mockAltinn2HyphenLinkService.serviceName}`;
+const mockOption: string = mapAltinn2LinkServiceToSelectOption(mockAltinn2LinkService).label;
+const mockHyphenOption: string = mapAltinn2LinkServiceToSelectOption(
+  mockAltinn2HyphenLinkService,
+).label;
 
 const mockOnSelectService = jest.fn();
 

--- a/frontend/resourceadm/components/ImportResourceModal/ServiceContent/ServiceContent.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ServiceContent/ServiceContent.tsx
@@ -91,21 +91,23 @@ export const ServiceContent = ({
         <Combobox
           value={
             selectedService
-              ? mapAltinn2LinkServiceToSelectOption([selectedService]).map((ls) => ls.value)
+              ? [mapAltinn2LinkServiceToSelectOption(selectedService).value]
               : undefined
           }
           label={t('resourceadm.dashboard_import_modal_select_service')}
           onValueChange={(newValue: string[]) => {
             handleSelectService(newValue[0]);
           }}
+          filter={(inputValue: string, option) => option.label.indexOf(inputValue) > -1}
         >
-          {mapAltinn2LinkServiceToSelectOption(altinn2LinkServices).map((ls) => {
-            return (
-              <Combobox.Option key={ls.value} value={ls.value}>
-                {ls.label}
-              </Combobox.Option>
-            );
-          })}
+          <Combobox.Empty>
+            {t('resourceadm.dashboard_import_modal_no_services_found')}
+          </Combobox.Empty>
+          {altinn2LinkServices.map(mapAltinn2LinkServiceToSelectOption).map((ls) => (
+            <Combobox.Option key={ls.value} value={ls.value}>
+              {ls.label}
+            </Combobox.Option>
+          ))}
         </Combobox>
       );
     }

--- a/frontend/resourceadm/components/ImportResourceModal/ServiceContent/ServiceContent.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ServiceContent/ServiceContent.tsx
@@ -98,7 +98,9 @@ export const ServiceContent = ({
           onValueChange={(newValue: string[]) => {
             handleSelectService(newValue[0]);
           }}
-          filter={(inputValue: string, option) => option.label.indexOf(inputValue) > -1}
+          filter={(inputValue: string, option) =>
+            option.label.toLowerCase().indexOf(inputValue.toLowerCase()) > -1
+          }
         >
           <Combobox.Empty>
             {t('resourceadm.dashboard_import_modal_no_services_found')}

--- a/frontend/resourceadm/components/ImportResourceModal/ServiceContent/ServiceContent.tsx
+++ b/frontend/resourceadm/components/ImportResourceModal/ServiceContent/ServiceContent.tsx
@@ -99,7 +99,7 @@ export const ServiceContent = ({
             handleSelectService(newValue[0]);
           }}
           filter={(inputValue: string, option) =>
-            option.label.toLowerCase().indexOf(inputValue.toLowerCase()) > -1
+            option.label.toLowerCase().indexOf(inputValue?.toLowerCase()) > -1
           }
         >
           <Combobox.Empty>

--- a/frontend/resourceadm/hooks/queries/useGetAltinn2LinkServicesQuery.ts
+++ b/frontend/resourceadm/hooks/queries/useGetAltinn2LinkServicesQuery.ts
@@ -22,5 +22,9 @@ export const useGetAltinn2LinkServicesQuery = (
   return useQuery<Altinn2LinkService[], ResourceError>({
     queryKey: [QueryKey.Altinn2Services, org, environment],
     queryFn: () => getAltinn2LinkServices(org, environment),
+    select: (services: Altinn2LinkService[]) =>
+      [...services].sort((a, b) =>
+        a.serviceName.toLowerCase().localeCompare(b.serviceName.toLowerCase()),
+      ),
   });
 };

--- a/frontend/resourceadm/utils/mapperUtils/mapperUtils.test.ts
+++ b/frontend/resourceadm/utils/mapperUtils/mapperUtils.test.ts
@@ -19,11 +19,11 @@ describe('mapperUtils', () => {
     ];
 
     it('should map and sort Altinn2LinkService to SelectOption correctly', () => {
-      const result = mapAltinn2LinkServiceToSelectOption(mockLinkServices);
+      const result = mockLinkServices.map(mapAltinn2LinkServiceToSelectOption);
 
       expect(result).toHaveLength(mockLinkServices.length);
-      expect(result[0].value).toBe(JSON.stringify(mockLinkServices[1]));
-      expect(result[0].label).toBe('acn: code2-edition2-name2');
+      expect(result[0].value).toBe(JSON.stringify(mockLinkServices[0]));
+      expect(result[0].label).toBe('name1 (code1/edition1)');
     });
   });
 });

--- a/frontend/resourceadm/utils/mapperUtils/mapperUtils.ts
+++ b/frontend/resourceadm/utils/mapperUtils/mapperUtils.ts
@@ -25,21 +25,15 @@ export const sortResourceListByDate = (resourceList: ResourceListItem[]): Resour
  * Maps an Altinn2LinkService object to an object with value and label to be
  * used for a Select option.
  *
- * @param linkServices the list of link services from Altinn 2
+ * @param ls the link service from Altinn 2
  *
  * @returns an object that looks like this: { value: string, label: string }
  */
-export const mapAltinn2LinkServiceToSelectOption = (linkServices: Altinn2LinkService[]) => {
-  const sortedServices = [...linkServices].sort((a, b) => {
-    const serviceOwnerValue = a.serviceOwnerCode.localeCompare(b.serviceOwnerCode);
-    return serviceOwnerValue === 0
-      ? a.externalServiceCode.localeCompare(b.externalServiceCode)
-      : serviceOwnerValue;
-  });
-  return sortedServices.map((ls: Altinn2LinkService) => ({
+export const mapAltinn2LinkServiceToSelectOption = (ls: Altinn2LinkService) => {
+  return {
     value: JSON.stringify(ls),
-    label: `${ls.serviceOwnerCode}: ${ls.externalServiceCode}-${ls.externalServiceEditionCode}-${ls.serviceName}`,
-  }));
+    label: `${ls.serviceName} (${ls.externalServiceCode}/${ls.externalServiceEditionCode})`,
+  };
 };
 
 /**


### PR DESCRIPTION
## Description

- Show link services sorted by service name (case-insensitive)
- Show link service in ComboBox as `<serviceName> (<serviceCode>/<serviceEditionCode>)`
- Add custom filter function to ComboBox to allow searching anywhere in option label
- Link service list should only show Altinn 2 link services (not Altinn 3 resources)
- Show empty option if no service is found when filtering list

## Related Issue(s)

- #12985

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
