### PR TITLE
Fix click-and-hold scrolling in Designer

### DIFF
--- a/frontend/app-development/layout/App.css
+++ b/frontend/app-development/layout/App.css
@@ -30,8 +30,9 @@ button[class*='Button-module_small__'] svg {
 }
 
 ::-webkit-scrollbar {
-  width: 5px;
+  width: 6px;
 }
+
 ::-webkit-scrollbar-thumb {
   background: darkgray;
   border-radius: 5px;

--- a/frontend/libs/studio-components/src/components/StudioResizableLayout/StudioResizableLayoutHandle/StudioResizableLayoutHandle.module.css
+++ b/frontend/libs/studio-components/src/components/StudioResizableLayout/StudioResizableLayoutHandle/StudioResizableLayoutHandle.module.css
@@ -15,7 +15,7 @@
 }
 
 .resizeHandleH:after {
-  inset: 0px -6px;
+  inset: 0 -5px 0 0;
 }
 
 .resizeHandleV {
@@ -23,7 +23,7 @@
 }
 
 .resizeHandleV:after {
-  inset: -6px 0px;
+  inset: 0 0 -5px 0;
 }
 
 .hideLeftSide {


### PR DESCRIPTION
## Description
* Disabled the left side of the resize handle so that it doesn't interfere with the scrollbar. 
* Made the same change to the horizontal axis, so the behaviour is the same in case we want to use the other axis in the future.
* Added 1px width to the scrollbar in webkit browsers in Designer. It's hardly noticable for anyone, but makes it a little bit easier to click and drag.

This solution was inspired by Rider/Windows, which appears to work the same way:

https://github.com/user-attachments/assets/f77d6217-95de-4469-b34c-09f9d9c106b4



## Related Issue(s)
- #12787 
- #13176 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

