### PR TITLE
fix(usecase): run use-case-prod from main not production

### DIFF
--- a/frontend/testing/cypress/use-cases-prod.yaml
+++ b/frontend/testing/cypress/use-cases-prod.yaml
@@ -16,7 +16,7 @@ schedules:
   displayName: Bruksmønster
   branches:
     include:
-    - production
+    - main
   always: true
 
 steps:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We should change use-case-prod to run from main instead of production, since main is the "new" production with continues deploy.

## Related Issue(s)

- PR itself

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)