### PR TITLE
Resourceadm: add subscription keys before sending delegation count request

### DIFF
--- a/backend/src/Designer/TypedHttpClients/Altinn2DelegationMigration/Altinn2DelegationMigrationClient.cs
+++ b/backend/src/Designer/TypedHttpClients/Altinn2DelegationMigration/Altinn2DelegationMigrationClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Configuration;
+using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Models;
 using Microsoft.Extensions.Options;
 
@@ -27,7 +28,9 @@ namespace Altinn.Studio.Designer.TypedHttpClients.Altinn2DelegationMigration
                 : $"{_platformSettings.ResourceRegistryDefaultBaseUrl}";
 
             string relativeUrl = $"/resourceregistry/api/v1/altinn2export/delegationcount/?serviceCode={serviceCode}&serviceEditionCode={serviceEditionCode}";
-            using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}{relativeUrl}");
+            Uri uri = new($"{baseUrl}{relativeUrl}");
+            HttpClientHelper.AddSubscriptionKeys(_httpClient, uri, _platformSettings);
+            using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
             using HttpResponseMessage response = await _httpClient.SendAsync(request);
 
             return await response.Content.ReadAsAsync<DelegationCountOverview>();


### PR DESCRIPTION
## Description

- Add missing subscription keys which should have been added in https://github.com/Altinn/altinn-studio/pull/13162

## Related Issue(s)

- this PR

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
