### PR TITLE
fix: reset ref for file uploader after submission

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioFileUploader/StudioFileUploader.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioFileUploader/StudioFileUploader.test.tsx
@@ -76,6 +76,15 @@ describe('StudioFileUploader', () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it('should call submit callback twice when uploading the same file consecutively', async () => {
+    const user = userEvent.setup();
+    renderFileUploader();
+    const file = new File(['test'], 'fileNameMock.json', { type: 'image/png' });
+    await user.upload(getFileInputElement(), file);
+    await user.upload(getFileInputElement(), file);
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+  });
+
   it('Applies given class name to the root element', () => {
     testRootClassNameAppending((className: string) => renderFileUploader({ className }));
   });

--- a/frontend/libs/studio-components/src/components/StudioFileUploader/StudioFileUploader.tsx
+++ b/frontend/libs/studio-components/src/components/StudioFileUploader/StudioFileUploader.tsx
@@ -39,6 +39,11 @@ export const StudioFileUploader = forwardRef<HTMLInputElement, StudioFileUploade
       if (file) {
         onSubmit?.(file);
       }
+      resetRef(internalRef);
+    };
+
+    const handleButtonClick = () => {
+      internalRef.current?.click();
     };
 
     return (
@@ -56,7 +61,7 @@ export const StudioFileUploader = forwardRef<HTMLInputElement, StudioFileUploade
           color={color}
           disabled={disabled}
           icon={<UploadIcon />}
-          onClick={() => internalRef?.current?.click()}
+          onClick={handleButtonClick}
           size={size}
           variant={variant}
         >
@@ -70,3 +75,7 @@ export const StudioFileUploader = forwardRef<HTMLInputElement, StudioFileUploade
 StudioFileUploader.displayName = 'StudioFileUploader';
 
 const getFile = (fileRef: RefObject<HTMLInputElement>): File => fileRef?.current?.files?.item(0);
+
+const resetRef = (fileRef: RefObject<HTMLInputElement>): void => {
+  fileRef.current.value = '';
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reset ref for file uploader after submission in order to trigger onChange if uploading the exact same file multiple times in a row.

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
