### PR TITLE
feat: Backend slack integration

### DIFF
--- a/backend/src/Designer/Configuration/FeedbackFormSettings.cs
+++ b/backend/src/Designer/Configuration/FeedbackFormSettings.cs
@@ -1,15 +1,23 @@
+using Altinn.Studio.Designer.Configuration.Marker;
+
 namespace Altinn.Studio.Designer.Configuration
 {
     /// <summary>
-    /// Class representation for basic service configuration
+    /// Class representation for basic FeedbackForm configuration
     /// </summary>
-    public class FeedbackFormSettings
+    public class FeedbackFormSettings: ISettingsMarker
     {
+        /// <summary>
+        /// Gets or sets the Slack settings
+        /// </summary>
         public SlackSettings SlackSettings { get; set; }
     }
 
     public class SlackSettings
     {
+        /// <summary>
+        /// Gets or sets the WebhookUrl
+        /// </summary>
         public string WebhookUrl { get; set; }
     }
 }

--- a/backend/src/Designer/Configuration/FeedbackFormSettings.cs
+++ b/backend/src/Designer/Configuration/FeedbackFormSettings.cs
@@ -1,0 +1,15 @@
+namespace Altinn.Studio.Designer.Configuration
+{
+    /// <summary>
+    /// Class representation for basic service configuration
+    /// </summary>
+    public class FeedbackFormSettings
+    {
+        public SlackSettings SlackSettings { get; set; }
+    }
+
+    public class SlackSettings
+    {
+        public string WebhookUrl { get; set; }
+    }
+}

--- a/backend/src/Designer/Configuration/FeedbackFormSettings.cs
+++ b/backend/src/Designer/Configuration/FeedbackFormSettings.cs
@@ -5,7 +5,7 @@ namespace Altinn.Studio.Designer.Configuration
     /// <summary>
     /// Class representation for basic FeedbackForm configuration
     /// </summary>
-    public class FeedbackFormSettings: ISettingsMarker
+    public class FeedbackFormSettings : ISettingsMarker
     {
         /// <summary>
         /// Gets or sets the Slack settings

--- a/backend/src/Designer/Controllers/FeedbackFormController.cs
+++ b/backend/src/Designer/Controllers/FeedbackFormController.cs
@@ -16,7 +16,7 @@ namespace Altinn.Studio.Designer.Controllers;
 [ApiController]
 [ValidateAntiForgeryToken]
 [Route("designer/api/{org}/{app:regex(^(?!datamodels$)[[a-z]][[a-z0-9-]]{{1,28}}[[a-z0-9]]$)}/feedbackform")]
-public class FeedbackFormController: ControllerBase
+public class FeedbackFormController : ControllerBase
 {
     private readonly ISlackClient _slackClient;
     private readonly GeneralSettings _generalSettings;

--- a/backend/src/Designer/Controllers/FeedbackFormController.cs
+++ b/backend/src/Designer/Controllers/FeedbackFormController.cs
@@ -1,0 +1,54 @@
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Models.Dto;
+using Altinn.Studio.Designer.TypedHttpClients.Slack;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Altinn.Studio.Designer.Controllers;
+
+/// <summary>
+/// Controller containing actions related to feedback form
+/// </summary>
+[Authorize]
+[ApiController]
+[ValidateAntiForgeryToken]
+[Route("designer/api/{org}/{app:regex(^(?!datamodels$)[[a-z]][[a-z0-9-]]{{1,28}}[[a-z0-9]]$)}/feedbackform")]
+public class FeedbackFormController: ControllerBase
+{
+    private readonly ISlackClient _slackClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FeedbackFormController"/> class.
+    /// </summary>
+    /// <param name="slackClient">A http client to send messages to slack</param>
+    public FeedbackFormController(ISlackClient slackClient)
+    {
+        _slackClient = slackClient;
+    }
+
+    /// <summary>
+    /// Endpoint for submitting feedback
+    /// </summary>
+    [HttpPost]
+    [Route("submit")]
+    public async Task<IActionResult> SubmitFeedback([FromRoute] string org, [FromRoute] string app, [FromBody] FeedbackForm feedback)
+    {
+        if (feedback == null)
+        {
+            return BadRequest("Feedback object is null");
+        }
+
+        if (string.IsNullOrEmpty(feedback.Text))
+        {
+            return BadRequest("Feedback text is null or empty");
+        }
+
+        await _slackClient.SendMessage(new SlackRequest
+        {
+            Text = feedback.Text,
+        });
+
+        return Ok();
+    }
+}

--- a/backend/src/Designer/Controllers/FeedbackFormController.cs
+++ b/backend/src/Designer/Controllers/FeedbackFormController.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Models.Dto;
@@ -37,7 +38,7 @@ public class FeedbackFormController : ControllerBase
     /// </summary>
     [HttpPost]
     [Route("submit")]
-    public async Task<IActionResult> SubmitFeedback([FromRoute] string org, [FromRoute] string app, [FromBody] FeedbackForm feedback)
+    public async Task<IActionResult> SubmitFeedback([FromRoute] string org, [FromRoute] string app, [FromBody] FeedbackForm feedback, CancellationToken cancellationToken)
     {
         if (feedback == null)
         {
@@ -67,7 +68,7 @@ public class FeedbackFormController : ControllerBase
         await _slackClient.SendMessage(new SlackRequest
         {
             Text = JsonSerializer.Serialize(feedback.Answers, new JsonSerializerOptions { WriteIndented = true })
-        });
+        }, cancellationToken);
 
         return Ok();
     }

--- a/backend/src/Designer/Controllers/FeedbackFormController.cs
+++ b/backend/src/Designer/Controllers/FeedbackFormController.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Configuration;
@@ -62,7 +61,7 @@ public class FeedbackFormController: ControllerBase
 
         if (!feedback.Answers.ContainsKey("env"))
         {
-            feedback.Answers.Add("env", GetEnvironmentNameForSlackMessage());
+            feedback.Answers.Add("env", _generalSettings.HostName);
         }
 
         await _slackClient.SendMessage(new SlackRequest
@@ -71,25 +70,5 @@ public class FeedbackFormController: ControllerBase
         });
 
         return Ok();
-    }
-
-    private string GetEnvironmentNameForSlackMessage()
-    {
-        string hostname = _generalSettings.HostName;
-        if (hostname == null)
-        {
-            return "unknown";
-        }
-        if (hostname.StartsWith("dev")) {
-            return "dev";
-        }
-        if (hostname.StartsWith("staging")) {
-            return "staging";
-        }
-        if (hostname.Equals("altinn.studio")) {
-            return "prod";
-        }
-
-        return "local";
     }
 }

--- a/backend/src/Designer/Controllers/FeedbackFormController.cs
+++ b/backend/src/Designer/Controllers/FeedbackFormController.cs
@@ -66,7 +66,7 @@ public class FeedbackFormController: ControllerBase
 
         await _slackClient.SendMessage(new SlackRequest
         {
-            Text = JsonSerializer.Serialize(feedback, new JsonSerializerOptions { WriteIndented = true })
+            Text = JsonSerializer.Serialize(feedback.Answers, new JsonSerializerOptions { WriteIndented = true })
         });
 
         return Ok();

--- a/backend/src/Designer/Models/Dto/FeedbackForm.cs
+++ b/backend/src/Designer/Models/Dto/FeedbackForm.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Altinn.Studio.Designer.Models.Dto
@@ -7,7 +8,7 @@ namespace Altinn.Studio.Designer.Models.Dto
     /// </summary>
     public class FeedbackForm
     {
-        [JsonPropertyName("text")]
-        public string Text { get; set; }
+        [JsonPropertyName("answers")]
+        public Dictionary<string, string> Answers  { get; set; }
     }
 }

--- a/backend/src/Designer/Models/Dto/FeedbackForm.cs
+++ b/backend/src/Designer/Models/Dto/FeedbackForm.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Studio.Designer.Models.Dto
+{
+    /// <summary>
+    /// Represents a feedback form
+    /// </summary>
+    public class FeedbackForm
+    {
+        [JsonPropertyName("text")]
+        public string Text { get; set; }
+    }
+}

--- a/backend/src/Designer/Models/Dto/FeedbackForm.cs
+++ b/backend/src/Designer/Models/Dto/FeedbackForm.cs
@@ -9,6 +9,6 @@ namespace Altinn.Studio.Designer.Models.Dto
     public class FeedbackForm
     {
         [JsonPropertyName("answers")]
-        public Dictionary<string, string> Answers  { get; set; }
+        public Dictionary<string, string> Answers { get; set; }
     }
 }

--- a/backend/src/Designer/Program.cs
+++ b/backend/src/Designer/Program.cs
@@ -198,6 +198,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration configuration
 
     services.AddMaskinportenHttpClient<MaskinPortenClientDefinition>("MaskinportenHttpClient", maskinportenSettings);
 
+    services.Configure<FeedbackFormSettings>(configuration.GetSection("FeedbackFormSettings"));
     services.RegisterServiceImplementations(configuration);
 
     services.AddHttpContextAccessor();

--- a/backend/src/Designer/Program.cs
+++ b/backend/src/Designer/Program.cs
@@ -197,8 +197,6 @@ void ConfigureServices(IServiceCollection services, IConfiguration configuration
     configuration.GetSection("MaskinportenClientSettings").Bind(maskinportenSettings);
 
     services.AddMaskinportenHttpClient<MaskinPortenClientDefinition>("MaskinportenHttpClient", maskinportenSettings);
-
-    services.Configure<FeedbackFormSettings>(configuration.GetSection("FeedbackFormSettings"));
     services.RegisterServiceImplementations(configuration);
 
     services.AddHttpContextAccessor();

--- a/backend/src/Designer/Program.cs
+++ b/backend/src/Designer/Program.cs
@@ -197,6 +197,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration configuration
     configuration.GetSection("MaskinportenClientSettings").Bind(maskinportenSettings);
 
     services.AddMaskinportenHttpClient<MaskinPortenClientDefinition>("MaskinportenHttpClient", maskinportenSettings);
+
     services.RegisterServiceImplementations(configuration);
 
     services.AddHttpContextAccessor();

--- a/backend/src/Designer/TypedHttpClients/Slack/ISlackClient.cs
+++ b/backend/src/Designer/TypedHttpClients/Slack/ISlackClient.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Altinn.Studio.Designer.TypedHttpClients.Slack
+{
+    public interface ISlackClient
+    {
+        public Task SendMessage(SlackRequest request, CancellationToken cancellationToken = default);
+    }
+}

--- a/backend/src/Designer/TypedHttpClients/Slack/SlackClient.cs
+++ b/backend/src/Designer/TypedHttpClients/Slack/SlackClient.cs
@@ -1,5 +1,4 @@
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Net.Mime;
 using System.Text;
 using System.Text.Json;

--- a/backend/src/Designer/TypedHttpClients/Slack/SlackClient.cs
+++ b/backend/src/Designer/TypedHttpClients/Slack/SlackClient.cs
@@ -1,0 +1,33 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Mime;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Altinn.Studio.Designer.TypedHttpClients.Slack;
+
+public class SlackClient : ISlackClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public SlackClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task SendMessage(SlackRequest request, CancellationToken cancellationToken = default)
+    {
+        using var payloadContent = new StringContent(JsonSerializer.Serialize(request, _jsonSerializerOptions),
+            Encoding.UTF8,
+            MediaTypeNames.Application.Json);
+
+        using var response = await _httpClient.PostAsync(string.Empty, payloadContent, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/backend/src/Designer/TypedHttpClients/Slack/SlackRequest.cs
+++ b/backend/src/Designer/TypedHttpClients/Slack/SlackRequest.cs
@@ -1,0 +1,7 @@
+namespace Altinn.Studio.Designer.TypedHttpClients.Slack
+{
+    public class SlackRequest
+    {
+        public string Text { get; set; }
+    }
+}

--- a/backend/src/Designer/TypedHttpClients/TypedHttpClientRegistration.cs
+++ b/backend/src/Designer/TypedHttpClients/TypedHttpClientRegistration.cs
@@ -16,6 +16,8 @@ using Altinn.Studio.Designer.TypedHttpClients.EidLogger;
 using Altinn.Studio.Designer.TypedHttpClients.KubernetesWrapper;
 using Altinn.Studio.Designer.TypedHttpClients.MaskinPorten;
 using Altinn.Studio.Designer.TypedHttpClients.ResourceRegistryOptions;
+using Altinn.Studio.Designer.TypedHttpClients.Slack;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -55,6 +57,7 @@ namespace Altinn.Studio.Designer.TypedHttpClients
             services.AddEidLoggerTypedHttpClient(config);
             services.AddTransient<GiteaTokenDelegatingHandler>();
             services.AddMaskinportenHttpClient();
+            services.AddSlackClient(config);
 
             return services;
         }
@@ -134,6 +137,18 @@ namespace Altinn.Studio.Designer.TypedHttpClients
                     })
             .AddHttpMessageHandler<AnsattPortenTokenDelegatingHandler>();
 
+        }
+
+        private static IHttpClientBuilder AddSlackClient(this IServiceCollection services, IConfiguration config)
+        {
+            FeedbackFormSettings feedbackFormSettings = config.GetSection("FeedbackFormSettings").Get<FeedbackFormSettings>();
+            string token = config["FeedbackFormSlackToken"];
+            return services.AddHttpClient<ISlackClient, SlackClient>(client =>
+            {
+                client.BaseAddress = new Uri(feedbackFormSettings.SlackSettings.WebhookUrl + config["FeedbackFormSlackWebhookSecret"]);
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", token);
+            }).AddHttpMessageHandler<EnsureSuccessHandler>();
         }
     }
 }

--- a/backend/src/Designer/TypedHttpClients/TypedHttpClientRegistration.cs
+++ b/backend/src/Designer/TypedHttpClients/TypedHttpClientRegistration.cs
@@ -17,7 +17,6 @@ using Altinn.Studio.Designer.TypedHttpClients.KubernetesWrapper;
 using Altinn.Studio.Designer.TypedHttpClients.MaskinPorten;
 using Altinn.Studio.Designer.TypedHttpClients.ResourceRegistryOptions;
 using Altinn.Studio.Designer.TypedHttpClients.Slack;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/backend/src/Designer/appsettings.json
+++ b/backend/src/Designer/appsettings.json
@@ -130,5 +130,10 @@
     },
     "MaskinPortenHttpClientSettings" : {
         "BaseUrl": "https://api.test.samarbeid.digdir.no"
+    },
+    "FeedbackFormSettings": {
+        "SlackSettings": {
+            "WebhookUrl": "https://hooks.slack.com/services/"
+        }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/FeedbackFormController/Base/FeedbackFormControllerTestBase.cs
+++ b/backend/tests/Designer.Tests/Controllers/FeedbackFormController/Base/FeedbackFormControllerTestBase.cs
@@ -1,0 +1,22 @@
+
+using Designer.Tests.Controllers.ApiTests;
+using Designer.Tests.Fixtures;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Designer.Tests.Controllers.FeedbackFormController.Base;
+
+public class FeedbackFormControllerTestBase<TControllerTest> : DesignerEndpointsTestsBase<TControllerTest>
+    where TControllerTest : class
+{
+    public FeedbackFormControllerTestBase(WebApplicationFactory<Program> factory) : base(factory)
+    {
+        JsonConfigOverrides.Add(
+            $$"""
+                     {
+                           "GeneralSettings": {
+                               "HostName": "TestHostName"
+                           }
+                     }
+                  """);
+    }
+}

--- a/backend/tests/Designer.Tests/Controllers/FeedbackFormController/SendMessageToSlackTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/FeedbackFormController/SendMessageToSlackTests.cs
@@ -1,0 +1,89 @@
+
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Models.Dto;
+using Designer.Tests.Controllers.FeedbackFormController.Base;
+using Designer.Tests.Controllers.FeedbackFormController.Utils;
+using Designer.Tests.Fixtures;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Designer.Tests.Controllers.FeedbackFormController;
+
+public class SendMessageToSlackTests : FeedbackFormControllerTestBase<SendMessageToSlackTests>, IClassFixture<WebApplicationFactory<Program>>, IClassFixture<MockServerFixture>
+{
+    private static string VersionPrefix(string org, string repository) =>
+        $"/designer/api/{org}/{repository}/feedbackform/submit";
+
+    private readonly MockServerFixture _mockServerFixture;
+
+    public SendMessageToSlackTests(WebApplicationFactory<Program> factory, MockServerFixture mockServerFixture) : base(factory)
+    {
+        _mockServerFixture = mockServerFixture;
+        JsonConfigOverrides.Add(
+            $$"""
+                    {
+                      "FeedbackFormSettings" : {
+                            "SlackSettings": {
+                                "WebhookUrl": "{{mockServerFixture.MockApi.Url}}"
+                            }
+                        }
+                    }
+                """
+        );
+    }
+
+    [Fact]
+    public async Task SendMessageToSlack_Should_ReturnOk()
+    {
+        _mockServerFixture.PrepareSlackResponse(_mockServerFixture.MockApi.Url);
+        var mockAnswers = new FeedbackForm
+        {
+            Answers = new Dictionary<string, string>
+            {
+                { "message", "test" }
+            }
+        };
+        using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, VersionPrefix("ttd", "non-existing-app"))
+        {
+            Content = JsonContent.Create(mockAnswers)
+        };
+
+
+        using var response = await HttpClient.SendAsync(httpRequestMessage);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task SendMessageToSlack_NullAnswers_Should_ReturnBadRequest()
+    {
+        object mockAnswers = null;
+        using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, VersionPrefix("ttd", "non-existing-app"))
+        {
+            Content = JsonContent.Create(mockAnswers)
+        };
+
+        using var response = await HttpClient.SendAsync(httpRequestMessage);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SendMessageToSlack_WithMissingAnswers_Should_ReturnBadRequest()
+    {
+        var mockAnswers = new FeedbackForm
+        {
+            Answers = null
+        };
+        using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, VersionPrefix("ttd", "non-existing-app"))
+        {
+            Content = JsonContent.Create(mockAnswers)
+        };
+
+        using var response = await HttpClient.SendAsync(httpRequestMessage);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/backend/tests/Designer.Tests/Controllers/FeedbackFormController/Utils/SlackMockServerExtensions.cs
+++ b/backend/tests/Designer.Tests/Controllers/FeedbackFormController/Utils/SlackMockServerExtensions.cs
@@ -1,0 +1,27 @@
+using System.Net.Mime;
+using Designer.Tests.Fixtures;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+namespace Designer.Tests.Controllers.FeedbackFormController.Utils;
+
+public static class SlackMockServerExtensions
+{
+    public static void PrepareSlackResponse(this MockServerFixture mockServerFixture, string path)
+    {
+        var request = Request.Create()
+            .UsingPost()
+            .WithPath("/");
+
+        var response = Response.Create()
+            .WithStatusCode(200)
+            .WithHeader("content-type", MediaTypeNames.Application.Json);
+
+        mockServerFixture.MockApi.Given(request)
+            .RespondWith(
+                response
+                );
+
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Backend implementation for feedback form.
This can be viewed as a POC/MVP, in order to start receiving feedback from our users in a simple manner.

- Created a client for posting messages to slack
  - token and secret portion of webhook url are placed in keyvault (only dev currently)
- Created controller and endpoint for posting feedback answers to Slack using the new client.

Tested the implementation in dev, and it works as expected. See the #studio-feedback channel in our internal slack for the test responses (ask me for access).

Very happy to get some feedback if there are better ways to solve this!

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
