### PR TITLE
fix: keep nil values during (de)serialization

### DIFF
--- a/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -182,7 +182,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             else
             {
                 elementOrder += 1;
-                AddXmlElementAnnotation(element, classBuilder, elementOrder);
+                AddXmlElementAnnotation(element, classBuilder, elementOrder, !isValueType && (element.Nillable ?? false));
 
                 // Temporary fix - as long as we use System.Text.Json for serialization and  Newtonsoft.Json for
                 // deserialization, we need both JsonProperty and JsonPropertyName annotations.
@@ -265,16 +265,21 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             }
         }
 
-        private void AddXmlElementAnnotation(ElementMetadata element, StringBuilder classBuilder, int elementOrder)
+        private void AddXmlElementAnnotation(ElementMetadata element, StringBuilder classBuilder, int elementOrder, bool addNillableAttribute = false)
         {
-            if (element.OrderOblivious)
+            string additionalAttributeParams = string.Empty;
+            if (!element.OrderOblivious)
             {
-                classBuilder.AppendLine($"""{Indent(2)}[XmlElement("{element.XName}")]""");
+                additionalAttributeParams += $", Order = {elementOrder}";
             }
-            else
+
+            if (addNillableAttribute)
             {
-                classBuilder.AppendLine($"""{Indent(2)}[XmlElement("{element.XName}", Order = {elementOrder})]""");
+                additionalAttributeParams += ", IsNullable = true";
             }
+
+
+            classBuilder.AppendLine($"""{Indent(2)}[XmlElement("{element.XName}"{additionalAttributeParams})]""");
         }
 
         private void AddShouldSerializeForTagContent(ElementMetadata element, StringBuilder classBuilder, ModelMetadata modelMetadata)

--- a/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
+++ b/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
@@ -76,7 +76,7 @@ namespace DataModeling.Tests
                 .Then.CompiledAssembly.Should().NotBeNull();
         }
 
-        private void GeneratedClassesShouldBeEquivalentToExpected(string expectedCsharpClassPath)
+        private void GeneratedClassesShouldBeEquivalentToExpected(string expectedCsharpClassPath, bool overwriteExpected = false)
         {
             string expectedClasses = SharedResourcesHelper.LoadTestDataAsString(expectedCsharpClassPath);
 
@@ -86,7 +86,10 @@ namespace DataModeling.Tests
             _testOutput.WriteLine(CSharpClasses);
 
             // Save the current generated classes to the expected file so they can be compared with git diff.
-            SharedResourcesHelper.WriteUpdatedTestData(expectedCsharpClassPath, CSharpClasses);
+            if (overwriteExpected)
+            {
+                SharedResourcesHelper.WriteUpdatedTestData(expectedCsharpClassPath, CSharpClasses);
+            }
 
             var expectedAssembly = Compiler.CompileToAssembly(expectedClasses);
 

--- a/backend/tests/DataModeling.Tests/Utils/SerializationHelper.cs
+++ b/backend/tests/DataModeling.Tests/Utils/SerializationHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Xml.Serialization;
+using SharedResources.Tests;
 
 namespace DataModeling.Tests.Utils
 {
@@ -20,7 +21,7 @@ namespace DataModeling.Tests.Utils
         public static string SerializeXml(object o)
         {
             var xmlSerializer = new XmlSerializer(o.GetType());
-            using var textWriter = new StringWriter();
+            using var textWriter = new Utf8StringWriter();
             xmlSerializer.Serialize(textWriter, o);
             return textWriter.ToString();
         }

--- a/backend/tests/DataModeling.Tests/XmlDeserializeSerializeTests.cs
+++ b/backend/tests/DataModeling.Tests/XmlDeserializeSerializeTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Linq;
+using System.Xml.Linq;
+using System.Xml.Serialization;
+using DataModeling.Tests.BaseClasses;
+using DataModeling.Tests.Utils;
+using FluentAssertions;
+using SharedResources.Tests;
+using Xunit;
+
+namespace DataModeling.Tests;
+
+public class XmlDeserializeSerializeTests : CsharpModelConversionTestsBase<XmlDeserializeSerializeTests>
+{
+    [Theory]
+    [InlineData("Model/XmlSchema/XsAll/xsall-example.xsd", "Model/Xml/XsAll/xsall-example-nillable-sample.xml")]
+    public void XmlDeserializeSerializeShouldKeepNillValue(string xsdSchemaPath, string xmlPath)
+    {
+        Given.That.XsdSchemaLoaded(xsdSchemaPath)
+            .When.LoadedXsdSchemaConvertedToJsonSchema()
+            .And.ConvertedJsonSchemaConvertedToModelMetadata()
+            .And.ModelMetadataConvertedToCsharpClass()
+            .And.CSharpClassesCompiledToAssembly()
+            .Then.CompiledAssembly.Should().NotBeNull();
+
+        And.DeserializeAndSerializeShouldProduceSameXml(xmlPath);
+    }
+
+    private void DeserializeAndSerializeShouldProduceSameXml(string xmlPath)
+    {
+        Type csharpType = CompiledAssembly.Types().Single(type => type.CustomAttributes.Any(att => att.AttributeType == typeof(XmlRootAttribute)));
+
+        string loadedXml = SharedResourcesHelper.LoadTestDataAsString(xmlPath);
+
+        // Deserialize xml to new object of type csharpType
+        object deserializedObject = SerializationHelper.Deserialize(loadedXml, csharpType);
+
+        // serialize xml back to string
+        string serializedXml = SerializationHelper.SerializeXml(deserializedObject);
+
+        // Compare the original xml with the serialized xml
+        var expected = XDocument.Parse(loadedXml);
+        var result = XDocument.Parse(serializedXml);
+        Assert.True(XNode.DeepEquals(expected, result));
+    }
+}

--- a/testdata/Model/CSharp/Gitea/Kursdomene_APINøkkel_M_2020-05-26_5702_34556_SERES.cs
+++ b/testdata/Model/CSharp/Gitea/Kursdomene_APINøkkel_M_2020-05-26_5702_34556_SERES.cs
@@ -63,12 +63,12 @@ namespace Altinn.App.Models
     [JsonPropertyName("beskrivelse")]
     public string beskrivelse { get; set; }
 
-    [XmlElement("miljoe", Order = 6)]
+    [XmlElement("miljoe", Order = 6, IsNullable = true)]
     [JsonProperty("miljoe")]
     [JsonPropertyName("miljoe")]
     public string miljoe { get; set; }
 
-    [XmlElement("nettleserApplikasjonWebadresse", Order = 7)]
+    [XmlElement("nettleserApplikasjonWebadresse", Order = 7, IsNullable = true)]
     [JsonProperty("nettleserApplikasjonWebadresse")]
     [JsonPropertyName("nettleserApplikasjonWebadresse")]
     public string nettleserApplikasjonWebadresse { get; set; }
@@ -77,32 +77,32 @@ namespace Altinn.App.Models
 
   public class APIRessurs
   {
-    [XmlElement("profile", Order = 1)]
+    [XmlElement("profile", Order = 1, IsNullable = true)]
     [JsonProperty("profile")]
     [JsonPropertyName("profile")]
     public string profile { get; set; }
 
-    [XmlElement("organizationReportee", Order = 2)]
+    [XmlElement("organizationReportee", Order = 2, IsNullable = true)]
     [JsonProperty("organizationReportee")]
     [JsonPropertyName("organizationReportee")]
     public string organizationReportee { get; set; }
 
-    [XmlElement("meldingsboks", Order = 3)]
+    [XmlElement("meldingsboks", Order = 3, IsNullable = true)]
     [JsonProperty("meldingsboks")]
     [JsonPropertyName("meldingsboks")]
     public string meldingsboks { get; set; }
 
-    [XmlElement("lookup", Order = 4)]
+    [XmlElement("lookup", Order = 4, IsNullable = true)]
     [JsonProperty("lookup")]
     [JsonPropertyName("lookup")]
     public string lookup { get; set; }
 
-    [XmlElement("broker", Order = 5)]
+    [XmlElement("broker", Order = 5, IsNullable = true)]
     [JsonProperty("broker")]
     [JsonPropertyName("broker")]
     public string broker { get; set; }
 
-    [XmlElement("autorisasjon", Order = 6)]
+    [XmlElement("autorisasjon", Order = 6, IsNullable = true)]
     [JsonProperty("autorisasjon")]
     [JsonPropertyName("autorisasjon")]
     public string autorisasjon { get; set; }

--- a/testdata/Model/CSharp/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.cs
+++ b/testdata/Model/CSharp/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.cs
@@ -59,12 +59,12 @@ namespace Altinn.App.Models
     [JsonPropertyName("sektor")]
     public string sektor { get; set; }
 
-    [XmlElement("navnNynorsk", Order = 4)]
+    [XmlElement("navnNynorsk", Order = 4, IsNullable = true)]
     [JsonProperty("navnNynorsk")]
     [JsonPropertyName("navnNynorsk")]
     public string navnNynorsk { get; set; }
 
-    [XmlElement("navnEngelsk", Order = 5)]
+    [XmlElement("navnEngelsk", Order = 5, IsNullable = true)]
     [JsonProperty("navnEngelsk")]
     [JsonPropertyName("navnEngelsk")]
     public string navnEngelsk { get; set; }

--- a/testdata/Model/CSharp/Gitea/dat-skjema.cs
+++ b/testdata/Model/CSharp/Gitea/dat-skjema.cs
@@ -207,7 +207,7 @@ namespace Altinn.App.Models
     public bool? BekreftRiktig { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
-    [XmlElement("AnsatteInnen", Order = 4)]
+    [XmlElement("AnsatteInnen", Order = 4, IsNullable = true)]
     [JsonProperty("AnsatteInnen")]
     [JsonPropertyName("AnsatteInnen")]
     public string AnsatteInnen { get; set; }

--- a/testdata/Model/CSharp/Gitea/nbib-melding.cs
+++ b/testdata/Model/CSharp/Gitea/nbib-melding.cs
@@ -12,32 +12,32 @@ namespace Altinn.App.Models
   [XmlRoot(ElementName="Message")]
   public class MessageV1
   {
-    [XmlElement("ProcessTask", Order = 1)]
+    [XmlElement("ProcessTask", Order = 1, IsNullable = true)]
     [JsonProperty("ProcessTask")]
     [JsonPropertyName("ProcessTask")]
     public string ProcessTask { get; set; }
 
-    [XmlElement("ServiceName", Order = 2)]
+    [XmlElement("ServiceName", Order = 2, IsNullable = true)]
     [JsonProperty("ServiceName")]
     [JsonPropertyName("ServiceName")]
     public string ServiceName { get; set; }
 
-    [XmlElement("Title", Order = 3)]
+    [XmlElement("Title", Order = 3, IsNullable = true)]
     [JsonProperty("Title")]
     [JsonPropertyName("Title")]
     public string Title { get; set; }
 
-    [XmlElement("Body", Order = 4)]
+    [XmlElement("Body", Order = 4, IsNullable = true)]
     [JsonProperty("Body")]
     [JsonPropertyName("Body")]
     public string Body { get; set; }
 
-    [XmlElement("Reference", Order = 5)]
+    [XmlElement("Reference", Order = 5, IsNullable = true)]
     [JsonProperty("Reference")]
     [JsonPropertyName("Reference")]
     public string Reference { get; set; }
 
-    [XmlElement("Sender", Order = 6)]
+    [XmlElement("Sender", Order = 6, IsNullable = true)]
     [JsonProperty("Sender")]
     [JsonPropertyName("Sender")]
     public string Sender { get; set; }

--- a/testdata/Model/CSharp/Gitea/skjema.cs
+++ b/testdata/Model/CSharp/Gitea/skjema.cs
@@ -331,7 +331,7 @@ namespace Altinn.App.Models
     public string SamfunnskritiskBransje { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
-    [XmlElement("BenyttesFraDato", Order = 15)]
+    [XmlElement("BenyttesFraDato", Order = 15, IsNullable = true)]
     [JsonProperty("BenyttesFraDato")]
     [JsonPropertyName("BenyttesFraDato")]
     public string BenyttesFraDato { get; set; }

--- a/testdata/Model/CSharp/Gitea/srf-fufinn-behovsendring.cs
+++ b/testdata/Model/CSharp/Gitea/srf-fufinn-behovsendring.cs
@@ -50,7 +50,7 @@ namespace Altinn.App.Models
 
   public class InnsenderPerson
   {
-    [XmlElement("navn", Order = 1)]
+    [XmlElement("navn", Order = 1, IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
@@ -87,27 +87,27 @@ namespace Altinn.App.Models
 
   public class Adresse
   {
-    [XmlElement("adresse1", Order = 1)]
+    [XmlElement("adresse1", Order = 1, IsNullable = true)]
     [JsonProperty("adresse1")]
     [JsonPropertyName("adresse1")]
     public string adresse1 { get; set; }
 
-    [XmlElement("adresse2", Order = 2)]
+    [XmlElement("adresse2", Order = 2, IsNullable = true)]
     [JsonProperty("adresse2")]
     [JsonPropertyName("adresse2")]
     public string adresse2 { get; set; }
 
-    [XmlElement("postnummer", Order = 3)]
+    [XmlElement("postnummer", Order = 3, IsNullable = true)]
     [JsonProperty("postnummer")]
     [JsonPropertyName("postnummer")]
     public string postnummer { get; set; }
 
-    [XmlElement("poststed", Order = 4)]
+    [XmlElement("poststed", Order = 4, IsNullable = true)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
     public string poststed { get; set; }
 
-    [XmlElement("land", Order = 5)]
+    [XmlElement("land", Order = 5, IsNullable = true)]
     [JsonProperty("land")]
     [JsonPropertyName("land")]
     public string land { get; set; }
@@ -116,12 +116,12 @@ namespace Altinn.App.Models
 
   public class InnsenderOrganisasjon
   {
-    [XmlElement("kontaktperson", Order = 1)]
+    [XmlElement("kontaktperson", Order = 1, IsNullable = true)]
     [JsonProperty("kontaktperson")]
     [JsonPropertyName("kontaktperson")]
     public string kontaktperson { get; set; }
 
-    [XmlElement("organisasjonsnavn", Order = 2)]
+    [XmlElement("organisasjonsnavn", Order = 2, IsNullable = true)]
     [JsonProperty("organisasjonsnavn")]
     [JsonPropertyName("organisasjonsnavn")]
     public string organisasjonsnavn { get; set; }
@@ -158,7 +158,7 @@ namespace Altinn.App.Models
 
   public class HvemGjelderHenvendelsen
   {
-    [XmlElement("navn", Order = 1)]
+    [XmlElement("navn", Order = 1, IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
@@ -179,7 +179,7 @@ namespace Altinn.App.Models
 
   public class HvorSkalHenvendelsenSendes
   {
-    [XmlElement("fylke", Order = 1)]
+    [XmlElement("fylke", Order = 1, IsNullable = true)]
     [JsonProperty("fylke")]
     [JsonPropertyName("fylke")]
     public string fylke { get; set; }
@@ -188,7 +188,7 @@ namespace Altinn.App.Models
 
   public class SkjemaSpesifikt
   {
-    [XmlElement("andreBehov", Order = 1)]
+    [XmlElement("andreBehov", Order = 1, IsNullable = true)]
     [JsonProperty("andreBehov")]
     [JsonPropertyName("andreBehov")]
     public string andreBehov { get; set; }
@@ -283,12 +283,12 @@ namespace Altinn.App.Models
     [JsonPropertyName("hjelpeapparat")]
     public Hjelpeapparat hjelpeapparat { get; set; }
 
-    [XmlElement("endringEllerNy", Order = 20)]
+    [XmlElement("endringEllerNy", Order = 20, IsNullable = true)]
     [JsonProperty("endringEllerNy")]
     [JsonPropertyName("endringEllerNy")]
     public string endringEllerNy { get; set; }
 
-    [XmlElement("innsenderRelasjon", Order = 21)]
+    [XmlElement("innsenderRelasjon", Order = 21, IsNullable = true)]
     [JsonProperty("innsenderRelasjon")]
     [JsonPropertyName("innsenderRelasjon")]
     public string innsenderRelasjon { get; set; }
@@ -297,12 +297,12 @@ namespace Altinn.App.Models
 
   public class Bank
   {
-    [XmlElement("bankRepresentasjon", Order = 1)]
+    [XmlElement("bankRepresentasjon", Order = 1, IsNullable = true)]
     [JsonProperty("bankRepresentasjon")]
     [JsonPropertyName("bankRepresentasjon")]
     public string bankRepresentasjon { get; set; }
 
-    [XmlElement("bankLaan", Order = 2)]
+    [XmlElement("bankLaan", Order = 2, IsNullable = true)]
     [JsonProperty("bankLaan")]
     [JsonPropertyName("bankLaan")]
     public string bankLaan { get; set; }
@@ -311,7 +311,7 @@ namespace Altinn.App.Models
 
   public class Forsikringsselskap
   {
-    [XmlElement("forsikringForvalte", Order = 1)]
+    [XmlElement("forsikringForvalte", Order = 1, IsNullable = true)]
     [JsonProperty("forsikringForvalte")]
     [JsonPropertyName("forsikringForvalte")]
     public string forsikringForvalte { get; set; }
@@ -320,12 +320,12 @@ namespace Altinn.App.Models
 
   public class Helfo
   {
-    [XmlElement("helfoRefusjon", Order = 1)]
+    [XmlElement("helfoRefusjon", Order = 1, IsNullable = true)]
     [JsonProperty("helfoRefusjon")]
     [JsonPropertyName("helfoRefusjon")]
     public string helfoRefusjon { get; set; }
 
-    [XmlElement("helfoFastlege", Order = 2)]
+    [XmlElement("helfoFastlege", Order = 2, IsNullable = true)]
     [JsonProperty("helfoFastlege")]
     [JsonPropertyName("helfoFastlege")]
     public string helfoFastlege { get; set; }
@@ -334,12 +334,12 @@ namespace Altinn.App.Models
 
   public class Husbanken
   {
-    [XmlElement("husbankenBostoette", Order = 1)]
+    [XmlElement("husbankenBostoette", Order = 1, IsNullable = true)]
     [JsonProperty("husbankenBostoette")]
     [JsonPropertyName("husbankenBostoette")]
     public string husbankenBostoette { get; set; }
 
-    [XmlElement("husbankenStartlaan", Order = 2)]
+    [XmlElement("husbankenStartlaan", Order = 2, IsNullable = true)]
     [JsonProperty("husbankenStartlaan")]
     [JsonPropertyName("husbankenStartlaan")]
     public string husbankenStartlaan { get; set; }
@@ -348,7 +348,7 @@ namespace Altinn.App.Models
 
   public class Inkassoselskap
   {
-    [XmlElement("inkasseForhandle", Order = 1)]
+    [XmlElement("inkasseForhandle", Order = 1, IsNullable = true)]
     [JsonProperty("inkasseForhandle")]
     [JsonPropertyName("inkasseForhandle")]
     public string inkasseForhandle { get; set; }
@@ -357,7 +357,7 @@ namespace Altinn.App.Models
 
   public class Innkreving
   {
-    [XmlElement("innkrevingGjeldsordning", Order = 1)]
+    [XmlElement("innkrevingGjeldsordning", Order = 1, IsNullable = true)]
     [JsonProperty("innkrevingGjeldsordning")]
     [JsonPropertyName("innkrevingGjeldsordning")]
     public string innkrevingGjeldsordning { get; set; }
@@ -366,37 +366,37 @@ namespace Altinn.App.Models
 
   public class Kartverket
   {
-    [XmlElement("kartSalgEiendom", Order = 1)]
+    [XmlElement("kartSalgEiendom", Order = 1, IsNullable = true)]
     [JsonProperty("kartSalgEiendom")]
     [JsonPropertyName("kartSalgEiendom")]
     public string kartSalgEiendom { get; set; }
 
-    [XmlElement("kartKjoepEiendom", Order = 2)]
+    [XmlElement("kartKjoepEiendom", Order = 2, IsNullable = true)]
     [JsonProperty("kartKjoepEiendom")]
     [JsonPropertyName("kartKjoepEiendom")]
     public string kartKjoepEiendom { get; set; }
 
-    [XmlElement("kartArv", Order = 3)]
+    [XmlElement("kartArv", Order = 3, IsNullable = true)]
     [JsonProperty("kartArv")]
     [JsonPropertyName("kartArv")]
     public string kartArv { get; set; }
 
-    [XmlElement("kartEndreEiendom", Order = 4)]
+    [XmlElement("kartEndreEiendom", Order = 4, IsNullable = true)]
     [JsonProperty("kartEndreEiendom")]
     [JsonPropertyName("kartEndreEiendom")]
     public string kartEndreEiendom { get; set; }
 
-    [XmlElement("kartAvtaler", Order = 5)]
+    [XmlElement("kartAvtaler", Order = 5, IsNullable = true)]
     [JsonProperty("kartAvtaler")]
     [JsonPropertyName("kartAvtaler")]
     public string kartAvtaler { get; set; }
 
-    [XmlElement("kartSletting", Order = 6)]
+    [XmlElement("kartSletting", Order = 6, IsNullable = true)]
     [JsonProperty("kartSletting")]
     [JsonPropertyName("kartSletting")]
     public string kartSletting { get; set; }
 
-    [XmlElement("kartLaaneopptak", Order = 7)]
+    [XmlElement("kartLaaneopptak", Order = 7, IsNullable = true)]
     [JsonProperty("kartLaaneopptak")]
     [JsonPropertyName("kartLaaneopptak")]
     public string kartLaaneopptak { get; set; }
@@ -405,27 +405,27 @@ namespace Altinn.App.Models
 
   public class Kommune
   {
-    [XmlElement("kommuneBygg", Order = 1)]
+    [XmlElement("kommuneBygg", Order = 1, IsNullable = true)]
     [JsonProperty("kommuneBygg")]
     [JsonPropertyName("kommuneBygg")]
     public string kommuneBygg { get; set; }
 
-    [XmlElement("kommuneHelse", Order = 2)]
+    [XmlElement("kommuneHelse", Order = 2, IsNullable = true)]
     [JsonProperty("kommuneHelse")]
     [JsonPropertyName("kommuneHelse")]
     public string kommuneHelse { get; set; }
 
-    [XmlElement("kommuneSosial", Order = 3)]
+    [XmlElement("kommuneSosial", Order = 3, IsNullable = true)]
     [JsonProperty("kommuneSosial")]
     [JsonPropertyName("kommuneSosial")]
     public string kommuneSosial { get; set; }
 
-    [XmlElement("kommuneSkole", Order = 4)]
+    [XmlElement("kommuneSkole", Order = 4, IsNullable = true)]
     [JsonProperty("kommuneSkole")]
     [JsonPropertyName("kommuneSkole")]
     public string kommuneSkole { get; set; }
 
-    [XmlElement("kommuneSkatt", Order = 5)]
+    [XmlElement("kommuneSkatt", Order = 5, IsNullable = true)]
     [JsonProperty("kommuneSkatt")]
     [JsonPropertyName("kommuneSkatt")]
     public string kommuneSkatt { get; set; }
@@ -434,7 +434,7 @@ namespace Altinn.App.Models
 
   public class Kredittvurderingsselskap
   {
-    [XmlElement("kredittKredittsperre", Order = 1)]
+    [XmlElement("kredittKredittsperre", Order = 1, IsNullable = true)]
     [JsonProperty("kredittKredittsperre")]
     [JsonPropertyName("kredittKredittsperre")]
     public string kredittKredittsperre { get; set; }
@@ -443,12 +443,12 @@ namespace Altinn.App.Models
 
   public class Namsmannen
   {
-    [XmlElement("namsmannenGjeldsordning", Order = 1)]
+    [XmlElement("namsmannenGjeldsordning", Order = 1, IsNullable = true)]
     [JsonProperty("namsmannenGjeldsordning")]
     [JsonPropertyName("namsmannenGjeldsordning")]
     public string namsmannenGjeldsordning { get; set; }
 
-    [XmlElement("namsmannenTvangsfullbyrdelse", Order = 2)]
+    [XmlElement("namsmannenTvangsfullbyrdelse", Order = 2, IsNullable = true)]
     [JsonProperty("namsmannenTvangsfullbyrdelse")]
     [JsonPropertyName("namsmannenTvangsfullbyrdelse")]
     public string namsmannenTvangsfullbyrdelse { get; set; }
@@ -457,27 +457,27 @@ namespace Altinn.App.Models
 
   public class Nav
   {
-    [XmlElement("navArbeid", Order = 1)]
+    [XmlElement("navArbeid", Order = 1, IsNullable = true)]
     [JsonProperty("navArbeid")]
     [JsonPropertyName("navArbeid")]
     public string navArbeid { get; set; }
 
-    [XmlElement("navFamilie", Order = 2)]
+    [XmlElement("navFamilie", Order = 2, IsNullable = true)]
     [JsonProperty("navFamilie")]
     [JsonPropertyName("navFamilie")]
     public string navFamilie { get; set; }
 
-    [XmlElement("navHjelpemidler", Order = 3)]
+    [XmlElement("navHjelpemidler", Order = 3, IsNullable = true)]
     [JsonProperty("navHjelpemidler")]
     [JsonPropertyName("navHjelpemidler")]
     public string navHjelpemidler { get; set; }
 
-    [XmlElement("navPensjon", Order = 4)]
+    [XmlElement("navPensjon", Order = 4, IsNullable = true)]
     [JsonProperty("navPensjon")]
     [JsonPropertyName("navPensjon")]
     public string navPensjon { get; set; }
 
-    [XmlElement("navSosial", Order = 5)]
+    [XmlElement("navSosial", Order = 5, IsNullable = true)]
     [JsonProperty("navSosial")]
     [JsonPropertyName("navSosial")]
     public string navSosial { get; set; }
@@ -486,7 +486,7 @@ namespace Altinn.App.Models
 
   public class Pasientreiser
   {
-    [XmlElement("pasientRefusjon", Order = 1)]
+    [XmlElement("pasientRefusjon", Order = 1, IsNullable = true)]
     [JsonProperty("pasientRefusjon")]
     [JsonPropertyName("pasientRefusjon")]
     public string pasientRefusjon { get; set; }
@@ -495,22 +495,22 @@ namespace Altinn.App.Models
 
   public class Skatteetaten
   {
-    [XmlElement("skattInnkreving", Order = 1)]
+    [XmlElement("skattInnkreving", Order = 1, IsNullable = true)]
     [JsonProperty("skattInnkreving")]
     [JsonPropertyName("skattInnkreving")]
     public string skattInnkreving { get; set; }
 
-    [XmlElement("skattPostadresse", Order = 2)]
+    [XmlElement("skattPostadresse", Order = 2, IsNullable = true)]
     [JsonProperty("skattPostadresse")]
     [JsonPropertyName("skattPostadresse")]
     public string skattPostadresse { get; set; }
 
-    [XmlElement("skattFlytting", Order = 3)]
+    [XmlElement("skattFlytting", Order = 3, IsNullable = true)]
     [JsonProperty("skattFlytting")]
     [JsonPropertyName("skattFlytting")]
     public string skattFlytting { get; set; }
 
-    [XmlElement("skattSkatt", Order = 4)]
+    [XmlElement("skattSkatt", Order = 4, IsNullable = true)]
     [JsonProperty("skattSkatt")]
     [JsonPropertyName("skattSkatt")]
     public string skattSkatt { get; set; }
@@ -519,17 +519,17 @@ namespace Altinn.App.Models
 
   public class Tingretten
   {
-    [XmlElement("tingrettUskifte", Order = 1)]
+    [XmlElement("tingrettUskifte", Order = 1, IsNullable = true)]
     [JsonProperty("tingrettUskifte")]
     [JsonPropertyName("tingrettUskifte")]
     public string tingrettUskifte { get; set; }
 
-    [XmlElement("tingrettPrivatDoedsbo", Order = 2)]
+    [XmlElement("tingrettPrivatDoedsbo", Order = 2, IsNullable = true)]
     [JsonProperty("tingrettPrivatDoedsbo")]
     [JsonPropertyName("tingrettPrivatDoedsbo")]
     public string tingrettPrivatDoedsbo { get; set; }
 
-    [XmlElement("tingrettBegjaereDoedsbo", Order = 3)]
+    [XmlElement("tingrettBegjaereDoedsbo", Order = 3, IsNullable = true)]
     [JsonProperty("tingrettBegjaereDoedsbo")]
     [JsonPropertyName("tingrettBegjaereDoedsbo")]
     public string tingrettBegjaereDoedsbo { get; set; }
@@ -538,27 +538,27 @@ namespace Altinn.App.Models
 
   public class OEvrige
   {
-    [XmlElement("oevrigeKjoepVarer", Order = 1)]
+    [XmlElement("oevrigeKjoepVarer", Order = 1, IsNullable = true)]
     [JsonProperty("oevrigeKjoepVarer")]
     [JsonPropertyName("oevrigeKjoepVarer")]
     public string oevrigeKjoepVarer { get; set; }
 
-    [XmlElement("oevrigeHusleiekontrakt", Order = 2)]
+    [XmlElement("oevrigeHusleiekontrakt", Order = 2, IsNullable = true)]
     [JsonProperty("oevrigeHusleiekontrakt")]
     [JsonPropertyName("oevrigeHusleiekontrakt")]
     public string oevrigeHusleiekontrakt { get; set; }
 
-    [XmlElement("oevrigeLoesoere", Order = 3)]
+    [XmlElement("oevrigeLoesoere", Order = 3, IsNullable = true)]
     [JsonProperty("oevrigeLoesoere")]
     [JsonPropertyName("oevrigeLoesoere")]
     public string oevrigeLoesoere { get; set; }
 
-    [XmlElement("oevrigeUtgifter", Order = 4)]
+    [XmlElement("oevrigeUtgifter", Order = 4, IsNullable = true)]
     [JsonProperty("oevrigeUtgifter")]
     [JsonPropertyName("oevrigeUtgifter")]
     public string oevrigeUtgifter { get; set; }
 
-    [XmlElement("oevrigeAvslutteHusleie", Order = 5)]
+    [XmlElement("oevrigeAvslutteHusleie", Order = 5, IsNullable = true)]
     [JsonProperty("oevrigeAvslutteHusleie")]
     [JsonPropertyName("oevrigeAvslutteHusleie")]
     public string oevrigeAvslutteHusleie { get; set; }
@@ -567,12 +567,12 @@ namespace Altinn.App.Models
 
   public class Statsforvalter
   {
-    [XmlElement("statsforvalterTvangsvedtak", Order = 1)]
+    [XmlElement("statsforvalterTvangsvedtak", Order = 1, IsNullable = true)]
     [JsonProperty("statsforvalterTvangsvedtak")]
     [JsonPropertyName("statsforvalterTvangsvedtak")]
     public string statsforvalterTvangsvedtak { get; set; }
 
-    [XmlElement("statsforvalterSamtykke", Order = 2)]
+    [XmlElement("statsforvalterSamtykke", Order = 2, IsNullable = true)]
     [JsonProperty("statsforvalterSamtykke")]
     [JsonPropertyName("statsforvalterSamtykke")]
     public string statsforvalterSamtykke { get; set; }
@@ -581,22 +581,22 @@ namespace Altinn.App.Models
 
   public class Vergehaver
   {
-    [XmlElement("telefonsamtaleMulig", Order = 1)]
+    [XmlElement("telefonsamtaleMulig", Order = 1, IsNullable = true)]
     [JsonProperty("telefonsamtaleMulig")]
     [JsonPropertyName("telefonsamtaleMulig")]
     public string telefonsamtaleMulig { get; set; }
 
-    [XmlElement("telefonsamtaleHvorfor", Order = 2)]
+    [XmlElement("telefonsamtaleHvorfor", Order = 2, IsNullable = true)]
     [JsonProperty("telefonsamtaleHvorfor")]
     [JsonPropertyName("telefonsamtaleHvorfor")]
     public string telefonsamtaleHvorfor { get; set; }
 
-    [XmlElement("borPaaInstitusjon", Order = 3)]
+    [XmlElement("borPaaInstitusjon", Order = 3, IsNullable = true)]
     [JsonProperty("borPaaInstitusjon")]
     [JsonPropertyName("borPaaInstitusjon")]
     public string borPaaInstitusjon { get; set; }
 
-    [XmlElement("hvilkenInstitusjon", Order = 4)]
+    [XmlElement("hvilkenInstitusjon", Order = 4, IsNullable = true)]
     [JsonProperty("hvilkenInstitusjon")]
     [JsonPropertyName("hvilkenInstitusjon")]
     public string hvilkenInstitusjon { get; set; }
@@ -622,7 +622,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("telefonnummer")]
     public string telefonnummer { get; set; }
 
-    [XmlElement("navn", Order = 2)]
+    [XmlElement("navn", Order = 2, IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }

--- a/testdata/Model/CSharp/Gitea/srf-fufinn-behovskartleggin.cs
+++ b/testdata/Model/CSharp/Gitea/srf-fufinn-behovskartleggin.cs
@@ -50,7 +50,7 @@ namespace Altinn.App.Models
 
   public class InnsenderPerson
   {
-    [XmlElement("navn", Order = 1)]
+    [XmlElement("navn", Order = 1, IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
@@ -87,27 +87,27 @@ namespace Altinn.App.Models
 
   public class Adresse
   {
-    [XmlElement("adresse1", Order = 1)]
+    [XmlElement("adresse1", Order = 1, IsNullable = true)]
     [JsonProperty("adresse1")]
     [JsonPropertyName("adresse1")]
     public string adresse1 { get; set; }
 
-    [XmlElement("adresse2", Order = 2)]
+    [XmlElement("adresse2", Order = 2, IsNullable = true)]
     [JsonProperty("adresse2")]
     [JsonPropertyName("adresse2")]
     public string adresse2 { get; set; }
 
-    [XmlElement("postnummer", Order = 3)]
+    [XmlElement("postnummer", Order = 3, IsNullable = true)]
     [JsonProperty("postnummer")]
     [JsonPropertyName("postnummer")]
     public string postnummer { get; set; }
 
-    [XmlElement("poststed", Order = 4)]
+    [XmlElement("poststed", Order = 4, IsNullable = true)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
     public string poststed { get; set; }
 
-    [XmlElement("land", Order = 5)]
+    [XmlElement("land", Order = 5, IsNullable = true)]
     [JsonProperty("land")]
     [JsonPropertyName("land")]
     public string land { get; set; }
@@ -116,12 +116,12 @@ namespace Altinn.App.Models
 
   public class InnsenderOrganisasjon
   {
-    [XmlElement("kontaktperson", Order = 1)]
+    [XmlElement("kontaktperson", Order = 1, IsNullable = true)]
     [JsonProperty("kontaktperson")]
     [JsonPropertyName("kontaktperson")]
     public string kontaktperson { get; set; }
 
-    [XmlElement("organisasjonsnavn", Order = 2)]
+    [XmlElement("organisasjonsnavn", Order = 2, IsNullable = true)]
     [JsonProperty("organisasjonsnavn")]
     [JsonPropertyName("organisasjonsnavn")]
     public string organisasjonsnavn { get; set; }
@@ -158,7 +158,7 @@ namespace Altinn.App.Models
 
   public class HvemGjelderHenvendelsen
   {
-    [XmlElement("navn", Order = 1)]
+    [XmlElement("navn", Order = 1, IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
@@ -179,7 +179,7 @@ namespace Altinn.App.Models
 
   public class HvorSkalHenvendelsenSendes
   {
-    [XmlElement("fylke", Order = 1)]
+    [XmlElement("fylke", Order = 1, IsNullable = true)]
     [JsonProperty("fylke")]
     [JsonPropertyName("fylke")]
     public string fylke { get; set; }
@@ -188,7 +188,7 @@ namespace Altinn.App.Models
 
   public class SkjemaSpesifikt
   {
-    [XmlElement("andreBehov", Order = 1)]
+    [XmlElement("andreBehov", Order = 1, IsNullable = true)]
     [JsonProperty("andreBehov")]
     [JsonPropertyName("andreBehov")]
     public string andreBehov { get; set; }
@@ -283,12 +283,12 @@ namespace Altinn.App.Models
     [JsonPropertyName("hjelpeapparat")]
     public Hjelpeapparat hjelpeapparat { get; set; }
 
-    [XmlElement("endringEllerNy", Order = 20)]
+    [XmlElement("endringEllerNy", Order = 20, IsNullable = true)]
     [JsonProperty("endringEllerNy")]
     [JsonPropertyName("endringEllerNy")]
     public string endringEllerNy { get; set; }
 
-    [XmlElement("innsenderRelasjon", Order = 21)]
+    [XmlElement("innsenderRelasjon", Order = 21, IsNullable = true)]
     [JsonProperty("innsenderRelasjon")]
     [JsonPropertyName("innsenderRelasjon")]
     public string innsenderRelasjon { get; set; }
@@ -297,12 +297,12 @@ namespace Altinn.App.Models
 
   public class Bank
   {
-    [XmlElement("bankRepresentasjon", Order = 1)]
+    [XmlElement("bankRepresentasjon", Order = 1, IsNullable = true)]
     [JsonProperty("bankRepresentasjon")]
     [JsonPropertyName("bankRepresentasjon")]
     public string bankRepresentasjon { get; set; }
 
-    [XmlElement("bankLaan", Order = 2)]
+    [XmlElement("bankLaan", Order = 2, IsNullable = true)]
     [JsonProperty("bankLaan")]
     [JsonPropertyName("bankLaan")]
     public string bankLaan { get; set; }
@@ -311,7 +311,7 @@ namespace Altinn.App.Models
 
   public class Forsikringsselskap
   {
-    [XmlElement("forsikringForvalte", Order = 1)]
+    [XmlElement("forsikringForvalte", Order = 1, IsNullable = true)]
     [JsonProperty("forsikringForvalte")]
     [JsonPropertyName("forsikringForvalte")]
     public string forsikringForvalte { get; set; }
@@ -320,12 +320,12 @@ namespace Altinn.App.Models
 
   public class Helfo
   {
-    [XmlElement("helfoRefusjon", Order = 1)]
+    [XmlElement("helfoRefusjon", Order = 1, IsNullable = true)]
     [JsonProperty("helfoRefusjon")]
     [JsonPropertyName("helfoRefusjon")]
     public string helfoRefusjon { get; set; }
 
-    [XmlElement("helfoFastlege", Order = 2)]
+    [XmlElement("helfoFastlege", Order = 2, IsNullable = true)]
     [JsonProperty("helfoFastlege")]
     [JsonPropertyName("helfoFastlege")]
     public string helfoFastlege { get; set; }
@@ -334,12 +334,12 @@ namespace Altinn.App.Models
 
   public class Husbanken
   {
-    [XmlElement("husbankenBostoette", Order = 1)]
+    [XmlElement("husbankenBostoette", Order = 1, IsNullable = true)]
     [JsonProperty("husbankenBostoette")]
     [JsonPropertyName("husbankenBostoette")]
     public string husbankenBostoette { get; set; }
 
-    [XmlElement("husbankenStartlaan", Order = 2)]
+    [XmlElement("husbankenStartlaan", Order = 2, IsNullable = true)]
     [JsonProperty("husbankenStartlaan")]
     [JsonPropertyName("husbankenStartlaan")]
     public string husbankenStartlaan { get; set; }
@@ -348,7 +348,7 @@ namespace Altinn.App.Models
 
   public class Inkassoselskap
   {
-    [XmlElement("inkasseForhandle", Order = 1)]
+    [XmlElement("inkasseForhandle", Order = 1, IsNullable = true)]
     [JsonProperty("inkasseForhandle")]
     [JsonPropertyName("inkasseForhandle")]
     public string inkasseForhandle { get; set; }
@@ -357,7 +357,7 @@ namespace Altinn.App.Models
 
   public class Innkreving
   {
-    [XmlElement("innkrevingGjeldsordning", Order = 1)]
+    [XmlElement("innkrevingGjeldsordning", Order = 1, IsNullable = true)]
     [JsonProperty("innkrevingGjeldsordning")]
     [JsonPropertyName("innkrevingGjeldsordning")]
     public string innkrevingGjeldsordning { get; set; }
@@ -366,37 +366,37 @@ namespace Altinn.App.Models
 
   public class Kartverket
   {
-    [XmlElement("kartSalgEiendom", Order = 1)]
+    [XmlElement("kartSalgEiendom", Order = 1, IsNullable = true)]
     [JsonProperty("kartSalgEiendom")]
     [JsonPropertyName("kartSalgEiendom")]
     public string kartSalgEiendom { get; set; }
 
-    [XmlElement("kartKjoepEiendom", Order = 2)]
+    [XmlElement("kartKjoepEiendom", Order = 2, IsNullable = true)]
     [JsonProperty("kartKjoepEiendom")]
     [JsonPropertyName("kartKjoepEiendom")]
     public string kartKjoepEiendom { get; set; }
 
-    [XmlElement("kartArv", Order = 3)]
+    [XmlElement("kartArv", Order = 3, IsNullable = true)]
     [JsonProperty("kartArv")]
     [JsonPropertyName("kartArv")]
     public string kartArv { get; set; }
 
-    [XmlElement("kartEndreEiendom", Order = 4)]
+    [XmlElement("kartEndreEiendom", Order = 4, IsNullable = true)]
     [JsonProperty("kartEndreEiendom")]
     [JsonPropertyName("kartEndreEiendom")]
     public string kartEndreEiendom { get; set; }
 
-    [XmlElement("kartAvtaler", Order = 5)]
+    [XmlElement("kartAvtaler", Order = 5, IsNullable = true)]
     [JsonProperty("kartAvtaler")]
     [JsonPropertyName("kartAvtaler")]
     public string kartAvtaler { get; set; }
 
-    [XmlElement("kartSletting", Order = 6)]
+    [XmlElement("kartSletting", Order = 6, IsNullable = true)]
     [JsonProperty("kartSletting")]
     [JsonPropertyName("kartSletting")]
     public string kartSletting { get; set; }
 
-    [XmlElement("kartLaaneopptak", Order = 7)]
+    [XmlElement("kartLaaneopptak", Order = 7, IsNullable = true)]
     [JsonProperty("kartLaaneopptak")]
     [JsonPropertyName("kartLaaneopptak")]
     public string kartLaaneopptak { get; set; }
@@ -405,27 +405,27 @@ namespace Altinn.App.Models
 
   public class Kommune
   {
-    [XmlElement("kommuneBygg", Order = 1)]
+    [XmlElement("kommuneBygg", Order = 1, IsNullable = true)]
     [JsonProperty("kommuneBygg")]
     [JsonPropertyName("kommuneBygg")]
     public string kommuneBygg { get; set; }
 
-    [XmlElement("kommuneHelse", Order = 2)]
+    [XmlElement("kommuneHelse", Order = 2, IsNullable = true)]
     [JsonProperty("kommuneHelse")]
     [JsonPropertyName("kommuneHelse")]
     public string kommuneHelse { get; set; }
 
-    [XmlElement("kommuneSosial", Order = 3)]
+    [XmlElement("kommuneSosial", Order = 3, IsNullable = true)]
     [JsonProperty("kommuneSosial")]
     [JsonPropertyName("kommuneSosial")]
     public string kommuneSosial { get; set; }
 
-    [XmlElement("kommuneSkole", Order = 4)]
+    [XmlElement("kommuneSkole", Order = 4, IsNullable = true)]
     [JsonProperty("kommuneSkole")]
     [JsonPropertyName("kommuneSkole")]
     public string kommuneSkole { get; set; }
 
-    [XmlElement("kommuneSkatt", Order = 5)]
+    [XmlElement("kommuneSkatt", Order = 5, IsNullable = true)]
     [JsonProperty("kommuneSkatt")]
     [JsonPropertyName("kommuneSkatt")]
     public string kommuneSkatt { get; set; }
@@ -434,7 +434,7 @@ namespace Altinn.App.Models
 
   public class Kredittvurderingsselskap
   {
-    [XmlElement("kredittKredittsperre", Order = 1)]
+    [XmlElement("kredittKredittsperre", Order = 1, IsNullable = true)]
     [JsonProperty("kredittKredittsperre")]
     [JsonPropertyName("kredittKredittsperre")]
     public string kredittKredittsperre { get; set; }
@@ -443,12 +443,12 @@ namespace Altinn.App.Models
 
   public class Namsmannen
   {
-    [XmlElement("namsmannenGjeldsordning", Order = 1)]
+    [XmlElement("namsmannenGjeldsordning", Order = 1, IsNullable = true)]
     [JsonProperty("namsmannenGjeldsordning")]
     [JsonPropertyName("namsmannenGjeldsordning")]
     public string namsmannenGjeldsordning { get; set; }
 
-    [XmlElement("namsmannenTvangsfullbyrdelse", Order = 2)]
+    [XmlElement("namsmannenTvangsfullbyrdelse", Order = 2, IsNullable = true)]
     [JsonProperty("namsmannenTvangsfullbyrdelse")]
     [JsonPropertyName("namsmannenTvangsfullbyrdelse")]
     public string namsmannenTvangsfullbyrdelse { get; set; }
@@ -457,27 +457,27 @@ namespace Altinn.App.Models
 
   public class Nav
   {
-    [XmlElement("navArbeid", Order = 1)]
+    [XmlElement("navArbeid", Order = 1, IsNullable = true)]
     [JsonProperty("navArbeid")]
     [JsonPropertyName("navArbeid")]
     public string navArbeid { get; set; }
 
-    [XmlElement("navFamilie", Order = 2)]
+    [XmlElement("navFamilie", Order = 2, IsNullable = true)]
     [JsonProperty("navFamilie")]
     [JsonPropertyName("navFamilie")]
     public string navFamilie { get; set; }
 
-    [XmlElement("navHjelpemidler", Order = 3)]
+    [XmlElement("navHjelpemidler", Order = 3, IsNullable = true)]
     [JsonProperty("navHjelpemidler")]
     [JsonPropertyName("navHjelpemidler")]
     public string navHjelpemidler { get; set; }
 
-    [XmlElement("navPensjon", Order = 4)]
+    [XmlElement("navPensjon", Order = 4, IsNullable = true)]
     [JsonProperty("navPensjon")]
     [JsonPropertyName("navPensjon")]
     public string navPensjon { get; set; }
 
-    [XmlElement("navSosial", Order = 5)]
+    [XmlElement("navSosial", Order = 5, IsNullable = true)]
     [JsonProperty("navSosial")]
     [JsonPropertyName("navSosial")]
     public string navSosial { get; set; }
@@ -486,7 +486,7 @@ namespace Altinn.App.Models
 
   public class Pasientreiser
   {
-    [XmlElement("pasientRefusjon", Order = 1)]
+    [XmlElement("pasientRefusjon", Order = 1, IsNullable = true)]
     [JsonProperty("pasientRefusjon")]
     [JsonPropertyName("pasientRefusjon")]
     public string pasientRefusjon { get; set; }
@@ -495,22 +495,22 @@ namespace Altinn.App.Models
 
   public class Skatteetaten
   {
-    [XmlElement("skattInnkreving", Order = 1)]
+    [XmlElement("skattInnkreving", Order = 1, IsNullable = true)]
     [JsonProperty("skattInnkreving")]
     [JsonPropertyName("skattInnkreving")]
     public string skattInnkreving { get; set; }
 
-    [XmlElement("skattPostadresse", Order = 2)]
+    [XmlElement("skattPostadresse", Order = 2, IsNullable = true)]
     [JsonProperty("skattPostadresse")]
     [JsonPropertyName("skattPostadresse")]
     public string skattPostadresse { get; set; }
 
-    [XmlElement("skattFlytting", Order = 3)]
+    [XmlElement("skattFlytting", Order = 3, IsNullable = true)]
     [JsonProperty("skattFlytting")]
     [JsonPropertyName("skattFlytting")]
     public string skattFlytting { get; set; }
 
-    [XmlElement("skattSkatt", Order = 4)]
+    [XmlElement("skattSkatt", Order = 4, IsNullable = true)]
     [JsonProperty("skattSkatt")]
     [JsonPropertyName("skattSkatt")]
     public string skattSkatt { get; set; }
@@ -519,17 +519,17 @@ namespace Altinn.App.Models
 
   public class Tingretten
   {
-    [XmlElement("tingrettUskifte", Order = 1)]
+    [XmlElement("tingrettUskifte", Order = 1, IsNullable = true)]
     [JsonProperty("tingrettUskifte")]
     [JsonPropertyName("tingrettUskifte")]
     public string tingrettUskifte { get; set; }
 
-    [XmlElement("tingrettPrivatDoedsbo", Order = 2)]
+    [XmlElement("tingrettPrivatDoedsbo", Order = 2, IsNullable = true)]
     [JsonProperty("tingrettPrivatDoedsbo")]
     [JsonPropertyName("tingrettPrivatDoedsbo")]
     public string tingrettPrivatDoedsbo { get; set; }
 
-    [XmlElement("tingrettBegjaereDoedsbo", Order = 3)]
+    [XmlElement("tingrettBegjaereDoedsbo", Order = 3, IsNullable = true)]
     [JsonProperty("tingrettBegjaereDoedsbo")]
     [JsonPropertyName("tingrettBegjaereDoedsbo")]
     public string tingrettBegjaereDoedsbo { get; set; }
@@ -538,27 +538,27 @@ namespace Altinn.App.Models
 
   public class OEvrige
   {
-    [XmlElement("oevrigeKjoepVarer", Order = 1)]
+    [XmlElement("oevrigeKjoepVarer", Order = 1, IsNullable = true)]
     [JsonProperty("oevrigeKjoepVarer")]
     [JsonPropertyName("oevrigeKjoepVarer")]
     public string oevrigeKjoepVarer { get; set; }
 
-    [XmlElement("oevrigeHusleiekontrakt", Order = 2)]
+    [XmlElement("oevrigeHusleiekontrakt", Order = 2, IsNullable = true)]
     [JsonProperty("oevrigeHusleiekontrakt")]
     [JsonPropertyName("oevrigeHusleiekontrakt")]
     public string oevrigeHusleiekontrakt { get; set; }
 
-    [XmlElement("oevrigeLoesoere", Order = 3)]
+    [XmlElement("oevrigeLoesoere", Order = 3, IsNullable = true)]
     [JsonProperty("oevrigeLoesoere")]
     [JsonPropertyName("oevrigeLoesoere")]
     public string oevrigeLoesoere { get; set; }
 
-    [XmlElement("oevrigeUtgifter", Order = 4)]
+    [XmlElement("oevrigeUtgifter", Order = 4, IsNullable = true)]
     [JsonProperty("oevrigeUtgifter")]
     [JsonPropertyName("oevrigeUtgifter")]
     public string oevrigeUtgifter { get; set; }
 
-    [XmlElement("oevrigeAvslutteHusleie", Order = 5)]
+    [XmlElement("oevrigeAvslutteHusleie", Order = 5, IsNullable = true)]
     [JsonProperty("oevrigeAvslutteHusleie")]
     [JsonPropertyName("oevrigeAvslutteHusleie")]
     public string oevrigeAvslutteHusleie { get; set; }
@@ -567,12 +567,12 @@ namespace Altinn.App.Models
 
   public class Statsforvalter
   {
-    [XmlElement("statsforvalterTvangsvedtak", Order = 1)]
+    [XmlElement("statsforvalterTvangsvedtak", Order = 1, IsNullable = true)]
     [JsonProperty("statsforvalterTvangsvedtak")]
     [JsonPropertyName("statsforvalterTvangsvedtak")]
     public string statsforvalterTvangsvedtak { get; set; }
 
-    [XmlElement("statsforvalterSamtykke", Order = 2)]
+    [XmlElement("statsforvalterSamtykke", Order = 2, IsNullable = true)]
     [JsonProperty("statsforvalterSamtykke")]
     [JsonPropertyName("statsforvalterSamtykke")]
     public string statsforvalterSamtykke { get; set; }
@@ -581,22 +581,22 @@ namespace Altinn.App.Models
 
   public class Vergehaver
   {
-    [XmlElement("telefonsamtaleMulig", Order = 1)]
+    [XmlElement("telefonsamtaleMulig", Order = 1, IsNullable = true)]
     [JsonProperty("telefonsamtaleMulig")]
     [JsonPropertyName("telefonsamtaleMulig")]
     public string telefonsamtaleMulig { get; set; }
 
-    [XmlElement("telefonsamtaleHvorfor", Order = 2)]
+    [XmlElement("telefonsamtaleHvorfor", Order = 2, IsNullable = true)]
     [JsonProperty("telefonsamtaleHvorfor")]
     [JsonPropertyName("telefonsamtaleHvorfor")]
     public string telefonsamtaleHvorfor { get; set; }
 
-    [XmlElement("borPaaInstitusjon", Order = 3)]
+    [XmlElement("borPaaInstitusjon", Order = 3, IsNullable = true)]
     [JsonProperty("borPaaInstitusjon")]
     [JsonPropertyName("borPaaInstitusjon")]
     public string borPaaInstitusjon { get; set; }
 
-    [XmlElement("hvilkenInstitusjon", Order = 4)]
+    [XmlElement("hvilkenInstitusjon", Order = 4, IsNullable = true)]
     [JsonProperty("hvilkenInstitusjon")]
     [JsonPropertyName("hvilkenInstitusjon")]
     public string hvilkenInstitusjon { get; set; }
@@ -622,7 +622,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("telefonnummer")]
     public string telefonnummer { get; set; }
 
-    [XmlElement("navn", Order = 2)]
+    [XmlElement("navn", Order = 2, IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }

--- a/testdata/Model/CSharp/Gitea/srf-melding-til-statsforvalteren.cs
+++ b/testdata/Model/CSharp/Gitea/srf-melding-til-statsforvalteren.cs
@@ -50,7 +50,7 @@ namespace Altinn.App.Models
 
   public class InnsenderPerson
   {
-    [XmlElement("navn", Order = 1)]
+    [XmlElement("navn", Order = 1, IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
@@ -87,27 +87,27 @@ namespace Altinn.App.Models
 
   public class Adresse
   {
-    [XmlElement("adresse1", Order = 1)]
+    [XmlElement("adresse1", Order = 1, IsNullable = true)]
     [JsonProperty("adresse1")]
     [JsonPropertyName("adresse1")]
     public string adresse1 { get; set; }
 
-    [XmlElement("adresse2", Order = 2)]
+    [XmlElement("adresse2", Order = 2, IsNullable = true)]
     [JsonProperty("adresse2")]
     [JsonPropertyName("adresse2")]
     public string adresse2 { get; set; }
 
-    [XmlElement("postnummer", Order = 3)]
+    [XmlElement("postnummer", Order = 3, IsNullable = true)]
     [JsonProperty("postnummer")]
     [JsonPropertyName("postnummer")]
     public string postnummer { get; set; }
 
-    [XmlElement("poststed", Order = 4)]
+    [XmlElement("poststed", Order = 4, IsNullable = true)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
     public string poststed { get; set; }
 
-    [XmlElement("land", Order = 5)]
+    [XmlElement("land", Order = 5, IsNullable = true)]
     [JsonProperty("land")]
     [JsonPropertyName("land")]
     public string land { get; set; }
@@ -116,12 +116,12 @@ namespace Altinn.App.Models
 
   public class InnsenderOrganisasjon
   {
-    [XmlElement("kontaktperson", Order = 1)]
+    [XmlElement("kontaktperson", Order = 1, IsNullable = true)]
     [JsonProperty("kontaktperson")]
     [JsonPropertyName("kontaktperson")]
     public string kontaktperson { get; set; }
 
-    [XmlElement("organisasjonsnavn", Order = 2)]
+    [XmlElement("organisasjonsnavn", Order = 2, IsNullable = true)]
     [JsonProperty("organisasjonsnavn")]
     [JsonPropertyName("organisasjonsnavn")]
     public string organisasjonsnavn { get; set; }
@@ -158,7 +158,7 @@ namespace Altinn.App.Models
 
   public class HvemGjelderHenvendelsen
   {
-    [XmlElement("navn", Order = 1)]
+    [XmlElement("navn", Order = 1, IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
@@ -179,7 +179,7 @@ namespace Altinn.App.Models
 
   public class HvorSkalHenvendelsenSendes
   {
-    [XmlElement("fylke", Order = 1)]
+    [XmlElement("fylke", Order = 1, IsNullable = true)]
     [JsonProperty("fylke")]
     [JsonPropertyName("fylke")]
     public string fylke { get; set; }
@@ -197,17 +197,17 @@ namespace Altinn.App.Models
 
   public class HvaGjelderHenvendelsen
   {
-    [XmlElement("melding", Order = 1)]
+    [XmlElement("melding", Order = 1, IsNullable = true)]
     [JsonProperty("melding")]
     [JsonPropertyName("melding")]
     public string melding { get; set; }
 
-    [XmlElement("emne", Order = 2)]
+    [XmlElement("emne", Order = 2, IsNullable = true)]
     [JsonProperty("emne")]
     [JsonPropertyName("emne")]
     public string emne { get; set; }
 
-    [XmlElement("tema", Order = 3)]
+    [XmlElement("tema", Order = 3, IsNullable = true)]
     [JsonProperty("tema")]
     [JsonPropertyName("tema")]
     public string tema { get; set; }

--- a/testdata/Model/CSharp/XsAll/ferdigattest/v4/ferdigattest.cs
+++ b/testdata/Model/CSharp/XsAll/ferdigattest/v4/ferdigattest.cs
@@ -120,17 +120,17 @@ namespace Altinn.App.Models
     [JsonPropertyName("adresse")]
     public EiendommensAdresseType adresse { get; set; }
 
-    [XmlElement("bygningsnummer")]
+    [XmlElement("bygningsnummer", IsNullable = true)]
     [JsonProperty("bygningsnummer")]
     [JsonPropertyName("bygningsnummer")]
     public string bygningsnummer { get; set; }
 
-    [XmlElement("bolignummer")]
+    [XmlElement("bolignummer", IsNullable = true)]
     [JsonProperty("bolignummer")]
     [JsonPropertyName("bolignummer")]
     public string bolignummer { get; set; }
 
-    [XmlElement("kommunenavn")]
+    [XmlElement("kommunenavn", IsNullable = true)]
     [JsonProperty("kommunenavn")]
     [JsonPropertyName("kommunenavn")]
     public string kommunenavn { get; set; }
@@ -139,7 +139,7 @@ namespace Altinn.App.Models
 
   public class MatrikkelnummerType
   {
-    [XmlElement("kommunenummer")]
+    [XmlElement("kommunenummer", IsNullable = true)]
     [JsonProperty("kommunenummer")]
     [JsonPropertyName("kommunenummer")]
     public string kommunenummer { get; set; }
@@ -172,47 +172,47 @@ namespace Altinn.App.Models
 
   public class EiendommensAdresseType
   {
-    [XmlElement("adresselinje1")]
+    [XmlElement("adresselinje1", IsNullable = true)]
     [JsonProperty("adresselinje1")]
     [JsonPropertyName("adresselinje1")]
     public string adresselinje1 { get; set; }
 
-    [XmlElement("adresselinje2")]
+    [XmlElement("adresselinje2", IsNullable = true)]
     [JsonProperty("adresselinje2")]
     [JsonPropertyName("adresselinje2")]
     public string adresselinje2 { get; set; }
 
-    [XmlElement("adresselinje3")]
+    [XmlElement("adresselinje3", IsNullable = true)]
     [JsonProperty("adresselinje3")]
     [JsonPropertyName("adresselinje3")]
     public string adresselinje3 { get; set; }
 
-    [XmlElement("postnr")]
+    [XmlElement("postnr", IsNullable = true)]
     [JsonProperty("postnr")]
     [JsonPropertyName("postnr")]
     public string postnr { get; set; }
 
-    [XmlElement("poststed")]
+    [XmlElement("poststed", IsNullable = true)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
     public string poststed { get; set; }
 
-    [XmlElement("landkode")]
+    [XmlElement("landkode", IsNullable = true)]
     [JsonProperty("landkode")]
     [JsonPropertyName("landkode")]
     public string landkode { get; set; }
 
-    [XmlElement("gatenavn")]
+    [XmlElement("gatenavn", IsNullable = true)]
     [JsonProperty("gatenavn")]
     [JsonPropertyName("gatenavn")]
     public string gatenavn { get; set; }
 
-    [XmlElement("husnr")]
+    [XmlElement("husnr", IsNullable = true)]
     [JsonProperty("husnr")]
     [JsonPropertyName("husnr")]
     public string husnr { get; set; }
 
-    [XmlElement("bokstav")]
+    [XmlElement("bokstav", IsNullable = true)]
     [JsonProperty("bokstav")]
     [JsonPropertyName("bokstav")]
     public string bokstav { get; set; }
@@ -237,22 +237,22 @@ namespace Altinn.App.Models
 
   public class MetadataType
   {
-    [XmlElement("fraSluttbrukersystem")]
+    [XmlElement("fraSluttbrukersystem", IsNullable = true)]
     [JsonProperty("fraSluttbrukersystem")]
     [JsonPropertyName("fraSluttbrukersystem")]
     public string fraSluttbrukersystem { get; set; }
 
-    [XmlElement("ftbId")]
+    [XmlElement("ftbId", IsNullable = true)]
     [JsonProperty("ftbId")]
     [JsonPropertyName("ftbId")]
     public string ftbId { get; set; }
 
-    [XmlElement("prosjektnavn")]
+    [XmlElement("prosjektnavn", IsNullable = true)]
     [JsonProperty("prosjektnavn")]
     [JsonPropertyName("prosjektnavn")]
     public string prosjektnavn { get; set; }
 
-    [XmlElement("prosjektnr")]
+    [XmlElement("prosjektnr", IsNullable = true)]
     [JsonProperty("prosjektnr")]
     [JsonPropertyName("prosjektnr")]
     public string prosjektnr { get; set; }
@@ -274,12 +274,12 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
-    [XmlElement("kodeverdi")]
+    [XmlElement("kodeverdi", IsNullable = true)]
     [JsonProperty("kodeverdi")]
     [JsonPropertyName("kodeverdi")]
     public string kodeverdi { get; set; }
 
-    [XmlElement("kodebeskrivelse")]
+    [XmlElement("kodebeskrivelse", IsNullable = true)]
     [JsonProperty("kodebeskrivelse")]
     [JsonPropertyName("kodebeskrivelse")]
     public string kodebeskrivelse { get; set; }
@@ -302,7 +302,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("type")]
     public KodeListe type { get; set; }
 
-    [XmlElement("foelgebrev")]
+    [XmlElement("foelgebrev", IsNullable = true)]
     [JsonProperty("foelgebrev")]
     [JsonPropertyName("foelgebrev")]
     public string foelgebrev { get; set; }
@@ -337,7 +337,7 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
-    [XmlElement("utfallId")]
+    [XmlElement("utfallId", IsNullable = true)]
     [JsonProperty("utfallId")]
     [JsonPropertyName("utfallId")]
     public string utfallId { get; set; }
@@ -357,12 +357,12 @@ namespace Altinn.App.Models
     [JsonPropertyName("tema")]
     public KodeType tema { get; set; }
 
-    [XmlElement("tittel")]
+    [XmlElement("tittel", IsNullable = true)]
     [JsonProperty("tittel")]
     [JsonPropertyName("tittel")]
     public string tittel { get; set; }
 
-    [XmlElement("beskrivelse")]
+    [XmlElement("beskrivelse", IsNullable = true)]
     [JsonProperty("beskrivelse")]
     [JsonPropertyName("beskrivelse")]
     public string beskrivelse { get; set; }
@@ -377,7 +377,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("erUtfallBesvart")]
     public bool? erUtfallBesvart { get; set; }
 
-    [XmlElement("kommentar")]
+    [XmlElement("kommentar", IsNullable = true)]
     [JsonProperty("kommentar")]
     [JsonPropertyName("kommentar")]
     public string kommentar { get; set; }
@@ -391,12 +391,12 @@ namespace Altinn.App.Models
 
   public class SjekkpunktType
   {
-    [XmlElement("sjekkpunktId")]
+    [XmlElement("sjekkpunktId", IsNullable = true)]
     [JsonProperty("sjekkpunktId")]
     [JsonPropertyName("sjekkpunktId")]
     public string sjekkpunktId { get; set; }
 
-    [XmlElement("sjekkpunktEier")]
+    [XmlElement("sjekkpunktEier", IsNullable = true)]
     [JsonProperty("sjekkpunktEier")]
     [JsonPropertyName("sjekkpunktEier")]
     public string sjekkpunktEier { get; set; }
@@ -422,7 +422,7 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
-    [XmlElement("versjonsnummer")]
+    [XmlElement("versjonsnummer", IsNullable = true)]
     [JsonProperty("versjonsnummer")]
     [JsonPropertyName("versjonsnummer")]
     public string versjonsnummer { get; set; }
@@ -433,12 +433,12 @@ namespace Altinn.App.Models
     public KodeType vedleggstype { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
-    [XmlElement("versjonsdato")]
+    [XmlElement("versjonsdato", IsNullable = true)]
     [JsonProperty("versjonsdato")]
     [JsonPropertyName("versjonsdato")]
     public string versjonsdato { get; set; }
 
-    [XmlElement("filnavn")]
+    [XmlElement("filnavn", IsNullable = true)]
     [JsonProperty("filnavn")]
     [JsonPropertyName("filnavn")]
     public string filnavn { get; set; }
@@ -453,18 +453,18 @@ namespace Altinn.App.Models
     public bool? tilfredsstillerTiltaketKraveneFerdigattest { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
-    [XmlElement("utfoertInnen")]
+    [XmlElement("utfoertInnen", IsNullable = true)]
     [JsonProperty("utfoertInnen")]
     [JsonPropertyName("utfoertInnen")]
     public string utfoertInnen { get; set; }
 
-    [XmlElement("typeArbeider")]
+    [XmlElement("typeArbeider", IsNullable = true)]
     [JsonProperty("typeArbeider")]
     [JsonPropertyName("typeArbeider")]
     public string typeArbeider { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
-    [XmlElement("bekreftelseInnen")]
+    [XmlElement("bekreftelseInnen", IsNullable = true)]
     [JsonProperty("bekreftelseInnen")]
     [JsonPropertyName("bekreftelseInnen")]
     public string bekreftelseInnen { get; set; }
@@ -497,17 +497,17 @@ namespace Altinn.App.Models
     [JsonPropertyName("partstype")]
     public KodeType partstype { get; set; }
 
-    [XmlElement("foedselsnummer")]
+    [XmlElement("foedselsnummer", IsNullable = true)]
     [JsonProperty("foedselsnummer")]
     [JsonPropertyName("foedselsnummer")]
     public string foedselsnummer { get; set; }
 
-    [XmlElement("organisasjonsnummer")]
+    [XmlElement("organisasjonsnummer", IsNullable = true)]
     [JsonProperty("organisasjonsnummer")]
     [JsonPropertyName("organisasjonsnummer")]
     public string organisasjonsnummer { get; set; }
 
-    [XmlElement("navn")]
+    [XmlElement("navn", IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
@@ -517,17 +517,17 @@ namespace Altinn.App.Models
     [JsonPropertyName("adresse")]
     public EnkelAdresseType adresse { get; set; }
 
-    [XmlElement("telefonnummer")]
+    [XmlElement("telefonnummer", IsNullable = true)]
     [JsonProperty("telefonnummer")]
     [JsonPropertyName("telefonnummer")]
     public string telefonnummer { get; set; }
 
-    [XmlElement("mobilnummer")]
+    [XmlElement("mobilnummer", IsNullable = true)]
     [JsonProperty("mobilnummer")]
     [JsonPropertyName("mobilnummer")]
     public string mobilnummer { get; set; }
 
-    [XmlElement("epost")]
+    [XmlElement("epost", IsNullable = true)]
     [JsonProperty("epost")]
     [JsonPropertyName("epost")]
     public string epost { get; set; }
@@ -541,32 +541,32 @@ namespace Altinn.App.Models
 
   public class EnkelAdresseType
   {
-    [XmlElement("adresselinje1")]
+    [XmlElement("adresselinje1", IsNullable = true)]
     [JsonProperty("adresselinje1")]
     [JsonPropertyName("adresselinje1")]
     public string adresselinje1 { get; set; }
 
-    [XmlElement("adresselinje2")]
+    [XmlElement("adresselinje2", IsNullable = true)]
     [JsonProperty("adresselinje2")]
     [JsonPropertyName("adresselinje2")]
     public string adresselinje2 { get; set; }
 
-    [XmlElement("adresselinje3")]
+    [XmlElement("adresselinje3", IsNullable = true)]
     [JsonProperty("adresselinje3")]
     [JsonPropertyName("adresselinje3")]
     public string adresselinje3 { get; set; }
 
-    [XmlElement("postnr")]
+    [XmlElement("postnr", IsNullable = true)]
     [JsonProperty("postnr")]
     [JsonPropertyName("postnr")]
     public string postnr { get; set; }
 
-    [XmlElement("poststed")]
+    [XmlElement("poststed", IsNullable = true)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
     public string poststed { get; set; }
 
-    [XmlElement("landkode")]
+    [XmlElement("landkode", IsNullable = true)]
     [JsonProperty("landkode")]
     [JsonPropertyName("landkode")]
     public string landkode { get; set; }
@@ -575,22 +575,22 @@ namespace Altinn.App.Models
 
   public class KontaktpersonType
   {
-    [XmlElement("navn")]
+    [XmlElement("navn", IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
 
-    [XmlElement("telefonnummer")]
+    [XmlElement("telefonnummer", IsNullable = true)]
     [JsonProperty("telefonnummer")]
     [JsonPropertyName("telefonnummer")]
     public string telefonnummer { get; set; }
 
-    [XmlElement("mobilnummer")]
+    [XmlElement("mobilnummer", IsNullable = true)]
     [JsonProperty("mobilnummer")]
     [JsonPropertyName("mobilnummer")]
     public string mobilnummer { get; set; }
 
-    [XmlElement("epost")]
+    [XmlElement("epost", IsNullable = true)]
     [JsonProperty("epost")]
     [JsonPropertyName("epost")]
     public string epost { get; set; }

--- a/testdata/Model/CSharp/XsAll/igangsettingstillatelse/v4/igangsettingstillatelse.cs
+++ b/testdata/Model/CSharp/XsAll/igangsettingstillatelse/v4/igangsettingstillatelse.cs
@@ -100,17 +100,17 @@ namespace Altinn.App.Models
     [JsonPropertyName("adresse")]
     public EiendommensAdresseType adresse { get; set; }
 
-    [XmlElement("bygningsnummer")]
+    [XmlElement("bygningsnummer", IsNullable = true)]
     [JsonProperty("bygningsnummer")]
     [JsonPropertyName("bygningsnummer")]
     public string bygningsnummer { get; set; }
 
-    [XmlElement("bolignummer")]
+    [XmlElement("bolignummer", IsNullable = true)]
     [JsonProperty("bolignummer")]
     [JsonPropertyName("bolignummer")]
     public string bolignummer { get; set; }
 
-    [XmlElement("kommunenavn")]
+    [XmlElement("kommunenavn", IsNullable = true)]
     [JsonProperty("kommunenavn")]
     [JsonPropertyName("kommunenavn")]
     public string kommunenavn { get; set; }
@@ -119,7 +119,7 @@ namespace Altinn.App.Models
 
   public class MatrikkelnummerType
   {
-    [XmlElement("kommunenummer")]
+    [XmlElement("kommunenummer", IsNullable = true)]
     [JsonProperty("kommunenummer")]
     [JsonPropertyName("kommunenummer")]
     public string kommunenummer { get; set; }
@@ -152,47 +152,47 @@ namespace Altinn.App.Models
 
   public class EiendommensAdresseType
   {
-    [XmlElement("adresselinje1")]
+    [XmlElement("adresselinje1", IsNullable = true)]
     [JsonProperty("adresselinje1")]
     [JsonPropertyName("adresselinje1")]
     public string adresselinje1 { get; set; }
 
-    [XmlElement("adresselinje2")]
+    [XmlElement("adresselinje2", IsNullable = true)]
     [JsonProperty("adresselinje2")]
     [JsonPropertyName("adresselinje2")]
     public string adresselinje2 { get; set; }
 
-    [XmlElement("adresselinje3")]
+    [XmlElement("adresselinje3", IsNullable = true)]
     [JsonProperty("adresselinje3")]
     [JsonPropertyName("adresselinje3")]
     public string adresselinje3 { get; set; }
 
-    [XmlElement("postnr")]
+    [XmlElement("postnr", IsNullable = true)]
     [JsonProperty("postnr")]
     [JsonPropertyName("postnr")]
     public string postnr { get; set; }
 
-    [XmlElement("poststed")]
+    [XmlElement("poststed", IsNullable = true)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
     public string poststed { get; set; }
 
-    [XmlElement("landkode")]
+    [XmlElement("landkode", IsNullable = true)]
     [JsonProperty("landkode")]
     [JsonPropertyName("landkode")]
     public string landkode { get; set; }
 
-    [XmlElement("gatenavn")]
+    [XmlElement("gatenavn", IsNullable = true)]
     [JsonProperty("gatenavn")]
     [JsonPropertyName("gatenavn")]
     public string gatenavn { get; set; }
 
-    [XmlElement("husnr")]
+    [XmlElement("husnr", IsNullable = true)]
     [JsonProperty("husnr")]
     [JsonPropertyName("husnr")]
     public string husnr { get; set; }
 
-    [XmlElement("bokstav")]
+    [XmlElement("bokstav", IsNullable = true)]
     [JsonProperty("bokstav")]
     [JsonPropertyName("bokstav")]
     public string bokstav { get; set; }
@@ -217,22 +217,22 @@ namespace Altinn.App.Models
 
   public class MetadataType
   {
-    [XmlElement("fraSluttbrukersystem")]
+    [XmlElement("fraSluttbrukersystem", IsNullable = true)]
     [JsonProperty("fraSluttbrukersystem")]
     [JsonPropertyName("fraSluttbrukersystem")]
     public string fraSluttbrukersystem { get; set; }
 
-    [XmlElement("ftbId")]
+    [XmlElement("ftbId", IsNullable = true)]
     [JsonProperty("ftbId")]
     [JsonPropertyName("ftbId")]
     public string ftbId { get; set; }
 
-    [XmlElement("prosjektnavn")]
+    [XmlElement("prosjektnavn", IsNullable = true)]
     [JsonProperty("prosjektnavn")]
     [JsonPropertyName("prosjektnavn")]
     public string prosjektnavn { get; set; }
 
-    [XmlElement("prosjektnr")]
+    [XmlElement("prosjektnr", IsNullable = true)]
     [JsonProperty("prosjektnr")]
     [JsonPropertyName("prosjektnr")]
     public string prosjektnr { get; set; }
@@ -254,12 +254,12 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
-    [XmlElement("kodeverdi")]
+    [XmlElement("kodeverdi", IsNullable = true)]
     [JsonProperty("kodeverdi")]
     [JsonPropertyName("kodeverdi")]
     public string kodeverdi { get; set; }
 
-    [XmlElement("kodebeskrivelse")]
+    [XmlElement("kodebeskrivelse", IsNullable = true)]
     [JsonProperty("kodebeskrivelse")]
     [JsonPropertyName("kodebeskrivelse")]
     public string kodebeskrivelse { get; set; }
@@ -287,7 +287,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("gjelderHeleTiltaket")]
     public bool? gjelderHeleTiltaket { get; set; }
 
-    [XmlElement("delAvTiltaket")]
+    [XmlElement("delAvTiltaket", IsNullable = true)]
     [JsonProperty("delAvTiltaket")]
     [JsonPropertyName("delAvTiltaket")]
     public string delAvTiltaket { get; set; }
@@ -297,12 +297,12 @@ namespace Altinn.App.Models
     [JsonPropertyName("type")]
     public KodeListe type { get; set; }
 
-    [XmlElement("delsoeknadsnummer")]
+    [XmlElement("delsoeknadsnummer", IsNullable = true)]
     [JsonProperty("delsoeknadsnummer")]
     [JsonPropertyName("delsoeknadsnummer")]
     public string delsoeknadsnummer { get; set; }
 
-    [XmlElement("foelgebrev")]
+    [XmlElement("foelgebrev", IsNullable = true)]
     [JsonProperty("foelgebrev")]
     [JsonPropertyName("foelgebrev")]
     public string foelgebrev { get; set; }
@@ -337,18 +337,18 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
-    [XmlElement("delAvTiltaket")]
+    [XmlElement("delAvTiltaket", IsNullable = true)]
     [JsonProperty("delAvTiltaket")]
     [JsonPropertyName("delAvTiltaket")]
     public string delAvTiltaket { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
-    [XmlElement("tillatelsedato")]
+    [XmlElement("tillatelsedato", IsNullable = true)]
     [JsonProperty("tillatelsedato")]
     [JsonPropertyName("tillatelsedato")]
     public string tillatelsedato { get; set; }
 
-    [XmlElement("kommentar")]
+    [XmlElement("kommentar", IsNullable = true)]
     [JsonProperty("kommentar")]
     [JsonPropertyName("kommentar")]
     public string kommentar { get; set; }
@@ -358,7 +358,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("type")]
     public KodeListe type { get; set; }
 
-    [XmlElement("delsoeknadsnummer")]
+    [XmlElement("delsoeknadsnummer", IsNullable = true)]
     [JsonProperty("delsoeknadsnummer")]
     [JsonPropertyName("delsoeknadsnummer")]
     public string delsoeknadsnummer { get; set; }
@@ -384,7 +384,7 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
-    [XmlElement("utfallId")]
+    [XmlElement("utfallId", IsNullable = true)]
     [JsonProperty("utfallId")]
     [JsonPropertyName("utfallId")]
     public string utfallId { get; set; }
@@ -404,12 +404,12 @@ namespace Altinn.App.Models
     [JsonPropertyName("tema")]
     public KodeType tema { get; set; }
 
-    [XmlElement("tittel")]
+    [XmlElement("tittel", IsNullable = true)]
     [JsonProperty("tittel")]
     [JsonPropertyName("tittel")]
     public string tittel { get; set; }
 
-    [XmlElement("beskrivelse")]
+    [XmlElement("beskrivelse", IsNullable = true)]
     [JsonProperty("beskrivelse")]
     [JsonPropertyName("beskrivelse")]
     public string beskrivelse { get; set; }
@@ -424,7 +424,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("erUtfallBesvart")]
     public bool? erUtfallBesvart { get; set; }
 
-    [XmlElement("kommentar")]
+    [XmlElement("kommentar", IsNullable = true)]
     [JsonProperty("kommentar")]
     [JsonPropertyName("kommentar")]
     public string kommentar { get; set; }
@@ -438,12 +438,12 @@ namespace Altinn.App.Models
 
   public class SjekkpunktType
   {
-    [XmlElement("sjekkpunktId")]
+    [XmlElement("sjekkpunktId", IsNullable = true)]
     [JsonProperty("sjekkpunktId")]
     [JsonPropertyName("sjekkpunktId")]
     public string sjekkpunktId { get; set; }
 
-    [XmlElement("sjekkpunktEier")]
+    [XmlElement("sjekkpunktEier", IsNullable = true)]
     [JsonProperty("sjekkpunktEier")]
     [JsonPropertyName("sjekkpunktEier")]
     public string sjekkpunktEier { get; set; }
@@ -469,7 +469,7 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
-    [XmlElement("versjonsnummer")]
+    [XmlElement("versjonsnummer", IsNullable = true)]
     [JsonProperty("versjonsnummer")]
     [JsonPropertyName("versjonsnummer")]
     public string versjonsnummer { get; set; }
@@ -480,12 +480,12 @@ namespace Altinn.App.Models
     public KodeType vedleggstype { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
-    [XmlElement("versjonsdato")]
+    [XmlElement("versjonsdato", IsNullable = true)]
     [JsonProperty("versjonsdato")]
     [JsonPropertyName("versjonsdato")]
     public string versjonsdato { get; set; }
 
-    [XmlElement("filnavn")]
+    [XmlElement("filnavn", IsNullable = true)]
     [JsonProperty("filnavn")]
     [JsonPropertyName("filnavn")]
     public string filnavn { get; set; }
@@ -499,17 +499,17 @@ namespace Altinn.App.Models
     [JsonPropertyName("partstype")]
     public KodeType partstype { get; set; }
 
-    [XmlElement("foedselsnummer")]
+    [XmlElement("foedselsnummer", IsNullable = true)]
     [JsonProperty("foedselsnummer")]
     [JsonPropertyName("foedselsnummer")]
     public string foedselsnummer { get; set; }
 
-    [XmlElement("organisasjonsnummer")]
+    [XmlElement("organisasjonsnummer", IsNullable = true)]
     [JsonProperty("organisasjonsnummer")]
     [JsonPropertyName("organisasjonsnummer")]
     public string organisasjonsnummer { get; set; }
 
-    [XmlElement("navn")]
+    [XmlElement("navn", IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
@@ -519,17 +519,17 @@ namespace Altinn.App.Models
     [JsonPropertyName("adresse")]
     public EnkelAdresseType adresse { get; set; }
 
-    [XmlElement("telefonnummer")]
+    [XmlElement("telefonnummer", IsNullable = true)]
     [JsonProperty("telefonnummer")]
     [JsonPropertyName("telefonnummer")]
     public string telefonnummer { get; set; }
 
-    [XmlElement("mobilnummer")]
+    [XmlElement("mobilnummer", IsNullable = true)]
     [JsonProperty("mobilnummer")]
     [JsonPropertyName("mobilnummer")]
     public string mobilnummer { get; set; }
 
-    [XmlElement("epost")]
+    [XmlElement("epost", IsNullable = true)]
     [JsonProperty("epost")]
     [JsonPropertyName("epost")]
     public string epost { get; set; }
@@ -543,32 +543,32 @@ namespace Altinn.App.Models
 
   public class EnkelAdresseType
   {
-    [XmlElement("adresselinje1")]
+    [XmlElement("adresselinje1", IsNullable = true)]
     [JsonProperty("adresselinje1")]
     [JsonPropertyName("adresselinje1")]
     public string adresselinje1 { get; set; }
 
-    [XmlElement("adresselinje2")]
+    [XmlElement("adresselinje2", IsNullable = true)]
     [JsonProperty("adresselinje2")]
     [JsonPropertyName("adresselinje2")]
     public string adresselinje2 { get; set; }
 
-    [XmlElement("adresselinje3")]
+    [XmlElement("adresselinje3", IsNullable = true)]
     [JsonProperty("adresselinje3")]
     [JsonPropertyName("adresselinje3")]
     public string adresselinje3 { get; set; }
 
-    [XmlElement("postnr")]
+    [XmlElement("postnr", IsNullable = true)]
     [JsonProperty("postnr")]
     [JsonPropertyName("postnr")]
     public string postnr { get; set; }
 
-    [XmlElement("poststed")]
+    [XmlElement("poststed", IsNullable = true)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
     public string poststed { get; set; }
 
-    [XmlElement("landkode")]
+    [XmlElement("landkode", IsNullable = true)]
     [JsonProperty("landkode")]
     [JsonPropertyName("landkode")]
     public string landkode { get; set; }
@@ -577,22 +577,22 @@ namespace Altinn.App.Models
 
   public class KontaktpersonType
   {
-    [XmlElement("navn")]
+    [XmlElement("navn", IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
 
-    [XmlElement("telefonnummer")]
+    [XmlElement("telefonnummer", IsNullable = true)]
     [JsonProperty("telefonnummer")]
     [JsonPropertyName("telefonnummer")]
     public string telefonnummer { get; set; }
 
-    [XmlElement("mobilnummer")]
+    [XmlElement("mobilnummer", IsNullable = true)]
     [JsonProperty("mobilnummer")]
     [JsonPropertyName("mobilnummer")]
     public string mobilnummer { get; set; }
 
-    [XmlElement("epost")]
+    [XmlElement("epost", IsNullable = true)]
     [JsonProperty("epost")]
     [JsonPropertyName("epost")]
     public string epost { get; set; }

--- a/testdata/Model/CSharp/XsAll/midlertidigbrukstillatelse/v4/midlertidigbrukstillatelse.cs
+++ b/testdata/Model/CSharp/XsAll/midlertidigbrukstillatelse/v4/midlertidigbrukstillatelse.cs
@@ -70,7 +70,7 @@ namespace Altinn.App.Models
     public PartType ansvarligSoeker { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
-    [XmlElement("datoFerdigattest")]
+    [XmlElement("datoFerdigattest", IsNullable = true)]
     [JsonProperty("datoFerdigattest")]
     [JsonPropertyName("datoFerdigattest")]
     public string datoFerdigattest { get; set; }
@@ -121,17 +121,17 @@ namespace Altinn.App.Models
     [JsonPropertyName("adresse")]
     public EiendommensAdresseType adresse { get; set; }
 
-    [XmlElement("bygningsnummer")]
+    [XmlElement("bygningsnummer", IsNullable = true)]
     [JsonProperty("bygningsnummer")]
     [JsonPropertyName("bygningsnummer")]
     public string bygningsnummer { get; set; }
 
-    [XmlElement("bolignummer")]
+    [XmlElement("bolignummer", IsNullable = true)]
     [JsonProperty("bolignummer")]
     [JsonPropertyName("bolignummer")]
     public string bolignummer { get; set; }
 
-    [XmlElement("kommunenavn")]
+    [XmlElement("kommunenavn", IsNullable = true)]
     [JsonProperty("kommunenavn")]
     [JsonPropertyName("kommunenavn")]
     public string kommunenavn { get; set; }
@@ -140,7 +140,7 @@ namespace Altinn.App.Models
 
   public class MatrikkelnummerType
   {
-    [XmlElement("kommunenummer")]
+    [XmlElement("kommunenummer", IsNullable = true)]
     [JsonProperty("kommunenummer")]
     [JsonPropertyName("kommunenummer")]
     public string kommunenummer { get; set; }
@@ -173,47 +173,47 @@ namespace Altinn.App.Models
 
   public class EiendommensAdresseType
   {
-    [XmlElement("adresselinje1")]
+    [XmlElement("adresselinje1", IsNullable = true)]
     [JsonProperty("adresselinje1")]
     [JsonPropertyName("adresselinje1")]
     public string adresselinje1 { get; set; }
 
-    [XmlElement("adresselinje2")]
+    [XmlElement("adresselinje2", IsNullable = true)]
     [JsonProperty("adresselinje2")]
     [JsonPropertyName("adresselinje2")]
     public string adresselinje2 { get; set; }
 
-    [XmlElement("adresselinje3")]
+    [XmlElement("adresselinje3", IsNullable = true)]
     [JsonProperty("adresselinje3")]
     [JsonPropertyName("adresselinje3")]
     public string adresselinje3 { get; set; }
 
-    [XmlElement("postnr")]
+    [XmlElement("postnr", IsNullable = true)]
     [JsonProperty("postnr")]
     [JsonPropertyName("postnr")]
     public string postnr { get; set; }
 
-    [XmlElement("poststed")]
+    [XmlElement("poststed", IsNullable = true)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
     public string poststed { get; set; }
 
-    [XmlElement("landkode")]
+    [XmlElement("landkode", IsNullable = true)]
     [JsonProperty("landkode")]
     [JsonPropertyName("landkode")]
     public string landkode { get; set; }
 
-    [XmlElement("gatenavn")]
+    [XmlElement("gatenavn", IsNullable = true)]
     [JsonProperty("gatenavn")]
     [JsonPropertyName("gatenavn")]
     public string gatenavn { get; set; }
 
-    [XmlElement("husnr")]
+    [XmlElement("husnr", IsNullable = true)]
     [JsonProperty("husnr")]
     [JsonPropertyName("husnr")]
     public string husnr { get; set; }
 
-    [XmlElement("bokstav")]
+    [XmlElement("bokstav", IsNullable = true)]
     [JsonProperty("bokstav")]
     [JsonPropertyName("bokstav")]
     public string bokstav { get; set; }
@@ -238,22 +238,22 @@ namespace Altinn.App.Models
 
   public class MetadataType
   {
-    [XmlElement("fraSluttbrukersystem")]
+    [XmlElement("fraSluttbrukersystem", IsNullable = true)]
     [JsonProperty("fraSluttbrukersystem")]
     [JsonPropertyName("fraSluttbrukersystem")]
     public string fraSluttbrukersystem { get; set; }
 
-    [XmlElement("ftbId")]
+    [XmlElement("ftbId", IsNullable = true)]
     [JsonProperty("ftbId")]
     [JsonPropertyName("ftbId")]
     public string ftbId { get; set; }
 
-    [XmlElement("prosjektnavn")]
+    [XmlElement("prosjektnavn", IsNullable = true)]
     [JsonProperty("prosjektnavn")]
     [JsonPropertyName("prosjektnavn")]
     public string prosjektnavn { get; set; }
 
-    [XmlElement("prosjektnr")]
+    [XmlElement("prosjektnr", IsNullable = true)]
     [JsonProperty("prosjektnr")]
     [JsonPropertyName("prosjektnr")]
     public string prosjektnr { get; set; }
@@ -275,12 +275,12 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
-    [XmlElement("kodeverdi")]
+    [XmlElement("kodeverdi", IsNullable = true)]
     [JsonProperty("kodeverdi")]
     [JsonPropertyName("kodeverdi")]
     public string kodeverdi { get; set; }
 
-    [XmlElement("kodebeskrivelse")]
+    [XmlElement("kodebeskrivelse", IsNullable = true)]
     [JsonProperty("kodebeskrivelse")]
     [JsonPropertyName("kodebeskrivelse")]
     public string kodebeskrivelse { get; set; }
@@ -303,7 +303,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("gjelderHeleTiltaket")]
     public bool? gjelderHeleTiltaket { get; set; }
 
-    [XmlElement("delAvTiltaket")]
+    [XmlElement("delAvTiltaket", IsNullable = true)]
     [JsonProperty("delAvTiltaket")]
     [JsonPropertyName("delAvTiltaket")]
     public string delAvTiltaket { get; set; }
@@ -313,12 +313,12 @@ namespace Altinn.App.Models
     [JsonPropertyName("type")]
     public KodeListe type { get; set; }
 
-    [XmlElement("delsoeknadsnummer")]
+    [XmlElement("delsoeknadsnummer", IsNullable = true)]
     [JsonProperty("delsoeknadsnummer")]
     [JsonPropertyName("delsoeknadsnummer")]
     public string delsoeknadsnummer { get; set; }
 
-    [XmlElement("foelgebrev")]
+    [XmlElement("foelgebrev", IsNullable = true)]
     [JsonProperty("foelgebrev")]
     [JsonPropertyName("foelgebrev")]
     public string foelgebrev { get; set; }
@@ -353,18 +353,18 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
-    [XmlElement("delAvTiltaket")]
+    [XmlElement("delAvTiltaket", IsNullable = true)]
     [JsonProperty("delAvTiltaket")]
     [JsonPropertyName("delAvTiltaket")]
     public string delAvTiltaket { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
-    [XmlElement("tillatelsedato")]
+    [XmlElement("tillatelsedato", IsNullable = true)]
     [JsonProperty("tillatelsedato")]
     [JsonPropertyName("tillatelsedato")]
     public string tillatelsedato { get; set; }
 
-    [XmlElement("kommentar")]
+    [XmlElement("kommentar", IsNullable = true)]
     [JsonProperty("kommentar")]
     [JsonPropertyName("kommentar")]
     public string kommentar { get; set; }
@@ -374,7 +374,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("type")]
     public KodeListe type { get; set; }
 
-    [XmlElement("delsoeknadsnummer")]
+    [XmlElement("delsoeknadsnummer", IsNullable = true)]
     [JsonProperty("delsoeknadsnummer")]
     [JsonPropertyName("delsoeknadsnummer")]
     public string delsoeknadsnummer { get; set; }
@@ -400,7 +400,7 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
-    [XmlElement("utfallId")]
+    [XmlElement("utfallId", IsNullable = true)]
     [JsonProperty("utfallId")]
     [JsonPropertyName("utfallId")]
     public string utfallId { get; set; }
@@ -420,12 +420,12 @@ namespace Altinn.App.Models
     [JsonPropertyName("tema")]
     public KodeType tema { get; set; }
 
-    [XmlElement("tittel")]
+    [XmlElement("tittel", IsNullable = true)]
     [JsonProperty("tittel")]
     [JsonPropertyName("tittel")]
     public string tittel { get; set; }
 
-    [XmlElement("beskrivelse")]
+    [XmlElement("beskrivelse", IsNullable = true)]
     [JsonProperty("beskrivelse")]
     [JsonPropertyName("beskrivelse")]
     public string beskrivelse { get; set; }
@@ -440,7 +440,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("erUtfallBesvart")]
     public bool? erUtfallBesvart { get; set; }
 
-    [XmlElement("kommentar")]
+    [XmlElement("kommentar", IsNullable = true)]
     [JsonProperty("kommentar")]
     [JsonPropertyName("kommentar")]
     public string kommentar { get; set; }
@@ -454,12 +454,12 @@ namespace Altinn.App.Models
 
   public class SjekkpunktType
   {
-    [XmlElement("sjekkpunktId")]
+    [XmlElement("sjekkpunktId", IsNullable = true)]
     [JsonProperty("sjekkpunktId")]
     [JsonPropertyName("sjekkpunktId")]
     public string sjekkpunktId { get; set; }
 
-    [XmlElement("sjekkpunktEier")]
+    [XmlElement("sjekkpunktEier", IsNullable = true)]
     [JsonProperty("sjekkpunktEier")]
     [JsonPropertyName("sjekkpunktEier")]
     public string sjekkpunktEier { get; set; }
@@ -485,7 +485,7 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
-    [XmlElement("versjonsnummer")]
+    [XmlElement("versjonsnummer", IsNullable = true)]
     [JsonProperty("versjonsnummer")]
     [JsonPropertyName("versjonsnummer")]
     public string versjonsnummer { get; set; }
@@ -496,12 +496,12 @@ namespace Altinn.App.Models
     public KodeType vedleggstype { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
-    [XmlElement("versjonsdato")]
+    [XmlElement("versjonsdato", IsNullable = true)]
     [JsonProperty("versjonsdato")]
     [JsonPropertyName("versjonsdato")]
     public string versjonsdato { get; set; }
 
-    [XmlElement("filnavn")]
+    [XmlElement("filnavn", IsNullable = true)]
     [JsonProperty("filnavn")]
     [JsonPropertyName("filnavn")]
     public string filnavn { get; set; }
@@ -515,17 +515,17 @@ namespace Altinn.App.Models
     [JsonPropertyName("partstype")]
     public KodeType partstype { get; set; }
 
-    [XmlElement("foedselsnummer")]
+    [XmlElement("foedselsnummer", IsNullable = true)]
     [JsonProperty("foedselsnummer")]
     [JsonPropertyName("foedselsnummer")]
     public string foedselsnummer { get; set; }
 
-    [XmlElement("organisasjonsnummer")]
+    [XmlElement("organisasjonsnummer", IsNullable = true)]
     [JsonProperty("organisasjonsnummer")]
     [JsonPropertyName("organisasjonsnummer")]
     public string organisasjonsnummer { get; set; }
 
-    [XmlElement("navn")]
+    [XmlElement("navn", IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
@@ -535,17 +535,17 @@ namespace Altinn.App.Models
     [JsonPropertyName("adresse")]
     public EnkelAdresseType adresse { get; set; }
 
-    [XmlElement("telefonnummer")]
+    [XmlElement("telefonnummer", IsNullable = true)]
     [JsonProperty("telefonnummer")]
     [JsonPropertyName("telefonnummer")]
     public string telefonnummer { get; set; }
 
-    [XmlElement("mobilnummer")]
+    [XmlElement("mobilnummer", IsNullable = true)]
     [JsonProperty("mobilnummer")]
     [JsonPropertyName("mobilnummer")]
     public string mobilnummer { get; set; }
 
-    [XmlElement("epost")]
+    [XmlElement("epost", IsNullable = true)]
     [JsonProperty("epost")]
     [JsonPropertyName("epost")]
     public string epost { get; set; }
@@ -559,32 +559,32 @@ namespace Altinn.App.Models
 
   public class EnkelAdresseType
   {
-    [XmlElement("adresselinje1")]
+    [XmlElement("adresselinje1", IsNullable = true)]
     [JsonProperty("adresselinje1")]
     [JsonPropertyName("adresselinje1")]
     public string adresselinje1 { get; set; }
 
-    [XmlElement("adresselinje2")]
+    [XmlElement("adresselinje2", IsNullable = true)]
     [JsonProperty("adresselinje2")]
     [JsonPropertyName("adresselinje2")]
     public string adresselinje2 { get; set; }
 
-    [XmlElement("adresselinje3")]
+    [XmlElement("adresselinje3", IsNullable = true)]
     [JsonProperty("adresselinje3")]
     [JsonPropertyName("adresselinje3")]
     public string adresselinje3 { get; set; }
 
-    [XmlElement("postnr")]
+    [XmlElement("postnr", IsNullable = true)]
     [JsonProperty("postnr")]
     [JsonPropertyName("postnr")]
     public string postnr { get; set; }
 
-    [XmlElement("poststed")]
+    [XmlElement("poststed", IsNullable = true)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
     public string poststed { get; set; }
 
-    [XmlElement("landkode")]
+    [XmlElement("landkode", IsNullable = true)]
     [JsonProperty("landkode")]
     [JsonPropertyName("landkode")]
     public string landkode { get; set; }
@@ -593,22 +593,22 @@ namespace Altinn.App.Models
 
   public class KontaktpersonType
   {
-    [XmlElement("navn")]
+    [XmlElement("navn", IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
 
-    [XmlElement("telefonnummer")]
+    [XmlElement("telefonnummer", IsNullable = true)]
     [JsonProperty("telefonnummer")]
     [JsonPropertyName("telefonnummer")]
     public string telefonnummer { get; set; }
 
-    [XmlElement("mobilnummer")]
+    [XmlElement("mobilnummer", IsNullable = true)]
     [JsonProperty("mobilnummer")]
     [JsonPropertyName("mobilnummer")]
     public string mobilnummer { get; set; }
 
-    [XmlElement("epost")]
+    [XmlElement("epost", IsNullable = true)]
     [JsonProperty("epost")]
     [JsonPropertyName("epost")]
     public string epost { get; set; }
@@ -617,12 +617,12 @@ namespace Altinn.App.Models
 
   public class GjenstaaendeArbeiderType
   {
-    [XmlElement("gjenstaaendeInnenfor")]
+    [XmlElement("gjenstaaendeInnenfor", IsNullable = true)]
     [JsonProperty("gjenstaaendeInnenfor")]
     [JsonPropertyName("gjenstaaendeInnenfor")]
     public string gjenstaaendeInnenfor { get; set; }
 
-    [XmlElement("gjenstaaendeUtenfor")]
+    [XmlElement("gjenstaaendeUtenfor", IsNullable = true)]
     [JsonProperty("gjenstaaendeUtenfor")]
     [JsonPropertyName("gjenstaaendeUtenfor")]
     public string gjenstaaendeUtenfor { get; set; }
@@ -636,19 +636,19 @@ namespace Altinn.App.Models
     [JsonPropertyName("harTilstrekkeligSikkerhet")]
     public bool? harTilstrekkeligSikkerhet { get; set; }
 
-    [XmlElement("typeArbeider")]
+    [XmlElement("typeArbeider", IsNullable = true)]
     [JsonProperty("typeArbeider")]
     [JsonPropertyName("typeArbeider")]
     public string typeArbeider { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
-    [XmlElement("utfoertInnen")]
+    [XmlElement("utfoertInnen", IsNullable = true)]
     [JsonProperty("utfoertInnen")]
     [JsonPropertyName("utfoertInnen")]
     public string utfoertInnen { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
-    [XmlElement("bekreftelseInnen")]
+    [XmlElement("bekreftelseInnen", IsNullable = true)]
     [JsonProperty("bekreftelseInnen")]
     [JsonPropertyName("bekreftelseInnen")]
     public string bekreftelseInnen { get; set; }

--- a/testdata/Model/CSharp/XsAll/planvarsel/v2/planvarsel.cs
+++ b/testdata/Model/CSharp/XsAll/planvarsel/v2/planvarsel.cs
@@ -34,7 +34,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("beroerteParter")]
     public BeroertPartListe beroerteParter { get; set; }
 
-    [XmlElement("kommunenavn")]
+    [XmlElement("kommunenavn", IsNullable = true)]
     [JsonProperty("kommunenavn")]
     [JsonPropertyName("kommunenavn")]
     public string kommunenavn { get; set; }
@@ -78,22 +78,22 @@ namespace Altinn.App.Models
     [JsonPropertyName("partstype")]
     public KodeType partstype { get; set; }
 
-    [XmlElement("foedselsnummer")]
+    [XmlElement("foedselsnummer", IsNullable = true)]
     [JsonProperty("foedselsnummer")]
     [JsonPropertyName("foedselsnummer")]
     public string foedselsnummer { get; set; }
 
-    [XmlElement("organisasjonsnummer")]
+    [XmlElement("organisasjonsnummer", IsNullable = true)]
     [JsonProperty("organisasjonsnummer")]
     [JsonPropertyName("organisasjonsnummer")]
     public string organisasjonsnummer { get; set; }
 
-    [XmlElement("navn")]
+    [XmlElement("navn", IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
 
-    [XmlElement("epost")]
+    [XmlElement("epost", IsNullable = true)]
     [JsonProperty("epost")]
     [JsonPropertyName("epost")]
     public string epost { get; set; }
@@ -103,7 +103,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("adresse")]
     public EnkelAdresseType adresse { get; set; }
 
-    [XmlElement("telefon")]
+    [XmlElement("telefon", IsNullable = true)]
     [JsonProperty("telefon")]
     [JsonPropertyName("telefon")]
     public string telefon { get; set; }
@@ -112,12 +112,12 @@ namespace Altinn.App.Models
 
   public class KodeType
   {
-    [XmlElement("kodeverdi")]
+    [XmlElement("kodeverdi", IsNullable = true)]
     [JsonProperty("kodeverdi")]
     [JsonPropertyName("kodeverdi")]
     public string kodeverdi { get; set; }
 
-    [XmlElement("kodebeskrivelse")]
+    [XmlElement("kodebeskrivelse", IsNullable = true)]
     [JsonProperty("kodebeskrivelse")]
     [JsonPropertyName("kodebeskrivelse")]
     public string kodebeskrivelse { get; set; }
@@ -126,32 +126,32 @@ namespace Altinn.App.Models
 
   public class EnkelAdresseType
   {
-    [XmlElement("adresselinje1")]
+    [XmlElement("adresselinje1", IsNullable = true)]
     [JsonProperty("adresselinje1")]
     [JsonPropertyName("adresselinje1")]
     public string adresselinje1 { get; set; }
 
-    [XmlElement("adresselinje2")]
+    [XmlElement("adresselinje2", IsNullable = true)]
     [JsonProperty("adresselinje2")]
     [JsonPropertyName("adresselinje2")]
     public string adresselinje2 { get; set; }
 
-    [XmlElement("adresselinje3")]
+    [XmlElement("adresselinje3", IsNullable = true)]
     [JsonProperty("adresselinje3")]
     [JsonPropertyName("adresselinje3")]
     public string adresselinje3 { get; set; }
 
-    [XmlElement("postnr")]
+    [XmlElement("postnr", IsNullable = true)]
     [JsonProperty("postnr")]
     [JsonPropertyName("postnr")]
     public string postnr { get; set; }
 
-    [XmlElement("poststed")]
+    [XmlElement("poststed", IsNullable = true)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
     public string poststed { get; set; }
 
-    [XmlElement("landkode")]
+    [XmlElement("landkode", IsNullable = true)]
     [JsonProperty("landkode")]
     [JsonPropertyName("landkode")]
     public string landkode { get; set; }
@@ -182,27 +182,27 @@ namespace Altinn.App.Models
     [JsonPropertyName("partstype")]
     public KodeType partstype { get; set; }
 
-    [XmlElement("foedselsnummer")]
+    [XmlElement("foedselsnummer", IsNullable = true)]
     [JsonProperty("foedselsnummer")]
     [JsonPropertyName("foedselsnummer")]
     public string foedselsnummer { get; set; }
 
-    [XmlElement("organisasjonsnummer")]
+    [XmlElement("organisasjonsnummer", IsNullable = true)]
     [JsonProperty("organisasjonsnummer")]
     [JsonPropertyName("organisasjonsnummer")]
     public string organisasjonsnummer { get; set; }
 
-    [XmlElement("navn")]
+    [XmlElement("navn", IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
 
-    [XmlElement("telefon")]
+    [XmlElement("telefon", IsNullable = true)]
     [JsonProperty("telefon")]
     [JsonPropertyName("telefon")]
     public string telefon { get; set; }
 
-    [XmlElement("epost")]
+    [XmlElement("epost", IsNullable = true)]
     [JsonProperty("epost")]
     [JsonPropertyName("epost")]
     public string epost { get; set; }
@@ -212,12 +212,12 @@ namespace Altinn.App.Models
     [JsonPropertyName("adresse")]
     public EnkelAdresseType adresse { get; set; }
 
-    [XmlElement("beskrivelseForVarsel")]
+    [XmlElement("beskrivelseForVarsel", IsNullable = true)]
     [JsonProperty("beskrivelseForVarsel")]
     [JsonPropertyName("beskrivelseForVarsel")]
     public string beskrivelseForVarsel { get; set; }
 
-    [XmlElement("systemReferanse")]
+    [XmlElement("systemReferanse", IsNullable = true)]
     [JsonProperty("systemReferanse")]
     [JsonPropertyName("systemReferanse")]
     public string systemReferanse { get; set; }
@@ -263,17 +263,17 @@ namespace Altinn.App.Models
     [JsonPropertyName("adresse")]
     public EiendommensAdresseType adresse { get; set; }
 
-    [XmlElement("bygningsnummer")]
+    [XmlElement("bygningsnummer", IsNullable = true)]
     [JsonProperty("bygningsnummer")]
     [JsonPropertyName("bygningsnummer")]
     public string bygningsnummer { get; set; }
 
-    [XmlElement("bolignummer")]
+    [XmlElement("bolignummer", IsNullable = true)]
     [JsonProperty("bolignummer")]
     [JsonPropertyName("bolignummer")]
     public string bolignummer { get; set; }
 
-    [XmlElement("kommunenavn")]
+    [XmlElement("kommunenavn", IsNullable = true)]
     [JsonProperty("kommunenavn")]
     [JsonPropertyName("kommunenavn")]
     public string kommunenavn { get; set; }
@@ -282,7 +282,7 @@ namespace Altinn.App.Models
 
   public class MatrikkelnummerType
   {
-    [XmlElement("kommunenummer")]
+    [XmlElement("kommunenummer", IsNullable = true)]
     [JsonProperty("kommunenummer")]
     [JsonPropertyName("kommunenummer")]
     public string kommunenummer { get; set; }
@@ -315,47 +315,47 @@ namespace Altinn.App.Models
 
   public class EiendommensAdresseType
   {
-    [XmlElement("adresselinje1")]
+    [XmlElement("adresselinje1", IsNullable = true)]
     [JsonProperty("adresselinje1")]
     [JsonPropertyName("adresselinje1")]
     public string adresselinje1 { get; set; }
 
-    [XmlElement("adresselinje2")]
+    [XmlElement("adresselinje2", IsNullable = true)]
     [JsonProperty("adresselinje2")]
     [JsonPropertyName("adresselinje2")]
     public string adresselinje2 { get; set; }
 
-    [XmlElement("adresselinje3")]
+    [XmlElement("adresselinje3", IsNullable = true)]
     [JsonProperty("adresselinje3")]
     [JsonPropertyName("adresselinje3")]
     public string adresselinje3 { get; set; }
 
-    [XmlElement("postnr")]
+    [XmlElement("postnr", IsNullable = true)]
     [JsonProperty("postnr")]
     [JsonPropertyName("postnr")]
     public string postnr { get; set; }
 
-    [XmlElement("poststed")]
+    [XmlElement("poststed", IsNullable = true)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
     public string poststed { get; set; }
 
-    [XmlElement("landkode")]
+    [XmlElement("landkode", IsNullable = true)]
     [JsonProperty("landkode")]
     [JsonPropertyName("landkode")]
     public string landkode { get; set; }
 
-    [XmlElement("gatenavn")]
+    [XmlElement("gatenavn", IsNullable = true)]
     [JsonProperty("gatenavn")]
     [JsonPropertyName("gatenavn")]
     public string gatenavn { get; set; }
 
-    [XmlElement("husnr")]
+    [XmlElement("husnr", IsNullable = true)]
     [JsonProperty("husnr")]
     [JsonPropertyName("husnr")]
     public string husnr { get; set; }
 
-    [XmlElement("bokstav")]
+    [XmlElement("bokstav", IsNullable = true)]
     [JsonProperty("bokstav")]
     [JsonPropertyName("bokstav")]
     public string bokstav { get; set; }
@@ -378,12 +378,12 @@ namespace Altinn.App.Models
     [JsonPropertyName("signaturdato")]
     public DateTime? signaturdato { get; set; }
 
-    [XmlElement("signertAv")]
+    [XmlElement("signertAv", IsNullable = true)]
     [JsonProperty("signertAv")]
     [JsonPropertyName("signertAv")]
     public string signertAv { get; set; }
 
-    [XmlElement("signertPaaVegneAv")]
+    [XmlElement("signertPaaVegneAv", IsNullable = true)]
     [JsonProperty("signertPaaVegneAv")]
     [JsonPropertyName("signertPaaVegneAv")]
     public string signertPaaVegneAv { get; set; }
@@ -409,7 +409,7 @@ namespace Altinn.App.Models
 
     public bool ShouldSerializeAltinnRowId() => AltinnRowId != default;
 
-    [XmlElement("navn")]
+    [XmlElement("navn", IsNullable = true)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
     public string navn { get; set; }
@@ -423,12 +423,12 @@ namespace Altinn.App.Models
 
   public class MetadataType
   {
-    [XmlElement("ftbId")]
+    [XmlElement("ftbId", IsNullable = true)]
     [JsonProperty("ftbId")]
     [JsonPropertyName("ftbId")]
     public string ftbId { get; set; }
 
-    [XmlElement("hovedinnsendingsnummer")]
+    [XmlElement("hovedinnsendingsnummer", IsNullable = true)]
     [JsonProperty("hovedinnsendingsnummer")]
     [JsonPropertyName("hovedinnsendingsnummer")]
     public string hovedinnsendingsnummer { get; set; }
@@ -438,7 +438,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("klartForSigneringFraSluttbrukersystem")]
     public bool? klartForSigneringFraSluttbrukersystem { get; set; }
 
-    [XmlElement("fraSluttbrukersystem")]
+    [XmlElement("fraSluttbrukersystem", IsNullable = true)]
     [JsonProperty("fraSluttbrukersystem")]
     [JsonPropertyName("fraSluttbrukersystem")]
     public string fraSluttbrukersystem { get; set; }
@@ -447,17 +447,17 @@ namespace Altinn.App.Models
 
   public class PlanType
   {
-    [XmlElement("plannavn")]
+    [XmlElement("plannavn", IsNullable = true)]
     [JsonProperty("plannavn")]
     [JsonPropertyName("plannavn")]
     public string plannavn { get; set; }
 
-    [XmlElement("arealplanId")]
+    [XmlElement("arealplanId", IsNullable = true)]
     [JsonProperty("arealplanId")]
     [JsonPropertyName("arealplanId")]
     public string arealplanId { get; set; }
 
-    [XmlElement("hjemmesidePlanforslag")]
+    [XmlElement("hjemmesidePlanforslag", IsNullable = true)]
     [JsonProperty("hjemmesidePlanforslag")]
     [JsonPropertyName("hjemmesidePlanforslag")]
     public string hjemmesidePlanforslag { get; set; }
@@ -467,7 +467,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("kravKonsekvensUtredning")]
     public bool? kravKonsekvensUtredning { get; set; }
 
-    [XmlElement("planHensikt")]
+    [XmlElement("planHensikt", IsNullable = true)]
     [JsonProperty("planHensikt")]
     [JsonPropertyName("planHensikt")]
     public string planHensikt { get; set; }
@@ -477,7 +477,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("fristForInnspill")]
     public DateTime? fristForInnspill { get; set; }
 
-    [XmlElement("hjemmesidePlanprogram")]
+    [XmlElement("hjemmesidePlanprogram", IsNullable = true)]
     [JsonProperty("hjemmesidePlanprogram")]
     [JsonPropertyName("hjemmesidePlanprogram")]
     public string hjemmesidePlanprogram { get; set; }
@@ -487,7 +487,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("plantype")]
     public KodeType plantype { get; set; }
 
-    [XmlElement("begrunnelseKU")]
+    [XmlElement("begrunnelseKU", IsNullable = true)]
     [JsonProperty("begrunnelseKU")]
     [JsonPropertyName("begrunnelseKU")]
     public string begrunnelseKU { get; set; }
@@ -497,7 +497,7 @@ namespace Altinn.App.Models
     [JsonPropertyName("kommunensSaksnummer")]
     public SaksnummerType kommunensSaksnummer { get; set; }
 
-    [XmlElement("saksgangOgMedvirkning")]
+    [XmlElement("saksgangOgMedvirkning", IsNullable = true)]
     [JsonProperty("saksgangOgMedvirkning")]
     [JsonPropertyName("saksgangOgMedvirkning")]
     public string saksgangOgMedvirkning { get; set; }

--- a/testdata/Model/Xml/XsAll/xsall-example-nillable-sample.xml
+++ b/testdata/Model/Xml/XsAll/xsall-example-nillable-sample.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <refElement xsi:nil="true" />
+</root>

--- a/testdata/Model/XmlSchema/XsAll/xsall-example.xsd
+++ b/testdata/Model/XmlSchema/XsAll/xsall-example.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xsd:schema attributeFormDefault="unqualified"
+            elementFormDefault="qualified"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <xsd:element name="root" type="SampleType" />
+
+  <xsd:complexType name="SampleType">
+    <xsd:all>
+      <xsd:element name="refElement" type="xsd:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+    </xsd:all>
+  </xsd:complexType>
+</xsd:schema>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sets `IsNullable = true` to in `XmlElement` attribute for reference properties, if they are defined as nillable in xsd.

### Known limitations

Since we're using c# model, when desiralizing XML and serializing it back back, we can't always reproduce the same same XML.

#### Example

According to xsd schema:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<xsd:schema attributeFormDefault="unqualified"
            elementFormDefault="qualified"
            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <xsd:element name="root" type="SampleType" />

  <xsd:complexType name="SampleType">
    <xsd:all>
      <xsd:element name="refElement" type="xsd:string" nillable="true" minOccurs="0" maxOccurs="1"/>
    </xsd:all>
  </xsd:complexType>
</xsd:schema>
```
following XML is valid since minOccurs is set to "0":
```xml
<?xml version="1.0" encoding="utf-8"?>
<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
</root>
```
But when deserializing and serializing it back we'll produce following XML:

```xml
<?xml version="1.0" encoding="utf-8"?>
<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
  <refElement xsi:nil="true" />
</root>
```
Since the node type is string, functionally XMLs will be equivalent.


<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/app-lib-dotnet/issues/911
- https://github.com/Altinn/app-lib-dotnet/issues/911

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
