### PR TITLE
Resourceadm: increase timeout in Playwright tests

### DIFF
--- a/frontend/resourceadm/testing/playwright/pages/ResourcePage.ts
+++ b/frontend/resourceadm/testing/playwright/pages/ResourcePage.ts
@@ -182,7 +182,7 @@ export class ResourcePage extends ResourceEnvironment {
   }
 
   public async addPolicyRule(): Promise<void> {
-    await expect(this.addPolicyRuleButton).toBeVisible(); // wait for policy page to be displayed
+    await expect(this.addPolicyRuleButton).toBeVisible({ timeout: 15000 }); // wait for policy page to be displayed
     const isPolicyRuleVisible = await this.ruleHeader.isVisible();
     if (!isPolicyRuleVisible) {
       await this.addPolicyRuleButton.click();
@@ -213,7 +213,7 @@ export class ResourcePage extends ResourceEnvironment {
   }
 
   public async verifyRepoNotInSyncVisible(): Promise<void> {
-    await expect(this.repoSyncAlert).toBeVisible();
+    await expect(this.repoSyncAlert).toBeVisible({ timeout: 15000 });
   }
 
   public async clickUploadChangesButton(): Promise<void> {
@@ -225,6 +225,6 @@ export class ResourcePage extends ResourceEnvironment {
   }
 
   public async verifyDeployAlertVisible(): Promise<void> {
-    await expect(this.publishAlert).toBeVisible();
+    await expect(this.publishAlert).toBeVisible({ timeout: 15000 });
   }
 }


### PR DESCRIPTION
## Description

Increase timeout of expect in resourceadm Playwright tests (some visual changes can take longer than 5000ms to be visible in dev.altinn.studio)

## Related Issue(s)

- this PR

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
