### PR TITLE
docs: Fix preview of StudioProperty component

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioProperty/StudioProperties.mdx
+++ b/frontend/libs/studio-components/src/components/StudioProperty/StudioProperties.mdx
@@ -1,15 +1,44 @@
 import { Canvas, Meta } from '@storybook/blocks';
-import { Heading, Paragraph } from '@digdir/designsystemet-react';
 import * as StudioPropertyStories from './StudioProperty.stories';
+import { StudioHeading } from '../StudioHeading';
+import { StudioParagraph } from '../StudioParagraph';
+import { StudioList } from '../StudioList';
+import { PlusCircleIcon } from '@studio/icons';
 
 <Meta of={StudioPropertyStories} />
 
-<Heading level={1} size='small'>
+<StudioHeading level={1} size='small'>
   StudioProperty
-</Heading>
-<Paragraph>
-  StudioProperty is a composed component designed to presentation of related data elements, by
-  providing group, fieldset, and individual editable properties.
-</Paragraph>
+</StudioHeading>
+<StudioParagraph>
+  StudioProperty is a composed component designed to present configurable content. It may be used to
+  let the user view and edit complex data structures.
+</StudioParagraph>
+<StudioParagraph>
+  It provides the following elements:
+  <StudioList.Root>
+    <StudioList.Unordered>
+      <StudioList.Item>
+        `StudioProperty.Group`: Groups the list of `Fieldset` and `Button` components together,
+        providing proper spacing between the components.
+      </StudioList.Item>
+      <StudioList.Item>
+        `StudioProperty.Fieldset`: Editable state of a property. Its children should be form
+        elements to set up the given property. It may also contain a nested `StudioProperty.Group`
+        component.
+      </StudioList.Item>
+      <StudioList.Item>
+        `StudioProperty.Button`: A button element to represent a given property. When no value is
+        given, it defaults to only show the property name with a <PlusCircleIcon /> icon.
+      </StudioList.Item>
+    </StudioList.Unordered>
+  </StudioList.Root>
+</StudioParagraph>
+<StudioParagraph>
+  The `StudioProperty.Fieldset` and `StudioProperty.Button` are designed to switch between each
+  other, but this switching must be implemented by the consumer. The button should switch to a
+  fieldset when clicked, while the fieldset should contain a button in its `menubar` prop to switch
+  back to a button.
+</StudioParagraph>
 
 <Canvas of={StudioPropertyStories.Preview} />

--- a/frontend/libs/studio-components/src/components/StudioProperty/StudioProperty.stories.tsx
+++ b/frontend/libs/studio-components/src/components/StudioProperty/StudioProperty.stories.tsx
@@ -1,52 +1,24 @@
-import type { ChangeEvent } from 'react';
-import React, { useEffect } from 'react';
+import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
-import { StudioProperty } from './index';
-import { ObjectUtils } from '@studio/pure-functions';
-import { StudioTextfield } from '../StudioTextfield';
-import { StudioButton } from '../StudioButton';
-import { XMarkIcon } from '@studio/icons';
+import { ComposedComponent } from './test-data/ComposedComponent';
+import { buttons } from './test-data/buttons';
+import { Decorator } from './storybook-utils/Decorator';
 
 const meta: Meta = {
   title: 'Components/StudioProperty',
-  component: ComposedPreviewComponent,
+  component: ComposedComponent,
   decorators: [
     (Story) => (
-      <div style={{ width: 500, border: '1px solid #000', padding: 'var(--fds-spacing-5) 0' }}>
+      <Decorator>
         <Story />
-      </div>
+      </Decorator>
     ),
   ],
 };
 
-export const Preview: PreviewStory = (args): React.ReactElement => (
-  <ComposedPreviewComponent {...args} />
-);
+export const Preview: PreviewStory = (args): React.ReactElement => <ComposedComponent {...args} />;
 
-Preview.args = {
-  buttons: [
-    {
-      property: 'Home',
-      value: 'Sweet Home 41, 0000 No Where',
-    },
-    {
-      property: 'Cabin',
-      value: 'Mountain Street, 99999 Snow Place',
-    },
-    {
-      property: 'Work',
-      value: 'Workstation 1, 12345 Office Town',
-    },
-    {
-      property: 'School',
-      value: '',
-    },
-    {
-      property: 'Kindergarten',
-      value: '',
-    },
-  ],
-};
+Preview.args = { buttons };
 
 type PreviewProps = {
   buttons: PreviewButtonProps[];
@@ -58,101 +30,5 @@ type PreviewButtonProps = {
 };
 
 type PreviewStory = StoryFn<PreviewProps>;
-
-function ComposedPreviewComponent({ buttons: givenButtons }: PreviewProps) {
-  const [buttons, setButtons] = React.useState(givenButtons);
-
-  useEffect(() => {
-    setButtons(givenButtons);
-  }, [givenButtons]);
-
-  const handleButtonChange = (index: number) => (value: string) => {
-    setButtons(updateButtonValue(buttons, index, value));
-  };
-
-  return (
-    <StudioProperty.Group>
-      {buttons.map((buttonProps, index) => (
-        <PreviewProperty
-          key={buttonProps.property}
-          onChange={handleButtonChange(index)}
-          property={buttonProps.property}
-          value={buttonProps.value}
-        />
-      ))}
-    </StudioProperty.Group>
-  );
-}
-
-function updateButtonValue(
-  buttons: PreviewButtonProps[],
-  index: number,
-  value: string,
-): PreviewButtonProps[] {
-  const newButtons = ObjectUtils.deepCopy<PreviewButtonProps[]>(buttons);
-  newButtons[index].value = value;
-  return newButtons;
-}
-
-type PreviewPropertyProps = PreviewButtonProps & {
-  onChange: (value: string) => void;
-};
-
-function PreviewProperty({ property, value, onChange }: PreviewPropertyProps): React.ReactElement {
-  const [isEditMode, setIsEditMode] = React.useState(false);
-
-  if (isEditMode) {
-    return (
-      <PreviewFieldset
-        property={property}
-        value={value}
-        onChange={onChange}
-        onClose={() => setIsEditMode(false)}
-      />
-    );
-  } else {
-    return (
-      <StudioProperty.Button
-        property={property}
-        value={value}
-        onClick={() => setIsEditMode(true)}
-      />
-    );
-  }
-}
-
-type PreviewFieldsetProps = PreviewPropertyProps & {
-  onClose: () => void;
-};
-
-function PreviewFieldset({
-  property,
-  value,
-  onChange,
-  onClose,
-}: PreviewFieldsetProps): React.ReactElement {
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onChange(event.target.value);
-  };
-
-  return (
-    <StudioProperty.Fieldset
-      legend={property}
-      menubar={<StudioButton icon={<XMarkIcon />} onClick={onClose} variant='secondary' />}
-    >
-      <StudioTextfield
-        autoFocus
-        hideLabel
-        label={property}
-        onChange={handleChange}
-        style={{
-          margin:
-            '0 var(--studio-property-fieldset-spacing) var(--studio-property-fieldset-spacing)',
-        }}
-        value={value}
-      />
-    </StudioProperty.Fieldset>
-  );
-}
 
 export default meta;

--- a/frontend/libs/studio-components/src/components/StudioProperty/StudioProperty.stories.tsx
+++ b/frontend/libs/studio-components/src/components/StudioProperty/StudioProperty.stories.tsx
@@ -1,37 +1,24 @@
-import React from 'react';
+import type { ChangeEvent } from 'react';
+import React, { useEffect } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
-import {
-  StudioProperty,
-  type StudioPropertyButtonProps,
-  type StudioPropertyGroupProps,
-  type StudioPropertyFieldsetProps,
-} from './index';
-import { type StudioPropertyGroup } from './StudioPropertyGroup';
-
-type PreviewProps = {
-  withoutNegativeMargin: StudioPropertyGroupProps['withoutNegativeMargin'];
-  legend: StudioPropertyFieldsetProps['legend'];
-  buttons: StudioPropertyButtonProps[];
-};
-
-type PreviewStory = StoryFn<PreviewProps>;
-
-const ComposedPreviewComponent = ({ withoutNegativeMargin, legend, buttons }: PreviewProps) => {
-  return (
-    <StudioProperty.Group withoutNegativeMargin={withoutNegativeMargin}>
-      <StudioProperty.Fieldset legend={legend}>
-        {buttons.map((button) => (
-          <StudioProperty.Button key={button.property} {...button} />
-        ))}
-      </StudioProperty.Fieldset>
-    </StudioProperty.Group>
-  );
-};
+import { StudioProperty } from './index';
+import { ObjectUtils } from '@studio/pure-functions';
+import { StudioTextfield } from '../StudioTextfield';
+import { StudioButton } from '../StudioButton';
+import { XMarkIcon } from '@studio/icons';
 
 const meta: Meta = {
   title: 'Components/StudioProperty',
   component: ComposedPreviewComponent,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 500, border: '1px solid #000', padding: 'var(--fds-spacing-5) 0' }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
+
 export const Preview: PreviewStory = (args): React.ReactElement => (
   <ComposedPreviewComponent {...args} />
 );
@@ -50,40 +37,122 @@ Preview.args = {
       property: 'Work',
       value: 'Workstation 1, 12345 Office Town',
     },
+    {
+      property: 'School',
+      value: '',
+    },
+    {
+      property: 'Kindergarten',
+      value: '',
+    },
   ],
-  withoutNegativeMargin: false,
-  legend: 'My addresses',
 };
 
-type GroupStory = StoryFn<typeof StudioPropertyGroup>;
-export const Group: GroupStory = (args): React.ReactElement => (
-  <StudioProperty.Group withoutNegativeMargin={args.withoutNegativeMargin}>
-    {args.children}
-  </StudioProperty.Group>
-);
-
-Group.args = {
-  withoutNegativeMargin: false,
-  children: "StudioPropertyGroup's children should be StudioProperty.Fieldset component",
+type PreviewProps = {
+  buttons: PreviewButtonProps[];
 };
 
-type FieldsetStory = StoryFn<StudioPropertyFieldsetProps>;
-export const Fieldset: FieldsetStory = (args): React.ReactElement => (
-  <StudioProperty.Fieldset {...args}>{args.children}</StudioProperty.Fieldset>
-);
-
-Fieldset.args = {
-  legend: 'My addresses',
-  children: 'StudioProperty.Fieldset children should be StudioProperty.Button components',
+type PreviewButtonProps = {
+  property: string;
+  value: string;
 };
 
-type ButtonStory = StoryFn<StudioPropertyButtonProps>;
-export const Button: ButtonStory = (args): React.ReactElement => (
-  <StudioProperty.Button {...args} />
-);
-Button.args = {
-  property: 'Home',
-  value: 'Sweet Home 41, 0000 No Where',
+type PreviewStory = StoryFn<PreviewProps>;
+
+function ComposedPreviewComponent({ buttons: givenButtons }: PreviewProps) {
+  const [buttons, setButtons] = React.useState(givenButtons);
+
+  useEffect(() => {
+    setButtons(givenButtons);
+  }, [givenButtons]);
+
+  const handleButtonChange = (index: number) => (value: string) => {
+    setButtons(updateButtonValue(buttons, index, value));
+  };
+
+  return (
+    <StudioProperty.Group>
+      {buttons.map((buttonProps, index) => (
+        <PreviewProperty
+          key={buttonProps.property}
+          onChange={handleButtonChange(index)}
+          property={buttonProps.property}
+          value={buttonProps.value}
+        />
+      ))}
+    </StudioProperty.Group>
+  );
+}
+
+function updateButtonValue(
+  buttons: PreviewButtonProps[],
+  index: number,
+  value: string,
+): PreviewButtonProps[] {
+  const newButtons = ObjectUtils.deepCopy<PreviewButtonProps[]>(buttons);
+  newButtons[index].value = value;
+  return newButtons;
+}
+
+type PreviewPropertyProps = PreviewButtonProps & {
+  onChange: (value: string) => void;
 };
+
+function PreviewProperty({ property, value, onChange }: PreviewPropertyProps): React.ReactElement {
+  const [isEditMode, setIsEditMode] = React.useState(false);
+
+  if (isEditMode) {
+    return (
+      <PreviewFieldset
+        property={property}
+        value={value}
+        onChange={onChange}
+        onClose={() => setIsEditMode(false)}
+      />
+    );
+  } else {
+    return (
+      <StudioProperty.Button
+        property={property}
+        value={value}
+        onClick={() => setIsEditMode(true)}
+      />
+    );
+  }
+}
+
+type PreviewFieldsetProps = PreviewPropertyProps & {
+  onClose: () => void;
+};
+
+function PreviewFieldset({
+  property,
+  value,
+  onChange,
+  onClose,
+}: PreviewFieldsetProps): React.ReactElement {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <StudioProperty.Fieldset
+      legend={property}
+      menubar={<StudioButton icon={<XMarkIcon />} onClick={onClose} variant='secondary' />}
+    >
+      <StudioTextfield
+        autoFocus
+        hideLabel
+        label={property}
+        onChange={handleChange}
+        style={{
+          margin:
+            '0 var(--studio-property-fieldset-spacing) var(--studio-property-fieldset-spacing)',
+        }}
+        value={value}
+      />
+    </StudioProperty.Fieldset>
+  );
+}
 
 export default meta;

--- a/frontend/libs/studio-components/src/components/StudioProperty/StudioProperty.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioProperty/StudioProperty.test.tsx
@@ -1,0 +1,49 @@
+import type { RenderResult } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import { ComposedComponent } from './test-data/ComposedComponent';
+import React from 'react';
+import { buttons } from './test-data/buttons';
+import { userEvent } from '@storybook/test';
+import type { UserEvent } from '@testing-library/user-event';
+
+describe('StudioProperty composition', () => {
+  it('Renders the buttons', () => {
+    renderComposition();
+    buttons.forEach((button) => {
+      expect(screen.getByRole('button', { name: button.property })).toBeInTheDocument();
+    });
+  });
+
+  it('Renders a fieldset when the user clicks a button', async () => {
+    const user = userEvent.setup();
+    renderComposition();
+    await openFirstProperty(user);
+    expect(screen.getByRole('group', { name: buttons[0].property })).toBeInTheDocument();
+  });
+
+  it('Closes the fieldset when the user clicks the "Close" button', async () => {
+    const user = userEvent.setup();
+    renderComposition();
+    await openFirstProperty(user);
+    await act(() => user.click(screen.getByRole('button', { name: 'Close' })));
+    expect(screen.queryByRole('group', { name: buttons[0].property })).not.toBeInTheDocument();
+  });
+
+  it('Updates the data when the user changes a value', async () => {
+    const user = userEvent.setup();
+    renderComposition();
+    await openFirstProperty(user);
+    const input = screen.getByRole('textbox');
+    const additonalText = 'additional text';
+    await act(() => user.type(input, additonalText));
+    expect(input).toHaveValue(buttons[0].value + additonalText);
+  });
+});
+
+function renderComposition(): RenderResult {
+  return render(<ComposedComponent buttons={buttons} />);
+}
+
+async function openFirstProperty(user: UserEvent): Promise<void> {
+  await act(() => user.click(screen.getByRole('button', { name: buttons[0].property })));
+}

--- a/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyButton/StudioPropertyButton.stories.tsx
+++ b/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyButton/StudioPropertyButton.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { StudioProperty } from '../index';
+
+type Story = StoryFn<typeof StudioProperty.Button>;
+
+const meta: Meta = {
+  title: 'Components/StudioProperty/Button',
+  component: StudioProperty.Button,
+  decorators: [
+    (Story) => (
+      <div style={{ width: '300px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const WithValue: Story = (args): React.ReactElement => <StudioProperty.Button {...args} />;
+
+WithValue.args = {
+  property: 'Contact details',
+  value: 'Navn Navnesen, Gateveien 1, 0000 Oslo, Norway',
+};
+
+export const Empty: Story = (args): React.ReactElement => <StudioProperty.Button {...args} />;
+
+Empty.args = {
+  property: 'Contact details',
+  value: '',
+};
+
+export default meta;

--- a/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyFieldset/StudioPropertyFieldset.stories.tsx
+++ b/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyFieldset/StudioPropertyFieldset.stories.tsx
@@ -1,34 +1,29 @@
 import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 import { StudioProperty } from '../index';
-import { StudioTextarea } from '../../StudioTextarea';
 import { StudioButton } from '../../StudioButton';
 import { TrashIcon, FloppydiskIcon, XMarkIcon } from '@studio/icons';
-import { StudioTextfield } from '../../StudioTextfield';
+import { FieldsetContent } from './test-data/FieldsetContent';
 
 type Story = StoryFn<typeof StudioProperty.Fieldset>;
 
 const meta: Meta = {
   title: 'Components/StudioProperty/Fieldset',
   component: StudioProperty.Fieldset,
+  argTypes: {
+    children: {
+      table: { disable: true },
+    },
+    menubar: {
+      table: { disable: true },
+    },
+  },
 };
 export const Preview: Story = (args): React.ReactElement => <StudioProperty.Fieldset {...args} />;
 
 Preview.args = {
   legend: 'Contact details',
-  children: (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 'var(--studio-property-fieldset-spacing)',
-        margin: '0 var(--studio-property-fieldset-spacing) var(--studio-property-fieldset-spacing)',
-      }}
-    >
-      <StudioTextfield label='Name' />
-      <StudioTextarea label='Address' />
-    </div>
-  ),
+  children: <FieldsetContent />,
   menubar: (
     <>
       <StudioButton variant='secondary' color='success' title='Save' icon={<FloppydiskIcon />} />

--- a/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyFieldset/StudioPropertyFieldset.stories.tsx
+++ b/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyFieldset/StudioPropertyFieldset.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { StudioProperty } from '../index';
+import { StudioTextarea } from '../../StudioTextarea';
+import { StudioButton } from '../../StudioButton';
+import { TrashIcon, FloppydiskIcon, XMarkIcon } from '@studio/icons';
+import { StudioTextfield } from '../../StudioTextfield';
+
+type Story = StoryFn<typeof StudioProperty.Fieldset>;
+
+const meta: Meta = {
+  title: 'Components/StudioProperty/Fieldset',
+  component: StudioProperty.Fieldset,
+};
+export const Preview: Story = (args): React.ReactElement => <StudioProperty.Fieldset {...args} />;
+
+Preview.args = {
+  legend: 'Contact details',
+  children: (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--studio-property-fieldset-spacing)',
+        margin: '0 var(--studio-property-fieldset-spacing) var(--studio-property-fieldset-spacing)',
+      }}
+    >
+      <StudioTextfield label='Name' />
+      <StudioTextarea label='Address' />
+    </div>
+  ),
+  menubar: (
+    <>
+      <StudioButton variant='secondary' color='success' title='Save' icon={<FloppydiskIcon />} />
+      <StudioButton variant='secondary' title='Delete' color='danger' icon={<TrashIcon />} />
+      <StudioButton variant='secondary' title='Cancel' icon={<XMarkIcon />} />
+    </>
+  ),
+};
+export default meta;

--- a/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyFieldset/StudioPropertyFieldset.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyFieldset/StudioPropertyFieldset.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, within } from '@testing-library/react';
 import { StudioPropertyFieldset } from './StudioPropertyFieldset';
 import { testRootClassNameAppending } from '../../../test-utils/testRootClassNameAppending';
 import { testRefForwarding } from '../../../test-utils/testRefForwarding';
+import { FieldsetContent } from './test-data/FieldsetContent';
 
 jest.mock('./StudioPropertyFieldset.module.css', () => ({
   propertyFieldset: 'propertyFieldset',
@@ -43,6 +44,16 @@ describe('StudioPropertyFieldset', () => {
   it('Renders a compact fieldset when the compact prop is true', () => {
     render(<StudioPropertyFieldset legend='Test' compact />);
     expect(getGroup()).toHaveClass('compact');
+  });
+
+  it('Renders children', () => {
+    render(
+      <StudioPropertyFieldset legend='Test'>
+        <FieldsetContent />
+      </StudioPropertyFieldset>,
+    );
+    expect(within(getGroup()).getByRole('textbox', { name: 'Name' })).toBeInTheDocument();
+    expect(within(getGroup()).getByRole('textbox', { name: 'Address' })).toBeInTheDocument();
   });
 });
 

--- a/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyFieldset/test-data/FieldsetContent/FieldsetContent.module.css
+++ b/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyFieldset/test-data/FieldsetContent/FieldsetContent.module.css
@@ -1,0 +1,6 @@
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--studio-property-fieldset-spacing);
+  margin: 0 var(--studio-property-fieldset-spacing) var(--studio-property-fieldset-spacing);
+}

--- a/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyFieldset/test-data/FieldsetContent/FieldsetContent.tsx
+++ b/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyFieldset/test-data/FieldsetContent/FieldsetContent.tsx
@@ -1,0 +1,13 @@
+import { StudioTextfield } from '../../../../StudioTextfield';
+import { StudioTextarea } from '../../../../StudioTextarea';
+import React from 'react';
+import classes from './FieldsetContent.module.css';
+
+export function FieldsetContent() {
+  return (
+    <div className={classes.fields}>
+      <StudioTextfield label='Name' />
+      <StudioTextarea label='Address' />
+    </div>
+  );
+}

--- a/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyFieldset/test-data/FieldsetContent/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyFieldset/test-data/FieldsetContent/index.ts
@@ -1,0 +1,1 @@
+export * from './FieldsetContent';

--- a/frontend/libs/studio-components/src/components/StudioProperty/storybook-utils/Decorator/Decorator.module.css
+++ b/frontend/libs/studio-components/src/components/StudioProperty/storybook-utils/Decorator/Decorator.module.css
@@ -1,0 +1,5 @@
+.decorator {
+  border: 1px solid #000;
+  padding: var(--fds-spacing-5) 0;
+  width: 500px;
+}

--- a/frontend/libs/studio-components/src/components/StudioProperty/storybook-utils/Decorator/Decorator.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioProperty/storybook-utils/Decorator/Decorator.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { Decorator } from './Decorator';
+import React from 'react';
+
+describe('Decorator', () => {
+  it('Renders content', () => {
+    const content = 'content';
+    render(<Decorator>{content}</Decorator>);
+    expect(screen.getByText(content)).toBeInTheDocument();
+  });
+});

--- a/frontend/libs/studio-components/src/components/StudioProperty/storybook-utils/Decorator/Decorator.tsx
+++ b/frontend/libs/studio-components/src/components/StudioProperty/storybook-utils/Decorator/Decorator.tsx
@@ -1,0 +1,9 @@
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+import classes from './Decorator.module.css';
+
+export type DecoratorProps = PropsWithChildren<{}>;
+
+export function Decorator({ children }: DecoratorProps) {
+  return <div className={classes.decorator}>{children}</div>;
+}

--- a/frontend/libs/studio-components/src/components/StudioProperty/storybook-utils/Decorator/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioProperty/storybook-utils/Decorator/index.ts
@@ -1,0 +1,1 @@
+export * from './Decorator';

--- a/frontend/libs/studio-components/src/components/StudioProperty/test-data/ComposedComponent/ComposedComponent.module.css
+++ b/frontend/libs/studio-components/src/components/StudioProperty/test-data/ComposedComponent/ComposedComponent.module.css
@@ -1,0 +1,3 @@
+.textfield {
+  margin: 0 var(--studio-property-fieldset-spacing) var(--studio-property-fieldset-spacing);
+}

--- a/frontend/libs/studio-components/src/components/StudioProperty/test-data/ComposedComponent/ComposedComponent.tsx
+++ b/frontend/libs/studio-components/src/components/StudioProperty/test-data/ComposedComponent/ComposedComponent.tsx
@@ -1,0 +1,111 @@
+import React, { type ChangeEvent, useEffect } from 'react';
+import { StudioProperty } from '../../';
+import { StudioButton } from '../../../StudioButton';
+import { XMarkIcon } from '../../../../../../studio-icons';
+import { StudioTextfield } from '../../../StudioTextfield';
+import { ObjectUtils } from '@studio/pure-functions';
+import classes from './ComposedComponent.module.css';
+
+export type ComposedComponentProps = {
+  buttons: ComposedComponentButtonProps[];
+};
+
+export type ComposedComponentButtonProps = {
+  property: string;
+  value: string;
+};
+
+export function ComposedComponent({ buttons: givenButtons }: ComposedComponentProps) {
+  const [buttons, setButtons] = React.useState(givenButtons);
+
+  useEffect(() => {
+    setButtons(givenButtons);
+  }, [givenButtons]);
+
+  const handleButtonChange = (index: number) => (value: string) => {
+    setButtons(updateButtonValue(buttons, index, value));
+  };
+
+  return (
+    <StudioProperty.Group>
+      {buttons.map((buttonProps, index) => (
+        <PreviewProperty
+          key={buttonProps.property}
+          onChange={handleButtonChange(index)}
+          property={buttonProps.property}
+          value={buttonProps.value}
+        />
+      ))}
+    </StudioProperty.Group>
+  );
+}
+
+function updateButtonValue(
+  buttons: ComposedComponentButtonProps[],
+  index: number,
+  value: string,
+): ComposedComponentButtonProps[] {
+  const newButtons = ObjectUtils.deepCopy<ComposedComponentButtonProps[]>(buttons);
+  newButtons[index].value = value;
+  return newButtons;
+}
+
+type PreviewPropertyProps = ComposedComponentButtonProps & {
+  onChange: (value: string) => void;
+};
+
+function PreviewProperty({ property, value, onChange }: PreviewPropertyProps): React.ReactElement {
+  const [isEditMode, setIsEditMode] = React.useState(false);
+
+  if (isEditMode) {
+    return (
+      <PreviewFieldset
+        property={property}
+        value={value}
+        onChange={onChange}
+        onClose={() => setIsEditMode(false)}
+      />
+    );
+  } else {
+    return (
+      <StudioProperty.Button
+        property={property}
+        value={value}
+        onClick={() => setIsEditMode(true)}
+      />
+    );
+  }
+}
+
+type PreviewFieldsetProps = PreviewPropertyProps & {
+  onClose: () => void;
+};
+
+function PreviewFieldset({
+  property,
+  value,
+  onChange,
+  onClose,
+}: PreviewFieldsetProps): React.ReactElement {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <StudioProperty.Fieldset
+      legend={property}
+      menubar={
+        <StudioButton icon={<XMarkIcon />} onClick={onClose} variant='secondary' title='Close' />
+      }
+    >
+      <StudioTextfield
+        autoFocus
+        className={classes.textfield}
+        hideLabel
+        label={property}
+        onChange={handleChange}
+        value={value}
+      />
+    </StudioProperty.Fieldset>
+  );
+}

--- a/frontend/libs/studio-components/src/components/StudioProperty/test-data/ComposedComponent/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioProperty/test-data/ComposedComponent/index.ts
@@ -1,0 +1,1 @@
+export * from './ComposedComponent';

--- a/frontend/libs/studio-components/src/components/StudioProperty/test-data/buttons.ts
+++ b/frontend/libs/studio-components/src/components/StudioProperty/test-data/buttons.ts
@@ -1,0 +1,24 @@
+import type { ComposedComponentButtonProps } from './ComposedComponent';
+
+export const buttons: ComposedComponentButtonProps[] = [
+  {
+    property: 'Home',
+    value: 'Sweet Home 41, 0000 No Where',
+  },
+  {
+    property: 'Cabin',
+    value: 'Mountain Street, 99999 Snow Place',
+  },
+  {
+    property: 'Work',
+    value: 'Workstation 1, 12345 Office Town',
+  },
+  {
+    property: 'School',
+    value: '',
+  },
+  {
+    property: 'Kindergarten',
+    value: '',
+  },
+];


### PR DESCRIPTION
## Description
The documentation about `StudioProperty` in Storybook is deficient and not quite correct. This pull request improves the examples with proper usage of the components. I have also improved the description of the components, so that it becomes more clear how they should be used. Since this is a component with quite specific use cases, we should keep the MDX file.


https://github.com/user-attachments/assets/617b003b-7fb2-48af-b9f3-4520b503e11e

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
