### PR TITLE
fix: allow appmetadata to be undefined when validating name when data model is uploaded

### DIFF
--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/utils/validationUtils.test.ts
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/utils/validationUtils.test.ts
@@ -1,5 +1,5 @@
 import { mockAppMetadata, mockDataTypeId } from '../../../../../test/applicationMetadataMock';
-import { extractDataTypeNamesFromAppMetadata } from './validationUtils';
+import { extractDataTypeNamesFromAppMetadata, findFileNameError } from './validationUtils';
 
 describe('extractDataTypeNamesFromAppMetadata', () => {
   it('should extract data type names when application metadata is provided', () => {
@@ -19,5 +19,25 @@ describe('extractDataTypeNamesFromAppMetadata', () => {
   it('should return an empty array when application metadata is undefined', () => {
     const dataTypeNames = extractDataTypeNamesFromAppMetadata(undefined);
     expect(dataTypeNames).toEqual([]);
+  });
+});
+
+describe('findFileNameError', () => {
+  it('should validate name as invalid if name does not match regEx', () => {
+    const fileName = 'æ';
+    const validationResult = findFileNameError(fileName, mockAppMetadata);
+    expect(validationResult).toEqual('invalidFileName');
+  });
+
+  it('should validate name as invalid if name exists in appMetadata', () => {
+    const fileName = mockAppMetadata.dataTypes[0].id;
+    const validationResult = findFileNameError(fileName, mockAppMetadata);
+    expect(validationResult).toEqual('fileExists');
+  });
+
+  it('should validate name as valid if appMetadata is undefined', () => {
+    const fileName = 'fileName';
+    const validationResult = findFileNameError(fileName, undefined);
+    expect(validationResult).toEqual(null);
   });
 });

--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/utils/validationUtils.ts
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/utils/validationUtils.ts
@@ -46,7 +46,7 @@ const isNameFormatValid = (fileNameWithoutExtension: string): boolean => {
 const doesFileExistInMetadata = (
   appMetadata: ApplicationMetadata,
   fileNameWithoutExtension: string,
-): boolean => appMetadata.dataTypes?.some((dataType) => dataType.id === fileNameWithoutExtension);
+): boolean => appMetadata?.dataTypes?.some((dataType) => dataType.id === fileNameWithoutExtension);
 
 export const extractDataTypeNamesFromAppMetadata = (
   appMetadata?: ApplicationMetadata,


### PR DESCRIPTION
## Description

allow appMetadata to be undefined when validating name when data model is uploaded

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
