### PR TITLE
added validation for CreateCustomReceiptForm and test.

### DIFF
--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigEndEvent/CustomReceiptContent/CreateCustomReceiptForm/CreateCustomReceiptForm.test.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigEndEvent/CustomReceiptContent/CreateCustomReceiptForm/CreateCustomReceiptForm.test.tsx
@@ -105,6 +105,41 @@ describe('CreateCustomReceiptForm', () => {
     expect(mockOnCloseForm).toHaveBeenCalledTimes(0);
   });
 
+  it('Displays error when there is just one character present for layouSetId', async () => {
+    const user = userEvent.setup();
+    renderCreateCustomReceiptForm();
+
+    const layoutSetInput = screen.getByLabelText(
+      textMock('process_editor.configuration_panel_custom_receipt_textfield_label'),
+    );
+    await user.type(layoutSetInput, 'a');
+
+    const combobox = screen.getByRole('combobox', {
+      name: textMock('process_editor.configuration_panel_custom_receipt_select_data_model_label'),
+    });
+    await user.click(combobox);
+
+    const optionElement = screen.getByRole('option', { name: mockAllDataModelIds[0] });
+    await user.click(optionElement);
+    await user.keyboard('{Escape}');
+
+    const createButton = screen.getByRole('button', {
+      name: textMock('process_editor.configuration_panel_custom_receipt_create_button'),
+    });
+    await user.click(createButton);
+
+    const layoutIdError = screen.getByText(
+      textMock('process_editor.configuration_panel_custom_receipt_layout_set_name_validation'),
+    );
+    expect(layoutIdError).toBeInTheDocument();
+
+    const dataModelIdError = screen.queryByText(
+      textMock('process_editor.configuration_panel_custom_receipt_create_data_model_error'),
+    );
+    expect(dataModelIdError).not.toBeInTheDocument();
+    expect(mockOnCloseForm).toHaveBeenCalledTimes(0);
+  });
+
   it('shows correct errormessage when layoutSetId is empty when typing in the textbox', async () => {
     const user = userEvent.setup();
     renderCreateCustomReceiptForm({

--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigEndEvent/CustomReceiptContent/CreateCustomReceiptForm/CreateCustomReceiptForm.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigEndEvent/CustomReceiptContent/CreateCustomReceiptForm/CreateCustomReceiptForm.tsx
@@ -47,6 +47,10 @@ export const CreateCustomReceiptForm = ({
   const updateErrors = (customReceiptForm: CustomReceiptType) => {
     const { layoutSetId, dataModelId } = customReceiptForm;
     setLayoutSetError(!layoutSetId ? t('validation_errors.required') : null);
+    layoutSetId.length === 1 &&
+      setLayoutSetError(
+        t('process_editor.configuration_panel_custom_receipt_layout_set_name_validation'),
+      );
 
     setDataModelError(
       !dataModelId


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added a validation for `CreateCustomReceiptForm  `component to show the error message as long as the user types just one character.
- Added test for it. 

## Related Issue(s)

- #13414 
- #13118 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
