### PR TITLE
fix: correct css for studioTextfieldToggleView

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioToggleableTextfield/StudioTextfieldToggleView/StudioTextfieldToggleView.module.css
+++ b/frontend/libs/studio-components/src/components/StudioToggleableTextfield/StudioTextfieldToggleView/StudioTextfieldToggleView.module.css
@@ -13,6 +13,7 @@
   align-items: center;
   color: var(--fds-semantic-text-neutral-default);
   width: 100%;
+  gap: var(--fds-spacing-1);
 }
 
 .textContainer,

--- a/frontend/libs/studio-components/src/components/StudioToggleableTextfield/StudioTextfieldToggleView/StudioTextfieldToggleView.module.css
+++ b/frontend/libs/studio-components/src/components/StudioToggleableTextfield/StudioTextfieldToggleView/StudioTextfieldToggleView.module.css
@@ -15,6 +15,7 @@
   width: 100%;
 }
 
+.textContainer,
 .label,
 .ellipsis {
   overflow: hidden;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix css that got lost after earlier adaptions on `StudioTextfieldToggleView` when adding more `<span>` elements.

**PROD:**
![Skjermbilde 2024-09-25 kl  08 39 27](https://github.com/user-attachments/assets/5b1af8b6-a2aa-4456-a811-0836074fdfa7)

**THIS BRANCH:**
![Skjermbilde 2024-09-25 kl  08 39 54](https://github.com/user-attachments/assets/09b06512-3892-4cb6-a651-31f1eeca1ee3)

**When used in the [upload image PR](https://github.com/Altinn/altinn-studio/pull/13322), it will look like this:**
![Skjermbilde 2024-09-25 kl  08 47 42](https://github.com/user-attachments/assets/9dedaf18-5fad-47d0-b20e-69d3de2cf8d8)
![Skjermbilde 2024-09-25 kl  08 47 50](https://github.com/user-attachments/assets/3cb34448-f40f-4cfb-b00b-ed8f6a788d15)

Also added a gap between the icon and the text:

![Skjermbilde 2024-09-25 kl  08 52 46](https://github.com/user-attachments/assets/a22ff6e1-13ed-4c95-9b20-7a47f9090f39)


## Related Issue(s)

- [PR that created the error](https://github.com/Altinn/altinn-studio/commit/a5b89ebcd5c8a682251ba2267aa473537ebd5aaf#diff-989c68793faf7a6fd22604893a0499ed45084bcbf76f74b87a7224477a34ec47)

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

