### PR TITLE
Fixed classNames of text editor

### DIFF
--- a/frontend/packages/text-editor/src/RightMenu.module.css
+++ b/frontend/packages/text-editor/src/RightMenu.module.css
@@ -1,11 +1,4 @@
-.RightMenu__verticalContent {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.RightMenu__sidebar {
+.rightMenuSidebar {
   border-left: 1px solid #c9c9c9;
   background: #f4f3f4;
   padding: 2rem;
@@ -14,7 +7,14 @@
   gap: 3rem;
 }
 
-.RightMenu__radioGroup {
+.rightMenuVerticalContent {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.rightMenu__radioGroup {
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -24,7 +24,7 @@
   padding-bottom: 1rem;
 }
 
-.RightMenu__radio {
+.rightMenuRadio {
   display: flex;
   justify-content: space-between;
 }

--- a/frontend/packages/text-editor/src/RightMenu.tsx
+++ b/frontend/packages/text-editor/src/RightMenu.tsx
@@ -43,20 +43,20 @@ export const RightMenu = ({
   };
 
   return (
-    <aside className={classes.RightMenu__sidebar}>
-      <div className={classes.RightMenu__verticalContent}>
+    <aside className={classes.rightMenuSidebar}>
+      <div className={classes.rightMenuVerticalContent}>
         <Heading level={2} size='small'>
           {t('schema_editor.language')}
         </Heading>
         <div> {t('schema_editor.language_info_melding')}</div>
       </div>
-      <div className={classes.RightMenu__verticalContent}>
+      <div className={classes.rightMenuVerticalContent}>
         <Fieldset legend={t('schema_editor.active_languages')}>
-          <div className={classes.RightMenu__radioGroup}>
+          <div className={classes.rightMenuRadioGroup}>
             {availableLanguages?.map((langCode) => {
               return (
                 <div key={langCode}>
-                  <div className={classes.RightMenu__radio}>
+                  <div className={classes.rightMenuRadio}>
                     <Checkbox
                       value={getLangName({ code: langCode })}
                       name={langCode}

--- a/frontend/packages/text-editor/src/TextEditor.module.css
+++ b/frontend/packages/text-editor/src/TextEditor.module.css
@@ -1,4 +1,4 @@
-.TextEditor {
+.textEditor {
   width: 100%;
   height: calc(100vh - var(--header-height));
   display: grid;
@@ -6,47 +6,15 @@
   justify-items: center;
 }
 
-.RightMenu__verticalContent {
+.textEditorMain {
   width: 100%;
+  background-color: #fff;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  overflow: scroll;
 }
 
-.TextEditor__title-md {
-  font-size: 2.4rem;
-}
-
-.TextEditor__title-sm {
-  font-size: 1.6rem;
-  font-weight: bold;
-}
-
-.RightMenu__sidebar {
-  border-left: 1px solid #c9c9c9;
-  background: #f4f3f4;
-  padding: 2rem;
-  display: flex;
-  flex-direction: column;
-  gap: 3rem;
-}
-
-.RightMenu__radioGroup {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  justify-content: space-between;
-  border-bottom: 1px solid #bcc7cc;
-  padding-bottom: 1rem;
-}
-
-.RightMenu__radio {
-  display: flex;
-  justify-content: space-between;
-}
-
-.TextEditor__topRow {
+.textEditorTopRow {
   border-bottom: 1px solid #bcc7cc;
   padding: 2rem;
   display: flex;
@@ -66,17 +34,9 @@
   align-items: center;
 }
 
-.TextEditor__body {
+.textEditorBody {
   margin-left: 2rem;
   overflow: auto;
-}
-
-.TextEditor__main {
-  width: 100%;
-  background-color: #fff;
-  display: flex;
-  flex-direction: column;
-  overflow: scroll;
 }
 
 ::-webkit-scrollbar {

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -89,9 +89,9 @@ export const TextEditor = ({
   const handleSearchChange = (event: any) => setSearchQuery(event.target.value);
 
   return (
-    <div className={classes.TextEditor}>
-      <div className={classes.TextEditor__main}>
-        <div className={classes.TextEditor__topRow}>
+    <div className={classes.textEditor}>
+      <div className={classes.textEditorMain}>
+        <div className={classes.textEditorTopRow}>
           <StudioButton variant='primary' color='first' onClick={handleAddNewEntryClick}>
             {t('text_editor.new_text')}
           </StudioButton>
@@ -117,7 +117,7 @@ export const TextEditor = ({
             </div>
           </div>
         </div>
-        <div className={classes.TextEditor__body}>
+        <div className={classes.textEditorBody}>
           <TextList
             removeEntry={removeEntry}
             resourceRows={resourceRows}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some class names of the text editor stopped working after upgrading `css-loader`.
Using camelCase and removing the BEM modifier syntax (__) seemed to fix the issue 🤔 🤷‍♂️ .

<table>
<tr>
<th>BEFORE</th>
<th>AFTER</th>
</tr>
<tr>
<td>

<img width="2056" alt="text-editor-before" src="https://github.com/user-attachments/assets/c3bd0bf7-4128-42bf-aa4f-9ab4725d108a">

</td>
<td>

<img width="2056" alt="text-editor-after" src="https://github.com/user-attachments/assets/13a4ff22-cea7-4067-9111-346fbe09d2f3">

</td>
</tr>
</table>

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)