### PR TITLE
refactor: Correct ordered list props type

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioList/StudioList.tsx
+++ b/frontend/libs/studio-components/src/components/StudioList/StudioList.tsx
@@ -1,6 +1,7 @@
 import type {
   ListHeadingProps,
   ListItemProps,
+  ListOrderedProps,
   ListUnorderedProps,
 } from '@digdir/designsystemet-react';
 import { List } from '@digdir/designsystemet-react';
@@ -23,5 +24,5 @@ export type { StudioListRootProps } from './StudioListRoot';
 
 export type StudioListItemProps = ListItemProps;
 export type StudioListUnorderedProps = ListUnorderedProps;
-export type StudioListOrderedProps = ListUnorderedProps;
+export type StudioListOrderedProps = ListOrderedProps;
 export type StudioListHeadingProps = ListHeadingProps;


### PR DESCRIPTION
## Description
Corrected the `StudioListOrderedProps` type, which used the `ListUnorderedProps` type from The Design System instead of `ListOrderedProps`.

## Verification
- [x] **Your** code builds clean without any errors or warnings
