### PR TITLE
fix: exportUtils pageOrder can be nullish, add optional chaining

### DIFF
--- a/frontend/packages/ux-editor/src/utils/exportUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/exportUtils.ts
@@ -48,7 +48,7 @@ export class ExportUtils {
       formId: this.layoutSetName,
       pages: [],
     };
-    this.pageOrder.forEach((layoutName: string, index: number) => {
+    this.pageOrder?.forEach((layoutName: string, index: number) => {
       exportForm.pages.push(this.generateLayoutExportFormat(layoutName, index));
     });
     return exportForm;


### PR DESCRIPTION
## Description

ExportUtils constructor parameter pageOrder can be nullish (see [ExportForm.tsx:25](https://github.com/Altinn/altinn-studio/blob/15bd10af75dd7a65720c82ef6f5ef072a44451e8/frontend/packages/ux-editor/src/components/Elements/ExportForm.tsx#L25)) which causes an exception at exportUtils.ts:51. Add optional chaining here to avoid runtime errors.

## Related Issue(s)

- Just this PR

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added optional chaining to prevent potential runtime errors when accessing `pageOrder`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->