### PR TITLE
feat: add file name validation function in `studio-pure-functions`

### DIFF
--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/SelectedSchemaEditor.tsx
@@ -111,6 +111,6 @@ const SchemaEditorWithDebounce = ({ jsonSchema, modelPath }: SchemaEditorWithDeb
 };
 
 const extractModelNameFromPath = (path: string): string => {
-  const filename = FileNameUtils.extractFilename(path);
+  const filename = FileNameUtils.extractFileName(path);
   return FileNameUtils.removeSchemaExtension(filename);
 };

--- a/frontend/libs/studio-pure-functions/src/FileNameUtils/FileNameUtils.test.ts
+++ b/frontend/libs/studio-pure-functions/src/FileNameUtils/FileNameUtils.test.ts
@@ -1,4 +1,4 @@
-import { FileNameUtils } from './FilenameUtils';
+import { FileNameUtils, FileNameValidationResult } from './FileNameUtils';
 
 describe('FileNameUtils', () => {
   describe('removeExtension', () => {
@@ -55,15 +55,15 @@ describe('FileNameUtils', () => {
     });
   });
 
-  describe('extractFilename', () => {
+  describe('extractFileName', () => {
     it('Returns filename if path contains a slash', () => {
-      expect(FileNameUtils.extractFilename('/path/to/filename')).toEqual('filename');
-      expect(FileNameUtils.extractFilename('/path/to/filename.json')).toEqual('filename.json');
+      expect(FileNameUtils.extractFileName('/path/to/filename')).toEqual('filename');
+      expect(FileNameUtils.extractFileName('/path/to/filename.json')).toEqual('filename.json');
     });
 
     it('Returns path if path does not contain a slash', () => {
-      expect(FileNameUtils.extractFilename('filename')).toEqual('filename');
-      expect(FileNameUtils.extractFilename('filename.json')).toEqual('filename.json');
+      expect(FileNameUtils.extractFileName('filename')).toEqual('filename');
+      expect(FileNameUtils.extractFileName('filename.json')).toEqual('filename.json');
     });
   });
 
@@ -88,6 +88,81 @@ describe('FileNameUtils', () => {
     it('Returns empty string if path is only fileName and "excludeLastSlash" is true', () => {
       expect(FileNameUtils.removeFileNameFromPath('filename', true)).toEqual('');
       expect(FileNameUtils.removeFileNameFromPath('filename.json', true)).toEqual('');
+    });
+  });
+
+  describe('validateFileName', () => {
+    it('Returns "FileNameIsEmpty" when file name is empty', () => {
+      const fileName: string = '';
+      const fileNameValidation: FileNameValidationResult = FileNameUtils.validateFileName(
+        fileName,
+        [],
+      );
+      expect(fileNameValidation).toBe(FileNameValidationResult.FileNameIsEmpty);
+    });
+
+    it('Returns "NoRegExMatch" when file name does not match given regex', () => {
+      const fileName: string = 'ABC';
+      const fileNameRegEx: RegExp = /^[a-z]+$/;
+      const fileNameValidation: FileNameValidationResult = FileNameUtils.validateFileName(
+        fileName,
+        [],
+        fileNameRegEx,
+      );
+      expect(fileNameValidation).toBe(FileNameValidationResult.NoRegExMatch);
+    });
+
+    it('Returns "FileExists" when file name matches regEx and exists in list', () => {
+      const fileName: string = 'fileName1';
+      const invalidFileNames: string[] = ['fileName1', 'fileName2', 'fileName3'];
+      const fileNameRegEx: RegExp = /^[a-zA-Z0-9]+$/;
+      const fileNameValidation: FileNameValidationResult = FileNameUtils.validateFileName(
+        fileName,
+        invalidFileNames,
+        fileNameRegEx,
+      );
+      expect(fileNameValidation).toBe(FileNameValidationResult.FileExists);
+    });
+
+    it('Returns "FileExists" when no regEx is provided and exists in list', () => {
+      const fileName: string = 'fileName1';
+      const invalidFileNames: string[] = ['fileName1', 'fileName2', 'fileName3'];
+      const fileNameValidation: FileNameValidationResult = FileNameUtils.validateFileName(
+        fileName,
+        invalidFileNames,
+      );
+      expect(fileNameValidation).toBe(FileNameValidationResult.FileExists);
+    });
+
+    it('Returns "Valid" when file name matches regEx and does not exist in list of invalid names', () => {
+      const fileName: string = 'fileName';
+      const invalidFileNames: string[] = ['fileName2', 'fileName3'];
+      const fileNameRegEx: RegExp = /^[a-zA-Z]+$/;
+      const fileNameValidation: FileNameValidationResult = FileNameUtils.validateFileName(
+        fileName,
+        invalidFileNames,
+        fileNameRegEx,
+      );
+      expect(fileNameValidation).toBe(FileNameValidationResult.Valid);
+    });
+
+    it('Returns "Valid" when no regEx is provided and file name does not exist in list of invalid names', () => {
+      const fileName: string = 'fileName';
+      const invalidFileNames: string[] = ['fileName2', 'fileName3'];
+      const fileNameValidation: FileNameValidationResult = FileNameUtils.validateFileName(
+        fileName,
+        invalidFileNames,
+      );
+      expect(fileNameValidation).toBe(FileNameValidationResult.Valid);
+    });
+
+    it('Returns "Valid" when no regEx is provided and list of invalid names is empty', () => {
+      const fileName: string = 'fileName';
+      const fileNameValidation: FileNameValidationResult = FileNameUtils.validateFileName(
+        fileName,
+        [],
+      );
+      expect(fileNameValidation).toBe(FileNameValidationResult.Valid);
     });
   });
 });

--- a/frontend/libs/studio-pure-functions/src/FileNameUtils/FileNameUtils.ts
+++ b/frontend/libs/studio-pure-functions/src/FileNameUtils/FileNameUtils.ts
@@ -1,5 +1,12 @@
 import { StringUtils } from '@studio/pure-functions';
 
+export enum FileNameValidationResult {
+  FileNameIsEmpty = 'fileNameIsEmpty',
+  NoRegExMatch = 'noRegExMatch',
+  FileExists = 'fileExists',
+  Valid = 'valid',
+}
+
 export class FileNameUtils {
   /**
    * Remove extension from filename.
@@ -26,17 +33,47 @@ export class FileNameUtils {
    */
   static isXsdFile = (filename: string): boolean => filename.toLowerCase().endsWith('.xsd');
 
-  static extractFilename = (path: string): string => {
+  static extractFileName = (path: string): string => {
     const indexOfLastSlash = path.lastIndexOf('/');
     return indexOfLastSlash < 0 ? path : path.substring(indexOfLastSlash + 1);
   };
 
   static removeFileNameFromPath = (path: string, excludeLastSlash: boolean = false): string => {
-    const fileName = this.extractFilename(path);
+    const fileName = this.extractFileName(path);
     const indexOfLastSlash = path.lastIndexOf('/');
     return path.slice(
       0,
       path.lastIndexOf(excludeLastSlash && indexOfLastSlash > 0 ? '/' + fileName : fileName),
     );
+  };
+
+  /**
+   * Validates if file name does not exist in list of invalid names and if name matches regEx, if provided.
+   * @param fileName
+   * @param invalidFileNames
+   * @param regEx
+   * @returns FileNameValidationResult
+   */
+  static validateFileName = (
+    fileName: string,
+    invalidFileNames: string[],
+    regEx?: RegExp,
+  ): FileNameValidationResult => {
+    if (fileName === '') {
+      return FileNameValidationResult.FileNameIsEmpty;
+    }
+
+    const isFileNameNotMatchingRegEx: boolean = regEx ? Boolean(!fileName.match(regEx)) : false;
+    const isFileNameInInvalidList: boolean = invalidFileNames.some(
+      (invalidFileName) => invalidFileName === fileName,
+    );
+
+    if (isFileNameNotMatchingRegEx) {
+      return FileNameValidationResult.NoRegExMatch;
+    }
+    if (isFileNameInInvalidList) {
+      return FileNameValidationResult.FileExists;
+    }
+    return FileNameValidationResult.Valid;
   };
 }

--- a/frontend/libs/studio-pure-functions/src/FileNameUtils/index.ts
+++ b/frontend/libs/studio-pure-functions/src/FileNameUtils/index.ts
@@ -1,1 +1,2 @@
-export { FileNameUtils } from './FilenameUtils';
+export { FileNameUtils } from './FileNameUtils';
+export { FileNameValidationResult } from './FileNameUtils';

--- a/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/ShareChangesPopover/CommitAndPushContent/FileChangesInfoModal/FilePath/FilePath.tsx
+++ b/frontend/packages/shared/src/components/GiteaHeader/VersionControlButtons/components/ShareChangesPopover/CommitAndPushContent/FileChangesInfoModal/FilePath/FilePath.tsx
@@ -20,7 +20,7 @@ export const FilePath = ({ filePath, diff, repoDiffStatus }: FilePathProps) => {
     return <FilePathWithoutDiff filePath={filePath} />;
   }
 
-  const fileName = FileNameUtils.extractFilename(filePath);
+  const fileName = FileNameUtils.extractFileName(filePath);
   const linesToRender = convertPureGitDiffToUserFriendlyDiff(diff);
 
   return (
@@ -56,7 +56,7 @@ type FormattedFilePathProps = {
 };
 
 const FormattedFilePath = ({ filePath }: FormattedFilePathProps) => {
-  const fileName = FileNameUtils.extractFilename(filePath);
+  const fileName = FileNameUtils.extractFileName(filePath);
   const filePathWithoutName = FileNameUtils.removeFileNameFromPath(filePath, true);
 
   return (

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditImage/LocalImage/ImportImage/AddImageFromLibrary/ChooseFromLibrary/ImageLibraryPreview.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditImage/LocalImage/ImportImage/AddImageFromLibrary/ChooseFromLibrary/ImageLibraryPreview.tsx
@@ -42,7 +42,7 @@ const ImageFromLibrary = ({
   onAddImageReference,
   imageSource,
 }: ImageFromLibraryProps) => {
-  const fileName = FileNameUtils.extractFilename(imageFilePath);
+  const fileName = FileNameUtils.extractFileName(imageFilePath);
   // The img component requires an alt which we can set to be the descriptions from the metadata in the library when this is available.
   // TODO: Add description when we know how to store them. See analysis issue: https://github.com/Altinn/altinn-studio/issues/13346
   return (

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditImage/LocalImage/PreviewImageSummary/PreviewFileInfo.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditImage/LocalImage/PreviewImageSummary/PreviewFileInfo.tsx
@@ -11,7 +11,7 @@ export const PreviewFileInfo = ({ existingImageUrl }: PreviewFileInfoProps) => {
   return (
     <div className={classes.fileInfoContainer}>
       <StudioParagraph size='small' className={classes.fileName} title={existingImageUrl}>
-        {FileNameUtils.extractFilename(existingImageUrl)}
+        {FileNameUtils.extractFileName(existingImageUrl)}
       </StudioParagraph>
     </div>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In order to reduce duplicated code in all the places we are validating a file name based on general and plain constrictions, like:
1. not being empty
2. not being the same as any elements in a provided list of invalid names
3. matching a provided regEx - optional

## Related Issue(s)
This need arised during the implementation of file name and title validation for code lists in the library

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
