### PR TITLE
fix: add duplication validatior for code list items

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/utils.test.ts
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/utils.test.ts
@@ -2,6 +2,7 @@ import type { CodeList } from './types/CodeList';
 import {
   addEmptyCodeListItem,
   changeCodeListItem,
+  isCodeListItemDuplicate,
   isCodeListEmpty,
   removeCodeListItem,
 } from './utils';
@@ -85,6 +86,20 @@ describe('StudioCodelistEditor utils', () => {
     it('Returns false when the code list is not empty', () => {
       const codeList = createTestCodeList();
       expect(isCodeListEmpty(codeList)).toBe(false);
+    });
+  });
+
+  describe('isCodeListItemDuplicate', () => {
+    it('Returns true when the code list items are duplicate', () => {
+      const oldCodeList = testCodeList[0];
+      const newCodeList = testCodeList[0];
+      expect(isCodeListItemDuplicate(oldCodeList, newCodeList)).toBeTruthy();
+    });
+
+    it('Return false when code list items are different', () => {
+      const oldCodeList = testCodeList[0];
+      const newCodeList = testCodeList[1];
+      expect(isCodeListItemDuplicate(oldCodeList, newCodeList)).toBeFalsy();
     });
   });
 });

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/utils.test.ts
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/utils.test.ts
@@ -76,6 +76,12 @@ describe('StudioCodelistEditor utils', () => {
       const updatedCodeList = changeCodeListItem(codeList, 1, updatedItem);
       expect(updatedCodeList).not.toBe(codeList);
     });
+
+    it('Returns the old code list item if there are no changes', () => {
+      const codeList = createTestCodeList();
+      const updatedCodeList = changeCodeListItem(codeList, 1, codeList[1]);
+      expect(updatedCodeList).toEqual(codeList);
+    });
   });
 
   describe('isCodeListEmpty', () => {

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/utils.ts
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/utils.ts
@@ -23,9 +23,19 @@ export function changeCodeListItem(
   index: number,
   newItem: CodeListItem,
 ): CodeList {
+  if (isCodeListItemDuplicate(codeList[index], newItem)) return codeList;
   return ArrayUtils.replaceByIndex<CodeListItem>(codeList, index, newItem);
 }
 
 export function isCodeListEmpty(codeList: CodeList): boolean {
   return codeList.length === 0;
+}
+
+export function isCodeListItemDuplicate(oldItem: CodeListItem, newItem: CodeListItem): boolean {
+  return (
+    oldItem.label === newItem.label &&
+    oldItem.value === newItem.value &&
+    oldItem.description === newItem.description &&
+    oldItem.helpText === newItem.helpText
+  );
 }


### PR DESCRIPTION
## Description
Added validation for when to call `onChange` in `StudioCodeListEditor`. The change will not effect current code, but is related to [this PR](https://github.com/Altinn/altinn-studio/pull/14137) which is currently in test. Spesifically the change where we're moving away from using `onChange` to `onBlur`.

This will allow the user to move around in the editor without sending multiple requests to our backend without any changes.

## Related Issue
- #13685 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)