### PR TITLE
fix: fixing the z-index bug on data model page

### DIFF
--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/CreateNewWrapper.module.css
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/CreateNewWrapper.module.css
@@ -1,0 +1,4 @@
+.popoverContent {
+  /* This is so that it goes above the header which has an z-index of 2000 */
+  z-index: 2001;
+}

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/CreateNewWrapper.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/CreateNewWrapper.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import classes from './CreateNewWrapper.module.css';
 import { ErrorMessage, Textfield } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import { PlusIcon } from '@studio/icons';
@@ -91,7 +92,7 @@ export function CreateNewWrapper({
         {<PlusIcon />}
         {t('general.create_new')}
       </StudioPopover.Trigger>
-      <StudioPopover.Content>
+      <StudioPopover.Content className={classes.popoverContent}>
         <Textfield
           id='newModelInput'
           label={t('schema_editor.create_model_description')}


### PR DESCRIPTION
## Description
- Adding higher z-index to make sure the popover opens up above the header 

## Related Issue(s)

- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)