### PR TITLE
chore: .net8 -> .net9

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/designer-dotnet-test.yaml
+++ b/.github/workflows/designer-dotnet-test.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.0.x
+            9.0.x
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/dotnet-format.yaml
+++ b/.github/workflows/dotnet-format.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.0.x
+            9.0.x
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/gitea-designer-integration-tests.yaml
+++ b/.github/workflows/gitea-designer-integration-tests.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.0.x
+            9.0.x
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY . .
 RUN yarn build
 
 # Building the backend
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS generate-studio-backend
+FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS generate-studio-backend
 ARG DESIGNER_VERSION=''
 WORKDIR /build
 COPY backend .
@@ -52,7 +52,7 @@ WORKDIR /version
 RUN echo "{\"designerVersion\":\"$DESIGNER_VERSION\",\"appTemplateVersion\":\"$(curl -s https://api.github.com/repos/Altinn/app-template-dotnet/releases/latest | jq -r .tag_name)\"}" > version.json
 
 # Building the final image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS final
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine AS final
 EXPOSE 80
 WORKDIR /app
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \

--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Company>Altinn</Company>
     <Product>Altinn Studio</Product>
   </PropertyGroup>

--- a/backend/Migrations.Dockerfile
+++ b/backend/Migrations.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
 
 WORKDIR /app
 

--- a/backend/packagegroups/NuGet.props
+++ b/backend/packagegroups/NuGet.props
@@ -19,12 +19,12 @@
     <PackageReference Update="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Update="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.24" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0" />
     <PackageReference Update="Microsoft.Azure.KeyVault" Version="3.0.5" />
     <PackageReference Update="Microsoft.Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Update="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Update="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.24" />
-    <PackageReference Update="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.10" />
+    <PackageReference Update="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
     <PackageReference Update="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Update="HtmlAgilityPack" Version="1.11.67" />
     <PackageReference Update="Microsoft.DiaSymReader.Native" Version="1.7.0" />
@@ -45,7 +45,7 @@
 
   <ItemGroup Label="Packages used for testing">
     <PackageReference Update="FluentAssertions" Version="6.12.1" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <!-- Do not upgrade Moq version from 4.18.4 -->
     <PackageReference Update="Moq" Version="4.18.4" />
@@ -59,8 +59,8 @@
     <PackageReference Update="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
     <PackageReference Update="Testcontainers" Version="3.10.0" />
     <PackageReference Update="Testcontainers.PostgreSql" Version="3.10.0" />
-    <PackageReference Update="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
-    <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
+    <PackageReference Update="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
+    <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
     <PackageReference Update="WireMock.Net" Version="1.6.7" />
     <PackageReference Update="DistributedLock.FileSystem" Version="1.0.2" />
   </ItemGroup>

--- a/backend/packagegroups/NuGet.props
+++ b/backend/packagegroups/NuGet.props
@@ -26,13 +26,13 @@
     <PackageReference Update="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.24" />
     <PackageReference Update="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
     <PackageReference Update="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
+    <PackageReference Update="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageReference Update="HtmlAgilityPack" Version="1.11.67" />
     <PackageReference Update="Microsoft.DiaSymReader.Native" Version="1.7.0" />
     <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
     <PackageReference Update="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10" />
     <PackageReference Update="Microsoft.FeatureManagement.AspNetCore" Version="3.5.0" />
     <PackageReference Update="Scrutor" Version="4.2.2" />
-    <PackageReference Update="Swashbuckle.AspNetCore" Version="6.8.1" />
     <PackageReference Update="Polly" Version="8.4.2" />
     <PackageReference Update="Altinn.Authorization.ABAC" Version="0.0.8" />
     <PackageReference Update="Altinn.ApiClients.Maskinporten" Version="9.2.0" />

--- a/backend/src/Designer/Designer.csproj
+++ b/backend/src/Designer/Designer.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.Azure.KeyVault" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
@@ -58,7 +59,6 @@
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Scrutor" />
-    <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(CodeAnalisysCompatibleVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(CodeAnalisysCompatibleVersion)" />
   </ItemGroup>

--- a/backend/src/Designer/Program.cs
+++ b/backend/src/Designer/Program.cs
@@ -243,18 +243,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration configuration
     services.ConfigureLocalization();
     services.AddPolicyBasedAuthorization();
 
-    services.AddSwaggerGen(c =>
-    {
-        c.SwaggerDoc("v1", new OpenApiInfo { Title = "Altinn Designer API", Version = "v1" });
-        try
-        {
-            c.IncludeXmlComments(GetXmlCommentsPathForControllers());
-        }
-        catch
-        {
-            // Catch swashbuckle exception if it doesn't find the generated XML documentation file
-        }
-    });
+    services.AddOpenApi("v1");
 
     // Auto register all settings classes
     services.RegisterSettingsByBaseType<ISettingsMarker>(configuration);
@@ -320,16 +309,7 @@ void Configure(IConfiguration configuration)
         }
     });
 
-    const string swaggerRoutePrefix = "designer/swagger";
-    app.UseSwagger(c =>
-    {
-        c.RouteTemplate = swaggerRoutePrefix + "/{documentName}/swagger.json";
-    });
-    app.UseSwaggerUI(c =>
-    {
-        c.RoutePrefix = swaggerRoutePrefix;
-        c.SwaggerEndpoint($"/{swaggerRoutePrefix}/v1/swagger.json", "Altinn Designer API V1");
-    });
+    app.MapOpenApi("/designer/openapi/{documentName}/openapi.json");
 
     if (!app.Environment.IsDevelopment())
     {

--- a/backend/src/Designer/Program.cs
+++ b/backend/src/Designer/Program.cs
@@ -38,7 +38,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.FeatureManagement;
 using Microsoft.Net.Http.Headers;
-using Microsoft.OpenApi.Models;
 
 ILogger logger;
 

--- a/backend/src/Designer/wwwroot/designer/openapi.html
+++ b/backend/src/Designer/wwwroot/designer/openapi.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Elements in HTML</title>
+    <!-- Embed elements Elements via Web Component -->
+    <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+</head>
+<body>
+
+
+<!--This ui is based on https://github.com/stoplightio/elements  -->
+
+<elements-api
+    apiDescriptionUrl="/designer/openapi/v1/openapi.json"
+    router="hash"
+    layout="sidebar"
+/>
+
+</body>
+</html>

--- a/backend/tests/DataModeling.Tests/Utils/RandomObjectModelGenerator.cs
+++ b/backend/tests/DataModeling.Tests/Utils/RandomObjectModelGenerator.cs
@@ -78,6 +78,12 @@ public static class RandomObjectModelGenerator
             return;
         }
 
+        // Do not generate AltinnRowId
+        if (property.PropertyType == typeof(Guid) && property.Name.Equals("AltinnRowId"))
+        {
+            return;
+        }
+
         property.SetValue(obj, GeneratePrimitiveType(property.PropertyType, property.CustomAttributes));
     }
 
@@ -124,6 +130,11 @@ public static class RandomObjectModelGenerator
         if (type == typeof(bool))
         {
             return Random.Next(2) == 1;
+        }
+
+        if (type == typeof(Guid))
+        {
+            return Guid.NewGuid();
         }
 
         throw new Exception("Not primitive type");
@@ -283,7 +294,7 @@ public static class RandomObjectModelGenerator
 
     private static bool IsPrimitive(Type type)
     {
-        return type.IsPrimitive || type == typeof(string) || type == typeof(DateTime) || type == typeof(decimal);
+        return type.IsPrimitive || type == typeof(string) || type == typeof(DateTime) || type == typeof(decimal) || type == typeof(Guid);
     }
 
     private static bool IsNumberType(Type type)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Updated dotnet version .net8 -> .net9
- Swashbuckle replaced with Microsoft.AspNetCore.OpenApi docs genration.
- Following openapi UI added: https://github.com/stoplightio/elements

<!--- Describe your changes in detail -->

## Related Issue(s)

- Pr itself
- #12588

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
