### PR TITLE
feat: refactor SchemaModelService to update appMetadata when creating new data model

### DIFF
--- a/backend/src/Designer/Controllers/DatamodelsController.cs
+++ b/backend/src/Designer/Controllers/DatamodelsController.cs
@@ -163,17 +163,17 @@ namespace Altinn.Studio.Designer.Controllers
             Request.EnableBuffering();
             Guard.AssertArgumentNotNull(theFile, nameof(theFile));
 
-            string fileName = GetFileNameFromUploadedFile(theFile);
-            Guard.AssertFileExtensionIsOfType(fileName, ".xsd");
+            string fileNameWithExtension = GetFileNameFromUploadedFile(theFile);
+            Guard.AssertFileExtensionIsOfType(fileNameWithExtension, ".xsd");
 
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
 
             var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, repository, developer);
             var fileStream = theFile.OpenReadStream();
-            await _modelNameValidator.ValidateModelNameForNewXsdSchemaAsync(fileStream, fileName, editingContext);
-            string jsonSchema = await _schemaModelService.BuildSchemaFromXsd(editingContext, fileName, theFile.OpenReadStream(), cancellationToken);
+            await _modelNameValidator.ValidateModelNameForNewXsdSchemaAsync(fileStream, fileNameWithExtension, editingContext);
+            string jsonSchema = await _schemaModelService.BuildSchemaFromXsd(editingContext, fileNameWithExtension, theFile.OpenReadStream(), cancellationToken);
 
-            return Created(Uri.EscapeDataString(fileName), jsonSchema);
+            return Created(Uri.EscapeDataString(fileNameWithExtension), jsonSchema);
         }
 
         /// <summary>

--- a/backend/src/Designer/Services/Interfaces/ISchemaModelService.cs
+++ b/backend/src/Designer/Services/Interfaces/ISchemaModelService.cs
@@ -48,10 +48,10 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// Builds a JSON schema based on the uploaded XSD.
         /// </summary>
         /// <param name="altinnRepoEditingContext">An <see cref="AltinnRepoEditingContext"/>.</param>
-        /// <param name="modelName">The name of the new model.</param>
+        /// <param name="fileNameWithExtension">The name of the new file.</param>
         /// <param name="xsdStream">Stream representing the XSD.</param>
         /// <param name="cancellationToken">An <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-        Task<string> BuildSchemaFromXsd(AltinnRepoEditingContext altinnRepoEditingContext, string modelName, Stream xsdStream, CancellationToken cancellationToken = default);
+        Task<string> BuildSchemaFromXsd(AltinnRepoEditingContext altinnRepoEditingContext, string fileNameWithExtension, Stream xsdStream, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a JSON schema based on a template.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactor SchemaModelService to update appMetadata when creating new data model:
- Remove some functions that was executed multiple times and instead only pass the calculated value that was actually needed in the underlying functions.
- Simplified `UpdateCSharpClasses` to only update csharp classes and move the logic to get the full type name out in separate method `GetFullTypeName`. Also created a separate function for `NamespaceNeedsToBeSeparated` that is now used in `UpdateCSharpClasses`.
- Removed return value of `UpdateModelFilesFromJsonSchema` as it was not used.
- Moved call to `UpdateApplicationMetadata` function from `ProcessNewXsd` to `BuildSchemaFromXsd`.
- Changed name of `ProcessNewXsd` to `GenerateJsonSchemaAndCSharp` since that is more concrete.
- The most crucial change is adding call to `UpdateApplicationMetadata` function in `CreateSchemaFromTemplate`.
- Deleted `SerializeModelMetadata` since it was not used.

In addition I changed the name of fileName in the `BuildSchemaFromXsd`, which is called when uploading xsd, to `fileNameWithExtension` to make a clearer what variables of the name that has extensions and not.

## Related Issue(s)

- #14123 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
