### PR TITLE
fix(process): ensure layoutset is added when adding signing task

### DIFF
--- a/frontend/app-development/features/processEditor/handlers/OnProcessTaskAddHandler.test.ts
+++ b/frontend/app-development/features/processEditor/handlers/OnProcessTaskAddHandler.test.ts
@@ -118,7 +118,7 @@ describe('OnProcessTaskAddHandler', () => {
     expect(mutateApplicationPolicyMock).toHaveBeenCalledWith(expectedResponse);
   });
 
-  it('should add datatype when signing task is added', () => {
+  it('should add layoutset and datatype when signing task is added', () => {
     const onProcessTaskAddHandler = createOnProcessTaskHandler();
 
     const taskMetadata: OnProcessTaskEvent = {
@@ -128,11 +128,19 @@ describe('OnProcessTaskAddHandler', () => {
 
     onProcessTaskAddHandler.handleOnProcessTaskAdd(taskMetadata);
 
+    expect(addLayoutSetMock).toHaveBeenCalledWith({
+      layoutSetConfig: {
+        id: 'testElementId',
+        tasks: ['testElementId'],
+      },
+      layoutSetIdToUpdate: 'testElementId',
+      taskType: 'signing',
+    });
+
     expect(addDataTypeToAppMetadataMock).toHaveBeenCalledWith({
       dataTypeId: 'signatureInformation-1234',
       taskId: 'testElementId',
     });
-    expect(addLayoutSetMock).not.toHaveBeenCalled();
     expect(mutateApplicationPolicyMock).not.toHaveBeenCalled();
   });
 

--- a/frontend/app-development/features/processEditor/handlers/OnProcessTaskAddHandler.ts
+++ b/frontend/app-development/features/processEditor/handlers/OnProcessTaskAddHandler.ts
@@ -87,11 +87,12 @@ export class OnProcessTaskAddHandler {
   }
 
   /**
-   * Adds a dataType to the added signing task
+   * Adds a dataType and layoutset to the added signing task
    * @param taskMetadata
    * @private
    */
   private handleSigningTaskAdd(taskMetadata: OnProcessTaskEvent): void {
+    this.addLayoutSet(this.createLayoutSetConfig(taskMetadata));
     const studioModeler = new StudioModeler(taskMetadata.taskEvent.element as any);
     const dataTypeId = studioModeler.getDataTypeIdFromBusinessObject(
       taskMetadata.taskType,

--- a/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
+++ b/frontend/packages/process-editor/src/hooks/useBpmnEditor.ts
@@ -36,7 +36,11 @@ export const useBpmnEditor = (): UseBpmnViewerResult => {
       taskEvent,
       taskType: bpmnDetails.taskType,
     });
-    if (bpmnDetails.taskType === 'data' || bpmnDetails.taskType === 'payment')
+    if (
+      bpmnDetails.taskType === 'data' ||
+      bpmnDetails.taskType === 'payment' ||
+      bpmnDetails.taskType === 'signing'
+    )
       addAction(bpmnDetails.id);
   };
 

--- a/frontend/testing/playwright/tests/process-editor/process-editor.spec.ts
+++ b/frontend/testing/playwright/tests/process-editor/process-editor.spec.ts
@@ -132,6 +132,7 @@ test('that the user can edit the id of a task and add data-types to sign', async
   const giteaPage = new GiteaPage(page, { app: testAppName });
 
   const signingTask = await addNewSigningTaskToProcessEditor(page);
+  await processEditorPage.skipRecommendedTask();
 
   const randomGeneratedId = await processEditorPage.getTaskIdFromOpenNewlyAddedTask();
 

--- a/frontend/testing/playwright/tests/process-editor/process-editor.spec.ts
+++ b/frontend/testing/playwright/tests/process-editor/process-editor.spec.ts
@@ -132,7 +132,6 @@ test('that the user can edit the id of a task and add data-types to sign', async
   const giteaPage = new GiteaPage(page, { app: testAppName });
 
   const signingTask = await addNewSigningTaskToProcessEditor(page);
-  await processEditorPage.skipRecommendedTask();
 
   const randomGeneratedId = await processEditorPage.getTaskIdFromOpenNewlyAddedTask();
 
@@ -216,6 +215,7 @@ const addNewSigningTaskToProcessEditor = async (page: Page): Promise<string> => 
     extraMovingDistanceX,
     extraMovingDistanceY,
   );
+  await processEditorPage.skipRecommendedTask();
   await processEditorPage.waitForTaskToBeVisibleInConfigPanel(signingTask);
 
   return signingTask;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per the documentation of the signing task, a layoutset needs to be associated with the task. 
Updated the handlers that handle adding tasks to the process to add a layoutset for the signing task.
Also ensure that the RecommendedNextAction for naming layoutset is shown in this case.

Future: We could automatically add the signing button, in the same way that we add the payment component for payment layoutset. However, I am leaving that to a later PR.

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
