### PR TITLE
Fix/ Stateless layout makes studio crash

### DIFF
--- a/frontend/packages/shared/src/utils/layoutSetsUtils.test.ts
+++ b/frontend/packages/shared/src/utils/layoutSetsUtils.test.ts
@@ -43,4 +43,16 @@ describe('getLayoutSetNameForCustomReceipt', () => {
     };
     expect(getLayoutSetNameForCustomReceipt(layoutSetsWithEmptySets)).toBeUndefined();
   });
+
+  it('should return undefined if layoutSets has a set with no task ids', () => {
+    const layoutSetsWithUndefinedTasks: LayoutSets = {
+      sets: [
+        {
+          id: layoutSetName,
+          tasks: null,
+        },
+      ],
+    };
+    expect(getLayoutSetNameForCustomReceipt(layoutSetsWithUndefinedTasks)).toBeUndefined();
+  });
 });

--- a/frontend/packages/shared/src/utils/layoutSetsUtils.ts
+++ b/frontend/packages/shared/src/utils/layoutSetsUtils.ts
@@ -3,7 +3,7 @@ import type { LayoutSets } from 'app-shared/types/api/LayoutSetsResponse';
 import { validateLayoutNameAndLayoutSetName } from 'app-shared/utils/LayoutAndLayoutSetNameValidationUtils/validateLayoutNameAndLayoutSetName';
 
 export const getLayoutSetNameForCustomReceipt = (layoutSets: LayoutSets): string | undefined => {
-  return layoutSets?.sets?.find((set) => set.tasks.includes(PROTECTED_TASK_NAME_CUSTOM_RECEIPT))
+  return layoutSets?.sets?.find((set) => set.tasks?.includes(PROTECTED_TASK_NAME_CUSTOM_RECEIPT))
     ?.id;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes stateless layout issue that causes AS to crash on "lage"-page. The stateless layout does not have a task ID.

<!--- Describe your changes in detail -->

## Related Issue(s)

- https://altinn.slack.com/archives/C02EJ9HKQA3/p1720778314300849

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
