### PR TITLE
fix: typesInspector width

### DIFF
--- a/frontend/packages/schema-editor/src/components/SchemaEditor/SchemaEditor.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaEditor/SchemaEditor.tsx
@@ -39,7 +39,7 @@ export const SchemaEditor = () => {
             <TypesInspector schemaItems={definitions} />
           </aside>
         </StudioResizableLayout.Element>
-        <StudioResizableLayout.Element>
+        <StudioResizableLayout.Element minimumSize={250}>
           <div className={classes.editor}>
             <NodePanel schemaPointer={selectedType?.schemaPointer} />
           </div>

--- a/frontend/packages/schema-editor/src/components/SchemaEditor/SchemaEditor.tsx
+++ b/frontend/packages/schema-editor/src/components/SchemaEditor/SchemaEditor.tsx
@@ -34,7 +34,7 @@ export const SchemaEditor = () => {
         orientation='horizontal'
         localStorageContext={`datamodel:${user.id}:${org}`}
       >
-        <StudioResizableLayout.Element minimumSize={100} maximumSize={280}>
+        <StudioResizableLayout.Element minimumSize={200} maximumSize={500}>
           <aside className={classes.inspector}>
             <TypesInspector schemaItems={definitions} />
           </aside>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Increases minimum width, so that the `Typer` heading and `+` button can't overlap
* Increases maximum width, so that long type names can be completely seen without ellipsis

### Before

https://github.com/user-attachments/assets/41611ec5-4d40-44d8-893b-1b39c202a22b

### After

https://github.com/user-attachments/assets/3a882234-f61f-42ea-a46f-cfd9ad224222

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)