### PR TITLE
Fix label of data model selection

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -808,6 +808,7 @@
   "process_editor.configuration_panel_custom_receipt_select_data_model_label": "Datamodellknytning",
   "process_editor.configuration_panel_custom_receipt_spinner_title": "Laster inn kvittering",
   "process_editor.configuration_panel_custom_receipt_textfield_label": "Navn på sidegruppe",
+  "process_editor.configuration_panel_data_model": "Datamodell:",
   "process_editor.configuration_panel_data_model_selection_description": "Velg en datamodell å knytte til prosessteget",
   "process_editor.configuration_panel_data_task": "Oppgave: Utfylling",
   "process_editor.configuration_panel_data_types_to_sign_required": "Du må velge minst en datatype",

--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigEndEvent/CustomReceiptContent/CustomReceipt/CustomReceipt.test.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigEndEvent/CustomReceiptContent/CustomReceipt/CustomReceipt.test.tsx
@@ -84,7 +84,7 @@ describe('CustomReceipt', () => {
     await user.click(propertyButton);
 
     const combobox = screen.getByRole('combobox', {
-      name: textMock('process_editor.configuration_panel_set_data_model'),
+      name: textMock('process_editor.configuration_panel_data_model'),
     });
     await user.click(combobox);
     const newOption: string = mockAllDataModelIds[1];

--- a/frontend/packages/process-editor/src/components/ConfigPanel/EditDataTypes/EditDataTypes.test.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/EditDataTypes/EditDataTypes.test.tsx
@@ -55,7 +55,7 @@ describe('EditDataTypes', () => {
     });
     await user.click(addDataModelButton);
     const combobox = screen.getByRole('combobox', {
-      name: textMock('process_editor.configuration_panel_set_data_model'),
+      name: textMock('process_editor.configuration_panel_data_model'),
     });
     const description = screen.getByText(
       textMock('process_editor.configuration_panel_data_model_selection_description'),
@@ -94,7 +94,7 @@ describe('EditDataTypes', () => {
     expect(description).toBeInTheDocument();
 
     const combobox = screen.getByRole('combobox', {
-      name: textMock('process_editor.configuration_panel_set_data_model'),
+      name: textMock('process_editor.configuration_panel_data_model'),
     });
     await user.click(combobox);
 
@@ -124,7 +124,7 @@ describe('EditDataTypes', () => {
 
     await user.click(updateDataTypeButton);
     const combobox = screen.getByRole('combobox', {
-      name: textMock('process_editor.configuration_panel_set_data_model'),
+      name: textMock('process_editor.configuration_panel_data_model'),
     });
     expect(combobox).toHaveValue(existingDataType);
   });

--- a/frontend/packages/process-editor/src/components/ConfigPanel/EditDataTypes/SelectDataTypes/SelectDataTypes.test.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/EditDataTypes/SelectDataTypes/SelectDataTypes.test.tsx
@@ -39,7 +39,7 @@ describe('SelectDataTypes', () => {
       },
     );
     const combobox = screen.getByRole('combobox', {
-      name: textMock('process_editor.configuration_panel_set_data_model'),
+      name: textMock('process_editor.configuration_panel_data_model'),
     });
     await user.click(combobox);
     await user.click(screen.getByRole('option', { name: dataTypeToConnect }));
@@ -57,7 +57,7 @@ describe('SelectDataTypes', () => {
     renderSelectDataTypes({ dataModelIds, existingDataType });
 
     const combobox = screen.getByRole('combobox', {
-      name: textMock('process_editor.configuration_panel_set_data_model'),
+      name: textMock('process_editor.configuration_panel_data_model'),
     });
     expect(combobox).toHaveValue(existingDataType);
 
@@ -79,7 +79,7 @@ describe('SelectDataTypes', () => {
       },
     );
     const combobox = screen.getByRole('combobox', {
-      name: textMock('process_editor.configuration_panel_set_data_model'),
+      name: textMock('process_editor.configuration_panel_data_model'),
     });
     await user.click(combobox);
     await user.click(screen.getByRole('option', { name: dataTypeToConnect }));
@@ -125,7 +125,7 @@ describe('SelectDataTypes', () => {
       },
     );
     const combobox = screen.getByRole('combobox', {
-      name: textMock('process_editor.configuration_panel_set_data_model'),
+      name: textMock('process_editor.configuration_panel_data_model'),
     });
     await user.click(combobox);
     await user.click(screen.getByRole('option', { name: existingDataType }));

--- a/frontend/packages/process-editor/src/components/ConfigPanel/EditDataTypes/SelectDataTypes/SelectDataTypes.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/EditDataTypes/SelectDataTypes/SelectDataTypes.tsx
@@ -45,7 +45,7 @@ export const SelectDataTypes = ({
   return (
     <div className={classes.dataTypeSelectAndButtons}>
       <Combobox
-        label={t('process_editor.configuration_panel_set_data_model')}
+        label={t('process_editor.configuration_panel_data_model')}
         value={currentValue}
         description={t('process_editor.configuration_panel_data_model_selection_description')}
         size='small'

--- a/frontend/testing/playwright/pages/ProcessEditorPage/DataModelConfig.ts
+++ b/frontend/testing/playwright/pages/ProcessEditorPage/DataModelConfig.ts
@@ -18,7 +18,7 @@ export class DataModelConfig extends BasePage {
 
   public async waitForComboboxToBeVisible(): Promise<void> {
     const combobox = this.page.getByRole('combobox', {
-      name: this.textMock('process_editor.configuration_panel_set_data_model'),
+      name: this.textMock('process_editor.configuration_panel_data_model'),
     });
     await expect(combobox).toBeVisible();
   }

--- a/frontend/testing/playwright/pages/ProcessEditorPage/DataModelConfig.ts
+++ b/frontend/testing/playwright/pages/ProcessEditorPage/DataModelConfig.ts
@@ -49,7 +49,7 @@ export class DataModelConfig extends BasePage {
   public async clickOnCombobox(): Promise<void> {
     await this.page
       .getByRole('combobox', {
-        name: this.textMock('process_editor.configuration_panel_set_data_model'),
+        name: this.textMock('process_editor.configuration_panel_data_model'),
       })
       .click();
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR should fix the label of the data model selection:
![datamodelname (1)](https://github.com/Altinn/altinn-studio/assets/24462611/7eaf24f3-bb21-4993-9ce0-26d3c0e80fe4)

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)