### PR TITLE
roll back azure identity dependency

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.PDF/pom.xml
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
-      <version>1.13.1</version>
+      <version>1.13.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Newer version of dependency causing issues. Rolling back. 