### PR TITLE
fix: use gitRepoMethods to move files/dirs in appGitRepo

### DIFF
--- a/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -425,20 +425,9 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         public void ChangeLayoutSetFolderName(string oldLayoutSetName, string newLayoutSetName, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (DirectoryExistsByRelativePath(GetPathToLayoutSet(newLayoutSetName)))
-            {
-                throw new NonUniqueLayoutSetIdException("Suggested new layout set name already exist");
-            }
-            string destAbsolutePath = GetAbsoluteFileOrDirectoryPathSanitized(GetPathToLayoutSet(newLayoutSetName, true));
-
-            string sourceRelativePath = GetPathToLayoutSet(oldLayoutSetName, true);
-            if (!DirectoryExistsByRelativePath(sourceRelativePath))
-            {
-                throw new NotFoundException("Layout set you are trying to change doesn't exist");
-            }
-
-            string sourceAbsolutePath = GetAbsoluteFileOrDirectoryPathSanitized(sourceRelativePath);
-            Directory.Move(sourceAbsolutePath, destAbsolutePath);
+            string currentDirectoryPath = GetPathToLayoutSet(oldLayoutSetName, true);
+            string newDirectoryPath = GetPathToLayoutSet(newLayoutSetName, true);
+            MoveDirectoryByRelativePath(currentDirectoryPath, newDirectoryPath);
         }
 
         /// <summary>
@@ -575,15 +564,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         {
             string currentFilePath = GetPathToLayoutFile(layoutSetName, layoutFileName);
             string newFilePath = GetPathToLayoutFile(layoutSetName, newFileName);
-            if (!FileExistsByRelativePath(currentFilePath))
-            {
-                throw new FileNotFoundException("Layout does not exist.");
-            }
-            if (FileExistsByRelativePath(newFilePath))
-            {
-                throw new ArgumentException("New layout name must be unique.");
-            }
-            File.Move(GetAbsoluteFileOrDirectoryPathSanitized(currentFilePath), GetAbsoluteFileOrDirectoryPathSanitized(newFilePath));
+            MoveFileByRelativePath(currentFilePath, newFilePath, newFileName);
         }
 
         public async Task<LayoutSets> GetLayoutSetsFile(CancellationToken cancellationToken = default)

--- a/backend/src/Designer/Infrastructure/GitRepository/GitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/GitRepository.cs
@@ -254,19 +254,46 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         /// <param name="destinationFileName">FileName for the destination file</param>
         protected void MoveFileByRelativePath(string sourceRelativeFilePath, string destRelativeFilePath, string destinationFileName)
         {
-            if (FileExistsByRelativePath(sourceRelativeFilePath))
+            if (!FileExistsByRelativePath(sourceRelativeFilePath))
             {
-                Guard.AssertNotNullOrEmpty(sourceRelativeFilePath, nameof(sourceRelativeFilePath));
-
-                string sourceAbsoluteFilePath = GetAbsoluteFileOrDirectoryPathSanitized(sourceRelativeFilePath);
-                string destAbsoluteFilePath = GetAbsoluteFileOrDirectoryPathSanitized(destRelativeFilePath);
-                string destAbsoluteParentDirPath = destAbsoluteFilePath.Remove(destAbsoluteFilePath.IndexOf(destinationFileName, StringComparison.Ordinal));
-                Directory.CreateDirectory(destAbsoluteParentDirPath);
-                Guard.AssertFilePathWithinParentDirectory(RepositoryDirectory, sourceAbsoluteFilePath);
-                Guard.AssertFilePathWithinParentDirectory(RepositoryDirectory, destAbsoluteFilePath);
-
-                File.Move(sourceAbsoluteFilePath, destAbsoluteFilePath);
+                throw new FileNotFoundException($"File {sourceRelativeFilePath} does not exist.");
             }
+
+            if (FileExistsByRelativePath(destRelativeFilePath))
+            {
+                throw new IOException($"Suggested file name {destinationFileName} already exists.");
+            }
+            string sourceAbsoluteFilePath = GetAbsoluteFileOrDirectoryPathSanitized(sourceRelativeFilePath);
+            string destAbsoluteFilePath = GetAbsoluteFileOrDirectoryPathSanitized(destRelativeFilePath);
+            string destAbsoluteParentDirPath = destAbsoluteFilePath.Remove(destAbsoluteFilePath.IndexOf(destinationFileName, StringComparison.Ordinal));
+            Directory.CreateDirectory(destAbsoluteParentDirPath);
+            Guard.AssertFilePathWithinParentDirectory(RepositoryDirectory, sourceAbsoluteFilePath);
+            Guard.AssertFilePathWithinParentDirectory(RepositoryDirectory, destAbsoluteFilePath);
+
+            File.Move(sourceAbsoluteFilePath, destAbsoluteFilePath);
+        }
+
+        /// <summary>
+        /// Move the specified folder to specified destination
+        /// </summary>
+        /// <param name="sourceRelativeDirectoryPath">Relative path to folder to be moved.</param>
+        /// <param name="destRelativeDirectoryPath">Relative path to destination of moved folder.</param>
+        protected void MoveDirectoryByRelativePath(string sourceRelativeDirectoryPath, string destRelativeDirectoryPath)
+        {
+            if (!DirectoryExistsByRelativePath(sourceRelativeDirectoryPath))
+            {
+                throw new DirectoryNotFoundException($"Directory {sourceRelativeDirectoryPath} does not exist.");
+            }
+            if (DirectoryExistsByRelativePath(destRelativeDirectoryPath))
+            {
+                throw new IOException($"Suggested directory {destRelativeDirectoryPath} already exists.");
+            }
+            string sourceAbsoluteDirectoryPath = GetAbsoluteFileOrDirectoryPathSanitized(sourceRelativeDirectoryPath);
+            string destAbsoluteDirectoryPath = GetAbsoluteFileOrDirectoryPathSanitized(destRelativeDirectoryPath);
+            Guard.AssertFilePathWithinParentDirectory(RepositoryDirectory, sourceAbsoluteDirectoryPath);
+            Guard.AssertFilePathWithinParentDirectory(RepositoryDirectory, destAbsoluteDirectoryPath);
+
+            Directory.Move(sourceAbsoluteDirectoryPath, destAbsoluteDirectoryPath);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Making logic for moving files and folders in `GitRepository.cs` more general and use the general methods in `AppGitRepository.cs` with the specific file- and folder-names. 

## Related Issue(s)

- #13951 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
