### PR TITLE
fix: remove help text in FormComponentConfig

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/FormComponentConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/config/FormComponentConfig.tsx
@@ -153,6 +153,7 @@ export const FormComponentConfig = ({
               component={component}
               handleComponentChange={handleComponentUpdate}
               propertyKey='validFileEndings'
+              helpText={validFileEndings?.description}
             />
           )}
         </>

--- a/frontend/packages/ux-editor/src/components/config/FormComponentConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/config/FormComponentConfig.tsx
@@ -135,7 +135,6 @@ export const FormComponentConfig = ({
         <>
           <EditBooleanValue
             propertyKey='hasCustomFileEndings'
-            helpText={hasCustomFileEndings.description}
             component={component}
             defaultValue={hasCustomFileEndings.default}
             handleComponentChange={(updatedComponent: FormComponent) => {
@@ -154,7 +153,6 @@ export const FormComponentConfig = ({
               component={component}
               handleComponentChange={handleComponentUpdate}
               propertyKey='validFileEndings'
-              helpText={validFileEndings?.description}
             />
           )}
         </>

--- a/frontend/packages/ux-editor/src/components/config/FormComponentConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/config/FormComponentConfig.tsx
@@ -126,7 +126,6 @@ export const FormComponentConfig = ({
             propertyKey={propertyKey}
             defaultValue={properties[propertyKey].default}
             key={propertyKey}
-            helpText={properties[propertyKey]?.description}
           />
         );
       })}
@@ -169,7 +168,6 @@ export const FormComponentConfig = ({
             handleComponentChange={handleComponentUpdate}
             propertyKey={propertyKey}
             key={propertyKey}
-            helpText={properties[propertyKey]?.description}
             enumValues={properties[propertyKey]?.enum || properties[propertyKey]?.examples}
           />
         );
@@ -183,7 +181,6 @@ export const FormComponentConfig = ({
             handleComponentChange={handleComponentUpdate}
             propertyKey={propertyKey}
             key={propertyKey}
-            helpText={properties[propertyKey]?.description}
             enumValues={properties[propertyKey]?.enum}
           />
         );
@@ -197,7 +194,6 @@ export const FormComponentConfig = ({
             handleComponentChange={handleComponentUpdate}
             propertyKey={propertyKey}
             key={propertyKey}
-            helpText={properties[propertyKey]?.description}
             enumValues={properties[propertyKey]?.items?.enum}
             multiple={true}
           />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Removed help text `(?)` in FormComponentConfig

## Related Issue(s)

- #13981 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
