### PR TITLE
Resourceadm: await promises in Playwright tests

### DIFF
--- a/frontend/resourceadm/testing/playwright/pages/ResourcePage.ts
+++ b/frontend/resourceadm/testing/playwright/pages/ResourcePage.ts
@@ -167,7 +167,8 @@ export class ResourcePage extends ResourceEnvironment {
   }
 
   public async setAvailableForType(): Promise<void> {
-    if (!this.availableForTypeCheckbox.isChecked()) {
+    const isAvailableForChecked = await this.availableForTypeCheckbox.isChecked();
+    if (!isAvailableForChecked) {
       await this.availableForTypeCheckbox.click();
     }
   }
@@ -181,7 +182,8 @@ export class ResourcePage extends ResourceEnvironment {
   }
 
   public async addPolicyRule(): Promise<void> {
-    if (!this.ruleHeader.isVisible()) {
+    const isPolicyRuleVisible = await this.ruleHeader.isVisible();
+    if (!isPolicyRuleVisible) {
       await this.addPolicyRuleButton.click();
       await this.setPolicyAction();
       await this.setPolicySubject();


### PR DESCRIPTION
## Description

For some tests in resourceadm Playwright tests we use conditions to evaluate if an action needs to be done. These conditions depend on whether something is visible or checked in the ui. These Playwright functions return promises, which must be awaited before the return value is used.

## Related Issue(s)

- this PR

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
