### PR TITLE
feat(workspace): Renovate to update ResourceAdm dependencies in separate PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,14 +3,20 @@
   "extends": ["local>Altinn/renovate-config"],
   "packageRules": [
     {
-      "groupName": "LibGit2Sharp dependency",
+      "groupName": "LibGit2Sharp dependencies",
       "groupSlug": "LibGit2Sharp",
       "matchPackageNames": ["LibGit2Sharp"]
     },
     {
-      "groupName": "gitea dependency",
+      "groupName": "gitea dependencies",
       "groupSlug": "gitea",
       "matchPackageNames": ["gitea/gitea"]
+    },
+    {
+      "groupName": "ResourceAdm dependencies",
+      "groupSlug": "resourceadm",
+      "paths": ["frontend/resourceadm/*"],
+      "labels": ["area/resource-adm"]
     }
   ],
   "ignorePaths": ["testdata/**", "src/**"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the dependencies for the ResourceAdm package and adds the label `area/resource-adm` to clearly indicate that it belongs to the ResourceAdm team/folder within our monorepo. This helps improve the organization and ensures the right team is assigned to review and manage these updates. 🙌 

## Related Issue(s)

- #13354 

## Verification

- [x] **Your** code builds clean without any errors or warnings