### PR TITLE
feat: enable visualization of code list usage in library

### DIFF
--- a/frontend/app-development/features/appContentLibrary/AppContentLibrary.test.tsx
+++ b/frontend/app-development/features/appContentLibrary/AppContentLibrary.test.tsx
@@ -63,7 +63,7 @@ describe('AppContentLibrary', () => {
   });
 
   it('renders a spinner when waiting for option lists', () => {
-    renderAppContentLibrary({ optionListsData: [] });
+    renderAppContentLibrary({ shouldPutDataOnCache: false });
     const spinner = screen.getByText(textMock('general.loading'));
     expect(spinner).toBeInTheDocument();
   });
@@ -146,16 +146,19 @@ const goToLibraryPage = async (user: UserEvent, libraryPage: string) => {
 
 type renderAppContentLibraryProps = {
   queries?: Partial<ServicesContextProps>;
+  shouldPutDataOnCache?: boolean;
   optionListsData?: OptionsListsResponse;
 };
 
 const renderAppContentLibrary = ({
   queries = {},
+  shouldPutDataOnCache = true,
   optionListsData = optionListsDataMock,
 }: renderAppContentLibraryProps = {}) => {
   const queryClientMock = createQueryClientMock();
-  if (optionListsData.length) {
+  if (shouldPutDataOnCache) {
     queryClientMock.setQueryData([QueryKey.OptionLists, org, app], optionListsData);
+    queryClientMock.setQueryData([QueryKey.OptionListsUsage, org, app], []);
   }
   renderWithProviders(queries, queryClientMock)(<AppContentLibrary />);
 };

--- a/frontend/app-development/features/appContentLibrary/AppContentLibrary.tsx
+++ b/frontend/app-development/features/appContentLibrary/AppContentLibrary.tsx
@@ -39,8 +39,8 @@ export function AppContentLibrary(): React.ReactElement {
   const codeListsData = convertOptionsListsDataToCodeListsData(optionListsData);
 
   const codeListsUsages: CodeListReference[] =
-      convertOptionListsUsageToCodeListsUsage(optionListsUsage);
-  
+    convertOptionListsUsageToCodeListsUsage(optionListsUsage);
+
   const handleUpdateCodeListId = (optionListId: string, newOptionListId: string) => {
     updateOptionListId({ optionListId, newOptionListId });
   };

--- a/frontend/app-development/features/appContentLibrary/AppContentLibrary.tsx
+++ b/frontend/app-development/features/appContentLibrary/AppContentLibrary.tsx
@@ -1,7 +1,7 @@
 import type { CodeListReference, CodeListWithMetadata } from '@studio/content-library';
 import { ResourceContentLibraryImpl } from '@studio/content-library';
 import React from 'react';
-import { useOptionListsQuery } from 'app-shared/hooks/queries';
+import { useOptionListsQuery, useOptionListsReferencesQuery } from 'app-shared/hooks/queries';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { convertOptionsListsDataToCodeListsData } from './utils/convertOptionsListsDataToCodeListsData';
 import { StudioPageSpinner } from '@studio/components';
@@ -15,8 +15,7 @@ import {
   useUpdateOptionListMutation,
   useUpdateOptionListIdMutation,
 } from 'app-shared/hooks/mutations';
-import { useOptionListsReferencesQuery } from 'app-shared/hooks/queries';
-import { convertOptionListsUsageToCodeListsUsage } from './utils/convertOptionListsUsageToCodeListsUsage';
+import { mapToCodeListsUsage } from './utils/mapToCodeListsUsage';
 
 export function AppContentLibrary(): React.ReactElement {
   const { org, app } = useStudioEnvironmentParams();
@@ -30,16 +29,15 @@ export function AppContentLibrary(): React.ReactElement {
   });
   const { mutate: updateOptionList } = useUpdateOptionListMutation(org, app);
   const { mutate: updateOptionListId } = useUpdateOptionListIdMutation(org, app);
-  const { data: optionListsUsage, isPending: optionListsUsageIsPending } =
+  const { data: optionListsUsages, isPending: optionListsUsageIsPending } =
     useOptionListsReferencesQuery(org, app);
-  
+
   if (optionListsDataPending || optionListsUsageIsPending)
     return <StudioPageSpinner spinnerTitle={t('general.loading')}></StudioPageSpinner>;
 
   const codeListsData = convertOptionsListsDataToCodeListsData(optionListsData);
 
-  const codeListsUsages: CodeListReference[] =
-    convertOptionListsUsageToCodeListsUsage(optionListsUsage);
+  const codeListsUsages: CodeListReference[] = mapToCodeListsUsage({ optionListsUsages });
 
   const handleUpdateCodeListId = (optionListId: string, newOptionListId: string) => {
     updateOptionListId({ optionListId, newOptionListId });

--- a/frontend/app-development/features/appContentLibrary/utils/convertOptionListsUsageToCodeListsUsage.test.ts
+++ b/frontend/app-development/features/appContentLibrary/utils/convertOptionListsUsageToCodeListsUsage.test.ts
@@ -1,0 +1,35 @@
+import type { CodeListIdSource } from '@studio/content-library';
+import { convertOptionListsUsageToCodeListsUsage } from './convertOptionListsUsageToCodeListsUsage';
+import type { OptionListsReferences } from 'app-shared/types/api/OptionsLists';
+
+const optionListId: string = 'optionListId';
+const optionListIdSources: CodeListIdSource[] = [
+  {
+    layoutSetId: 'layoutSetId',
+    layoutName: 'layoutName',
+    componentIds: ['componentId1', 'componentId2'],
+  },
+];
+const optionListsUsage: OptionListsReferences = [
+  {
+    optionListId,
+    optionListIdSources,
+  },
+];
+
+describe('convertOptionListsUsageToCodeListsUsage', () => {
+  it('converts optionListsUsage to codeListUsage', () => {
+    const codeListUsage = convertOptionListsUsageToCodeListsUsage(optionListsUsage);
+    expect(codeListUsage).toEqual([
+      {
+        codeListId: optionListId,
+        codeListIdSources: optionListIdSources,
+      },
+    ]);
+  });
+
+  it('converts undefined optionListsUsage to empty array', () => {
+    const codeListUsage = convertOptionListsUsageToCodeListsUsage(undefined);
+    expect(codeListUsage).toEqual([]);
+  });
+});

--- a/frontend/app-development/features/appContentLibrary/utils/convertOptionListsUsageToCodeListsUsage.ts
+++ b/frontend/app-development/features/appContentLibrary/utils/convertOptionListsUsageToCodeListsUsage.ts
@@ -1,0 +1,15 @@
+import type { OptionListsReferences } from 'app-shared/types/api/OptionsLists';
+import type { CodeListReference } from '@studio/content-library';
+
+export const convertOptionListsUsageToCodeListsUsage = (
+  optionListsUsages: OptionListsReferences,
+): CodeListReference[] => {
+  const codeListsUsages: CodeListReference[] = [];
+  optionListsUsages.map((optionListsUsage) =>
+    codeListsUsages.push({
+      codeListId: optionListsUsage.optionListId,
+      codeListIdSources: optionListsUsage.optionListIdSources,
+    }),
+  );
+  return codeListsUsages;
+};

--- a/frontend/app-development/features/appContentLibrary/utils/convertOptionListsUsageToCodeListsUsage.ts
+++ b/frontend/app-development/features/appContentLibrary/utils/convertOptionListsUsageToCodeListsUsage.ts
@@ -5,6 +5,7 @@ export const convertOptionListsUsageToCodeListsUsage = (
   optionListsUsages: OptionListsReferences,
 ): CodeListReference[] => {
   const codeListsUsages: CodeListReference[] = [];
+  if (!optionListsUsages) return codeListsUsages;
   optionListsUsages.map((optionListsUsage) =>
     codeListsUsages.push({
       codeListId: optionListsUsage.optionListId,

--- a/frontend/app-development/features/appContentLibrary/utils/mapToCodeListsUsage.test.ts
+++ b/frontend/app-development/features/appContentLibrary/utils/mapToCodeListsUsage.test.ts
@@ -1,5 +1,5 @@
 import type { CodeListIdSource } from '@studio/content-library';
-import { convertOptionListsUsageToCodeListsUsage } from './convertOptionListsUsageToCodeListsUsage';
+import { mapToCodeListsUsage } from './mapToCodeListsUsage';
 import type { OptionListsReferences } from 'app-shared/types/api/OptionsLists';
 
 const optionListId: string = 'optionListId';
@@ -10,16 +10,16 @@ const optionListIdSources: CodeListIdSource[] = [
     componentIds: ['componentId1', 'componentId2'],
   },
 ];
-const optionListsUsage: OptionListsReferences = [
+const optionListsUsages: OptionListsReferences = [
   {
     optionListId,
     optionListIdSources,
   },
 ];
 
-describe('convertOptionListsUsageToCodeListsUsage', () => {
-  it('converts optionListsUsage to codeListUsage', () => {
-    const codeListUsage = convertOptionListsUsageToCodeListsUsage(optionListsUsage);
+describe('mapToCodeListsUsage', () => {
+  it('maps optionListsUsage to codeListUsage', () => {
+    const codeListUsage = mapToCodeListsUsage({ optionListsUsages });
     expect(codeListUsage).toEqual([
       {
         codeListId: optionListId,
@@ -28,8 +28,8 @@ describe('convertOptionListsUsageToCodeListsUsage', () => {
     ]);
   });
 
-  it('converts undefined optionListsUsage to empty array', () => {
-    const codeListUsage = convertOptionListsUsageToCodeListsUsage(undefined);
+  it('maps undefined optionListsUsage to empty array', () => {
+    const codeListUsage = mapToCodeListsUsage({ optionListsUsages: undefined });
     expect(codeListUsage).toEqual([]);
   });
 });

--- a/frontend/app-development/features/appContentLibrary/utils/mapToCodeListsUsage.ts
+++ b/frontend/app-development/features/appContentLibrary/utils/mapToCodeListsUsage.ts
@@ -1,9 +1,13 @@
 import type { OptionListsReferences } from 'app-shared/types/api/OptionsLists';
 import type { CodeListReference } from '@studio/content-library';
 
-export const convertOptionListsUsageToCodeListsUsage = (
-  optionListsUsages: OptionListsReferences,
-): CodeListReference[] => {
+type MapToCodeListsUsageProps = {
+  optionListsUsages: OptionListsReferences;
+};
+
+export const mapToCodeListsUsage = ({
+  optionListsUsages,
+}: MapToCodeListsUsageProps): CodeListReference[] => {
   const codeListsUsages: CodeListReference[] = [];
   if (!optionListsUsages) return codeListsUsages;
   optionListsUsages.map((optionListsUsage) =>

--- a/frontend/libs/studio-content-library/mocks/mockPagesConfig.ts
+++ b/frontend/libs/studio-content-library/mocks/mockPagesConfig.ts
@@ -15,6 +15,7 @@ export const mockPagesConfig: PagesConfig = {
       onUpdateCodeListId: () => {},
       onUpdateCodeList: () => {},
       onUploadCodeList: () => {},
+      codeListsUsages: [],
     },
   },
   images: {

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.test.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.test.tsx
@@ -154,7 +154,7 @@ const defaultCodeListPageProps: CodeListPageProps = {
   onUpdateCodeListId: onUpdateCodeListIdMock,
   onUpdateCodeList: onUpdateCodeListMock,
   onUploadCodeList: onUploadCodeListMock,
-  codeListsUsages: []
+  codeListsUsages: [],
 };
 
 const renderCodeListPage = (props: Partial<CodeListPageProps> = {}) => {

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.test.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.test.tsx
@@ -154,6 +154,7 @@ const defaultCodeListPageProps: CodeListPageProps = {
   onUpdateCodeListId: onUpdateCodeListIdMock,
   onUpdateCodeList: onUpdateCodeListMock,
   onUploadCodeList: onUploadCodeListMock,
+  codeListsUsages: []
 };
 
 const renderCodeListPage = (props: Partial<CodeListPageProps> = {}) => {

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.tsx
@@ -7,6 +7,7 @@ import { CodeLists } from './CodeLists';
 import { CodeListsCounterMessage } from './CodeListsCounterMessage';
 import classes from './CodeListPage.module.css';
 import { ArrayUtils, FileNameUtils } from '@studio/pure-functions';
+import type { CodeListReference } from './types/CodeListReference';
 
 export type CodeListWithMetadata = {
   codeList: CodeList;
@@ -24,6 +25,7 @@ export type CodeListPageProps = {
   onUpdateCodeListId: (codeListId: string, newCodeListId: string) => void;
   onUpdateCodeList: (updatedCodeList: CodeListWithMetadata) => void;
   onUploadCodeList: (uploadedCodeList: File) => void;
+  codeListsUsages: CodeListReference[];
 };
 
 export function CodeListPage({
@@ -31,6 +33,7 @@ export function CodeListPage({
   onUpdateCodeListId,
   onUpdateCodeList,
   onUploadCodeList,
+  codeListsUsages,
 }: CodeListPageProps): React.ReactElement {
   const { t } = useTranslation();
   const [codeListInEditMode, setCodeListInEditMode] = useState<string>(undefined);
@@ -62,6 +65,7 @@ export function CodeListPage({
         onUpdateCodeList={onUpdateCodeList}
         codeListInEditMode={codeListInEditMode}
         codeListNames={codeListTitles}
+        codeListsUsages={codeListsUsages}
       />
     </div>
   );

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.test.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import type { CodeListsProps } from './CodeLists';
-import { updateCodeListWithMetadata, CodeLists } from './CodeLists';
+import { getCodeListSourcesById, updateCodeListWithMetadata, CodeLists } from './CodeLists';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import type { CodeListWithMetadata } from '../CodeListPage';
 import type { RenderResult } from '@testing-library/react';
@@ -9,6 +9,7 @@ import type { UserEvent } from '@testing-library/user-event';
 import userEvent from '@testing-library/user-event';
 import type { CodeList as StudioComponentsCodeList } from '@studio/components';
 import { codeListsDataMock } from '../../../../../../mocks/mockPagesConfig';
+import type { CodeListIdSource, CodeListReference } from '../types/CodeListReference';
 
 const codeListName = codeListsDataMock[0].title;
 const onUpdateCodeListIdMock = jest.fn();
@@ -124,6 +125,7 @@ const defaultProps: CodeListsProps = {
   onUpdateCodeList: onUpdateCodeListMock,
   codeListInEditMode: undefined,
   codeListNames: [],
+  codeListsUsages: [],
 };
 
 const renderCodeLists = (props: Partial<CodeListsProps> = {}): RenderResult => {
@@ -154,5 +156,39 @@ describe('updateCodeListWithMetadata', () => {
       title: codeListsDataMock[0].title,
       codeList: updatedCodeList,
     });
+  });
+});
+
+const codeListId1: string = 'codeListId1';
+const codeListId2: string = 'codeListId2';
+const componentIds: string[] = ['componentId1', 'componentId2'];
+const codeListIdSources1: CodeListIdSource[] = [
+  { layoutSetId: 'layoutSetId', layoutName: 'layoutName', componentIds },
+];
+const codeListIdSources2: CodeListIdSource[] = [...codeListIdSources1];
+
+describe('getCodeListSourcesById', () => {
+  it('returns an array of CodeListSources if given Id is present in codeListsUsages array', () => {
+    const codeListUsages: CodeListReference[] = [
+      { codeListId: codeListId1, codeListIdSources: codeListIdSources1 },
+      { codeListId: codeListId2, codeListIdSources: codeListIdSources2 },
+    ];
+    const codeListSources = getCodeListSourcesById(codeListUsages, codeListId1);
+
+    expect(codeListSources).toBe(codeListIdSources1);
+    expect(codeListSources).not.toBe(codeListIdSources2);
+  });
+
+  it('returns an empty array if given Id is not present in codeListsUsages array', () => {
+    const codeListUsages: CodeListReference[] = [
+      { codeListId: codeListId2, codeListIdSources: codeListIdSources2 },
+    ];
+    const codeListSources = getCodeListSourcesById(codeListUsages, codeListId1);
+    expect(codeListSources).toEqual([]);
+  });
+
+  it('returns an empty array if codeListsUsages array is empty', () => {
+    const codeListSources = getCodeListSourcesById([], codeListId1);
+    expect(codeListSources).toEqual([]);
   });
 });

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
@@ -24,17 +24,19 @@ export function CodeLists({
   codeListsUsages,
 }: CodeListsProps) {
   return codeListsData.map((codeListData) => {
-        const codeListSources = getCodeListSourcesById(codeListsUsages, codeListData.title);
-        return <CodeList
-            key={codeListData.title}
-            codeListData={codeListData}
-            onUpdateCodeListId={onUpdateCodeListId}
-            onUpdateCodeList={onUpdateCodeList}
-            codeListInEditMode={codeListInEditMode}
-            codeListNames={codeListNames}
-            codeListSources={codeListSources}
-        />
-      });
+    const codeListSources = getCodeListSourcesById(codeListsUsages, codeListData.title);
+    return (
+      <CodeList
+        key={codeListData.title}
+        codeListData={codeListData}
+        onUpdateCodeListId={onUpdateCodeListId}
+        onUpdateCodeList={onUpdateCodeList}
+        codeListInEditMode={codeListInEditMode}
+        codeListNames={codeListNames}
+        codeListSources={codeListSources}
+      />
+    );
+  });
 }
 
 export const getCodeListSourcesById = (
@@ -47,7 +49,10 @@ export const getCodeListSourcesById = (
   return codeListUsages?.codeListIdSources ?? [];
 };
 
-type CodeListProps = Omit<CodeListsProps, 'codeListsData' | 'codeListsUsages'> & { codeListData: CodeListData, codeListSources: CodeListIdSource[] };
+type CodeListProps = Omit<CodeListsProps, 'codeListsData' | 'codeListsUsages'> & {
+  codeListData: CodeListData;
+  codeListSources: CodeListIdSource[];
+};
 
 function CodeList({
   codeListData,

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
@@ -37,14 +37,14 @@ export function CodeLists({
       });
 }
 
-const getCodeListSourcesById = (
-    codeListsUsages: CodeListReference[],
-    codeListTitle: string,
+export const getCodeListSourcesById = (
+  codeListsUsages: CodeListReference[],
+  codeListTitle: string,
 ): CodeListIdSource[] => {
-  const codeListUsages = codeListsUsages?.find(
-      (codeListUsage) => codeListUsage.codeListId === codeListTitle,
+  const codeListUsages: CodeListReference | undefined = codeListsUsages.find(
+    (codeListUsage) => codeListUsage.codeListId === codeListTitle,
   );
-  return codeListUsages?.codeListIdSources;
+  return codeListUsages?.codeListIdSources ?? [];
 };
 
 type CodeListProps = Omit<CodeListsProps, 'codeListsData' | 'codeListsUsages'> & { codeListData: CodeListData, codeListSources: CodeListIdSource[] };

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
@@ -4,6 +4,7 @@ import { Accordion } from '@digdir/designsystemet-react';
 import { StudioAlert, type CodeList as StudioComponentsCodeList } from '@studio/components';
 import { EditCodeList } from './EditCodeList/EditCodeList';
 import { useTranslation } from 'react-i18next';
+import type { CodeListIdSource, CodeListReference } from '../types/CodeListReference';
 
 export type CodeListsProps = {
   codeListsData: CodeListData[];
@@ -11,6 +12,7 @@ export type CodeListsProps = {
   onUpdateCodeList: (updatedCodeList: CodeListWithMetadata) => void;
   codeListInEditMode: string | undefined;
   codeListNames: string[];
+  codeListsUsages: CodeListReference[];
 };
 
 export function CodeLists({
@@ -19,20 +21,33 @@ export function CodeLists({
   onUpdateCodeList,
   codeListInEditMode,
   codeListNames,
+  codeListsUsages,
 }: CodeListsProps) {
-  return codeListsData.map((codeListData) => (
-    <CodeList
-      key={codeListData.title}
-      codeListData={codeListData}
-      onUpdateCodeListId={onUpdateCodeListId}
-      onUpdateCodeList={onUpdateCodeList}
-      codeListInEditMode={codeListInEditMode}
-      codeListNames={codeListNames}
-    />
-  ));
+  return codeListsData.map((codeListData) => {
+        const codeListSources = getCodeListSourcesById(codeListsUsages, codeListData.title);
+        return <CodeList
+            key={codeListData.title}
+            codeListData={codeListData}
+            onUpdateCodeListId={onUpdateCodeListId}
+            onUpdateCodeList={onUpdateCodeList}
+            codeListInEditMode={codeListInEditMode}
+            codeListNames={codeListNames}
+            codeListSources={codeListSources}
+        />
+      });
 }
 
-type CodeListProps = Omit<CodeListsProps, 'codeListsData'> & { codeListData: CodeListData };
+const getCodeListSourcesById = (
+    codeListsUsages: CodeListReference[],
+    codeListTitle: string,
+): CodeListIdSource[] => {
+  const codeListUsages = codeListsUsages?.find(
+      (codeListUsage) => codeListUsage.codeListId === codeListTitle,
+  );
+  return codeListUsages?.codeListIdSources;
+};
+
+type CodeListProps = Omit<CodeListsProps, 'codeListsData' | 'codeListsUsages'> & { codeListData: CodeListData, codeListSources: CodeListIdSource[] };
 
 function CodeList({
   codeListData,
@@ -40,6 +55,7 @@ function CodeList({
   onUpdateCodeList,
   codeListInEditMode,
   codeListNames,
+  codeListSources,
 }: CodeListProps) {
   const { t } = useTranslation();
 
@@ -58,6 +74,7 @@ function CodeList({
           onUpdateCodeListId={onUpdateCodeListId}
           onUpdateCodeList={onUpdateCodeList}
           codeListNames={codeListNames}
+          codeListSources={codeListSources}
         />
       </Accordion.Item>
     </Accordion>
@@ -71,6 +88,7 @@ function CodeListAccordionContent({
   onUpdateCodeListId,
   onUpdateCodeList,
   codeListNames,
+  codeListSources,
 }: CodeListAccordionContentProps): React.ReactElement {
   const { t } = useTranslation();
 

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/index.ts
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/index.ts
@@ -1,2 +1,3 @@
 export { CodeListPage } from './CodeListPage';
 export type { CodeListWithMetadata, CodeListData, CodeListPageProps } from './CodeListPage';
+export type { CodeListIdSource, CodeListReference } from './types/CodeListReference';

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/types/CodeListReference.ts
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/types/CodeListReference.ts
@@ -1,0 +1,10 @@
+export type CodeListReference = {
+  codeListId: string;
+  codeListIdSources: CodeListIdSource[];
+};
+
+export type CodeListIdSource = {
+  layoutSetId: string;
+  layoutName: string;
+  componentIds: string[];
+};

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/index.ts
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/index.ts
@@ -1,1 +1,6 @@
-export type { CodeListWithMetadata, CodeListData,  CodeListIdSource, CodeListReference } from './CodeListPage';
+export type {
+  CodeListWithMetadata,
+  CodeListData,
+  CodeListIdSource,
+  CodeListReference,
+} from './CodeListPage';

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/index.ts
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/index.ts
@@ -1,1 +1,1 @@
-export type { CodeListWithMetadata, CodeListData } from './CodeListPage';
+export type { CodeListWithMetadata, CodeListData,  CodeListIdSource, CodeListReference } from './CodeListPage';

--- a/frontend/libs/studio-content-library/src/index.ts
+++ b/frontend/libs/studio-content-library/src/index.ts
@@ -1,2 +1,3 @@
 export { ResourceContentLibraryImpl } from './config/ContentResourceLibraryImpl';
-export type { CodeListWithMetadata, CodeListData } from './ContentLibrary/LibraryBody/pages';
+export type { CodeListWithMetadata, CodeListData, CodeListIdSource,
+  CodeListReference, } from './ContentLibrary/LibraryBody/pages';

--- a/frontend/libs/studio-content-library/src/index.ts
+++ b/frontend/libs/studio-content-library/src/index.ts
@@ -1,3 +1,7 @@
 export { ResourceContentLibraryImpl } from './config/ContentResourceLibraryImpl';
-export type { CodeListWithMetadata, CodeListData, CodeListIdSource,
-  CodeListReference, } from './ContentLibrary/LibraryBody/pages';
+export type {
+  CodeListWithMetadata,
+  CodeListData,
+  CodeListIdSource,
+  CodeListReference,
+} from './ContentLibrary/LibraryBody/pages';

--- a/frontend/packages/shared/src/api/paths.js
+++ b/frontend/packages/shared/src/api/paths.js
@@ -43,6 +43,7 @@ export const ruleHandlerPath = (org, app, layoutSetName) => `${basePath}/${org}/
 export const widgetSettingsPath = (org, app) => `${basePath}/${org}/${app}/app-development/widget-settings`; // Get
 export const optionListPath = (org, app, optionsListId) => `${basePath}/${org}/${app}/options/${optionsListId}`; // Get
 export const optionListsPath = (org, app) => `${basePath}/${org}/${app}/options/option-lists`; // Get
+export const optionListReferencesPath = (org, app) => `${basePath}/${org}/${app}/options/usage`; // Get
 export const optionListIdsPath = (org, app) => `${basePath}/${org}/${app}/app-development/option-list-ids`; // Get
 export const optionListUpdatePath = (org, app, optionsListId) => `${basePath}/${org}/${app}/options/${optionsListId}`; // Put
 export const optionListIdUpdatePath = (org, app, optionsListId) => `${basePath}/${org}/${app}/options/change-name/${optionsListId}`; // Put

--- a/frontend/packages/shared/src/api/queries.ts
+++ b/frontend/packages/shared/src/api/queries.ts
@@ -58,6 +58,7 @@ import {
   selectedMaskinportenScopesPath,
   resourceAccessPackageServicesPath,
   optionListPath,
+  optionListReferencesPath,
 } from './paths';
 
 import type { AppReleasesResponse, DataModelMetadataResponse, SearchRepoFilterParams, SearchRepositoryResponse } from 'app-shared/types/api';
@@ -118,6 +119,7 @@ export const getLayoutSets = (owner: string, app: string) => get<LayoutSets>(lay
 export const getLayoutSetsExtended = (owner: string, app: string) => get<LayoutSetsModel>(layoutSetsPath(owner, app) + '/extended');
 export const getOptionList = (owner: string, app: string, optionsListId: string) => get<OptionsList>(optionListPath(owner, app, optionsListId));
 export const getOptionLists = (owner: string, app: string) => get<OptionsListsResponse>(optionListsPath(owner, app));
+export const getOptionListsReferences = (owner: string, app: string) => get<any>(optionListReferencesPath(owner, app));
 export const getOptionListIds = (owner: string, app: string) => get<string[]>(optionListIdsPath(owner, app));
 export const getOrgList = () => get<OrgList>(orgListUrl());
 export const getOrganizations = () => get<Organization[]>(orgsListPath());

--- a/frontend/packages/shared/src/api/queries.ts
+++ b/frontend/packages/shared/src/api/queries.ts
@@ -90,7 +90,7 @@ import type { Policy } from 'app-shared/types/Policy';
 import type { RepoDiffResponse } from 'app-shared/types/api/RepoDiffResponse';
 import type { ExternalImageUrlValidationResponse } from 'app-shared/types/api/ExternalImageUrlValidationResponse';
 import type { MaskinportenScopes } from 'app-shared/types/MaskinportenScope';
-import type { OptionsList, OptionsListsResponse } from 'app-shared/types/api/OptionsLists';
+import type { OptionListsReferences, OptionsList, OptionsListsResponse } from 'app-shared/types/api/OptionsLists';
 import type { LayoutSetsModel } from '../types/api/dto/LayoutSetsModel';
 import type { AccessPackageResource, PolicyAccessPackageAreaGroup } from 'app-shared/types/PolicyAccessPackages';
 
@@ -119,7 +119,7 @@ export const getLayoutSets = (owner: string, app: string) => get<LayoutSets>(lay
 export const getLayoutSetsExtended = (owner: string, app: string) => get<LayoutSetsModel>(layoutSetsPath(owner, app) + '/extended');
 export const getOptionList = (owner: string, app: string, optionsListId: string) => get<OptionsList>(optionListPath(owner, app, optionsListId));
 export const getOptionLists = (owner: string, app: string) => get<OptionsListsResponse>(optionListsPath(owner, app));
-export const getOptionListsReferences = (owner: string, app: string) => get<any>(optionListReferencesPath(owner, app));
+export const getOptionListsReferences = (owner: string, app: string) => get<OptionListsReferences>(optionListReferencesPath(owner, app));
 export const getOptionListIds = (owner: string, app: string) => get<string[]>(optionListIdsPath(owner, app));
 export const getOrgList = () => get<OrgList>(orgListUrl());
 export const getOrganizations = () => get<Organization[]>(orgsListPath());

--- a/frontend/packages/shared/src/hooks/queries/index.ts
+++ b/frontend/packages/shared/src/hooks/queries/index.ts
@@ -4,6 +4,7 @@ export { useDataModelsJsonQuery } from './useDataModelsJsonQuery';
 export { useDataModelsXsdQuery } from './useDataModelsXsdQuery';
 export { useOptionListQuery } from './useOptionListQuery';
 export { useOptionListsQuery } from './useOptionListsQuery';
+export { useOptionListsReferencesQuery } from './useOptionListsReferencesQuery';
 export { useRepoMetadataQuery } from './useRepoMetadataQuery';
 export { useRepoPullQuery } from './useRepoPullQuery';
 export { useRepoStatusQuery } from './useRepoStatusQuery';

--- a/frontend/packages/shared/src/hooks/queries/useOptionListsReferencesQuery.test.ts
+++ b/frontend/packages/shared/src/hooks/queries/useOptionListsReferencesQuery.test.ts
@@ -1,0 +1,18 @@
+import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { app, org } from '@studio/testing/testids';
+import { renderHookWithProviders } from 'app-shared/mocks/renderHookWithProviders';
+import { waitFor } from '@testing-library/react';
+import { useOptionListsReferencesQuery } from './useOptionListsReferencesQuery';
+
+describe('useOptionListsReferencesQuery', () => {
+  it('calls getOptionListsReferences with the correct parameters', () => {
+    render();
+    expect(queriesMock.getOptionListsReferences).toHaveBeenCalledWith(org, app);
+  });
+});
+
+const render = async () => {
+  const { result } = renderHookWithProviders(() => useOptionListsReferencesQuery(org, app));
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  return result;
+};

--- a/frontend/packages/shared/src/hooks/queries/useOptionListsReferencesQuery.ts
+++ b/frontend/packages/shared/src/hooks/queries/useOptionListsReferencesQuery.ts
@@ -1,0 +1,17 @@
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import type { OptionListsReferences } from 'app-shared/types/api/OptionsLists';
+
+// TODO: FIX TYPE
+export const useOptionListsReferencesQuery = (
+  org: string,
+  app: string,
+): UseQueryResult<OptionListsReferences> => {
+  const { getOptionListsReferences } = useServicesContext();
+  return useQuery<OptionListsReferences>({
+    queryKey: [QueryKey.OptionListsUsage, org, app],
+    queryFn: () => getOptionListsReferences(org, app),
+  });
+};

--- a/frontend/packages/shared/src/hooks/queries/useOptionListsReferencesQuery.ts
+++ b/frontend/packages/shared/src/hooks/queries/useOptionListsReferencesQuery.ts
@@ -4,7 +4,6 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import type { OptionListsReferences } from 'app-shared/types/api/OptionsLists';
 
-// TODO: FIX TYPE
 export const useOptionListsReferencesQuery = (
   org: string,
   app: string,

--- a/frontend/packages/shared/src/mocks/queriesMock.ts
+++ b/frontend/packages/shared/src/mocks/queriesMock.ts
@@ -69,7 +69,7 @@ import type { DeploymentsResponse } from 'app-shared/types/api/DeploymentsRespon
 import type { RepoDiffResponse } from 'app-shared/types/api/RepoDiffResponse';
 import type { ExternalImageUrlValidationResponse } from 'app-shared/types/api/ExternalImageUrlValidationResponse';
 import type { MaskinportenScope } from 'app-shared/types/MaskinportenScope';
-import type { OptionsList, OptionsListsResponse } from 'app-shared/types/api/OptionsLists';
+import type { OptionListsReferences, OptionsList, OptionsListsResponse } from 'app-shared/types/api/OptionsLists';
 import type { LayoutSetsModel } from '../types/api/dto/LayoutSetsModel';
 import { layoutSetsExtendedMock } from '@altinn/ux-editor/testing/layoutSetsMock';
 
@@ -110,6 +110,9 @@ export const queriesMock: ServicesContextProps = {
   getOptionListIds: jest.fn().mockImplementation(() => Promise.resolve<string[]>([])),
   getOptionList: jest.fn().mockImplementation(() => Promise.resolve<OptionsList>([])),
   getOptionLists: jest.fn().mockImplementation(() => Promise.resolve<OptionsListsResponse>([])),
+  getOptionListsReferences: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve<OptionListsReferences>([])),
   getOrgList: jest.fn().mockImplementation(() => Promise.resolve<OrgList>(orgList)),
   getOrganizations: jest.fn().mockImplementation(() => Promise.resolve<Organization[]>([])),
   getRepoMetadata: jest.fn().mockImplementation(() => Promise.resolve<Repository>(repository)),

--- a/frontend/packages/shared/src/mocks/queriesMock.ts
+++ b/frontend/packages/shared/src/mocks/queriesMock.ts
@@ -69,7 +69,11 @@ import type { DeploymentsResponse } from 'app-shared/types/api/DeploymentsRespon
 import type { RepoDiffResponse } from 'app-shared/types/api/RepoDiffResponse';
 import type { ExternalImageUrlValidationResponse } from 'app-shared/types/api/ExternalImageUrlValidationResponse';
 import type { MaskinportenScope } from 'app-shared/types/MaskinportenScope';
-import type { OptionListsReferences, OptionsList, OptionsListsResponse } from 'app-shared/types/api/OptionsLists';
+import type {
+  OptionListsReferences,
+  OptionsList,
+  OptionsListsResponse,
+} from 'app-shared/types/api/OptionsLists';
 import type { LayoutSetsModel } from '../types/api/dto/LayoutSetsModel';
 import { layoutSetsExtendedMock } from '@altinn/ux-editor/testing/layoutSetsMock';
 

--- a/frontend/packages/shared/src/types/QueryKey.ts
+++ b/frontend/packages/shared/src/types/QueryKey.ts
@@ -28,6 +28,7 @@ export enum QueryKey {
   LayoutSets = 'LayoutSets',
   LayoutSetsExtended = 'LayoutSetsExtended',
   OptionList = 'OptionList',
+  OptionListsUsage = 'OptionListsUsage',
   OptionLists = 'OptionLists',
   OptionListIds = 'OptionListIds',
   OrgList = 'OrgList',

--- a/frontend/packages/shared/src/types/api/OptionsLists.ts
+++ b/frontend/packages/shared/src/types/api/OptionsLists.ts
@@ -1,4 +1,5 @@
 import type { Option } from 'app-shared/types/Option';
+import type { CodeListIdSource } from '@studio/content-library';
 
 export type OptionsList = Option[];
 
@@ -9,3 +10,10 @@ export type OptionsListData = {
 };
 
 export type OptionsListsResponse = OptionsListData[];
+
+export type OptionListsReference = {
+  optionListId: string;
+  optionListIdSources: CodeListIdSource[];
+};
+
+export type OptionListsReferences = OptionListsReference[];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

⚠️ Not implemented design in this PR, just an example of what data we have about the usage ⚠️ 
![Skjermbilde 2024-12-19 kl  08 43 47](https://github.com/user-attachments/assets/9e3b9b17-ef7d-445b-bb90-187fc80058e5)

## Related Issue(s)
This PR will allow us to deny deletion and code-list-id-editing if a code list is in use. However, it will not actually show where the code list is used, but the data to visualize it will be available in the library. Adding support to view where it is used will be another issue.

- #13950 
- #13951 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
