### PR TITLE
feat: Delete all Summary 2.0 components that has a reference to deleted layout set

### DIFF
--- a/backend/src/Designer/Controllers/AppDevelopmentController.cs
+++ b/backend/src/Designer/Controllers/AppDevelopmentController.cs
@@ -402,13 +402,14 @@ namespace Altinn.Studio.Designer.Controllers
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
             var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer);
-            LayoutSets layoutSets = await _appDevelopmentService.DeleteLayoutSet(editingContext, layoutSetIdToUpdate, cancellationToken);
-
             await _mediator.Publish(new LayoutSetDeletedEvent
             {
                 EditingContext = editingContext,
                 LayoutSetId = layoutSetIdToUpdate
             }, cancellationToken);
+
+            LayoutSets layoutSets = await _appDevelopmentService.DeleteLayoutSet(editingContext, layoutSetIdToUpdate, cancellationToken);
+
             return Ok(layoutSets);
         }
 


### PR DESCRIPTION
## Description

Delete all Summary 2.0 components that has a reference to a deleted layout set

## Related Issue(s)

- #13525

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
