### PR TITLE
fix: pdf container jar name in start command (PDF)

### DIFF
--- a/src/Altinn.Platform/Altinn.Platform.PDF/Dockerfile
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/Dockerfile
@@ -13,4 +13,4 @@ COPY --from=build /build/target .
 RUN addgroup --gid 3000 dotnet && adduser --uid 1000 --ingroup dotnet --disabled-password --shell /bin/false dotnet
 # update permissions of files if neccessary before becoming dotnet user
 USER dotnet
-CMD ["java", "-jar", "./Altinn.Platform.PDF-1.0.jar"]
+CMD ["java", "-jar", "./Altinn.Platform.PDF-1.0.0.jar"]

--- a/src/Altinn.Platform/Altinn.Platform.PDF/README.md
+++ b/src/Altinn.Platform/Altinn.Platform.PDF/README.md
@@ -24,6 +24,14 @@ git clone https://github.com/Altinn/altinn-studio
 cd altinn-studio
 ```
 
+#### Running the application using Podman
+
+The PDF component can be run locally using podman. To build and run the application use the command.
+
+```cmd
+podman compose up -d --build
+```
+
 #### Running the application with Maven
 
 The PDF components can be run locally when developing/debugging.


### PR DESCRIPTION
## Description

I was dumb and changed the version number of the application without testing the result. This PR fixes the start command for the application. Also added a simple command to run PDF locally in Podman to the readme.