### PR TITLE
Increase timeout for e2e-tests for process-editor

### DIFF
--- a/frontend/testing/playwright/playwright.config.ts
+++ b/frontend/testing/playwright/playwright.config.ts
@@ -123,6 +123,7 @@ export default defineConfig<ExtendedTestOptions>({
       dependencies: [TestNames.SETUP],
       testDir: './tests/process-editor/',
       testMatch: '*.spec.ts',
+      timeout: 60000,
       use: {
         ...devices['Desktop Chrome'],
         storageState: '.playwright/auth/user.json',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Our end-to-end test cases within ProcessEditor have become too extensive, necessitating an increase in our timeout to allow them to run properly. To address this, we should split the larger tests into smaller, more manageable ones. I've already made improvements to the action tests, which can be found in [this pull request](https://github.com/Altinn/altinn-studio/pull/12982). Once this PR is merged into the main branch, we should continue breaking down the tests further. This will enable us to reduce the timeout back to 30,000 ms.

## Related Issue(s)

- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)