### PR TITLE
test: Centralize test data for code list editor

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditor.stories.tsx
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditor.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { StudioCodeListEditor } from './StudioCodeListEditor';
+import { codeListWithoutTextResources } from './test-data/codeListWithoutTextResources';
+import { texts } from './test-data/texts';
 
 type Story = StoryObj<typeof StudioCodeListEditor>;
 
@@ -11,44 +13,7 @@ export default meta;
 
 export const Preview: Story = {
   args: {
-    codeList: [
-      {
-        label: 'Test 1',
-        value: 'test1',
-        description: 'Test 1 description',
-        helpText: 'Test 1 help text',
-      },
-      {
-        label: 'Test 2',
-        value: 'test2',
-        description: 'Test 2 description',
-        helpText: 'Test 2 help text',
-      },
-      {
-        label: 'Test 3',
-        value: 'test3',
-        description: 'Test 3 description',
-        helpText: 'Test 3 help text',
-      },
-    ],
-    texts: {
-      add: 'Add',
-      codeList: 'Code list',
-      delete: 'Delete',
-      deleteItem: (number) => `Delete item number ${number}`,
-      description: 'Description',
-      emptyCodeList: 'The code list is empty.',
-      valueErrors: {
-        duplicateValue: 'The value must be unique.',
-      },
-      generalError: 'The code list cannot be saved because it is not valid.',
-      helpText: 'Help text',
-      itemDescription: (number) => `Description for item number ${number}`,
-      itemHelpText: (number) => `Help text for item number ${number}`,
-      itemLabel: (number) => `Label for item number ${number}`,
-      itemValue: (number) => `Value for item number ${number}`,
-      label: 'Label',
-      value: 'Value',
-    },
+    codeList: codeListWithoutTextResources,
+    texts,
   },
 };

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditor.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditor.test.tsx
@@ -2,55 +2,17 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import type { StudioCodeListEditorProps } from './StudioCodeListEditor';
 import { StudioCodeListEditor } from './StudioCodeListEditor';
-import type { CodeListEditorTexts } from './types/CodeListEditorTexts';
 import type { CodeList } from './types/CodeList';
 import userEvent from '@testing-library/user-event';
+import { codeListWithoutTextResources } from './test-data/codeListWithoutTextResources';
+import { texts } from './test-data/texts';
 
 // Test data:
-const texts: CodeListEditorTexts = {
-  add: 'Add',
-  codeList: 'Code list',
-  delete: 'Delete',
-  deleteItem: (number) => `Delete item number ${number}`,
-  description: 'Description',
-  emptyCodeList: 'The code list is empty.',
-  valueErrors: {
-    duplicateValue: 'The value must be unique.',
-  },
-  generalError: 'The code list cannot be saved because it is not valid.',
-  helpText: 'Help text',
-  itemDescription: (number) => `Description for item number ${number}`,
-  itemHelpText: (number) => `Help text for item number ${number}`,
-  itemLabel: (number) => `Label for item number ${number}`,
-  itemValue: (number) => `Value for item number ${number}`,
-  label: 'Label',
-  value: 'Value',
-};
-const codeList: CodeList = [
-  {
-    label: 'Test 1',
-    value: 'test1',
-    description: 'Test 1 description',
-    helpText: 'Test 1 help text',
-  },
-  {
-    label: 'Test 2',
-    value: 'test2',
-    description: 'Test 2 description',
-    helpText: 'Test 2 help text',
-  },
-  {
-    label: 'Test 3',
-    value: 'test3',
-    description: 'Test 3 description',
-    helpText: 'Test 3 help text',
-  },
-];
 const onBlurAny = jest.fn();
 const onChange = jest.fn();
 const onInvalid = jest.fn();
 const defaultProps: StudioCodeListEditorProps = {
-  codeList,
+  codeList: codeListWithoutTextResources,
   texts,
   onBlurAny,
   onChange,
@@ -91,7 +53,7 @@ describe('StudioCodeListEditor', () => {
   it('Renders a table of code list items', () => {
     renderCodeListEditor();
     expect(screen.getByRole('table')).toBeInTheDocument();
-    const numberOfCodeListItems = codeList.length;
+    const numberOfCodeListItems = codeListWithoutTextResources.length;
     const expectedNumberOfRows = numberOfCodeListItems + numberOfHeadingRows;
     expect(screen.getAllByRole('row')).toHaveLength(expectedNumberOfRows);
   });
@@ -123,9 +85,9 @@ describe('StudioCodeListEditor', () => {
     await user.type(labelInput, newValue);
     expect(onChange).toHaveBeenCalledTimes(newValue.length);
     expect(onChange).toHaveBeenLastCalledWith([
-      { ...codeList[0], label: newValue },
-      codeList[1],
-      codeList[2],
+      { ...codeListWithoutTextResources[0], label: newValue },
+      codeListWithoutTextResources[1],
+      codeListWithoutTextResources[2],
     ]);
   });
 
@@ -137,9 +99,9 @@ describe('StudioCodeListEditor', () => {
     await user.type(valueInput, newValue);
     expect(onChange).toHaveBeenCalledTimes(newValue.length);
     expect(onChange).toHaveBeenLastCalledWith([
-      { ...codeList[0], value: newValue },
-      codeList[1],
-      codeList[2],
+      { ...codeListWithoutTextResources[0], value: newValue },
+      codeListWithoutTextResources[1],
+      codeListWithoutTextResources[2],
     ]);
   });
 
@@ -151,9 +113,9 @@ describe('StudioCodeListEditor', () => {
     await user.type(descriptionInput, newValue);
     expect(onChange).toHaveBeenCalledTimes(newValue.length);
     expect(onChange).toHaveBeenLastCalledWith([
-      { ...codeList[0], description: newValue },
-      codeList[1],
-      codeList[2],
+      { ...codeListWithoutTextResources[0], description: newValue },
+      codeListWithoutTextResources[1],
+      codeListWithoutTextResources[2],
     ]);
   });
 
@@ -165,9 +127,9 @@ describe('StudioCodeListEditor', () => {
     await user.type(helpTextInput, newValue);
     expect(onChange).toHaveBeenCalledTimes(newValue.length);
     expect(onChange).toHaveBeenLastCalledWith([
-      { ...codeList[0], helpText: newValue },
-      codeList[1],
-      codeList[2],
+      { ...codeListWithoutTextResources[0], helpText: newValue },
+      codeListWithoutTextResources[1],
+      codeListWithoutTextResources[2],
     ]);
   });
 
@@ -177,7 +139,10 @@ describe('StudioCodeListEditor', () => {
     const deleteButton = screen.getByRole('button', { name: texts.deleteItem(1) });
     await user.click(deleteButton);
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith([codeList[1], codeList[2]]);
+    expect(onChange).toHaveBeenCalledWith([
+      codeListWithoutTextResources[1],
+      codeListWithoutTextResources[2],
+    ]);
   });
 
   it('Calls the onChange callback with the new code list when an item is added', async () => {
@@ -186,7 +151,7 @@ describe('StudioCodeListEditor', () => {
     await userEvent.click(addButton);
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith([
-      ...codeList,
+      ...codeListWithoutTextResources,
       {
         label: '',
         value: '',
@@ -203,16 +168,16 @@ describe('StudioCodeListEditor', () => {
     await user.tab();
     expect(onBlurAny).toHaveBeenCalledTimes(1);
     expect(onBlurAny).toHaveBeenLastCalledWith([
-      { ...codeList[0], value: newValue },
-      codeList[1],
-      codeList[2],
+      { ...codeListWithoutTextResources[0], value: newValue },
+      codeListWithoutTextResources[1],
+      codeListWithoutTextResources[2],
     ]);
   });
 
   it('Updates itself when the user changes something', async () => {
     const user = userEvent.setup();
     renderCodeListEditor();
-    const numberOfCodeListItems = codeList.length;
+    const numberOfCodeListItems = codeListWithoutTextResources.length;
     const expectedNumberOfRows = numberOfCodeListItems + numberOfHeadingRows;
     const addButton = screen.getByRole('button', { name: texts.add });
     await user.click(addButton);
@@ -233,7 +198,7 @@ describe('StudioCodeListEditor', () => {
       },
     ];
     const { rerender } = renderCodeListEditor();
-    const numberOfCodeListItems = codeList.length;
+    const numberOfCodeListItems = codeListWithoutTextResources.length;
     const expectedNumberOfRows = numberOfCodeListItems + numberOfHeadingRows;
     expect(screen.getAllByRole('row')).toHaveLength(expectedNumberOfRows);
     rerender(<StudioCodeListEditor {...defaultProps} codeList={newCodeList} />);

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/test-data/codeListWithoutTextResources.ts
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/test-data/codeListWithoutTextResources.ts
@@ -1,0 +1,25 @@
+import type { CodeList } from '../types/CodeList';
+import type { CodeListItem } from '../types/CodeListItem';
+
+const item1: CodeListItem = {
+  description: 'Test 1 description',
+  helpText: 'Test 1 help text',
+  label: 'Test 1',
+  value: 'test1',
+};
+
+const item2: CodeListItem = {
+  description: 'Test 2 description',
+  helpText: 'Test 2 help text',
+  label: 'Test 2',
+  value: 'test2',
+};
+
+const item3: CodeListItem = {
+  description: 'Test 3 description',
+  helpText: 'Test 3 help text',
+  label: 'Test 3',
+  value: 'test3',
+};
+
+export const codeListWithoutTextResources: CodeList = [item1, item2, item3];

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/test-data/texts.ts
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/test-data/texts.ts
@@ -1,0 +1,23 @@
+import type { CodeListEditorTexts, ValueErrorMessages } from '../types/CodeListEditorTexts';
+
+const valueErrors: ValueErrorMessages = {
+  duplicateValue: 'The value must be unique.',
+};
+
+export const texts: CodeListEditorTexts = {
+  add: 'Add',
+  codeList: 'Code list',
+  delete: 'Delete',
+  deleteItem: (number) => `Delete item number ${number}`,
+  description: 'Description',
+  emptyCodeList: 'The code list is empty.',
+  generalError: 'The code list cannot be saved because it is not valid.',
+  helpText: 'Help text',
+  itemDescription: (number) => `Description for item number ${number}`,
+  itemHelpText: (number) => `Help text for item number ${number}`,
+  itemLabel: (number) => `Label for item number ${number}`,
+  itemValue: (number) => `Value for item number ${number}`,
+  label: 'Label',
+  value: 'Value',
+  valueErrors,
+};

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/types/CodeListEditorTexts.ts
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/types/CodeListEditorTexts.ts
@@ -18,4 +18,4 @@ export type CodeListEditorTexts = {
   value: string;
 };
 
-type ValueErrorMessages = Record<ValueError, string>;
+export type ValueErrorMessages = Record<ValueError, string>;


### PR DESCRIPTION
## Description
Collected the test data for the code list editor in one folder. Now the unit tests and Storybook use the same data.

As this will be extended with a version with text resources, I have changed the name of the `codeList` test array to `codeListWithoutTextResources`.

## Related Issue(s)
- #13739

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)