### PR TITLE
feat: Add StudioErrorMessage component

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioErrorMessage/StudioErrorMessage.stories.tsx
+++ b/frontend/libs/studio-components/src/components/StudioErrorMessage/StudioErrorMessage.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { StudioErrorMessage } from './StudioErrorMessage';
+
+type Story = StoryFn<typeof StudioErrorMessage>;
+
+const meta: Meta = {
+  title: 'Components/StudioErrorMessage',
+  component: StudioErrorMessage,
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'lg'],
+    },
+    children: {
+      control: 'text',
+    },
+  },
+};
+export const Preview: Story = (args): React.ReactElement => <StudioErrorMessage {...args} />;
+
+Preview.args = {
+  children: 'Lorem ipsum dolor sit amet.',
+  size: 'sm',
+};
+export default meta;

--- a/frontend/libs/studio-components/src/components/StudioErrorMessage/StudioErrorMessage.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioErrorMessage/StudioErrorMessage.test.tsx
@@ -1,0 +1,36 @@
+import type { ForwardedRef } from 'react';
+import React from 'react';
+import type { StudioErrorMessageProps } from './StudioErrorMessage';
+import { StudioErrorMessage } from './StudioErrorMessage';
+import { render, screen } from '@testing-library/react';
+import { testCustomAttributes } from '../../test-utils/testCustomAttributes';
+import { testRefForwarding } from '../../test-utils/testRefForwarding';
+import { testRootClassNameAppending } from '../../test-utils/testRootClassNameAppending';
+
+// Test data:
+const errorMessage = 'Test error message';
+const defaultProps: StudioErrorMessageProps = { children: errorMessage };
+
+describe('StudioErrorMessage', () => {
+  it('Renders the given error message', () => {
+    renderErrorMessage();
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+  });
+
+  it('Forwards the ref', () => {
+    testRefForwarding<HTMLParagraphElement>((ref) => renderErrorMessage({}, ref));
+  });
+
+  it('Accepts custom attributes', () => {
+    testCustomAttributes<HTMLParagraphElement>(renderErrorMessage);
+  });
+
+  it('Applies the class name to the root element', () => {
+    testRootClassNameAppending((className) => renderErrorMessage({ className }));
+  });
+});
+
+const renderErrorMessage = (
+  props: StudioErrorMessageProps = {},
+  ref?: ForwardedRef<HTMLParagraphElement>,
+) => render(<StudioErrorMessage {...defaultProps} {...props} ref={ref} />);

--- a/frontend/libs/studio-components/src/components/StudioErrorMessage/StudioErrorMessage.tsx
+++ b/frontend/libs/studio-components/src/components/StudioErrorMessage/StudioErrorMessage.tsx
@@ -1,0 +1,11 @@
+import React, { forwardRef } from 'react';
+import type { ErrorMessageProps } from '@digdir/designsystemet-react';
+import { ErrorMessage } from '@digdir/designsystemet-react';
+
+export type StudioErrorMessageProps = ErrorMessageProps;
+
+export const StudioErrorMessage = forwardRef<HTMLParagraphElement, StudioErrorMessageProps>(
+  (props, ref) => <ErrorMessage size='sm' {...props} ref={ref} />,
+);
+
+StudioErrorMessage.displayName = 'StudioErrorMessage';

--- a/frontend/libs/studio-components/src/components/StudioErrorMessage/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioErrorMessage/index.ts
@@ -1,0 +1,1 @@
+export * from './StudioErrorMessage';

--- a/frontend/libs/studio-components/src/components/index.ts
+++ b/frontend/libs/studio-components/src/components/index.ts
@@ -1,5 +1,5 @@
-export * from './StudioAlert';
 export * from './StudioActionCloseButton';
+export * from './StudioAlert';
 export * from './StudioAnimateHeight';
 export * from './StudioAvatar';
 export * from './StudioBetaTag';
@@ -18,6 +18,7 @@ export * from './StudioDisplayTile';
 export * from './StudioDivider';
 export * from './StudioDropdownMenu';
 export * from './StudioError';
+export * from './StudioErrorMessage';
 export * from './StudioExpression';
 export * from './StudioFieldset';
 export * from './StudioFileUploader';


### PR DESCRIPTION
## Description
Added an `StudioErrorMessage` component based on the `ErrorMessage` component from The Design System.

![image](https://github.com/user-attachments/assets/49bcedd6-d6a7-477b-96de-d60413fdfbd8)

## Related Issue(s)
- #13342

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
