### PR TITLE
refactor(resource-adm): rename limitedByRRR property to accessListMode

### DIFF
--- a/backend/src/Designer/Enums/ResourceAccessListMode.cs
+++ b/backend/src/Designer/Enums/ResourceAccessListMode.cs
@@ -1,0 +1,12 @@
+namespace Altinn.Studio.Designer.Enums
+{
+    /// <summary>
+    /// Enum representation of the different types of ResourceAccessListModes supported by the resource registry
+    /// </summary>
+    public enum ResourceAccessListMode
+    {
+        Disabled = 0,
+
+        Enabled = 1,
+     }
+}

--- a/backend/src/Designer/Enums/ResourceAccessListMode.cs
+++ b/backend/src/Designer/Enums/ResourceAccessListMode.cs
@@ -8,5 +8,5 @@ namespace Altinn.Studio.Designer.Enums
         Disabled = 0,
 
         Enabled = 1,
-     }
+    }
 }

--- a/backend/src/Designer/Models/ServiceResource.cs
+++ b/backend/src/Designer/Models/ServiceResource.cs
@@ -100,7 +100,7 @@ namespace Altinn.Studio.Designer.Models
         /// Sets the access list mode for the resource
         /// </summary>
         [JsonConverter(typeof(JsonStringEnumConverter))]
-        public ResourceAccessListMode AccessListMode { get; set;  }
+        public ResourceAccessListMode AccessListMode { get; set; }
 
         /// <summary>
         /// The user acting on behalf of party can be a selfidentifed users

--- a/backend/src/Designer/Models/ServiceResource.cs
+++ b/backend/src/Designer/Models/ServiceResource.cs
@@ -97,9 +97,10 @@ namespace Altinn.Studio.Designer.Models
         public List<Keyword>? Keywords { get; set; }
 
         /// <summary>
-        /// Defines if the resource is limited by Resource Rights Registry
+        /// Sets the access list mode for the resource
         /// </summary>
-        public bool LimitedByRRR { get; set; }
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public ResourceAccessListMode AccessListMode { get; set;  }
 
         /// <summary>
         /// The user acting on behalf of party can be a selfidentifed users

--- a/frontend/packages/shared/src/types/ResourceAdm.ts
+++ b/frontend/packages/shared/src/types/ResourceAdm.ts
@@ -23,8 +23,10 @@ export interface Resource {
   enterpriseUserEnabled?: boolean;
   availableForType?: ResourceAvailableForTypeOption[];
   contactPoints?: ResourceContactPoint[];
-  limitedByRRR?: boolean;
+  accessListMode?: ResourceAccessListMode;
 }
+
+export type ResourceAccessListMode = 'Disabled' | 'Enabled';
 
 export interface ResourceContactPoint {
   category: string;

--- a/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
+++ b/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
@@ -366,7 +366,7 @@ describe('AboutResourcePage', () => {
       <ServicesContextProvider {...queriesMock} client={createQueryClientMock()}>
         <AboutResourcePage
           {...defaultProps}
-          resourceData={{ ...mockResource2, limitedByRRR: true }}
+          resourceData={{ ...mockResource2, accessListMode: 'Enabled' }}
         />
       </ServicesContextProvider>,
     );

--- a/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
+++ b/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
@@ -298,17 +298,17 @@ export const AboutResourcePage = ({
           toggleTextTranslationKey='resourceadm.about_resource_visible_show_text'
         />
         <ResourceSwitchInput
-          id='limitedByRRR'
+          id='accessListMode'
           label={t('resourceadm.about_resource_limited_by_rrr_label')}
           description={t('resourceadm.about_resource_limited_by_rrr_description')}
-          value={resourceData.limitedByRRR ?? false}
+          value={resourceData.accessListMode === 'Enabled' ?? false}
           onFocus={() => setTranslationType('none')}
           onChange={(isChecked: boolean) =>
-            handleSave({ ...resourceData, limitedByRRR: isChecked })
+            handleSave({ ...resourceData, accessListMode: isChecked ? 'Enabled' : 'Disabled' })
           }
           toggleTextTranslationKey='resourceadm.about_resource_use_rrr_show_text'
         />
-        {resourceData.limitedByRRR && (
+        {resourceData.accessListMode === 'Enabled' && (
           <div data-testid='rrr-buttons'>
             <AccessListEnvLinks />
           </div>


### PR DESCRIPTION
## Description

- Rename `limitedByRRR` property to `accessListMode`, change type from boolean to enum

## Related Issue(s)

- #13504

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
