### PR TITLE
feat: also resolve app version from experimental package

### DIFF
--- a/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
+++ b/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
@@ -538,9 +538,11 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
             var csprojFiles = altinnAppGitRepository.FindFiles(new[] { "*.csproj" });
 
+            string[] packageNames = ["Altinn.App.Api", "Altinn.App.Api.Experimental"];
+
             foreach (string csprojFile in csprojFiles)
             {
-                if (PackageVersionHelper.TryGetPackageVersionFromCsprojFile(csprojFile, "Altinn.App.Api",
+                if (PackageVersionHelper.TryGetPackageVersionFromCsprojFile(csprojFile, packageNames,
                         out SemanticVersion version))
                 {
                     return version;

--- a/backend/tests/Designer.Tests/Helpers/PackageVersionHelperTests.cs
+++ b/backend/tests/Designer.Tests/Helpers/PackageVersionHelperTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using Altinn.Studio.Designer.Helpers;
 using DotNet.Testcontainers.Builders;
 using FluentAssertions;
@@ -15,13 +16,18 @@ namespace Designer.Tests.Helpers
         {
             string testTemplateCsProjPath = Path.Combine(CommonDirectoryPath.GetSolutionDirectory().DirectoryPath, "..", "testdata", "AppTemplates", "AspNet", "App", "App.csproj");
 
-            bool result = PackageVersionHelper.TryGetPackageVersionFromCsprojFile(testTemplateCsProjPath, packageName, out var version);
-
-            result.Should().Be(expectedResult);
-
-            if (result)
+            string[] packages = [packageName, $"{packageName}.Experimental"];
+            string[][] inputs = [packages, packages.Reverse().ToArray()];
+            foreach (var input in inputs)
             {
-                version.ToString().Should().Be(expectedVersion);
+                bool result = PackageVersionHelper.TryGetPackageVersionFromCsprojFile(testTemplateCsProjPath, input, out var version);
+
+                result.Should().Be(expectedResult);
+
+                if (result)
+                {
+                    version.ToString().Should().Be(expectedVersion);
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

We are publishing experimental versions of the app packages: 

https://www.nuget.org/packages/Altinn.App.Core.Experimental/ &
https://www.nuget.org/packages/Altinn.App.Api.Experimental/

This is to allow us to publish packages from feature branches for testing. Service Owners may want to test with these packages as well.

I wonder if this code needs to be updated?

## Related Issue(s)

- N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
