### PR TITLE
fix: use same regex for layoutsets in FE and BE

### DIFF
--- a/backend/src/Designer/Filters/AppDevelopment/AppDevelopmentErrorCodes.cs
+++ b/backend/src/Designer/Filters/AppDevelopment/AppDevelopmentErrorCodes.cs
@@ -4,7 +4,7 @@ namespace Altinn.Studio.Designer.Filters.AppDevelopment
     {
         public const string NonUniqueLayoutSetIdError = "AD_01";
         public const string NonUniqueTaskForLayoutSetError = "AD_02";
-        public const string EmptyLayoutSetIdError = "AD_03";
+        public const string InvalidLayoutSetIdError = "AD_03";
         public const string ConflictingFileNameError = "AD_04";
         public const string UploadedImageNotValid = nameof(UploadedImageNotValid);
     }

--- a/backend/src/Designer/Filters/AppDevelopment/AppDevelopmentExceptionFilterAttribute.cs
+++ b/backend/src/Designer/Filters/AppDevelopment/AppDevelopmentExceptionFilterAttribute.cs
@@ -27,7 +27,7 @@ namespace Altinn.Studio.Designer.Filters.AppDevelopment
             }
             if (context.Exception is InvalidLayoutSetIdException)
             {
-                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, AppDevelopmentErrorCodes.EmptyLayoutSetIdError, HttpStatusCode.BadRequest)) { StatusCode = (int)HttpStatusCode.BadRequest };
+                context.Result = new ObjectResult(ProblemDetailsUtils.GenerateProblemDetails(context.Exception, AppDevelopmentErrorCodes.InvalidLayoutSetIdError, HttpStatusCode.BadRequest)) { StatusCode = (int)HttpStatusCode.BadRequest };
             }
             if (context.Exception is ConflictingFileNameException)
             {

--- a/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
+++ b/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
@@ -28,7 +28,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
     {
         private readonly IAltinnGitRepositoryFactory _altinnGitRepositoryFactory;
         private readonly ISchemaModelService _schemaModelService;
-        private readonly string _layoutSetNameRegEx = "[a-zA-Z0-9-]{2,28}";
+        private readonly string _layoutSetNameRegEx = @"^[a-zA-Z0-9_\-]{2,28}$";
 
         /// <summary>
         /// Constructor

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateLayoutSetNameTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateLayoutSetNameTests.cs
@@ -95,6 +95,26 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
         }
 
         [Theory]
+        [InlineData("ttd", "app-with-layoutsets", "testUser", "layoutSet1")]
+        public async Task UpdateLayoutSet_NewLayoutSetNameDoesNotMatchRegex_ReturnsBadRequest(string org, string app, string developer,
+            string oldLayoutSetName)
+        {
+            string targetRepository = TestDataHelper.GenerateTestRepoName();
+            await CopyRepositoryForTest(org, app, developer, targetRepository);
+            string newLayoutSetName = ".abc";
+
+            string url = $"{VersionPrefix(org, targetRepository)}/layout-set/{oldLayoutSetName}";
+
+            using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, url)
+            {
+                Content = new StringContent($"\"{newLayoutSetName}\"", Encoding.UTF8, MediaTypeNames.Application.Json)
+            };
+
+            using var response = await HttpClient.SendAsync(httpRequestMessage);
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+
+        [Theory]
         [InlineData("ttd", "app-without-layoutsets", "testUser", null)]
         public async Task UpdateLayoutSetName_AppWithoutLayoutSets_ReturnsNotFound(string org, string app, string developer,
             string oldLayoutSetName)

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1,7 +1,7 @@
 {
   "api_errors.AD_01": "En annen sidegruppe har allerede dette navnet.",
   "api_errors.AD_02": "Det finnes allerede en sidegruppe med denne oppgaven.",
-  "api_errors.AD_03": "Navnet på sidegruppen er ugyldig. Du kan bruke tall, understrek, bindestrek, og store/små bokstaver fra det engelske alfabetet.",
+  "api_errors.AD_03": "Navnet på sidegruppen er ugyldig. Den må være mellom 2 og 28 tegn og kan inneholde tall, understrek, bindestrek, og store/små bokstaver fra det engelske alfabetet.",
   "api_errors.DM_01": "Kunne ikke bygge datamodellen.",
   "api_errors.DM_05": "Kunne ikke lese ugyldig XML.",
   "api_errors.DM_CsharpCompiler_NameCollision": "Navnet <bold>{{nodeName}}</bold> er det samme som på et overordnet element. Gi ett av elementene et annet navn.",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1,7 +1,7 @@
 {
   "api_errors.AD_01": "En annen sidegruppe har allerede dette navnet.",
   "api_errors.AD_02": "Det finnes allerede en sidegruppe med denne oppgaven.",
-  "api_errors.AD_03": "Navnet på sidegruppen er ugyldig. Den må være mellom 2 og 28 tegn og kan inneholde tall, understrek, bindestrek, og store/små bokstaver fra det engelske alfabetet.",
+  "api_errors.AD_03": "Navnet på sidegruppen er ugyldig. Det må ha mellom 2 og 28 tegn og kan inneholde tall, understrek, bindestrek, og store/små bokstaver fra det engelske alfabetet.",
   "api_errors.DM_01": "Kunne ikke bygge datamodellen.",
   "api_errors.DM_05": "Kunne ikke lese ugyldig XML.",
   "api_errors.DM_CsharpCompiler_NameCollision": "Navnet <bold>{{nodeName}}</bold> er det samme som på et overordnet element. Gi ett av elementene et annet navn.",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1,7 +1,7 @@
 {
   "api_errors.AD_01": "En annen sidegruppe har allerede dette navnet.",
   "api_errors.AD_02": "Det finnes allerede en sidegruppe med denne oppgaven.",
-  "api_errors.AD_03": "Navnet på sidegruppen kan ikke være tomt.",
+  "api_errors.AD_03": "Navnet på sidegruppen er ugyldig. Du kan bruke tall, understrek, bindestrek, og store/små bokstaver fra det engelske alfabetet.",
   "api_errors.DM_01": "Kunne ikke bygge datamodellen.",
   "api_errors.DM_05": "Kunne ikke lese ugyldig XML.",
   "api_errors.DM_CsharpCompiler_NameCollision": "Navnet <bold>{{nodeName}}</bold> er det samme som på et overordnet element. Gi ett av elementene et annet navn.",

--- a/frontend/libs/studio-pure-functions/src/FileNameUtils/FileNameUtils.test.ts
+++ b/frontend/libs/studio-pure-functions/src/FileNameUtils/FileNameUtils.test.ts
@@ -104,6 +104,12 @@ describe('FileNameUtils', () => {
       expect(fileNameError).toBe(FileNameErrorResult.NoRegExMatch);
     });
 
+    it('Returns "NoRegExMatch" when file name does not match file name regex in terms of length', () => {
+      const fileName: string = '12345678901234567890123456789';
+      const fileNameError: FileNameErrorResult = FileNameUtils.findFileNameError(fileName, []);
+      expect(fileNameError).toBe(FileNameErrorResult.NoRegExMatch);
+    });
+
     it('Returns "FileExists" when file name matches regEx and name exists in list', () => {
       const fileName: string = 'fileName1';
       const invalidFileNames: string[] = [fileName, 'fileName2', 'fileName3'];

--- a/frontend/libs/studio-pure-functions/src/FileNameUtils/FileNameUtils.ts
+++ b/frontend/libs/studio-pure-functions/src/FileNameUtils/FileNameUtils.ts
@@ -1,6 +1,6 @@
 import { StringUtils } from '@studio/pure-functions';
 
-export const FILE_NAME_REGEX = /^[a-zA-Z0-9_\-]{1,50}$/;
+export const FILE_NAME_REGEX = /^[a-zA-Z0-9_\-]{2,28}$/;
 
 export enum FileNameErrorResult {
   FileNameIsEmpty = 'fileNameIsEmpty',

--- a/frontend/packages/shared/src/utils/layoutSetsUtils.ts
+++ b/frontend/packages/shared/src/utils/layoutSetsUtils.ts
@@ -16,10 +16,10 @@ export const getLayoutSetIdValidationErrorKey = (
 ): string => {
   if (oldLayoutSetId === newLayoutSetId) return null;
   if (!newLayoutSetId || newLayoutSetId.trim() === '') return 'validation_errors.required';
-  if (!validateLayoutNameAndLayoutSetName(newLayoutSetId))
-    return 'validation_errors.file_name_invalid';
   if (newLayoutSetId.length === 1)
     return 'process_editor.configuration_panel_custom_receipt_layout_set_name_validation';
+  if (!validateLayoutNameAndLayoutSetName(newLayoutSetId))
+    return 'validation_errors.file_name_invalid';
   if (layoutSets.sets.some((set) => StringUtils.areCaseInsensitiveEqual(set.id, newLayoutSetId)))
     return 'process_editor.configuration_panel_layout_set_id_not_unique';
   return null;


### PR DESCRIPTION
## Description

- Adjust reg ex in backend to have same restrictions as in frontend.
- Use same length restrictions in frontend as in backend.
- Change error type passed from backend when name does not match regex. Also adapt text in frontend.

## Related Issue(s)

- #13689 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
