### PR TITLE
fix: Add IOptionValue type to Option class for handling string, double and bool

### DIFF
--- a/backend/src/Designer/Controllers/OptionsController.cs
+++ b/backend/src/Designer/Controllers/OptionsController.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Models.Interfaces;
 using Altinn.Studio.Designer.Services.Interfaces;
 using LibGit2Sharp;
 using Microsoft.AspNetCore.Authorization;
@@ -58,16 +59,16 @@ public class OptionsController : ControllerBase
     /// <returns>Dictionary of all option lists belonging to the app</returns>
     [HttpGet]
     [Route("option-lists")]
-    public async Task<ActionResult<Dictionary<string, List<Option>>>> GetOptionLists(string org, string repo)
+    public async Task<ActionResult<Dictionary<string, List<Option<IOptionValue>>>>> GetOptionLists(string org, string repo)
     {
         try
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
             string[] optionListIds = _optionsService.GetOptionsListIds(org, repo, developer);
-            Dictionary<string, List<Option>> optionLists = [];
+            Dictionary<string, List<Option<IOptionValue>>> optionLists = [];
             foreach (string optionListId in optionListIds)
             {
-                List<Option> optionList = await _optionsService.GetOptionsList(org, repo, developer, optionListId);
+                List<Option<IOptionValue>> optionList = await _optionsService.GetOptionsList(org, repo, developer, optionListId);
                 optionLists.Add(optionListId, optionList);
             }
             return Ok(optionLists);
@@ -90,14 +91,14 @@ public class OptionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [Route("{optionsListId}")]
-    public async Task<ActionResult<List<Option>>> GetOptionsList(string org, string repo, [FromRoute] string optionsListId, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<List<Option<IOptionValue>>>> GetOptionsList(string org, string repo, [FromRoute] string optionsListId, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
 
         try
         {
-            List<Option> optionsList = await _optionsService.GetOptionsList(org, repo, developer, optionsListId, cancellationToken);
+            List<Option<IOptionValue>> optionsList = await _optionsService.GetOptionsList(org, repo, developer, optionsListId, cancellationToken);
             return Ok(optionsList);
         }
         catch (NotFoundException ex)
@@ -119,7 +120,7 @@ public class OptionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("{optionsListId}")]
-    public async Task<ActionResult> CreateOrOverwriteOptionsList(string org, string repo, [FromRoute] string optionsListId, [FromBody] List<Option> payload, CancellationToken cancellationToken = default)
+    public async Task<ActionResult> CreateOrOverwriteOptionsList(string org, string repo, [FromRoute] string optionsListId, [FromBody] List<Option<IOptionValue>> payload, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
@@ -146,7 +147,7 @@ public class OptionsController : ControllerBase
 
         try
         {
-            List<Option> newOptionsList = await _optionsService.UploadNewOption(org, repo, developer, fileName, file, cancellationToken);
+            List<Option<IOptionValue>> newOptionsList = await _optionsService.UploadNewOption(org, repo, developer, fileName, file, cancellationToken);
             return Ok(newOptionsList);
         }
         catch (JsonException e)

--- a/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -13,6 +13,7 @@ using Altinn.Studio.Designer.Exceptions.AppDevelopment;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.App;
+using Altinn.Studio.Designer.Models.Interfaces;
 using Altinn.Studio.Designer.TypedHttpClients.Exceptions;
 using LibGit2Sharp;
 using JsonSerializer = System.Text.Json.JsonSerializer;
@@ -767,7 +768,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         /// <param name="payload">The contents of the new options list as a string</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
         /// <returns>The new options list as a string.</returns>
-        public async Task<string> CreateOrOverwriteOptionsList(string optionsListId, List<Option> payload, CancellationToken cancellationToken = default)
+        public async Task<string> CreateOrOverwriteOptionsList(string optionsListId, List<Option<IOptionValue>> payload, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/backend/src/Designer/Models/Interfaces/IOptionValue.cs
+++ b/backend/src/Designer/Models/Interfaces/IOptionValue.cs
@@ -1,0 +1,18 @@
+namespace Altinn.Studio.Designer.Models.Interfaces;
+
+public interface IOptionValue;
+
+public class StringOptionValue(string value) : IOptionValue
+{
+    public string Value { get; } = value;
+}
+
+public class BoolOptionValue(bool value) : IOptionValue
+{
+    public bool Value { get; } = value;
+}
+
+public class DoubleOptionValue(double value) : IOptionValue
+{
+    public double Value { get; } = value;
+}

--- a/backend/src/Designer/Models/Option.cs
+++ b/backend/src/Designer/Models/Option.cs
@@ -1,19 +1,20 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using Altinn.Studio.Designer.Models.Interfaces;
 
 namespace Altinn.Studio.Designer.Models;
 
 /// <summary>
 /// Options used in checkboxes, radio buttons and dropdowns.
 /// </summary>
-public class Option
+public class Option<T> where T : IOptionValue
 {
     /// <summary>
     /// Value that connects the option to the data model.
     /// </summary>
     [Required]
     [JsonPropertyName("value")]
-    public string Value { get; set; }
+    public T Value { get; set; }
 
     /// <summary>
     /// Label to present to the user.

--- a/backend/src/Designer/Services/Implementation/TextsService.cs
+++ b/backend/src/Designer/Services/Implementation/TextsService.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Models.Interfaces;
 using Altinn.Studio.Designer.Services.Interfaces;
 
 namespace Altinn.Studio.Designer.Services.Implementation
@@ -379,7 +380,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
             if (layoutObject["options"] is JsonArray optionsArray)
             {
-                List<Option> options = optionsArray.Deserialize<List<Option>>();
+                List<Option<IOptionValue>> options = optionsArray.Deserialize<List<Option<IOptionValue>>>();
                 if (options != null && UpdateOptionListKeys(options, mutation))
                 {
                     layoutObject["options"] = JsonSerializer.SerializeToNode(options);
@@ -412,7 +413,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             List<string> updatedFiles = [];
             foreach (string optionListId in optionListIds)
             {
-                List<Option> options = await _optionsService.GetOptionsList(org, app, developer, optionListId);
+                List<Option<IOptionValue>> options = await _optionsService.GetOptionsList(org, app, developer, optionListId);
                 bool hasMutated = false;
                 foreach (TextIdMutation mutation in keyMutations)
                 {
@@ -428,7 +429,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             return updatedFiles;
         }
 
-        private static bool UpdateOptionListKeys(List<Option> options, TextIdMutation keyMutation)
+        private static bool UpdateOptionListKeys(List<Option<IOptionValue>> options, TextIdMutation keyMutation)
         {
             if (!keyMutation.NewId.HasValue)
             {
@@ -436,7 +437,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             }
 
             bool mutated = false;
-            foreach (Option option in options)
+            foreach (Option<IOptionValue> option in options)
             {
                 if (option.Label == keyMutation.OldId)
                 {

--- a/backend/src/Designer/Services/Interfaces/IOptionsService.cs
+++ b/backend/src/Designer/Services/Interfaces/IOptionsService.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Models.Interfaces;
 using Microsoft.AspNetCore.Http;
 
 namespace Altinn.Studio.Designer.Services.Interfaces;
@@ -29,7 +30,7 @@ public interface IOptionsService
     /// <param name="optionsListId">Name of the options list to fetch</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
     /// <returns>The options list</returns>
-    public Task<List<Option>> GetOptionsList(string org, string repo, string developer, string optionsListId, CancellationToken cancellationToken = default);
+    public Task<List<Option<IOptionValue>>> GetOptionsList(string org, string repo, string developer, string optionsListId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Creates a new options list in the app repository.
@@ -41,7 +42,7 @@ public interface IOptionsService
     /// <param name="optionsListId">Name of the new options list</param>
     /// <param name="payload">The options list contents</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    public Task<List<Option>> CreateOrOverwriteOptionsList(string org, string repo, string developer, string optionsListId, List<Option> payload, CancellationToken cancellationToken = default);
+    public Task<List<Option<IOptionValue>>> CreateOrOverwriteOptionsList(string org, string repo, string developer, string optionsListId, List<Option<IOptionValue>> payload, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds a new option to the option list.
@@ -53,7 +54,7 @@ public interface IOptionsService
     /// <param name="optionsListId">Name of the new options list</param>
     /// <param name="payload">The options list contents</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    public Task<List<Option>> UploadNewOption(string org, string repo, string developer, string optionsListId, IFormFile payload, CancellationToken cancellationToken = default);
+    public Task<List<Option<IOptionValue>>> UploadNewOption(string org, string repo, string developer, string optionsListId, IFormFile payload, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes an options list from the app repository.

--- a/backend/tests/Designer.Tests/Controllers/ApiTests/ApiTestsBase.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApiTests/ApiTestsBase.cs
@@ -5,8 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
-using Designer.Tests.Fixtures;
-using DotNet.Testcontainers.Builders;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;

--- a/backend/tests/Designer.Tests/Controllers/OptionsController/GetOptionsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OptionsController/GetOptionsTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Models.Interfaces;
 using Designer.Tests.Controllers.ApiTests;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -67,17 +68,19 @@ public class GetOptionsTests : DesignerEndpointsTestsBase<GetOptionsTests>, ICla
         // Act
         using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
         string responseBody = await response.Content.ReadAsStringAsync();
-        var responseList = JsonSerializer.Deserialize<List<Option>>(responseBody);
+        var responseList = JsonSerializer.Deserialize<List<Option<IOptionValue>>>(responseBody);
 
         // Assert
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
         Assert.Equal(2, responseList.Count);
 
-        Assert.Equal("label1", responseList[0].Label);
-        Assert.Equal("value1", responseList[0].Value);
+        var stringOptionValue1 = responseList[0]?.Value as StringOptionValue;
+        Assert.NotNull(stringOptionValue1);
+        Assert.Equal("value1", stringOptionValue1.Value);
 
-        Assert.Equal("label2", responseList[1].Label);
-        Assert.Equal("value2", responseList[1].Value);
+        var stringOptionValue2 = responseList[1]?.Value as StringOptionValue;
+        Assert.NotNull(stringOptionValue2);
+        Assert.Equal("value2", stringOptionValue2.Value);
     }
 
     [Fact]

--- a/backend/tests/Designer.Tests/Controllers/OptionsController/UpdateOptionsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OptionsController/UpdateOptionsTests.cs
@@ -4,8 +4,10 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Models.Interfaces;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
@@ -31,17 +33,22 @@ public class UpdateOptionsTests : DesignerEndpointsTestsBase<UpdateOptionsTests>
         string targetRepository = TestDataHelper.GenerateTestRepoName();
         await CopyRepositoryForTest(Org, repo, Developer, targetRepository);
 
-        var newOptionsList = new List<Option>
+        var newOptionsList = new List<Option<IOptionValue>>
         {
-            new Option
+            new()
             {
                 Label = "label1",
-                Value = "value1",
+                Value = new StringOptionValue("value1"),
             },
-            new Option
+            new ()
             {
                 Label = "label2",
-                Value = "value2",
+                Value = new BoolOptionValue(false),
+            },
+            new ()
+            {
+                Label = "label3",
+                Value = new DoubleOptionValue(3.1415),
             }
         };
 
@@ -52,7 +59,7 @@ public class UpdateOptionsTests : DesignerEndpointsTestsBase<UpdateOptionsTests>
         // Act
         using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
         string responseBody = await response.Content.ReadAsStringAsync();
-        var responseList = JsonSerializer.Deserialize<List<Option>>(responseBody);
+        var responseList = JsonSerializer.Deserialize<List<Option<IOptionValue>>>(responseBody);
 
         // Assert
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
@@ -77,18 +84,23 @@ public class UpdateOptionsTests : DesignerEndpointsTestsBase<UpdateOptionsTests>
         string targetRepository = TestDataHelper.GenerateTestRepoName();
         await CopyRepositoryForTest(Org, repo, Developer, targetRepository);
 
-        var newOptionsList = new List<Option>
+        var newOptionsList = new List<Option<IOptionValue>>
         {
-            new Option
+            new ()
             {
                 Label = "aNewLabelThatDidNotExistBefore",
-                Value = "aNewValueThatDidNotExistBefore",
+                Value = new StringOptionValue("aNewValueThatDidNotExistBefore"),
             },
-            new Option
+            new ()
             {
                 Label = "label2",
-                Value = "value2",
-            }
+                Value = new BoolOptionValue(false),
+            },
+            new ()
+            {
+            Label = "label3",
+            Value = new DoubleOptionValue(3.1415),
+        }
         };
 
         string apiUrl = $"/designer/api/{Org}/{targetRepository}/options/{optionsListId}";
@@ -98,7 +110,7 @@ public class UpdateOptionsTests : DesignerEndpointsTestsBase<UpdateOptionsTests>
         // Act
         using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
         string responseBody = await response.Content.ReadAsStringAsync();
-        var responseList = JsonSerializer.Deserialize<List<Option>>(responseBody);
+        var responseList = JsonSerializer.Deserialize<List<Option<IOptionValue>>>(responseBody);
 
         // Assert
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
@@ -127,24 +139,24 @@ public class UpdateOptionsTests : DesignerEndpointsTestsBase<UpdateOptionsTests>
 
         if (optionsListId == "options-missing-label")
         {
-            var invalidOptionsList = new List<Option>
+            var invalidOptionsList = new List<Option<IOptionValue>>
             {
-                new Option
+                new()
                 {
                     // Missing Label
-                    Value = "value1",
+                    Value = new StringOptionValue("value1"),
                 },
-                new Option
+                new ()
                 {
                     Label = "label2",
-                    Value = "value2",
+                    Value = new StringOptionValue("value2"),
                 }
             };
             httpRequestMessage.Content = JsonContent.Create(invalidOptionsList);
         }
         else if (optionsListId == "options-empty-json")
         {
-            httpRequestMessage.Content = JsonContent.Create<List<Option>>(null);
+            httpRequestMessage.Content = JsonContent.Create<List<Option<IOptionValue>>>(null);
         }
 
         // Act

--- a/backend/tests/Designer.Tests/Infrastructure/GitRepository/AltinnAppGitRepositoryTests.cs
+++ b/backend/tests/Designer.Tests/Infrastructure/GitRepository/AltinnAppGitRepositoryTests.cs
@@ -8,6 +8,7 @@ using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.App;
+using Altinn.Studio.Designer.Models.Interfaces;
 using Designer.Tests.Utils;
 using FluentAssertions;
 using Xunit;
@@ -319,17 +320,17 @@ namespace Designer.Tests.Infrastructure.GitRepository
             await TestDataHelper.CopyRepositoryForTest(org, repository, developer, targetRepository);
             AltinnAppGitRepository altinnAppGitRepository = PrepareRepositoryForTest(org, targetRepository, developer);
 
-            var newOptionsList = new List<Option>
+            var newOptionsList = new List<Option<IOptionValue>>
             {
-                new Option
+                new ()
                 {
                     Label = "label1",
-                    Value = "value1",
+                    Value = new StringOptionValue("value1"),
                 },
-                new Option
+                new ()
                 {
                     Label = "label2",
-                    Value = "value2",
+                    Value = new StringOptionValue("value2"),
                 }
             };
             var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
@@ -355,17 +356,17 @@ namespace Designer.Tests.Infrastructure.GitRepository
             await TestDataHelper.CopyRepositoryForTest(org, repository, developer, targetRepository);
             AltinnAppGitRepository altinnAppGitRepository = PrepareRepositoryForTest(org, targetRepository, developer);
 
-            var newOptionsList = new List<Option>
+            var newOptionsList = new List<Option<IOptionValue>>
             {
-                new Option
+                new ()
                 {
                     Label = "label1",
-                    Value = "newValue1",
+                    Value = new StringOptionValue("newValue1"),
                 },
-                new Option
+                new ()
                 {
                     Label = "label2",
-                    Value = "newValue2",
+                    Value = new StringOptionValue("newValue2"),
                 }
             };
             var jsonOptions = new JsonSerializerOptions { WriteIndented = true };

--- a/backend/tests/Designer.Tests/Services/OptionsServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/OptionsServiceTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Factories;
 using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Models.Interfaces;
 using Altinn.Studio.Designer.Services.Implementation;
 using Designer.Tests.Utils;
 using LibGit2Sharp;
@@ -51,17 +52,17 @@ public class OptionsServiceTests
     {
         // Arrange
         // This  options list matches the options in 'app-with-options'
-        var expectedOptions = new List<Option>
+        var expectedOptions = new List<Option<IOptionValue>>
         {
-            new Option
+            new ()
             {
                 Label = "label1",
-                Value = "value1",
+                Value = new StringOptionValue("value1"),
             },
-            new Option
+            new ()
             {
                 Label = "label2",
-                Value = "value2",
+                Value = new StringOptionValue("value2"),
             }
         };
 
@@ -106,17 +107,17 @@ public class OptionsServiceTests
     public async Task CreateOrOverwriteOptionsList_ShouldReturnUpdatedOptionsList_WhenOptionsListDoesNotAlreadyExist()
     {
         // Arrange
-        var newOptions = new List<Option>
+        var newOptions = new List<Option<IOptionValue>>
         {
-            new Option
+            new ()
             {
                 Label = "label1",
-                Value = "value1",
+                Value = new StringOptionValue("value1"),
             },
-            new Option
+            new ()
             {
                 Label = "label2",
-                Value = "value2",
+                Value = new StringOptionValue("value2"),
             }
         };
 
@@ -145,17 +146,17 @@ public class OptionsServiceTests
     public async Task CreateOrOverwriteOptionsList_ShouldReturnUpdatedOptionsList_WhenOptionsAlreadyExist()
     {
         // Arrange
-        var newOptions = new List<Option>
+        var newOptions = new List<Option<IOptionValue>>
         {
-            new Option
+            new ()
             {
                 Label = "someNewOption",
-                Value = "someNewValue",
+                Value = new StringOptionValue("someNewValue"),
             },
-            new Option
+            new ()
             {
                 Label = "label2",
-                Value = "value2",
+                Value = new StringOptionValue("value2"),
             }
         };
 


### PR DESCRIPTION
## Description

Add IOptionValue type to Option class for handling string, double and bool for the value field in the Option class. This must be added in order for the backend to handle uploads and updates of option-files that have values that are not only strings, but also numbers and boolean.

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

