### PR TITLE
fix: Generate unique pointer correctly

### DIFF
--- a/frontend/packages/schema-model/src/lib/SchemaModel.test.ts
+++ b/frontend/packages/schema-model/src/lib/SchemaModel.test.ts
@@ -3,6 +3,8 @@ import {
   allOfNodeChildMock,
   allOfNodeMock,
   arrayNodeMock,
+  combinationDefNodeChild1Mock,
+  combinationDefNodeMock,
   combinationNodeWithMultipleChildrenMock,
   defNodeMock,
   defNodeWithChildrenChildMock,
@@ -16,6 +18,7 @@ import {
   parentNodeMock,
   referenceDefinitionMock,
   referenceNodeMock,
+  referenceToCombinationDefNodeMock,
   referenceToObjectNodeMock,
   requiredNodeMock,
   rootNodeMock,
@@ -145,17 +148,23 @@ describe('SchemaModel', () => {
   });
 
   describe('getSchemaPointerByUniquePointer', () => {
-    const uniqueGrandChildPointer =
-      '#/properties/referenceToParent/properties/child/properties/grandchild';
-    const uniqueChildPointer = '#/properties/referenceToParent/properties/child';
-
-    it('Returns the schema pointer for a given unique pointer', () => {
+    it('Returns the schema pointer for a given unique pointer to an object', () => {
+      const uniqueGrandChildPointer =
+        '#/properties/referenceToParent/properties/child/properties/grandchild';
+      const uniqueChildPointer = '#/properties/referenceToParent/properties/child';
       expect(schemaModel.getSchemaPointerByUniquePointer(uniqueChildPointer)).toEqual(
         defNodeWithChildrenChildMock.schemaPointer,
       );
       expect(schemaModel.getSchemaPointerByUniquePointer(uniqueGrandChildPointer)).toEqual(
         defNodeWithChildrenGrandchildMock.schemaPointer,
       );
+    });
+
+    it('Returns the schema pointer for a given unique pointer to a combination', () => {
+      const uniquePointer = '#/properties/referenceToCombinationDef/oneOf/0';
+      const expectedResult = combinationDefNodeChild1Mock.schemaPointer;
+      const result = schemaModel.getSchemaPointerByUniquePointer(uniquePointer);
+      expect(result).toEqual(expectedResult);
     });
   });
 
@@ -172,7 +181,7 @@ describe('SchemaModel', () => {
       );
     });
 
-    it('Returns a pointer reflecting the path to a given node in a reference', () => {
+    it('Returns a pointer reflecting the path to a given node in a reference to an object', () => {
       const expectedChildPointer = '#/properties/referenceToParent/properties/child';
       const expectedGrandchildPointer =
         '#/properties/referenceToParent/properties/child/properties/grandchild';
@@ -189,6 +198,14 @@ describe('SchemaModel', () => {
           expectedChildPointer,
         ),
       ).toEqual(expectedGrandchildPointer);
+    });
+
+    it('Returns a pointer reflecting the path to a given node in a reference to a combination', () => {
+      const { schemaPointer } = combinationDefNodeChild1Mock;
+      const uniquePointerOfParent = referenceToCombinationDefNodeMock.schemaPointer;
+      const result = schemaModel.getUniquePointer(schemaPointer, uniquePointerOfParent);
+      const expectedResult = '#/properties/referenceToCombinationDef/oneOf/0';
+      expect(result).toEqual(expectedResult);
     });
   });
 
@@ -229,6 +246,7 @@ describe('SchemaModel', () => {
         unusedDefinitionMock,
         unusedDefinitionWithSameNameAsExistingObjectMock,
         referenceDefinitionMock,
+        combinationDefNodeMock,
       ]);
     });
   });
@@ -244,6 +262,7 @@ describe('SchemaModel', () => {
         referenceToObjectNodeMock,
         nodeWithSameNameAsStringNodeMock,
         combinationNodeWithMultipleChildrenMock,
+        referenceToCombinationDefNodeMock,
       ]);
     });
   });
@@ -264,6 +283,8 @@ describe('SchemaModel', () => {
         referenceDefinitionMock,
         nodeWithSameNameAsStringNodeMock,
         combinationNodeWithMultipleChildrenMock,
+        referenceToCombinationDefNodeMock,
+        combinationDefNodeMock,
       ]);
     });
   });

--- a/frontend/packages/schema-model/src/lib/SchemaModel.ts
+++ b/frontend/packages/schema-model/src/lib/SchemaModel.ts
@@ -1,7 +1,6 @@
 import {
   CombinationKind,
   FieldType,
-  Keyword,
   type NodePosition,
   type UiSchemaNode,
   type UiSchemaNodes,
@@ -31,6 +30,7 @@ import { replaceStart } from 'app-shared/utils/stringUtils';
 import {
   createDefinitionPointer,
   createPropertyPointer,
+  extractCategoryFromPointer,
   extractNameFromPointer,
   makePointerFromArray,
 } from './pointerUtils';
@@ -90,7 +90,7 @@ export class SchemaModel {
     const parentNodePointer = this.getParentSchemaPointerByUniquePointer(uniquePointer);
     return makePointerFromArray([
       parentNodePointer,
-      Keyword.Properties,
+      extractCategoryFromPointer(uniquePointer),
       extractNameFromPointer(uniquePointer),
     ]);
   }
@@ -109,8 +109,8 @@ export class SchemaModel {
 
   public getUniquePointer(schemaPointer: string, uniqueParentPointer?: string): string {
     if (!uniqueParentPointer || !isDefinitionPointer(schemaPointer)) return schemaPointer;
-
-    return `${uniqueParentPointer}/properties/${extractNameFromPointer(schemaPointer)}`;
+    const category = extractCategoryFromPointer(schemaPointer);
+    return `${uniqueParentPointer}/${category}/${extractNameFromPointer(schemaPointer)}`;
   }
 
   public hasNode(schemaPointer: string): boolean {

--- a/frontend/packages/schema-model/src/lib/pointerUtils.test.ts
+++ b/frontend/packages/schema-model/src/lib/pointerUtils.test.ts
@@ -3,6 +3,7 @@ import {
   changeNameInPointer,
   createDefinitionPointer,
   createPropertyPointer,
+  extractCategoryFromPointer,
   extractNameFromPointer,
   makePointerFromArray,
 } from './pointerUtils';
@@ -13,6 +14,7 @@ import {
   simpleParentNodeMock,
   stringNodeMock,
 } from '../../test/uiSchemaMock';
+import { CombinationKind, Keyword } from '@altinn/schema-model/types';
 
 describe('pointerUtils', () => {
   test('makePointerFromArray', () => {
@@ -62,6 +64,29 @@ describe('pointerUtils', () => {
 
     it('Returns an empty string when an empty string is passed', () => {
       expect(extractNameFromPointer('')).toBe('');
+    });
+  });
+
+  describe('extractCategoryFromPointer', () => {
+    it('Returns "properties" when the pointer is a property pointer', () => {
+      expect(extractCategoryFromPointer('#/properties/hello')).toBe(Keyword.Properties);
+      expect(extractCategoryFromPointer('#/anyOf/hello/properties/world')).toBe(Keyword.Properties);
+      expect(extractCategoryFromPointer('#/$defs/test/properties/hello')).toBe(Keyword.Properties);
+    });
+
+    it('Returns the combination kind when the pointer is a combination pointer', () => {
+      expect(extractCategoryFromPointer('#/allOf/0')).toBe(CombinationKind.AllOf);
+      expect(extractCategoryFromPointer('#/properties/test/anyOf/1')).toBe(CombinationKind.AnyOf);
+      expect(extractCategoryFromPointer('#/allOf/test/oneOf/2')).toBe(CombinationKind.OneOf);
+      expect(extractCategoryFromPointer('#/$defs/test/anyOf/3')).toBe(CombinationKind.AnyOf);
+    });
+
+    it('Returns "$defs" when the pointer is a definition pointer', () => {
+      expect(extractCategoryFromPointer('#/$defs/test')).toBe(Keyword.Definitions);
+    });
+
+    it('Returns undefined when the pointer is the root pointer', () => {
+      expect(extractCategoryFromPointer('#')).toBe(undefined);
     });
   });
 

--- a/frontend/packages/schema-model/src/lib/pointerUtils.ts
+++ b/frontend/packages/schema-model/src/lib/pointerUtils.ts
@@ -1,5 +1,6 @@
 import type { UiSchemaNode } from '../types';
-import { Keyword, ObjectKind } from '../types';
+import { CombinationKind, Keyword, ObjectKind } from '../types';
+
 import { ROOT_POINTER } from './constants';
 import type { FieldNode } from '../types/FieldNode';
 import type { CombinationNode } from '../types/CombinationNode';
@@ -43,6 +44,23 @@ export const makePointerFromArray = (array: string[]): string => {
 export const extractNameFromPointer = (pointer: string): string => {
   const parts = pointer.split('/');
   return parts.pop();
+};
+
+export const extractCategoryFromPointer = (
+  pointer: string,
+): Keyword.Properties | Keyword.Definitions | CombinationKind | undefined => {
+  const parts = pointer.split('/');
+  const category = parts[parts.length - 2];
+  switch (category) {
+    case Keyword.Properties:
+    case Keyword.Definitions:
+    case CombinationKind.AllOf:
+    case CombinationKind.AnyOf:
+    case CombinationKind.OneOf:
+      return category;
+    default:
+      return undefined;
+  }
 };
 
 export const changeNameInPointer = (pointer: string, newName: string): string => {

--- a/frontend/packages/schema-model/test/uiSchemaMock.ts
+++ b/frontend/packages/schema-model/test/uiSchemaMock.ts
@@ -45,6 +45,11 @@ const combinationNodeChild1Pointer = '#/properties/combinationNodeWithMultipleCh
 const combinationNodeChild2Pointer = '#/properties/combinationNodeWithMultipleChildren/anyOf/1';
 const combinationNodeChild3Pointer = '#/properties/combinationNodeWithMultipleChildren/anyOf/2';
 
+const combinationDefNodePointer = '#/$defs/combinationDef';
+const combinationDefNodeChild1Pointer = '#/$defs/combinationDef/oneOf/0';
+const combinationDefNodeChild2Pointer = '#/$defs/combinationDef/oneOf/1';
+const referenceToCombinationDefNodePointer = '#/properties/referenceToCombinationDef';
+
 export const nodeMockBase: UiSchemaNode = {
   objectKind: ObjectKind.Field,
   fieldType: FieldType.String,
@@ -77,6 +82,8 @@ export const rootNodeMock: FieldNode = {
     referenceDefinitionPointer,
     nodeWithSameNameAsStringNodePointer,
     combinationNodeWithMultipleChildrenPointer,
+    referenceToCombinationDefNodePointer,
+    combinationDefNodePointer,
   ],
 };
 
@@ -274,6 +281,30 @@ export const combinationNodeChild3Mock: FieldNode = {
   title: 'Child 3',
 };
 
+export const combinationDefNodeMock: CombinationNode = {
+  ...nodeMockBase,
+  schemaPointer: combinationDefNodePointer,
+  objectKind: ObjectKind.Combination,
+  combinationType: CombinationKind.OneOf,
+  children: [combinationDefNodeChild1Pointer, combinationDefNodeChild2Pointer],
+};
+
+export const combinationDefNodeChild1Mock: FieldNode = {
+  ...nodeMockBase,
+  schemaPointer: combinationDefNodeChild1Pointer,
+};
+
+export const combinationDefNodeChild2Mock: FieldNode = {
+  ...nodeMockBase,
+  schemaPointer: combinationDefNodeChild2Pointer,
+};
+
+export const referenceToCombinationDefNodeMock: ReferenceNode = {
+  ...defaultReferenceNode,
+  schemaPointer: referenceToCombinationDefNodePointer,
+  reference: combinationDefNodePointer,
+};
+
 export const uiSchemaMock: UiSchemaNodes = [
   rootNodeMock,
   parentNodeMock,
@@ -305,4 +336,8 @@ export const uiSchemaMock: UiSchemaNodes = [
   combinationNodeChild1Mock,
   combinationNodeChild2Mock,
   combinationNodeChild3Mock,
+  combinationDefNodeMock,
+  combinationDefNodeChild1Mock,
+  combinationDefNodeChild2Mock,
+  referenceToCombinationDefNodeMock,
 ];


### PR DESCRIPTION
## Description
The newly introduced `uniquePointer` concept, which generates a unique ID for each node in the tree view, does not take combinations into account, which leads to errors. This pull request adds an `extractCategoryFromPointer` function that basically returns the part of the pointer that comes before the name (`properties`, `anyOf` etc.). This function is then used to generate the unique pointer correctly.

## Steps to reproduce the bug
1. Create a new datamodel or open an existing one in the data modelling tool
2. Add a combination node to the root
3. Convert the new node to a type
4. Open the new type, either from the type button or from the type panel on the left
5. Add a child node to the type
6. Click on the child node and see that an error appears

https://github.com/user-attachments/assets/2d61dbef-1c39-4452-8604-f22210a429bd

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
