### PR TITLE
chore(process): Inform user of consequences of switching layoutset default data model

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -639,6 +639,7 @@
   "process_editor.configuration_panel_custom_receipt_spinner_title": "Laster inn kvittering",
   "process_editor.configuration_panel_custom_receipt_textfield_label": "Navn på kvittering",
   "process_editor.configuration_panel_data_model_selection_description": "Velg en datamodell å knytte til prosessteget",
+  "process_editor.configuration_panel_data_model_selection_description_existing_model": "Du har allerede valgt en datamodell. Hvis du har brukt denne datamodellen i skjema kan eventuelle knytninger til datamodellfelt i skjemaet bli ugyldige. Felter det gjelder vil vises med feilmelding i forhåndsvisningen",
   "process_editor.configuration_panel_data_task": "Oppgave: Utfylling",
   "process_editor.configuration_panel_data_types_to_sign_required": "Du må velge minst én datatype",
   "process_editor.configuration_panel_design_title": "Utforming",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -639,7 +639,7 @@
   "process_editor.configuration_panel_custom_receipt_spinner_title": "Laster inn kvittering",
   "process_editor.configuration_panel_custom_receipt_textfield_label": "Navn på kvittering",
   "process_editor.configuration_panel_data_model_selection_description": "Velg en datamodell å knytte til prosessteget",
-  "process_editor.configuration_panel_data_model_selection_description_existing_model": "Du har allerede valgt en datamodell. Hvis du har brukt denne datamodellen i skjema kan eventuelle knytninger til datamodellfelt i skjemaet bli ugyldige. Felter det gjelder vil vises med feilmelding i forhåndsvisningen",
+  "process_editor.configuration_panel_data_model_selection_description_existing_model": "Du har allerede valgt en datamodell. Hvis du har brukt denne datamodellen i et skjema, kan du få ugyldige knytninger til datamodellfelt i skjemaet. Du får en feilmelding om hvilke felter det gjelder, i forhåndsvisningen",
   "process_editor.configuration_panel_data_task": "Oppgave: Utfylling",
   "process_editor.configuration_panel_data_types_to_sign_required": "Du må velge minst én datatype",
   "process_editor.configuration_panel_design_title": "Utforming",

--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypes/EditDataTypes.test.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypes/EditDataTypes.test.tsx
@@ -89,7 +89,9 @@ describe('EditDataTypes', () => {
     });
     await user.click(updateDataTypeButton);
     const description = screen.getByText(
-      textMock('process_editor.configuration_panel_data_model_selection_description'),
+      textMock(
+        'process_editor.configuration_panel_data_model_selection_description_existing_model',
+      ),
     );
     expect(description).toBeInTheDocument();
 

--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypes/SelectDataTypes/SelectDataTypes.module.css
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypes/SelectDataTypes/SelectDataTypes.module.css
@@ -8,6 +8,11 @@
   flex: 1;
 }
 
+.root {
+  display: flex;
+  flex-direction: column;
+}
+
 .dataTypeSelectAndButtons {
   display: flex;
   flex-direction: row;

--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypes/SelectDataTypes/SelectDataTypes.test.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypes/SelectDataTypes/SelectDataTypes.test.tsx
@@ -132,6 +132,42 @@ describe('SelectDataTypes', () => {
     expect(mutateDataTypesMock).not.toHaveBeenCalled();
     expect(mockOnClose).toHaveBeenCalled();
   });
+
+  it('should show selected value in combobox when data type is selected', () => {
+    const existingDataType = 'dataModel0';
+    const dataModelIds = [existingDataType, 'dataModel1', 'dataModel2'];
+    renderSelectDataTypes({
+      existingDataType,
+      dataModelIds,
+    });
+    const combobox = screen.getByRole('combobox', {
+      name: textMock('process_editor.configuration_panel_set_data_model_label'),
+    });
+    expect(combobox).toHaveValue(existingDataType);
+  });
+
+  it('should show default description text when no data type is selected', () => {
+    renderSelectDataTypes();
+    const description = screen.getByText(
+      textMock('process_editor.configuration_panel_data_model_selection_description'),
+    );
+    expect(description).toBeInTheDocument();
+  });
+
+  it('should show extended description text when data type is already selected', () => {
+    const existingDataType = 'dataModel0';
+    const dataModelIds = [existingDataType, 'dataModel1', 'dataModel2'];
+    renderSelectDataTypes({
+      existingDataType: 'dataModel0',
+      dataModelIds,
+    });
+    const description = screen.getByText(
+      textMock(
+        'process_editor.configuration_panel_data_model_selection_description_existing_model',
+      ),
+    );
+    expect(description).toBeInTheDocument();
+  });
 });
 
 const renderSelectDataTypes = (

--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypes/SelectDataTypes/SelectDataTypes.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypes/SelectDataTypes/SelectDataTypes.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Combobox } from '@digdir/designsystemet-react';
-import { StudioButton, StudioDeleteButton } from '@studio/components';
+import { StudioButton, StudioCombobox, StudioDeleteButton } from '@studio/components';
 import { useBpmnApiContext } from '../../../../../contexts/BpmnApiContext';
 import { useTranslation } from 'react-i18next';
 import { XMarkIcon } from '@studio/icons';
@@ -44,26 +43,36 @@ export const SelectDataTypes = ({
 
   return (
     <div className={classes.dataTypeSelectAndButtons}>
-      <Combobox
+      <StudioCombobox
         label={t('process_editor.configuration_panel_set_data_model_label')}
-        value={currentValue && dataModelIds.includes(existingDataType) ? currentValue : undefined}
-        description={t('process_editor.configuration_panel_data_model_selection_description')}
+        value={
+          existingDataType && dataModelOptionsToDisplay.includes(existingDataType)
+            ? currentValue
+            : undefined
+        }
+        description={
+          existingDataType
+            ? t(
+                'process_editor.configuration_panel_data_model_selection_description_existing_model',
+              )
+            : t('process_editor.configuration_panel_data_model_selection_description')
+        }
         size='small'
         className={classes.dataTypeSelect}
       >
-        <Combobox.Empty>
+        <StudioCombobox.Empty>
           {t('process_editor.configuration_panel_no_data_model_to_select')}
-        </Combobox.Empty>
+        </StudioCombobox.Empty>
         {dataModelOptionsToDisplay.map((option) => (
-          <Combobox.Option
+          <StudioCombobox.Option
             value={option}
             key={option}
             onClick={() => handleChangeDataModel([option])}
           >
             {option}
-          </Combobox.Option>
+          </StudioCombobox.Option>
         ))}
-      </Combobox>
+      </StudioCombobox>
       <div className={classes.buttons}>
         <StudioButton
           icon={<XMarkIcon />}

--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypes/SelectDataTypes/SelectDataTypes.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditDataTypes/SelectDataTypes/SelectDataTypes.tsx
@@ -41,22 +41,21 @@ export const SelectDataTypes = ({
     ? [...new Set([...dataModelIds, existingDataType])]
     : dataModelIds;
 
+  const descriptionText = existingDataType
+    ? t('process_editor.configuration_panel_data_model_selection_description_existing_model')
+    : t('process_editor.configuration_panel_data_model_selection_description');
+
+  const value =
+    existingDataType && dataModelOptionsToDisplay.includes(existingDataType)
+      ? currentValue
+      : undefined;
+
   return (
     <div className={classes.dataTypeSelectAndButtons}>
       <StudioCombobox
         label={t('process_editor.configuration_panel_set_data_model_label')}
-        value={
-          existingDataType && dataModelOptionsToDisplay.includes(existingDataType)
-            ? currentValue
-            : undefined
-        }
-        description={
-          existingDataType
-            ? t(
-                'process_editor.configuration_panel_data_model_selection_description_existing_model',
-              )
-            : t('process_editor.configuration_panel_data_model_selection_description')
-        }
+        value={value}
+        description={descriptionText}
         size='small'
         className={classes.dataTypeSelect}
       >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added an alternative text for combobox description when a data model is already selected. The text explains the consequences of switching to a different data model.

With no previously selected data model (as before):
![Screenshot 2024-10-15 at 11 09 01](https://github.com/user-attachments/assets/91700e2e-1d38-437c-a0c9-db1f1855a560)


With previously selected data model (new text):
![Screenshot 2024-10-15 at 11 08 52](https://github.com/user-attachments/assets/e8e89b84-3957-47a4-9614-0feefe373110)

Also fixed the following that I noticed:
- Bug that did not show the selected value as selected in the combobox. The combobox appeared to have no selected value, even though one was selected.
- Replaced use of `Combobox` directly from design system with `StudioCombobox`.

Would like feedback on the text content for the new text, maybe @Ildest could take a look?

>"Du har allerede valgt en datamodell. Hvis du har brukt denne datamodellen i skjema kan eventuelle knytninger til datamodellfelt i skjemaet bli ugyldige. Felter det gjelder vil vises med feilmelding i forhåndsvisningen"


## Related Issue(s)

- #13793 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

