### PR TITLE
fix display of default data model binding

### DIFF
--- a/frontend/packages/ux-editor/src/utils/dataModelUtils.test.ts
+++ b/frontend/packages/ux-editor/src/utils/dataModelUtils.test.ts
@@ -281,4 +281,13 @@ describe('getDataModel', () => {
     const dataModel = getDataModel(isDataModelValid, dataModelMetadata, currentDataModel);
     expect(dataModel).toEqual(currentDataModel);
   });
+
+  it('should return default data model if current data model is empty string', () => {
+    const isDataModelValid = true;
+    const currentDataModel = '';
+    const dataModelMetadata = dataModelMetadataMock;
+
+    const dataModel = getDataModel(isDataModelValid, dataModelMetadata, currentDataModel);
+    expect(dataModel).toEqual(defaultModel);
+  });
 });

--- a/frontend/packages/ux-editor/src/utils/dataModelUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/dataModelUtils.ts
@@ -145,7 +145,7 @@ export const getDataModel = (
   currentDataModel?: string,
 ): string => {
   if (dataModelMetadata) {
-    return isDataModelValid && currentDataModel !== undefined
+    return isDataModelValid && currentDataModel !== undefined && currentDataModel !== ''
       ? currentDataModel
       : dataModelMetadata[0]?.id;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix display of default selected data model when featureFlag is not enabled. Related to, https://github.com/Altinn/altinn-studio/issues/12738
Atm it doesn't display the name of the default data model binding.

Before:
<img width="383" alt="image" src="https://github.com/user-attachments/assets/34cc566d-60b3-4331-a229-c8c5142fffa9">

After:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/bc059dfe-faaa-4ddf-80ff-17463d734529">



<!--- Describe your changes in detail -->

## Related Issue(s)

- itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
