### PR TITLE
Forced the process editor to reload after updating the xml

### DIFF
--- a/frontend/app-development/features/processEditor/ProcessEditor.tsx
+++ b/frontend/app-development/features/processEditor/ProcessEditor.tsx
@@ -30,7 +30,11 @@ export const ProcessEditor = (): React.ReactElement => {
   const { data: currentPolicy, isPending: isPendingCurrentPolicy } = useAppPolicyQuery(org, app);
   const { mutate: mutateApplicationPolicy } = useAppPolicyMutation(org, app);
   const { setSettingsModalOpen, setSettingsModalSelectedTab } = useSettingsModalContext();
-  const { data: bpmnXml, isError: hasBpmnQueryError } = useBpmnQuery(org, app);
+  const {
+    data: bpmnXml,
+    isError: hasBpmnQueryError,
+    isPending: isBpmnPending,
+  } = useBpmnQuery(org, app);
   const { data: appLibData, isLoading: appLibDataLoading } = useAppVersionQuery(org, app);
   const { mutate: mutateBpmn, isPending: mutateBpmnPending } = useBpmnMutation(org, app);
   const { mutate: mutateLayoutSetId, isPending: mutateLayoutSetIdPending } =
@@ -112,7 +116,7 @@ export const ProcessEditor = (): React.ReactElement => {
     onProcessTaskRemoveHandler.handleOnProcessTaskRemove(taskMetadata);
   };
 
-  if (appLibDataLoading || appMetadataPending) {
+  if (isBpmnPending || appLibDataLoading || appMetadataPending) {
     return <StudioPageSpinner spinnerTitle={t('process_editor.loading')} showSpinnerTitle />;
   }
 

--- a/frontend/packages/shared/src/hooks/mutations/useBpmnMutation.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useBpmnMutation.ts
@@ -12,9 +12,10 @@ export const useBpmnMutation = (org: string, app: string, resetQueries: boolean 
   return useMutation({
     mutationFn: ({ form }: UseBpmnMutationPayload) => updateBpmnXml(org, app, form),
     onSuccess: async () => {
+      const queryKey = [QueryKey.FetchBpmn, org, app];
       resetQueries
-        ? await queryClient.resetQueries({ queryKey: [QueryKey.FetchBpmn, org, app] })
-        : await queryClient.invalidateQueries({ queryKey: [QueryKey.FetchBpmn, org, app] });
+        ? await queryClient.resetQueries({ queryKey })
+        : await queryClient.invalidateQueries({ queryKey });
     },
   });
 };

--- a/frontend/packages/shared/src/hooks/mutations/useBpmnMutation.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useBpmnMutation.ts
@@ -6,13 +6,15 @@ type UseBpmnMutationPayload = {
   form: FormData;
 };
 
-export const useBpmnMutation = (org: string, app: string) => {
+export const useBpmnMutation = (org: string, app: string, resetQueries: boolean = false) => {
   const { updateBpmnXml } = useServicesContext();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ form }: UseBpmnMutationPayload) => updateBpmnXml(org, app, form),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: [QueryKey.FetchBpmn, org, app] });
+      resetQueries
+        ? await queryClient.resetQueries({ queryKey: [QueryKey.FetchBpmn, org, app] })
+        : await queryClient.invalidateQueries({ queryKey: [QueryKey.FetchBpmn, org, app] });
     },
   });
 };

--- a/frontend/packages/shared/src/hooks/useUpdateBpmn.ts
+++ b/frontend/packages/shared/src/hooks/useUpdateBpmn.ts
@@ -25,7 +25,7 @@ const updateBpmn = async (
 
 export const useUpdateBpmn = (org: string, app: string) => {
   const { refetch: refetchBpmn } = useBpmnQuery(org, app, false);
-  const { mutate: mutateBpmn } = useBpmnMutation(org, app);
+  const { mutate: mutateBpmn } = useBpmnMutation(org, app, true);
 
   return async (updateCriteria: (definitions: Definitions) => boolean) => {
     const { data: bpmnXml } = await refetchBpmn();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When we update or delete a datatype linked to a signing task, we need to update the XML/BPMN file.

If we open the process editor immediately after updating a FileUpload component linked to a signing task, the XML doesn’t have time to update, and the process editor uses the old XML, as the process editor is initialized only once:
https://github.com/Altinn/altinn-studio/blob/95d7612c0608232b191c18c943df7237e0ec7d1e/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts#L96

This PR fixes the issue by forcing the process editor to reload after programmatically updating the XML, but this solution is not fully optimal as a second loading is visible.
The best solution would be to fix the dependencies and allow the process editor to reinitialize when the XML changes, or alternatively, [move the logic to the backend](https://github.com/Altinn/altinn-studio/issues/13401), but these solutions require more refactoring/work.

<table>
<tr>
<th>BEFORE the fix</th>
<th>AFTER the fix</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/1355848c-56ef-48fb-934a-fdd492f89b1f

</td>
<td>

https://github.com/user-attachments/assets/d83cf78b-ad29-4027-89c3-9f75ad1a04ea

</td>
</tr>
</table>

## Related Issue(s)

- https://github.com/Altinn/altinn-studio/pull/13357#issuecomment-2298750117

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
