### PR TITLE
Resourceadm: use module classname instead of global classname for sr-only class

### DIFF
--- a/frontend/resourceadm/components/AccessListMembers/AccessListMembers.module.css
+++ b/frontend/resourceadm/components/AccessListMembers/AccessListMembers.module.css
@@ -56,7 +56,7 @@
   width: 45%;
 }
 
-.sr-only {
+.srOnly {
   position: absolute;
   width: 1px;
   height: 1px;

--- a/frontend/resourceadm/components/AccessListMembers/AccessListMembersTable.tsx
+++ b/frontend/resourceadm/components/AccessListMembers/AccessListMembersTable.tsx
@@ -83,7 +83,7 @@ export const AccessListMembersTable = ({
       headerCellClass: cn(hiddenHeaderClassName, classes.smallColumn),
       bodyCellFormatter: (value: string) => (
         <>
-          <div className='sr-only'>{stringNumberToAriaLabel(value)}</div>
+          <div className={classes.srOnly}>{stringNumberToAriaLabel(value)}</div>
           <div aria-hidden='true'>{value}</div>
         </>
       ),


### PR DESCRIPTION
## Description

Replace css class `className='sr-only'` with css module `className={classes.srOnly}`.

## Related Issue(s)

- this PR

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
