### PR TITLE
chore(ui-editor): remove custom component from toolbar list

### DIFF
--- a/frontend/packages/ux-editor/src/data/formItemConfig.test.ts
+++ b/frontend/packages/ux-editor/src/data/formItemConfig.test.ts
@@ -14,9 +14,14 @@ describe('formItemConfig', () => {
     confOnScreenComponents,
   ];
   const allAvailableComponents = allAvailableLists.flat();
-  const excludedComponents = [ComponentType.Payment, ComponentType.Subform, ComponentType.Summary2];
+  const excludedComponents = [
+    ComponentType.Custom,
+    ComponentType.Payment,
+    ComponentType.Subform,
+    ComponentType.Summary2,
+  ];
 
-  /**  Test that all components, except Payment, Subform and Summary2 (since behind featureFlag), are available in one of the visible lists */
+  /**  Test that all components, except Custom, Payment, Subform and Summary2 (since behind featureFlag), are available in one of the visible lists */
   it.each(
     Object.values(ComponentType).filter(
       (componentType) => !excludedComponents.includes(componentType),

--- a/frontend/packages/ux-editor/src/data/formItemConfig.ts
+++ b/frontend/packages/ux-editor/src/data/formItemConfig.ts
@@ -504,7 +504,6 @@ export const advancedItems: FormItemConfigs[ComponentType][] = [
   formItemConfigs[ComponentType.Accordion],
   formItemConfigs[ComponentType.AccordionGroup],
   formItemConfigs[ComponentType.List],
-  formItemConfigs[ComponentType.Custom],
   formItemConfigs[ComponentType.RepeatingGroup],
   formItemConfigs[ComponentType.PaymentDetails],
   shouldDisplayFeature(FeatureFlag.Subform) && formItemConfigs[ComponentType.Subform],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
See https://github.com/Altinn/altinn-studio/issues/14361 for reasoning.
This PR only removes the component from the component toolbar, and does not remove the json schemas or any of the config setups. Layouts with this component in use will still be able to configure it.

## Related Issue(s)

- #14361 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
