### PR TITLE
add version.json in designer image

### DIFF
--- a/.github/workflows/designer-deploy.yaml
+++ b/.github/workflows/designer-deploy.yaml
@@ -36,6 +36,7 @@ jobs:
       client-id: ${{ secrets.AZURE_CLIENT_ID_FC }}
       tenant-id: ${{ secrets.AZURE_TENANT_ID_FC }}
       subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_FC }}
+      build-args: DESIGNER_VERSION=${{ needs.get-short-sha.outputs.short-sha }}
 
   helm-push:
     needs: get-short-sha

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN yarn build
 
 # Building the backend
 FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS generate-studio-backend
+ARG DESIGNER_VERSION=''
 WORKDIR /build
 COPY backend .
 RUN dotnet publish src/Designer/Designer.csproj -c Release -o /app_output
@@ -45,6 +46,9 @@ RUN rm -f /app_output/Altinn.Studio.Designer.staticwebassets.runtime.json
 WORKDIR /app_template
 RUN apk add jq zip
 RUN wget -O - https://api.github.com/repos/Altinn/app-template-dotnet/releases/latest | jq '.assets[]|select(.name | startswith("app-template-dotnet-") and endswith(".zip"))' | jq '.browser_download_url' | xargs wget -O apptemplate.zip && unzip apptemplate.zip && rm apptemplate.zip
+# Create version file
+WORKDIR /version
+RUN echo "{\"designerVersion\":\"$DESIGNER_VERSION\",\"appTemplateVersion\":\"$(curl -s https://api.github.com/repos/Altinn/app-template-dotnet/releases/latest | jq -r .tag_name)\"}" > version.json
 
 # Building the final image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS final
@@ -61,8 +65,10 @@ COPY --from=generate-studio-frontend /build/frontend/dist/dashboard ./wwwroot/de
 COPY --from=generate-studio-frontend /build/frontend/dist/resourceadm ./wwwroot/designer/frontend/resourceadm
 COPY --from=generate-studio-frontend /build/frontend/dist/language ./wwwroot/designer/frontend/lang
 COPY --from=generate-studio-frontend /build/frontend/dist/studio-root ./wwwroot/designer/frontend/studio-root
+COPY --from=generate-studio-backend /version/version.json ./wwwroot/designer/version.json
 
 ## Copying app template
 COPY --from=generate-studio-backend /app_template ./Templates/AspNet
+
 
 ENTRYPOINT ["dotnet", "Altinn.Studio.Designer.dll"]

--- a/development/setup.js
+++ b/development/setup.js
@@ -8,6 +8,8 @@ const path = require('path');
 const writeEnvFile = require('./utils/write-env-file.js');
 
 const startingDockerCompose = () => runCommand('docker compose up -d --remove-orphans --build');
+const restartComposeServices = () =>
+  runCommand('docker compose down && docker compose up -d --remove-orphans');
 
 const createUser = (username, password, admin) =>
   runCommand(
@@ -102,7 +104,7 @@ const createOidcClientIfNotExists = async (env) => {
 
   writeEnvFile(env);
   // reload designer with new clientid and secret
-  startingDockerCompose();
+  restartComposeServices();
 };
 
 const addUserToSomeTestDepTeams = async (env) => {

--- a/development/setup.js
+++ b/development/setup.js
@@ -105,6 +105,7 @@ const createOidcClientIfNotExists = async (env) => {
   writeEnvFile(env);
   // reload designer with new clientid and secret
   restartComposeServices();
+  await waitFor('http://studio.localhost/repos/');
 };
 
 const addUserToSomeTestDepTeams = async (env) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Creates the version json file on build time in docker image.
It should be useful for us to check which version of designer and app template is running in the environment.

Version file contains short sha commit of altinn-studio repo and the release tag of the app template repo.
Version is available on `/designer/version.json` URL.

Example of versjon.json

```json
{
  "designerVersion": "c527f97",
  "appTemplateVersion": "v8.0.0"
}
```

<!--- Describe your changes in detail -->

## Related Issue(s)
Pr itself.

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
