### PR TITLE
Make StudioButton small for adding expression on sequence flow in process editor

### DIFF
--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigSequenceFlow/ConfigSequenceFlow.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigSequenceFlow/ConfigSequenceFlow.tsx
@@ -79,6 +79,7 @@ export const ConfigSequenceFlow = (): React.ReactElement => {
         {!expression ? (
           <StudioButton
             variant='secondary'
+            size='small'
             icon={<PlusIcon />}
             fullWidth
             onClick={onAddNewExpressionClicked}


### PR DESCRIPTION
## Description
add `size='small'` for Button when adding an expression on sequence flow in process editor

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
