### PR TITLE
fix: don't fetch `applicationmetadata.json` for datamodelling apps

### DIFF
--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/CreateNewWrapper.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/CreateNewWrapper.tsx
@@ -42,7 +42,7 @@ export function CreateNewWrapper({
   };
 
   const dataTypeWithNameExists = (id: string) => {
-    return appMetadata.dataTypes?.find(
+    return appMetadata?.dataTypes?.find(
       (dataType) => dataType.id.toLowerCase() === id.toLowerCase(),
     );
   };

--- a/frontend/packages/shared/src/hooks/queries/useAppMetadataQuery.ts
+++ b/frontend/packages/shared/src/hooks/queries/useAppMetadataQuery.ts
@@ -2,7 +2,9 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import type { ApplicationMetadata } from 'app-shared/types/ApplicationMetadata';
+import { RepositoryType } from 'app-shared/types/global';
 import { QueryKey } from 'app-shared/types/QueryKey';
+import { getRepositoryType } from 'app-shared/utils/repository';
 import type { AxiosError } from 'axios';
 
 /**
@@ -18,9 +20,11 @@ export const useAppMetadataQuery = (
   app: string,
 ): UseQueryResult<ApplicationMetadata, AxiosError> => {
   const { getAppMetadata } = useServicesContext();
+  const repoType = getRepositoryType(org, app);
 
   return useQuery<ApplicationMetadata, AxiosError>({
     queryKey: [QueryKey.AppMetadata, org, app],
     queryFn: () => getAppMetadata(org, app),
+    enabled: repoType !== RepositoryType.DataModels,
   });
 };


### PR DESCRIPTION
## Description

Set `enabled` to false for datamodelling apps in `useAppMetadataQuery`

## Related Issue(s)

ref. conversation on slack:
https://digdir.slack.com/archives/C077KTTCBSS/p1727168283832559

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
