### PR TITLE
fix: implement override datamodel option

### DIFF
--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/XSDUpload.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/XSDUpload.tsx
@@ -10,6 +10,8 @@ import type { MetadataOption } from '../../../../types/MetadataOption';
 import { fileSelectorInputId } from '@studio/testing/testids';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppMetadataQuery } from 'app-shared/hooks/queries';
+import { useValidateFileName } from './useValidateFileName';
+import { removeExtension } from 'app-shared/utils/filenameUtils';
 
 export interface XSDUploadProps {
   selectedOption?: MetadataOption;
@@ -31,6 +33,11 @@ export const XSDUpload = ({
       hideDefaultError: (error: AxiosError<ApiError>) => !error.response?.data?.errorCode,
     },
   );
+  const {
+    validateFileName,
+    getDuplicatedDataTypeIdNotBeingDataModelInAppMetadata,
+    getDuplicatedDataModelIdsInAppMetadata,
+  } = useValidateFileName(appMetadata);
 
   const uploadButton = React.useRef(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
@@ -44,26 +51,22 @@ export const XSDUpload = ({
     });
   };
 
-  const fileNameRegEx: RegExp = /^[a-zA-Z][a-zA-Z0-9_.\-æÆøØåÅ ]*$/;
-
-  const validateFileName = (fileName: string): boolean => {
-    const nameFollowsRegexRules = Boolean(fileName.match(fileNameRegEx));
-    if (!nameFollowsRegexRules) {
-      toast.error(t('app_data_modelling.upload_xsd_invalid_error'));
-      return false;
+  const handleInvalidFileName = (file?: FormData, fileName?: string) => {
+    const fileNameWithoutExtension = removeExtension(fileName);
+    if (getDuplicatedDataModelIdsInAppMetadata(appMetadata, fileNameWithoutExtension)) {
+      const userConfirmed = window.confirm(
+        t('schema_editor.error_upload_data_model_id_exists_override_option'),
+      );
+      if (userConfirmed) {
+        uploadDataModel(file);
+      }
     }
-
-    const fileNameWithoutExtension = fileName.split('.').slice(0, -1).join('.');
-    const duplicateDataType = Boolean(
-      appMetadata.dataTypes?.find(
-        (dataType) => dataType.id.toLowerCase() === fileNameWithoutExtension.toLowerCase(),
-      ),
-    );
-    if (duplicateDataType) {
+    if (
+      getDuplicatedDataTypeIdNotBeingDataModelInAppMetadata(appMetadata, fileNameWithoutExtension)
+    ) {
+      // Only show error if there are duplicates that does not have AppLogic.classRef
       toast.error(t('schema_editor.error_data_type_name_exists'));
-      return false;
     }
-    return true;
   };
 
   return (
@@ -78,8 +81,8 @@ export const XSDUpload = ({
           ref={fileInputRef}
           uploaderButtonText={uploadButtonText}
           customFileValidation={{
-            validateFileName,
-            onInvalidFileName: () => {},
+            validateFileName: validateFileName,
+            onInvalidFileName: handleInvalidFileName,
           }}
           dataTestId={fileSelectorInputId}
         />

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/useValidateFileName.ts
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/useValidateFileName.ts
@@ -1,0 +1,50 @@
+import type { ApplicationMetadata } from 'app-shared/types/ApplicationMetadata';
+import { removeExtension } from 'app-shared/utils/filenameUtils';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
+
+export const useValidateFileName = (appMetadata: ApplicationMetadata) => {
+  const { t } = useTranslation();
+
+  const fileNameRegEx: RegExp = /^[a-zA-Z][a-zA-Z0-9_.\-æÆøØåÅ ]*$/;
+  const validateFileName = (fileName: string): boolean => {
+    const fileNameWithoutExtension = removeExtension(fileName);
+    const nameFollowsRegexRules = Boolean(fileName.match(fileNameRegEx));
+
+    if (!nameFollowsRegexRules) {
+      toast.error(t('app_data_modelling.upload_xsd_invalid_error'));
+      return false;
+    }
+    return !Boolean(
+      appMetadata.dataTypes?.find((dataType) => dataType.id === fileNameWithoutExtension),
+    );
+  };
+
+  const getDuplicatedDataModelIdsInAppMetadata = (
+    appMetadata: ApplicationMetadata,
+    fileNameWithoutExtension: string,
+  ): boolean => {
+    return Boolean(
+      appMetadata.dataTypes
+        ?.filter((dataType) => dataType.appLogic?.classRef !== undefined)
+        .find((dataType) => dataType.id === fileNameWithoutExtension),
+    );
+  };
+
+  const getDuplicatedDataTypeIdNotBeingDataModelInAppMetadata = (
+    appMetadata: ApplicationMetadata,
+    fileNameWithoutExtension: string,
+  ): boolean => {
+    return Boolean(
+      appMetadata.dataTypes
+        ?.filter((dataType) => dataType.appLogic?.classRef === undefined)
+        .find((dataType) => dataType.id.toLowerCase() === fileNameWithoutExtension.toLowerCase()),
+    );
+  };
+
+  return {
+    validateFileName,
+    getDuplicatedDataModelIdsInAppMetadata,
+    getDuplicatedDataTypeIdNotBeingDataModelInAppMetadata,
+  };
+};

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -842,6 +842,7 @@
   "schema_editor.error_could_not_detect_taskType_description": "Dette gjør at vi ikke kan vise riktig liste over tilgjengelige komponenter. Velg en annen sidegruppe eller prøv å last siden på nytt.",
   "schema_editor.error_data_type_name_exists": "Modellen kan ikke ha samme navn som datatyper i løsningen.",
   "schema_editor.error_model_name_exists": "Modellnavnet {{newModelName}} er allerede i bruk.",
+  "schema_editor.error_upload_data_model_id_exists_override_option": "Det eksisterer allerede en modell med dette navnet. Ønsker du å overskrive den?",
   "schema_editor.field": "Objekt",
   "schema_editor.field_name": "Navn på felt",
   "schema_editor.fields": "Felter",


### PR DESCRIPTION
## Description
In order to allow uploading a datamodel with an existing ID this PR introduces a confirm dialog that asks if the user wants to override the model. 

With todays code, [this PR](https://github.com/Altinn/altinn-studio/pull/13445) made it illegal to upload a model with an ID that already was used by a dataType in appmetadata. And before that we simply overrided the dataType without warning if you uploaded a datamodel with an existing ID. This was also the case if you uploaded a datamodel with the same ID as a fileupload-component. The PR mentioned above was created to prohibit this case, but that "by mistake" also introduced this prohibition to upload datamodels with same ids as exisitng datamodels. 

After discussions with both @Annikenkbrathen and @Jondyr, as well as insights for app-migration-team, we concluded that being able to override should be an option when your uploaded datamodel collide with another datamodel, but you should be informed that you are about to override a datamodel. 

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

