### PR TITLE
feat: use StudioContentMenu in ResourceAdm

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioContentMenu/StudioContentMenu.module.css
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/StudioContentMenu.module.css
@@ -1,0 +1,4 @@
+.tabsContainer {
+  background-color: var(--fds-semantic-surface-action-second-subtle);
+  height: 100%;
+}

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/StudioContentMenu.stories.tsx
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/StudioContentMenu.stories.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { StudioContentMenu } from './StudioContentMenu';
+import { BookIcon, VideoIcon, QuestionmarkDiamondIcon, ExternalLinkIcon } from '@studio/icons';
+import { StudioContentMenuWrapper } from './StudioContentMenuWrapper';
+
+type Story = StoryFn<typeof StudioContentMenu>;
+
+const meta: Meta = {
+  title: 'Components/StudioContentMenu',
+  component: StudioContentMenu,
+  argTypes: {
+    contentTabs: {
+      control: 'object',
+      description:
+        'Array of menu tabs with icons, names, and ids. Add prop `to` if tab should navigate to a different url',
+      table: {
+        type: { summary: 'StudioMenuTabType<TabId>[]' },
+      },
+    },
+    selectedTabId: {
+      table: { disable: true },
+    },
+    onChangeTab: {
+      table: { disable: true },
+    },
+  },
+};
+
+export default meta;
+
+export const Preview: Story = (args) => (
+  <StudioContentMenuWrapper {...args}></StudioContentMenuWrapper>
+);
+
+Preview.args = {
+  contentTabs: [
+    {
+      tabId: 'booksTab',
+      tabName: 'Bøker',
+      icon: <BookIcon />,
+    },
+    {
+      tabId: 'videosTab',
+      tabName: 'Filmer',
+      icon: <VideoIcon />,
+    },
+    {
+      tabId: 'tabWithVeryLongTabName',
+      tabName: 'LoremIpsumLoremIpsumLoremIpsum',
+      icon: <QuestionmarkDiamondIcon />,
+    },
+    {
+      tabId: 'tabAsLink',
+      tabName: 'Gå til Designsystemet',
+      icon: <ExternalLinkIcon />,
+      to: 'https://next.storybook.designsystemet.no',
+    },
+  ],
+};

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/StudioContentMenu.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/StudioContentMenu.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import type { StudioContentMenuProps } from './StudioContentMenu';
+import { StudioContentMenu } from './StudioContentMenu';
+import type { StudioMenuTabType } from './types/StudioMenuTabType';
+
+type StudioMenuTabName = 'tab1' | 'tab2' | 'tab3';
+
+const onChangeTabMock = jest.fn();
+
+const tab1Name = 'My tab';
+const tab1Id: StudioMenuTabName = 'tab1';
+const tab1: StudioMenuTabType<StudioMenuTabName> = {
+  tabName: tab1Name,
+  tabId: tab1Id,
+  icon: <svg></svg>,
+};
+const tab2Name = 'My second tab';
+const tab2Id: StudioMenuTabName = 'tab2';
+const tab2: StudioMenuTabType<StudioMenuTabName> = {
+  tabName: tab2Name,
+  tabId: tab2Id,
+  icon: <svg></svg>,
+};
+
+describe('StudioContentMenu', () => {
+  afterEach(jest.clearAllMocks);
+
+  it('renders an empty contentMenu when there is no provided tabs', () => {
+    renderStudioContentMenu({ contentTabs: [] });
+    const emptyMenu = screen.getByRole('tablist');
+    expect(emptyMenu).toBeInTheDocument();
+  });
+
+  it('renders the title and icon of a given menu tab', () => {
+    const iconTitle = 'My icon';
+    renderStudioContentMenu({
+      contentTabs: [
+        {
+          ...tab1,
+          icon: <svg data-testid={iconTitle}></svg>,
+        },
+      ],
+    });
+    const menuTab = screen.getByRole('tab', { name: tab1Name });
+    const menuIcon = screen.getByTestId(iconTitle);
+    expect(menuTab).toBeInTheDocument();
+    expect(menuIcon).toBeInTheDocument();
+  });
+
+  it('renders a tab with "to" prop as a link element', () => {
+    const link = 'url-link';
+    renderStudioContentMenu({
+      contentTabs: [
+        {
+          ...tab1,
+          to: link,
+        },
+      ],
+    });
+    const menuTab = screen.getByRole('tab', { name: tab1Name });
+    const linkTab = screen.getByRole('link', { name: tab1Name });
+    expect(menuTab).toBeInTheDocument();
+    expect(linkTab).toBeInTheDocument();
+    expect(linkTab).toHaveAttribute('href', link);
+  });
+
+  it('allows changing focus to next tab using keyboard', async () => {
+    const user = userEvent.setup();
+    renderStudioContentMenu({
+      contentTabs: [tab1, tab2],
+    });
+    const tab1Element = screen.getByRole('tab', { name: tab1Name });
+    await user.click(tab1Element);
+    const tab2Element = screen.getByRole('tab', { name: tab2Name });
+    expect(tab2Element).not.toHaveFocus();
+    await user.keyboard('{ArrowDown}');
+    expect(tab2Element).toHaveFocus();
+  });
+
+  it('keeps focus on current tab if pressing keyDown when focus is on last tab in menu', async () => {
+    const user = userEvent.setup();
+    renderStudioContentMenu({
+      contentTabs: [tab1, tab2],
+    });
+    const tab2Element = screen.getByRole('tab', { name: tab2Name });
+    await user.click(tab2Element);
+    expect(tab2Element).toHaveFocus();
+    await user.keyboard('{ArrowDown}');
+    expect(tab2Element).toHaveFocus();
+  });
+
+  it('allows changing focus to previous tab using keyboard', async () => {
+    const user = userEvent.setup();
+    renderStudioContentMenu({
+      contentTabs: [tab1, tab2],
+    });
+    const tab2Element = screen.getByRole('tab', { name: tab2Name });
+    await user.click(tab2Element);
+    const tab1Element = screen.getByRole('tab', { name: tab1Name });
+    expect(tab1Element).not.toHaveFocus();
+    await user.keyboard('{ArrowUp}');
+    expect(tab1Element).toHaveFocus();
+  });
+
+  it('keeps focus on current tab if pressing keyUp when focus is on first tab in menu', async () => {
+    const user = userEvent.setup();
+    renderStudioContentMenu({
+      contentTabs: [tab1, tab2],
+    });
+    const tab1Element = screen.getByRole('tab', { name: tab1Name });
+    await user.click(tab1Element);
+    expect(tab1Element).toHaveFocus();
+    await user.keyboard('{ArrowUp}');
+    expect(tab1Element).toHaveFocus();
+  });
+
+  it('calls onChangeTab when clicking enter on a tab with focus', async () => {
+    const user = userEvent.setup();
+    renderStudioContentMenu({
+      contentTabs: [tab1, tab2],
+    });
+    const tab1Element = screen.getByRole('tab', { name: tab1Name });
+    await user.click(tab1Element);
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{Enter}');
+    expect(onChangeTabMock).toHaveBeenCalledTimes(2);
+    expect(onChangeTabMock).toHaveBeenNthCalledWith(1, tab1Id);
+    expect(onChangeTabMock).toHaveBeenNthCalledWith(2, tab2Id);
+  });
+
+  it('calls onChangeTab when clicking on a menu tab', async () => {
+    const user = userEvent.setup();
+    renderStudioContentMenu({
+      contentTabs: [tab1],
+    });
+    const menuTab = screen.getByRole('tab', { name: tab1Name });
+    await user.click(menuTab);
+    expect(onChangeTabMock).toHaveBeenCalledTimes(1);
+    expect(onChangeTabMock).toHaveBeenCalledWith(tab1Id);
+  });
+
+  it('calls onChangeTab when clicking on a menu tab with link', async () => {
+    const link = 'url-link';
+    const user = userEvent.setup();
+    renderStudioContentMenu({
+      contentTabs: [
+        {
+          ...tab1,
+          to: link,
+        },
+      ],
+    });
+    const menuTab = screen.getByRole('tab', { name: tab1Name });
+    await user.click(menuTab);
+    expect(onChangeTabMock).toHaveBeenCalledTimes(1);
+    expect(onChangeTabMock).toHaveBeenCalledWith(tab1Id);
+  });
+});
+
+const renderStudioContentMenu = ({
+  contentTabs,
+}: Partial<StudioContentMenuProps<StudioMenuTabName>> = {}) => {
+  render(
+    <StudioContentMenu
+      contentTabs={contentTabs}
+      selectedTabId={undefined}
+      onChangeTab={onChangeTabMock}
+    />,
+  );
+};

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/StudioContentMenu.tsx
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/StudioContentMenu.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
+import classes from './StudioContentMenu.module.css';
+import { StudioMenuTabContainer } from './StudioMenuTab';
+import type { StudioMenuTabType } from './types/StudioMenuTabType';
+
+export type StudioContentMenuProps<TabId extends string> = {
+  contentTabs: StudioMenuTabType<TabId>[];
+  selectedTabId: TabId;
+  onChangeTab: (tabId: TabId) => void;
+};
+
+export function StudioContentMenu<TabId extends string>({
+  contentTabs,
+  selectedTabId,
+  onChangeTab,
+}: StudioContentMenuProps<TabId>): ReactElement {
+  const [selectedTab, setSelectedTab] = useState<string>(selectedTabId ?? contentTabs[0]?.tabId);
+  const handleChangeTab = (tabId: TabId) => {
+    onChangeTab(tabId);
+    setSelectedTab(tabId);
+  };
+
+  return (
+    <div className={classes.tabsContainer} role='tablist'>
+      {contentTabs.map((contentTab) => (
+        <StudioMenuTabContainer
+          key={contentTab.tabId}
+          contentTab={contentTab}
+          isTabSelected={contentTab.tabId === selectedTab}
+          onClick={() => handleChangeTab(contentTab.tabId)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/StudioContentMenuWrapper.module.css
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/StudioContentMenuWrapper.module.css
@@ -1,0 +1,4 @@
+.contentMenuWrapper {
+  height: 300px;
+  width: 200px;
+}

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/StudioContentMenuWrapper.tsx
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/StudioContentMenuWrapper.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type { StudioContentMenuProps } from './StudioContentMenu';
+import { StudioContentMenu } from './StudioContentMenu';
+import classes from './StudioContentMenuWrapper.module.css';
+
+export type StudioContentMenuWrapperProps<TabId extends string> = StudioContentMenuProps<TabId>;
+
+export function StudioContentMenuWrapper<TabId extends string>({
+  contentTabs,
+  selectedTabId,
+  onChangeTab,
+}: StudioContentMenuWrapperProps<TabId>) {
+  return (
+    <div className={classes.contentMenuWrapper}>
+      <StudioContentMenu
+        contentTabs={contentTabs}
+        selectedTabId={selectedTabId}
+        onChangeTab={onChangeTab}
+      />
+    </div>
+  );
+}

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/StudioMenuTab/StudioMenuTab.tsx
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/StudioMenuTab/StudioMenuTab.tsx
@@ -1,0 +1,19 @@
+import classes from './StudioMenuTabContainer.module.css';
+import { StudioParagraph } from '@studio/components';
+import React from 'react';
+import type { StudioMenuTabAsButtonType } from '../types/StudioMenuTabType';
+
+type MenuTabContentProps<TabId extends string> = {
+  contentTab: StudioMenuTabAsButtonType<TabId>;
+};
+
+export function StudioMenuTab<TabId extends string>({ contentTab }: MenuTabContentProps<TabId>) {
+  return (
+    <>
+      <div className={classes.icon}>{contentTab.icon}</div>
+      <StudioParagraph size='small' variant='short' className={classes.tabTitle}>
+        {contentTab.tabName}
+      </StudioParagraph>
+    </>
+  );
+}

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/StudioMenuTab/StudioMenuTabAsLink.tsx
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/StudioMenuTab/StudioMenuTabAsLink.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import classes from './StudioMenuTabContainer.module.css';
+import { StudioLink, StudioParagraph } from '@studio/components';
+import type { StudioMenuTabAsLinkType } from '../types/StudioMenuTabType';
+
+export type StudioMenuTabAsLinkProps<TabId extends string> = {
+  contentTab: StudioMenuTabAsLinkType<TabId>;
+};
+
+export function StudioMenuTabAsLink<TabId extends string>({
+  contentTab,
+}: StudioMenuTabAsLinkProps<TabId>): React.ReactElement {
+  return (
+    <StudioLink href={contentTab.to}>
+      <div className={classes.linkIcon}>{contentTab.icon}</div>
+      <StudioParagraph size='small' variant='short' className={classes.tabTitle}>
+        {contentTab.tabName}
+      </StudioParagraph>
+    </StudioLink>
+  );
+}

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/StudioMenuTab/StudioMenuTabContainer.module.css
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/StudioMenuTab/StudioMenuTabContainer.module.css
@@ -1,0 +1,39 @@
+:root {
+  --selected-border-marking: 3px;
+}
+
+.tabIsSelected,
+.tab {
+  display: flex;
+  align-items: center;
+  gap: var(--fds-spacing-2);
+  border: solid 1px var(--fds-semantic-border-action-second-subtle);
+  padding: var(--fds-spacing-3);
+  cursor: pointer;
+}
+
+.linkIcon {
+  color: var(--fds-semantic-text-neutral-default);
+}
+
+.linkIcon,
+.icon {
+  display: flex;
+  align-items: center;
+  font-size: var(--fds-spacing-8);
+}
+
+.tabTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tabIsSelected {
+  border-left: var(--selected-border-marking) solid var(--semantic-surface-action-default);
+  background-color: white;
+}
+
+.tab:hover,
+.tabIsSelected:hover {
+  background-color: var(--fds-semantic-surface-action-no_fill-hover);
+}

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/StudioMenuTab/StudioMenuTabContainer.tsx
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/StudioMenuTab/StudioMenuTabContainer.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import type { ReactElement } from 'react';
+import classes from './StudioMenuTabContainer.module.css';
+import { moveFocus } from '../utils/dom-utils';
+import type { StudioMenuTabAsLinkType, StudioMenuTabType } from '../types/StudioMenuTabType';
+import { StudioMenuTabAsLink } from './StudioMenuTabAsLink';
+import { StudioMenuTab } from './StudioMenuTab';
+
+type StudioMenuTabProps<TabId extends string> = {
+  contentTab: StudioMenuTabType<TabId>;
+  isTabSelected: boolean;
+  onClick: (tabId: TabId) => void;
+};
+
+export function StudioMenuTabContainer<TabId extends string>({
+  contentTab,
+  isTabSelected,
+  onClick,
+}: StudioMenuTabProps<TabId>): ReactElement {
+  const handleKeyDown = (event: React.KeyboardEvent<any>) => {
+    moveFocus(event);
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      onClick(contentTab.tabId);
+    }
+  };
+
+  return (
+    <div
+      className={isTabSelected ? classes.tabIsSelected : classes.tab}
+      onClick={() => onClick(contentTab.tabId)}
+      role='tab'
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+      title={contentTab.tabName}
+    >
+      {isStudioMenuTabAsLink(contentTab) ? (
+        <StudioMenuTabAsLink contentTab={contentTab} />
+      ) : (
+        <StudioMenuTab contentTab={contentTab} />
+      )}
+    </div>
+  );
+}
+
+function isStudioMenuTabAsLink<TabId extends string>(
+  contentTab: StudioMenuTabType<TabId>,
+): contentTab is StudioMenuTabAsLinkType<TabId> {
+  return 'to' in contentTab;
+}

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/StudioMenuTab/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/StudioMenuTab/index.ts
@@ -1,0 +1,1 @@
+export { StudioMenuTabContainer } from '../StudioMenuTab/StudioMenuTabContainer';

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/index.ts
@@ -1,0 +1,2 @@
+export { StudioContentMenu } from './StudioContentMenu';
+export type { StudioMenuTabType } from '../StudioContentMenu/types/StudioMenuTabType';

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/types/StudioMenuTabType.ts
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/types/StudioMenuTabType.ts
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+export type StudioMenuTabAsButtonType<TabId extends string> = {
+  icon: ReactNode;
+  tabName: string;
+  tabId: TabId;
+};
+
+export type StudioMenuTabAsLinkType<TabId extends string> = StudioMenuTabAsButtonType<TabId> & {
+  to: string;
+};
+
+export type StudioMenuTabType<TabId extends string> =
+  | StudioMenuTabAsButtonType<TabId>
+  | StudioMenuTabAsLinkType<TabId>;

--- a/frontend/libs/studio-components/src/components/StudioContentMenu/utils/dom-utils.ts
+++ b/frontend/libs/studio-components/src/components/StudioContentMenu/utils/dom-utils.ts
@@ -1,0 +1,48 @@
+import type React from 'react';
+
+export function moveFocus(event: React.KeyboardEvent<HTMLElement>) {
+  const nextTab = getNextTab(event);
+  if (nextTab) {
+    event.preventDefault();
+    nextTab.tabIndex = 0;
+    nextTab.focus();
+    event.currentTarget.tabIndex = -1;
+  }
+}
+
+function getNextTab({ key, currentTarget }: React.KeyboardEvent<HTMLElement>) {
+  const tablist = getParentTablist(currentTarget);
+  const tabs = getTabs(tablist);
+  switch (key) {
+    case 'ArrowUp':
+      return getTabElementAbove(tabs, currentTarget);
+    case 'ArrowDown':
+      return getTabElementBelow(tabs, currentTarget);
+    default:
+      return null;
+  }
+}
+
+function getTabElementAbove(tabs: HTMLElement[], currentTab: HTMLElement) {
+  const currentIndex = tabs.indexOf(currentTab);
+  if (currentIndex > 0) {
+    return tabs[currentIndex - 1] as HTMLElement;
+  }
+  return null;
+}
+
+function getTabElementBelow(tabs: HTMLElement[], currentTab: HTMLElement) {
+  const currentIndex = tabs.indexOf(currentTab);
+  if (currentIndex < tabs.length - 1) {
+    return tabs[currentIndex + 1] as HTMLElement;
+  }
+  return null;
+}
+
+function getTabs(tablist: HTMLElement): HTMLElement[] {
+  return Array.from(tablist.querySelectorAll('[role="tab"]')) as HTMLElement[];
+}
+
+function getParentTablist(element: HTMLElement): HTMLElement | null {
+  return element.closest('[role="tablist"]');
+}

--- a/frontend/libs/studio-components/src/components/index.ts
+++ b/frontend/libs/studio-components/src/components/index.ts
@@ -12,6 +12,7 @@ export * from './StudioCheckbox';
 export * from './StudioCodeFragment';
 export * from './StudioCodelistEditor';
 export * from './StudioCombobox';
+export * from './StudioContentMenu';
 export * from './StudioDecimalInput';
 export * from './StudioDeleteButton';
 export * from './StudioDisplayTile';

--- a/frontend/packages/shared/src/components/GoBackButton/GoBackButton.module.css
+++ b/frontend/packages/shared/src/components/GoBackButton/GoBackButton.module.css
@@ -1,0 +1,35 @@
+.navigationElement {
+  display: flex;
+  align-items: center;
+  padding-left: 15px;
+  padding-block: 20px;
+  border: none;
+  border-bottom: 1px solid var(--fds-semantic-border-divider-default);
+  background-color: var(--fds-semantic-background-subtle);
+  cursor: pointer;
+}
+
+.icon {
+  font-size: 1.8rem;
+  color: var(--fds-semantic-text-neutral-default);
+}
+
+.backButton {
+  display: flex;
+  align-items: center;
+  padding-left: 15px;
+  padding-block: 20px;
+  border: none;
+  border-bottom: 1px solid var(--fds-semantic-border-divider-default);
+  background-color: var(--fds-semantic-background-subtle);
+  cursor: pointer;
+}
+
+.backButton:hover {
+  background-color: var(--fds-semantic-surface-action-no_fill-hover);
+}
+
+.buttonText {
+  color: var(--fds-semantic-text-neutral-default);
+  margin-left: 10px;
+}

--- a/frontend/packages/shared/src/components/GoBackButton/GoBackButton.test.tsx
+++ b/frontend/packages/shared/src/components/GoBackButton/GoBackButton.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { GoBackButtonProps } from './GoBackButton';
+import { GoBackButton } from './GoBackButton';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockBackButtonText: string = 'Go back';
+
+describe('GoBackButton', () => {
+  afterEach(jest.clearAllMocks);
+
+  const defaultProps: GoBackButtonProps = {
+    className: '.navigationElement',
+    to: '/back',
+    text: mockBackButtonText,
+  };
+
+  it('calls the "onClickBackButton" function when the button is clicked', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <GoBackButton {...defaultProps} />
+      </MemoryRouter>,
+    );
+
+    const backButton = screen.getByRole('link', { name: mockBackButtonText });
+    expect(backButton).toBeInTheDocument();
+  });
+});

--- a/frontend/packages/shared/src/components/GoBackButton/GoBackButton.tsx
+++ b/frontend/packages/shared/src/components/GoBackButton/GoBackButton.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react';
+import React from 'react';
+import classes from './GoBackButton.module.css';
+import cn from 'classnames';
+import { ArrowLeftIcon } from '@studio/icons';
+import { Paragraph } from '@digdir/designsystemet-react';
+import { NavLink } from 'react-router-dom';
+
+export type GoBackButtonProps = {
+  /**
+   * Classname for navigation element
+   */
+  className?: string;
+  /**
+   * Text on the back button
+   */
+  text: string;
+  /**
+   * Where to navigate to
+   */
+  to: string;
+};
+
+/**
+ * @component
+ *    Displays the back button on top of the LeftNavigationBar
+ *
+ * @example
+ *      <GoBackButton
+ *        className={classes.navigationElement}
+ *        text={backButtonText}
+ *        to={someUrl}
+ *      />
+ *
+ * @property {string}[className] - Classname for navigation element
+ * @property {string}[text] - Text on the back button
+ * @property {string}[to] - Where to navigate to
+ *
+ * @returns {ReactNode} - The rendered component
+ */
+export const GoBackButton = ({ className, text, to }: GoBackButtonProps): ReactNode => {
+  return (
+    <NavLink className={cn(className, classes.backButton)} to={to}>
+      <ArrowLeftIcon className={classes.icon} />
+      <Paragraph asChild size='small' variant='short' className={classes.buttonText}>
+        <span>{text}</span>
+      </Paragraph>
+    </NavLink>
+  );
+};

--- a/frontend/packages/shared/src/components/GoBackButton/index.ts
+++ b/frontend/packages/shared/src/components/GoBackButton/index.ts
@@ -1,0 +1,1 @@
+export { GoBackButton } from './GoBackButton';

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.module.css
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.module.css
@@ -10,13 +10,9 @@
   height: 100vh;
   top: 0;
   position: sticky;
+  width: 250px;
 }
 
 .spinnerWrapper {
   padding: 10%;
-}
-
-.icon {
-  color: var(--fds-semantic-text-neutral-default);
-  font-size: 1.8rem;
 }

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
@@ -17,21 +17,22 @@ import { useEditResourceMutation } from '../../hooks/mutations';
 import { MigrationPage } from '../MigrationPage';
 import type { Resource } from 'app-shared/types/ResourceAdm';
 import { useTranslation } from 'react-i18next';
-import type { LeftNavigationTab } from 'app-shared/types/LeftNavigationTab';
 import {
   GavelSoundBlockIcon,
   InformationSquareIcon,
   MigrationIcon,
   UploadIcon,
 } from '@studio/icons';
-import { LeftNavigationBar } from 'app-shared/components/LeftNavigationBar';
-import { createNavigationTab, deepCompare, getAltinn2Reference } from '../../utils/resourceUtils';
+import { CreateMenuLinkTab, deepCompare, getAltinn2Reference } from '../../utils/resourceUtils';
 import type { EnvId } from '../../utils/resourceUtils';
 import { ResourceAccessLists } from '../../components/ResourceAccessLists';
 import { AccessListDetail } from '../../components/AccessListDetails';
 import { useGetAccessListQuery } from '../../hooks/queries/useGetAccessListQuery';
 import { useUrlParams } from '../../hooks/useUrlParams';
 import { shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
+import { GoBackButton } from 'app-shared/components/GoBackButton';
+import type { StudioMenuTabType } from '@studio/components';
+import { StudioContentMenu } from '@studio/components';
 
 /**
  * @component
@@ -114,7 +115,7 @@ export const ResourcePage = (): React.JSX.Element => {
           resourceErrorModalRef.current.showModal();
         }
       }
-      // Validate Ppolicy and display errors + modal
+      // Validate Policy and display errors + modal
       else if (currentPage === 'policy') {
         const data = await refetchValidatePolicy();
         const validationStatus = data?.data?.status ?? null;
@@ -149,7 +150,7 @@ export const ResourcePage = (): React.JSX.Element => {
   };
 
   /**
-   * Handles the navigation to a page that has erros. This is used from the deploy
+   * Handles the navigation to a page that has errors. This is used from the deploy
    * page when information is displayed about errors on the policy or the resource page.
    *
    * @param page the page to navigate to
@@ -178,43 +179,39 @@ export const ResourcePage = (): React.JSX.Element => {
     return !!altinn2References && shouldDisplayFeature('resourceMigration');
   };
 
-  const aboutPageId = 'about';
-  const policyPageId = 'policy';
-  const deployPageId = 'deploy';
-  const migrationPageId = 'migration';
-  const accessListsPageId = 'accesslists';
+  const aboutPageId: NavigationBarPage = 'about';
+  const policyPageId: NavigationBarPage = 'policy';
+  const deployPageId: NavigationBarPage = 'deploy';
+  const migrationPageId: NavigationBarPage = 'migration';
+  const accessListsPageId: NavigationBarPage = 'accesslists';
 
-  const leftNavigationTabs: LeftNavigationTab[] = [
-    createNavigationTab(
-      <InformationSquareIcon className={classes.icon} />,
+  const leftNavigationTabs: StudioMenuTabType<NavigationBarPage>[] = [
+    CreateMenuLinkTab(
+      <InformationSquareIcon />,
       aboutPageId,
-      () => navigateToPage(aboutPageId),
-      currentPage,
       getResourcePageURL(org, app, resourceId, 'about'),
     ),
-    createNavigationTab(
-      <GavelSoundBlockIcon className={classes.icon} />,
+    CreateMenuLinkTab(
+      <GavelSoundBlockIcon />,
       policyPageId,
-      () => navigateToPage(policyPageId),
-      currentPage,
       getResourcePageURL(org, app, resourceId, 'policy'),
     ),
-    createNavigationTab(
-      <UploadIcon className={classes.icon} />,
+    CreateMenuLinkTab(
+      <UploadIcon />,
       deployPageId,
-      () => navigateToPage(deployPageId),
-      currentPage,
       getResourcePageURL(org, app, resourceId, 'deploy'),
     ),
   ];
 
-  const migrationTab: LeftNavigationTab = createNavigationTab(
-    <MigrationIcon className={classes.icon} />,
+  const migrationTab: StudioMenuTabType<NavigationBarPage> = CreateMenuLinkTab(
+    <MigrationIcon />,
     migrationPageId,
-    () => navigateToPage(migrationPageId),
-    currentPage,
     getResourcePageURL(org, app, resourceId, 'migration'),
   );
+
+  const handleTabChange = async (tabId: NavigationBarPage) => {
+    await navigateToPage(tabId);
+  };
 
   /**
    * Gets the tabs to display. If showMigrate is true, the migration tab
@@ -222,7 +219,7 @@ export const ResourcePage = (): React.JSX.Element => {
    *
    * @returns the tabs to display in the LeftNavigationBar
    */
-  const getTabs = (): LeftNavigationTab[] => {
+  const getTabs = (): StudioMenuTabType<NavigationBarPage>[] => {
     return isMigrateEnabled() ? [...leftNavigationTabs, migrationTab] : leftNavigationTabs;
   };
 
@@ -239,14 +236,16 @@ export const ResourcePage = (): React.JSX.Element => {
   return (
     <div className={classes.resourceWrapper}>
       <div className={classes.leftNavWrapper}>
-        <LeftNavigationBar
-          upperTab='backButton'
-          tabs={getTabs()}
-          backLink={getResourceDashboardURL(org, app)}
-          backLinkText={t('resourceadm.left_nav_bar_back')}
-          selectedTab={
+        <GoBackButton
+          to={getResourceDashboardURL(org, app)}
+          text={t('resourceadm.left_nav_bar_back')}
+        />
+        <StudioContentMenu
+          contentTabs={getTabs()}
+          selectedTabId={
             currentPage === migrationPageId && !isMigrateEnabled() ? aboutPageId : currentPage
           }
+          onChangeTab={handleTabChange}
         />
       </div>
       {resourcePending || !resourceData ? (

--- a/frontend/resourceadm/utils/resourceUtils/index.ts
+++ b/frontend/resourceadm/utils/resourceUtils/index.ts
@@ -2,7 +2,7 @@ export {
   mapLanguageKeyToLanguageText,
   getMissingInputLanguageString,
   getIsActiveTab,
-  createNavigationTab,
+  CreateMenuLinkTab,
   getResourceIdentifierErrorMessage,
   deepCompare,
   getAvailableEnvironments,

--- a/frontend/resourceadm/utils/resourceUtils/resourceUtils.test.tsx
+++ b/frontend/resourceadm/utils/resourceUtils/resourceUtils.test.tsx
@@ -1,5 +1,5 @@
 import {
-  createNavigationTab,
+  CreateMenuLinkTab,
   getIsActiveTab,
   getMissingInputLanguageString,
   mapLanguageKeyToLanguageText,
@@ -9,10 +9,12 @@ import {
   validateResource,
 } from './';
 import type { EnvId } from './resourceUtils';
-import type { LeftNavigationTab } from 'app-shared/types/LeftNavigationTab';
 import { TestFlaskIcon } from '@studio/icons';
 import React from 'react';
 import type { Resource, SupportedLanguage } from 'app-shared/types/ResourceAdm';
+import type { NavigationBarPage } from '../../types/NavigationBarPage';
+import type { StudioMenuTabType } from '@studio/components';
+import { textMock } from '@studio/testing/mocks/i18nMock';
 
 describe('mapKeywordStringToKeywordTypeArray', () => {
   it('should split keywords correctly', () => {
@@ -120,26 +122,19 @@ describe('getIsActiveTab', () => {
 });
 
 describe('createNavigationTab', () => {
-  const mockOnClick = jest.fn();
-
   const mockTo: string = '/about';
 
-  const mockTab: LeftNavigationTab = {
+  const mockTab: StudioMenuTabType<NavigationBarPage> = {
     icon: <TestFlaskIcon />,
     tabName: 'resourceadm.left_nav_bar_about',
     tabId: 'about',
-    action: {
-      type: 'link',
-      onClick: mockOnClick,
-      to: mockTo,
-    },
-    isActiveTab: true,
+    to: mockTo,
   };
 
   it('creates a new tab when the function is called', () => {
-    const newTab = createNavigationTab(<TestFlaskIcon />, 'about', mockOnClick, 'about', mockTo);
+    const newTab = CreateMenuLinkTab(<TestFlaskIcon />, 'about', mockTo);
 
-    expect(newTab).toEqual(mockTab);
+    expect(newTab).toEqual({ ...mockTab, tabName: textMock(mockTab.tabName) });
   });
 });
 

--- a/frontend/resourceadm/utils/resourceUtils/resourceUtils.ts
+++ b/frontend/resourceadm/utils/resourceUtils/resourceUtils.ts
@@ -1,5 +1,4 @@
 import type { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
-import type { LeftNavigationTab } from 'app-shared/types/LeftNavigationTab';
 import type {
   ResourceTypeOption,
   ResourceStatusOption,
@@ -13,6 +12,8 @@ import type {
 import type { ReactNode } from 'react';
 import type { NavigationBarPage } from '../../types/NavigationBarPage';
 import { isAppPrefix, isSePrefix } from '../stringUtils';
+import type { StudioMenuTabType } from '@studio/components';
+import { useTranslation } from 'react-i18next';
 
 /**
  * The map of resource type
@@ -182,29 +183,21 @@ export const getIsActiveTab = (currentPage: NavigationBarPage, tabId: string): b
  *
  * @param icon the icon to display
  * @param tabId the id of the tab
- * @param onClick function to be executed on click
- * @param currentPage the current selected page
  * @param to where to navigate to
  *
  * @returns a LeftNavigationTab
  */
-export const createNavigationTab = (
+export const CreateMenuLinkTab = (
   icon: ReactNode,
-  tabId: string,
-  onClick: (tabId: string) => void,
-  currentPage: NavigationBarPage,
+  tabId: NavigationBarPage,
   to: string,
-): LeftNavigationTab => {
+): StudioMenuTabType<NavigationBarPage> => {
+  const { t } = useTranslation();
   return {
     icon,
-    tabName: `resourceadm.left_nav_bar_${tabId}`,
+    tabName: t(`resourceadm.left_nav_bar_${tabId}`),
     tabId,
-    action: {
-      type: 'link',
-      onClick,
-      to,
-    },
-    isActiveTab: getIsActiveTab(currentPage, tabId),
+    to,
   };
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implement StudioContentMenu in ResourceAdm.

### ResourceAdm

**Old menu in ResourceAdm:**
![Skjermbilde 2024-10-23 kl  15 27 36](https://github.com/user-attachments/assets/64638c80-5ea1-46b8-b19d-91d47a54bcde)

**New menu in ResourceAdm:**
![Skjermbilde 2024-10-23 kl  15 23 43](https://github.com/user-attachments/assets/b8fe254b-c8b0-4ff7-8939-486d11f49a16)

<!--- Describe your changes in detail -->

## Related Issue(s)

- #13818 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

