### PR TITLE
Disable structural sharing for `JsonSchema` query

### DIFF
--- a/frontend/app-development/hooks/queries/useSchemaQuery.ts
+++ b/frontend/app-development/hooks/queries/useSchemaQuery.ts
@@ -20,5 +20,6 @@ export const useSchemaQuery = (
       isXsdFile(modelPath)
         ? addXsdFromRepo(org, app, StringUtils.removeStart(modelPath, '/'))
         : getDataModel(org, app, modelPath),
+    structuralSharing: false,
   });
 };


### PR DESCRIPTION
## Description

Disables structural sharing check for just the `JsonSchema` query, see [this comment](https://github.com/Altinn/altinn-studio/issues/13022#issuecomment-2213816308) for reasoning.

## Related Issue(s)

- #13022

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
