### PR TITLE
Invalidate jsonSchema by modelName when uploading new model and update state with useEffect

### DIFF
--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSchemaQuery } from '../../../hooks/queries';
 import { useSchemaMutation } from '../../../hooks/mutations';
 import { StudioCenter, StudioPageSpinner } from '@studio/components';
@@ -64,6 +64,10 @@ const SchemaEditorWithDebounce = ({ jsonSchema, modelPath }: SchemaEditorWithDeb
   const [model, setModel] = useState<JsonSchema>(jsonSchema);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const updatedModel = useRef<JsonSchema>(jsonSchema);
+
+  useEffect(() => {
+    setModel(jsonSchema);
+  }, [jsonSchema]);
 
   const saveFunction = useCallback(
     () => mutate({ modelPath, model: updatedModel.current }),

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/SchemaSelect.module.css
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/SchemaSelect.module.css
@@ -1,4 +1,4 @@
 .select {
   cursor: pointer;
-  min-width: 400px;
+  min-width: 20vw;
 }

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/SchemaSelect.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/SchemaSelect.tsx
@@ -36,6 +36,7 @@ export const SchemaSelect = ({
       disabled={disabled}
       onChange={(e) => handleChange(e.target.value)}
       value={selectedOption?.value.repositoryRelativeUrl}
+      size='small'
     >
       {optionGroups.map((group) => (
         <optgroup label={group.label} key={group.label}>

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/TopToolbar.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/TopToolbar.tsx
@@ -55,7 +55,7 @@ export function TopToolbar({
         handleCreateSchema={handleCreateSchema}
         createPathOption={createPathOption}
       />
-      <XSDUpload disabled={false} />
+      <XSDUpload disabled={false} selectedOption={selectedOption} />
       <SchemaSelect
         dataModels={dataModels}
         disabled={false}

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/XSDUpload.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/XSDUpload.tsx
@@ -6,17 +6,22 @@ import { useUploadDataModelMutation } from '../../../../hooks/mutations/useUploa
 import type { AxiosError } from 'axios';
 import type { ApiError } from 'app-shared/types/api/ApiError';
 import { toast } from 'react-toastify';
+import type { MetadataOption } from '../../../../types/MetadataOption';
 
 export interface XSDUploadProps {
   disabled?: boolean;
   submitButtonRenderer?: (fileInputClickHandler: (event: any) => void) => JSX.Element;
+  selectedOption?: MetadataOption;
 }
 
-export const XSDUpload = ({ disabled, submitButtonRenderer }: XSDUploadProps) => {
+export const XSDUpload = ({ disabled, submitButtonRenderer, selectedOption }: XSDUploadProps) => {
   const { t } = useTranslation();
-  const { mutate: uploadDataModel, isPending: uploading } = useUploadDataModelMutation({
-    hideDefaultError: true,
-  });
+  const { mutate: uploadDataModel, isPending: uploading } = useUploadDataModelMutation(
+    selectedOption?.value?.repositoryRelativeUrl,
+    {
+      hideDefaultError: true,
+    },
+  );
 
   const uploadButton = React.useRef(null);
 

--- a/frontend/app-development/hooks/mutations/useUploadDataModelMutation.test.ts
+++ b/frontend/app-development/hooks/mutations/useUploadDataModelMutation.test.ts
@@ -12,14 +12,16 @@ const file = new File(['hello'], 'hello.xsd', { type: 'text/xml' });
 
 const renderHook = async ({
   queryClient,
+  modelPath,
 }: {
   queryClient?: QueryClient;
+  modelPath?: string;
 } = {}) => {
   const uploadDataModelResult = renderHookWithMockStore(
     {},
     {},
     queryClient,
-  )(() => useUploadDataModelMutation()).renderHookResult.result;
+  )(() => useUploadDataModelMutation(modelPath)).renderHookResult.result;
   await waitFor(() => uploadDataModelResult.current.mutate(file));
   expect(uploadDataModelResult.current.isSuccess).toBe(true);
 };
@@ -47,6 +49,19 @@ describe('useUploadDataModelMutation', () => {
     });
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: [QueryKey.AppMetadataModelIds, org, app],
+    });
+  });
+
+  it('invalidates json schema metadata when upload is successful and a modelPath is provided', async () => {
+    const queryClient = createQueryClientMock();
+    const mockModelPath = '/App/models/mockModel.schema.json';
+    const invalidateQueriesSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    await renderHook({ queryClient, modelPath: mockModelPath });
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledTimes(4);
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: [QueryKey.JsonSchema, org, app, mockModelPath],
     });
   });
 });

--- a/frontend/app-development/hooks/mutations/useUploadDataModelMutation.ts
+++ b/frontend/app-development/hooks/mutations/useUploadDataModelMutation.ts
@@ -4,7 +4,7 @@ import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 
-export const useUploadDataModelMutation = (meta?: MutationMeta) => {
+export const useUploadDataModelMutation = (modelPath?: string, meta?: MutationMeta) => {
   const { uploadDataModel } = useServicesContext();
   const { org, app } = useStudioEnvironmentParams();
   const queryClient = useQueryClient();
@@ -15,6 +15,8 @@ export const useUploadDataModelMutation = (meta?: MutationMeta) => {
         queryClient.invalidateQueries({ queryKey: [QueryKey.DataModelsJson, org, app] }),
         queryClient.invalidateQueries({ queryKey: [QueryKey.DataModelsXsd, org, app] }),
         queryClient.invalidateQueries({ queryKey: [QueryKey.AppMetadataModelIds, org, app] }),
+        modelPath &&
+          queryClient.invalidateQueries({ queryKey: [QueryKey.JsonSchema, org, app, modelPath] }),
       ]);
     },
     meta,

--- a/frontend/packages/ux-editor/src/components/Elements/LayoutSetsContainer.module.css
+++ b/frontend/packages/ux-editor/src/components/Elements/LayoutSetsContainer.module.css
@@ -1,3 +1,3 @@
 .layoutSetsDropDown {
-  min-width: 400px;
+  min-width: 20vw;
 }


### PR DESCRIPTION
## Description
- Invalidate jsonSchema query by modelName to reflect correct view in schema editor
- set model state using useEffect since changes inside jsonSchema object are not recognized by react useState

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
