### PR TITLE
fix: Add defaultValue from schema to EditBooleanValue component

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1330,7 +1330,6 @@
   "ux_editor.container_not_editable_info": "Noen egenskaper for denne komponenten er ikke redigerbare for øyeblikket. Du kan legge til underkomponenter i kolonnen til venstre.",
   "ux_editor.edit_component.loading_schema": "Laster inn skjema",
   "ux_editor.edit_component.show_beta_func": "Vis ny konfigurasjon (BETA)",
-  "ux_editor.edit_component.show_beta_func_help_text": "Vi jobber med å få på plass støtte for å redigere alle innstillinger. Ved å huke av her kan du ta i bruk den nye konfigurasjonsvisningen, som støtter flere innstillinger. Merk at denne visningen fortsatt er under utvikling, og vil kunne oppleves som noe ustabil.",
   "ux_editor.edit_component.unknown_component": "Komponenten {{componentName}} gjenkjennes ikke av Studio og kan derfor ikke konfigureres.",
   "ux_editor.edit_component.unsupported_properties_message": "Vi jobber med å få på plass støtte for å redigere alle innstillinger. Følgende innstillinger er ikke støttet i skjemaeditor ennå, men kan konfigureres manuelt:",
   "ux_editor.edit_text_resource": "Rediger tekst",

--- a/frontend/packages/ux-editor-v3/src/components/config/EditFormComponent.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/config/EditFormComponent.tsx
@@ -20,7 +20,6 @@ import {
   removeFeatureFlagFromLocalStorage,
   shouldDisplayFeature,
 } from 'app-shared/utils/featureToggleUtils';
-import { FormField } from 'app-shared/components/FormField';
 import { formItemConfigs } from '../../data/formItemConfig';
 import { UnknownComponentAlert } from '../UnknownComponentAlert';
 
@@ -79,19 +78,9 @@ export const EditFormComponent = ({
 
   return (
     <Fieldset className={classes.root} legend=''>
-      <FormField
-        id={component.id}
-        value={showComponentConfigBeta || false}
-        onChange={toggleShowBetaFunc}
-        propertyPath={component.propertyPath}
-        componentType={component.type}
-        helpText={t('ux_editor.edit_component.show_beta_func_help_text')}
-        renderField={({ fieldProps }) => (
-          <Switch {...fieldProps} checked={fieldProps.value} size='small'>
-            {t('ux_editor.edit_component.show_beta_func')}
-          </Switch>
-        )}
-      />
+      <Switch onChange={toggleShowBetaFunc} checked={showComponentConfigBeta} size='small'>
+        {t('ux_editor.edit_component.show_beta_func')}
+      </Switch>
       <Heading level={2} size='xsmall'>
         {getComponentTitleByComponentType(component.type, t)} ({component.type})
       </Heading>

--- a/frontend/packages/ux-editor-v3/src/components/config/FormComponentConfig.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/config/FormComponentConfig.tsx
@@ -135,6 +135,7 @@ export const FormComponentConfig = ({
             propertyKey='hasCustomFileEndings'
             helpText={hasCustomFileEndings.description}
             component={component}
+            defaultValue={hasCustomFileEndings.default}
             handleComponentChange={(updatedComponent: FormComponent) => {
               if (!updatedComponent.hasCustomFileEndings) {
                 handleComponentUpdate({
@@ -163,6 +164,7 @@ export const FormComponentConfig = ({
           helpText={readOnly.description}
           component={component}
           handleComponentChange={handleComponentUpdate}
+          defaultValue={readOnly.default}
         />
       )}
       {required && (
@@ -171,6 +173,7 @@ export const FormComponentConfig = ({
           helpText={required.description}
           component={component}
           handleComponentChange={handleComponentUpdate}
+          defaultValue={required.default}
         />
       )}
 
@@ -187,6 +190,7 @@ export const FormComponentConfig = ({
               propertyKey={propertyKey}
               key={propertyKey}
               helpText={rest[propertyKey]?.description}
+              defaultValue={rest[propertyKey]?.default}
             />
           );
         }

--- a/frontend/packages/ux-editor-v3/src/components/config/editModal/EditBooleanValue.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/config/editModal/EditBooleanValue.tsx
@@ -8,6 +8,7 @@ import { getComponentPropertyLabel } from '../../../utils/language';
 export interface EditBooleanValueProps extends IGenericEditComponent {
   propertyKey: string;
   helpText?: string;
+  defaultValue?: boolean;
 }
 
 export const EditBooleanValue = ({
@@ -15,13 +16,14 @@ export const EditBooleanValue = ({
   handleComponentChange,
   propertyKey,
   helpText,
+  defaultValue,
 }: EditBooleanValueProps) => {
   const t = useText();
 
   const handleChange = () => {
     handleComponentChange({
       ...component,
-      [propertyKey]: !component[propertyKey],
+      [propertyKey]: getNewBooleanValue(),
     });
   };
 
@@ -29,10 +31,13 @@ export const EditBooleanValue = ({
     return Array.isArray(value);
   };
 
+  const getNewBooleanValue = () =>
+    component[propertyKey] === undefined ? !defaultValue : !component[propertyKey];
+
   return (
     <FormField
       id={component.id}
-      value={component[propertyKey] || false}
+      value={component[propertyKey]}
       onChange={handleChange}
       propertyPath={component.propertyPath}
       componentType={component.type}
@@ -45,7 +50,7 @@ export const EditBooleanValue = ({
         return (
           <Switch
             {...fieldProps}
-            checked={fieldProps.value}
+            checked={fieldProps.value ?? defaultValue}
             onChange={(e) => fieldProps.onChange(e.target.checked, e)}
             size='small'
             id={`${propertyKey}-checkbox-${component.id}`}

--- a/frontend/packages/ux-editor-v3/src/components/config/editModal/EditBooleanValue.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/config/editModal/EditBooleanValue.tsx
@@ -31,8 +31,7 @@ export const EditBooleanValue = ({
     return Array.isArray(value);
   };
 
-  const getNewBooleanValue = () =>
-    component[propertyKey] === undefined ? !defaultValue : !component[propertyKey];
+  const getNewBooleanValue = () => !(component[propertyKey] ?? defaultValue);
 
   return (
     <FormField

--- a/frontend/packages/ux-editor-v3/src/data/formItemConfig.ts
+++ b/frontend/packages/ux-editor-v3/src/data/formItemConfig.ts
@@ -179,7 +179,7 @@ export const formItemConfigs: FormItemConfigs = {
       type: ComponentTypeV3.Datepicker,
       minDate: '1900-01-01T12:00:00.000Z',
       maxDate: '2100-01-01T12:00:00.000Z',
-      timeStamp: false,
+      timeStamp: true,
       required: true,
       propertyPath: 'definitions/datepickerComponent',
     },

--- a/frontend/packages/ux-editor/src/components/config/FormComponentConfig.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/FormComponentConfig.test.tsx
@@ -33,7 +33,7 @@ describe('FormComponentConfig', () => {
   it('should render expected components', async () => {
     render({});
 
-    [
+    const properties = [
       'grid',
       'readOnly',
       'required',
@@ -42,15 +42,16 @@ describe('FormComponentConfig', () => {
       'variant',
       'autocomplete',
       'maxLength',
-      'triggers',
       'labelSettings',
       'pageBreak',
       'formatting',
-    ].forEach(async (propertyKey) => {
+    ];
+
+    for (const property of properties) {
       expect(
-        await screen.findByText(textMock(`ux_editor.component_properties.${propertyKey}`)),
+        await screen.findByText(textMock(`ux_editor.component_properties.${property}`)),
       ).toBeInTheDocument();
-    });
+    }
   });
 
   it('should render list of unsupported properties', () => {
@@ -167,6 +168,7 @@ describe('FormComponentConfig', () => {
   it('should call updateComponent with false value when checking a default true property switch', async () => {
     const user = userEvent.setup();
     const handleComponentUpdateMock = jest.fn();
+    //const { component: datePickerComponent } = componentMocks;
     render({
       props: {
         schema: DatepickerSchema,

--- a/frontend/packages/ux-editor/src/components/config/FormComponentConfig.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/FormComponentConfig.test.tsx
@@ -4,6 +4,7 @@ import { FormComponentConfig } from './FormComponentConfig';
 import { renderWithProviders } from '../../testing/mocks';
 import { componentMocks } from '../../testing/componentMocks';
 import InputSchema from '../../testing/schemas/json/component/Input.schema.v1.json';
+import DatepickerSchema from '../../testing/schemas/json/component/Datepicker.schema.v1.json';
 import type { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
 import { screen } from '@testing-library/react';
 import { textMock } from '@studio/testing/mocks/i18nMock';
@@ -148,6 +149,18 @@ describe('FormComponentConfig', () => {
     expect(
       screen.getByText(textMock('ux_editor.component_properties_description.pageBreak')),
     ).toBeInTheDocument();
+  });
+
+  it('should render default boolean values if defined', () => {
+    render({
+      props: {
+        schema: DatepickerSchema,
+      },
+    });
+    const timeStampSwitch = screen.getByRole('checkbox', {
+      name: textMock('ux_editor.component_properties.timeStamp'),
+    });
+    expect(timeStampSwitch).toBeChecked();
   });
 
   it('should show description from schema for objects if key is not defined', () => {

--- a/frontend/packages/ux-editor/src/components/config/FormComponentConfig.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/FormComponentConfig.test.tsx
@@ -9,6 +9,7 @@ import type { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
 import { screen } from '@testing-library/react';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import type { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
+import userEvent from '@testing-library/user-event';
 
 const somePropertyName = 'somePropertyName';
 const customTextMockToHandleUndefined = (
@@ -161,6 +162,24 @@ describe('FormComponentConfig', () => {
       name: textMock('ux_editor.component_properties.timeStamp'),
     });
     expect(timeStampSwitch).toBeChecked();
+  });
+
+  it('should call updateComponent with false value when checking a default true property switch', async () => {
+    const user = userEvent.setup();
+    const handleComponentUpdateMock = jest.fn();
+    render({
+      props: {
+        schema: DatepickerSchema,
+        handleComponentUpdate: handleComponentUpdateMock,
+      },
+    });
+    const timeStampSwitch = screen.getByRole('checkbox', {
+      name: textMock('ux_editor.component_properties.timeStamp'),
+    });
+    await user.click(timeStampSwitch);
+    expect(handleComponentUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeStamp: false }),
+    );
   });
 
   it('should show description from schema for objects if key is not defined', () => {

--- a/frontend/packages/ux-editor/src/components/config/FormComponentConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/config/FormComponentConfig.tsx
@@ -117,6 +117,7 @@ export const FormComponentConfig = ({
             component={component}
             handleComponentChange={handleComponentUpdate}
             propertyKey={propertyKey}
+            defaultValue={properties[propertyKey].default}
             key={propertyKey}
             helpText={properties[propertyKey]?.description}
           />
@@ -130,6 +131,7 @@ export const FormComponentConfig = ({
             propertyKey='hasCustomFileEndings'
             helpText={hasCustomFileEndings.description}
             component={component}
+            defaultValue={hasCustomFileEndings.default}
             handleComponentChange={(updatedComponent: FormComponent) => {
               if (!updatedComponent.hasCustomFileEndings) {
                 handleComponentUpdate({

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditBooleanValue.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditBooleanValue.tsx
@@ -22,7 +22,6 @@ export const EditBooleanValue = ({
   const componentPropertyLabel = useComponentPropertyLabel();
 
   const handleChange = () => {
-    debugger;
     handleComponentChange({
       ...component,
       [propertyKey]: getNewBooleanValue(),
@@ -33,9 +32,8 @@ export const EditBooleanValue = ({
     return Array.isArray(value);
   };
 
-  const getNewBooleanValue = () => {
-    return component[propertyKey] === undefined ? !defaultValue : !component[propertyKey];
-  };
+  const getNewBooleanValue = () =>
+    component[propertyKey] === undefined ? !defaultValue : !component[propertyKey];
 
   return (
     <FormField

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditBooleanValue.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditBooleanValue.tsx
@@ -32,8 +32,7 @@ export const EditBooleanValue = ({
     return Array.isArray(value);
   };
 
-  const getNewBooleanValue = () =>
-    component[propertyKey] === undefined ? !defaultValue : !component[propertyKey];
+  const getNewBooleanValue = () => !(component[propertyKey] ?? defaultValue);
 
   return (
     <FormField

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditBooleanValue.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditBooleanValue.tsx
@@ -8,6 +8,7 @@ import { useComponentPropertyLabel } from '../../../hooks/useComponentPropertyLa
 export interface EditBooleanValueProps extends IGenericEditComponent {
   propertyKey: string;
   helpText?: string;
+  defaultValue?: boolean;
 }
 
 export const EditBooleanValue = ({
@@ -15,14 +16,16 @@ export const EditBooleanValue = ({
   handleComponentChange,
   propertyKey,
   helpText,
+  defaultValue,
 }: EditBooleanValueProps) => {
   const t = useText();
   const componentPropertyLabel = useComponentPropertyLabel();
 
   const handleChange = () => {
+    debugger;
     handleComponentChange({
       ...component,
-      [propertyKey]: !component[propertyKey],
+      [propertyKey]: getNewBooleanValue(),
     });
   };
 
@@ -30,10 +33,14 @@ export const EditBooleanValue = ({
     return Array.isArray(value);
   };
 
+  const getNewBooleanValue = () => {
+    return component[propertyKey] === undefined ? !defaultValue : !component[propertyKey];
+  };
+
   return (
     <FormField
       id={component.id}
-      value={component[propertyKey] || false}
+      value={component[propertyKey]}
       onChange={handleChange}
       propertyPath={component.propertyPath}
       componentType={component.type}
@@ -46,7 +53,7 @@ export const EditBooleanValue = ({
         return (
           <Switch
             {...fieldProps}
-            checked={fieldProps.value}
+            checked={fieldProps.value ?? defaultValue}
             onChange={(e) => fieldProps.onChange(e.target.checked, e)}
             size='small'
             id={`${propertyKey}-checkbox-${component.id}`}

--- a/frontend/packages/ux-editor/src/data/formItemConfig.ts
+++ b/frontend/packages/ux-editor/src/data/formItemConfig.ts
@@ -163,7 +163,7 @@ export const formItemConfigs: FormItemConfigs = {
       },
       minDate: '1900-01-01T12:00:00.000Z',
       maxDate: '2100-01-01T12:00:00.000Z',
-      timeStamp: false,
+      timeStamp: true,
     },
     propertyPath: 'definitions/datepickerComponent',
     icon: CalendarIcon,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ensure default boolean values that are `true` from boolean properties in component schemas is reflected as `true` in config panel by checking the switch using the default value if there is no value from the component.

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)