### PR TITLE
chore(resource-adm): do not exchange maskinporten token to altinn token when publishing resource

### DIFF
--- a/backend/src/Designer/Services/Implementation/ResourceRegistryService.cs
+++ b/backend/src/Designer/Services/Implementation/ResourceRegistryService.cs
@@ -70,7 +70,6 @@ namespace Altinn.Studio.Designer.Services.Implementation
             {
                 publishResourceToResourceRegistryUrl = $"{GetResourceRegistryBaseUrl(env)}{_platformSettings.ResourceRegistryUrl}";
                 getResourceRegistryUrl = $"{publishResourceToResourceRegistryUrl}/{serviceResource.Identifier}";
-                tokenResponse = await _maskinPortenService.ExchangeToAltinnToken(tokenResponse, env);
                 fullWritePolicyToResourceRegistryUrl = $"{GetResourceRegistryBaseUrl(env)}{_platformSettings.ResourceRegistryUrl}/{serviceResource.Identifier}/policy";
             }
             else


### PR DESCRIPTION
## Description

- Exhanging maskinporten token to Altinn token before calling publish resource is no longer needed, as maskinporten token can now be used to call resource registry.

## Related Issue(s)

- this PR

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
