### PR TITLE
Resourceadm: fix agressive re-render using studio debounce

### DIFF
--- a/frontend/resourceadm/components/AccessListMembers/AccessListMembers.tsx
+++ b/frontend/resourceadm/components/AccessListMembers/AccessListMembers.tsx
@@ -47,9 +47,9 @@ export const AccessListMembers = ({
   const [isAddMode, setIsAddMode] = useState<boolean>(false);
   const [isSubPartySearch, setIsSubPartySearch] = useState<boolean>(false);
   const [searchText, setSearchText] = useState<string>('');
+  const [debouncedSearchText, setDebouncedSearchText] = useState<string>('');
   const [searchUrl, setSearchUrl] = useState<string>('');
   const { debounce } = useDebounce({ debounceTimeInMs: 500 });
-  debounce(() => setSearchUrl(searchText ? getPartiesQueryUrl(searchText, isSubPartySearch) : ''));
 
   const { mutate: removeListMember, isPending: isRemovingMember } =
     useRemoveAccessListMemberMutation(org, list.identifier, env);
@@ -66,6 +66,12 @@ export const AccessListMembers = ({
     isFetchingNextPage,
     fetchNextPage,
   } = useGetAccessListMembersQuery(org, list.identifier, env);
+
+  useEffect(() => {
+    setSearchUrl(
+      debouncedSearchText ? getPartiesQueryUrl(debouncedSearchText, isSubPartySearch) : '',
+    );
+  }, [debouncedSearchText, isSubPartySearch]);
 
   useEffect(() => {
     if (members?.pages?.length === 0) {
@@ -131,9 +137,9 @@ export const AccessListMembers = ({
           },
         ],
       };
-    } else if (partiesSearchData) {
+    } else if (partiesSearchData && !isSubPartySearch) {
       return partiesSearchData;
-    } else if (subPartiesSearchData) {
+    } else if (subPartiesSearchData && isSubPartySearch) {
       return subPartiesSearchData;
     } else {
       return undefined;
@@ -186,7 +192,10 @@ export const AccessListMembers = ({
               <Textfield
                 id='party-search'
                 value={searchText}
-                onChange={(event) => setSearchText(event.target.value)}
+                onChange={(event) => {
+                  debounce(() => setDebouncedSearchText(event.target.value));
+                  setSearchText(event.target.value);
+                }}
               />
               <div className={classes.noSearchResults} aria-live='polite'>
                 {resultData?.parties?.length === 0 && (


### PR DESCRIPTION
## Description

The current implementation of debounce in resource access lists makes it impossible to change paging; paging is always set back to first page when user navigates to another page.

## Related Issue(s)

- this PR

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
