### PR TITLE
feat: xsd:all support

### DIFF
--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -182,7 +182,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             else
             {
                 elementOrder += 1;
-                classBuilder.AppendLine(Indent(2) + "[XmlElement(\"" + element.XName + "\", Order = " + elementOrder + ")]");
+                AddXmlElementAnnotation(element, classBuilder, elementOrder);
 
                 // Temporary fix - as long as we use System.Text.Json for serialization and  Newtonsoft.Json for
                 // deserialization, we need both JsonProperty and JsonPropertyName annotations.
@@ -223,7 +223,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             var nullableReference = useNullableReferenceTypes ? "?" : string.Empty;
             WriteRestrictionAnnotations(classBuilder, element);
             elementOrder += 1;
-            classBuilder.AppendLine(Indent(2) + "[XmlElement(\"" + element.XName + "\", Order = " + elementOrder + ")]");
+            AddXmlElementAnnotation(element, classBuilder, elementOrder);
 
             // Temporary fix - as long as we use System.Text.Json for serialization and  Newtonsoft.Json for
             // deserialization, we need both JsonProperty and JsonPropertyName annotations.
@@ -262,6 +262,18 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             if (!primitiveType)
             {
                 referredTypes.Add(element);
+            }
+        }
+
+        private void AddXmlElementAnnotation(ElementMetadata element, StringBuilder classBuilder, int elementOrder)
+        {
+            if (element.OrderOblivious)
+            {
+                classBuilder.AppendLine($"""{Indent(2)}[XmlElement("{element.XName}")]""");
+            }
+            else
+            {
+                classBuilder.AppendLine($"""{Indent(2)}[XmlElement("{element.XName}", Order = {elementOrder})]""");
             }
         }
 

--- a/backend/src/DataModeling/Converter/Metadata/JsonSchemaToMetamodelConverter.cs
+++ b/backend/src/DataModeling/Converter/Metadata/JsonSchemaToMetamodelConverter.cs
@@ -274,7 +274,7 @@ namespace Altinn.Studio.DataModeling.Converter.Metadata
         {
             foreach (var (name, property) in keyword.Properties)
             {
-                var currentContext = new SchemaContext() { Id = CombineId(context.Id, name), Name = name, ParentId = context.Id, XPath = CombineXPath(context.XPath, context.Name), OrderOblivious = context.OrderOblivious};
+                var currentContext = new SchemaContext() { Id = CombineId(context.Id, name), Name = name, ParentId = context.Id, XPath = CombineXPath(context.XPath, context.Name), OrderOblivious = context.OrderOblivious };
                 var subSchemaPath = path.Combine(JsonPointer.Parse($"/{name}"));
 
                 if (property.TryGetKeyword(out XsdTextKeyword xsdTextKeyword))

--- a/backend/src/DataModeling/Converter/Metadata/JsonSchemaToMetamodelConverter.cs
+++ b/backend/src/DataModeling/Converter/Metadata/JsonSchemaToMetamodelConverter.cs
@@ -36,6 +36,9 @@ namespace Altinn.Studio.DataModeling.Converter.Metadata
 
             public bool XmlText { get; set; }
 
+
+            public bool OrderOblivious { get; set; } = false;
+
             public Dictionary<string, Restriction> Restrictions { get; set; } = new();
         }
 
@@ -185,6 +188,10 @@ namespace Altinn.Studio.DataModeling.Converter.Metadata
                     ProcessPropertiesKeyword(path, k, context);
                     break;
 
+                case XsdStructureKeyword { Value: "all" }:
+                    context.OrderOblivious = true;
+                    break;
+
                 default:
                     throw new MetamodelConvertException($"Keyword {keyword.Keyword()} not processed!. It's not supported in the current version of the JsonSchemaToMetamodelConverter.");
             }
@@ -267,7 +274,7 @@ namespace Altinn.Studio.DataModeling.Converter.Metadata
         {
             foreach (var (name, property) in keyword.Properties)
             {
-                var currentContext = new SchemaContext() { Id = CombineId(context.Id, name), Name = name, ParentId = context.Id, XPath = CombineXPath(context.XPath, context.Name) };
+                var currentContext = new SchemaContext() { Id = CombineId(context.Id, name), Name = name, ParentId = context.Id, XPath = CombineXPath(context.XPath, context.Name), OrderOblivious = context.OrderOblivious};
                 var subSchemaPath = path.Combine(JsonPointer.Parse($"/{name}"));
 
                 if (property.TryGetKeyword(out XsdTextKeyword xsdTextKeyword))
@@ -364,7 +371,7 @@ namespace Altinn.Studio.DataModeling.Converter.Metadata
             {
                 ProcessRegularType(path, subSchema, context);
 
-                foreach (var keyword in subSchema.Keywords)
+                foreach (var keyword in subSchema.Keywords.OrderByPriority())
                 {
                     var keywordPath = path.Combine(JsonPointer.Parse($"/{keyword.Keyword()}"));
 
@@ -478,7 +485,8 @@ namespace Altinn.Studio.DataModeling.Converter.Metadata
                     DataBindingName = GetDataBindingName(ElementType.Group, maxOccurs, id, null, xPath),
                     DisplayString = GetDisplayString(id, typeName, minOccurs, maxOccurs),
                     IsTagContent = context.XmlText,
-                    Nillable = context.IsNillable
+                    Nillable = context.IsNillable,
+                    OrderOblivious = context.OrderOblivious
                 });
         }
 
@@ -534,7 +542,8 @@ namespace Altinn.Studio.DataModeling.Converter.Metadata
                     DataBindingName = GetDataBindingName(@type, maxOccurs, id, fixedValue, xPath),
                     DisplayString = GetDisplayString(id, context.SchemaValueType.ToString(), minOccurs, maxOccurs),
                     IsTagContent = context.XmlText,
-                    Nillable = context.IsNillable
+                    Nillable = context.IsNillable,
+                    OrderOblivious = context.OrderOblivious
                 });
         }
 

--- a/backend/src/DataModeling/Metamodel/ElementMetadata.cs
+++ b/backend/src/DataModeling/Metamodel/ElementMetadata.cs
@@ -170,6 +170,8 @@ namespace Altinn.Studio.DataModeling.Metamodel
         [JsonPropertyName("nillable")]
         public bool? Nillable { get; set; }
 
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         [JsonProperty(PropertyName = "orderOblivious")]
         [JsonPropertyName("orderOblivious")]
         public bool OrderOblivious { get; set; } = false;

--- a/backend/src/DataModeling/Metamodel/ElementMetadata.cs
+++ b/backend/src/DataModeling/Metamodel/ElementMetadata.cs
@@ -169,5 +169,7 @@ namespace Altinn.Studio.DataModeling.Metamodel
         [JsonProperty(PropertyName = "nillable")]
         [JsonPropertyName("nillable")]
         public bool? Nillable { get; set; }
+
+        public bool OrderOblivious { get; set; } = false;
     }
 }

--- a/backend/src/DataModeling/Metamodel/ElementMetadata.cs
+++ b/backend/src/DataModeling/Metamodel/ElementMetadata.cs
@@ -170,6 +170,8 @@ namespace Altinn.Studio.DataModeling.Metamodel
         [JsonPropertyName("nillable")]
         public bool? Nillable { get; set; }
 
+        [JsonProperty(PropertyName = "orderOblivious")]
+        [JsonPropertyName("orderOblivious")]
         public bool OrderOblivious { get; set; } = false;
     }
 }

--- a/backend/src/DataModeling/Utils/JsonSchemaExtensions.cs
+++ b/backend/src/DataModeling/Utils/JsonSchemaExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Altinn.Studio.DataModeling.Json.Keywords;
 using Json.Schema;
 
 namespace Altinn.Studio.DataModeling.Utils
@@ -184,6 +185,17 @@ namespace Altinn.Studio.DataModeling.Utils
             }
 
             return builder;
+        }
+
+        /// <summary>
+        /// Orders the keywords by priority.
+        /// Currently the only keyword that should be prioritized is <see cref="XsdStructureKeyword"/>.
+        /// </summary>
+        /// <param name="keywords"></param>
+        /// <returns></returns>
+        public static IEnumerable<IJsonSchemaKeyword> OrderByPriority(this IEnumerable<IJsonSchemaKeyword> keywords)
+        {
+            return keywords.OrderBy(item => item.GetType() != typeof(XsdStructureKeyword));
         }
     }
 }

--- a/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
+++ b/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
@@ -25,11 +25,8 @@ namespace DataModeling.Tests
         public void Convert_FromXsd_Should_EqualExpected(string xsdSchemaPath, string expectedCsharpClassPath)
         {
             Given.That.XsdSchemaLoaded(xsdSchemaPath)
-                .When.LoadedXsdSchemaConvertedToJsonSchema();
-
-            var jsonschema = SerializeJsonSchema(ConvertedJsonSchema);
-
-                And.ConvertedJsonSchemaConvertedToModelMetadata()
+                .When.LoadedXsdSchemaConvertedToJsonSchema()
+                .And.ConvertedJsonSchemaConvertedToModelMetadata()
                 .And.ModelMetadataConvertedToCsharpClass()
                 .And.CSharpClassesCompiledToAssembly()
                 .Then

--- a/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
+++ b/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
@@ -1,11 +1,9 @@
-﻿using System.IO;
-using System.Linq;
+﻿using System.Linq;
 using System.Xml.Serialization;
 using Altinn.Studio.DataModeling.Converter.Csharp;
 using DataModeling.Tests.Assertions;
 using DataModeling.Tests.BaseClasses;
 using DataModeling.Tests.TestDataClasses;
-using Designer.Tests.Factories.ModelFactory.DataClasses;
 using FluentAssertions;
 using SharedResources.Tests;
 using Xunit;
@@ -27,8 +25,11 @@ namespace DataModeling.Tests
         public void Convert_FromXsd_Should_EqualExpected(string xsdSchemaPath, string expectedCsharpClassPath)
         {
             Given.That.XsdSchemaLoaded(xsdSchemaPath)
-                .When.LoadedXsdSchemaConvertedToJsonSchema()
-                .And.ConvertedJsonSchemaConvertedToModelMetadata()
+                .When.LoadedXsdSchemaConvertedToJsonSchema();
+
+            var jsonschema = SerializeJsonSchema(ConvertedJsonSchema);
+
+                And.ConvertedJsonSchemaConvertedToModelMetadata()
                 .And.ModelMetadataConvertedToCsharpClass()
                 .And.CSharpClassesCompiledToAssembly()
                 .Then

--- a/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
+++ b/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
@@ -9,36 +9,36 @@ public class CSharpE2ERestrictionsTestData : IEnumerable<object[]>
 {
     public IEnumerator<object[]> GetEnumerator()
     {
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t1", "string", "[MinLength(5)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t1", "string", "[MaxLength(20)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t2", "string", "[MinLength(10)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t2", "string", "[MaxLength(10)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t4", "string", @"[RegularExpression(@""^\d\.\d\.\d$"")]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "n1", "decimal?", @"[RegularExpression(@""^-?(([0-9]){1}(\.)?){0,10}$"")]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "n1", "decimal?", "[Range(-100d, 100d)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "n1", "decimal?", "[Required]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "i1", "int?", @"[RegularExpression(@""^-?[0-9]{0,10}$"")]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "i1", "int?", "[Required]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "i2", "decimal?", @"[RegularExpression(@""^-?[0-9]{0,10}$"")]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "i2", "decimal?", "[Required]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "nonPrimitive", "string", @"[RegularExpression(@""[0-9]+"")]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "nonPrimitive", "string", "[MinLength(5)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "nonPrimitive", "string", "[MaxLength(20)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeWithoutLimits", "int?", "[Range(Int32.MinValue, Int32.MaxValue)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeWithLimits", "int?", "[Range(-100, 100)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeLeftLimit", "int?", "[Range(-100, Int32.MaxValue)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeRightLimit", "int?", "[Range(Int32.MinValue, 100)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeWithoutLimits", "decimal?", "[Range(Double.MinValue, Double.MaxValue)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeWithLimits", "decimal?", "[Range(-100d, 100d)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeLeftLimit", "decimal?", "[Range(-100d, Double.MaxValue)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100d)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeWithoutLimits", "long?", "[Range(Int64.MinValue, Int64.MaxValue)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeWithLimits", "long?", "[Range(-100, 100)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeLeftLimit", "long?", "[Range(-100, Int64.MaxValue)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeRightLimit", "long?", "[Range(Int64.MinValue, 100)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeWithLimits", "decimal?", "[Range(-100.0, 100.0)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeLeftLimit", "decimal?", "[Range(-100.0, Double.MaxValue)]" };
-        yield return new object[] { "Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100.0d)]" };
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t1", "string", "[MinLength(5)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t1", "string", "[MaxLength(20)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t2", "string", "[MinLength(10)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t2", "string", "[MaxLength(10)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t4", "string", @"[RegularExpression(@""^\d\.\d\.\d$"")]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "n1", "decimal?", @"[RegularExpression(@""^-?(([0-9]){1}(\.)?){0,10}$"")]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "n1", "decimal?", "[Range(-100d, 100d)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "n1", "decimal?", "[Required]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "i1", "int?", @"[RegularExpression(@""^-?[0-9]{0,10}$"")]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "i1", "int?", "[Required]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "i2", "decimal?", @"[RegularExpression(@""^-?[0-9]{0,10}$"")]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "i2", "decimal?", "[Required]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "nonPrimitive", "string", @"[RegularExpression(@""[0-9]+"")]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "nonPrimitive", "string", "[MinLength(5)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "nonPrimitive", "string", "[MaxLength(20)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeWithoutLimits", "int?", "[Range(Int32.MinValue, Int32.MaxValue)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeWithLimits", "int?", "[Range(-100, 100)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeLeftLimit", "int?", "[Range(-100, Int32.MaxValue)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "intRangeRightLimit", "int?", "[Range(Int32.MinValue, 100)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeWithoutLimits", "decimal?", "[Range(Double.MinValue, Double.MaxValue)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeWithLimits", "decimal?", "[Range(-100d, 100d)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeLeftLimit", "decimal?", "[Range(-100d, Double.MaxValue)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "integerRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100d)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeWithoutLimits", "long?", "[Range(Int64.MinValue, Int64.MaxValue)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeWithLimits", "long?", "[Range(-100, 100)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeLeftLimit", "long?", "[Range(-100, Int64.MaxValue)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "longRangeRightLimit", "long?", "[Range(Int64.MinValue, 100)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeWithLimits", "decimal?", "[Range(-100.0, 100.0)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeLeftLimit", "decimal?", "[Range(-100.0, Double.MaxValue)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "decimalRangeRightLimit", "decimal?", "[Range(Double.MinValue, 100.0d)]"];
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/backend/tests/DataModeling.Tests/TestDataClasses/CSharpEnd2EndTestData.cs
+++ b/backend/tests/DataModeling.Tests/TestDataClasses/CSharpEnd2EndTestData.cs
@@ -2,41 +2,47 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Designer.Tests.Factories.ModelFactory.DataClasses;
+namespace DataModeling.Tests.TestDataClasses;
 
 [ExcludeFromCodeCoverage]
 public class CSharpEnd2EndTestData : IEnumerable<object[]>
 {
     public IEnumerator<object[]> GetEnumerator()
     {
-        yield return new object[] { "Model/XmlSchema/Gitea/nsm-klareringsportalen.xsd", "Model/CSharp/Gitea/nsm-klareringsportalen.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/stami-mu-bestilling-2021.xsd", "Model/CSharp/Gitea/stami-mu-bestilling-2021.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/dat-aarligmelding-bemanning.xsd", "Model/CSharp/Gitea/dat-aarligmelding-bemanning.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/dihe-redusert-foreldrebetaling-bhg.xsd", "Model/CSharp/Gitea/dihe-redusert-foreldrebetaling-bhg.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/hi-algeskjema.xsd", "Model/CSharp/Gitea/hi-algeskjema.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/Kursdomene_APINøkkel_M_2020-05-26_5702_34556_SERES.xsd", "Model/CSharp/Gitea/Kursdomene_APINøkkel_M_2020-05-26_5702_34556_SERES.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/nbib-melding.xsd", "Model/CSharp/Gitea/nbib-melding.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/udir-invitasjon-vfkl.xsd", "Model/CSharp/Gitea/udir-invitasjon-vfkl.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/udir-vfkl.xsd", "Model/CSharp/Gitea/udir-vfkl.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/bokskjema.xsd", "Model/CSharp/Gitea/bokskjema.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/dat-bilpleie-soknad.xsd", "Model/CSharp/Gitea/dat-bilpleie-soknad.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/dat-skjema.xsd", "Model/CSharp/Gitea/dat-skjema.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.xsd", "Model/CSharp/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/Kursdomene_BekrefteBruksvilkår_M_2020-05-25_5704_34554_SERES.xsd", "Model/CSharp/Gitea/Kursdomene_BekrefteBruksvilkår_M_2020-05-25_5704_34554_SERES.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/srf-fufinn-behovskartleggin.xsd", "Model/CSharp/Gitea/srf-fufinn-behovskartleggin.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/srf-melding-til-statsforvalteren.xsd", "Model/CSharp/Gitea/srf-melding-til-statsforvalteren.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/udi-unntak-karantenehotell-velferd.xsd", "Model/CSharp/Gitea/udi-unntak-karantenehotell-velferd.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/skjema.xsd", "Model/CSharp/Gitea/skjema.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/srf-fufinn-behovsendring.xsd", "Model/CSharp/Gitea/srf-fufinn-behovsendring.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/stami-atid-databehandler-2022.xsd", "Model/CSharp/Gitea/stami-atid-databehandler-2022.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/stami-mu-databehandler-2021.xsd", "Model/CSharp/Gitea/stami-mu-databehandler-2021.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/skd-formueinntekt-skattemelding-v2.xsd", "Model/CSharp/Gitea/skd-formueinntekt-skattemelding-v2.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/aal-vedlegg.xsd", "Model/CSharp/Gitea/aal-vedlegg.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/krt-1188a-1.xsd", "Model/CSharp/Gitea/krt-1188a-1.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/3422-39646.xsd", "Model/CSharp/Gitea/3422-39646.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/3430-39615.xsd", "Model/CSharp/Gitea/3430-39615.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.xsd", "Model/CSharp/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.cs" };
-        yield return new object[] { "Model/XmlSchema/Gitea/dev-nill-test.xsd", "Model/CSharp/Gitea/dev-nill-test.cs" };
+        yield return ["Model/XmlSchema/Gitea/nsm-klareringsportalen.xsd", "Model/CSharp/Gitea/nsm-klareringsportalen.cs"];
+        yield return ["Model/XmlSchema/Gitea/stami-mu-bestilling-2021.xsd", "Model/CSharp/Gitea/stami-mu-bestilling-2021.cs"];
+        yield return ["Model/XmlSchema/Gitea/dat-aarligmelding-bemanning.xsd", "Model/CSharp/Gitea/dat-aarligmelding-bemanning.cs"];
+        yield return ["Model/XmlSchema/Gitea/dihe-redusert-foreldrebetaling-bhg.xsd", "Model/CSharp/Gitea/dihe-redusert-foreldrebetaling-bhg.cs"];
+        yield return ["Model/XmlSchema/Gitea/hi-algeskjema.xsd", "Model/CSharp/Gitea/hi-algeskjema.cs"];
+        yield return ["Model/XmlSchema/Gitea/Kursdomene_APINøkkel_M_2020-05-26_5702_34556_SERES.xsd", "Model/CSharp/Gitea/Kursdomene_APINøkkel_M_2020-05-26_5702_34556_SERES.cs"];
+        yield return ["Model/XmlSchema/Gitea/nbib-melding.xsd", "Model/CSharp/Gitea/nbib-melding.cs"];
+        yield return ["Model/XmlSchema/Gitea/udir-invitasjon-vfkl.xsd", "Model/CSharp/Gitea/udir-invitasjon-vfkl.cs"];
+        yield return ["Model/XmlSchema/Gitea/udir-vfkl.xsd", "Model/CSharp/Gitea/udir-vfkl.cs"];
+        yield return ["Model/XmlSchema/Gitea/bokskjema.xsd", "Model/CSharp/Gitea/bokskjema.cs"];
+        yield return ["Model/XmlSchema/Gitea/dat-bilpleie-soknad.xsd", "Model/CSharp/Gitea/dat-bilpleie-soknad.cs"];
+        yield return ["Model/XmlSchema/Gitea/dat-skjema.xsd", "Model/CSharp/Gitea/dat-skjema.cs"];
+        yield return ["Model/XmlSchema/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.xsd", "Model/CSharp/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.cs"];
+        yield return ["Model/XmlSchema/Gitea/Kursdomene_BekrefteBruksvilkår_M_2020-05-25_5704_34554_SERES.xsd", "Model/CSharp/Gitea/Kursdomene_BekrefteBruksvilkår_M_2020-05-25_5704_34554_SERES.cs"];
+        yield return ["Model/XmlSchema/Gitea/srf-fufinn-behovskartleggin.xsd", "Model/CSharp/Gitea/srf-fufinn-behovskartleggin.cs"];
+        yield return ["Model/XmlSchema/Gitea/srf-melding-til-statsforvalteren.xsd", "Model/CSharp/Gitea/srf-melding-til-statsforvalteren.cs"];
+        yield return ["Model/XmlSchema/Gitea/udi-unntak-karantenehotell-velferd.xsd", "Model/CSharp/Gitea/udi-unntak-karantenehotell-velferd.cs"];
+        yield return ["Model/XmlSchema/Gitea/skjema.xsd", "Model/CSharp/Gitea/skjema.cs"];
+        yield return ["Model/XmlSchema/Gitea/srf-fufinn-behovsendring.xsd", "Model/CSharp/Gitea/srf-fufinn-behovsendring.cs"];
+        yield return ["Model/XmlSchema/Gitea/stami-atid-databehandler-2022.xsd", "Model/CSharp/Gitea/stami-atid-databehandler-2022.cs"];
+        yield return ["Model/XmlSchema/Gitea/stami-mu-databehandler-2021.xsd", "Model/CSharp/Gitea/stami-mu-databehandler-2021.cs"];
+        yield return ["Model/XmlSchema/Gitea/skd-formueinntekt-skattemelding-v2.xsd", "Model/CSharp/Gitea/skd-formueinntekt-skattemelding-v2.cs"];
+        yield return ["Model/XmlSchema/Gitea/aal-vedlegg.xsd", "Model/CSharp/Gitea/aal-vedlegg.cs"];
+        yield return ["Model/XmlSchema/Gitea/krt-1188a-1.xsd", "Model/CSharp/Gitea/krt-1188a-1.cs"];
+        yield return ["Model/XmlSchema/Gitea/3422-39646.xsd", "Model/CSharp/Gitea/3422-39646.cs"];
+        yield return ["Model/XmlSchema/Gitea/3430-39615.xsd", "Model/CSharp/Gitea/3430-39615.cs"];
+        yield return ["Model/XmlSchema/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.xsd", "Model/CSharp/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.cs"];
+        yield return ["Model/XmlSchema/Gitea/dev-nill-test.xsd", "Model/CSharp/Gitea/dev-nill-test.cs"];
+
+        // xs:all test cases
+        yield return ["Model/XmlSchema/XsAll/ferdigattest/v4/ferdigattest.xsd", "Model/CSharp/XsAll/ferdigattest/v4/ferdigattest.cs"];
+        yield return ["Model/XmlSchema/XsAll/igangsettingstillatelse/v4/igangsettingstillatelse.xsd", "Model/CSharp/XsAll/igangsettingstillatelse/v4/igangsettingstillatelse.cs"];
+        yield return ["Model/XmlSchema/XsAll/midlertidigbrukstillatelse/v4/midlertidigbrukstillatelse.xsd", "Model/CSharp/XsAll/midlertidigbrukstillatelse/v4/midlertidigbrukstillatelse.cs"];
+        yield return ["Model/XmlSchema/XsAll/planvarsel/v2/planvarsel.xsd", "Model/CSharp/XsAll/planvarsel/v2/planvarsel.cs"];
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/backend/tests/DataModeling.Tests/TestDataClasses/ValidationTestData.cs
+++ b/backend/tests/DataModeling.Tests/TestDataClasses/ValidationTestData.cs
@@ -7,19 +7,27 @@ public class ValidationTestData : IEnumerable<object[]>
 {
     public IEnumerator<object[]> GetEnumerator()
     {
-        yield return new object[] { "Model/XmlSchema/Gitea/nsm-klareringsportalen.xsd" };
-        yield return new object[] { "Model/XmlSchema/Gitea/stami-mu-bestilling-2021.xsd" };
-        yield return new object[] { "Model/XmlSchema/Gitea/dat-aarligmelding-bemanning.xsd" };
-        yield return new object[] { "Model/XmlSchema/Gitea/dihe-redusert-foreldrebetaling-bhg.xsd" };
-        yield return new object[] { "Model/XmlSchema/Gitea/nbib-melding.xsd" };
-        yield return new object[] { "Model/XmlSchema/Gitea/udir-vfkl.xsd" };
-        yield return new object[] { "Model/XmlSchema/Gitea/dat-bilpleie-soknad.xsd" };
-        yield return new object[] { "Model/XmlSchema/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.xsd" };
-        yield return new object[] { "Model/XmlSchema/Gitea/Kursdomene_BekrefteBruksvilkår_M_2020-05-25_5704_34554_SERES.xsd" };
-        yield return new object[] { "Model/XmlSchema/Gitea/stami-atid-databehandler-2022.xsd" };
-        yield return new object[] { "Model/XmlSchema/Gitea/stami-mu-databehandler-2021.xsd" };
-        yield return new object[] { "Model/XmlSchema/Gitea/skd-formueinntekt-skattemelding-v2.xsd" };
-        yield return new object[] { "Model/XmlSchema/Gitea/krt-1188a-1.xsd" };
+        yield return ["Model/XmlSchema/Gitea/nsm-klareringsportalen.xsd"];
+        yield return ["Model/XmlSchema/Gitea/stami-mu-bestilling-2021.xsd"];
+        yield return ["Model/XmlSchema/Gitea/dat-aarligmelding-bemanning.xsd"];
+        yield return ["Model/XmlSchema/Gitea/dihe-redusert-foreldrebetaling-bhg.xsd"];
+        yield return ["Model/XmlSchema/Gitea/nbib-melding.xsd"];
+        yield return ["Model/XmlSchema/Gitea/udir-vfkl.xsd"];
+        yield return ["Model/XmlSchema/Gitea/dat-bilpleie-soknad.xsd"];
+        yield return ["Model/XmlSchema/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.xsd"];
+        yield return ["Model/XmlSchema/Gitea/Kursdomene_BekrefteBruksvilkår_M_2020-05-25_5704_34554_SERES.xsd"];
+        yield return ["Model/XmlSchema/Gitea/stami-atid-databehandler-2022.xsd"];
+        yield return ["Model/XmlSchema/Gitea/stami-mu-databehandler-2021.xsd"];
+        yield return ["Model/XmlSchema/Gitea/skd-formueinntekt-skattemelding-v2.xsd"];
+        yield return ["Model/XmlSchema/Gitea/krt-1188a-1.xsd"];
+
+        // xs:all test cases
+        // some of are not supported due to not precise date regex
+        // yield return ["Model/XmlSchema/XsAll/ferdigattest/v4/ferdigattest.xsd"];
+        // yield return ["Model/XmlSchema/XsAll/igangsettingstillatelse/v4/igangsettingstillatelse.xsd"];
+        // yield return ["Model/XmlSchema/XsAll/midlertidigbrukstillatelse/v4/midlertidigbrukstillatelse.xsd"];
+        yield return ["Model/XmlSchema/XsAll/planvarsel/v2/planvarsel.xsd"];
+
 
         // Can generate non valid date string from regex
         // yield return new object[] { "Model/XmlSchema/Gitea/hi-algeskjema.xsd" };

--- a/testdata/Model/CSharp/XsAll/ferdigattest/v4/ferdigattest.cs
+++ b/testdata/Model/CSharp/XsAll/ferdigattest/v4/ferdigattest.cs
@@ -1,0 +1,599 @@
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
+namespace Altinn.App.Models
+{
+  [XmlRoot(ElementName="ferdigattest", Namespace="https://skjema.ft.dibk.no/ferdigattest/v4")]
+  public class FerdigattestType
+  {
+    [XmlAttribute("dataFormatProvider")]
+    [BindNever]
+    public string dataFormatProvider { get; set; } = "DIBK";
+
+    [XmlAttribute("dataFormatId")]
+    [BindNever]
+    public string dataFormatId { get; set; } = "10005";
+
+    [XmlAttribute("dataFormatVersion")]
+    [BindNever]
+    public string dataFormatVersion { get; set; } = "4";
+
+    [XmlElement("eiendomByggested")]
+    [JsonProperty("eiendomByggested")]
+    [JsonPropertyName("eiendomByggested")]
+    public EiendomListe eiendomByggested { get; set; }
+
+    [XmlElement("kommunensSaksnummer")]
+    [JsonProperty("kommunensSaksnummer")]
+    [JsonPropertyName("kommunensSaksnummer")]
+    public SaksnummerType kommunensSaksnummer { get; set; }
+
+    [XmlElement("metadata")]
+    [JsonProperty("metadata")]
+    [JsonPropertyName("metadata")]
+    public MetadataType metadata { get; set; }
+
+    [XmlElement("generelleVilkaar")]
+    [JsonProperty("generelleVilkaar")]
+    [JsonPropertyName("generelleVilkaar")]
+    public GenerelleVilkaarType generelleVilkaar { get; set; }
+
+    [XmlElement("soeknadGjelder")]
+    [JsonProperty("soeknadGjelder")]
+    [JsonPropertyName("soeknadGjelder")]
+    public BeskrivelseAvTiltakType soeknadGjelder { get; set; }
+
+    [XmlElement("utfallBesvarelse")]
+    [JsonProperty("utfallBesvarelse")]
+    [JsonPropertyName("utfallBesvarelse")]
+    public UtfallSvarListe utfallBesvarelse { get; set; }
+
+    [XmlElement("kravFerdigattest")]
+    [JsonProperty("kravFerdigattest")]
+    [JsonPropertyName("kravFerdigattest")]
+    public KravFerdigattestType kravFerdigattest { get; set; }
+
+    [XmlElement("foretattIkkeSoeknadspliktigeJusteringer")]
+    [JsonProperty("foretattIkkeSoeknadspliktigeJusteringer")]
+    [JsonPropertyName("foretattIkkeSoeknadspliktigeJusteringer")]
+    public bool? foretattIkkeSoeknadspliktigeJusteringer { get; set; }
+
+    [XmlElement("tilstrekkeligDokumentasjonOverlevertEier")]
+    [JsonProperty("tilstrekkeligDokumentasjonOverlevertEier")]
+    [JsonPropertyName("tilstrekkeligDokumentasjonOverlevertEier")]
+    public bool? tilstrekkeligDokumentasjonOverlevertEier { get; set; }
+
+    [XmlElement("varmesystem")]
+    [JsonProperty("varmesystem")]
+    [JsonPropertyName("varmesystem")]
+    public VarmesystemType varmesystem { get; set; }
+
+    [XmlElement("tiltakshaver")]
+    [JsonProperty("tiltakshaver")]
+    [JsonPropertyName("tiltakshaver")]
+    public PartType tiltakshaver { get; set; }
+
+    [XmlElement("ansvarligSoeker")]
+    [JsonProperty("ansvarligSoeker")]
+    [JsonPropertyName("ansvarligSoeker")]
+    public PartType ansvarligSoeker { get; set; }
+
+    [XmlElement("ansvarForByggesaken")]
+    [JsonProperty("ansvarForByggesaken")]
+    [JsonPropertyName("ansvarForByggesaken")]
+    public KodeType ansvarForByggesaken { get; set; }
+
+  }
+
+  public class EiendomListe
+  {
+    [XmlElement("eiendom")]
+    [JsonProperty("eiendom")]
+    [JsonPropertyName("eiendom")]
+    public List<EiendomType> eiendom { get; set; }
+
+  }
+
+  public class EiendomType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("eiendomsidentifikasjon")]
+    [JsonProperty("eiendomsidentifikasjon")]
+    [JsonPropertyName("eiendomsidentifikasjon")]
+    public MatrikkelnummerType eiendomsidentifikasjon { get; set; }
+
+    [XmlElement("adresse")]
+    [JsonProperty("adresse")]
+    [JsonPropertyName("adresse")]
+    public EiendommensAdresseType adresse { get; set; }
+
+    [XmlElement("bygningsnummer")]
+    [JsonProperty("bygningsnummer")]
+    [JsonPropertyName("bygningsnummer")]
+    public string bygningsnummer { get; set; }
+
+    [XmlElement("bolignummer")]
+    [JsonProperty("bolignummer")]
+    [JsonPropertyName("bolignummer")]
+    public string bolignummer { get; set; }
+
+    [XmlElement("kommunenavn")]
+    [JsonProperty("kommunenavn")]
+    [JsonPropertyName("kommunenavn")]
+    public string kommunenavn { get; set; }
+
+  }
+
+  public class MatrikkelnummerType
+  {
+    [XmlElement("kommunenummer")]
+    [JsonProperty("kommunenummer")]
+    [JsonPropertyName("kommunenummer")]
+    public string kommunenummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("gaardsnummer")]
+    [JsonProperty("gaardsnummer")]
+    [JsonPropertyName("gaardsnummer")]
+    public int? gaardsnummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("bruksnummer")]
+    [JsonProperty("bruksnummer")]
+    [JsonPropertyName("bruksnummer")]
+    public int? bruksnummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("festenummer")]
+    [JsonProperty("festenummer")]
+    [JsonPropertyName("festenummer")]
+    public int? festenummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("seksjonsnummer")]
+    [JsonProperty("seksjonsnummer")]
+    [JsonPropertyName("seksjonsnummer")]
+    public int? seksjonsnummer { get; set; }
+
+  }
+
+  public class EiendommensAdresseType
+  {
+    [XmlElement("adresselinje1")]
+    [JsonProperty("adresselinje1")]
+    [JsonPropertyName("adresselinje1")]
+    public string adresselinje1 { get; set; }
+
+    [XmlElement("adresselinje2")]
+    [JsonProperty("adresselinje2")]
+    [JsonPropertyName("adresselinje2")]
+    public string adresselinje2 { get; set; }
+
+    [XmlElement("adresselinje3")]
+    [JsonProperty("adresselinje3")]
+    [JsonPropertyName("adresselinje3")]
+    public string adresselinje3 { get; set; }
+
+    [XmlElement("postnr")]
+    [JsonProperty("postnr")]
+    [JsonPropertyName("postnr")]
+    public string postnr { get; set; }
+
+    [XmlElement("poststed")]
+    [JsonProperty("poststed")]
+    [JsonPropertyName("poststed")]
+    public string poststed { get; set; }
+
+    [XmlElement("landkode")]
+    [JsonProperty("landkode")]
+    [JsonPropertyName("landkode")]
+    public string landkode { get; set; }
+
+    [XmlElement("gatenavn")]
+    [JsonProperty("gatenavn")]
+    [JsonPropertyName("gatenavn")]
+    public string gatenavn { get; set; }
+
+    [XmlElement("husnr")]
+    [JsonProperty("husnr")]
+    [JsonPropertyName("husnr")]
+    public string husnr { get; set; }
+
+    [XmlElement("bokstav")]
+    [JsonProperty("bokstav")]
+    [JsonPropertyName("bokstav")]
+    public string bokstav { get; set; }
+
+  }
+
+  public class SaksnummerType
+  {
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("saksaar")]
+    [JsonProperty("saksaar")]
+    [JsonPropertyName("saksaar")]
+    public int? saksaar { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("sakssekvensnummer")]
+    [JsonProperty("sakssekvensnummer")]
+    [JsonPropertyName("sakssekvensnummer")]
+    public int? sakssekvensnummer { get; set; }
+
+  }
+
+  public class MetadataType
+  {
+    [XmlElement("fraSluttbrukersystem")]
+    [JsonProperty("fraSluttbrukersystem")]
+    [JsonPropertyName("fraSluttbrukersystem")]
+    public string fraSluttbrukersystem { get; set; }
+
+    [XmlElement("ftbId")]
+    [JsonProperty("ftbId")]
+    [JsonPropertyName("ftbId")]
+    public string ftbId { get; set; }
+
+    [XmlElement("prosjektnavn")]
+    [JsonProperty("prosjektnavn")]
+    [JsonPropertyName("prosjektnavn")]
+    public string prosjektnavn { get; set; }
+
+    [XmlElement("prosjektnr")]
+    [JsonProperty("prosjektnr")]
+    [JsonPropertyName("prosjektnr")]
+    public string prosjektnr { get; set; }
+
+    [XmlElement("foretrukketSpraak")]
+    [JsonProperty("foretrukketSpraak")]
+    [JsonPropertyName("foretrukketSpraak")]
+    public KodeType foretrukketSpraak { get; set; }
+
+  }
+
+  public class KodeType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("kodeverdi")]
+    [JsonProperty("kodeverdi")]
+    [JsonPropertyName("kodeverdi")]
+    public string kodeverdi { get; set; }
+
+    [XmlElement("kodebeskrivelse")]
+    [JsonProperty("kodebeskrivelse")]
+    [JsonPropertyName("kodebeskrivelse")]
+    public string kodebeskrivelse { get; set; }
+
+  }
+
+  public class GenerelleVilkaarType
+  {
+    [XmlElement("norskSvenskDansk")]
+    [JsonProperty("norskSvenskDansk")]
+    [JsonPropertyName("norskSvenskDansk")]
+    public bool? norskSvenskDansk { get; set; }
+
+  }
+
+  public class BeskrivelseAvTiltakType
+  {
+    [XmlElement("type")]
+    [JsonProperty("type")]
+    [JsonPropertyName("type")]
+    public KodeListe type { get; set; }
+
+    [XmlElement("foelgebrev")]
+    [JsonProperty("foelgebrev")]
+    [JsonPropertyName("foelgebrev")]
+    public string foelgebrev { get; set; }
+
+  }
+
+  public class KodeListe
+  {
+    [XmlElement("kode")]
+    [JsonProperty("kode")]
+    [JsonPropertyName("kode")]
+    public List<KodeType> kode { get; set; }
+
+  }
+
+  public class UtfallSvarListe
+  {
+    [XmlElement("utfallSvar")]
+    [JsonProperty("utfallSvar")]
+    [JsonPropertyName("utfallSvar")]
+    public List<UtfallSvarType> utfallSvar { get; set; }
+
+  }
+
+  public class UtfallSvarType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("utfallId")]
+    [JsonProperty("utfallId")]
+    [JsonPropertyName("utfallId")]
+    public string utfallId { get; set; }
+
+    [XmlElement("utfallType")]
+    [JsonProperty("utfallType")]
+    [JsonPropertyName("utfallType")]
+    public KodeType utfallType { get; set; }
+
+    [XmlElement("utloestFraSjekkpunkt")]
+    [JsonProperty("utloestFraSjekkpunkt")]
+    [JsonPropertyName("utloestFraSjekkpunkt")]
+    public SjekkpunktType utloestFraSjekkpunkt { get; set; }
+
+    [XmlElement("tema")]
+    [JsonProperty("tema")]
+    [JsonPropertyName("tema")]
+    public KodeType tema { get; set; }
+
+    [XmlElement("tittel")]
+    [JsonProperty("tittel")]
+    [JsonPropertyName("tittel")]
+    public string tittel { get; set; }
+
+    [XmlElement("beskrivelse")]
+    [JsonProperty("beskrivelse")]
+    [JsonPropertyName("beskrivelse")]
+    public string beskrivelse { get; set; }
+
+    [XmlElement("erUtfallBesvaresSenere")]
+    [JsonProperty("erUtfallBesvaresSenere")]
+    [JsonPropertyName("erUtfallBesvaresSenere")]
+    public bool? erUtfallBesvaresSenere { get; set; }
+
+    [XmlElement("erUtfallBesvart")]
+    [JsonProperty("erUtfallBesvart")]
+    [JsonPropertyName("erUtfallBesvart")]
+    public bool? erUtfallBesvart { get; set; }
+
+    [XmlElement("kommentar")]
+    [JsonProperty("kommentar")]
+    [JsonPropertyName("kommentar")]
+    public string kommentar { get; set; }
+
+    [XmlElement("vedleggsliste")]
+    [JsonProperty("vedleggsliste")]
+    [JsonPropertyName("vedleggsliste")]
+    public VedleggListe vedleggsliste { get; set; }
+
+  }
+
+  public class SjekkpunktType
+  {
+    [XmlElement("sjekkpunktId")]
+    [JsonProperty("sjekkpunktId")]
+    [JsonPropertyName("sjekkpunktId")]
+    public string sjekkpunktId { get; set; }
+
+    [XmlElement("sjekkpunktEier")]
+    [JsonProperty("sjekkpunktEier")]
+    [JsonPropertyName("sjekkpunktEier")]
+    public string sjekkpunktEier { get; set; }
+
+  }
+
+  public class VedleggListe
+  {
+    [XmlElement("vedlegg")]
+    [JsonProperty("vedlegg")]
+    [JsonPropertyName("vedlegg")]
+    public List<VedleggType> vedlegg { get; set; }
+
+  }
+
+  public class VedleggType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("versjonsnummer")]
+    [JsonProperty("versjonsnummer")]
+    [JsonPropertyName("versjonsnummer")]
+    public string versjonsnummer { get; set; }
+
+    [XmlElement("vedleggstype")]
+    [JsonProperty("vedleggstype")]
+    [JsonPropertyName("vedleggstype")]
+    public KodeType vedleggstype { get; set; }
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlElement("versjonsdato")]
+    [JsonProperty("versjonsdato")]
+    [JsonPropertyName("versjonsdato")]
+    public string versjonsdato { get; set; }
+
+    [XmlElement("filnavn")]
+    [JsonProperty("filnavn")]
+    [JsonPropertyName("filnavn")]
+    public string filnavn { get; set; }
+
+  }
+
+  public class KravFerdigattestType
+  {
+    [XmlElement("tilfredsstillerTiltaketKraveneFerdigattest")]
+    [JsonProperty("tilfredsstillerTiltaketKraveneFerdigattest")]
+    [JsonPropertyName("tilfredsstillerTiltaketKraveneFerdigattest")]
+    public bool? tilfredsstillerTiltaketKraveneFerdigattest { get; set; }
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlElement("utfoertInnen")]
+    [JsonProperty("utfoertInnen")]
+    [JsonPropertyName("utfoertInnen")]
+    public string utfoertInnen { get; set; }
+
+    [XmlElement("typeArbeider")]
+    [JsonProperty("typeArbeider")]
+    [JsonPropertyName("typeArbeider")]
+    public string typeArbeider { get; set; }
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlElement("bekreftelseInnen")]
+    [JsonProperty("bekreftelseInnen")]
+    [JsonPropertyName("bekreftelseInnen")]
+    public string bekreftelseInnen { get; set; }
+
+  }
+
+  public class VarmesystemType
+  {
+    [XmlElement("varmefordeling")]
+    [JsonProperty("varmefordeling")]
+    [JsonPropertyName("varmefordeling")]
+    public KodeListe varmefordeling { get; set; }
+
+    [XmlElement("energiforsyning")]
+    [JsonProperty("energiforsyning")]
+    [JsonPropertyName("energiforsyning")]
+    public KodeListe energiforsyning { get; set; }
+
+    [XmlElement("relevant")]
+    [JsonProperty("relevant")]
+    [JsonPropertyName("relevant")]
+    public bool? relevant { get; set; }
+
+  }
+
+  public class PartType
+  {
+    [XmlElement("partstype")]
+    [JsonProperty("partstype")]
+    [JsonPropertyName("partstype")]
+    public KodeType partstype { get; set; }
+
+    [XmlElement("foedselsnummer")]
+    [JsonProperty("foedselsnummer")]
+    [JsonPropertyName("foedselsnummer")]
+    public string foedselsnummer { get; set; }
+
+    [XmlElement("organisasjonsnummer")]
+    [JsonProperty("organisasjonsnummer")]
+    [JsonPropertyName("organisasjonsnummer")]
+    public string organisasjonsnummer { get; set; }
+
+    [XmlElement("navn")]
+    [JsonProperty("navn")]
+    [JsonPropertyName("navn")]
+    public string navn { get; set; }
+
+    [XmlElement("adresse")]
+    [JsonProperty("adresse")]
+    [JsonPropertyName("adresse")]
+    public EnkelAdresseType adresse { get; set; }
+
+    [XmlElement("telefonnummer")]
+    [JsonProperty("telefonnummer")]
+    [JsonPropertyName("telefonnummer")]
+    public string telefonnummer { get; set; }
+
+    [XmlElement("mobilnummer")]
+    [JsonProperty("mobilnummer")]
+    [JsonPropertyName("mobilnummer")]
+    public string mobilnummer { get; set; }
+
+    [XmlElement("epost")]
+    [JsonProperty("epost")]
+    [JsonPropertyName("epost")]
+    public string epost { get; set; }
+
+    [XmlElement("kontaktperson")]
+    [JsonProperty("kontaktperson")]
+    [JsonPropertyName("kontaktperson")]
+    public KontaktpersonType kontaktperson { get; set; }
+
+  }
+
+  public class EnkelAdresseType
+  {
+    [XmlElement("adresselinje1")]
+    [JsonProperty("adresselinje1")]
+    [JsonPropertyName("adresselinje1")]
+    public string adresselinje1 { get; set; }
+
+    [XmlElement("adresselinje2")]
+    [JsonProperty("adresselinje2")]
+    [JsonPropertyName("adresselinje2")]
+    public string adresselinje2 { get; set; }
+
+    [XmlElement("adresselinje3")]
+    [JsonProperty("adresselinje3")]
+    [JsonPropertyName("adresselinje3")]
+    public string adresselinje3 { get; set; }
+
+    [XmlElement("postnr")]
+    [JsonProperty("postnr")]
+    [JsonPropertyName("postnr")]
+    public string postnr { get; set; }
+
+    [XmlElement("poststed")]
+    [JsonProperty("poststed")]
+    [JsonPropertyName("poststed")]
+    public string poststed { get; set; }
+
+    [XmlElement("landkode")]
+    [JsonProperty("landkode")]
+    [JsonPropertyName("landkode")]
+    public string landkode { get; set; }
+
+  }
+
+  public class KontaktpersonType
+  {
+    [XmlElement("navn")]
+    [JsonProperty("navn")]
+    [JsonPropertyName("navn")]
+    public string navn { get; set; }
+
+    [XmlElement("telefonnummer")]
+    [JsonProperty("telefonnummer")]
+    [JsonPropertyName("telefonnummer")]
+    public string telefonnummer { get; set; }
+
+    [XmlElement("mobilnummer")]
+    [JsonProperty("mobilnummer")]
+    [JsonPropertyName("mobilnummer")]
+    public string mobilnummer { get; set; }
+
+    [XmlElement("epost")]
+    [JsonProperty("epost")]
+    [JsonPropertyName("epost")]
+    public string epost { get; set; }
+
+  }
+}

--- a/testdata/Model/CSharp/XsAll/igangsettingstillatelse/v4/igangsettingstillatelse.cs
+++ b/testdata/Model/CSharp/XsAll/igangsettingstillatelse/v4/igangsettingstillatelse.cs
@@ -1,0 +1,601 @@
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
+namespace Altinn.App.Models
+{
+  [XmlRoot(ElementName="igangsettingstillatelse", Namespace="https://skjema.ft.dibk.no/igangsettingstillatelse/v4")]
+  public class IgangsettingstillatelseType
+  {
+    [XmlAttribute("dataFormatProvider")]
+    [BindNever]
+    public string dataFormatProvider { get; set; } = "DIBK";
+
+    [XmlAttribute("dataFormatId")]
+    [BindNever]
+    public string dataFormatId { get; set; } = "10003";
+
+    [XmlAttribute("dataFormatVersion")]
+    [BindNever]
+    public string dataFormatVersion { get; set; } = "4";
+
+    [XmlElement("eiendomByggested")]
+    [JsonProperty("eiendomByggested")]
+    [JsonPropertyName("eiendomByggested")]
+    public EiendomListe eiendomByggested { get; set; }
+
+    [XmlElement("kommunensSaksnummer")]
+    [JsonProperty("kommunensSaksnummer")]
+    [JsonPropertyName("kommunensSaksnummer")]
+    public SaksnummerType kommunensSaksnummer { get; set; }
+
+    [XmlElement("metadata")]
+    [JsonProperty("metadata")]
+    [JsonPropertyName("metadata")]
+    public MetadataType metadata { get; set; }
+
+    [XmlElement("generelleVilkaar")]
+    [JsonProperty("generelleVilkaar")]
+    [JsonPropertyName("generelleVilkaar")]
+    public GenerelleVilkaarType generelleVilkaar { get; set; }
+
+    [XmlElement("soeknadGjelder")]
+    [JsonProperty("soeknadGjelder")]
+    [JsonPropertyName("soeknadGjelder")]
+    public SoeknadenGjelderType soeknadGjelder { get; set; }
+
+    [XmlElement("delsoeknader")]
+    [JsonProperty("delsoeknader")]
+    [JsonPropertyName("delsoeknader")]
+    public DelsoeknadListe delsoeknader { get; set; }
+
+    [XmlElement("utfallBesvarelse")]
+    [JsonProperty("utfallBesvarelse")]
+    [JsonPropertyName("utfallBesvarelse")]
+    public UtfallSvarListe utfallBesvarelse { get; set; }
+
+    [XmlElement("ansvarligSoeker")]
+    [JsonProperty("ansvarligSoeker")]
+    [JsonPropertyName("ansvarligSoeker")]
+    public PartType ansvarligSoeker { get; set; }
+
+    [XmlElement("ansvarForByggesaken")]
+    [JsonProperty("ansvarForByggesaken")]
+    [JsonPropertyName("ansvarForByggesaken")]
+    public KodeType ansvarForByggesaken { get; set; }
+
+  }
+
+  public class EiendomListe
+  {
+    [XmlElement("eiendom")]
+    [JsonProperty("eiendom")]
+    [JsonPropertyName("eiendom")]
+    public List<EiendomType> eiendom { get; set; }
+
+  }
+
+  public class EiendomType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("eiendomsidentifikasjon")]
+    [JsonProperty("eiendomsidentifikasjon")]
+    [JsonPropertyName("eiendomsidentifikasjon")]
+    public MatrikkelnummerType eiendomsidentifikasjon { get; set; }
+
+    [XmlElement("adresse")]
+    [JsonProperty("adresse")]
+    [JsonPropertyName("adresse")]
+    public EiendommensAdresseType adresse { get; set; }
+
+    [XmlElement("bygningsnummer")]
+    [JsonProperty("bygningsnummer")]
+    [JsonPropertyName("bygningsnummer")]
+    public string bygningsnummer { get; set; }
+
+    [XmlElement("bolignummer")]
+    [JsonProperty("bolignummer")]
+    [JsonPropertyName("bolignummer")]
+    public string bolignummer { get; set; }
+
+    [XmlElement("kommunenavn")]
+    [JsonProperty("kommunenavn")]
+    [JsonPropertyName("kommunenavn")]
+    public string kommunenavn { get; set; }
+
+  }
+
+  public class MatrikkelnummerType
+  {
+    [XmlElement("kommunenummer")]
+    [JsonProperty("kommunenummer")]
+    [JsonPropertyName("kommunenummer")]
+    public string kommunenummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("gaardsnummer")]
+    [JsonProperty("gaardsnummer")]
+    [JsonPropertyName("gaardsnummer")]
+    public int? gaardsnummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("bruksnummer")]
+    [JsonProperty("bruksnummer")]
+    [JsonPropertyName("bruksnummer")]
+    public int? bruksnummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("festenummer")]
+    [JsonProperty("festenummer")]
+    [JsonPropertyName("festenummer")]
+    public int? festenummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("seksjonsnummer")]
+    [JsonProperty("seksjonsnummer")]
+    [JsonPropertyName("seksjonsnummer")]
+    public int? seksjonsnummer { get; set; }
+
+  }
+
+  public class EiendommensAdresseType
+  {
+    [XmlElement("adresselinje1")]
+    [JsonProperty("adresselinje1")]
+    [JsonPropertyName("adresselinje1")]
+    public string adresselinje1 { get; set; }
+
+    [XmlElement("adresselinje2")]
+    [JsonProperty("adresselinje2")]
+    [JsonPropertyName("adresselinje2")]
+    public string adresselinje2 { get; set; }
+
+    [XmlElement("adresselinje3")]
+    [JsonProperty("adresselinje3")]
+    [JsonPropertyName("adresselinje3")]
+    public string adresselinje3 { get; set; }
+
+    [XmlElement("postnr")]
+    [JsonProperty("postnr")]
+    [JsonPropertyName("postnr")]
+    public string postnr { get; set; }
+
+    [XmlElement("poststed")]
+    [JsonProperty("poststed")]
+    [JsonPropertyName("poststed")]
+    public string poststed { get; set; }
+
+    [XmlElement("landkode")]
+    [JsonProperty("landkode")]
+    [JsonPropertyName("landkode")]
+    public string landkode { get; set; }
+
+    [XmlElement("gatenavn")]
+    [JsonProperty("gatenavn")]
+    [JsonPropertyName("gatenavn")]
+    public string gatenavn { get; set; }
+
+    [XmlElement("husnr")]
+    [JsonProperty("husnr")]
+    [JsonPropertyName("husnr")]
+    public string husnr { get; set; }
+
+    [XmlElement("bokstav")]
+    [JsonProperty("bokstav")]
+    [JsonPropertyName("bokstav")]
+    public string bokstav { get; set; }
+
+  }
+
+  public class SaksnummerType
+  {
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("saksaar")]
+    [JsonProperty("saksaar")]
+    [JsonPropertyName("saksaar")]
+    public int? saksaar { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("sakssekvensnummer")]
+    [JsonProperty("sakssekvensnummer")]
+    [JsonPropertyName("sakssekvensnummer")]
+    public int? sakssekvensnummer { get; set; }
+
+  }
+
+  public class MetadataType
+  {
+    [XmlElement("fraSluttbrukersystem")]
+    [JsonProperty("fraSluttbrukersystem")]
+    [JsonPropertyName("fraSluttbrukersystem")]
+    public string fraSluttbrukersystem { get; set; }
+
+    [XmlElement("ftbId")]
+    [JsonProperty("ftbId")]
+    [JsonPropertyName("ftbId")]
+    public string ftbId { get; set; }
+
+    [XmlElement("prosjektnavn")]
+    [JsonProperty("prosjektnavn")]
+    [JsonPropertyName("prosjektnavn")]
+    public string prosjektnavn { get; set; }
+
+    [XmlElement("prosjektnr")]
+    [JsonProperty("prosjektnr")]
+    [JsonPropertyName("prosjektnr")]
+    public string prosjektnr { get; set; }
+
+    [XmlElement("foretrukketSpraak")]
+    [JsonProperty("foretrukketSpraak")]
+    [JsonPropertyName("foretrukketSpraak")]
+    public KodeType foretrukketSpraak { get; set; }
+
+  }
+
+  public class KodeType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("kodeverdi")]
+    [JsonProperty("kodeverdi")]
+    [JsonPropertyName("kodeverdi")]
+    public string kodeverdi { get; set; }
+
+    [XmlElement("kodebeskrivelse")]
+    [JsonProperty("kodebeskrivelse")]
+    [JsonPropertyName("kodebeskrivelse")]
+    public string kodebeskrivelse { get; set; }
+
+  }
+
+  public class GenerelleVilkaarType
+  {
+    [XmlElement("beroererArbeidsplasser")]
+    [JsonProperty("beroererArbeidsplasser")]
+    [JsonPropertyName("beroererArbeidsplasser")]
+    public bool? beroererArbeidsplasser { get; set; }
+
+    [XmlElement("norskSvenskDansk")]
+    [JsonProperty("norskSvenskDansk")]
+    [JsonPropertyName("norskSvenskDansk")]
+    public bool? norskSvenskDansk { get; set; }
+
+  }
+
+  public class SoeknadenGjelderType
+  {
+    [XmlElement("gjelderHeleTiltaket")]
+    [JsonProperty("gjelderHeleTiltaket")]
+    [JsonPropertyName("gjelderHeleTiltaket")]
+    public bool? gjelderHeleTiltaket { get; set; }
+
+    [XmlElement("delAvTiltaket")]
+    [JsonProperty("delAvTiltaket")]
+    [JsonPropertyName("delAvTiltaket")]
+    public string delAvTiltaket { get; set; }
+
+    [XmlElement("type")]
+    [JsonProperty("type")]
+    [JsonPropertyName("type")]
+    public KodeListe type { get; set; }
+
+    [XmlElement("delsoeknadsnummer")]
+    [JsonProperty("delsoeknadsnummer")]
+    [JsonPropertyName("delsoeknadsnummer")]
+    public string delsoeknadsnummer { get; set; }
+
+    [XmlElement("foelgebrev")]
+    [JsonProperty("foelgebrev")]
+    [JsonPropertyName("foelgebrev")]
+    public string foelgebrev { get; set; }
+
+  }
+
+  public class KodeListe
+  {
+    [XmlElement("kode")]
+    [JsonProperty("kode")]
+    [JsonPropertyName("kode")]
+    public List<KodeType> kode { get; set; }
+
+  }
+
+  public class DelsoeknadListe
+  {
+    [XmlElement("delsoeknad")]
+    [JsonProperty("delsoeknad")]
+    [JsonPropertyName("delsoeknad")]
+    public List<DelsoeknadType> delsoeknad { get; set; }
+
+  }
+
+  public class DelsoeknadType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("delAvTiltaket")]
+    [JsonProperty("delAvTiltaket")]
+    [JsonPropertyName("delAvTiltaket")]
+    public string delAvTiltaket { get; set; }
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlElement("tillatelsedato")]
+    [JsonProperty("tillatelsedato")]
+    [JsonPropertyName("tillatelsedato")]
+    public string tillatelsedato { get; set; }
+
+    [XmlElement("kommentar")]
+    [JsonProperty("kommentar")]
+    [JsonPropertyName("kommentar")]
+    public string kommentar { get; set; }
+
+    [XmlElement("type")]
+    [JsonProperty("type")]
+    [JsonPropertyName("type")]
+    public KodeListe type { get; set; }
+
+    [XmlElement("delsoeknadsnummer")]
+    [JsonProperty("delsoeknadsnummer")]
+    [JsonPropertyName("delsoeknadsnummer")]
+    public string delsoeknadsnummer { get; set; }
+
+  }
+
+  public class UtfallSvarListe
+  {
+    [XmlElement("utfallSvar")]
+    [JsonProperty("utfallSvar")]
+    [JsonPropertyName("utfallSvar")]
+    public List<UtfallSvarType> utfallSvar { get; set; }
+
+  }
+
+  public class UtfallSvarType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("utfallId")]
+    [JsonProperty("utfallId")]
+    [JsonPropertyName("utfallId")]
+    public string utfallId { get; set; }
+
+    [XmlElement("utfallType")]
+    [JsonProperty("utfallType")]
+    [JsonPropertyName("utfallType")]
+    public KodeType utfallType { get; set; }
+
+    [XmlElement("utloestFraSjekkpunkt")]
+    [JsonProperty("utloestFraSjekkpunkt")]
+    [JsonPropertyName("utloestFraSjekkpunkt")]
+    public SjekkpunktType utloestFraSjekkpunkt { get; set; }
+
+    [XmlElement("tema")]
+    [JsonProperty("tema")]
+    [JsonPropertyName("tema")]
+    public KodeType tema { get; set; }
+
+    [XmlElement("tittel")]
+    [JsonProperty("tittel")]
+    [JsonPropertyName("tittel")]
+    public string tittel { get; set; }
+
+    [XmlElement("beskrivelse")]
+    [JsonProperty("beskrivelse")]
+    [JsonPropertyName("beskrivelse")]
+    public string beskrivelse { get; set; }
+
+    [XmlElement("erUtfallBesvaresSenere")]
+    [JsonProperty("erUtfallBesvaresSenere")]
+    [JsonPropertyName("erUtfallBesvaresSenere")]
+    public bool? erUtfallBesvaresSenere { get; set; }
+
+    [XmlElement("erUtfallBesvart")]
+    [JsonProperty("erUtfallBesvart")]
+    [JsonPropertyName("erUtfallBesvart")]
+    public bool? erUtfallBesvart { get; set; }
+
+    [XmlElement("kommentar")]
+    [JsonProperty("kommentar")]
+    [JsonPropertyName("kommentar")]
+    public string kommentar { get; set; }
+
+    [XmlElement("vedleggsliste")]
+    [JsonProperty("vedleggsliste")]
+    [JsonPropertyName("vedleggsliste")]
+    public VedleggListe vedleggsliste { get; set; }
+
+  }
+
+  public class SjekkpunktType
+  {
+    [XmlElement("sjekkpunktId")]
+    [JsonProperty("sjekkpunktId")]
+    [JsonPropertyName("sjekkpunktId")]
+    public string sjekkpunktId { get; set; }
+
+    [XmlElement("sjekkpunktEier")]
+    [JsonProperty("sjekkpunktEier")]
+    [JsonPropertyName("sjekkpunktEier")]
+    public string sjekkpunktEier { get; set; }
+
+  }
+
+  public class VedleggListe
+  {
+    [XmlElement("vedlegg")]
+    [JsonProperty("vedlegg")]
+    [JsonPropertyName("vedlegg")]
+    public List<VedleggType> vedlegg { get; set; }
+
+  }
+
+  public class VedleggType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("versjonsnummer")]
+    [JsonProperty("versjonsnummer")]
+    [JsonPropertyName("versjonsnummer")]
+    public string versjonsnummer { get; set; }
+
+    [XmlElement("vedleggstype")]
+    [JsonProperty("vedleggstype")]
+    [JsonPropertyName("vedleggstype")]
+    public KodeType vedleggstype { get; set; }
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlElement("versjonsdato")]
+    [JsonProperty("versjonsdato")]
+    [JsonPropertyName("versjonsdato")]
+    public string versjonsdato { get; set; }
+
+    [XmlElement("filnavn")]
+    [JsonProperty("filnavn")]
+    [JsonPropertyName("filnavn")]
+    public string filnavn { get; set; }
+
+  }
+
+  public class PartType
+  {
+    [XmlElement("partstype")]
+    [JsonProperty("partstype")]
+    [JsonPropertyName("partstype")]
+    public KodeType partstype { get; set; }
+
+    [XmlElement("foedselsnummer")]
+    [JsonProperty("foedselsnummer")]
+    [JsonPropertyName("foedselsnummer")]
+    public string foedselsnummer { get; set; }
+
+    [XmlElement("organisasjonsnummer")]
+    [JsonProperty("organisasjonsnummer")]
+    [JsonPropertyName("organisasjonsnummer")]
+    public string organisasjonsnummer { get; set; }
+
+    [XmlElement("navn")]
+    [JsonProperty("navn")]
+    [JsonPropertyName("navn")]
+    public string navn { get; set; }
+
+    [XmlElement("adresse")]
+    [JsonProperty("adresse")]
+    [JsonPropertyName("adresse")]
+    public EnkelAdresseType adresse { get; set; }
+
+    [XmlElement("telefonnummer")]
+    [JsonProperty("telefonnummer")]
+    [JsonPropertyName("telefonnummer")]
+    public string telefonnummer { get; set; }
+
+    [XmlElement("mobilnummer")]
+    [JsonProperty("mobilnummer")]
+    [JsonPropertyName("mobilnummer")]
+    public string mobilnummer { get; set; }
+
+    [XmlElement("epost")]
+    [JsonProperty("epost")]
+    [JsonPropertyName("epost")]
+    public string epost { get; set; }
+
+    [XmlElement("kontaktperson")]
+    [JsonProperty("kontaktperson")]
+    [JsonPropertyName("kontaktperson")]
+    public KontaktpersonType kontaktperson { get; set; }
+
+  }
+
+  public class EnkelAdresseType
+  {
+    [XmlElement("adresselinje1")]
+    [JsonProperty("adresselinje1")]
+    [JsonPropertyName("adresselinje1")]
+    public string adresselinje1 { get; set; }
+
+    [XmlElement("adresselinje2")]
+    [JsonProperty("adresselinje2")]
+    [JsonPropertyName("adresselinje2")]
+    public string adresselinje2 { get; set; }
+
+    [XmlElement("adresselinje3")]
+    [JsonProperty("adresselinje3")]
+    [JsonPropertyName("adresselinje3")]
+    public string adresselinje3 { get; set; }
+
+    [XmlElement("postnr")]
+    [JsonProperty("postnr")]
+    [JsonPropertyName("postnr")]
+    public string postnr { get; set; }
+
+    [XmlElement("poststed")]
+    [JsonProperty("poststed")]
+    [JsonPropertyName("poststed")]
+    public string poststed { get; set; }
+
+    [XmlElement("landkode")]
+    [JsonProperty("landkode")]
+    [JsonPropertyName("landkode")]
+    public string landkode { get; set; }
+
+  }
+
+  public class KontaktpersonType
+  {
+    [XmlElement("navn")]
+    [JsonProperty("navn")]
+    [JsonPropertyName("navn")]
+    public string navn { get; set; }
+
+    [XmlElement("telefonnummer")]
+    [JsonProperty("telefonnummer")]
+    [JsonPropertyName("telefonnummer")]
+    public string telefonnummer { get; set; }
+
+    [XmlElement("mobilnummer")]
+    [JsonProperty("mobilnummer")]
+    [JsonPropertyName("mobilnummer")]
+    public string mobilnummer { get; set; }
+
+    [XmlElement("epost")]
+    [JsonProperty("epost")]
+    [JsonPropertyName("epost")]
+    public string epost { get; set; }
+
+  }
+}

--- a/testdata/Model/CSharp/XsAll/midlertidigbrukstillatelse/v4/midlertidigbrukstillatelse.cs
+++ b/testdata/Model/CSharp/XsAll/midlertidigbrukstillatelse/v4/midlertidigbrukstillatelse.cs
@@ -1,0 +1,657 @@
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
+namespace Altinn.App.Models
+{
+  [XmlRoot(ElementName="midlertidigbrukstillatelse", Namespace="https://skjema.ft.dibk.no/midlertidigbrukstillatelse/v4")]
+  public class MidlertidigBrukstillatelseType
+  {
+    [XmlAttribute("dataFormatProvider")]
+    [BindNever]
+    public string dataFormatProvider { get; set; } = "DIBK";
+
+    [XmlAttribute("dataFormatId")]
+    [BindNever]
+    public string dataFormatId { get; set; } = "10004";
+
+    [XmlAttribute("dataFormatVersion")]
+    [BindNever]
+    public string dataFormatVersion { get; set; } = "4";
+
+    [XmlElement("eiendomByggested")]
+    [JsonProperty("eiendomByggested")]
+    [JsonPropertyName("eiendomByggested")]
+    public EiendomListe eiendomByggested { get; set; }
+
+    [XmlElement("kommunensSaksnummer")]
+    [JsonProperty("kommunensSaksnummer")]
+    [JsonPropertyName("kommunensSaksnummer")]
+    public SaksnummerType kommunensSaksnummer { get; set; }
+
+    [XmlElement("metadata")]
+    [JsonProperty("metadata")]
+    [JsonPropertyName("metadata")]
+    public MetadataType metadata { get; set; }
+
+    [XmlElement("generelleVilkaar")]
+    [JsonProperty("generelleVilkaar")]
+    [JsonPropertyName("generelleVilkaar")]
+    public GenerelleVilkaarType generelleVilkaar { get; set; }
+
+    [XmlElement("soeknadGjelder")]
+    [JsonProperty("soeknadGjelder")]
+    [JsonPropertyName("soeknadGjelder")]
+    public SoeknadGjelderType soeknadGjelder { get; set; }
+
+    [XmlElement("delsoeknader")]
+    [JsonProperty("delsoeknader")]
+    [JsonPropertyName("delsoeknader")]
+    public DelsoeknadListe delsoeknader { get; set; }
+
+    [XmlElement("utfallBesvarelse")]
+    [JsonProperty("utfallBesvarelse")]
+    [JsonPropertyName("utfallBesvarelse")]
+    public UtfallSvarListe utfallBesvarelse { get; set; }
+
+    [XmlElement("tiltakshaver")]
+    [JsonProperty("tiltakshaver")]
+    [JsonPropertyName("tiltakshaver")]
+    public PartType tiltakshaver { get; set; }
+
+    [XmlElement("ansvarligSoeker")]
+    [JsonProperty("ansvarligSoeker")]
+    [JsonPropertyName("ansvarligSoeker")]
+    public PartType ansvarligSoeker { get; set; }
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlElement("datoFerdigattest")]
+    [JsonProperty("datoFerdigattest")]
+    [JsonPropertyName("datoFerdigattest")]
+    public string datoFerdigattest { get; set; }
+
+    [XmlElement("gjenstaaendeArbeider")]
+    [JsonProperty("gjenstaaendeArbeider")]
+    [JsonPropertyName("gjenstaaendeArbeider")]
+    public GjenstaaendeArbeiderType gjenstaaendeArbeider { get; set; }
+
+    [XmlElement("sikkerhetsnivaa")]
+    [JsonProperty("sikkerhetsnivaa")]
+    [JsonPropertyName("sikkerhetsnivaa")]
+    public SikkerhetsnivaaType sikkerhetsnivaa { get; set; }
+
+    [XmlElement("ansvarForByggesaken")]
+    [JsonProperty("ansvarForByggesaken")]
+    [JsonPropertyName("ansvarForByggesaken")]
+    public KodeType ansvarForByggesaken { get; set; }
+
+  }
+
+  public class EiendomListe
+  {
+    [XmlElement("eiendom")]
+    [JsonProperty("eiendom")]
+    [JsonPropertyName("eiendom")]
+    public List<EiendomType> eiendom { get; set; }
+
+  }
+
+  public class EiendomType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("eiendomsidentifikasjon")]
+    [JsonProperty("eiendomsidentifikasjon")]
+    [JsonPropertyName("eiendomsidentifikasjon")]
+    public MatrikkelnummerType eiendomsidentifikasjon { get; set; }
+
+    [XmlElement("adresse")]
+    [JsonProperty("adresse")]
+    [JsonPropertyName("adresse")]
+    public EiendommensAdresseType adresse { get; set; }
+
+    [XmlElement("bygningsnummer")]
+    [JsonProperty("bygningsnummer")]
+    [JsonPropertyName("bygningsnummer")]
+    public string bygningsnummer { get; set; }
+
+    [XmlElement("bolignummer")]
+    [JsonProperty("bolignummer")]
+    [JsonPropertyName("bolignummer")]
+    public string bolignummer { get; set; }
+
+    [XmlElement("kommunenavn")]
+    [JsonProperty("kommunenavn")]
+    [JsonPropertyName("kommunenavn")]
+    public string kommunenavn { get; set; }
+
+  }
+
+  public class MatrikkelnummerType
+  {
+    [XmlElement("kommunenummer")]
+    [JsonProperty("kommunenummer")]
+    [JsonPropertyName("kommunenummer")]
+    public string kommunenummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("gaardsnummer")]
+    [JsonProperty("gaardsnummer")]
+    [JsonPropertyName("gaardsnummer")]
+    public int? gaardsnummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("bruksnummer")]
+    [JsonProperty("bruksnummer")]
+    [JsonPropertyName("bruksnummer")]
+    public int? bruksnummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("festenummer")]
+    [JsonProperty("festenummer")]
+    [JsonPropertyName("festenummer")]
+    public int? festenummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("seksjonsnummer")]
+    [JsonProperty("seksjonsnummer")]
+    [JsonPropertyName("seksjonsnummer")]
+    public int? seksjonsnummer { get; set; }
+
+  }
+
+  public class EiendommensAdresseType
+  {
+    [XmlElement("adresselinje1")]
+    [JsonProperty("adresselinje1")]
+    [JsonPropertyName("adresselinje1")]
+    public string adresselinje1 { get; set; }
+
+    [XmlElement("adresselinje2")]
+    [JsonProperty("adresselinje2")]
+    [JsonPropertyName("adresselinje2")]
+    public string adresselinje2 { get; set; }
+
+    [XmlElement("adresselinje3")]
+    [JsonProperty("adresselinje3")]
+    [JsonPropertyName("adresselinje3")]
+    public string adresselinje3 { get; set; }
+
+    [XmlElement("postnr")]
+    [JsonProperty("postnr")]
+    [JsonPropertyName("postnr")]
+    public string postnr { get; set; }
+
+    [XmlElement("poststed")]
+    [JsonProperty("poststed")]
+    [JsonPropertyName("poststed")]
+    public string poststed { get; set; }
+
+    [XmlElement("landkode")]
+    [JsonProperty("landkode")]
+    [JsonPropertyName("landkode")]
+    public string landkode { get; set; }
+
+    [XmlElement("gatenavn")]
+    [JsonProperty("gatenavn")]
+    [JsonPropertyName("gatenavn")]
+    public string gatenavn { get; set; }
+
+    [XmlElement("husnr")]
+    [JsonProperty("husnr")]
+    [JsonPropertyName("husnr")]
+    public string husnr { get; set; }
+
+    [XmlElement("bokstav")]
+    [JsonProperty("bokstav")]
+    [JsonPropertyName("bokstav")]
+    public string bokstav { get; set; }
+
+  }
+
+  public class SaksnummerType
+  {
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("saksaar")]
+    [JsonProperty("saksaar")]
+    [JsonPropertyName("saksaar")]
+    public int? saksaar { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("sakssekvensnummer")]
+    [JsonProperty("sakssekvensnummer")]
+    [JsonPropertyName("sakssekvensnummer")]
+    public int? sakssekvensnummer { get; set; }
+
+  }
+
+  public class MetadataType
+  {
+    [XmlElement("fraSluttbrukersystem")]
+    [JsonProperty("fraSluttbrukersystem")]
+    [JsonPropertyName("fraSluttbrukersystem")]
+    public string fraSluttbrukersystem { get; set; }
+
+    [XmlElement("ftbId")]
+    [JsonProperty("ftbId")]
+    [JsonPropertyName("ftbId")]
+    public string ftbId { get; set; }
+
+    [XmlElement("prosjektnavn")]
+    [JsonProperty("prosjektnavn")]
+    [JsonPropertyName("prosjektnavn")]
+    public string prosjektnavn { get; set; }
+
+    [XmlElement("prosjektnr")]
+    [JsonProperty("prosjektnr")]
+    [JsonPropertyName("prosjektnr")]
+    public string prosjektnr { get; set; }
+
+    [XmlElement("foretrukketSpraak")]
+    [JsonProperty("foretrukketSpraak")]
+    [JsonPropertyName("foretrukketSpraak")]
+    public KodeType foretrukketSpraak { get; set; }
+
+  }
+
+  public class KodeType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("kodeverdi")]
+    [JsonProperty("kodeverdi")]
+    [JsonPropertyName("kodeverdi")]
+    public string kodeverdi { get; set; }
+
+    [XmlElement("kodebeskrivelse")]
+    [JsonProperty("kodebeskrivelse")]
+    [JsonPropertyName("kodebeskrivelse")]
+    public string kodebeskrivelse { get; set; }
+
+  }
+
+  public class GenerelleVilkaarType
+  {
+    [XmlElement("norskSvenskDansk")]
+    [JsonProperty("norskSvenskDansk")]
+    [JsonPropertyName("norskSvenskDansk")]
+    public bool? norskSvenskDansk { get; set; }
+
+  }
+
+  public class SoeknadGjelderType
+  {
+    [XmlElement("gjelderHeleTiltaket")]
+    [JsonProperty("gjelderHeleTiltaket")]
+    [JsonPropertyName("gjelderHeleTiltaket")]
+    public bool? gjelderHeleTiltaket { get; set; }
+
+    [XmlElement("delAvTiltaket")]
+    [JsonProperty("delAvTiltaket")]
+    [JsonPropertyName("delAvTiltaket")]
+    public string delAvTiltaket { get; set; }
+
+    [XmlElement("type")]
+    [JsonProperty("type")]
+    [JsonPropertyName("type")]
+    public KodeListe type { get; set; }
+
+    [XmlElement("delsoeknadsnummer")]
+    [JsonProperty("delsoeknadsnummer")]
+    [JsonPropertyName("delsoeknadsnummer")]
+    public string delsoeknadsnummer { get; set; }
+
+    [XmlElement("foelgebrev")]
+    [JsonProperty("foelgebrev")]
+    [JsonPropertyName("foelgebrev")]
+    public string foelgebrev { get; set; }
+
+  }
+
+  public class KodeListe
+  {
+    [XmlElement("kode")]
+    [JsonProperty("kode")]
+    [JsonPropertyName("kode")]
+    public List<KodeType> kode { get; set; }
+
+  }
+
+  public class DelsoeknadListe
+  {
+    [XmlElement("delsoeknad")]
+    [JsonProperty("delsoeknad")]
+    [JsonPropertyName("delsoeknad")]
+    public List<DelsoeknadType> delsoeknad { get; set; }
+
+  }
+
+  public class DelsoeknadType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("delAvTiltaket")]
+    [JsonProperty("delAvTiltaket")]
+    [JsonPropertyName("delAvTiltaket")]
+    public string delAvTiltaket { get; set; }
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlElement("tillatelsedato")]
+    [JsonProperty("tillatelsedato")]
+    [JsonPropertyName("tillatelsedato")]
+    public string tillatelsedato { get; set; }
+
+    [XmlElement("kommentar")]
+    [JsonProperty("kommentar")]
+    [JsonPropertyName("kommentar")]
+    public string kommentar { get; set; }
+
+    [XmlElement("type")]
+    [JsonProperty("type")]
+    [JsonPropertyName("type")]
+    public KodeListe type { get; set; }
+
+    [XmlElement("delsoeknadsnummer")]
+    [JsonProperty("delsoeknadsnummer")]
+    [JsonPropertyName("delsoeknadsnummer")]
+    public string delsoeknadsnummer { get; set; }
+
+  }
+
+  public class UtfallSvarListe
+  {
+    [XmlElement("utfallSvar")]
+    [JsonProperty("utfallSvar")]
+    [JsonPropertyName("utfallSvar")]
+    public List<UtfallSvarType> utfallSvar { get; set; }
+
+  }
+
+  public class UtfallSvarType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("utfallId")]
+    [JsonProperty("utfallId")]
+    [JsonPropertyName("utfallId")]
+    public string utfallId { get; set; }
+
+    [XmlElement("utfallType")]
+    [JsonProperty("utfallType")]
+    [JsonPropertyName("utfallType")]
+    public KodeType utfallType { get; set; }
+
+    [XmlElement("utloestFraSjekkpunkt")]
+    [JsonProperty("utloestFraSjekkpunkt")]
+    [JsonPropertyName("utloestFraSjekkpunkt")]
+    public SjekkpunktType utloestFraSjekkpunkt { get; set; }
+
+    [XmlElement("tema")]
+    [JsonProperty("tema")]
+    [JsonPropertyName("tema")]
+    public KodeType tema { get; set; }
+
+    [XmlElement("tittel")]
+    [JsonProperty("tittel")]
+    [JsonPropertyName("tittel")]
+    public string tittel { get; set; }
+
+    [XmlElement("beskrivelse")]
+    [JsonProperty("beskrivelse")]
+    [JsonPropertyName("beskrivelse")]
+    public string beskrivelse { get; set; }
+
+    [XmlElement("erUtfallBesvaresSenere")]
+    [JsonProperty("erUtfallBesvaresSenere")]
+    [JsonPropertyName("erUtfallBesvaresSenere")]
+    public bool? erUtfallBesvaresSenere { get; set; }
+
+    [XmlElement("erUtfallBesvart")]
+    [JsonProperty("erUtfallBesvart")]
+    [JsonPropertyName("erUtfallBesvart")]
+    public bool? erUtfallBesvart { get; set; }
+
+    [XmlElement("kommentar")]
+    [JsonProperty("kommentar")]
+    [JsonPropertyName("kommentar")]
+    public string kommentar { get; set; }
+
+    [XmlElement("vedleggsliste")]
+    [JsonProperty("vedleggsliste")]
+    [JsonPropertyName("vedleggsliste")]
+    public VedleggListe vedleggsliste { get; set; }
+
+  }
+
+  public class SjekkpunktType
+  {
+    [XmlElement("sjekkpunktId")]
+    [JsonProperty("sjekkpunktId")]
+    [JsonPropertyName("sjekkpunktId")]
+    public string sjekkpunktId { get; set; }
+
+    [XmlElement("sjekkpunktEier")]
+    [JsonProperty("sjekkpunktEier")]
+    [JsonPropertyName("sjekkpunktEier")]
+    public string sjekkpunktEier { get; set; }
+
+  }
+
+  public class VedleggListe
+  {
+    [XmlElement("vedlegg")]
+    [JsonProperty("vedlegg")]
+    [JsonPropertyName("vedlegg")]
+    public List<VedleggType> vedlegg { get; set; }
+
+  }
+
+  public class VedleggType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("versjonsnummer")]
+    [JsonProperty("versjonsnummer")]
+    [JsonPropertyName("versjonsnummer")]
+    public string versjonsnummer { get; set; }
+
+    [XmlElement("vedleggstype")]
+    [JsonProperty("vedleggstype")]
+    [JsonPropertyName("vedleggstype")]
+    public KodeType vedleggstype { get; set; }
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlElement("versjonsdato")]
+    [JsonProperty("versjonsdato")]
+    [JsonPropertyName("versjonsdato")]
+    public string versjonsdato { get; set; }
+
+    [XmlElement("filnavn")]
+    [JsonProperty("filnavn")]
+    [JsonPropertyName("filnavn")]
+    public string filnavn { get; set; }
+
+  }
+
+  public class PartType
+  {
+    [XmlElement("partstype")]
+    [JsonProperty("partstype")]
+    [JsonPropertyName("partstype")]
+    public KodeType partstype { get; set; }
+
+    [XmlElement("foedselsnummer")]
+    [JsonProperty("foedselsnummer")]
+    [JsonPropertyName("foedselsnummer")]
+    public string foedselsnummer { get; set; }
+
+    [XmlElement("organisasjonsnummer")]
+    [JsonProperty("organisasjonsnummer")]
+    [JsonPropertyName("organisasjonsnummer")]
+    public string organisasjonsnummer { get; set; }
+
+    [XmlElement("navn")]
+    [JsonProperty("navn")]
+    [JsonPropertyName("navn")]
+    public string navn { get; set; }
+
+    [XmlElement("adresse")]
+    [JsonProperty("adresse")]
+    [JsonPropertyName("adresse")]
+    public EnkelAdresseType adresse { get; set; }
+
+    [XmlElement("telefonnummer")]
+    [JsonProperty("telefonnummer")]
+    [JsonPropertyName("telefonnummer")]
+    public string telefonnummer { get; set; }
+
+    [XmlElement("mobilnummer")]
+    [JsonProperty("mobilnummer")]
+    [JsonPropertyName("mobilnummer")]
+    public string mobilnummer { get; set; }
+
+    [XmlElement("epost")]
+    [JsonProperty("epost")]
+    [JsonPropertyName("epost")]
+    public string epost { get; set; }
+
+    [XmlElement("kontaktperson")]
+    [JsonProperty("kontaktperson")]
+    [JsonPropertyName("kontaktperson")]
+    public KontaktpersonType kontaktperson { get; set; }
+
+  }
+
+  public class EnkelAdresseType
+  {
+    [XmlElement("adresselinje1")]
+    [JsonProperty("adresselinje1")]
+    [JsonPropertyName("adresselinje1")]
+    public string adresselinje1 { get; set; }
+
+    [XmlElement("adresselinje2")]
+    [JsonProperty("adresselinje2")]
+    [JsonPropertyName("adresselinje2")]
+    public string adresselinje2 { get; set; }
+
+    [XmlElement("adresselinje3")]
+    [JsonProperty("adresselinje3")]
+    [JsonPropertyName("adresselinje3")]
+    public string adresselinje3 { get; set; }
+
+    [XmlElement("postnr")]
+    [JsonProperty("postnr")]
+    [JsonPropertyName("postnr")]
+    public string postnr { get; set; }
+
+    [XmlElement("poststed")]
+    [JsonProperty("poststed")]
+    [JsonPropertyName("poststed")]
+    public string poststed { get; set; }
+
+    [XmlElement("landkode")]
+    [JsonProperty("landkode")]
+    [JsonPropertyName("landkode")]
+    public string landkode { get; set; }
+
+  }
+
+  public class KontaktpersonType
+  {
+    [XmlElement("navn")]
+    [JsonProperty("navn")]
+    [JsonPropertyName("navn")]
+    public string navn { get; set; }
+
+    [XmlElement("telefonnummer")]
+    [JsonProperty("telefonnummer")]
+    [JsonPropertyName("telefonnummer")]
+    public string telefonnummer { get; set; }
+
+    [XmlElement("mobilnummer")]
+    [JsonProperty("mobilnummer")]
+    [JsonPropertyName("mobilnummer")]
+    public string mobilnummer { get; set; }
+
+    [XmlElement("epost")]
+    [JsonProperty("epost")]
+    [JsonPropertyName("epost")]
+    public string epost { get; set; }
+
+  }
+
+  public class GjenstaaendeArbeiderType
+  {
+    [XmlElement("gjenstaaendeInnenfor")]
+    [JsonProperty("gjenstaaendeInnenfor")]
+    [JsonPropertyName("gjenstaaendeInnenfor")]
+    public string gjenstaaendeInnenfor { get; set; }
+
+    [XmlElement("gjenstaaendeUtenfor")]
+    [JsonProperty("gjenstaaendeUtenfor")]
+    [JsonPropertyName("gjenstaaendeUtenfor")]
+    public string gjenstaaendeUtenfor { get; set; }
+
+  }
+
+  public class SikkerhetsnivaaType
+  {
+    [XmlElement("harTilstrekkeligSikkerhet")]
+    [JsonProperty("harTilstrekkeligSikkerhet")]
+    [JsonPropertyName("harTilstrekkeligSikkerhet")]
+    public bool? harTilstrekkeligSikkerhet { get; set; }
+
+    [XmlElement("typeArbeider")]
+    [JsonProperty("typeArbeider")]
+    [JsonPropertyName("typeArbeider")]
+    public string typeArbeider { get; set; }
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlElement("utfoertInnen")]
+    [JsonProperty("utfoertInnen")]
+    [JsonPropertyName("utfoertInnen")]
+    public string utfoertInnen { get; set; }
+
+    [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
+    [XmlElement("bekreftelseInnen")]
+    [JsonProperty("bekreftelseInnen")]
+    [JsonPropertyName("bekreftelseInnen")]
+    public string bekreftelseInnen { get; set; }
+
+  }
+}

--- a/testdata/Model/CSharp/XsAll/planvarsel/v2/planvarsel.cs
+++ b/testdata/Model/CSharp/XsAll/planvarsel/v2/planvarsel.cs
@@ -1,0 +1,522 @@
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
+namespace Altinn.App.Models
+{
+  [XmlRoot(ElementName="Planvarsel", Namespace="https://skjema.ft.dibk.no/planvarsel/2.0")]
+  public class PlanvarselType
+  {
+    [XmlAttribute("dataFormatProvider")]
+    [BindNever]
+    public string dataFormatProvider { get; set; } = "DIBK";
+
+    [XmlAttribute("dataFormatId")]
+    [BindNever]
+    public string dataFormatId { get; set; } = "11000";
+
+    [XmlAttribute("dataFormatVersion")]
+    [BindNever]
+    public string dataFormatVersion { get; set; } = "2.0";
+
+    [XmlElement("forslagsstiller")]
+    [JsonProperty("forslagsstiller")]
+    [JsonPropertyName("forslagsstiller")]
+    public PartType forslagsstiller { get; set; }
+
+    [XmlElement("beroerteParter")]
+    [JsonProperty("beroerteParter")]
+    [JsonPropertyName("beroerteParter")]
+    public BeroertPartListe beroerteParter { get; set; }
+
+    [XmlElement("kommunenavn")]
+    [JsonProperty("kommunenavn")]
+    [JsonPropertyName("kommunenavn")]
+    public string kommunenavn { get; set; }
+
+    [XmlElement("eiendomByggested")]
+    [JsonProperty("eiendomByggested")]
+    [JsonPropertyName("eiendomByggested")]
+    public EiendomListe eiendomByggested { get; set; }
+
+    [XmlElement("signatur")]
+    [JsonProperty("signatur")]
+    [JsonPropertyName("signatur")]
+    public SignaturType signatur { get; set; }
+
+    [XmlElement("gjeldendePlan")]
+    [JsonProperty("gjeldendePlan")]
+    [JsonPropertyName("gjeldendePlan")]
+    public GjeldendePlanListe gjeldendePlan { get; set; }
+
+    [XmlElement("plankonsulent")]
+    [JsonProperty("plankonsulent")]
+    [JsonPropertyName("plankonsulent")]
+    public PartType plankonsulent { get; set; }
+
+    [XmlElement("metadata")]
+    [JsonProperty("metadata")]
+    [JsonPropertyName("metadata")]
+    public MetadataType metadata { get; set; }
+
+    [XmlElement("planforslag")]
+    [JsonProperty("planforslag")]
+    [JsonPropertyName("planforslag")]
+    public PlanType planforslag { get; set; }
+
+  }
+
+  public class PartType
+  {
+    [XmlElement("partstype")]
+    [JsonProperty("partstype")]
+    [JsonPropertyName("partstype")]
+    public KodeType partstype { get; set; }
+
+    [XmlElement("foedselsnummer")]
+    [JsonProperty("foedselsnummer")]
+    [JsonPropertyName("foedselsnummer")]
+    public string foedselsnummer { get; set; }
+
+    [XmlElement("organisasjonsnummer")]
+    [JsonProperty("organisasjonsnummer")]
+    [JsonPropertyName("organisasjonsnummer")]
+    public string organisasjonsnummer { get; set; }
+
+    [XmlElement("navn")]
+    [JsonProperty("navn")]
+    [JsonPropertyName("navn")]
+    public string navn { get; set; }
+
+    [XmlElement("epost")]
+    [JsonProperty("epost")]
+    [JsonPropertyName("epost")]
+    public string epost { get; set; }
+
+    [XmlElement("adresse")]
+    [JsonProperty("adresse")]
+    [JsonPropertyName("adresse")]
+    public EnkelAdresseType adresse { get; set; }
+
+    [XmlElement("telefon")]
+    [JsonProperty("telefon")]
+    [JsonPropertyName("telefon")]
+    public string telefon { get; set; }
+
+  }
+
+  public class KodeType
+  {
+    [XmlElement("kodeverdi")]
+    [JsonProperty("kodeverdi")]
+    [JsonPropertyName("kodeverdi")]
+    public string kodeverdi { get; set; }
+
+    [XmlElement("kodebeskrivelse")]
+    [JsonProperty("kodebeskrivelse")]
+    [JsonPropertyName("kodebeskrivelse")]
+    public string kodebeskrivelse { get; set; }
+
+  }
+
+  public class EnkelAdresseType
+  {
+    [XmlElement("adresselinje1")]
+    [JsonProperty("adresselinje1")]
+    [JsonPropertyName("adresselinje1")]
+    public string adresselinje1 { get; set; }
+
+    [XmlElement("adresselinje2")]
+    [JsonProperty("adresselinje2")]
+    [JsonPropertyName("adresselinje2")]
+    public string adresselinje2 { get; set; }
+
+    [XmlElement("adresselinje3")]
+    [JsonProperty("adresselinje3")]
+    [JsonPropertyName("adresselinje3")]
+    public string adresselinje3 { get; set; }
+
+    [XmlElement("postnr")]
+    [JsonProperty("postnr")]
+    [JsonPropertyName("postnr")]
+    public string postnr { get; set; }
+
+    [XmlElement("poststed")]
+    [JsonProperty("poststed")]
+    [JsonPropertyName("poststed")]
+    public string poststed { get; set; }
+
+    [XmlElement("landkode")]
+    [JsonProperty("landkode")]
+    [JsonPropertyName("landkode")]
+    public string landkode { get; set; }
+
+  }
+
+  public class BeroertPartListe
+  {
+    [XmlElement("beroertpart")]
+    [JsonProperty("beroertpart")]
+    [JsonPropertyName("beroertpart")]
+    public List<BeroertPartType> beroertpart { get; set; }
+
+  }
+
+  public class BeroertPartType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("partstype")]
+    [JsonProperty("partstype")]
+    [JsonPropertyName("partstype")]
+    public KodeType partstype { get; set; }
+
+    [XmlElement("foedselsnummer")]
+    [JsonProperty("foedselsnummer")]
+    [JsonPropertyName("foedselsnummer")]
+    public string foedselsnummer { get; set; }
+
+    [XmlElement("organisasjonsnummer")]
+    [JsonProperty("organisasjonsnummer")]
+    [JsonPropertyName("organisasjonsnummer")]
+    public string organisasjonsnummer { get; set; }
+
+    [XmlElement("navn")]
+    [JsonProperty("navn")]
+    [JsonPropertyName("navn")]
+    public string navn { get; set; }
+
+    [XmlElement("telefon")]
+    [JsonProperty("telefon")]
+    [JsonPropertyName("telefon")]
+    public string telefon { get; set; }
+
+    [XmlElement("epost")]
+    [JsonProperty("epost")]
+    [JsonPropertyName("epost")]
+    public string epost { get; set; }
+
+    [XmlElement("adresse")]
+    [JsonProperty("adresse")]
+    [JsonPropertyName("adresse")]
+    public EnkelAdresseType adresse { get; set; }
+
+    [XmlElement("beskrivelseForVarsel")]
+    [JsonProperty("beskrivelseForVarsel")]
+    [JsonPropertyName("beskrivelseForVarsel")]
+    public string beskrivelseForVarsel { get; set; }
+
+    [XmlElement("systemReferanse")]
+    [JsonProperty("systemReferanse")]
+    [JsonPropertyName("systemReferanse")]
+    public string systemReferanse { get; set; }
+
+    [XmlElement("erHoeringsmyndighet")]
+    [JsonProperty("erHoeringsmyndighet")]
+    [JsonPropertyName("erHoeringsmyndighet")]
+    public bool? erHoeringsmyndighet { get; set; }
+
+    [XmlElement("gjelderEiendom")]
+    [JsonProperty("gjelderEiendom")]
+    [JsonPropertyName("gjelderEiendom")]
+    public GjelderEiendomListe gjelderEiendom { get; set; }
+
+  }
+
+  public class GjelderEiendomListe
+  {
+    [XmlElement("gjeldereiendom")]
+    [JsonProperty("gjeldereiendom")]
+    [JsonPropertyName("gjeldereiendom")]
+    public List<EiendomType> gjeldereiendom { get; set; }
+
+  }
+
+  public class EiendomType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("eiendomsidentifikasjon")]
+    [JsonProperty("eiendomsidentifikasjon")]
+    [JsonPropertyName("eiendomsidentifikasjon")]
+    public MatrikkelnummerType eiendomsidentifikasjon { get; set; }
+
+    [XmlElement("adresse")]
+    [JsonProperty("adresse")]
+    [JsonPropertyName("adresse")]
+    public EiendommensAdresseType adresse { get; set; }
+
+    [XmlElement("bygningsnummer")]
+    [JsonProperty("bygningsnummer")]
+    [JsonPropertyName("bygningsnummer")]
+    public string bygningsnummer { get; set; }
+
+    [XmlElement("bolignummer")]
+    [JsonProperty("bolignummer")]
+    [JsonPropertyName("bolignummer")]
+    public string bolignummer { get; set; }
+
+    [XmlElement("kommunenavn")]
+    [JsonProperty("kommunenavn")]
+    [JsonPropertyName("kommunenavn")]
+    public string kommunenavn { get; set; }
+
+  }
+
+  public class MatrikkelnummerType
+  {
+    [XmlElement("kommunenummer")]
+    [JsonProperty("kommunenummer")]
+    [JsonPropertyName("kommunenummer")]
+    public string kommunenummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("gaardsnummer")]
+    [JsonProperty("gaardsnummer")]
+    [JsonPropertyName("gaardsnummer")]
+    public int? gaardsnummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("bruksnummer")]
+    [JsonProperty("bruksnummer")]
+    [JsonPropertyName("bruksnummer")]
+    public int? bruksnummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("festenummer")]
+    [JsonProperty("festenummer")]
+    [JsonPropertyName("festenummer")]
+    public int? festenummer { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("seksjonsnummer")]
+    [JsonProperty("seksjonsnummer")]
+    [JsonPropertyName("seksjonsnummer")]
+    public int? seksjonsnummer { get; set; }
+
+  }
+
+  public class EiendommensAdresseType
+  {
+    [XmlElement("adresselinje1")]
+    [JsonProperty("adresselinje1")]
+    [JsonPropertyName("adresselinje1")]
+    public string adresselinje1 { get; set; }
+
+    [XmlElement("adresselinje2")]
+    [JsonProperty("adresselinje2")]
+    [JsonPropertyName("adresselinje2")]
+    public string adresselinje2 { get; set; }
+
+    [XmlElement("adresselinje3")]
+    [JsonProperty("adresselinje3")]
+    [JsonPropertyName("adresselinje3")]
+    public string adresselinje3 { get; set; }
+
+    [XmlElement("postnr")]
+    [JsonProperty("postnr")]
+    [JsonPropertyName("postnr")]
+    public string postnr { get; set; }
+
+    [XmlElement("poststed")]
+    [JsonProperty("poststed")]
+    [JsonPropertyName("poststed")]
+    public string poststed { get; set; }
+
+    [XmlElement("landkode")]
+    [JsonProperty("landkode")]
+    [JsonPropertyName("landkode")]
+    public string landkode { get; set; }
+
+    [XmlElement("gatenavn")]
+    [JsonProperty("gatenavn")]
+    [JsonPropertyName("gatenavn")]
+    public string gatenavn { get; set; }
+
+    [XmlElement("husnr")]
+    [JsonProperty("husnr")]
+    [JsonPropertyName("husnr")]
+    public string husnr { get; set; }
+
+    [XmlElement("bokstav")]
+    [JsonProperty("bokstav")]
+    [JsonPropertyName("bokstav")]
+    public string bokstav { get; set; }
+
+  }
+
+  public class EiendomListe
+  {
+    [XmlElement("eiendom")]
+    [JsonProperty("eiendom")]
+    [JsonPropertyName("eiendom")]
+    public List<EiendomType> eiendom { get; set; }
+
+  }
+
+  public class SignaturType
+  {
+    [XmlElement("signaturdato")]
+    [JsonProperty("signaturdato")]
+    [JsonPropertyName("signaturdato")]
+    public DateTime? signaturdato { get; set; }
+
+    [XmlElement("signertAv")]
+    [JsonProperty("signertAv")]
+    [JsonPropertyName("signertAv")]
+    public string signertAv { get; set; }
+
+    [XmlElement("signertPaaVegneAv")]
+    [JsonProperty("signertPaaVegneAv")]
+    [JsonPropertyName("signertPaaVegneAv")]
+    public string signertPaaVegneAv { get; set; }
+
+  }
+
+  public class GjeldendePlanListe
+  {
+    [XmlElement("gjeldendeplan")]
+    [JsonProperty("gjeldendeplan")]
+    [JsonPropertyName("gjeldendeplan")]
+    public List<GjeldendePlanType> gjeldendeplan { get; set; }
+
+  }
+
+  public class GjeldendePlanType
+  {
+    [XmlAttribute("altinnRowId")]
+    [JsonPropertyName("altinnRowId")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [Newtonsoft.Json.JsonIgnore]
+    public Guid AltinnRowId { get; set; }
+
+    public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
+
+    [XmlElement("navn")]
+    [JsonProperty("navn")]
+    [JsonPropertyName("navn")]
+    public string navn { get; set; }
+
+    [XmlElement("plantype")]
+    [JsonProperty("plantype")]
+    [JsonPropertyName("plantype")]
+    public KodeType plantype { get; set; }
+
+  }
+
+  public class MetadataType
+  {
+    [XmlElement("ftbId")]
+    [JsonProperty("ftbId")]
+    [JsonPropertyName("ftbId")]
+    public string ftbId { get; set; }
+
+    [XmlElement("hovedinnsendingsnummer")]
+    [JsonProperty("hovedinnsendingsnummer")]
+    [JsonPropertyName("hovedinnsendingsnummer")]
+    public string hovedinnsendingsnummer { get; set; }
+
+    [XmlElement("klartForSigneringFraSluttbrukersystem")]
+    [JsonProperty("klartForSigneringFraSluttbrukersystem")]
+    [JsonPropertyName("klartForSigneringFraSluttbrukersystem")]
+    public bool? klartForSigneringFraSluttbrukersystem { get; set; }
+
+    [XmlElement("fraSluttbrukersystem")]
+    [JsonProperty("fraSluttbrukersystem")]
+    [JsonPropertyName("fraSluttbrukersystem")]
+    public string fraSluttbrukersystem { get; set; }
+
+  }
+
+  public class PlanType
+  {
+    [XmlElement("plannavn")]
+    [JsonProperty("plannavn")]
+    [JsonPropertyName("plannavn")]
+    public string plannavn { get; set; }
+
+    [XmlElement("arealplanId")]
+    [JsonProperty("arealplanId")]
+    [JsonPropertyName("arealplanId")]
+    public string arealplanId { get; set; }
+
+    [XmlElement("hjemmesidePlanforslag")]
+    [JsonProperty("hjemmesidePlanforslag")]
+    [JsonPropertyName("hjemmesidePlanforslag")]
+    public string hjemmesidePlanforslag { get; set; }
+
+    [XmlElement("kravKonsekvensUtredning")]
+    [JsonProperty("kravKonsekvensUtredning")]
+    [JsonPropertyName("kravKonsekvensUtredning")]
+    public bool? kravKonsekvensUtredning { get; set; }
+
+    [XmlElement("planHensikt")]
+    [JsonProperty("planHensikt")]
+    [JsonPropertyName("planHensikt")]
+    public string planHensikt { get; set; }
+
+    [XmlElement("fristForInnspill")]
+    [JsonProperty("fristForInnspill")]
+    [JsonPropertyName("fristForInnspill")]
+    public DateTime? fristForInnspill { get; set; }
+
+    [XmlElement("hjemmesidePlanprogram")]
+    [JsonProperty("hjemmesidePlanprogram")]
+    [JsonPropertyName("hjemmesidePlanprogram")]
+    public string hjemmesidePlanprogram { get; set; }
+
+    [XmlElement("plantype")]
+    [JsonProperty("plantype")]
+    [JsonPropertyName("plantype")]
+    public KodeType plantype { get; set; }
+
+    [XmlElement("begrunnelseKU")]
+    [JsonProperty("begrunnelseKU")]
+    [JsonPropertyName("begrunnelseKU")]
+    public string begrunnelseKU { get; set; }
+
+    [XmlElement("kommunensSaksnummer")]
+    [JsonProperty("kommunensSaksnummer")]
+    [JsonPropertyName("kommunensSaksnummer")]
+    public SaksnummerType kommunensSaksnummer { get; set; }
+
+    [XmlElement("saksgangOgMedvirkning")]
+    [JsonProperty("saksgangOgMedvirkning")]
+    [JsonPropertyName("saksgangOgMedvirkning")]
+    public string saksgangOgMedvirkning { get; set; }
+
+  }
+
+  public class SaksnummerType
+  {
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("saksaar")]
+    [JsonProperty("saksaar")]
+    [JsonPropertyName("saksaar")]
+    public int? saksaar { get; set; }
+
+    [Range(Int32.MinValue,Int32.MaxValue)]
+    [XmlElement("sakssekvensnummer")]
+    [JsonProperty("sakssekvensnummer")]
+    [JsonPropertyName("sakssekvensnummer")]
+    public int? sakssekvensnummer { get; set; }
+
+  }
+}

--- a/testdata/Model/XmlSchema/XsAll/ferdigattest/v4/ferdigattest.xsd
+++ b/testdata/Model/XmlSchema/XsAll/ferdigattest/v4/ferdigattest.xsd
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="https://skjema.ft.dibk.no/ferdigattest/v4"
+  xmlns="https://skjema.ft.dibk.no/ferdigattest/v4" elementFormDefault="qualified">
+  <xs:element name="ferdigattest" type="FerdigattestType" />
+  <xs:complexType name="FerdigattestType">
+    <xs:all>
+      <xs:element name="eiendomByggested" minOccurs="0" maxOccurs="1" nillable="true" type="EiendomListe" />
+      <xs:element name="kommunensSaksnummer" minOccurs="0" maxOccurs="1" nillable="true" type="SaksnummerType" />
+      <xs:element name="metadata" minOccurs="0" maxOccurs="1" nillable="true" type="MetadataType" />
+      <xs:element name="generelleVilkaar" minOccurs="0" maxOccurs="1" nillable="true" type="GenerelleVilkaarType" />
+      <xs:element name="soeknadGjelder" minOccurs="0" maxOccurs="1" nillable="true" type="BeskrivelseAvTiltakType" />
+      <xs:element name="utfallBesvarelse" minOccurs="0" maxOccurs="1" nillable="true" type="UtfallSvarListe" />
+      <xs:element name="kravFerdigattest" minOccurs="0" maxOccurs="1" nillable="true" type="KravFerdigattestType" />
+      <xs:element name="foretattIkkeSoeknadspliktigeJusteringer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean" />
+      <xs:element name="tilstrekkeligDokumentasjonOverlevertEier" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean" />
+      <xs:element name="varmesystem" minOccurs="0" maxOccurs="1" nillable="true" type="VarmesystemType" />
+      <xs:element name="tiltakshaver" minOccurs="0" maxOccurs="1" nillable="true" type="PartType" />
+      <xs:element name="ansvarligSoeker" minOccurs="0" maxOccurs="1" nillable="true" type="PartType" />
+      <xs:element name="ansvarForByggesaken" minOccurs="0" maxOccurs="1" nillable="true" type="KodeType" />
+    </xs:all>
+    <xs:attribute name="dataFormatProvider" type="xs:string" use="required" fixed="DIBK"/>
+    <xs:attribute name="dataFormatId" type="xs:string" use="required" fixed="10005"/>
+    <xs:attribute name="dataFormatVersion" type="xs:string" use="required" fixed="4"/>
+  </xs:complexType>
+  <xs:element name="Eiendom" type="EiendomType" />
+  <xs:complexType name="EiendomListe">
+    <xs:sequence>
+      <xs:element name="eiendom" type="EiendomType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="EiendomType">
+    <xs:all>
+      <xs:element name="eiendomsidentifikasjon" minOccurs="0" maxOccurs="1" nillable="true" type="MatrikkelnummerType" />
+      <xs:element name="adresse" minOccurs="0" maxOccurs="1" nillable="true" type="EiendommensAdresseType" />
+      <xs:element name="bygningsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="bolignummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="kommunenavn" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Matrikkelnummer" type="MatrikkelnummerType" />
+  <xs:complexType name="MatrikkelnummerType">
+    <xs:all>
+      <xs:element name="kommunenummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="gaardsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:int" />
+      <xs:element name="bruksnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:int" />
+      <xs:element name="festenummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:int" />
+      <xs:element name="seksjonsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:int" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="EiendommensAdresse" type="EiendommensAdresseType" />
+  <xs:complexType name="EiendommensAdresseType">
+    <xs:all>
+      <xs:element name="adresselinje1" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="adresselinje2" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="adresselinje3" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="postnr" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="poststed" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="landkode" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="gatenavn" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="husnr" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="bokstav" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Saksnummer" type="SaksnummerType" />
+  <xs:complexType name="SaksnummerType">
+    <xs:all>
+      <xs:element name="saksaar" minOccurs="0" maxOccurs="1" nillable="true" type="xs:int" />
+      <xs:element name="sakssekvensnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:int" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Metadata" type="MetadataType" />
+  <xs:complexType name="MetadataType">
+    <xs:all>
+      <xs:element name="fraSluttbrukersystem" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="ftbId" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="prosjektnavn" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="prosjektnr" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="foretrukketSpraak" minOccurs="0" maxOccurs="1" nillable="true" type="KodeType" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Part" type="PartType" />
+  <xs:complexType name="PartType">
+    <xs:all>
+      <xs:element name="partstype" minOccurs="0" maxOccurs="1" nillable="true" type="KodeType" />
+      <xs:element name="foedselsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="organisasjonsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="navn" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="adresse" minOccurs="0" maxOccurs="1" nillable="true" type="EnkelAdresseType" />
+      <xs:element name="telefonnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="mobilnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="epost" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="kontaktperson" minOccurs="0" maxOccurs="1" nillable="true" type="KontaktpersonType" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Kontaktperson" type="KontaktpersonType" />
+  <xs:complexType name="KontaktpersonType">
+    <xs:all>
+      <xs:element name="navn" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="telefonnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="mobilnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="epost" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="EnkelAdresse" type="EnkelAdresseType" />
+  <xs:complexType name="EnkelAdresseType">
+    <xs:all>
+      <xs:element name="adresselinje1" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="adresselinje2" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="adresselinje3" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="postnr" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="poststed" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="landkode" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="BeskrivelseAvTiltak" type="BeskrivelseAvTiltakType" />
+  <xs:complexType name="BeskrivelseAvTiltakType">
+    <xs:all>
+      <xs:element name="type" minOccurs="0" maxOccurs="1" nillable="true" type="KodeListe" />
+      <xs:element name="foelgebrev" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="GenerelleVilkaar" type="GenerelleVilkaarType" />
+  <xs:complexType name="GenerelleVilkaarType">
+    <xs:all>
+      <xs:element name="norskSvenskDansk" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="UtfallSvar" type="UtfallSvarType" />
+  <xs:complexType name="UtfallSvarListe">
+    <xs:sequence>
+      <xs:element name="utfallSvar" type="UtfallSvarType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="UtfallSvarType">
+    <xs:all>
+      <xs:element name="utfallId" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="utfallType" minOccurs="0" maxOccurs="1" nillable="true" type="KodeType" />
+      <xs:element name="utloestFraSjekkpunkt" minOccurs="0" maxOccurs="1" nillable="true" type="SjekkpunktType" />
+      <xs:element name="tema" minOccurs="0" maxOccurs="1" nillable="true" type="KodeType" />
+      <xs:element name="tittel" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="beskrivelse" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="erUtfallBesvaresSenere" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean" />
+      <xs:element name="erUtfallBesvart" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean" />
+      <xs:element name="kommentar" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="vedleggsliste" minOccurs="0" maxOccurs="1" nillable="true" type="VedleggListe" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Sjekkpunkt" type="SjekkpunktType" />
+  <xs:complexType name="SjekkpunktType">
+    <xs:all>
+      <xs:element name="sjekkpunktId" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="sjekkpunktEier" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Vedlegg" type="VedleggType" />
+  <xs:complexType name="VedleggListe">
+    <xs:sequence>
+      <xs:element name="vedlegg" type="VedleggType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="VedleggType">
+    <xs:all>
+      <xs:element name="versjonsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="vedleggstype" minOccurs="0" maxOccurs="1" nillable="true" type="KodeType" />
+      <xs:element name="versjonsdato" minOccurs="0" maxOccurs="1" nillable="true" type="xs:date" />
+      <xs:element name="filnavn" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="KravFerdigattest" type="KravFerdigattestType" />
+  <xs:complexType name="KravFerdigattestType">
+    <xs:all>
+      <xs:element name="tilfredsstillerTiltaketKraveneFerdigattest" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean" />
+      <xs:element name="utfoertInnen" minOccurs="0" maxOccurs="1" nillable="true" type="xs:date" />
+      <xs:element name="typeArbeider" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="bekreftelseInnen" minOccurs="0" maxOccurs="1" nillable="true" type="xs:date" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Varmesystem" type="VarmesystemType" />
+  <xs:complexType name="VarmesystemType">
+    <xs:all>
+      <xs:element name="varmefordeling" minOccurs="0" maxOccurs="1" nillable="true" type="KodeListe" />
+      <xs:element name="energiforsyning" minOccurs="0" maxOccurs="1" nillable="true" type="KodeListe" />
+      <xs:element name="relevant" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Kode" type="KodeType" />
+  <xs:complexType name="KodeListe">
+    <xs:sequence>
+      <xs:element name="kode" type="KodeType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="KodeType">
+    <xs:all>
+      <xs:element name="kodeverdi" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="kodebeskrivelse" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+</xs:schema>

--- a/testdata/Model/XmlSchema/XsAll/igangsettingstillatelse/v4/igangsettingstillatelse.xsd
+++ b/testdata/Model/XmlSchema/XsAll/igangsettingstillatelse/v4/igangsettingstillatelse.xsd
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns="https://skjema.ft.dibk.no/igangsettingstillatelse/v4"
+	targetNamespace="https://skjema.ft.dibk.no/igangsettingstillatelse/v4" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:element name="igangsettingstillatelse" type="IgangsettingstillatelseType"/>
+	<xs:complexType name="IgangsettingstillatelseType">
+		<xs:all>
+			<xs:element name="eiendomByggested" type="EiendomListe" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="kommunensSaksnummer" type="SaksnummerType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="metadata" type="MetadataType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="generelleVilkaar" type="GenerelleVilkaarType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="soeknadGjelder" type="SoeknadenGjelderType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="delsoeknader" type="DelsoeknadListe" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="utfallBesvarelse" type="UtfallSvarListe" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ansvarligSoeker" type="PartType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ansvarForByggesaken" type="KodeType" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+		<xs:attribute name="dataFormatProvider" type="xs:string" use="required" fixed="DIBK"/>
+		<xs:attribute name="dataFormatId" type="xs:string" use="required" fixed="10003"/>
+		<xs:attribute name="dataFormatVersion" type="xs:string" use="required" fixed="4"/>
+	</xs:complexType>
+	<xs:element name="Eiendom" type="EiendomType"/>
+	<xs:complexType name="EiendomListe">
+		<xs:sequence>
+			<xs:element name="eiendom" type="EiendomType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EiendomType">
+		<xs:all>
+			<xs:element name="eiendomsidentifikasjon" type="MatrikkelnummerType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresse" type="EiendommensAdresseType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="bygningsnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="bolignummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="kommunenavn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Matrikkelnummer" type="MatrikkelnummerType"/>
+	<xs:complexType name="MatrikkelnummerType">
+		<xs:all>
+			<xs:element name="kommunenummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="gaardsnummer" type="xs:int" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="bruksnummer" type="xs:int" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="festenummer" type="xs:int" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="seksjonsnummer" type="xs:int" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="EiendommensAdresse" type="EiendommensAdresseType"/>
+	<xs:complexType name="EiendommensAdresseType">
+		<xs:all>
+			<xs:element name="adresselinje1" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresselinje2" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresselinje3" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="postnr" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="poststed" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="landkode" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="gatenavn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="husnr" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="bokstav" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Saksnummer" type="SaksnummerType"/>
+	<xs:complexType name="SaksnummerType">
+		<xs:all>
+			<xs:element name="saksaar" type="xs:int" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="sakssekvensnummer" type="xs:int" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Metadata" type="MetadataType"/>
+	<xs:complexType name="MetadataType">
+		<xs:all>
+			<xs:element name="fraSluttbrukersystem" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ftbId" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="prosjektnavn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="prosjektnr" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="foretrukketSpraak" type="KodeType" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="GenerelleVilkaar" type="GenerelleVilkaarType"/>
+	<xs:complexType name="GenerelleVilkaarType">
+		<xs:all>
+			<xs:element name="beroererArbeidsplasser" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="norskSvenskDansk" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="SoeknadenGjelder" type="SoeknadenGjelderType"/>
+	<xs:complexType name="SoeknadenGjelderType">
+		<xs:all>
+			<xs:element name="gjelderHeleTiltaket" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="delAvTiltaket" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="type" type="KodeListe" nillable="true" minOccurs="0" maxOccurs="1" />
+			<xs:element name="delsoeknadsnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="foelgebrev" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Delsoeknad" type="DelsoeknadType"/>
+	<xs:complexType name="DelsoeknadListe">
+		<xs:sequence>
+			<xs:element name="delsoeknad" type="DelsoeknadType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DelsoeknadType">
+		<xs:all>
+			<xs:element name="delAvTiltaket" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="tillatelsedato" type="xs:date" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="kommentar" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="type" type="KodeListe" nillable="true" minOccurs="0" maxOccurs="1" />
+			<xs:element name="delsoeknadsnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="UtfallSvar" type="UtfallSvarType"/>
+	<xs:complexType name="UtfallSvarListe">
+		<xs:sequence>
+			<xs:element name="utfallSvar" type="UtfallSvarType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="UtfallSvarType">
+		<xs:all>
+			<xs:element name="utfallId" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="utfallType" type="KodeType" nillable="true" minOccurs="0" maxOccurs="1" />
+			<xs:element name="utloestFraSjekkpunkt" type="SjekkpunktType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="tema" type="KodeType" nillable="true" minOccurs="0" maxOccurs="1" />
+			<xs:element name="tittel" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="beskrivelse" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="erUtfallBesvaresSenere" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="erUtfallBesvart" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="kommentar" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="vedleggsliste" type="VedleggListe" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Sjekkpunkt" type="SjekkpunktType"/>
+	<xs:complexType name="SjekkpunktType">
+		<xs:all>
+			<xs:element name="sjekkpunktId" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="sjekkpunktEier" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Vedlegg" type="VedleggType"/>
+	<xs:complexType name="VedleggListe">
+		<xs:sequence>
+			<xs:element name="vedlegg" type="VedleggType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="VedleggType">
+		<xs:all>
+			<xs:element name="versjonsnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="vedleggstype" type="KodeType" nillable="true" minOccurs="0" maxOccurs="1" />
+			<xs:element name="versjonsdato" type="xs:date" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="filnavn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Part" type="PartType"/>
+	<xs:complexType name="PartType">
+		<xs:all>
+			<xs:element name="partstype" type="KodeType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="foedselsnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="organisasjonsnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="navn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresse" type="EnkelAdresseType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="telefonnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="mobilnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="epost" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="kontaktperson" type="KontaktpersonType" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="EnkelAdresse" type="EnkelAdresseType"/>
+	<xs:complexType name="EnkelAdresseType">
+		<xs:all>
+			<xs:element name="adresselinje1" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresselinje2" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresselinje3" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="postnr" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="poststed" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="landkode" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Kontaktperson" type="KontaktpersonType"/>
+	<xs:complexType name="KontaktpersonType">
+		<xs:all>
+			<xs:element name="navn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="telefonnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="mobilnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="epost" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Kode" type="KodeType"/>
+	<xs:complexType name="KodeListe">
+		<xs:sequence>
+			<xs:element name="kode" type="KodeType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="KodeType">
+		<xs:all>
+			<xs:element name="kodeverdi" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="kodebeskrivelse" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+</xs:schema>

--- a/testdata/Model/XmlSchema/XsAll/midlertidigbrukstillatelse/v4/midlertidigbrukstillatelse.xsd
+++ b/testdata/Model/XmlSchema/XsAll/midlertidigbrukstillatelse/v4/midlertidigbrukstillatelse.xsd
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="https://skjema.ft.dibk.no/midlertidigbrukstillatelse/v4"
+  targetNamespace="https://skjema.ft.dibk.no/midlertidigbrukstillatelse/v4" elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <xs:element name="midlertidigbrukstillatelse" type="MidlertidigBrukstillatelseType" />
+  <xs:complexType name="MidlertidigBrukstillatelseType">
+    <xs:all>
+      <xs:element name="eiendomByggested" minOccurs="0" maxOccurs="1" nillable="true" type="EiendomListe" />
+      <xs:element name="kommunensSaksnummer" minOccurs="0" maxOccurs="1" nillable="true" type="SaksnummerType" />
+      <xs:element name="metadata" minOccurs="0" maxOccurs="1" nillable="true" type="MetadataType" />
+      <xs:element name="generelleVilkaar" minOccurs="0" maxOccurs="1" nillable="true" type="GenerelleVilkaarType" />
+      <xs:element name="soeknadGjelder" minOccurs="0" maxOccurs="1" nillable="true" type="SoeknadGjelderType" />
+      <xs:element name="delsoeknader" minOccurs="0" maxOccurs="1" nillable="true" type="DelsoeknadListe" />
+      <xs:element name="utfallBesvarelse" minOccurs="0" maxOccurs="1" nillable="true" type="UtfallSvarListe" />
+      <xs:element name="tiltakshaver" minOccurs="0" maxOccurs="1" nillable="true" type="PartType" />
+      <xs:element name="ansvarligSoeker" minOccurs="0" maxOccurs="1" nillable="true" type="PartType" />
+      <xs:element name="datoFerdigattest" minOccurs="0" maxOccurs="1" nillable="true" type="xs:date" />
+      <xs:element name="gjenstaaendeArbeider" minOccurs="0" maxOccurs="1" nillable="true" type="GjenstaaendeArbeiderType" />
+      <xs:element name="sikkerhetsnivaa" minOccurs="0" maxOccurs="1" nillable="true" type="SikkerhetsnivaaType" />
+      <xs:element name="ansvarForByggesaken" minOccurs="0" maxOccurs="1" nillable="true" type="KodeType" />
+    </xs:all>
+    <xs:attribute name="dataFormatProvider" type="xs:string" use="required" fixed="DIBK"/>
+    <xs:attribute name="dataFormatId" type="xs:string" use="required" fixed="10004"/>
+    <xs:attribute name="dataFormatVersion" type="xs:string" use="required" fixed="4"/>
+  </xs:complexType>
+  <xs:element name="Eiendom" type="EiendomType" />
+  <xs:complexType name="EiendomListe">
+    <xs:sequence>
+      <xs:element name="eiendom" type="EiendomType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="EiendomType">
+    <xs:all>
+      <xs:element name="eiendomsidentifikasjon" minOccurs="0" maxOccurs="1" nillable="true" type="MatrikkelnummerType" />
+      <xs:element name="adresse" minOccurs="0" maxOccurs="1" nillable="true" type="EiendommensAdresseType" />
+      <xs:element name="bygningsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="bolignummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="kommunenavn" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Matrikkelnummer" type="MatrikkelnummerType" />
+  <xs:complexType name="MatrikkelnummerType">
+    <xs:all>
+      <xs:element name="kommunenummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="gaardsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:int" />
+      <xs:element name="bruksnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:int" />
+      <xs:element name="festenummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:int" />
+      <xs:element name="seksjonsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:int" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="EiendommensAdresse" type="EiendommensAdresseType" />
+  <xs:complexType name="EiendommensAdresseListe">
+    <xs:sequence>
+      <xs:element name="eiendommensadresse" type="EiendommensAdresseType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="EiendommensAdresseType">
+    <xs:all>
+      <xs:element name="adresselinje1" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="adresselinje2" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="adresselinje3" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="postnr" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="poststed" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="landkode" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="gatenavn" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="husnr" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="bokstav" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Saksnummer" type="SaksnummerType" />
+  <xs:complexType name="SaksnummerType">
+    <xs:all>
+      <xs:element name="saksaar" minOccurs="0" maxOccurs="1" nillable="true" type="xs:int" />
+      <xs:element name="sakssekvensnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:int" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Metadata" type="MetadataType" />
+  <xs:complexType name="MetadataType">
+    <xs:all>
+      <xs:element name="fraSluttbrukersystem" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="ftbId" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="prosjektnavn" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="prosjektnr" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="foretrukketSpraak" minOccurs="0" maxOccurs="1" nillable="true" type="KodeType" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="GenerelleVilkaar" type="GenerelleVilkaarType" />
+  <xs:complexType name="GenerelleVilkaarType">
+    <xs:all>
+      <xs:element name="norskSvenskDansk" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="SoeknadGjelder" type="SoeknadGjelderType" />
+  <xs:complexType name="SoeknadGjelderType">
+    <xs:all>
+      <xs:element name="gjelderHeleTiltaket" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean" />
+      <xs:element name="delAvTiltaket" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="type" minOccurs="0" maxOccurs="1" nillable="true" type="KodeListe" />
+      <xs:element name="delsoeknadsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="foelgebrev" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Delsoeknad" type="DelsoeknadType" />
+  <xs:complexType name="DelsoeknadListe">
+    <xs:sequence>
+      <xs:element name="delsoeknad" type="DelsoeknadType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="DelsoeknadType">
+    <xs:all>
+      <xs:element name="delAvTiltaket" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="tillatelsedato" minOccurs="0" maxOccurs="1" nillable="true" type="xs:date" />
+      <xs:element name="kommentar" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="type" minOccurs="0" maxOccurs="1" nillable="true" type="KodeListe" />
+      <xs:element name="delsoeknadsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="UtfallSvar" type="UtfallSvarType" />
+  <xs:complexType name="UtfallSvarListe">
+    <xs:sequence>
+      <xs:element name="utfallSvar" type="UtfallSvarType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="UtfallSvarType">
+    <xs:all>
+      <xs:element name="utfallId" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="utfallType" minOccurs="0" maxOccurs="1" nillable="true" type="KodeType" />
+      <xs:element name="utloestFraSjekkpunkt" minOccurs="0" maxOccurs="1" nillable="true" type="SjekkpunktType" />
+      <xs:element name="tema" minOccurs="0" maxOccurs="1" nillable="true" type="KodeType" />
+      <xs:element name="tittel" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="beskrivelse" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="erUtfallBesvaresSenere" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean" />
+      <xs:element name="erUtfallBesvart" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean" />
+      <xs:element name="kommentar" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="vedleggsliste" minOccurs="0" maxOccurs="1" nillable="true" type="VedleggListe" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Sjekkpunkt" type="SjekkpunktType"/>
+  <xs:complexType name="SjekkpunktType">
+    <xs:all>
+      <xs:element name="sjekkpunktId" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string"/>
+      <xs:element name="sjekkpunktEier" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string"/>
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Vedlegg" type="VedleggType" />
+  <xs:complexType name="VedleggListe">
+    <xs:sequence>
+      <xs:element name="vedlegg" type="VedleggType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="VedleggType">
+    <xs:all>
+      <xs:element name="versjonsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="vedleggstype" minOccurs="0" maxOccurs="1" nillable="true" type="KodeType" />
+      <xs:element name="versjonsdato" minOccurs="0" maxOccurs="1" nillable="true" type="xs:date" />
+      <xs:element name="filnavn" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Part" type="PartType" />
+  <xs:complexType name="PartType">
+    <xs:all>
+      <xs:element name="partstype" minOccurs="0" maxOccurs="1" nillable="true" type="KodeType" />
+      <xs:element name="foedselsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="organisasjonsnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="navn" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="adresse" minOccurs="0" maxOccurs="1" nillable="true" type="EnkelAdresseType" />
+      <xs:element name="telefonnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="mobilnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="epost" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="kontaktperson" minOccurs="0" maxOccurs="1" nillable="true" type="KontaktpersonType" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="EnkelAdresse" type="EnkelAdresseType" />
+  <xs:complexType name="EnkelAdresseType">
+    <xs:all>
+      <xs:element name="adresselinje1" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="adresselinje2" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="adresselinje3" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="postnr" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="poststed" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="landkode" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Kontaktperson" type="KontaktpersonType" />
+  <xs:complexType name="KontaktpersonType">
+    <xs:all>
+      <xs:element name="navn" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="telefonnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="mobilnummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="epost" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="GjenstaaendeArbeider" type="GjenstaaendeArbeiderType" />
+  <xs:complexType name="GjenstaaendeArbeiderType">
+    <xs:all>
+      <xs:element name="gjenstaaendeInnenfor" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="gjenstaaendeUtenfor" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Sikkerhetsnivaa" type="SikkerhetsnivaaType" />
+  <xs:complexType name="SikkerhetsnivaaType">
+    <xs:all>
+      <xs:element name="harTilstrekkeligSikkerhet" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean" />
+      <xs:element name="typeArbeider" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="utfoertInnen" minOccurs="0" maxOccurs="1" nillable="true" type="xs:date" />
+      <xs:element name="bekreftelseInnen" minOccurs="0" maxOccurs="1" nillable="true" type="xs:date" />
+    </xs:all>
+  </xs:complexType>
+  <xs:element name="Kode" type="KodeType" />
+  <xs:complexType name="KodeListe">
+    <xs:sequence>
+      <xs:element name="kode" type="KodeType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="KodeType">
+    <xs:all>
+      <xs:element name="kodeverdi" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+      <xs:element name="kodebeskrivelse" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string" />
+    </xs:all>
+  </xs:complexType>
+</xs:schema>

--- a/testdata/Model/XmlSchema/XsAll/planvarsel/v2/planvarsel.xsd
+++ b/testdata/Model/XmlSchema/XsAll/planvarsel/v2/planvarsel.xsd
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="https://skjema.ft.dibk.no/planvarsel/2.0"
+	xmlns="https://skjema.ft.dibk.no/planvarsel/2.0" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:element name="Planvarsel" type="PlanvarselType"/>
+	<xs:complexType name="PlanvarselType">
+		<xs:all>
+			<xs:element name="forslagsstiller" type="PartType" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="beroerteParter" type="BeroertPartListe" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="kommunenavn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="eiendomByggested" type="EiendomListe" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="signatur" type="SignaturType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="gjeldendePlan" type="GjeldendePlanListe" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="plankonsulent" type="PartType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="metadata" type="MetadataType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="planforslag" type="PlanType" minOccurs="1" maxOccurs="1"/>
+		</xs:all>
+		<xs:attribute name="dataFormatProvider" type="xs:string" use="required" fixed="DIBK"/>
+		<xs:attribute name="dataFormatId" type="xs:string" use="required" fixed="11000"/>
+		<xs:attribute name="dataFormatVersion" type="xs:string" use="required" fixed="2.0"/>
+	</xs:complexType>
+	<xs:element name="Kode" type="KodeType"/>
+	<xs:complexType name="KodeListe">
+		<xs:sequence>
+			<xs:element name="kode" type="KodeType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="KodeType">
+		<xs:all>
+			<xs:element name="kodeverdi" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="kodebeskrivelse" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="BeroertPart" type="BeroertPartType"/>
+	<xs:complexType name="BeroertPartListe">
+		<xs:sequence>
+			<xs:element name="beroertpart" type="BeroertPartType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BeroertPartType">
+		<xs:all>
+			<xs:element name="partstype" type="KodeType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="foedselsnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="organisasjonsnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="navn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="telefon" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="epost" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresse" type="EnkelAdresseType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="beskrivelseForVarsel" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="systemReferanse" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="erHoeringsmyndighet" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="gjelderEiendom" type="GjelderEiendomListe" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Eiendom" type="EiendomType"/>
+	<xs:complexType name="EiendomListe">
+		<xs:sequence>
+			<xs:element name="eiendom" type="EiendomType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EiendomType">
+		<xs:all>
+			<xs:element name="eiendomsidentifikasjon" type="MatrikkelnummerType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresse" type="EiendommensAdresseType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="bygningsnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="bolignummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="kommunenavn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="EiendommensAdresse" type="EiendommensAdresseType"/>
+	<xs:complexType name="EiendommensAdresseType">
+		<xs:all>
+			<xs:element name="adresselinje1" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresselinje2" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresselinje3" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="postnr" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="poststed" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="landkode" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="gatenavn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="husnr" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="bokstav" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Metadata" type="MetadataType"/>
+	<xs:complexType name="MetadataType">
+		<xs:all>
+			<xs:element name="ftbId" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="hovedinnsendingsnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="klartForSigneringFraSluttbrukersystem" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="fraSluttbrukersystem" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Part" type="PartType"/>
+	<xs:complexType name="PartType">
+		<xs:all>
+			<xs:element name="partstype" type="KodeType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="foedselsnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="organisasjonsnummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="navn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="epost" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresse" type="EnkelAdresseType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="telefon" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Plan" type="PlanType"/>
+	<xs:complexType name="PlanType">
+		<xs:all>
+			<xs:element name="plannavn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="arealplanId" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="hjemmesidePlanforslag" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="kravKonsekvensUtredning" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="planHensikt" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="fristForInnspill" type="xs:dateTime" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="hjemmesidePlanprogram" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="plantype" type="KodeType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="begrunnelseKU" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="kommunensSaksnummer" type="SaksnummerType" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="saksgangOgMedvirkning" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Saksnummer" type="SaksnummerType"/>
+	<xs:complexType name="SaksnummerType">
+		<xs:all>
+			<xs:element name="saksaar" type="xs:int" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="sakssekvensnummer" type="xs:int" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Signatur" type="SignaturType"/>
+	<xs:complexType name="SignaturType">
+		<xs:all>
+			<xs:element name="signaturdato" type="xs:dateTime" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="signertAv" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="signertPaaVegneAv" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="EnkelAdresse" type="EnkelAdresseType"/>
+	<xs:complexType name="EnkelAdresseType">
+		<xs:all>
+			<xs:element name="adresselinje1" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresselinje2" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="adresselinje3" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="postnr" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="poststed" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="landkode" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="GjelderEiendom" type="EiendomType"/>
+	<xs:complexType name="GjelderEiendomListe">
+		<xs:sequence>
+			<xs:element name="gjeldereiendom" type="EiendomType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="GjeldendePlan" type="GjeldendePlanType"/>
+	<xs:complexType name="GjeldendePlanListe">
+		<xs:sequence>
+			<xs:element name="gjeldendeplan" type="GjeldendePlanType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GjeldendePlanType">
+		<xs:all>
+			<xs:element name="navn" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="plantype" type="KodeType" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+	<xs:element name="Matrikkelnummer" type="MatrikkelnummerType"/>
+	<xs:complexType name="MatrikkelnummerType">
+		<xs:all>
+			<xs:element name="kommunenummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="gaardsnummer" type="xs:int" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="bruksnummer" type="xs:int" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="festenummer" type="xs:int" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="seksjonsnummer" type="xs:int" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:all>
+	</xs:complexType>
+</xs:schema>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Support for xs:all is supported in the pr in one direction
xsd -> json -> c# .
Note that round conversion is not supported.

<!--- Describe your changes in detail -->

## Related Issue(s)

- #13945

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
