### PR TITLE
fix: wrong translation keys for xsd upload error message

### DIFF
--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/XSDUpload.test.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/XSDUpload.test.tsx
@@ -133,7 +133,7 @@ describe('XSDUpload', () => {
     await user.upload(fileInput, file);
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
-      textMock('app_data_modelling.upload_xsd_invalid_error'),
+      textMock('schema_editor.invalid_datamodel_upload_filename'),
     );
   });
 

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/XSDUpload.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/XSDUpload.tsx
@@ -49,7 +49,7 @@ export const XSDUpload = ({
   const validateFileName = (fileName: string): boolean => {
     const nameFollowsRegexRules = Boolean(fileName.match(fileNameRegEx));
     if (!nameFollowsRegexRules) {
-      toast.error(t('app_data_modelling.upload_xsd_invalid_error'));
+      toast.error(t('schema_editor.invalid_datamodel_upload_filename'));
       return false;
     }
 


### PR DESCRIPTION
## Description

In [my PR](https://github.com/Altinn/altinn-studio/pull/13445) i moved a translation key used by the datamodel upload component. This was to share the error message key with the ux-editor page. When refactoring this to be two different error messages again, the old translation key was reintroduced in the component, but not re-added to `nb.json`.
This PR changes the component to use the correct translation key.

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
