### PR TITLE
chore(workspace): skip frontend pipelines when only backend code is changed

### DIFF
--- a/.github/workflows/frontend-config-coverage.yml
+++ b/.github/workflows/frontend-config-coverage.yml
@@ -7,6 +7,7 @@ on:
       - 'frontend/packages/ux-editor/**'
       - 'frontend/scripts/configurationStats/**'
       - '.github/workflows/frontend-config-coverage.yml'
+      - '!backend/**'
 
 jobs:
   stats:

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -9,6 +9,7 @@ on:
       - 'testdata/**'
       - '.github/workflows/frontend-unit-tests.yml'
       - 'package.json'
+      - '!backend/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This update modifies the frontend CI pipeline to avoid running unnecessary tests when only backend code changes. The pipeline will now be skipped if there are no changes to the frontend code, reducing unnecessary build time and improving efficiency.

## Related Issue(s)

- PR itself

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
