### PR TITLE
Resourceadm: fix race condition in Playwright test

### DIFF
--- a/frontend/resourceadm/testing/playwright/pages/ResourcePage.ts
+++ b/frontend/resourceadm/testing/playwright/pages/ResourcePage.ts
@@ -182,6 +182,7 @@ export class ResourcePage extends ResourceEnvironment {
   }
 
   public async addPolicyRule(): Promise<void> {
+    await expect(this.addPolicyRuleButton).toBeVisible(); // wait for policy page to be displayed
     const isPolicyRuleVisible = await this.ruleHeader.isVisible();
     if (!isPolicyRuleVisible) {
       await this.addPolicyRuleButton.click();


### PR DESCRIPTION
## Description

In our tests, we check if a policy rule header is visible: `const isPolicyRuleVisible = await this.ruleHeader.isVisible()`. However, if the page navigation is slow, this check might be run before we are on the policy page. We should first check that the add rule button is visible (to ensure we are on the policy page), before we check if a policy rule header is visible.

## Related Issue(s)

- this PR

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
