### PR TITLE
fix(resource-adm): remove feature toggle for resource migration

### DIFF
--- a/frontend/packages/shared/src/utils/featureToggleUtils.test.ts
+++ b/frontend/packages/shared/src/utils/featureToggleUtils.test.ts
@@ -58,14 +58,14 @@ describe('featureToggle url', () => {
     window.history.pushState(
       {},
       'PageUrl',
-      '/?featureFlags=resourceMigration,shouldOverrideAppLibCheck&persistFeatureFlag=true',
+      '/?featureFlags=addComponentModal,shouldOverrideAppLibCheck&persistFeatureFlag=true',
     );
     expect(shouldDisplayFeature(FeatureFlag.ComponentConfigBeta)).toBeFalsy();
     expect(shouldDisplayFeature(FeatureFlag.ShouldOverrideAppLibCheck)).toBeTruthy();
-    expect(shouldDisplayFeature(FeatureFlag.ResourceMigration)).toBeTruthy();
+    expect(shouldDisplayFeature(FeatureFlag.AddComponentModal)).toBeTruthy();
     expect(typedSessionStorage.getItem<string[]>('featureFlags')).toEqual([
       'shouldOverrideAppLibCheck',
-      'resourceMigration',
+      'addComponentModal',
     ]);
     expect(typedLocalStorage.getItem<string[]>('featureFlags')).toBeNull();
   });

--- a/frontend/packages/shared/src/utils/featureToggleUtils.ts
+++ b/frontend/packages/shared/src/utils/featureToggleUtils.ts
@@ -10,7 +10,6 @@ export enum FeatureFlag {
   Maskinporten = 'maskinporten',
   MultipleDataModelsPerTask = 'multipleDataModelsPerTask',
   OptionListEditor = 'optionListEditor',
-  ResourceMigration = 'resourceMigration',
   ShouldOverrideAppLibCheck = 'shouldOverrideAppLibCheck',
   Subform = 'subform',
   Summary2 = 'summary2',

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.test.tsx
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.test.tsx
@@ -10,7 +10,6 @@ import type { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import type { QueryClient } from '@tanstack/react-query';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
-import { addFeatureFlagToLocalStorage, FeatureFlag } from 'app-shared/utils/featureToggleUtils';
 
 const mockResource1: Resource = {
   identifier: 'r1',

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.test.tsx
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.test.tsx
@@ -93,8 +93,6 @@ describe('ResourcePage', () => {
   });
 
   it('displays migrate tab in left navigation bar when resource reference is present in resource', async () => {
-    addFeatureFlagToLocalStorage(FeatureFlag.ResourceMigration);
-
     const getResource = jest
       .fn()
       .mockImplementation(() => Promise.resolve<Resource>(mockResource1));

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
@@ -26,7 +26,6 @@ import { ResourceAccessLists } from '../../components/ResourceAccessLists';
 import { AccessListDetail } from '../../components/AccessListDetails';
 import { useGetAccessListQuery } from '../../hooks/queries/useGetAccessListQuery';
 import { useUrlParams } from '../../hooks/useUrlParams';
-import { shouldDisplayFeature, FeatureFlag } from 'app-shared/utils/featureToggleUtils';
 import { StudioContentMenu } from '@studio/components';
 import type { StudioContentMenuButtonTabProps } from '@studio/components';
 
@@ -162,7 +161,7 @@ export const ResourcePage = (): React.JSX.Element => {
    * Decide if the migration page should be accessible or not
    */
   const isMigrateEnabled = (): boolean => {
-    return !!altinn2References && shouldDisplayFeature(FeatureFlag.ResourceMigration);
+    return !!altinn2References;
   };
 
   const aboutPageId = 'about';


### PR DESCRIPTION
## Description

- Remove feature toggle for resource migration to release feature

## Related Issue(s)

- https://github.com/Altinn/altinn-studio/issues/13180

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
