### PR TITLE
Fix slack link on contact page

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -93,7 +93,7 @@
   "contact.slack.content": "Hvis du har spørsmål om hvordan du bygger en app, kan du snakke direkte med utviklingsteamet i Altinn Studio på Slack. De hjelper deg med å",
   "contact.slack.content_list": "<0>bygge appene slik du ønsker</0><0>svare på spørsmål og veilede deg</0><0>ta imot innspill på ny funksjonalitet</0>",
   "contact.slack.heading": "Skriv melding til oss Slack",
-  "contact.slack.link": "<0 href=\"https://altinn.slack.com\">altinn.slack.com</0>",
+  "contact.slack.link": "altinn.slack.com",
   "dashboard.all_apps": "Alle apper",
   "dashboard.all_data_models": "Alle datamodeller",
   "dashboard.all_resources": "Alle ressurser",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<table>
<tr>
<th>BEFORE</th>
<th>AFTER</th>
</tr>
<tr>
<td>

![slack-before](https://github.com/user-attachments/assets/1fc9399c-c91d-450d-b8f6-5c63ed739cac)

</td>
<td>

![slack-after](https://github.com/user-attachments/assets/bac13652-9c80-4883-912f-2d93456bf88c)

</td>
</tr>
</table>

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
