### PR TITLE
fix: Fix maxLength constraint of page names

### DIFF
--- a/frontend/packages/ux-editor-v3/src/utils/designViewUtils/designViewUtils.ts
+++ b/frontend/packages/ux-editor-v3/src/utils/designViewUtils/designViewUtils.ts
@@ -25,7 +25,7 @@ export const getPageNameErrorKey = (
     return 'ux_editor.pages_error_unique';
   } else if (!newNameCandidate) {
     return 'ux_editor.pages_error_empty';
-  } else if (newNameCandidate.length >= 30) {
+  } else if (newNameCandidate.length > 30) {
     return 'ux_editor.pages_error_length';
   } else if (!validateLayoutNameAndLayoutSetName(newNameCandidate)) {
     return 'ux_editor.pages_error_format';

--- a/frontend/packages/ux-editor/src/utils/designViewUtils/designViewUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/designViewUtils/designViewUtils.ts
@@ -27,7 +27,7 @@ export const getPageNameErrorKey = (
     return 'ux_editor.pages_error_empty';
   } else if (newNameCandidate.includes('.')) {
     return 'ux_editor.pages_error_invalid_format';
-  } else if (newNameCandidate.length >= 30) {
+  } else if (newNameCandidate.length > 30) {
     return 'ux_editor.pages_error_length';
   } else if (!validateLayoutNameAndLayoutSetName(newNameCandidate)) {
     return 'ux_editor.pages_error_format';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed the max length of the page names by increasing it from `29` to `30` to match the validation message.

<table>
<tr>
<th>BEFORE</th>
<th>AFTER</th>
</tr>
<tr>
<td>

![chars](https://github.com/user-attachments/assets/627cf346-771a-427a-9349-af50eb518602)

</td>
<td>

![30_chars](https://github.com/user-attachments/assets/0a905eef-24a0-41a4-b871-eb67bdc12ec2)

</td>
</tr>
</table>

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)