### PR TITLE
fix(resource-adm): Sikkerhetsnivå dropdown value in resource admin should not be hardcoded to 3

### DIFF
--- a/frontend/resourceadm/hooks/mutations/useEditResourcePolicyMutation.ts
+++ b/frontend/resourceadm/hooks/mutations/useEditResourcePolicyMutation.ts
@@ -17,6 +17,7 @@ export const useEditResourcePolicyMutation = (org: string, repo: string, id: str
   return useMutation({
     mutationFn: (payload: Policy) => updatePolicy(org, repo, id, payload),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QueryKey.ResourcePolicy, org, repo, id] });
       queryClient.invalidateQueries({ queryKey: [QueryKey.RepoStatus, org, repo] });
       queryClient.invalidateQueries({ queryKey: [QueryKey.ResourceList, org] });
       queryClient.invalidateQueries({ queryKey: [QueryKey.ResourcePolicy, org, repo, id] });

--- a/frontend/resourceadm/hooks/queries/useResourcePolicyQuery.ts
+++ b/frontend/resourceadm/hooks/queries/useResourcePolicyQuery.ts
@@ -25,8 +25,8 @@ export const useResourcePolicyQuery = (
     queryFn: () => getPolicy(org, repo, id),
     select: (data) => ({
       rules: data.rules ?? [],
-      requiredAuthenticationLevelEndUser: '3',
-      requiredAuthenticationLevelOrg: '3',
+      requiredAuthenticationLevelEndUser: data.requiredAuthenticationLevelEndUser ?? '3',
+      requiredAuthenticationLevelOrg: data.requiredAuthenticationLevelOrg ?? '3',
     }),
   });
 };

--- a/frontend/resourceadm/pages/PolicyEditorPage/PolicyEditorPage.module.css
+++ b/frontend/resourceadm/pages/PolicyEditorPage/PolicyEditorPage.module.css
@@ -1,5 +1,5 @@
 .policyEditorWrapper {
-  width: 90%;
+  max-width: 40rem;
   margin: 0;
   padding: var(--fds-spacing-10);
 }

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.module.css
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.module.css
@@ -3,7 +3,7 @@
 }
 
 .resourcePageWrapper {
-  max-width: 50rem;
+  flex-grow: 1;
 }
 
 .leftNavWrapper {

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.module.css
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.module.css
@@ -3,7 +3,7 @@
 }
 
 .resourcePageWrapper {
-  flex-grow: 1;
+  max-width: 50rem;
 }
 
 .leftNavWrapper {


### PR DESCRIPTION
## Description

- Fix issue in `select` function in GET policy query to not set Sikkerhetsnivå to 3 ever time after loading
- Invalidate policy after mutating policy
- Add max-width to policy editor in resource admin

## Related Issue(s)

- #13566 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
