### PR TITLE
Fix styling of app tables

### DIFF
--- a/frontend/dashboard/components/RepoList/RepoList.module.css
+++ b/frontend/dashboard/components/RepoList/RepoList.module.css
@@ -1,36 +1,20 @@
-/*.favoriteIconHeaderCell {*/
-/*  font-size: 0; !*Hides text, but keeps it accessible for screen readers*!*/
-/*  width: 46px; !*Has to be exactly 46px to make the width the same for empty and filled table columns*!*/
-/*}*/
-
-/*.nameHeaderCell {*/
-/*  width: 20%;*/
-/*}*/
-
-/*.createdByHeaderCell {*/
-/*  width: 20%;*/
-/*}*/
-
-/*.lastUpdatedHeaderCell {*/
-/*  width: 15%;*/
-/*}*/
-
-/*.actionIconsHeaderCell {*/
-/*  font-size: 0;*/
-/*}*/
-
-tr {
-  display: grid;
-  grid-template-columns: 4.5rem 1fr 1fr 0.5fr 1fr 11rem;
+.favoriteIconHeaderCell {
+  font-size: 0; /*Hides text, but keeps it accessible for screen readers*/
+  width: 46px; /*Has to be exactly 46px to make the width the same for empty and filled table columns*/
 }
 
-td {
-  display: flex;
-  align-items: center;
+.nameHeaderCell {
+  width: 25%;
 }
 
-/*Hides text, but keeps it accessible for screen readers*/
-.favoriteIconHeaderCell,
+.createdByHeaderCell {
+  width: 20%;
+}
+
+.lastUpdatedHeaderCell {
+  width: 15%;
+}
+
 .actionIconsHeaderCell {
   font-size: 0;
 }

--- a/frontend/dashboard/components/RepoList/RepoList.tsx
+++ b/frontend/dashboard/components/RepoList/RepoList.tsx
@@ -54,17 +54,20 @@ export const RepoList = ({
       accessor: 'name',
       heading: t('dashboard.name'),
       sortable: true,
+      headerCellClass: classes.nameHeaderCell,
       bodyCellFormatter: (repoFullName: string) => <RepoNameWithLink repoFullName={repoFullName} />,
     },
     {
       accessor: 'createdBy',
       heading: t('dashboard.created_by'),
       sortable: true,
+      headerCellClass: classes.createdByHeaderCell,
     },
     {
       accessor: 'updated',
       heading: t('dashboard.last_modified'),
       sortable: true,
+      headerCellClass: classes.lastUpdatedHeaderCell,
       bodyCellFormatter: (date: string) =>
         new Date(date).toLocaleDateString('nb', { dateStyle: 'short' }),
     },

--- a/frontend/resourceadm/components/ResourceTable/ResourceTable.module.css
+++ b/frontend/resourceadm/components/ResourceTable/ResourceTable.module.css
@@ -1,6 +1,11 @@
+.editLinkCell {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .editLink {
   color: #165db8;
-  font-size: 2rem;
+  font-size: 1.5em;
 }
 
 .tagContainer {

--- a/frontend/resourceadm/components/ResourceTable/ResourceTable.tsx
+++ b/frontend/resourceadm/components/ResourceTable/ResourceTable.tsx
@@ -54,7 +54,6 @@ export const ResourceTable = ({
       return (
         <StudioButton
           variant='tertiary'
-          size='small'
           icon={
             <PencilIcon
               title={t('resourceadm.dashboard_table_row_edit', {
@@ -72,7 +71,6 @@ export const ResourceTable = ({
       return (
         <StudioButton
           variant='tertiary'
-          size='small'
           icon={
             <FileImportIcon
               title={t('resourceadm.dashboard_table_row_import', {
@@ -161,6 +159,7 @@ export const ResourceTable = ({
     {
       accessor: 'links',
       heading: '',
+      bodyCellClass: classes.editLinkCell,
     },
   ];
 

--- a/frontend/resourceadm/components/ResourceTable/ResourceTable.tsx
+++ b/frontend/resourceadm/components/ResourceTable/ResourceTable.tsx
@@ -119,7 +119,7 @@ export const ResourceTable = ({
           })}
         </div>
       ),
-      links: renderLinkCell(listItem),
+      links: <div className={classes.editLinkCell}>{renderLinkCell(listItem)}</div>,
     };
   });
 
@@ -159,7 +159,6 @@ export const ResourceTable = ({
     {
       accessor: 'links',
       heading: '',
-      bodyCellClass: classes.editLinkCell,
     },
   ];
 


### PR DESCRIPTION
## Description
- Uses classes to style the width of the app tables, so that the resource table doesn't get affected by it.
- Made the resource table edit icon align to the right, and made its size scale with the app table edit icons.

**Before:**
![image](https://github.com/Altinn/altinn-studio/assets/148075168/c8850376-30d2-4623-9348-1488dd5bc956)

**After:**
![image](https://github.com/Altinn/altinn-studio/assets/148075168/9bcdd3ed-7878-4e3d-847a-30eacac3f619)
