### PR TITLE
chore(LogicalExpressionEditor): refactor to use UseUniqueKeys

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/LogicalExpressionEditor.tsx
+++ b/frontend/libs/studio-components/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/LogicalExpressionEditor.tsx
@@ -13,16 +13,14 @@ import {
 import type { SimpleSubexpression } from '../../types/SimpleSubexpression';
 import classes from './LogicalExpressionEditor.module.css';
 import { StudioButton } from '../../../StudioButton';
-import type { MutableRefObject, ReactNode } from 'react';
-import React, { Fragment, useRef } from 'react';
+import React, { Fragment, type ReactNode } from 'react';
 import { PlusIcon } from '@studio/icons';
 import { Subexpression } from './SubExpression';
 import { useStudioExpressionContext } from '../../StudioExpressionContext';
 import { LogicalOperatorToggle } from './LogicalOperatorToggle';
 import { OperatorBetweenSubexpressions } from './OperatorBetweenSubexpressions';
 import { Fieldset } from '@digdir/designsystemet-react';
-import { v4 as uuidv4 } from 'uuid';
-import { ArrayUtils } from '@studio/pure-functions';
+import { type UseUniqueKey, useUniqueKeys } from '../../../../hooks';
 
 export type LogicalExpressionEditorProps = {
   expression: SimpleLogicalExpression;
@@ -36,16 +34,11 @@ export const LogicalExpressionEditor = ({
   onChange,
 }: LogicalExpressionEditorProps) => {
   const { texts } = useStudioExpressionContext();
-  const internalIds = useRef<string[]>([]); // Used to keep track of the order of the subcomponents
   const { subexpressions, logicalOperator } = expression;
 
-  const areInternalIdsInSync = internalIds.current.length === subexpressions.length;
-  if (!areInternalIdsInSync) {
-    internalIds.current = [];
-    for (let i = 0; i < subexpressions.length; i++) {
-      internalIds.current.push(uuidv4());
-    }
-  }
+  const { removeUniqueKey, addUniqueKey, getUniqueKey } = useUniqueKeys({
+    numberOfKeys: subexpressions.length,
+  });
 
   const handleOperatorChange = (operator: LogicalTupleOperator) =>
     onChange(changeOperator(expression, operator));
@@ -55,7 +48,7 @@ export const LogicalExpressionEditor = ({
 
   const handleAddSubexpression = () => {
     onChange(addDefaultSubexpression(expression));
-    internalIds.current.push(uuidv4());
+    addUniqueKey();
   };
 
   return (
@@ -71,7 +64,8 @@ export const LogicalExpressionEditor = ({
             ) : undefined
           }
           expressions={subexpressions}
-          internalIds={internalIds}
+          getUniqueKey={getUniqueKey}
+          removeUniqueKey={removeUniqueKey}
           onChange={handleSubexpressionsChange}
         />
         {showAddSubexpression && (
@@ -87,30 +81,30 @@ export const LogicalExpressionEditor = ({
 type SubexpressionListProps = {
   componentBetween: ReactNode;
   expressions: SimpleSubexpression[];
-  internalIds: MutableRefObject<string[]>;
   onChange: (subexpressions: SimpleSubexpression[]) => void;
-};
+} & Pick<UseUniqueKey, 'getUniqueKey' | 'removeUniqueKey'>;
 
 const SubexpressionList = ({
   expressions,
   onChange,
   componentBetween,
-  internalIds,
+  getUniqueKey,
+  removeUniqueKey,
 }: SubexpressionListProps) => {
   const { texts } = useStudioExpressionContext();
 
-  const handleSubexpressionChange = (index: number, expression: SimpleSubexpression) =>
+  const handleSubexpressionChange = (index: number, expression: SimpleSubexpression): void =>
     onChange(changeSubexpression(expressions, index, expression));
 
-  const handleDeleteExpression = (index: number) => {
+  const handleDeleteExpression = (index: number): void => {
     onChange(deleteSubexpression(expressions, index));
-    internalIds.current = ArrayUtils.removeItemByIndex(internalIds.current, index);
+    removeUniqueKey(index);
   };
 
   return (
     <>
       {expressions.map((expression, index) => (
-        <Fragment key={internalIds.current[index]}>
+        <Fragment key={getUniqueKey(index)}>
           <Subexpression
             expression={expression}
             legend={texts.subexpression(index)}

--- a/frontend/libs/studio-components/src/hooks/useUniqueKeys.ts
+++ b/frontend/libs/studio-components/src/hooks/useUniqueKeys.ts
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { ArrayUtils } from '@studio/pure-functions';
 
-type UseUniqueKey = {
+export type UseUniqueKey = {
   addUniqueKey: () => void;
   removeUniqueKey: (index: number) => void;
   getUniqueKey: (index: number) => string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We have implemented a custom hook called `useUniqueKeys` to manage lists that lack unique identifiers for individual items. This hook dynamically generates unique keys for each item, ensuring that our list elements can be efficiently tracked and manipulated in React components. I refactored the `LogicalExpresisonEditor` to use the `useUniqueKeys` hook.
 
## Related Issue(s)

- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
