### PR TITLE
Make sure parent path accounts for references when adding nodes

### DIFF
--- a/frontend/packages/schema-editor/src/components/SchemaEditor/hooks/useAddReference.ts
+++ b/frontend/packages/schema-editor/src/components/SchemaEditor/hooks/useAddReference.ts
@@ -12,7 +12,8 @@ export const useAddReference = (): HandleAdd<string> => {
     (reference: string, position: ItemPosition) => {
       const index = calculatePositionInFullList(savableModel, position);
       const target: NodePosition = { parentPointer: position.parentId, index };
-      const refName = savableModel.generateUniqueChildName(target.parentPointer, 'ref');
+      const pointer = savableModel.getFinalNode(target.parentPointer).pointer;
+      const refName = savableModel.generateUniqueChildName(pointer, 'ref');
       const ref = savableModel.addReference(refName, reference, target);
       setSelectedNodePointer(ref.pointer);
     },


### PR DESCRIPTION
## Description

This issue seems to happen because the name generation does not use the correct path when adding to a parent reference. For the innflytter-model example, the name generation path uses the absolute path `"#/$defs/Skjema/properties/Innflytter"` while the actual parent path the node is added to is `"#/$defs/Innflytter"`.

Steps to reproduce:
1. Add an object {1} to a data model.
2. Convert it to a type.
3. Add any other type to {1}; it should get the name ref0.
4. Add another type to {1}; it will try to name it ref0 and throw an error.

I assume being able to alter a reference type instance without also altering the origin type is not intended. The proposed solution uses `SchemaModel.getFinalNode` to ensure the actual path used for name generation is using the reference path of the parent if needed.

## Related Issue(s)

- #12981

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
