### PR TITLE
fix: Remove AT21 from resource registry settings

### DIFF
--- a/backend/src/Designer/appsettings.json
+++ b/backend/src/Designer/appsettings.json
@@ -53,9 +53,6 @@
         }
     },
     "ResourceRegistryIntegrationSettings": {
-        "AT21": {
-            "ResourceRegistryEnvBaseUrl": "https://platform.at21.altinn.cloud"
-        },
         "AT22": {
             "ResourceRegistryEnvBaseUrl": "https://platform.at22.altinn.cloud",
             "SblBridgeBaseUrl": "https://at22.altinn.cloud/sblbridge/"


### PR DESCRIPTION
## Description

- AT21 is no longer used

## Related Issue(s)

- this pr, see also https://altinn.slack.com/archives/C02EJ9HKQA3/p1730900147196019

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
