### PR TITLE
fix: make in-editor linting work in both JetBrains and VSCode

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -8,7 +8,7 @@
   "plugins": ["jsx-a11y", "react", "react-hooks", "@typescript-eslint", "import"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": "./frontend/tsconfig.json"
+    "project": "./**/tsconfig.json"
   },
   "rules": {
     "react/destructuring-assignment": "off",


### PR DESCRIPTION
## Description 
This fixes the problem that Rider and WebStorm does not discover the ESLint settings, while at the same time keeping VSCode linting intact. This makes the typechecking in JetBrains' editors work much faster.

Should be tested with VSCode and a JetBrains editor.

## Details
Me and Konrad get this `Parsing error: Cannot read file 'C:/.../altinn-studio/frontend/frontend/tsconfig.json'` in Rider. Notice that frontend is mentioned twice.

I first tried to manually point to working directories and config files in Rider's ESLint-settings, but could not make it work.

Then I tried to change this in `.frontend/.eslintrc.json`
```
"parserOptions": {
  "project": "./frontend/tsconfig.json"
},
```
to
```
"parserOptions": {
  "project": "./tsconfig.json"
},
```
Then it worked in Rider. But VSCode complained that it could not find tsconfig.json.
I eventually tried this:
```
"parserOptions": {
    "project": "./**/tsconfig.json"
  },
```
Now in-editor linting works in both editors, even with ESLint settings in Rider and WebStorm set to Auto.

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
