### PR TITLE
feat(settings): open settings modal on redirect from ansattporten

### DIFF
--- a/frontend/app-development/hooks/useOpenSettingsModalBasedQueryParam.test.ts
+++ b/frontend/app-development/hooks/useOpenSettingsModalBasedQueryParam.test.ts
@@ -1,6 +1,6 @@
 import { renderHookWithProviders } from '../test/mocks';
 import {
-  queryParamKey,
+  openSettingsModalWithTabQueryKey,
   useOpenSettingsModalBasedQueryParam,
 } from './useOpenSettingsModalBasedQueryParam';
 import { useSearchParams } from 'react-router-dom';
@@ -44,7 +44,7 @@ function setupSearchParamMock(searchParams: URLSearchParams): jest.Mock {
 
 function buildSearchParams(queryParamValue: string): URLSearchParams {
   const searchParams: URLSearchParams = new URLSearchParams();
-  searchParams.set(queryParamKey, queryParamValue);
+  searchParams.set(openSettingsModalWithTabQueryKey, queryParamValue);
   return searchParams;
 }
 

--- a/frontend/app-development/hooks/useOpenSettingsModalBasedQueryParam.ts
+++ b/frontend/app-development/hooks/useOpenSettingsModalBasedQueryParam.ts
@@ -4,7 +4,7 @@ import { useSettingsModalContext } from '../contexts/SettingsModalContext';
 import type { SettingsModalTabId } from '../types/SettingsModalTabId';
 import { useSettingsModalMenuTabConfigs } from '../layout/PageHeader/SubHeader/SettingsModalButton/SettingsModal/hooks/useSettingsModalMenuTabConfigs';
 
-export const queryParamKey: string = 'openSettingsModalWithTab';
+export const openSettingsModalWithTabQueryKey: string = 'openSettingsModalWithTab';
 
 export function useOpenSettingsModalBasedQueryParam(): void {
   const [searchParams] = useSearchParams();
@@ -14,7 +14,9 @@ export function useOpenSettingsModalBasedQueryParam(): void {
   const tabIds = settingsModalTabs.map(({ tabId }) => tabId);
 
   useEffect((): void => {
-    const tabToOpen: SettingsModalTabId = searchParams.get(queryParamKey) as SettingsModalTabId;
+    const tabToOpen: SettingsModalTabId = searchParams.get(
+      openSettingsModalWithTabQueryKey,
+    ) as SettingsModalTabId;
     const shouldOpenModal: boolean = isValidTab(tabToOpen, tabIds);
     if (shouldOpenModal) {
       settingsRef.current.openSettings(tabToOpen);

--- a/frontend/app-development/layout/PageHeader/SubHeader/SettingsModalButton/SettingsModal/components/Tabs/Maskinporten/AnsattportenLogin/AnsattportenLogin.test.tsx
+++ b/frontend/app-development/layout/PageHeader/SubHeader/SettingsModalButton/SettingsModal/components/Tabs/Maskinporten/AnsattportenLogin/AnsattportenLogin.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { AnsattportenLogin } from './AnsattportenLogin';
+import { AnsattportenLogin, getRedirectUrl } from './AnsattportenLogin';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 
 jest.mock('app-shared/api/paths');
@@ -40,10 +40,22 @@ describe('AnsattportenLogin', () => {
   });
 });
 
+describe('getRedirectUrl', () => {
+  it('should build and return correct redirect url', () => {
+    mockWindowLocationHref();
+    const result = getRedirectUrl();
+    expect(result).toBe('/path/to/page?openSettingsModalWithTab=maskinporten');
+  });
+});
+
 function mockWindowLocationHref(): jest.Mock {
   const hrefMock = jest.fn();
   delete window.location;
-  window.location = { href: '' } as Location;
+  window.location = {
+    href: '',
+    origin: 'https://unit-test-com',
+    pathname: '/path/to/page',
+  } as Location;
   Object.defineProperty(window.location, 'href', {
     set: hrefMock,
   });

--- a/frontend/app-development/layout/PageHeader/SubHeader/SettingsModalButton/SettingsModal/components/Tabs/Maskinporten/AnsattportenLogin/AnsattportenLogin.tsx
+++ b/frontend/app-development/layout/PageHeader/SubHeader/SettingsModalButton/SettingsModal/components/Tabs/Maskinporten/AnsattportenLogin/AnsattportenLogin.tsx
@@ -4,12 +4,14 @@ import { useTranslation } from 'react-i18next';
 import { StudioButton, StudioParagraph } from '@studio/components';
 import { EnterIcon } from '@studio/icons';
 import { loginWithAnsattPorten } from 'app-shared/api/paths';
+import { openSettingsModalWithTabQueryKey } from '../../../../../../../../../hooks/useOpenSettingsModalBasedQueryParam';
+import type { SettingsModalTabId } from '../../../../../../../../../types/SettingsModalTabId';
 
 export const AnsattportenLogin = (): ReactElement => {
   const { t } = useTranslation();
 
   const handleLoginWithAnsattporten = (): void => {
-    window.location.href = loginWithAnsattPorten(window.location.pathname + window.location.search);
+    window.location.href = loginWithAnsattPorten(getRedirectUrl());
   };
 
   return (
@@ -39,3 +41,10 @@ const LoginIcon = (): ReactElement => {
     </div>
   );
 };
+
+export function getRedirectUrl(): string {
+  const maskinportenTab: SettingsModalTabId = 'maskinporten';
+  const url = new URL(window.location.origin + window.location.pathname);
+  url.searchParams.set(openSettingsModalWithTabQueryKey, maskinportenTab);
+  return url.pathname + url.search;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added functionality to ensure the settings modal opens with the correct tab preselected when redirecting from Ansattporten. After login, users are seamlessly redirected to the appropriate section.

https://github.com/user-attachments/assets/cb7ba844-a9bf-4d99-b3bb-5a244a775f26


## Related Issue(s)
- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
