### PR TITLE
fix: add ToastContainer to render helper function in library

### DIFF
--- a/frontend/libs/studio-content-library/src/ContentLibrary/ContentLibrary.test.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/ContentLibrary.test.tsx
@@ -6,7 +6,7 @@ import { mockPagesConfig } from '../../mocks/mockPagesConfig';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import { RouterContext } from '../contexts/RouterContext';
 import type { PageName } from '../types/PageName';
-import { renderWithBrowserRouter } from '../../test-utils/renderWithBrowserRouter';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
 
 const navigateMock = jest.fn();
 
@@ -52,7 +52,7 @@ describe('ContentLibrary', () => {
 });
 
 const renderContentLibrary = (currentPage: PageName = undefined) => {
-  renderWithBrowserRouter(
+  renderWithProviders(
     <RouterContext.Provider value={{ currentPage, navigate: navigateMock }}>
       <ContentLibrary pages={mockPagesConfig} />
     </RouterContext.Provider>,

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/PagesRouter/PagesRouter.test.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/PagesRouter/PagesRouter.test.tsx
@@ -5,7 +5,7 @@ import { PagesRouter } from './PagesRouter';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import { RouterContext } from '../../../contexts/RouterContext';
 import type { PageName } from '../../../types/PageName';
-import { renderWithBrowserRouter } from '../../../../test-utils/renderWithBrowserRouter';
+import { renderWithProviders } from '../../../../test-utils/renderWithProviders';
 
 const navigateMock = jest.fn();
 
@@ -35,7 +35,7 @@ describe('PagesRouter', () => {
 });
 
 const renderPagesRouter = (pageNames: PageName[] = ['codeList', 'images']) => {
-  renderWithBrowserRouter(
+  renderWithProviders(
     <RouterContext.Provider value={{ currentPage: 'codeList', navigate: navigateMock }}>
       <PagesRouter pageNames={pageNames} />
     </RouterContext.Provider>,

--- a/frontend/libs/studio-content-library/src/config/ContentResourceLibraryImpl.test.tsx
+++ b/frontend/libs/studio-content-library/src/config/ContentResourceLibraryImpl.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import type { PagesConfig } from '../types/PagesProps';
 import { ResourceContentLibraryImpl } from './ContentResourceLibraryImpl';
 import { textMock } from '@studio/testing/mocks/i18nMock';
-import { renderWithBrowserRouter } from '../../test-utils/renderWithBrowserRouter';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
 
 describe('ContentResourceLibraryImpl', () => {
   it('renders ContentResourceLibraryImpl with given pages', () => {
@@ -53,5 +53,5 @@ describe('ContentResourceLibraryImpl', () => {
 const renderContentResourceLibraryImpl = (pages: PagesConfig) => {
   const contentResourceLibraryImpl = new ResourceContentLibraryImpl({ pages });
   const { getContentResourceLibrary } = contentResourceLibraryImpl;
-  renderWithBrowserRouter(getContentResourceLibrary());
+  renderWithProviders(getContentResourceLibrary());
 };

--- a/frontend/libs/studio-content-library/test-utils/renderWithBrowserRouter.tsx
+++ b/frontend/libs/studio-content-library/test-utils/renderWithBrowserRouter.tsx
@@ -1,9 +1,0 @@
-import type { ReactNode } from 'react';
-import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
-import type { RenderResult } from '@testing-library/react';
-import { render } from '@testing-library/react';
-
-export function renderWithBrowserRouter(component: ReactNode): RenderResult {
-  return render(<BrowserRouter>{component}</BrowserRouter>);
-}

--- a/frontend/libs/studio-content-library/test-utils/renderWithProviders.tsx
+++ b/frontend/libs/studio-content-library/test-utils/renderWithProviders.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import type { RenderResult } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { ToastContainer, Slide } from 'react-toastify';
+
+export function renderWithProviders(component: ReactNode): RenderResult {
+  return render(
+    <>
+      <ToastContainer position='top-center' theme='colored' transition={Slide} draggable={false} />
+      <BrowserRouter>{component}</BrowserRouter>
+    </>,
+  );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ensure that the tests in the library is surrounded by a context that includes the ToastContainer as well so it is possible to test that the toast is rendered when it is suppose to.

## Related Issue(s)
Need this to test that the toast is rendered during validation
- #14157 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
