### PR TITLE
fix: select default data model when data model binding is not provided for a component

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1783,7 +1783,7 @@
   "ux_editor.properties_panel.subform_table_columns.cell_content_default_label": "Default",
   "ux_editor.properties_panel.subform_table_columns.cell_content_query_label": "Query",
   "ux_editor.properties_panel.subform_table_columns.choose_component": "Velg komponenten fra underskjemaet som skal vises her",
-  "ux_editor.properties_panel.subform_table_columns.choose_component_description": "Listen viser bare de komponentene der det er lagt til ledetekster",
+  "ux_editor.properties_panel.subform_table_columns.choose_component_description": "Listen viser bare de komponentene som har minst én datamodellbinding og en ledetekst",
   "ux_editor.properties_panel.subform_table_columns.column_header": "Kolonne {{columnNumber}}",
   "ux_editor.properties_panel.subform_table_columns.delete_column": "Slett kolonne {{columnNumber}}",
   "ux_editor.properties_panel.subform_table_columns.header_content_label": "Header Content",

--- a/frontend/packages/ux-editor/src/hooks/useValidDataModels.test.ts
+++ b/frontend/packages/ux-editor/src/hooks/useValidDataModels.test.ts
@@ -41,6 +41,20 @@ describe('useValidDataModels', () => {
     expect(dataModels).toEqual([defaultDataModel, secondDataModel]);
   });
 
+  it('should return default data model when current data model is not provided', async () => {
+    const { result } = setupUseValidDataModelsHook('');
+
+    expect(result.current.isLoadingDataModels).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoadingDataModels).toBe(false);
+    });
+
+    const { selectedDataModel, isDataModelValid } = result.current;
+    expect(isDataModelValid).toBe(true);
+    expect(selectedDataModel).toEqual(defaultDataModel);
+  });
+
   it('should return the default data model from metadata when the current selected data model no longer exists', async () => {
     const { result } = setupUseValidDataModelsHook('invalidModel');
 

--- a/frontend/packages/ux-editor/src/hooks/useValidDataModels.ts
+++ b/frontend/packages/ux-editor/src/hooks/useValidDataModels.ts
@@ -18,10 +18,10 @@ export const useValidDataModels = (currentDataModel: string) => {
 
   const dataModel = Boolean(currentDataModel)
     ? currentDataModel
-    : layoutSets?.sets.find((layoutSet) => layoutSet.id === selectedFormLayoutSetName)?.dataType;
+    : (layoutSets?.sets.find((layoutSet) => layoutSet.id === selectedFormLayoutSetName)?.dataType ??
+      dataModels?.[0]);
 
   const isDataModelValid = validateSelectedDataModel(dataModel, dataModels);
-
   const { data: dataModelMetadata, isPending: isPendingDataModelMetadata } =
     useDataModelMetadataQuery(
       {

--- a/frontend/packages/ux-editor/src/hooks/useValidDataModels.ts
+++ b/frontend/packages/ux-editor/src/hooks/useValidDataModels.ts
@@ -3,10 +3,12 @@ import { useDataModelMetadataQuery } from './queries/useDataModelMetadataQuery';
 import { useAppContext } from './useAppContext';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { getDataModel, validateSelectedDataModel } from '../utils/dataModelUtils';
+import { useLayoutSetsQuery } from 'app-shared/hooks/queries/useLayoutSetsQuery';
 
 export const useValidDataModels = (currentDataModel: string) => {
   const { selectedFormLayoutSetName } = useAppContext();
   const { org, app } = useStudioEnvironmentParams();
+  const { data: layoutSets } = useLayoutSetsQuery(org, app);
 
   const {
     data: dataModels,
@@ -14,7 +16,11 @@ export const useValidDataModels = (currentDataModel: string) => {
     isRefetching: isFetchingDataModels,
   } = useAppMetadataModelIdsQuery(org, app, false);
 
-  const isDataModelValid = validateSelectedDataModel(currentDataModel, dataModels);
+  const dataModel = Boolean(currentDataModel)
+    ? currentDataModel
+    : layoutSets?.sets.find((layoutSet) => layoutSet.id === selectedFormLayoutSetName)?.dataType;
+
+  const isDataModelValid = validateSelectedDataModel(dataModel, dataModels);
 
   const { data: dataModelMetadata, isPending: isPendingDataModelMetadata } =
     useDataModelMetadataQuery(
@@ -22,7 +28,7 @@ export const useValidDataModels = (currentDataModel: string) => {
         org,
         app,
         layoutSetName: selectedFormLayoutSetName,
-        dataModelName: isDataModelValid && currentDataModel ? currentDataModel : dataModels?.[0],
+        dataModelName: isDataModelValid ? dataModel : dataModels?.[0],
       },
       { enabled: !isPendingDataModels && !isFetchingDataModels },
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If a data model binding is not provided for a component, it previously defaulted to the first data model in the list. This behavior has been updated to use the default data model instead.

<!--- Describe your changes in detail -->

## Related Issue(s)

- itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
