### PR TITLE
feat: add StudioSearch component

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioSearch/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioSearch/index.ts
@@ -1,0 +1,4 @@
+export {
+  Search as StudioSearch,
+  type SearchProps as StudioSearchProps,
+} from '@digdir/designsystemet-react';

--- a/frontend/libs/studio-components/src/components/index.ts
+++ b/frontend/libs/studio-components/src/components/index.ts
@@ -49,6 +49,7 @@ export * from './StudioProperty';
 export * from './StudioRecommendedNextAction';
 export * from './StudioRedirectBox';
 export * from './StudioResizableLayout';
+export * from './StudioSearch';
 export * from './StudioSectionHeader';
 export * from './StudioSpinner';
 export * from './StudioSwitch';

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListsActionsBar/CodeListsActionsBar.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListsActionsBar/CodeListsActionsBar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Search } from '@digdir/designsystemet-react';
-import { StudioFileUploader } from '@studio/components';
+import { StudioFileUploader, StudioSearch } from '@studio/components';
 import classes from './CodeListsActionsBar.module.css';
 import { useTranslation } from 'react-i18next';
 import type { CodeListWithMetadata } from '../CodeListPage';
@@ -36,7 +35,7 @@ export function CodeListsActionsBar({
 
   return (
     <div className={classes.actionsBar}>
-      <Search
+      <StudioSearch
         className={classes.searchField}
         size='sm'
         placeholder={t('app_content_library.code_lists.search_placeholder')}

--- a/frontend/packages/text-editor/src/TextEditor.module.css
+++ b/frontend/packages/text-editor/src/TextEditor.module.css
@@ -24,7 +24,7 @@
 .filterAndSearch {
   display: flex;
   flex-direction: row;
-  align-items: flex-end;
+  align-items: center;
   gap: 1rem;
 }
 

--- a/frontend/packages/text-editor/src/TextEditor.test.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.test.tsx
@@ -153,13 +153,13 @@ describe('TextEditor', () => {
     renderTextEditor({});
 
     const textEntries = screen.getAllByRole('textbox');
-    expect(textEntries[1]).toHaveValue(textValue1);
+    expect(textEntries[0]).toHaveValue(textValue1);
 
     const sortAlphabeticallyButton = screen.getByText(textMock('text_editor.sort_alphabetically'));
     await user.click(sortAlphabeticallyButton);
 
     const sortedTranslations = screen.getAllByRole('textbox');
-    expect(sortedTranslations[1]).toHaveValue(textValue2);
+    expect(sortedTranslations[0]).toHaveValue(textValue2);
   });
 
   it('signals correctly when a translation is changed', async () => {

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -2,10 +2,9 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import classes from './TextEditor.module.css';
 import type { LangCode, TextResourceEntryDeletion, TextResourceIdMutation } from './types';
 import type { UpsertTextResourceMutation } from 'app-shared/hooks/mutations/useUpsertTextResourceMutation';
-import { SearchField } from '@altinn/altinn-design-system';
 import { Chip } from '@digdir/designsystemet-react';
 import { ArrowsUpDownIcon } from '@studio/icons';
-import { StudioButton } from '@studio/components';
+import { StudioButton, StudioSearch } from '@studio/components';
 import { RightMenu } from './RightMenu';
 import { getRandNumber, mapResourceFilesToTableRows } from './utils';
 import { defaultLangCode } from './constants';
@@ -108,9 +107,9 @@ export const TextEditor = ({
               }
             </Chip.Toggle>
             <div>
-              <SearchField
-                id='text-editor-search'
-                label={t('text_editor.search_for_text')}
+              <StudioSearch
+                size='small'
+                placeholder={t('text_editor.search_for_text')}
                 value={searchQuery}
                 onChange={handleSearchChange}
               />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- add `StudioSearch` component.
- use new component in code list page in library.
- use new component in text editor.

<img width="1097" alt="Skjermbilde 2025-01-03 kl  10 39 20" src="https://github.com/user-attachments/assets/510e6a51-c57d-4f0e-8182-9f811c0d459e" />

## Related Issue(s)

- #14273 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
