### PR TITLE
Use grid-template for schema editor and keys to reset scroll

### DIFF
--- a/frontend/packages/schema-editor/src/components/SchemaEditor/SchemaEditor.module.css
+++ b/frontend/packages/schema-editor/src/components/SchemaEditor/SchemaEditor.module.css
@@ -1,8 +1,8 @@
 .editor {
   background-color: white;
-  box-sizing: border-box;
+  display: grid;
+  grid-template-rows: auto 1fr;
   flex: 1;
-  height: 100%;
   min-height: 200px;
   overflow-y: auto;
 }

--- a/frontend/packages/schema-editor/src/components/SchemaEditor/SchemaEditor.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaEditor/SchemaEditor.tsx
@@ -26,6 +26,7 @@ export const SchemaEditor = () => {
         onMove={moveProperty}
         rootId={ROOT_POINTER}
         itemId={selectedTypePointer ?? null}
+        key={selectedType?.pointer}
       >
         <aside className={classes.inspector}>
           <TypesInspector schemaItems={definitions} />

--- a/frontend/packages/ux-editor/src/components/Properties/Properties.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/Properties.tsx
@@ -25,7 +25,7 @@ export const Properties = () => {
   };
 
   return (
-    <div className={classes.root}>
+    <div className={classes.root} key={formItemId}>
       {!formItem ? (
         <PageConfigPanel />
       ) : (


### PR DESCRIPTION
## Description
- Change css to use grid and grid-rows-template in schema editor to ensure correct height to agin ensure scrollbar is visible only when suppose to
- Add key to dragAndDrop component with schemaType as value in order to reset scroll position in data model editor when selecting a new type
- Add key to Properties component with formItemId as value in ux-editor to reset scroll when switching component

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
