### PR TITLE
fix: ensure stream is closed after being read from app-dev's GetDefinitions method

### DIFF
--- a/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -816,8 +816,18 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         public Definitions GetDefinitions()
         {
             Stream processDefinitionStream = GetProcessDefinitionFile();
+            
+            MemoryStream memoryStream = new MemoryStream();
+            processDefinitionStream.CopyTo(memoryStream);
+            
+            memoryStream.Position = 0;
+    
             XmlSerializer serializer = new(typeof(Definitions));
-            return (Definitions)serializer.Deserialize(processDefinitionStream);
+            Definitions definitions = (Definitions)serializer.Deserialize(memoryStream);
+            
+            processDefinitionStream.Close();
+
+            return definitions;
         }
 
         /// <summary>

--- a/backend/src/Designer/Middleware/UserRequestSynchronization/Services/RequestSyncEvaluators/EndpointNameSyncEvaluator.cs
+++ b/backend/src/Designer/Middleware/UserRequestSynchronization/Services/RequestSyncEvaluators/EndpointNameSyncEvaluator.cs
@@ -54,6 +54,7 @@ public class EndpointNameSyncEvaluator : IRequestSyncEvaluator
                 nameof(ProcessModelingController.AddDataTypeToApplicationMetadata),
                 nameof(ProcessModelingController.DeleteDataTypeFromApplicationMetadata),
                 nameof(ProcessModelingController.UpsertProcessDefinitionAndNotify),
+                nameof(ProcessModelingController.ProcessDataTypesChangedNotify),
                 nameof(ProcessModelingController.SaveProcessDefinitionFromTemplate)
             )
         },


### PR DESCRIPTION
## Description

Ensure stream is closed after being read from app-dev's GetDefinitions method

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
