### PR TITLE
test: Add test data for a code list with text resource references

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/test-data/codeListWithTextResources.ts
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/test-data/codeListWithTextResources.ts
@@ -1,0 +1,37 @@
+import type { CodeListItem } from '../types/CodeListItem';
+import {
+  description1Resource,
+  description2Resource,
+  description3Resource,
+  helpText1Resource,
+  helpText2Resource,
+  helpText3Resource,
+  label1Resource,
+  label2Resource,
+  label3Resource,
+} from './textResources';
+import type { CodeList } from '../types/CodeList';
+import { codeListWithoutTextResources } from './codeListWithoutTextResources';
+
+const item1: CodeListItem = {
+  ...codeListWithoutTextResources[0],
+  description: description1Resource.id,
+  helpText: helpText1Resource.id,
+  label: label1Resource.id,
+};
+
+const item2: CodeListItem = {
+  ...codeListWithoutTextResources[1],
+  description: description2Resource.id,
+  helpText: helpText2Resource.id,
+  label: label2Resource.id,
+};
+
+const item3: CodeListItem = {
+  ...codeListWithoutTextResources[2],
+  description: description3Resource.id,
+  helpText: helpText3Resource.id,
+  label: label3Resource.id,
+};
+
+export const codeListWithTextResources: CodeList = [item1, item2, item3];

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/test-data/textResources.ts
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/test-data/textResources.ts
@@ -1,0 +1,54 @@
+import type { TextResource } from '../../../types/TextResource';
+
+const label1Id = 'label1';
+const description1Id = 'description1';
+const helpText1Id = 'helpText1';
+const label2Id = 'label2';
+const description2Id = 'description2';
+const helpText2Id = 'helpText2';
+const label3Id = 'label3';
+const description3Id = 'description3';
+const helpText3Id = 'helpText3';
+const label4Id = 'label4';
+const description4Id = 'description4';
+const helpText4Id = 'helpText4';
+const label1 = 'Label 1';
+const description1 = 'Description 1';
+const helpText1 = 'Help text 1';
+const label2 = 'Label 2';
+const description2 = 'Description 2';
+const helpText2 = 'Help text 2';
+const label3 = 'Label 3';
+const description3 = 'Description 3';
+const helpText3 = 'Help text 3';
+const label4 = 'Label 4';
+const description4 = 'Description 4';
+const helpText4 = 'Help text 4';
+
+export const label1Resource: TextResource = { id: label1Id, value: label1 };
+export const description1Resource: TextResource = { id: description1Id, value: description1 };
+export const helpText1Resource: TextResource = { id: helpText1Id, value: helpText1 };
+export const label2Resource: TextResource = { id: label2Id, value: label2 };
+export const description2Resource: TextResource = { id: description2Id, value: description2 };
+export const helpText2Resource: TextResource = { id: helpText2Id, value: helpText2 };
+export const label3Resource: TextResource = { id: label3Id, value: label3 };
+export const description3Resource: TextResource = { id: description3Id, value: description3 };
+export const helpText3Resource: TextResource = { id: helpText3Id, value: helpText3 };
+export const label4Resource: TextResource = { id: label4Id, value: label4 };
+export const description4Resource: TextResource = { id: description4Id, value: description4 };
+export const helpText4Resource: TextResource = { id: helpText4Id, value: helpText4 };
+
+export const textResources: TextResource[] = [
+  label1Resource,
+  description1Resource,
+  helpText1Resource,
+  label2Resource,
+  description2Resource,
+  helpText2Resource,
+  label3Resource,
+  description3Resource,
+  helpText3Resource,
+  label4Resource,
+  description4Resource,
+  helpText4Resource,
+];


### PR DESCRIPTION
## Description
Currently, the code list editor supports texts defined directly on the component only. But in reality, the values defined on these fields are just text _keys_ – references to items in some list of key-value pairs. The goal is to make the user able to pick an item from this list. This pull request adds some test data for this implementation: A list of text resource items and a code list with references to these resources. It will be used in a future pull request. 

## Related Issue(s)
- #13739

## Verification
- [x] **Your** code builds clean without any errors or warnings
