### PR TITLE
fix: Disallow trailing commas when uploading options lists

### DIFF
--- a/backend/src/Designer/Services/Implementation/OptionsService.cs
+++ b/backend/src/Designer/Services/Implementation/OptionsService.cs
@@ -116,7 +116,7 @@ public class OptionsService : IOptionsService
         cancellationToken.ThrowIfCancellationRequested();
 
         List<Option> deserializedOptions = JsonSerializer.Deserialize<List<Option>>(payload.OpenReadStream(),
-            new JsonSerializerOptions { WriteIndented = true, AllowTrailingCommas = true });
+            new JsonSerializerOptions { WriteIndented = true });
 
         bool optionListHasInvalidNullFields = deserializedOptions.Exists(option => option.Value == null || option.Label == null);
         if (optionListHasInvalidNullFields)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We should not allow trailing commas in option lists, because Apps do not support option lists that contain them.

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted JSON deserialization options to improve input validation and error handling for option uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->