### PR TITLE
Update CSS loader to version 7

### DIFF
--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -65,6 +65,7 @@ module.exports = {
               },
               modules: {
                 localIdentName: '[name]__[local]--[hash:base64:5]',
+                namedExport: false,
               },
             },
           },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@typescript-eslint/eslint-plugin": "7.17.0",
     "@typescript-eslint/parser": "7.17.0",
     "cross-env": "7.0.3",
-    "css-loader": "6.11.0",
+    "css-loader": "7.1.2",
     "css-minimizer-webpack-plugin": "^7.0.0",
     "eslint": "8.57.0",
     "eslint-plugin-import": "2.29.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8139,7 +8139,7 @@ __metadata:
     ajv: "npm:8.17.1"
     ajv-formats: "npm:3.0.1"
     cross-env: "npm:7.0.3"
-    css-loader: "npm:6.11.0"
+    css-loader: "npm:7.1.2"
     css-minimizer-webpack-plugin: "npm:^7.0.0"
     eslint: "npm:8.57.0"
     eslint-plugin-import: "npm:2.29.1"
@@ -10059,9 +10059,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-loader@npm:6.11.0":
-  version: 6.11.0
-  resolution: "css-loader@npm:6.11.0"
+"css-loader@npm:7.1.2":
+  version: 7.1.2
+  resolution: "css-loader@npm:7.1.2"
   dependencies:
     icss-utils: "npm:^5.1.0"
     postcss: "npm:^8.4.33"
@@ -10073,13 +10073,13 @@ __metadata:
     semver: "npm:^7.5.4"
   peerDependencies:
     "@rspack/core": 0.x || 1.x
-    webpack: ^5.0.0
+    webpack: ^5.27.0
   peerDependenciesMeta:
     "@rspack/core":
       optional: true
     webpack:
       optional: true
-  checksum: 10/9e3665509f6786d46683de5c5f5c4bdd4aa62396b4017b41dbbb41ea5ada4012c80ee1e3302b79b504bc24da7fa69e3552d99006cecc953e0d9eef4a3053b929
+  checksum: 10/ddde22fb103888320f60a1414a6a04638d2e9760a532a52d03c45e6e2830b32dd76c734aeef426f78dd95b2d15f77eeec3854ac53061aff02569732dc6e6801c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Updated the CSS loader dependency to the latest version. In this version, the option `modules.namedExport` is `true` by default, so we need to explicitly set it to `false`.

## Related Issue(s)
- #13246

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
