### PR TITLE
chore: remove fluent assertions library

### DIFF
--- a/backend/packagegroups/NuGet.props
+++ b/backend/packagegroups/NuGet.props
@@ -53,7 +53,6 @@
   </ItemGroup>
 
   <ItemGroup Label="Packages used for testing">
-    <PackageReference Update="FluentAssertions" Version="7.0.0" />
     <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <!-- Do not upgrade Moq version from 4.18.4 -->

--- a/backend/src/Designer/Repository/ORMImplementation/Mappers/DeploymentMapper.cs
+++ b/backend/src/Designer/Repository/ORMImplementation/Mappers/DeploymentMapper.cs
@@ -28,6 +28,7 @@ public static class DeploymentMapper
             EnvName = deploymentEntity.EnvName,
             Buildresult = deploymentEntity.Build.Result.ToEnumMemberAttributeValue(),
             Created = deploymentEntity.Created.ToUniversalTime(),
+            CreatedBy = deploymentEntity.CreatedBy,
             Entity = JsonSerializer.Serialize(deploymentEntity, s_jsonOptions),
             Build = BuildMapper.MapToDbModel(deploymentEntity.Build, BuildType.Deployment),
         };

--- a/backend/tests/DataModeling.Tests/AltinnJsonSchemaValidationTests.cs
+++ b/backend/tests/DataModeling.Tests/AltinnJsonSchemaValidationTests.cs
@@ -16,8 +16,9 @@ namespace DataModeling.Tests
         public void ValidJsonSchema_ShouldNotHave_ValidationIssues(string jsonSchemaPath)
         {
             When.JsonSchemaLoaded(jsonSchemaPath)
-                .And.LoadedJsonSchemaValidated()
-                .Then.ValidationResult.IsValid.Should().BeTrue();
+                .And.LoadedJsonSchemaValidated();
+
+            Assert.True(ValidationResult.IsValid);
         }
 
         [Theory]
@@ -25,14 +26,15 @@ namespace DataModeling.Tests
         public void InvalidJsonSchema_ShouldHave_ValidationIssues(string jsonSchemaPath, params Tuple<string, string>[] expectedValidationIssues)
         {
             When.JsonSchemaLoaded(jsonSchemaPath)
-                .And.LoadedJsonSchemaValidated()
-                .Then.ValidationResult.IsValid.Should().BeFalse();
+                .And.LoadedJsonSchemaValidated();
 
-            And.ValidationResult.ValidationIssues.Should().HaveCount(expectedValidationIssues.Length);
+            Assert.False(ValidationResult.IsValid);
+
+            Assert.Equal(ValidationResult.ValidationIssues.Count, expectedValidationIssues.Length);
 
             foreach ((string expectedPointer, string expectedCode) in expectedValidationIssues)
             {
-                ValidationResult.ValidationIssues.Should().Contain(x => x.ErrorCode == expectedCode && JsonPointer.Parse(x.IssuePointer) == JsonPointer.Parse(expectedPointer));
+                Assert.Contains(ValidationResult.ValidationIssues, x => x.ErrorCode == expectedCode && JsonPointer.Parse(x.IssuePointer) == JsonPointer.Parse(expectedPointer));
             }
         }
 

--- a/backend/tests/DataModeling.Tests/AltinnJsonSchemaValidationTests.cs
+++ b/backend/tests/DataModeling.Tests/AltinnJsonSchemaValidationTests.cs
@@ -2,7 +2,6 @@
 using Altinn.Studio.DataModeling.Validator.Json;
 using DataModeling.Tests.BaseClasses;
 using DataModeling.Tests.TestDataClasses;
-using FluentAssertions;
 using Json.Pointer;
 using Xunit;
 

--- a/backend/tests/DataModeling.Tests/Assertions/TypeAssertions.cs
+++ b/backend/tests/DataModeling.Tests/Assertions/TypeAssertions.cs
@@ -15,15 +15,15 @@ public static class TypeAssertions
     {
         if (expected.IsPrimitive || expected == typeof(string) || expected == typeof(DateTime) || expected == typeof(decimal))
         {
-            expected.Should().Be(actual);
+            Assert.Equal(expected, actual);
             return;
         }
 
-        expected.Name.Should().Be(actual.Name);
-        expected.Namespace.Should().Be(actual.Namespace);
-        expected.IsArray.Should().Be(actual.IsArray);
-        expected.IsClass.Should().Be(actual.IsClass);
-        expected.IsGenericType.Should().Be(actual.IsGenericType);
+        Assert.Equal(expected.Name, actual.Name);
+        Assert.Equal(expected.Namespace, actual.Namespace);
+        Assert.Equal(expected.IsArray, actual.IsArray);
+        Assert.Equal(expected.IsClass, actual.IsClass);
+        Assert.Equal(expected.IsGenericType, actual.IsGenericType);
         if (expected.IsGenericType)
         {
             foreach (var expectedArg in expected.GenericTypeArguments)
@@ -46,7 +46,7 @@ public static class TypeAssertions
 
     private static void IsEquivalentTo(IReadOnlyCollection<FieldInfo> expected, IReadOnlyCollection<FieldInfo> actual)
     {
-        expected.Count.Should().Be(actual.Count);
+        Assert.Equal(expected.Count, actual.Count);
         foreach (var expectedItem in expected)
         {
             var actualItem = actual.Single(x => x.Name == expectedItem.Name);
@@ -56,16 +56,16 @@ public static class TypeAssertions
 
     private static void IsEquivalentTo(FieldInfo expected, FieldInfo actual)
     {
-        expected.Name.Should().Be(actual.Name);
+        Assert.Equal(expected.Name, actual.Name);
         IsEquivalentTo(expected.FieldType, actual.FieldType);
         IsEquivalentTo(expected.CustomAttributes, actual.CustomAttributes);
-        expected.IsPrivate.Should().Be(actual.IsPrivate);
-        expected.IsPublic.Should().Be(actual.IsPublic);
+        Assert.Equal(expected.IsPrivate, actual.IsPrivate);
+        Assert.Equal(expected.IsPublic, actual.IsPublic);
     }
 
     private static void IsEquivalentTo(IReadOnlyCollection<PropertyInfo> expected, IReadOnlyCollection<PropertyInfo> actual)
     {
-        expected.Count.Should().Be(actual.Count);
+        Assert.Equal(expected.Count, actual.Count);
         foreach (var expectedItem in expected)
         {
             var actualItem = actual.Single(x => x.Name == expectedItem.Name);
@@ -75,7 +75,7 @@ public static class TypeAssertions
 
     private static void IsEquivalentTo(PropertyInfo expected, PropertyInfo actual)
     {
-        expected.Name.Should().Be(actual.Name);
+        Assert.Equal(expected.Name, actual.Name);
         IsEquivalentTo(expected.PropertyType, actual.PropertyType);
         IsEquivalentTo(expected.CustomAttributes, actual.CustomAttributes);
     }
@@ -84,17 +84,17 @@ public static class TypeAssertions
     {
         var expectedStrings = expected.Select(e => e.ToString());
         var actualStrings = actual.Select(a => a.ToString());
-        expectedStrings.Should().BeEquivalentTo(actualStrings);
+        Assert.True(expectedStrings.SequenceEqual(actualStrings));
     }
 
     private static void IsEquivalentTo(TypeAttributes expected, TypeAttributes actual)
     {
-        expected.Should().Be(actual);
+        Assert.Equal(expected, actual);
     }
 
     private static void IsEquivalentTo(IReadOnlyCollection<MethodInfo> expected, IReadOnlyCollection<MethodInfo> actual)
     {
-        expected.Count.Should().Be(actual.Count);
+        Assert.Equal(expected.Count, actual.Count);
         foreach (var expectedItem in expected)
         {
             var actualItem = actual.Single(x => x.Name == expectedItem.Name);
@@ -104,17 +104,17 @@ public static class TypeAssertions
 
     private static void IsEquivalentTo(MethodInfo expected, MethodInfo actual)
     {
-        expected.Name.Should().Be(actual.Name);
+        Assert.Equal(expected.Name, actual.Name);
         IsEquivalentTo(expected.ReturnType, actual.ReturnType);
-        actual.IsPublic.Should().Be(expected.IsPublic);
+        Assert.Equal(expected.IsPublic, actual.IsPublic);
     }
 
     public static void PropertyShouldContainCustomAnnotationAndHaveTypeType(Type type, string propertyName, string propertyType, string expectedAnnotationString)
     {
-        var property = type.Properties().Single(x => x.Name == propertyName);
+        var property = type.GetProperties().Single(x => x.Name == propertyName);
         var simpleCompiledAssembly = Compiler.CompileToAssembly(DynamicAnnotationClassString(propertyName, propertyType, expectedAnnotationString));
-        var expectedProperty = simpleCompiledAssembly.Types()
-            .First(x => x.Name == "DynamicAnnotationClass").Properties().Single();
+        var expectedProperty = simpleCompiledAssembly.GetTypes()
+            .First(x => x.Name == "DynamicAnnotationClass").GetProperties().Single();
         IsEquivalentTo(expectedProperty.PropertyType, property.PropertyType);
         var expectedAnnotation = expectedProperty.CustomAttributes.Single();
         Assert.Single(property.CustomAttributes, x => x.ToString() == expectedAnnotation.ToString());

--- a/backend/tests/DataModeling.Tests/Assertions/TypeAssertions.cs
+++ b/backend/tests/DataModeling.Tests/Assertions/TypeAssertions.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Altinn.Studio.DataModeling.Converter.Csharp;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Assertions;

--- a/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
+++ b/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
@@ -4,7 +4,6 @@ using Altinn.Studio.DataModeling.Converter.Csharp;
 using DataModeling.Tests.Assertions;
 using DataModeling.Tests.BaseClasses;
 using DataModeling.Tests.TestDataClasses;
-using FluentAssertions;
 using SharedResources.Tests;
 using Xunit;
 using Xunit.Abstractions;

--- a/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
+++ b/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
@@ -27,9 +27,9 @@ namespace DataModeling.Tests
                 .When.LoadedXsdSchemaConvertedToJsonSchema()
                 .And.ConvertedJsonSchemaConvertedToModelMetadata()
                 .And.ModelMetadataConvertedToCsharpClass()
-                .And.CSharpClassesCompiledToAssembly()
-                .Then
-                .CompiledAssembly.Should().NotBeNull();
+                .And.CSharpClassesCompiledToAssembly();
+
+            Assert.NotNull(CompiledAssembly);
 
             And.GeneratedClassesShouldBeEquivalentToExpected(expectedCsharpClassPath);
         }
@@ -43,8 +43,9 @@ namespace DataModeling.Tests
                 .When.LoadedXsdSchemaConvertedToJsonSchema()
                 .And.ConvertedJsonSchemaConvertedToModelMetadata()
                 .And.ModelMetadataConvertedToCsharpClass()
-                .And.CSharpClassesCompiledToAssembly()
-                .Then.CompiledAssembly.Should().NotBeNull();
+                .And.CSharpClassesCompiledToAssembly();
+
+            Assert.NotNull(CompiledAssembly);
 
             And.PropertyShouldHaveDefinedTypeAndContainAnnotation("Root", propertyName, expectedPropertyType, restrictionString);
         }
@@ -56,12 +57,14 @@ namespace DataModeling.Tests
             Given.That.JsonSchemaLoaded(jsonSchemaPath)
                 .When.LoadedJsonSchemaConvertedToModelMetadata()
                 .And.ModelMetadataConvertedToCsharpClass()
-                .And.CSharpClassesCompiledToAssembly()
-                .Then.CompiledAssembly.Should().NotBeNull();
+                .And.CSharpClassesCompiledToAssembly();
+
+            Assert.NotNull(CompiledAssembly);
 
             And.ClassesShouldBeGenerated(typesCreated)
-                .And.When.LoadedJsonSchemaConvertedToXsdSchema()
-                .Then.ConvertedXsdSchema.Should().NotBeNull();
+                .And.When.LoadedJsonSchemaConvertedToXsdSchema();
+
+            Assert.NotNull(ConvertedXsdSchema);
         }
 
         [Theory]
@@ -71,8 +74,9 @@ namespace DataModeling.Tests
             Given.That.JsonSchemaLoaded(jsonSchemaPath)
                 .When.LoadedJsonSchemaConvertedToModelMetadata()
                 .And.ModelMetadataConvertedToCsharpClass()
-                .And.CSharpClassesCompiledToAssembly()
-                .Then.CompiledAssembly.Should().NotBeNull();
+                .And.CSharpClassesCompiledToAssembly();
+
+            Assert.NotNull(CompiledAssembly);
         }
 
         private void GeneratedClassesShouldBeEquivalentToExpected(string expectedCsharpClassPath, bool overwriteExpected = false)
@@ -93,15 +97,16 @@ namespace DataModeling.Tests
             var expectedAssembly = Compiler.CompileToAssembly(expectedClasses);
 
             // Compare root types.
-            var newType = CompiledAssembly.Types().Single(type => type.CustomAttributes.Any(att => att.AttributeType == typeof(XmlRootAttribute)));
+            var newType = CompiledAssembly.GetTypes().Single(type => type.CustomAttributes.Any(att => att.AttributeType == typeof(XmlRootAttribute)));
             var oldType = expectedAssembly.GetType(newType.FullName);
-            oldType.Should().NotBeNull();
+            Assert.NotNull(oldType);
+
             TypeAssertions.IsEquivalentTo(oldType, newType);
         }
 
         private void PropertyShouldHaveDefinedTypeAndContainAnnotation(string className, string propertyName, string propertyType, string annotationString)
         {
-            var type = CompiledAssembly.Types().Single(type => type.Name == className);
+            var type = CompiledAssembly.GetTypes().Single(type => type.Name == className);
             TypeAssertions.PropertyShouldContainCustomAnnotationAndHaveTypeType(type, propertyName, propertyType, annotationString);
         }
 
@@ -110,8 +115,9 @@ namespace DataModeling.Tests
         {
             foreach (string className in classNames)
             {
-                var type = CompiledAssembly.Types().Single(type => type.Name == className);
-                type.Should().NotBeNull();
+                var type = CompiledAssembly.GetTypes().Single(type => type.Name == className);
+
+                Assert.NotNull(type);
             }
             return this;
         }

--- a/backend/tests/DataModeling.Tests/DataModeling.Tests.csproj
+++ b/backend/tests/DataModeling.Tests/DataModeling.Tests.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />

--- a/backend/tests/DataModeling.Tests/DataValidationWithModelPopulatingTests.cs
+++ b/backend/tests/DataModeling.Tests/DataValidationWithModelPopulatingTests.cs
@@ -43,8 +43,10 @@ public class DataValidationWithModelPopulatingTests : CsharpModelConversionTests
             .When.LoadedXsdSchemaConvertedToJsonSchema()
             .And.ConvertedJsonSchemaConvertedToModelMetadata()
             .And.ModelMetadataConvertedToCsharpClass()
-            .And.CSharpClassesCompiledToAssembly()
-            .Then.CompiledAssembly.Should().NotBeNull();
+            .And.CSharpClassesCompiledToAssembly();
+
+        Assert.NotNull(CompiledAssembly);
+
 
         When.RepresentingTypeFromLoadedFromAssembly()
             .And.RandomRepresentingObjectGenerated()
@@ -55,7 +57,7 @@ public class DataValidationWithModelPopulatingTests : CsharpModelConversionTests
 
     private DataValidationWithModelPopulatingTests RepresentingTypeFromLoadedFromAssembly()
     {
-        RepresentingType = CompiledAssembly.Types().Single(type => type.CustomAttributes.Any(att => att.AttributeType == typeof(XmlRootAttribute)));
+        RepresentingType = CompiledAssembly.GetTypes().Single(type => type.CustomAttributes.Any(att => att.AttributeType == typeof(XmlRootAttribute)));
         return this;
     }
 
@@ -68,7 +70,8 @@ public class DataValidationWithModelPopulatingTests : CsharpModelConversionTests
     private DataValidationWithModelPopulatingTests RepresentingObject_ShouldBeValid()
     {
         var isValid = Validator.TryValidateObject(RandomRepresentingObject, new ValidationContext(RandomRepresentingObject), null, true);
-        isValid.Should().BeTrue();
+
+        Assert.True(isValid);
         return this;
     }
 
@@ -100,7 +103,8 @@ public class DataValidationWithModelPopulatingTests : CsharpModelConversionTests
         document.Schemas.Add(LoadedXsdSchema);
         ValidationEventHandler eventHandler = ValidationEventHandler;
         document.Validate(eventHandler);
-        isValid.Should().BeTrue();
+
+        Assert.True(isValid);
 
         return this;
     }
@@ -113,6 +117,7 @@ public class DataValidationWithModelPopulatingTests : CsharpModelConversionTests
         });
         var jsonNode = JsonNode.Parse(json);
         var validationResults = ConvertedJsonSchema.Evaluate(jsonNode);
-        validationResults.IsValid.Should().BeTrue();
+
+        Assert.True(validationResults.IsValid);
     }
 }

--- a/backend/tests/DataModeling.Tests/DataValidationWithModelPopulatingTests.cs
+++ b/backend/tests/DataModeling.Tests/DataValidationWithModelPopulatingTests.cs
@@ -11,7 +11,6 @@ using System.Xml.Schema;
 using System.Xml.Serialization;
 using DataModeling.Tests.BaseClasses;
 using DataModeling.Tests.Utils;
-using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/backend/tests/DataModeling.Tests/Json/Formats/CustomFormatsTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Formats/CustomFormatsTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json.Nodes;
 using Altinn.Studio.DataModeling.Json.Formats;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Formats;

--- a/backend/tests/DataModeling.Tests/Json/Formats/CustomFormatsTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Formats/CustomFormatsTests.cs
@@ -33,6 +33,7 @@ public class CustomFormatsTests
         objects.Add(node[property]);
 
         var result = checkDateMethod.Invoke(null, objects.ToArray());
-        expected.Should().Be((bool)result);
+
+        Assert.Equal(expected, (bool)result);
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/JsonSchemaNormalizerTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/JsonSchemaNormalizerTests.cs
@@ -4,7 +4,6 @@ using System.Text.Unicode;
 using System.Threading.Tasks;
 using Altinn.Studio.DataModeling.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
-using FluentAssertions;
 using SharedResources.Tests;
 using Xunit;
 

--- a/backend/tests/DataModeling.Tests/Json/JsonSchemaNormalizerTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/JsonSchemaNormalizerTests.cs
@@ -49,7 +49,7 @@ namespace DataModeling.Tests.Json
             var normalizedJsonSchema = jsonSchemaNormalizer.Normalize(jsonSchema);
             var normalizedJsonSchemaText = JsonSerializer.Serialize(normalizedJsonSchema, new JsonSerializerOptions() { Encoder = JavaScriptEncoder.Create(UnicodeRanges.BasicLatin, UnicodeRanges.Latin1Supplement) });
 
-            normalizedJsonSchemaText.Should().BeEquivalentTo(jsonSchemaText);
+            Assert.Equal(jsonSchemaText, normalizedJsonSchemaText);
             return Task.CompletedTask;
         }
 
@@ -77,7 +77,7 @@ namespace DataModeling.Tests.Json
 
             var json = JsonSerializer.Serialize(normalizedJsonSchema, new JsonSerializerOptions { WriteIndented = true });
 
-            normalizedJsonSchemaText.Should().BeEquivalentTo(expectedNormalizedJsonSchemaText);
+            Assert.Equal(expectedNormalizedJsonSchemaText, normalizedJsonSchemaText);
             return Task.CompletedTask;
         }
     }

--- a/backend/tests/DataModeling.Tests/Json/JsonSchemaSeresAnalyzerTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/JsonSchemaSeresAnalyzerTests.cs
@@ -39,7 +39,7 @@ namespace DataModeling.Tests.Json
 
             var results = analyzer.AnalyzeSchema(schema);
 
-            results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)).Should().Contain(CompatibleXsdType.ComplexType);
+            Assert.Contains(CompatibleXsdType.ComplexType, results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)));
         }
 
         [Theory]
@@ -57,10 +57,10 @@ namespace DataModeling.Tests.Json
 
             var results = analyzer.AnalyzeSchema(schema);
 
-            results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)).Should().Contain(CompatibleXsdType.ComplexContent);
-            results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)).Should().Contain(CompatibleXsdType.ComplexContentExtension);
-            results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)).Should().NotContain(CompatibleXsdType.SimpleContentExtension);
-            results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)).Should().NotContain(CompatibleXsdType.SimpleContentRestriction);
+            Assert.Contains(CompatibleXsdType.ComplexContent, results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)));
+            Assert.Contains(CompatibleXsdType.ComplexContentExtension, results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)));
+            Assert.DoesNotContain(CompatibleXsdType.SimpleContentExtension, results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)));
+            Assert.DoesNotContain(CompatibleXsdType.SimpleContentRestriction, results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)));
         }
 
         [Theory]
@@ -74,8 +74,8 @@ namespace DataModeling.Tests.Json
 
             var results = analyzer.AnalyzeSchema(schema);
 
-            results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)).Should().NotContain(CompatibleXsdType.ComplexContent);
-            results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)).Should().NotContain(CompatibleXsdType.ComplexContentExtension);
+            Assert.DoesNotContain(CompatibleXsdType.ComplexContent, results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)));
+            Assert.DoesNotContain(CompatibleXsdType.ComplexContentExtension, results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)));
         }
 
         [Theory]
@@ -92,8 +92,8 @@ namespace DataModeling.Tests.Json
 
             var results = analyzer.AnalyzeSchema(schema);
 
-            results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)).Should().Contain(CompatibleXsdType.SimpleType);
-            results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)).Should().Contain(CompatibleXsdType.Attribute);
+            Assert.Contains(CompatibleXsdType.SimpleType, results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)));
+            Assert.Contains(CompatibleXsdType.Attribute, results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)));
         }
 
         [Theory]
@@ -108,7 +108,7 @@ namespace DataModeling.Tests.Json
 
             var results = analyzer.AnalyzeSchema(schema);
 
-            results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)).Should().Contain(CompatibleXsdType.Nillable);
+            Assert.Contains(CompatibleXsdType.Nillable, results.GetCompatibleTypes(JsonPointer.Parse(jsonPointer)));
         }
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/JsonSchemaSeresAnalyzerTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/JsonSchemaSeresAnalyzerTests.cs
@@ -3,7 +3,6 @@ using Altinn.Studio.DataModeling.Converter.Json;
 using Altinn.Studio.DataModeling.Converter.Json.Strategy;
 using Altinn.Studio.DataModeling.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
-using FluentAssertions;
 using Json.Pointer;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/BaseClasses/ConverterTestBase.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/BaseClasses/ConverterTestBase.cs
@@ -61,10 +61,4 @@ where TKeywordType : IJsonSchemaKeyword
         return this as TTestType;
     }
 
-    // protected TTestType KeywordShouldBeNull()
-    // {
-    //     Assert.Null(Keyword);
-    //     return this as TTestType;
-    // }
-
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/BaseClasses/ConverterTestBase.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/BaseClasses/ConverterTestBase.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using System.Text.Unicode;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using Altinn.Studio.DataModeling.Utils;
-using FluentAssertions;
 using Json.Schema;
 using SharedResources.Tests;
 

--- a/backend/tests/DataModeling.Tests/Json/Keywords/BaseClasses/ConverterTestBase.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/BaseClasses/ConverterTestBase.cs
@@ -5,6 +5,7 @@ using Altinn.Studio.DataModeling.Json.Keywords;
 using Altinn.Studio.DataModeling.Utils;
 using Json.Schema;
 using SharedResources.Tests;
+using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.BaseClasses;
 
@@ -50,7 +51,20 @@ where TKeywordType : IJsonSchemaKeyword
 
     protected TTestType SerializedKeywordShouldBe(string json)
     {
-        KeywordNodeJson.Should().Be(json);
+        Assert.Equal(KeywordNodeJson, json);
         return this as TTestType;
     }
+
+    protected TTestType KeywordShouldNotBeNull()
+    {
+        Assert.NotNull(Keyword);
+        return this as TTestType;
+    }
+
+    // protected TTestType KeywordShouldBeNull()
+    // {
+    //     Assert.Null(Keyword);
+    //     return this as TTestType;
+    // }
+
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatExclusiveMaximumKeywordJsonConverterConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatExclusiveMaximumKeywordJsonConverterConverterTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Converter;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatExclusiveMaximumKeywordJsonConverterConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatExclusiveMaximumKeywordJsonConverterConverterTests.cs
@@ -30,9 +30,11 @@ public class FormatExclusiveMaximumKeywordJsonConverterConverterTests : ValueKey
 
         Given.That.JsonSchemaLoaded(jsonSchema)
             .When.KeywordReadFromSchema()
-            .Then.Keyword.Should().NotBeNull();
+            .Then.KeywordShouldNotBeNull();
 
-        And.Keyword.Value.Should().Be(value);
+        Assert.Equal(Keyword.Value, value);
+
+
     }
 
     [Theory]
@@ -46,6 +48,7 @@ public class FormatExclusiveMaximumKeywordJsonConverterConverterTests : ValueKey
 
         var ex = Assert.Throws<JsonException>(() =>
             Given.That.JsonSchemaLoaded(jsonSchema));
-        ex.Message.Should().Be("Expected string");
+
+        Assert.Equal("Expected string", ex.Message);
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatExclusiveMinimumKeywordJsonConverterConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatExclusiveMinimumKeywordJsonConverterConverterTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Converter;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatExclusiveMinimumKeywordJsonConverterConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatExclusiveMinimumKeywordJsonConverterConverterTests.cs
@@ -30,9 +30,9 @@ public class FormatExclusiveMinimumKeywordJsonConverterConverterTests : ValueKey
 
         Given.That.JsonSchemaLoaded(jsonSchema)
             .When.KeywordReadFromSchema()
-            .Then.Keyword.Should().NotBeNull();
+            .Then.KeywordShouldNotBeNull();
 
-        And.Keyword.Value.Should().Be(value);
+        Assert.Equal(Keyword.Value, value);
     }
 
     [Theory]
@@ -46,6 +46,7 @@ public class FormatExclusiveMinimumKeywordJsonConverterConverterTests : ValueKey
 
         var ex = Assert.Throws<JsonException>(() =>
             Given.That.JsonSchemaLoaded(jsonSchema));
-        ex.Message.Should().Be("Expected string");
+
+        Assert.Equal("Expected string", ex.Message);
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatMaximumKeywordJsonConverterConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatMaximumKeywordJsonConverterConverterTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Converter;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatMaximumKeywordJsonConverterConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatMaximumKeywordJsonConverterConverterTests.cs
@@ -30,9 +30,9 @@ public class FormatMaximumKeywordJsonConverterConverterTests : ValueKeywordConve
 
         Given.That.JsonSchemaLoaded(jsonSchema)
             .When.KeywordReadFromSchema()
-            .Then.Keyword.Should().NotBeNull();
+            .Then.KeywordShouldNotBeNull();
 
-        And.Keyword.Value.Should().Be(value);
+        Assert.Equal(Keyword.Value, value);
     }
 
     [Theory]
@@ -46,6 +46,7 @@ public class FormatMaximumKeywordJsonConverterConverterTests : ValueKeywordConve
 
         var ex = Assert.Throws<JsonException>(() =>
             Given.That.JsonSchemaLoaded(jsonSchema));
-        ex.Message.Should().Be("Expected string");
+
+        Assert.Equal("Expected string", ex.Message);
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatMinimumKeywordJsonConverterConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatMinimumKeywordJsonConverterConverterTests.cs
@@ -30,9 +30,9 @@ public class FormatMinimumKeywordJsonConverterConverterTests : ValueKeywordConve
 
         Given.That.JsonSchemaLoaded(jsonSchema)
             .When.KeywordReadFromSchema()
-            .Then.Keyword.Should().NotBeNull();
+            .Then.KeywordShouldNotBeNull();
 
-        And.Keyword.Value.Should().Be(value);
+        Assert.Equal(Keyword.Value, value);
     }
 
     [Theory]
@@ -46,6 +46,7 @@ public class FormatMinimumKeywordJsonConverterConverterTests : ValueKeywordConve
 
         var ex = Assert.Throws<JsonException>(() =>
             Given.That.JsonSchemaLoaded(jsonSchema));
-        ex.Message.Should().Be("Expected string");
+
+        Assert.Equal("Expected string", ex.Message);
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatMinimumKeywordJsonConverterConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Converter/FormatMinimumKeywordJsonConverterConverterTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Converter;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatExclusiveMaximumKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatExclusiveMaximumKeywordTests.cs
@@ -13,7 +13,7 @@ public class FormatExclusiveMaximumKeywordTests : ValueKeywordTestsBase<FormatEx
     public void CreatedKeyword_ShouldHaveValue(string value)
     {
         Keyword = new FormatExclusiveMaximumKeyword(value);
-        Keyword.Value.Should().Be(value);
+        Assert.Equal(value, Keyword.Value);
     }
 
     [Theory]
@@ -35,6 +35,7 @@ public class FormatExclusiveMaximumKeywordTests : ValueKeywordTestsBase<FormatEx
     {
         var expectedHashCode = value.GetHashCode();
         Given.That.KeywordCreatedWithValue(value);
-        expectedHashCode.GetHashCode().Should().Be(Keyword.GetHashCode());
+
+        Assert.Equal(expectedHashCode, Keyword.GetHashCode());
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatExclusiveMaximumKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatExclusiveMaximumKeywordTests.cs
@@ -1,6 +1,5 @@
 ﻿using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Keyword;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatExclusiveMinimumKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatExclusiveMinimumKeywordTests.cs
@@ -13,7 +13,7 @@ public class FormatExclusiveMinimumKeywordTests : ValueKeywordTestsBase<FormatEx
     public void CreatedKeyword_ShouldHaveValue(string value)
     {
         Keyword = new FormatExclusiveMinimumKeyword(value);
-        Keyword.Value.Should().Be(value);
+        Assert.Equal(value, Keyword.Value);
     }
 
     [Theory]
@@ -35,6 +35,6 @@ public class FormatExclusiveMinimumKeywordTests : ValueKeywordTestsBase<FormatEx
     {
         var expectedHashCode = value.GetHashCode();
         Given.That.KeywordCreatedWithValue(value);
-        expectedHashCode.GetHashCode().Should().Be(Keyword.GetHashCode());
+        Assert.Equal(expectedHashCode, Keyword.GetHashCode());
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatExclusiveMinimumKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatExclusiveMinimumKeywordTests.cs
@@ -1,6 +1,5 @@
 ﻿using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Keyword;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatMaximumKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatMaximumKeywordTests.cs
@@ -13,7 +13,7 @@ public class FormatMaximumKeywordTests : ValueKeywordTestsBase<FormatMaximumKeyw
     public void CreatedKeyword_ShouldHaveValue(string value)
     {
         Given.That.KeywordCreatedWithValue(value);
-        Keyword.Value.Should().Be(value);
+        Assert.Equal(value, Keyword.Value);
     }
 
     [Theory]
@@ -35,6 +35,6 @@ public class FormatMaximumKeywordTests : ValueKeywordTestsBase<FormatMaximumKeyw
     {
         var expectedHashCode = value.GetHashCode();
         Given.That.KeywordCreatedWithValue(value);
-        expectedHashCode.GetHashCode().Should().Be(Keyword.GetHashCode());
+        Assert.Equal(expectedHashCode, Keyword.GetHashCode());
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatMaximumKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatMaximumKeywordTests.cs
@@ -1,6 +1,5 @@
 ﻿using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Keyword;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatMinimumKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatMinimumKeywordTests.cs
@@ -13,7 +13,7 @@ public class FormatMinimumKeywordTests : ValueKeywordTestsBase<FormatMinimumKeyw
     public void CreatedKeyword_ShouldHaveValue(string value)
     {
         Keyword = new FormatMinimumKeyword(value);
-        Keyword.Value.Should().Be(value);
+        Assert.Equal(value, Keyword.Value);
     }
 
     [Theory]
@@ -35,6 +35,6 @@ public class FormatMinimumKeywordTests : ValueKeywordTestsBase<FormatMinimumKeyw
     {
         var expectedHashCode = value.GetHashCode();
         Given.That.KeywordCreatedWithValue(value);
-        expectedHashCode.GetHashCode().Should().Be(Keyword.GetHashCode());
+        Assert.Equal(expectedHashCode, Keyword.GetHashCode());
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatMinimumKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/FormatRange/Keyword/FormatMinimumKeywordTests.cs
@@ -1,6 +1,5 @@
 ﻿using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.FormatRange.Keyword;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Converter/XsdMaxOccursKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Converter/XsdMaxOccursKeywordJsonConverterTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.OccursKeywords.Converter

--- a/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Converter/XsdMaxOccursKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Converter/XsdMaxOccursKeywordJsonConverterTests.cs
@@ -23,9 +23,9 @@ namespace DataModeling.Tests.Json.Keywords.OccursKeywords.Converter
 
             Given.That.JsonSchemaLoaded(jsonSchema)
                 .When.KeywordReadFromSchema()
-                .Then.Keyword.Should().NotBeNull();
+                .Then.KeywordShouldNotBeNull();
 
-            And.Keyword.Value.Should().Be(value);
+            Assert.Equal(Keyword.Value, value);
         }
 
         [Theory]
@@ -50,7 +50,8 @@ namespace DataModeling.Tests.Json.Keywords.OccursKeywords.Converter
 
             var ex = Assert.Throws<JsonException>(() =>
                 Given.That.JsonSchemaLoaded(jsonSchema));
-            ex.Message.Should().Be("Expected string");
+
+            Assert.Equal("Expected string", ex.Message);
         }
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Converter/XsdMinOccursKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Converter/XsdMinOccursKeywordJsonConverterTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.OccursKeywords.Converter

--- a/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Converter/XsdMinOccursKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Converter/XsdMinOccursKeywordJsonConverterTests.cs
@@ -23,9 +23,9 @@ namespace DataModeling.Tests.Json.Keywords.OccursKeywords.Converter
 
             Given.That.JsonSchemaLoaded(jsonSchema)
                 .When.KeywordReadFromSchema()
-                .Then.Keyword.Should().NotBeNull();
+                .Then.KeywordShouldNotBeNull();
 
-            And.Keyword.Value.Should().Be(value);
+            Assert.Equal(Keyword.Value, value);
         }
 
         [Theory]
@@ -50,7 +50,8 @@ namespace DataModeling.Tests.Json.Keywords.OccursKeywords.Converter
 
             var ex = Assert.Throws<JsonException>(() =>
                 Given.That.JsonSchemaLoaded(jsonSchema));
-            ex.Message.Should().Be("Expected number");
+
+            Assert.Equal("Expected number", ex.Message);
         }
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Keyword/XsdMaxOccursKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Keyword/XsdMaxOccursKeywordTests.cs
@@ -1,6 +1,5 @@
 ﻿using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.OccursKeywords.Keyword;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Keyword/XsdMaxOccursKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Keyword/XsdMaxOccursKeywordTests.cs
@@ -16,7 +16,7 @@ public class XsdMaxOccursKeywordTests : ValueKeywordTestsBase<XsdMaxOccursKeywor
     public void CreatedKeyword_ShouldHaveValue(string value)
     {
         Keyword = new XsdMaxOccursKeyword(value);
-        Keyword.Value.Should().Be(value);
+        Assert.Equal(value, Keyword.Value);
     }
 
     [Theory]
@@ -44,6 +44,7 @@ public class XsdMaxOccursKeywordTests : ValueKeywordTestsBase<XsdMaxOccursKeywor
     {
         var expectedHashCode = value.GetHashCode();
         Given.That.KeywordCreatedWithValue(value);
-        expectedHashCode.GetHashCode().Should().Be(Keyword.GetHashCode());
+
+        Assert.Equal(expectedHashCode, Keyword.GetHashCode());
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Keyword/XsdMinOccursKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Keyword/XsdMinOccursKeywordTests.cs
@@ -1,6 +1,5 @@
 ﻿using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords.OccursKeywords.Keyword;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Keyword/XsdMinOccursKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/OccursKeywords/Keyword/XsdMinOccursKeywordTests.cs
@@ -15,7 +15,7 @@ public class XsdMinOccursKeywordTests : ValueKeywordTestsBase<XsdMinOccursKeywor
     public void CreatedKeyword_ShouldHaveValue(int value)
     {
         Keyword = new XsdMinOccursKeyword(value);
-        Keyword.Value.Should().Be(value);
+        Assert.Equal(value, Keyword.Value);
     }
 
     [Theory]
@@ -41,6 +41,6 @@ public class XsdMinOccursKeywordTests : ValueKeywordTestsBase<XsdMinOccursKeywor
     {
         var expectedHashCode = value.GetHashCode();
         Given.That.KeywordCreatedWithValue(value);
-        expectedHashCode.GetHashCode().Should().Be(Keyword.GetHashCode());
+        Assert.Equal(expectedHashCode, Keyword.GetHashCode());
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdNillableKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdNillableKeywordJsonConverterTests.cs
@@ -22,9 +22,9 @@ namespace DataModeling.Tests.Json.Keywords
 
             Given.That.JsonSchemaLoaded(jsonSchema)
                 .When.KeywordReadFromSchema()
-                .Then.Keyword.Should().NotBeNull();
+                .Then.KeywordShouldNotBeNull();
 
-            And.Keyword.Value.Should().Be(value);
+            Assert.Equal(Keyword.Value, value);
         }
 
         [Theory]
@@ -48,7 +48,8 @@ namespace DataModeling.Tests.Json.Keywords
 
             var ex = Assert.Throws<JsonException>(() =>
                 Given.That.JsonSchemaLoaded(jsonSchema));
-            ex.Message.Should().Be("Expected boolean");
+
+            Assert.Equal("Expected boolean", ex.Message);
         }
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdNillableKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdNillableKeywordJsonConverterTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdRootElementKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdRootElementKeywordJsonConverterTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdRootElementKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdRootElementKeywordJsonConverterTests.cs
@@ -22,9 +22,9 @@ namespace DataModeling.Tests.Json.Keywords
 
             Given.That.JsonSchemaLoaded(jsonSchema)
                 .When.KeywordReadFromSchema()
-                .Then.Keyword.Should().NotBeNull();
+                .Then.KeywordShouldNotBeNull();
 
-            And.Keyword.Value.Should().Be(value);
+            Assert.Equal(Keyword.Value, value);
         }
 
         [Theory]
@@ -48,7 +48,7 @@ namespace DataModeling.Tests.Json.Keywords
 
             var ex = Assert.Throws<JsonException>(() =>
                 Given.That.JsonSchemaLoaded(jsonSchema));
-            ex.Message.Should().Be("Expected string");
+            Assert.Equal("Expected string", ex.Message);
         }
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdRootElementKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdRootElementKeywordTests.cs
@@ -1,6 +1,5 @@
 ﻿using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdRootElementKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdRootElementKeywordTests.cs
@@ -28,6 +28,7 @@ public class XsdRootElementKeywordTests : ValueKeywordTestsBase<XsdRootElementKe
     {
         var expectedHashCode = value.GetHashCode();
         Given.That.KeywordCreatedWithValue(value);
-        expectedHashCode.GetHashCode().Should().Be(Keyword.GetHashCode());
+
+        Assert.Equal(expectedHashCode, Keyword.GetHashCode());
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdTextKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdTextKeywordJsonConverterTests.cs
@@ -21,9 +21,9 @@ namespace DataModeling.Tests.Json.Keywords
 
             Given.That.JsonSchemaLoaded(jsonSchema)
                 .When.KeywordReadFromSchema()
-                .Then.Keyword.Should().NotBeNull();
+                .Then.KeywordShouldNotBeNull();
 
-            And.Keyword.Value.Should().Be(value);
+            Assert.Equal(Keyword.Value, value);
         }
 
         [Theory]

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdTextKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdTextKeywordJsonConverterTests.cs
@@ -1,6 +1,5 @@
 using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdTextKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdTextKeywordTests.cs
@@ -1,6 +1,5 @@
 ﻿using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords;

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdTextKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdTextKeywordTests.cs
@@ -12,7 +12,7 @@ public class XsdTextKeywordTests : ValueKeywordTestsBase<XsdTextKeywordTests, Xs
     public void DefaultValue_ShouldBe_False()
     {
         Keyword = new XsdTextKeyword();
-        Keyword.Value.Should().Be(false);
+        Assert.False(Keyword.Value);
     }
 
     [Theory]

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordJsonConverterTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Json.Keywords

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordJsonConverterTests.cs
@@ -22,9 +22,9 @@ namespace DataModeling.Tests.Json.Keywords
 
             Given.That.JsonSchemaLoaded(jsonSchema)
                 .When.KeywordReadFromSchema()
-                .Then.Keyword.Should().NotBeNull();
+                .Then.KeywordShouldNotBeNull();
 
-            And.Keyword.Value.Should().Be(value);
+            Assert.Equal(Keyword.Value, value);
         }
 
         [Theory]
@@ -48,7 +48,7 @@ namespace DataModeling.Tests.Json.Keywords
 
             var ex = Assert.Throws<JsonException>(() =>
                 Given.That.JsonSchemaLoaded(jsonSchema));
-            ex.Message.Should().Be("Expected number");
+            Assert.Equal("Expected number", ex.Message);
         }
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordTests.cs
@@ -18,7 +18,7 @@ public class XsdTotalDigitsKeywordTests : ValueKeywordTestsBase<XsdTotalDigitsKe
     public void CreatedKeyword_ShouldHaveValue(uint value)
     {
         Keyword = new XsdTotalDigitsKeyword(value);
-        Keyword.Value.Should().Be(value);
+        Assert.Equal(value, Keyword.Value);
     }
 
     [Theory]
@@ -42,7 +42,7 @@ public class XsdTotalDigitsKeywordTests : ValueKeywordTestsBase<XsdTotalDigitsKe
     {
         var expectedHashCode = value.GetHashCode();
         Given.That.KeywordCreatedWithValue(value);
-        expectedHashCode.GetHashCode().Should().Be(Keyword.GetHashCode());
+        Assert.Equal(expectedHashCode, Keyword.GetHashCode());
     }
 
     [Theory]
@@ -56,7 +56,7 @@ public class XsdTotalDigitsKeywordTests : ValueKeywordTestsBase<XsdTotalDigitsKe
         var schema = JsonSchema.FromText(TotalDigitsSchema(totalDigitsValue));
         var node = JsonNode.Parse(TotalDigitsJson(jsonDataValue));
         var validationResults = schema.Evaluate(node, new EvaluationOptions() { ProcessCustomKeywords = true });
-        shouldBeValid.Should().Be(validationResults.IsValid);
+        Assert.Equal(shouldBeValid, validationResults.IsValid);
     }
 
     private static string TotalDigitsSchema(uint value) => @$"

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdTotalDigitsKeywordTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json.Nodes;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using DataModeling.Tests.Json.Keywords.BaseClasses;
-using FluentAssertions;
 using Json.Schema;
 using Xunit;
 

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdUnhandledEnumAttributesKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdUnhandledEnumAttributesKeywordJsonConverterTests.cs
@@ -23,10 +23,10 @@ namespace DataModeling.Tests.Json.Keywords
             var xsdUnhandledEnumAttributesKeyword = keywordConverter.Read(ref jsonReader, typeof(XsdUnhandledAttributesKeyword), new System.Text.Json.JsonSerializerOptions());
 
             // Assert
-            xsdUnhandledEnumAttributesKeyword.Properties.Should().HaveCount(3);
-            xsdUnhandledEnumAttributesKeyword.Properties.Single(p => p.Name == "frontend").Properties.Should().HaveCount(2);
-            xsdUnhandledEnumAttributesKeyword.Properties.Single(p => p.Name == "backend").Properties.Should().HaveCount(2);
-            xsdUnhandledEnumAttributesKeyword.Properties.Single(p => p.Name == "other").Properties.Should().HaveCount(2);
+            Assert.Equal(3, xsdUnhandledEnumAttributesKeyword.Properties.Count);
+            Assert.Equal(2, xsdUnhandledEnumAttributesKeyword.Properties.Single(p => p.Name == "frontend").Properties.Count);
+            Assert.Equal(2, xsdUnhandledEnumAttributesKeyword.Properties.Single(p => p.Name == "backend").Properties.Count);
+            Assert.Equal(2, xsdUnhandledEnumAttributesKeyword.Properties.Single(p => p.Name == "other").Properties.Count);
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace DataModeling.Tests.Json.Keywords
             var streamReader = new StreamReader(jsonStream);
             var jsonText = streamReader.ReadToEnd();
 
-            jsonText.Should().Be(@"{""@xsdUnhandledEnumAttributes"":{""frontend"":{""seres:elementtype"":""Datakodeelement"",""seres:guid"":""http://seres.no/guid/Kursdomene/Datakodeelement/other/784952""},""backend"":{""seres:elementtype"":""Datakodeelement"",""seres:guid"":""http://seres.no/guid/Kursdomene/Datakodeelement/other/784951""},""other"":{""seres:elementtype"":""Datakodeelement"",""seres:guid"":""http://seres.no/guid/Kursdomene/Datakodeelement/other/784950""}}}");
+            Assert.Equal(@"{""@xsdUnhandledEnumAttributes"":{""frontend"":{""seres:elementtype"":""Datakodeelement"",""seres:guid"":""http://seres.no/guid/Kursdomene/Datakodeelement/other/784952""},""backend"":{""seres:elementtype"":""Datakodeelement"",""seres:guid"":""http://seres.no/guid/Kursdomene/Datakodeelement/other/784951""},""other"":{""seres:elementtype"":""Datakodeelement"",""seres:guid"":""http://seres.no/guid/Kursdomene/Datakodeelement/other/784950""}}}", jsonText);
         }
     }
 }

--- a/backend/tests/DataModeling.Tests/Json/Keywords/XsdUnhandledEnumAttributesKeywordJsonConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/Keywords/XsdUnhandledEnumAttributesKeywordJsonConverterTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
-using FluentAssertions;
 using Xunit;
 using static Altinn.Studio.DataModeling.Json.Keywords.XsdUnhandledEnumAttributesKeyword;
 

--- a/backend/tests/DataModeling.Tests/Json/SeresStrategyTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/SeresStrategyTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Altinn.Studio.DataModeling.Converter.Json;
 using Altinn.Studio.DataModeling.Converter.Json.Strategy;
@@ -21,10 +22,11 @@ namespace DataModeling.Tests.Json
 
             var metadata = analyzer.AnalyzeSchema(schema);
 
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#")).Should().Equal(CompatibleXsdType.ComplexType);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/oneOf/[0]")).Should().Equal(CompatibleXsdType.ComplexType);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/melding-modell")).Should().Equal(CompatibleXsdType.ComplexType);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/melding-modell/properties/e1")).Should().Equal(CompatibleXsdType.SimpleType);
+            Assert.Equal(CompatibleXsdType.ComplexType, metadata.GetCompatibleTypes(JsonPointer.Parse("#")).Single());
+            Assert.Equal(CompatibleXsdType.ComplexType, metadata.GetCompatibleTypes(JsonPointer.Parse("#/oneOf/[0]")).Single());
+            Assert.Equal(CompatibleXsdType.ComplexType, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/melding-modell")).Single());
+            Assert.Equal(CompatibleXsdType.SimpleType, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/melding-modell/properties/e1")).Single());
+
             return Task.CompletedTask;
         }
 
@@ -39,7 +41,8 @@ namespace DataModeling.Tests.Json
 
             var metadata = analyzer.AnalyzeSchema(schema);
 
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/myBase")).Should().Contain(new[] { CompatibleXsdType.ComplexType, CompatibleXsdType.SimpleContentExtension });
+            Assert.Contains(CompatibleXsdType.ComplexType, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/myBase")));
+            Assert.Contains(CompatibleXsdType.SimpleContentExtension, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/myBase")));
             return Task.CompletedTask;
         }
 
@@ -47,43 +50,44 @@ namespace DataModeling.Tests.Json
         [InlineData(@"Model/JsonSchema/Seres/SeresSimpleTypeRestrictions.json")]
         public Task Analyze_SimpleType_Restriction(string path)
         {
-            JsonSchemaKeywords.RegisterXsdKeywords();
+           JsonSchemaKeywords.RegisterXsdKeywords();
 
             var schema = SharedResourcesHelper.LoadJsonSchemaTestData(path);
             var analyzer = new SeresJsonSchemaAnalyzer();
 
             var metadata = analyzer.AnalyzeSchema(schema);
 
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/t1")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/t2")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/t3")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/t4")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/n1")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/n2")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/f1")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/f2")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/f3")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/f4")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/f5")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/f6")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/c0")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction,
+                metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/t1")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/t2")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/t3")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/t4")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/n1")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/n2")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/f1")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/f2")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/f3")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/f4")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/f5")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/f6")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/properties/c0")));
 
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/simpleString")).Should().Contain(CompatibleXsdType.SimpleType);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/SeresType")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/simpleString")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/stringMinMaxLengthRestrictions")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/stringLengthRestrictions")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/stringEnumRestrictions")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/stringPatternRestrictions")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictions")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictions2")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictionsFractional0")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictionsFractional1")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictionsFractional2")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictionsFractional3")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictionsFractional4")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictionsFractional5")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/complexStructure")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
+            Assert.Contains(CompatibleXsdType.SimpleType, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/simpleString")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/SeresType")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/simpleString")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/stringMinMaxLengthRestrictions")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/stringLengthRestrictions")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/stringEnumRestrictions")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/stringPatternRestrictions")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictions")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictions2")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictionsFractional0")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictionsFractional1")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictionsFractional2")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictionsFractional3")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictionsFractional4")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/numberRestrictionsFractional5")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/complexStructure")));
             return Task.CompletedTask;
         }
 
@@ -98,13 +102,13 @@ namespace DataModeling.Tests.Json
 
             var metadata = analyzer.AnalyzeSchema(schema);
 
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/ageType")).Should().Contain(CompatibleXsdType.SimpleType);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/limitedAgeType")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/genderType")).Should().Contain(CompatibleXsdType.SimpleType);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/limitedGenderType")).Should().Contain(CompatibleXsdType.SimpleTypeRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/person")).Should().Contain(CompatibleXsdType.SimpleContentExtension);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/limitedPerson")).Should().Contain(CompatibleXsdType.SimpleContentRestriction);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/limitedPerson-inline")).Should().Contain(CompatibleXsdType.SimpleContentRestriction);
+            Assert.Contains(CompatibleXsdType.SimpleType, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/ageType")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/limitedAgeType")));
+            Assert.Contains(CompatibleXsdType.SimpleType, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/genderType")));
+            Assert.Contains(CompatibleXsdType.SimpleTypeRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/limitedGenderType")));
+            Assert.Contains(CompatibleXsdType.SimpleContentExtension, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/person")));
+            Assert.Contains(CompatibleXsdType.SimpleContentRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/limitedPerson")));
+            Assert.Contains(CompatibleXsdType.SimpleContentRestriction, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/limitedPerson-inline")));
             return Task.CompletedTask;
         }
 
@@ -119,10 +123,11 @@ namespace DataModeling.Tests.Json
 
             var metadata = analyzer.AnalyzeSchema(schema);
 
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#")).Should().Contain(CompatibleXsdType.ComplexContentExtension);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/myBase")).Should().Contain(CompatibleXsdType.ComplexType);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/badBoy")).Should().Contain(CompatibleXsdType.ComplexType);
-            metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/badBoy/properties/reallyNasty")).Should().Contain(CompatibleXsdType.ComplexContentExtension);
+            Assert.Contains(CompatibleXsdType.ComplexContentExtension, metadata.GetCompatibleTypes(JsonPointer.Parse("#")));
+            Assert.Contains(CompatibleXsdType.ComplexType, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/myBase")));
+            Assert.Contains(CompatibleXsdType.ComplexType, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/badBoy")));
+            Assert.Contains(CompatibleXsdType.ComplexContentExtension, metadata.GetCompatibleTypes(JsonPointer.Parse("#/$defs/badBoy/properties/reallyNasty")));
+
             return Task.CompletedTask;
         }
     }

--- a/backend/tests/DataModeling.Tests/Json/SeresStrategyTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/SeresStrategyTests.cs
@@ -50,7 +50,7 @@ namespace DataModeling.Tests.Json
         [InlineData(@"Model/JsonSchema/Seres/SeresSimpleTypeRestrictions.json")]
         public Task Analyze_SimpleType_Restriction(string path)
         {
-           JsonSchemaKeywords.RegisterXsdKeywords();
+            JsonSchemaKeywords.RegisterXsdKeywords();
 
             var schema = SharedResourcesHelper.LoadJsonSchemaTestData(path);
             var analyzer = new SeresJsonSchemaAnalyzer();

--- a/backend/tests/DataModeling.Tests/Json/SeresStrategyTests.cs
+++ b/backend/tests/DataModeling.Tests/Json/SeresStrategyTests.cs
@@ -2,7 +2,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.DataModeling.Converter.Json;
 using Altinn.Studio.DataModeling.Converter.Json.Strategy;
 using Altinn.Studio.DataModeling.Json.Keywords;
-using FluentAssertions;
 using Json.Pointer;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/DataModeling.Tests/JsonMetadataParserTests.cs
+++ b/backend/tests/DataModeling.Tests/JsonMetadataParserTests.cs
@@ -10,9 +10,10 @@ namespace DataModeling.Tests
         {
             Given.That.ModelMetadataLoaded(
                     "Model/Metadata/restriction-total-digits.json")
-                .When.ModelMetadataConvertedToCsharpClass()
-                .Then.CSharpClasses.Should().NotBeNull();
-            And.CSharpClasses.Should().Contain("[Range(-7.766279631452242E+18, 7.766279631452242E+18)]");
+                .When.ModelMetadataConvertedToCsharpClass();
+
+            Assert.NotNull(CSharpClasses);
+            Assert.Contains("[Range(-7.766279631452242E+18, 7.766279631452242E+18)]", CSharpClasses);
         }
 
         [Fact]
@@ -20,10 +21,12 @@ namespace DataModeling.Tests
         {
             Given.That.ModelMetadataLoaded(
                     "Model/Metadata/restriction-total-digits.json")
-                .When.ModelMetadataConvertedToCsharpClass()
-                .Then.CSharpClasses.Should().NotBeNull();
-            And.CSharpClasses.Should().Contain("[MinLength(1)]");
-            And.CSharpClasses.Should().Contain("[MaxLength(20)]");
+                .When.ModelMetadataConvertedToCsharpClass();
+
+            Assert.NotNull(CSharpClasses);
+
+            Assert.Contains("[MinLength(1)]", CSharpClasses);
+            Assert.Contains("[MaxLength(20)]", CSharpClasses);
         }
 
         [Fact]
@@ -31,9 +34,11 @@ namespace DataModeling.Tests
         {
             Given.That.ModelMetadataLoaded(
                     "Model/Metadata/RA-0678_M.json")
-                .When.ModelMetadataConvertedToCsharpClass()
-                .Then.CSharpClasses.Should().NotBeNull();
-            And.CSharpClasses.Should().Contain("[XmlRoot(ElementName=\"melding\")]");
+                .When.ModelMetadataConvertedToCsharpClass();
+
+            Assert.NotNull(CSharpClasses);
+
+            Assert.Contains("[XmlRoot(ElementName=\"melding\")]", CSharpClasses);
         }
 
         [Fact]
@@ -41,11 +46,13 @@ namespace DataModeling.Tests
         {
             Given.That.ModelMetadataLoaded(
                     "Model/Metadata/SimpleStringArray.json")
-                .When.ModelMetadataConvertedToCsharpClass()
-                .Then.CSharpClasses.Should().NotBeNull();
-            And.CSharpClasses.Should().Contain("List<string>");
-            And.CSharpClasses.Should().NotContain("List<String>");
-            And.CSharpClasses.Should().NotContain("public class String");
+                .When.ModelMetadataConvertedToCsharpClass();
+
+            Assert.NotNull(CSharpClasses);
+
+            Assert.Contains("List<string>", CSharpClasses);
+            Assert.DoesNotContain("List<String>", CSharpClasses);
+            Assert.DoesNotContain("public class String", CSharpClasses);
         }
 
         [Fact]
@@ -53,9 +60,12 @@ namespace DataModeling.Tests
         {
             Given.That.ModelMetadataLoaded(
                     "Model/Metadata/SeresBasicSchemaWithTargetNamespace.json")
-                .When.ModelMetadataConvertedToCsharpClass()
-                .Then.CSharpClasses.Should().NotBeNull();
-            And.CSharpClasses.Should().MatchRegex("\\[XmlRoot\\(.*Namespace=\"urn:no:altinn:message\"\\)\\]");
+                .When.ModelMetadataConvertedToCsharpClass();
+
+            Assert.NotNull(CSharpClasses);
+
+            Assert.Matches("\\[XmlRoot\\(.*Namespace=\"urn:no:altinn:message\"\\)\\]", CSharpClasses);
+
         }
     }
 }

--- a/backend/tests/DataModeling.Tests/JsonMetadataParserTests.cs
+++ b/backend/tests/DataModeling.Tests/JsonMetadataParserTests.cs
@@ -1,5 +1,4 @@
 using DataModeling.Tests.BaseClasses;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests

--- a/backend/tests/DataModeling.Tests/JsonSchemaToMetamodelConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/JsonSchemaToMetamodelConverterTests.cs
@@ -31,8 +31,9 @@ namespace DataModeling.Tests
                 .And.ExpectedMetamodelLoaded(expectedMetamodelPath)
                 .Then.MetamodelShouldBeEquivalentToExpected()
                 .And.When.ModelMetadataConvertedToCsharpClass()
-                .And.CSharpClassesCompiledToAssembly()
-                .Then.CompiledAssembly.Should().NotBeNull();
+                .And.CSharpClassesCompiledToAssembly();
+
+            Assert.NotNull(CompiledAssembly);
         }
 
         // Helper methods
@@ -52,7 +53,7 @@ namespace DataModeling.Tests
 
         private JsonSchemaToMetamodelConverterTests MetamodelShouldHaveOneRootElement()
         {
-            ModelMetadata.Elements.Values.Where(e => e.ParentElement == null).ToList().Count.Should().Be(1);
+            Assert.Single(ModelMetadata.Elements.Values.Where(e => e.ParentElement == null).ToList());
             return this;
         }
     }

--- a/backend/tests/DataModeling.Tests/JsonSchemaToMetamodelConverterTests.cs
+++ b/backend/tests/DataModeling.Tests/JsonSchemaToMetamodelConverterTests.cs
@@ -4,7 +4,6 @@ using System.Text.Json.Serialization;
 using Altinn.Studio.DataModeling.Metamodel;
 using DataModeling.Tests.BaseClasses;
 using Designer.Tests.Assertions;
-using FluentAssertions;
 using SharedResources.Tests;
 using Xunit;
 

--- a/backend/tests/DataModeling.Tests/ModelSerializationDeserializationTests.cs
+++ b/backend/tests/DataModeling.Tests/ModelSerializationDeserializationTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Studio.DataModeling.Json.Keywords;
-using FluentAssertions;
 using Json.Schema;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/DataModeling.Tests/ModelSerializationDeserializationTests.cs
+++ b/backend/tests/DataModeling.Tests/ModelSerializationDeserializationTests.cs
@@ -29,7 +29,7 @@ namespace DataModeling.Tests
 
             var validXml = ValidateXml(xml);
 
-            validXml.Should().BeTrue();
+            Assert.True(validXml);
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace DataModeling.Tests
         {
             _TestData.Model.CSharp.melding melding = DeserializeFromXmlResource(SERESBASIC_XML_RESOURCE);
 
-            melding.E1.Should().Be("Yo");
+            Assert.Equal("Yo", melding.E1);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace DataModeling.Tests
 
             bool validXml = ValidateXml(xml);
 
-            validXml.Should().BeTrue();
+            Assert.True(validXml);
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace DataModeling.Tests
 
             var validationResults = jsonSchema.Evaluate(jsonDocument.RootElement, new EvaluationOptions() { OutputFormat = OutputFormat.Hierarchical });
 
-            validationResults.IsValid.Should().BeTrue();
+            Assert.True(validationResults.IsValid);
             return Task.CompletedTask;
         }
 
@@ -71,7 +71,7 @@ namespace DataModeling.Tests
             var json = SharedResourcesHelper.LoadTestDataAsString(SERESBASIC_JSON_RESOURCE);
             _TestData.Model.CSharp.melding melding = JsonSerializer.Deserialize<_TestData.Model.CSharp.melding>(json);
 
-            melding.E1.Should().Be("Yo");
+            Assert.Equal("Yo", melding.E1);
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace DataModeling.Tests
 
             var validationResults = jsonSchema.Evaluate(jsonDocument.RootElement, new EvaluationOptions() { OutputFormat = OutputFormat.Hierarchical });
 
-            validationResults.IsValid.Should().BeTrue();
+            Assert.True(validationResults.IsValid);
         }
 
         private static _TestData.Model.CSharp.melding DeserializeFromXmlResource(string xmlResource)

--- a/backend/tests/DataModeling.Tests/ModelSerializationTests.cs
+++ b/backend/tests/DataModeling.Tests/ModelSerializationTests.cs
@@ -3,7 +3,6 @@ using System.Xml.Linq;
 using DataModeling.Tests.BaseClasses;
 using DataModeling.Tests.TestDataClasses;
 using DataModeling.Tests.Utils;
-using FluentAssertions;
 using SharedResources.Tests;
 using Xunit;
 using JsonSerializer = System.Text.Json.JsonSerializer;

--- a/backend/tests/DataModeling.Tests/ModelSerializationTests.cs
+++ b/backend/tests/DataModeling.Tests/ModelSerializationTests.cs
@@ -30,9 +30,9 @@ namespace DataModeling.Tests
                 .When.LoadedXsdSchemaConvertedToJsonSchema()
                 .And.ConvertedJsonSchemaConvertedToModelMetadata()
                 .And.ModelMetadataConvertedToCsharpClass()
-                .And.CSharpClassesCompiledToAssembly()
-                .Then
-                .CompiledAssembly.Should().NotBeNull();
+                .And.CSharpClassesCompiledToAssembly();
+
+            Assert.NotNull(CompiledAssembly);
 
             And.When.TypeReadFromCompiledAssembly(typeName)
                 .And.JsonDataLoaded(jsonPath)
@@ -49,9 +49,9 @@ namespace DataModeling.Tests
                 .When.LoadedXsdSchemaConvertedToJsonSchema()
                 .And.ConvertedJsonSchemaConvertedToModelMetadata()
                 .And.ModelMetadataConvertedToCsharpClass()
-                .And.CSharpClassesCompiledToAssembly()
-                .Then
-                .CompiledAssembly.Should().NotBeNull();
+                .And.CSharpClassesCompiledToAssembly();
+
+            Assert.NotNull(CompiledAssembly);
 
             And.When.TypeReadFromCompiledAssembly(typeName)
                 .And.XmlDataLoaded(jsonPath)
@@ -68,9 +68,9 @@ namespace DataModeling.Tests
                 .When.LoadedXsdSchemaConvertedToJsonSchema()
                 .And.ConvertedJsonSchemaConvertedToModelMetadata()
                 .And.ModelMetadataConvertedToCsharpClass()
-                .And.CSharpClassesCompiledToAssembly()
-                .Then
-                .CompiledAssembly.Should().NotBeNull();
+                .And.CSharpClassesCompiledToAssembly();
+
+            Assert.NotNull(CompiledAssembly);
 
             And.When.TypeReadFromCompiledAssembly(typeName)
                 .And.XmlDataLoaded(xmlPath)
@@ -108,7 +108,7 @@ namespace DataModeling.Tests
 
         private void SerializedJsonData_ShouldNotBeChanged()
         {
-            JsonUtils.DeepEquals(SerializedModelJson, JsonData).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(SerializedModelJson, JsonData));
         }
 
         // Xml helper methods
@@ -142,7 +142,7 @@ namespace DataModeling.Tests
 
         private void ModelObjects_ShouldBeEquivalent()
         {
-            DeserializedJsonModelObject.Should().BeEquivalentTo(DeserializedXmlModelObject);
+            Assert.True(JsonUtils.DeepEquals(JsonSerializer.Serialize(DeserializedJsonModelObject), JsonSerializer.Serialize(DeserializedXmlModelObject)));
         }
     }
 }

--- a/backend/tests/DataModeling.Tests/Templates/GeneralJsonTemplateTests.cs
+++ b/backend/tests/DataModeling.Tests/Templates/GeneralJsonTemplateTests.cs
@@ -24,11 +24,13 @@ namespace DataModeling.Tests.Templates
             // Assert
             JsonSchema jsonSchema = JsonSchema.FromText(actualJsonTemplate.GetJsonString());
             var idKeyword = jsonSchema.GetKeywordOrNull<IdKeyword>();
-            idKeyword.Id.Should().Be(expectedId);
-            jsonSchema.GetKeywordOrNull<XsdRootElementKeyword>().Value.Should().Be(expectedModelName);
+            Assert.Equal(expectedId, idKeyword.Id.ToString());
+
+            Assert.Equal(expectedModelName, jsonSchema.GetKeywordOrNull<XsdRootElementKeyword>().Value);
             var properties = jsonSchema.GetKeywordOrNull<PropertiesKeyword>();
-            properties.Properties.Should().NotBeEmpty();
-            properties.Properties.Count.Should().Be(3);
+
+            Assert.NotEmpty(properties.Properties);
+            Assert.Equal(3, properties.Properties.Count);
         }
     }
 }

--- a/backend/tests/DataModeling.Tests/Templates/GeneralJsonTemplateTests.cs
+++ b/backend/tests/DataModeling.Tests/Templates/GeneralJsonTemplateTests.cs
@@ -2,7 +2,6 @@ using System;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using Altinn.Studio.DataModeling.Templates;
 using Altinn.Studio.DataModeling.Utils;
-using FluentAssertions;
 using Json.Schema;
 using Xunit;
 

--- a/backend/tests/DataModeling.Tests/Templates/SeresJsonTemplateTests.cs
+++ b/backend/tests/DataModeling.Tests/Templates/SeresJsonTemplateTests.cs
@@ -5,7 +5,6 @@ using Altinn.Studio.DataModeling.Json;
 using Altinn.Studio.DataModeling.Json.Keywords;
 using Altinn.Studio.DataModeling.Templates;
 using Altinn.Studio.DataModeling.Utils;
-using FluentAssertions;
 using Json.Pointer;
 using Json.Schema;
 using Xunit;

--- a/backend/tests/DataModeling.Tests/Templates/SeresJsonTemplateTests.cs
+++ b/backend/tests/DataModeling.Tests/Templates/SeresJsonTemplateTests.cs
@@ -27,14 +27,15 @@ namespace DataModeling.Tests.Templates
             // Assert
             JsonSchema jsonSchema = JsonSchema.FromText(actualJsonTemplate.GetJsonString());
             var idKeyword = jsonSchema.GetKeywordOrNull<IdKeyword>();
-            idKeyword.Id.Should().Be(expectedId);
+            Assert.Equal(expectedId, idKeyword.Id.ToString());
 
             var infoKeyword = jsonSchema.GetKeywordOrNull<InfoKeyword>();
             var value = infoKeyword.Value;
-            value.GetProperty("meldingsnavn").GetString().Should().Be("melding");
-            value.GetProperty("modellnavn").GetString().Should().Be("melding-modell");
 
-            var messageType = jsonSchema.FollowReference(JsonPointer.Parse("#/$defs/melding-modell")).Should().NotBeNull();
+            Assert.Equal("melding", value.GetProperty("meldingsnavn").GetString());
+            Assert.Equal("melding-modell", value.GetProperty("modellnavn").GetString());
+
+            Assert.NotNull(jsonSchema.FollowReference(JsonPointer.Parse("#/$defs/melding-modell")));
         }
 
         [Fact]
@@ -48,17 +49,17 @@ namespace DataModeling.Tests.Templates
 
             XmlSchema xsd = ConvertJsonSchema(jsonSchema);
 
-            xsd.Items.Count.Should().Be(3);
-            xsd.Items[2].GetName().Should().Be("melding-modell");
+            Assert.Equal(3, xsd.Items.Count);
+            Assert.Equal("melding-modell", xsd.Items[2].GetName());
 
-            XmlSchemaComplexType complexType = xsd.Items[2].As<XmlSchemaComplexType>();
-            var attributes = complexType.Attributes.Count.Should().Be(3);
+            XmlSchemaComplexType complexType = xsd.Items[2] as XmlSchemaComplexType;
+            Assert.Equal(3, complexType.Attributes.Count);
 
             foreach (XmlSchemaAttribute attribute in complexType.Attributes)
             {
                 if (attribute.Name == "dataFormatProvider")
                 {
-                    attribute.FixedValue.Should().Be("SERES");
+                    Assert.Equal("SERES", attribute.FixedValue);
                 }
             }
         }

--- a/backend/tests/DataModeling.Tests/Utils/JsonSchemaNavigationExtensionsTests.cs
+++ b/backend/tests/DataModeling.Tests/Utils/JsonSchemaNavigationExtensionsTests.cs
@@ -1,5 +1,4 @@
 ﻿using Altinn.Studio.DataModeling.Utils;
-using FluentAssertions;
 using Json.Pointer;
 using Json.Schema;
 using Xunit;

--- a/backend/tests/DataModeling.Tests/Utils/JsonSchemaNavigationExtensionsTests.cs
+++ b/backend/tests/DataModeling.Tests/Utils/JsonSchemaNavigationExtensionsTests.cs
@@ -20,6 +20,7 @@ public class JsonSchemaNavigationExtensionsTests
                             ("test", new JsonSchemaBuilder().Type(SchemaValueType.String))))));
 
         var result = schema.FollowReference(JsonPointer.Parse(@"#/$defs/test/items/properties/test"));
-        result.Should().NotBeNull();
+
+        Assert.NotNull(result);
     }
 }

--- a/backend/tests/DataModeling.Tests/Utils/XmlSchemaTypesTests.cs
+++ b/backend/tests/DataModeling.Tests/Utils/XmlSchemaTypesTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Altinn.Studio.DataModeling.Utils;
-using FluentAssertions;
 using Xunit;
 
 namespace DataModeling.Tests.Utils;

--- a/backend/tests/DataModeling.Tests/Utils/XmlSchemaTypesTests.cs
+++ b/backend/tests/DataModeling.Tests/Utils/XmlSchemaTypesTests.cs
@@ -11,13 +11,13 @@ public class XmlSchemaTypesTests
     [MemberData(nameof(TestData))]
     public void AllTypesShouldContainType(string type)
     {
-        XmlSchemaTypes.AllKnownTypes.Should().Contain(type);
+        Assert.Contains(type, XmlSchemaTypes.AllKnownTypes);
     }
 
     [Fact]
     public void AllTypesShouldHave50Types()
     {
-        XmlSchemaTypes.AllKnownTypes.Count().Should().Be(49);
+        Assert.Equal(49, XmlSchemaTypes.AllKnownTypes.Count());
     }
 
     public static IEnumerable<object[]> TestData => new List<object[]>

--- a/backend/tests/DataModeling.Tests/XmlDeserializeSerializeTests.cs
+++ b/backend/tests/DataModeling.Tests/XmlDeserializeSerializeTests.cs
@@ -19,15 +19,16 @@ public class XmlDeserializeSerializeTests : CsharpModelConversionTestsBase<XmlDe
             .When.LoadedXsdSchemaConvertedToJsonSchema()
             .And.ConvertedJsonSchemaConvertedToModelMetadata()
             .And.ModelMetadataConvertedToCsharpClass()
-            .And.CSharpClassesCompiledToAssembly()
-            .Then.CompiledAssembly.Should().NotBeNull();
+            .And.CSharpClassesCompiledToAssembly();
+
+        Assert.NotNull(CompiledAssembly);
 
         And.DeserializeAndSerializeShouldProduceSameXml(xmlPath);
     }
 
     private void DeserializeAndSerializeShouldProduceSameXml(string xmlPath)
     {
-        Type csharpType = CompiledAssembly.Types().Single(type => type.CustomAttributes.Any(att => att.AttributeType == typeof(XmlRootAttribute)));
+        Type csharpType = CompiledAssembly.GetTypes().Single(type => type.CustomAttributes.Any(att => att.AttributeType == typeof(XmlRootAttribute)));
 
         string loadedXml = SharedResourcesHelper.LoadTestDataAsString(xmlPath);
 

--- a/backend/tests/DataModeling.Tests/XmlDeserializeSerializeTests.cs
+++ b/backend/tests/DataModeling.Tests/XmlDeserializeSerializeTests.cs
@@ -4,7 +4,6 @@ using System.Xml.Linq;
 using System.Xml.Serialization;
 using DataModeling.Tests.BaseClasses;
 using DataModeling.Tests.Utils;
-using FluentAssertions;
 using SharedResources.Tests;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/AnsattPortenController/AuthStatusTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AnsattPortenController/AuthStatusTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.AnsattPortenController.Base;
 using Designer.Tests.Controllers.ApiTests;
-using FluentAssertions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;

--- a/backend/tests/Designer.Tests/Controllers/AnsattPortenController/AuthStatusTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AnsattPortenController/AuthStatusTests.cs
@@ -53,10 +53,10 @@ public class AuthStatusTest : AnsattPortenControllerTestsBase<AuthStatusTest>, I
         using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, VersionPrefix);
 
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         AuthStatus authStatus = await response.Content.ReadAsAsync<AuthStatus>();
-        authStatus.IsLoggedIn.Should().BeFalse();
+        Assert.False(authStatus.IsLoggedIn);
     }
 
     [Fact]
@@ -74,9 +74,9 @@ public class AuthStatusTest : AnsattPortenControllerTestsBase<AuthStatusTest>, I
         using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, VersionPrefix);
 
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         AuthStatus authStatus = await response.Content.ReadAsAsync<AuthStatus>();
-        authStatus.IsLoggedIn.Should().BeTrue();
+        Assert.True(authStatus.IsLoggedIn);
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/AddLayoutSetTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/AddLayoutSetTests.cs
@@ -13,6 +13,7 @@ using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
 using Microsoft.AspNetCore.Mvc.Testing;
+using SharedResources.Tests;
 using Xunit;
 
 namespace Designer.Tests.Controllers.AppDevelopmentController
@@ -44,14 +45,14 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             LayoutSets layoutSetsAfter = await GetLayoutSetsFile(org, targetRepository, developer);
 
-            layoutSetsBefore.Schema.Should().NotBeNull();
+            Assert.NotNull(layoutSetsBefore.Schema);
             Assert.False(layoutSetsBefore.Sets.Exists(set => set.Id == newLayoutSetConfig.Id));
-            layoutSetsBefore.Sets.Count.Should().Be(layoutSetsAfter.Sets.Count - 1);
-            layoutSetsAfter.Schema.Should().NotBeNull();
+            Assert.Equal(layoutSetsAfter.Sets.Count - 1, layoutSetsBefore.Sets.Count);
+            Assert.NotNull(layoutSetsAfter.Schema);
             Assert.True(layoutSetsAfter.Sets.Exists(set => set.Id == newLayoutSetConfig.Id));
         }
 
@@ -74,7 +75,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string responseContent = await response.Content.ReadAsStringAsync();
             Dictionary<string, string> responseMessage = JsonSerializer.Deserialize<Dictionary<string, string>>(responseContent);
             Assert.Equal($"Layout set name, {layoutSetId}, already exists.", responseMessage["infoMessage"]);
@@ -100,7 +101,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string responseContent = await response.Content.ReadAsStringAsync();
             Dictionary<string, string> responseMessage = JsonSerializer.Deserialize<Dictionary<string, string>>(responseContent);
             Assert.Equal($"Layout set with task, {existingTaskId}, already exists.", responseMessage["infoMessage"]);
@@ -125,7 +126,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         [Theory]
@@ -147,7 +148,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
         [Theory]
@@ -169,7 +170,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             JsonNode initialLayout = await GetLayoutFile(org, targetRepository, developer, layoutSetId);
 
@@ -181,8 +182,9 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             JsonArray layout = initialLayout["data"]["layout"] as JsonArray;
-            layout.Count.Should().Be(1);
-            initialLayout["data"]["layout"][0].Should().BeEquivalentTo(defaultComponent, options => options.RespectingRuntimeTypes().IgnoringCyclicReferences());
+
+            Assert.Single(layout);
+            Assert.True(JsonUtils.DeepEquals(defaultComponent.ToJsonString(), initialLayout["data"]["layout"][0].ToJsonString()));
         }
 
         [Theory]
@@ -204,7 +206,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         private async Task<LayoutSets> GetLayoutSetsFile(string org, string app, string developer)

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/AddLayoutSetTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/AddLayoutSetTests.cs
@@ -12,7 +12,6 @@ using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/DeleteFormLayoutTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/DeleteFormLayoutTests.cs
@@ -30,13 +30,13 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string relativePath = string.IsNullOrEmpty(layoutSetName)
                 ? $"App/ui/layouts/{layoutName}.json"
                 : $"App/ui/{layoutSetName}/layouts/{layoutName}.json";
             string layoutFilePath = Path.Combine(TestRepoPath, relativePath);
-            File.Exists(layoutFilePath).Should().BeFalse();
+            Assert.False(File.Exists(layoutFilePath));
         }
 
         [Theory]
@@ -52,7 +52,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/DeleteFormLayoutTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/DeleteFormLayoutTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/DeleteLayoutSetTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/DeleteLayoutSetTests.cs
@@ -10,7 +10,6 @@ using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/DeleteLayoutSetTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/DeleteLayoutSetTests.cs
@@ -36,12 +36,12 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             LayoutSets layoutSetsAfter = await GetLayoutSetsFile(org, targetRepository, developer);
 
             Assert.True(layoutSetsBefore.Sets.Exists(set => set.Id == layoutSetToDeleteId));
-            layoutSetsAfter.Sets.Should().HaveCount(layoutSetsBefore.Sets.Count - 1);
+            Assert.Equal(layoutSetsBefore.Sets.Count - 1, layoutSetsAfter.Sets.Count);
             Assert.False(layoutSetsAfter.Sets.Exists(set => set.Id == layoutSetToDeleteId));
         }
 
@@ -62,16 +62,15 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             LayoutSets layoutSetsAfter = await GetLayoutSetsFile(org, targetRepository, developer);
             Application appMetadataAfter = await GetApplicationMetadataFile(org, targetRepository, developer);
 
-            appMetadataBefore.DataTypes.Find(dataType => dataType.Id == connectedDataType).TaskId.Should()
-                .Be(connectedTaskId);
+            Assert.Equal(connectedTaskId, appMetadataBefore.DataTypes.Find(dataType => dataType.Id == connectedDataType).TaskId);
             Assert.True(layoutSetsBefore.Sets.Exists(set => set.Id == layoutSetToDeleteId));
-            layoutSetsAfter.Sets.Should().HaveCount(layoutSetsBefore.Sets.Count - 1);
-            appMetadataAfter.DataTypes.Find(dataType => dataType.Id == connectedDataType).TaskId.Should().BeNull();
+            Assert.Equal(layoutSetsBefore.Sets.Count - 1, layoutSetsAfter.Sets.Count);
+            Assert.Null(appMetadataAfter.DataTypes.Find(dataType => dataType.Id == connectedDataType).TaskId);
             Assert.False(layoutSetsAfter.Sets.Exists(set => set.Id == layoutSetToDeleteId));
         }
 
@@ -90,7 +89,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             Assert.False(LayoutSetFolderExists(org, targetRepository, developer, layoutSetToDeleteId));
         }
@@ -110,7 +109,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseContent = await response.Content.ReadAsStringAsync();
 
@@ -130,7 +129,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [Theory]
@@ -146,17 +145,20 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             JsonNode formLayout = (await GetFormLayouts(org, targetRepository, developer, layoutSetWithRef))[layoutSetFile];
             JsonArray layout = formLayout["data"]?["layout"] as JsonArray;
 
-            layout.Should().NotBeNull();
-            layout
+            bool componentsReferencingDeletedLayoutSet = layout
                 .Where(jsonNode => jsonNode["layoutSet"] != null)
-                .Should()
-                .NotContain(jsonNode => jsonNode["layoutSet"].GetValue<string>() == deletedComponentId,
-                        $"No components should reference the deleted layout set {deletedComponentId}");
+                .Any(jsonNode => jsonNode["layoutSet"].GetValue<string>() == deletedComponentId);
+
+            Assert.False(componentsReferencingDeletedLayoutSet, $"No components should reference the deleted layout set {deletedComponentId}");
+
+            Assert.NotNull(layout);
+
+
         }
 
         private async Task<LayoutSets> GetLayoutSetsFile(string org, string app, string developer)

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/FileSync/ComponentIdChangeTests/LayoutFilesSyncComponentIdsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/FileSync/ComponentIdChangeTests/LayoutFilesSyncComponentIdsTests.cs
@@ -51,7 +51,7 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutFromRepo = TestDataHelper.GetFileFromRepo(Org, targetRepository, Developer, $"App/ui/{layoutSetName}/layouts/{layoutName}.json");
         JsonNode layout = JsonNode.Parse(layoutFromRepo);
@@ -66,8 +66,8 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             ?.SelectMany(rowsAfter => rowsAfter["cells"]?.AsArray() ?? new JsonArray())
             .Any(cell => cell["component"]?.ToString() == newComponentId) ?? false;
 
-        containsOldId.Should().BeFalse();
-        containsNewId.Should().BeTrue();
+        Assert.False(containsOldId);
+        Assert.True(containsNewId);
     }
 
     [Theory]
@@ -96,7 +96,7 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutFromRepo = TestDataHelper.GetFileFromRepo(Org, targetRepository, Developer, $"App/ui/{layoutSetName}/layouts/{layoutNameThatIsAffected}.json");
         JsonNode layout = JsonNode.Parse(layoutFromRepo);
@@ -111,8 +111,8 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             ?.SelectMany(rowsAfter => rowsAfter["cells"]?.AsArray() ?? new JsonArray())
             .Any(cell => cell["component"]?.ToString() == newComponentId) ?? false;
 
-        containsOldId.Should().BeFalse();
-        containsNewId.Should().BeTrue();
+        Assert.False(containsOldId);
+        Assert.True(containsNewId);
     }
 
     [Theory]
@@ -136,7 +136,7 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutFromRepo = TestDataHelper.GetFileFromRepo(Org, targetRepository, Developer, $"App/ui/{layoutSetName}/layouts/{layoutName}.json");
         JsonNode layout = JsonNode.Parse(layoutFromRepo);
@@ -144,17 +144,17 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
         JsonNode componentWithExpression = layout["data"]["layout"]?.AsArray()?.FirstOrDefault(item => item["id"]?.ToString() == "header-rep2");
         JsonArray expressionOnTitle = componentWithExpression?["textResourceBindings"]?["title"].AsArray();
 
-        ContainsValue(expressionOnLayout, oldComponentId).Should().BeFalse();
-        ContainsValue(expressionOnTitle, oldComponentId).Should().BeFalse();
+        Assert.False(ContainsValue(expressionOnLayout, oldComponentId));
+        Assert.False(ContainsValue(expressionOnTitle, oldComponentId));
         if (string.IsNullOrEmpty(newComponentId))
         {
-            ContainsValue(expressionOnLayout, newComponentId).Should().BeFalse();
-            ContainsValue(expressionOnTitle, newComponentId).Should().BeFalse();
+            Assert.False(ContainsValue(expressionOnLayout, newComponentId));
+            Assert.False(ContainsValue(expressionOnTitle, newComponentId));
         }
         else
         {
-            ContainsValue(expressionOnLayout, newComponentId).Should().BeTrue();
-            ContainsValue(expressionOnTitle, newComponentId).Should().BeTrue();
+            Assert.True(ContainsValue(expressionOnLayout, newComponentId));
+            Assert.True(ContainsValue(expressionOnTitle, newComponentId));
         }
     }
 
@@ -184,7 +184,7 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutFromRepo = TestDataHelper.GetFileFromRepo(Org, targetRepository, Developer, $"App/ui/{layoutSetName}/layouts/{layoutNameThatIsAffected}.json");
         JsonNode layout = JsonNode.Parse(layoutFromRepo);
@@ -192,17 +192,17 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
         JsonNode componentWithExpression = layout["data"]["layout"]?.AsArray()?.FirstOrDefault(item => item["id"]?.ToString() == "header-rep2");
         JsonArray expressionOnTitle = componentWithExpression?["textResourceBindings"]?["title"].AsArray();
 
-        ContainsValue(expressionOnLayout, oldComponentId).Should().BeFalse();
-        ContainsValue(expressionOnTitle, oldComponentId).Should().BeFalse();
+        Assert.False(ContainsValue(expressionOnLayout, oldComponentId));
+        Assert.False(ContainsValue(expressionOnTitle, oldComponentId));
         if (string.IsNullOrEmpty(newComponentId))
         {
-            ContainsValue(expressionOnLayout, newComponentId).Should().BeFalse();
-            ContainsValue(expressionOnTitle, newComponentId).Should().BeFalse();
+            Assert.False(ContainsValue(expressionOnLayout, newComponentId));
+            Assert.False(ContainsValue(expressionOnTitle, newComponentId));
         }
         else
         {
-            ContainsValue(expressionOnLayout, newComponentId).Should().BeTrue();
-            ContainsValue(expressionOnTitle, newComponentId).Should().BeTrue();
+            Assert.True(ContainsValue(expressionOnLayout, newComponentId));
+            Assert.True(ContainsValue(expressionOnTitle, newComponentId));
         }
     }
 
@@ -227,7 +227,7 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutFromRepo = TestDataHelper.GetFileFromRepo(Org, targetRepository, Developer, $"App/ui/{layoutSetName}/layouts/{layoutName}.json");
         JsonNode layout = JsonNode.Parse(layoutFromRepo);
@@ -235,11 +235,11 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
 
         if (string.IsNullOrEmpty(newComponentId))
         {
-            summaryComponentWithComponentRef["componentRef"].Should().BeNull();
+            Assert.Null(summaryComponentWithComponentRef["componentRef"]);
         }
         else
         {
-            summaryComponentWithComponentRef["componentRef"].ToString().Should().Be(newComponentId);
+            Assert.Equal(newComponentId, summaryComponentWithComponentRef["componentRef"].ToString());
         }
     }
 
@@ -269,7 +269,7 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutFromRepo = TestDataHelper.GetFileFromRepo(Org, targetRepository, Developer, $"App/ui/{layoutSetName}/layouts/{layoutNameThatIsAffected}.json");
         JsonNode layout = JsonNode.Parse(layoutFromRepo);
@@ -277,11 +277,11 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
 
         if (string.IsNullOrEmpty(newComponentId))
         {
-            summaryComponentWithComponentRef["componentRef"].Should().BeNull();
+            Assert.Null(summaryComponentWithComponentRef["componentRef"]);
         }
         else
         {
-            summaryComponentWithComponentRef["componentRef"].ToString().Should().Be(newComponentId);
+            Assert.Equal(newComponentId, summaryComponentWithComponentRef["componentRef"].ToString());
         }
     }
 
@@ -312,20 +312,20 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutFromRepo = TestDataHelper.GetFileFromRepo(Org, targetRepository, Developer, $"App/ui/{layoutSetName}/layouts/{layoutName}.json");
         JsonNode layout = JsonNode.Parse(layoutFromRepo);
         JsonNode tableColumnsWithIdAsPropertyName = layout["data"]["layout"]?.AsArray()?.FirstOrDefault(item => item["id"]?.ToString() == "mainGroup2")["tableColumns"];
 
-        tableColumnsWithIdAsPropertyName?[oldComponentId].Should().BeNull();
+        Assert.Null(tableColumnsWithIdAsPropertyName?[oldComponentId]);
         if (string.IsNullOrEmpty(newComponentId))
         {
-            (tableColumnsWithIdAsPropertyName as JsonObject).Count.Should().Be((originalTableColumns as JsonObject).Count - 1);
+            Assert.Equal((originalTableColumns as JsonObject).Count - 1, (tableColumnsWithIdAsPropertyName as JsonObject).Count);
         }
         else
         {
-            tableColumnsWithIdAsPropertyName?[newComponentId].Should().NotBeNull();
+            Assert.NotNull(tableColumnsWithIdAsPropertyName?[newComponentId]);
         }
     }
 
@@ -359,20 +359,20 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutFromRepo = TestDataHelper.GetFileFromRepo(Org, targetRepository, Developer, $"App/ui/{layoutSetName}/layouts/{layoutNameThatIsAffected}.json");
         JsonNode layout = JsonNode.Parse(layoutFromRepo);
         JsonNode tableColumnsWithIdAsPropertyName = layout["data"]["layout"]?.AsArray()?.FirstOrDefault(item => item["id"]?.ToString() == "mainGroup2")["tableColumns"];
 
-        tableColumnsWithIdAsPropertyName?[oldComponentId].Should().BeNull();
+        Assert.Null(tableColumnsWithIdAsPropertyName?[oldComponentId]);
         if (string.IsNullOrEmpty(newComponentId))
         {
-            (tableColumnsWithIdAsPropertyName as JsonObject).Count.Should().Be((originalTableColumns as JsonObject).Count - 1);
+            Assert.Equal((originalTableColumns as JsonObject).Count - 1, (tableColumnsWithIdAsPropertyName as JsonObject).Count);
         }
         else
         {
-            tableColumnsWithIdAsPropertyName?[newComponentId].Should().NotBeNull();
+            Assert.NotNull(tableColumnsWithIdAsPropertyName?[newComponentId]);
         }
     }
 
@@ -397,21 +397,21 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutFromRepo = TestDataHelper.GetFileFromRepo(Org, targetRepository, Developer, $"App/ui/{layoutSetName}/layouts/{layoutName}.json");
         JsonNode layout = JsonNode.Parse(layoutFromRepo);
         JsonNode repeatingGroupComponentWithIdInTableHeaders = layout["data"]["layout"]?.AsArray()?.FirstOrDefault(item => item["id"]?.ToString() == "mainGroup2");
         JsonArray tableHeaders = repeatingGroupComponentWithIdInTableHeaders["tableHeaders"].AsArray();
 
-        ContainsValue(tableHeaders, oldComponentId).Should().BeFalse();
+        Assert.False(ContainsValue(tableHeaders, oldComponentId));
         if (string.IsNullOrEmpty(newComponentId))
         {
-            ContainsValue(tableHeaders, newComponentId).Should().BeFalse();
+            Assert.False(ContainsValue(tableHeaders, newComponentId));
         }
         else
         {
-            ContainsValue(tableHeaders, newComponentId).Should().BeTrue();
+            Assert.True(ContainsValue(tableHeaders, newComponentId));
         }
     }
 
@@ -441,21 +441,21 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutFromRepo = TestDataHelper.GetFileFromRepo(Org, targetRepository, Developer, $"App/ui/{layoutSetName}/layouts/{layoutNameThatIsAffected}.json");
         JsonNode layout = JsonNode.Parse(layoutFromRepo);
         JsonNode repeatingGroupComponentWithIdInTableHeaders = layout["data"]["layout"]?.AsArray()?.FirstOrDefault(item => item["id"]?.ToString() == "mainGroup2");
         JsonArray tableHeaders = repeatingGroupComponentWithIdInTableHeaders["tableHeaders"].AsArray();
 
-        ContainsValue(tableHeaders, oldComponentId).Should().BeFalse();
+        Assert.False(ContainsValue(tableHeaders, oldComponentId));
         if (string.IsNullOrEmpty(newComponentId))
         {
-            ContainsValue(tableHeaders, newComponentId).Should().BeFalse();
+            Assert.False(ContainsValue(tableHeaders, newComponentId));
         }
         else
         {
-            ContainsValue(tableHeaders, newComponentId).Should().BeTrue();
+            Assert.True(ContainsValue(tableHeaders, newComponentId));
         }
     }
 
@@ -486,24 +486,24 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutFromRepo = TestDataHelper.GetFileFromRepo(Org, targetRepository, Developer, $"App/ui/{layoutSetName}/layouts/{layoutNameThatIsAffected}.json");
         JsonNode layout = JsonNode.Parse(layoutFromRepo);
         JsonNode repeatingGroupComponentWithIdInTableHeaders = layout["data"]["layout"]?.AsArray()?.FirstOrDefault(item => item["id"]?.ToString() == "mainGroup2");
         JsonArray tableHeaders = repeatingGroupComponentWithIdInTableHeaders["tableHeaders"].AsArray();
 
-        ContainsValue(tableHeaders, oldComponentId).Should().BeFalse();
-        ContainsValue(tableHeaders, oldComponentId2).Should().BeFalse();
+        Assert.False(ContainsValue(tableHeaders, oldComponentId));
+        Assert.False(ContainsValue(tableHeaders, oldComponentId2));
         if (string.IsNullOrEmpty(newComponentId))
         {
-            ContainsValue(tableHeaders, newComponentId).Should().BeFalse();
-            ContainsValue(tableHeaders, newComponentId2).Should().BeFalse();
+            Assert.False(ContainsValue(tableHeaders, newComponentId));
+            Assert.False(ContainsValue(tableHeaders, newComponentId2));
         }
         else
         {
-            ContainsValue(tableHeaders, newComponentId).Should().BeTrue();
-            ContainsValue(tableHeaders, newComponentId2).Should().BeTrue();
+            Assert.True(ContainsValue(tableHeaders, newComponentId));
+            Assert.True(ContainsValue(tableHeaders, newComponentId2));
         }
     }
 
@@ -533,13 +533,13 @@ public class LayoutFilesSyncComponentIdsTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutFromRepo = TestDataHelper.GetFileFromRepo(Org, targetRepository, Developer, $"App/ui/{layoutSetNameForOtherLayout}/layouts/{layoutNameThatIsAffected}.json");
         JsonNode layout = JsonNode.Parse(layoutFromRepo);
         JsonNode summaryComponentWithComponentRef = layout["data"]["layout"]?.AsArray()?.FirstOrDefault(item => item["id"]?.ToString() == "summary-1");
 
-        summaryComponentWithComponentRef["componentRef"].ToString().Should().Be(oldComponentId);
+        Assert.Equal(oldComponentId, summaryComponentWithComponentRef["componentRef"].ToString());
     }
 
     private string ArrangeApiRequestContent(string pathToLayoutToPost, List<ComponentIdChange> componentIdsChanges)

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/FileSync/ComponentIdChangeTests/LayoutFilesSyncComponentIdsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/FileSync/ComponentIdChangeTests/LayoutFilesSyncComponentIdsTests.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/FileSync/ComponentIdChangeTests/LayoutSettingsFileSyncComponentIdsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/FileSync/ComponentIdChangeTests/LayoutSettingsFileSyncComponentIdsTests.cs
@@ -45,15 +45,15 @@ public class LayoutSettingsFileSyncComponentIdsTests : DesignerEndpointsTestsBas
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutSettingsFromRepo = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, $"App/ui/{layoutSetName}/Settings.json");
 
         JsonNode layoutSettings = JsonNode.Parse(layoutSettingsFromRepo);
         JsonArray excludeFromPdfArray = layoutSettings["components"]?["excludeFromPdf"]?.AsArray();
 
-        excludeFromPdfArray.Where(node => node.GetValue<string>() == oldComponentId).Should().BeEmpty();
-        excludeFromPdfArray.Should().ContainSingle(node => node.GetValue<string>() == newComponentId);
+        Assert.DoesNotContain(excludeFromPdfArray, node => node.GetValue<string>() == oldComponentId);
+        Assert.Single(excludeFromPdfArray, node => node.GetValue<string>() == newComponentId);
     }
 
     [Theory]
@@ -81,15 +81,16 @@ public class LayoutSettingsFileSyncComponentIdsTests : DesignerEndpointsTestsBas
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutSettingsFromRepo = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, $"App/ui/{layoutSetName}/Settings.json");
 
         JsonNode layoutSettings = JsonNode.Parse(layoutSettingsFromRepo);
         JsonArray excludeFromPdfArray = layoutSettings["components"]?["excludeFromPdf"]?.AsArray();
 
-        excludeFromPdfArray.Count.Should().Be(originalExcludeFromPdfArray.Count - 1);
-        excludeFromPdfArray.Where(node => node.GetValue<string>() == oldComponentId).Should().BeEmpty();
+        Assert.DoesNotContain(excludeFromPdfArray!, node => node.GetValue<string>() == oldComponentId);
+
+        Assert.Equal(originalExcludeFromPdfArray!.Count - 1, excludeFromPdfArray.Count);
     }
 
     [Theory]
@@ -114,17 +115,18 @@ public class LayoutSettingsFileSyncComponentIdsTests : DesignerEndpointsTestsBas
             Content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         string layoutSettingsFromRepo = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, $"App/ui/{layoutSetName}/Settings.json");
 
         JsonNode layoutSettings = JsonNode.Parse(layoutSettingsFromRepo);
         JsonArray excludeFromPdfArray = layoutSettings["components"]?["excludeFromPdf"]?.AsArray();
 
-        excludeFromPdfArray.Where(node => node.GetValue<string>() == oldComponentId).Should().BeEmpty();
-        excludeFromPdfArray.Where(node => node.GetValue<string>() == oldComponentId2).Should().BeEmpty();
-        excludeFromPdfArray.Should().ContainSingle(node => node.GetValue<string>() == newComponentId);
-        excludeFromPdfArray.Should().ContainSingle(node => node.GetValue<string>() == newComponentId2);
+        Assert.DoesNotContain(excludeFromPdfArray, node => node.GetValue<string>() == oldComponentId);
+        Assert.DoesNotContain(excludeFromPdfArray, node => node.GetValue<string>() == oldComponentId2);
+
+        Assert.Single(excludeFromPdfArray, node => node.GetValue<string>() == newComponentId);
+        Assert.Single(excludeFromPdfArray, node => node.GetValue<string>() == newComponentId2);
     }
 
     private string ArrangeApiRequestContent(List<ComponentIdChange> componentIdsChanges)

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/FileSync/ComponentIdChangeTests/LayoutSettingsFileSyncComponentIdsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/FileSync/ComponentIdChangeTests/LayoutSettingsFileSyncComponentIdsTests.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetAppMetadataModelIdsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetAppMetadataModelIdsTests.cs
@@ -3,9 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
-using SharedResources.Tests;
 using Xunit;
 
 namespace Designer.Tests.Controllers.AppDevelopmentController

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetAppMetadataModelIdsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetAppMetadataModelIdsTests.cs
@@ -28,11 +28,11 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseContent = await response.Content.ReadAsStringAsync();
 
-            responseContent.Should().Be("[\"datamodel\",\"unUsedDatamodel\",\"HvemErHvem_M\"]");
+            Assert.Equal("[\"datamodel\",\"unUsedDatamodel\",\"HvemErHvem_M\"]", responseContent);
         }
 
         [Theory]
@@ -46,11 +46,11 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseContent = await response.Content.ReadAsStringAsync();
 
-            responseContent.Should().Be("[]");
+            Assert.Equal("[]", responseContent);
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetAppVersionTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetAppVersionTests.cs
@@ -41,12 +41,12 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             string url = VersionPrefix(org, targetRepository);
 
             using var response = await HttpClient.GetAsync(url);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             var responseVersion = await response.Content.ReadAsAsync<VersionResponse>();
 
-            responseVersion.BackendVersion.ToString().Should().Be(backendVersion);
-            responseVersion.FrontendVersion.Should().Be(frontendVersion);
+            Assert.Equal(backendVersion, responseVersion.BackendVersion.ToString());
+            Assert.Equal(frontendVersion, responseVersion.FrontendVersion);
         }
 
         [Theory]
@@ -60,7 +60,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             string url = VersionPrefix(org, targetRepository);
 
             using var response = await HttpClient.GetAsync(url);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [Theory]
@@ -70,7 +70,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             string url = VersionPrefix(org, app);
 
             using var response = await HttpClient.GetAsync(url);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [Theory]
@@ -84,9 +84,9 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             string url = VersionPrefix(org, targetRepository);
 
             using var response = await HttpClient.GetAsync(url);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var responseVersion = await response.Content.ReadAsAsync<VersionResponse>();
-            responseVersion.FrontendVersion.Should().BeNull();
+            Assert.Null(responseVersion.FrontendVersion);
         }
 
         [Theory]
@@ -101,9 +101,9 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             string url = VersionPrefix(org, targetRepository);
 
             using var response = await HttpClient.GetAsync(url);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var responseVersion = await response.Content.ReadAsAsync<VersionResponse>();
-            responseVersion.FrontendVersion.Should().BeNull();
+            Assert.Null(responseVersion.FrontendVersion);
 
         }
 

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetAppVersionTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetAppVersionTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetFormLayoutsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetFormLayoutsTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.TestDataClasses;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetFormLayoutsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetFormLayoutsTests.cs
@@ -34,7 +34,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseContent = await response.Content.ReadAsStringAsync();
             var responseJson = JsonNode.Parse(responseContent);
@@ -42,7 +42,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             foreach ((string expectedLayoutName, string expectedLayout) in expectedLayouts)
             {
                 string actualLayout = responseJson[Path.GetFileNameWithoutExtension(expectedLayoutName)].ToJsonString();
-                JsonUtils.DeepEquals(expectedLayout, actualLayout).Should().BeTrue();
+                Assert.True(JsonUtils.DeepEquals(expectedLayout, actualLayout));
             }
         }
 

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetLayoutSetsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetLayoutSetsTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetLayoutSetsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetLayoutSetsTests.cs
@@ -31,16 +31,16 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseContent = string.IsNullOrEmpty(layoutSetName) ? null : await response.Content.ReadAsStringAsync();
             if (string.IsNullOrEmpty(layoutSetName))
             {
-                responseContent.Should().BeNull();
+                Assert.Null(responseContent);
             }
             else
             {
-                JsonUtils.DeepEquals(expectedLayoutSets, responseContent).Should().BeTrue();
+                Assert.True(JsonUtils.DeepEquals(expectedLayoutSets, responseContent));
             }
         }
 
@@ -53,7 +53,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         private async Task<string> AddLayoutSetsToRepo(string createdFolderPath, string expectedLayoutSetsPath)

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetLayoutSettingsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetLayoutSettingsTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetLayoutSettingsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetLayoutSettingsTests.cs
@@ -35,10 +35,10 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseContent = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedLayoutSettings, responseContent).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedLayoutSettings, responseContent));
         }
 
         [Theory(Skip = "If App/ui is not present in repo, the controller returns 500")]
@@ -50,7 +50,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         private async Task<string> AddLayoutSettingsToRepo(string createdFolderPath, string layoutSetName, string expectedLayoutPath)

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetModelMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetModelMetadataTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetModelMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetModelMetadataTests.cs
@@ -32,9 +32,9 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             string responseContent = await response.Content.ReadAsStringAsync();
 
             // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            responseContent.Should().Be(expectedModelMetadata);
-            JsonUtils.DeepEquals(expectedModelMetadata, responseContent).Should().BeTrue();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(expectedModelMetadata, responseContent);
+            Assert.True(JsonUtils.DeepEquals(expectedModelMetadata, responseContent));
         }
 
         [Theory]
@@ -51,9 +51,9 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             string responseContent = await response.Content.ReadAsStringAsync();
 
             // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            responseContent.Should().Be(expectedModelMetadata);
-            JsonUtils.DeepEquals(expectedModelMetadata, responseContent).Should().BeTrue();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(expectedModelMetadata, responseContent);
+            Assert.True(JsonUtils.DeepEquals(expectedModelMetadata, responseContent));
         }
 
         [Theory]
@@ -70,7 +70,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var response = await HttpClient.SendAsync(httpRequestMessage);
 
             // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         private async Task<string> AddModelMetadataToRepo(string createdFolderPath, string expectedModelMetadataPath)

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetOptionListIdsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetOptionListIdsTests.cs
@@ -35,14 +35,14 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseContent = await response.Content.ReadAsStringAsync();
             List<string> responseList = JsonSerializer.Deserialize<List<string>>(responseContent);
-            responseList.Count.Should().Be(3);
+            Assert.Equal(3, responseList.Count);
             foreach (string id in expectedOptionsListIds)
             {
-                responseList.Should().Contain(id);
+                Assert.Contains(id, responseList);
             }
         }
 
@@ -55,7 +55,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
 
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetOptionListIdsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetOptionListIdsTests.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetRuleConfigTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetRuleConfigTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetRuleConfigTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetRuleConfigTests.cs
@@ -32,10 +32,10 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseContent = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedRuleConfig, responseContent).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedRuleConfig, responseContent));
         }
 
         [Theory]
@@ -47,7 +47,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
 
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }
 
         [Theory]
@@ -64,10 +64,10 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseContent = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedRuleConfig, responseContent).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedRuleConfig, responseContent));
         }
 
         private async Task<string> AddRuleConfigToRepo(string createdFolderPath, string layoutSetName, string expectedLayoutPath)

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetRuleHandlerTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetRuleHandlerTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetRuleHandlerTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/GetRuleHandlerTests.cs
@@ -35,10 +35,10 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseContent = await response.Content.ReadAsStringAsync();
-            expectedRuleHandler.Should().Be(responseContent);
+            Assert.Equal(expectedRuleHandler, responseContent);
         }
 
         [Theory]
@@ -50,7 +50,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }
 
         private static async Task<string> AddRuleHandler(string createdFolderPath, string layoutSetName, string expectedRuleHandlerPath)

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveFormLayoutTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveFormLayoutTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveFormLayoutTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveFormLayoutTests.cs
@@ -52,13 +52,13 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
                 ["layout"] = JsonNode.Parse(layout)
             };
             HttpResponseMessage response = await SendHttpRequest(url, payload);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string relativePath = string.IsNullOrEmpty(layoutSetName)
                 ? $"App/ui/layouts/{layoutName}.json"
                 : $"App/ui/{layoutSetName}/layouts/{layoutName}.json";
             string savedLayout = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, relativePath);
-            JsonUtils.DeepEquals(layout, savedLayout).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(layout, savedLayout));
         }
 
         [Theory]
@@ -83,13 +83,13 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
                 ["layout"] = JsonNode.Parse(layout)
             };
             HttpResponseMessage response = await SendHttpRequest(url, payload);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string relativePath = string.IsNullOrEmpty(layoutSetName)
                 ? $"App/ui/layouts/{layoutName}.json"
                 : $"App/ui/{layoutSetName}/layouts/{layoutName}.json";
             string savedLayout = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, relativePath);
-            JsonUtils.DeepEquals(layout, savedLayout).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(layout, savedLayout));
         }
 
         [Theory]
@@ -101,11 +101,11 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             string url = $"{VersionPrefix(org, targetRepository)}/form-layout/{layoutName}?layoutSetName={layoutSetName}";
             string layout = SharedResourcesHelper.LoadTestDataAsString(layoutPath);
 
-            TestDataHelper.FileExistsInRepo(org, targetRepository, developer, "App/config/texts/resource.nb.json").Should().BeTrue();
+            Assert.True(TestDataHelper.FileExistsInRepo(org, targetRepository, developer, "App/config/texts/resource.nb.json"));
             string file = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/texts/resource.nb.json");
             TextResource textResource = JsonSerializer.Deserialize<TextResource>(file, s_jsonOptions);
-            textResource.Resources.Should().NotContain(x => x.Id == "next");
-            textResource.Resources.Should().NotContain(x => x.Id == "back");
+            Assert.DoesNotContain(textResource.Resources, x => x.Id == "next");
+            Assert.DoesNotContain(textResource.Resources, x => x.Id == "back");
 
             var payload = new JsonObject
             {
@@ -113,12 +113,12 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
                 ["layout"] = JsonNode.Parse(layout)
             };
             HttpResponseMessage response = await SendHttpRequest(url, payload);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string newTextFile = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, $"App/config/texts/resource.nb.json");
             TextResource newTextResource = JsonSerializer.Deserialize<TextResource>(newTextFile, s_jsonOptions);
-            newTextResource.Resources.Should().ContainSingle(x => x.Id == "next");
-            newTextResource.Resources.Should().ContainSingle(x => x.Id == "back");
+            Assert.Single(newTextResource.Resources, x => x.Id == "next");
+            Assert.Single(newTextResource.Resources, x => x.Id == "back");
         }
 
         private async Task<HttpResponseMessage> SendHttpRequest(string url, JsonObject payload)

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveLayoutSettingsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveLayoutSettingsTests.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveLayoutSettingsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveLayoutSettingsTests.cs
@@ -43,13 +43,13 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string relativePath = string.IsNullOrEmpty(layoutSetName)
                 ? "App/ui/Settings.json"
                 : $"App/ui/{layoutSetName}/Settings.json";
             string savedLayoutSettings = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, relativePath);
-            JsonUtils.DeepEquals(layoutSettings, savedLayoutSettings).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(layoutSettings, savedLayoutSettings));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveRuleConfigTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveRuleConfigTests.cs
@@ -38,13 +38,13 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string relativePath = string.IsNullOrEmpty(layoutSetName)
                 ? "App/ui/RuleConfiguration.json"
                 : $"App/ui/{layoutSetName}/RuleConfiguration.json";
             string savedFile = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, relativePath);
-            JsonUtils.DeepEquals(content, savedFile).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(content, savedFile));
         }
 
     }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveRuleConfigTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveRuleConfigTests.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveRuleHandlerTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveRuleHandlerTests.cs
@@ -7,7 +7,6 @@ using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Mocks;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using SharedResources.Tests;

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveRuleHandlerTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/SaveRuleHandlerTests.cs
@@ -44,12 +44,12 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
             string relativePath = string.IsNullOrEmpty(layoutSetName)
                 ? "App/ui/RuleHandler.js"
                 : $"App/ui/{layoutSetName}/RuleHandler.js";
-            TestDataHelper.GetFileFromRepo(org, targetRepository, developer, relativePath).Should().BeEquivalentTo(content);
+            Assert.Equal(TestDataHelper.GetFileFromRepo(org, targetRepository, developer, relativePath), content);
         }
 
     }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateFormLayoutNameTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateFormLayoutNameTests.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateFormLayoutNameTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateFormLayoutNameTests.cs
@@ -36,7 +36,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string relativeOldLayoutPath = string.IsNullOrEmpty(layoutSetName)
                 ? $"App/ui/layouts/{layoutName}.json"
@@ -46,8 +46,8 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
                 : $"App/ui/{layoutSetName}/layouts/{newLayoutName}.json";
             string oldLayoutPath = Path.Combine(TestRepoPath, relativeOldLayoutPath);
             string newLayoutPath = Path.Combine(TestRepoPath, relativeNewLayoutPath);
-            File.Exists(oldLayoutPath).Should().BeFalse();
-            File.Exists(newLayoutPath).Should().BeTrue();
+            Assert.False(File.Exists(oldLayoutPath));
+            Assert.True(File.Exists(newLayoutPath));
         }
 
         [Theory]
@@ -65,7 +65,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
     }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateLayoutSetNameTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateLayoutSetNameTests.cs
@@ -40,14 +40,14 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             LayoutSets layoutSetsAfter = await GetLayoutSetsFile(org, targetRepository, developer);
 
-            layoutSetsBefore.Schema.Should().NotBeNull();
+            Assert.NotNull(layoutSetsBefore.Schema);
             Assert.False(layoutSetsBefore.Sets.Exists(set => set.Id == newLayoutSetName));
-            layoutSetsBefore.Sets.Should().HaveCount(layoutSetsAfter.Sets.Count);
-            layoutSetsAfter.Schema.Should().NotBeNull();
+            Assert.Equal(layoutSetsAfter.Sets.Count, layoutSetsBefore.Sets.Count);
+            Assert.NotNull(layoutSetsAfter.Schema);
             Assert.True(layoutSetsAfter.Sets.Exists(set => set.Id == newLayoutSetName));
         }
 
@@ -67,7 +67,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string responseContent = await response.Content.ReadAsStringAsync();
             Dictionary<string, string> responseMessage = JsonSerializer.Deserialize<Dictionary<string, string>>(responseContent);
             Assert.Equal($"Layout set name, {existingLayoutSetName}, already exists.", responseMessage["infoMessage"]);
@@ -90,7 +90,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         [Theory]
@@ -110,7 +110,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         [Theory]
@@ -130,7 +130,7 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
             };
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         private async Task<LayoutSets> GetLayoutSetsFile(string org, string app, string developer)

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateLayoutSetNameTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateLayoutSetNameTests.cs
@@ -10,7 +10,6 @@ using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/AppScopesController/GetAppScopesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppScopesController/GetAppScopesTests.cs
@@ -5,7 +5,6 @@ using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.AppScopesController.Base;
 using Designer.Tests.DbIntegrationTests;
 using Designer.Tests.Fixtures;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/AppScopesController/GetAppScopesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppScopesController/GetAppScopesTests.cs
@@ -27,10 +27,10 @@ public class GetAppScopesTests : AppScopesControllerTestsBase<GetAppScopesTests>
             , VersionPrefix(org, app));
 
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         AppScopesResponse repsponseContent = await response.Content.ReadAsAsync<AppScopesResponse>();
-        repsponseContent.Scopes.Should().BeEmpty();
+        Assert.Empty(repsponseContent.Scopes);
     }
 
     [Theory]
@@ -44,14 +44,14 @@ public class GetAppScopesTests : AppScopesControllerTestsBase<GetAppScopesTests>
             , VersionPrefix(org, app));
 
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         AppScopesResponse responseContent = await response.Content.ReadAsAsync<AppScopesResponse>();
-        responseContent.Scopes.Should().HaveCount(4);
+        Assert.Equal(4, responseContent.Scopes.Count);
 
         foreach (MaskinPortenScopeDto scope in responseContent.Scopes)
         {
-            entity.Scopes.Should().Contain(x => scope.Scope == x.Scope && scope.Description == x.Description);
+            Assert.Contains(entity.Scopes, x => x.Scope == scope.Scope && x.Description == scope.Description);
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/AppScopesController/GetScopesFromMaskinPortenTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppScopesController/GetScopesFromMaskinPortenTests.cs
@@ -42,11 +42,11 @@ public class GetScopesFromMaskinPortenTests : AppScopesControllerTestsBase<GetAp
             , VersionPrefix(org, app));
 
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         AppScopesResponse repsponseContent = await response.Content.ReadAsAsync<AppScopesResponse>();
         JsonArray array = (JsonArray)JsonNode.Parse(maskinPortenResponse);
-        repsponseContent.Scopes.Count.Should().Be(array.Count);
+        Assert.Equal(array.Count, repsponseContent.Scopes.Count);
     }
 
 

--- a/backend/tests/Designer.Tests/Controllers/AppScopesController/GetScopesFromMaskinPortenTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppScopesController/GetScopesFromMaskinPortenTests.cs
@@ -7,7 +7,6 @@ using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.AppScopesController.Base;
 using Designer.Tests.Controllers.AppScopesController.Utils;
 using Designer.Tests.Fixtures;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/AppScopesController/UpsertAppScopesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppScopesController/UpsertAppScopesTests.cs
@@ -11,7 +11,6 @@ using Designer.Tests.Controllers.AppScopesController.Base;
 using Designer.Tests.DbIntegrationTests;
 using Designer.Tests.Fixtures;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/AppScopesController/UpsertAppScopesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppScopesController/UpsertAppScopesTests.cs
@@ -51,17 +51,17 @@ public class UpsertAppScopesTests : AppScopesControllerTestsBase<UpsertAppScopes
         httpRequestMessage.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, MediaTypeNames.Application.Json);
 
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var dbEntity = await DesignerDbFixture.DbContext.AppScopes.SingleAsync(x => x.App == app && x.Org == org);
 
-        dbEntity.Should().NotBeNull();
+        Assert.NotNull(dbEntity);
 
         var scopes = JsonSerializer.Deserialize<ISet<MaskinPortenScopeEntity>>(dbEntity.Scopes, JsonSerializerOptions);
-        scopes.Should().HaveCount(payload.Scopes.Count);
+        Assert.Equal(payload.Scopes.Count, scopes.Count);
         foreach (MaskinPortenScopeEntity maskinPortenScopeEntity in scopes)
         {
-            payload.Scopes.Should().Contain(x => x.Scope == maskinPortenScopeEntity.Scope && x.Description == maskinPortenScopeEntity.Description);
+            Assert.Contains(payload.Scopes, x => x.Scope == maskinPortenScopeEntity.Scope && x.Description == maskinPortenScopeEntity.Description);
         }
     }
 

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/AddMetadataForAttachmentTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/AddMetadataForAttachmentTests.cs
@@ -11,7 +11,6 @@ using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.Models.App;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/AddMetadataForAttachmentTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/AddMetadataForAttachmentTests.cs
@@ -36,15 +36,16 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
             using var payloadContent = new StringContent(JsonSerializer.Serialize(payload, JsonSerializerOptions), Encoding.UTF8, MediaTypeNames.Application.Json);
             using var response = await HttpClient.PostAsync(url, payloadContent);
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string applicationMetadataFile = await File.ReadAllTextAsync(Path.Combine(TestRepoPath, "App", "config", "applicationmetadata.json"));
             var applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataFile, JsonSerializerOptions);
 
             var attachmentDataType = applicationMetadata.DataTypes.Single(x => x.Id == payload.Id);
-            attachmentDataType.MaxCount.Should().Be(payload.MaxCount);
-            attachmentDataType.MaxSize.Should().Be(payload.MaxSize);
-            attachmentDataType.MinCount.Should().Be(payload.MinCount);
+
+            Assert.Equal(payload.MaxCount, attachmentDataType.MaxCount);
+            Assert.Equal(payload.MaxSize, attachmentDataType.MaxSize);
+            Assert.Equal(payload.MinCount, attachmentDataType.MinCount);
         }
 
         /// <summary>

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/CreateApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/CreateApplicationMetadataTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/CreateApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/CreateApplicationMetadataTests.cs
@@ -28,7 +28,7 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
             using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, url);
             using var response = await HttpClient.SendAsync(request);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+            Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
         }
 
         [Theory]
@@ -45,7 +45,7 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
             using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, url);
             using var response = await HttpClient.SendAsync(request);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         }
 
     }

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/DeleteMetadataForAttachmentTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/DeleteMetadataForAttachmentTests.cs
@@ -35,7 +35,7 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
 
             var response = await HttpClient.SendAsync(requestMessage);
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string currentMetadata = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
             ApplicationMetadata applicationMetadataAfterDelete = JsonSerializer.Deserialize<ApplicationMetadata>(currentMetadata, JsonSerializerOptions);
             Assert.DoesNotContain(applicationMetadataAfterDelete.DataTypes, x => x.Id == attacmentIdToDelete);

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/DeleteMetadataForAttachmentTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/DeleteMetadataForAttachmentTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models.App;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/GetApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/GetApplicationMetadataTests.cs
@@ -33,10 +33,10 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
             string url = VersionPrefix(org, targetRepository);
             var response = await HttpClient.GetAsync(url);
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string responseContent = await response.Content.ReadAsStringAsync();
             string expectedJson = JsonSerializer.Serialize(JsonSerializer.Deserialize<ApplicationMetadata>(metadataFile, JsonSerializerOptions), JsonSerializerOptions);
-            JsonUtils.DeepEquals(expectedJson, responseContent).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedJson, responseContent));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/GetApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/GetApplicationMetadataTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models.App;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateApplicationMetadataTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models.App;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateApplicationMetadataTests.cs
@@ -34,11 +34,11 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
 
             using var response = await HttpClient.PutAsync(url, new StringContent(metadata, Encoding.UTF8, MediaTypeNames.Application.Json));
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string responseContent = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedMetadataJson, responseContent).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedMetadataJson, responseContent));
             string fileFromRepo = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
-            JsonUtils.DeepEquals(expectedMetadataJson, fileFromRepo).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedMetadataJson, fileFromRepo));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateMetadataForAttachmentTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateMetadataForAttachmentTests.cs
@@ -42,21 +42,23 @@ namespace Designer.Tests.Controllers.ApplicationMetadataController
             using var payloadContent = new StringContent(payload, Encoding.UTF8, MediaTypeNames.Application.Json);
             using var response = await HttpClient.PutAsync(url, payloadContent);
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string applicationMetadataFile = await File.ReadAllTextAsync(Path.Combine(TestRepoPath, "App", "config", "applicationmetadata.json"));
             var applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataFile, _jsonSerializerOptions);
 
             var attachmentDataType = applicationMetadata.DataTypes.Single(x => x.Id == payloadNode!["id"]!.ToString());
-            attachmentDataType.MaxCount.Should().Be(payloadNode!["maxCount"]!.GetValue<int>());
-            attachmentDataType.MaxSize.Should().Be(payloadNode!["maxSize"]!.GetValue<int>());
-            attachmentDataType.MinCount.Should().Be(payloadNode!["minCount"]!.GetValue<int>());
 
-            attachmentDataType.AllowedContentTypes.Count.Should().Be(expectedContentTypes.Length);
+            Assert.Equal(attachmentDataType.MaxCount, payloadNode!["maxCount"]!.GetValue<int>());
+            Assert.Equal(attachmentDataType.MaxSize, payloadNode!["maxSize"]!.GetValue<int>());
+            Assert.Equal(attachmentDataType.MinCount, payloadNode!["minCount"]!.GetValue<int>());
+
+
+            Assert.Equal(attachmentDataType.AllowedContentTypes.Count, expectedContentTypes.Length);
 
             foreach (string contentType in expectedContentTypes)
             {
-                attachmentDataType.AllowedContentTypes.Should().Contain(contentType);
+                Assert.Contains(contentType, attachmentDataType.AllowedContentTypes);
             }
         }
 

--- a/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateMetadataForAttachmentTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ApplicationMetadataController/UpdateMetadataForAttachmentTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models.App;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/CsharpNamespaceTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/CsharpNamespaceTests.cs
@@ -16,7 +16,6 @@ using Altinn.Studio.Designer.Filters.DataModeling;
 using Altinn.Studio.Designer.ViewModels.Request;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/CsharpNamespaceTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/CsharpNamespaceTests.cs
@@ -45,16 +45,14 @@ public class CsharpNamespaceTests : DesignerEndpointsTestsBase<CsharpNamespaceTe
 
         // get the csharp model from repo
         string csharpModel = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, expectedModelPath);
-        Regex.Match(csharpModel, $"^namespace {expectedNamespace}$".Replace(".", "\\."), RegexOptions.Multiline).Success.Should().BeTrue();
+        Assert.True(Regex.Match(csharpModel, $"^namespace {expectedNamespace}$".Replace(".", "\\."),
+            RegexOptions.Multiline).Success);
 
         string applicationMetadataContent = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
         var applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataContent, JsonSerializerOptions);
 
-        applicationMetadata.DataTypes.Should().Contain(x => x.AppLogic != null && x.AppLogic.ClassRef ==
-                                                            $"{expectedNamespace}.{expectedTypeName}");
-
-        applicationMetadata.DataTypes.Should().NotContain(x => x.AppLogic != null && x.AppLogic.ClassRef ==
-            $"{notExpectedNamespace}.{expectedTypeName}");
+        Assert.Contains(applicationMetadata.DataTypes, x => x.AppLogic != null && x.AppLogic.ClassRef == $"{expectedNamespace}.{expectedTypeName}");
+        Assert.DoesNotContain(applicationMetadata.DataTypes, x => x.AppLogic != null && x.AppLogic.ClassRef == $"{notExpectedNamespace}.{expectedTypeName}");
     }
 
     [Theory]
@@ -70,14 +68,14 @@ public class CsharpNamespaceTests : DesignerEndpointsTestsBase<CsharpNamespaceTe
         Assert.Equal(HttpStatusCode.Created, setupResponse.StatusCode);
 
         using var response = await UploadNewXsdSchema(xsdPath, url);
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
 
         var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(await response.Content.ReadAsStringAsync());
 
-        problemDetails.Should().NotBeNull();
+        Assert.NotNull(problemDetails);
 
         JsonElement errorCode = (JsonElement)problemDetails.Extensions[ProblemDetailsExtensionsCodes.ErrorCode];
-        errorCode.ToString().Should().Be(expectedErrorCode);
+        Assert.Equal(expectedErrorCode, errorCode.ToString());
     }
 
     [Theory]
@@ -92,7 +90,7 @@ public class CsharpNamespaceTests : DesignerEndpointsTestsBase<CsharpNamespaceTe
         Assert.Equal(HttpStatusCode.Created, setupResponse.StatusCode);
 
         using var response = await UploadNewXsdSchema(xsdPath, url);
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
 
@@ -106,19 +104,21 @@ public class CsharpNamespaceTests : DesignerEndpointsTestsBase<CsharpNamespaceTe
         string url = $"{VersionPrefix(org, targetRepo)}/datamodel?modelPath={modelPath}";
 
         using var response = await GenerateModels(expectedModelName, url);
-        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         // get the csharp model from repo
         string csharpModel = TestDataHelper.GetFileFromRepo(org, targetRepo, developer, expectedModelPath);
-        Regex.Match(csharpModel, $"^namespace {expectedNamespace}$".Replace(".", "\\."), RegexOptions.Multiline).Success.Should().BeTrue();
+        Assert.True(Regex.Match(csharpModel, $"^namespace {expectedNamespace}$".Replace(".", "\\."),
+            RegexOptions.Multiline).Success);
 
         string applicationMetadataContent = TestDataHelper.GetFileFromRepo(org, targetRepo, developer, "App/config/applicationmetadata.json");
         var applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataContent, JsonSerializerOptions);
 
-        applicationMetadata.DataTypes.Should().Contain(x => x.AppLogic != null && x.AppLogic.ClassRef ==
+        Assert.Contains(applicationMetadata.DataTypes, x => x.AppLogic != null && x.AppLogic.ClassRef ==
             $"{expectedNamespace}.{expectedModelName}");
 
-        applicationMetadata.DataTypes.Should().NotContain(x => x.AppLogic != null && x.AppLogic.ClassRef ==
+        Assert.DoesNotContain(applicationMetadata.DataTypes, x => x.AppLogic != null && x.AppLogic.ClassRef ==
             $"{notExpectedNamespace}.{expectedModelName}");
+
     }
 
 
@@ -136,14 +136,14 @@ public class CsharpNamespaceTests : DesignerEndpointsTestsBase<CsharpNamespaceTe
 
         var response =
             await GenerateNewJsonSchema(modelName, $"{VersionPrefix(org, targetRepository)}/new");
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
 
         var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(await response.Content.ReadAsStringAsync());
 
-        problemDetails.Should().NotBeNull();
+        Assert.NotNull(problemDetails);
 
         JsonElement errorCode = (JsonElement)problemDetails.Extensions[ProblemDetailsExtensionsCodes.ErrorCode];
-        errorCode.ToString().Should().Be(expectedErrorCode);
+        Assert.Equal(expectedErrorCode, errorCode.ToString());
     }
 
 
@@ -158,22 +158,22 @@ public class CsharpNamespaceTests : DesignerEndpointsTestsBase<CsharpNamespaceTe
         initModelName = Path.GetFileNameWithoutExtension(initModelName);
 
         var newJsonSchemaResponse = await GenerateNewJsonSchema(initModelName, $"{VersionPrefix(org, targetRepository)}/new");
-        newJsonSchemaResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        Assert.Equal(HttpStatusCode.Created, newJsonSchemaResponse.StatusCode);
 
         var generateInitModelsResponse = await GenerateModels(initModelName, $"{VersionPrefix(org, targetRepository)}/datamodel?modelPath={modelPath}");
-        generateInitModelsResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        Assert.Equal(HttpStatusCode.NoContent, generateInitModelsResponse.StatusCode);
         // Check classRef in application metadata
         string applicationMetadataContent = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
         var applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataContent, JsonSerializerOptions);
-        applicationMetadata.DataTypes.Single(d => d.Id == initModelName).AppLogic.ClassRef.Should().Be($"Altinn.App.Models.{initModelName}.{initModelName}");
+        Assert.Equal(applicationMetadata.DataTypes.Single(d => d.Id == initModelName).AppLogic.ClassRef, $"Altinn.App.Models.{initModelName}.{initModelName}");
 
         var generateNewModelsResponse = await GenerateModels(newModelName, $"{VersionPrefix(org, targetRepository)}/datamodel?modelPath={modelPath}");
-        generateNewModelsResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        Assert.Equal(HttpStatusCode.NoContent, generateNewModelsResponse.StatusCode);
 
         // Check classRef in application metadata
         applicationMetadataContent = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
         applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataContent, JsonSerializerOptions);
-        applicationMetadata.DataTypes.Single(d => d.Id == initModelName).AppLogic.ClassRef.Should().Be($"Altinn.App.Models.{newModelName}.{newModelName}");
+        Assert.Equal(applicationMetadata.DataTypes.Single(d => d.Id == initModelName).AppLogic.ClassRef, $"Altinn.App.Models.{newModelName}.{newModelName}");
     }
 
     private async Task<HttpResponseMessage> UploadNewXsdSchema(string xsdPath, string url)

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/DeleteDatamodelTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/DeleteDatamodelTests.cs
@@ -8,7 +8,6 @@ using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Mocks;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/DeleteDatamodelTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/DeleteDatamodelTests.cs
@@ -42,7 +42,7 @@ public class DeleteDatamodelTests : DesignerEndpointsTestsBase<DeleteDatamodelTe
         using HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, dataPathWithData);
 
         using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
     }
 
     [Theory]
@@ -54,18 +54,18 @@ public class DeleteDatamodelTests : DesignerEndpointsTestsBase<DeleteDatamodelTe
         string dataPathWithData = $"{VersionPrefix(org, targetRepository)}/datamodel?modelPath={modelPath}";
         string applicationMetadataFromRepoBefore = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
         string layoutSetsFromRepoBefore = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/ui/layout-sets.json");
-        applicationMetadataFromRepoBefore.Should().Contain("datamodel");
+        Assert.Contains("datamodel", applicationMetadataFromRepoBefore);
         LayoutSets layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsFromRepoBefore, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-        layoutSets.Sets.FindAll(set => set.DataType == "datamodel").Count.Should().Be(2);
+        Assert.Equal(2, layoutSets.Sets.FindAll(set => set.DataType == "datamodel").Count);
 
         using HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, dataPathWithData);
 
         using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
         string applicationMetadataFromRepoAfter = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
         string layoutSetsFromRepoAfter = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/ui/layout-sets.json");
-        applicationMetadataFromRepoAfter.Should().NotContain("datamodel");
-        layoutSetsFromRepoAfter.Should().NotContain("datamodel");
+        Assert.DoesNotContain("datamodel", applicationMetadataFromRepoAfter);
+        Assert.DoesNotContain("datamodel", layoutSetsFromRepoAfter);
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/GetTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/GetTests.cs
@@ -2,10 +2,12 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Microsoft.AspNetCore.Mvc.Testing;
+using SharedResources.Tests;
 using Xunit;
 
 namespace Designer.Tests.Controllers.DataModelsController;
@@ -26,7 +28,7 @@ public class GetTests : DesignerEndpointsTestsBase<GetTests>, IClassFixture<WebA
         using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Theory]
@@ -37,22 +39,24 @@ public class GetTests : DesignerEndpointsTestsBase<GetTests>, IClassFixture<WebA
         using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
         using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         DataType dataTypeResponse = await response.Content.ReadFromJsonAsync<DataType>();
-        dataTypeResponse.Should().NotBeNull();
-        dataTypeResponse.Should().BeEquivalentTo(new DataType
-        {
-            Id = "Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES",
-            AllowedContentTypes = new List<string> { "application/xml" },
-            AppLogic = new ApplicationLogic
+        Assert.NotNull(dataTypeResponse);
+        Assert.True(JsonUtils.DeepEquals(JsonSerializer.Serialize(dataTypeResponse, JsonSerializerOptions),
+            JsonSerializer.Serialize(new DataType
             {
-                AutoCreate = true,
-                ClassRef = "Altinn.App.Models.HvemErHvem_M"
-            },
-            TaskId = "Task_1",
-            MaxCount = 1,
-            MinCount = 1
-        });
+                Id = "Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES",
+                AllowedContentTypes = new List<string> { "application/xml" },
+                AppLogic = new ApplicationLogic
+                {
+                    AutoCreate = true,
+                    ClassRef = "Altinn.App.Models.HvemErHvem_M"
+                },
+                TaskId = "Task_1",
+                MaxCount = 1,
+                MinCount = 1
+            }, JsonSerializerOptions)
+            ));
     }
 
     [Theory]
@@ -63,7 +67,7 @@ public class GetTests : DesignerEndpointsTestsBase<GetTests>, IClassFixture<WebA
         using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
         using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadAsStringAsync()).Should().Be("null");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("null", await response.Content.ReadAsStringAsync());
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/GetTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/GetTests.cs
@@ -5,7 +5,6 @@ using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 using Designer.Tests.Controllers.ApiTests;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/GetXsdDatamodelsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/GetXsdDatamodelsTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models;
 using Designer.Tests.Controllers.ApiTests;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/GetXsdDatamodelsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/GetXsdDatamodelsTests.cs
@@ -27,7 +27,7 @@ public class GetXsdDatamodelsTests : DesignerEndpointsTestsBase<GetXsdDatamodels
         var response = await HttpClient.SendAsync(httpRequestMessage);
         var altinnCoreFiles = await response.Content.ReadAsAsync<List<AltinnCoreFile>>();
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        altinnCoreFiles.Count.Should().Be(2);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, altinnCoreFiles.Count);
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
@@ -21,7 +21,6 @@ using Altinn.Studio.DataModeling.Validator.Json;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Controllers.DataModelsController.Utils;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Json.Pointer;
 using Json.Schema;
 using Microsoft.AspNetCore.Mvc;

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/PutDatamodelTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using System.Web;
 using System.Xml;
 using System.Xml.Schema;
+using Altinn.AccessManagement.Tests.Utils;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.DataModeling.Converter.Json;
 using Altinn.Studio.DataModeling.Converter.Json.Strategy;
@@ -63,7 +64,7 @@ public class PutDatamodelTests : DesignerEndpointsTestsBase<PutDatamodelTests>, 
         };
 
         var response = await HttpClient.SendAsync(request);
-        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         await FilesWithCorrectNameAndContentShouldBeCreated(modelName);
     }
 
@@ -81,19 +82,19 @@ public class PutDatamodelTests : DesignerEndpointsTestsBase<PutDatamodelTests>, 
         };
 
         var response = await HttpClient.SendAsync(request);
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
         var problemDetailsJson = await response.Content.ReadAsStringAsync();
         var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(problemDetailsJson);
 
-        problemDetails.Should().NotBeNull();
-        problemDetails.Extensions.Should().ContainKey("customErrorMessages");
+        Assert.NotNull(problemDetails);
+        Assert.Contains("customErrorMessages", problemDetails.Extensions.Keys);
 
         var customErrorMessages = problemDetails.Extensions["customErrorMessages"];
-        customErrorMessages.Should().NotBeNull();
+        Assert.NotNull(customErrorMessages);
         var customErrorMessagesElement = (JsonElement)customErrorMessages;
         var firstErrorMessage = customErrorMessagesElement.EnumerateArray().FirstOrDefault().GetString();
-        firstErrorMessage.Should().Contain("'root': member names cannot be the same as their enclosing type");
+        Assert.Contains("'root': member names cannot be the same as their enclosing type", firstErrorMessage);
     }
 
     [Theory]
@@ -111,7 +112,7 @@ public class PutDatamodelTests : DesignerEndpointsTestsBase<PutDatamodelTests>, 
         };
 
         var response = await HttpClient.SendAsync(request);
-        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
     }
 
     [Theory(Skip = "Validator is excluded from put method for now.")]
@@ -129,7 +130,7 @@ public class PutDatamodelTests : DesignerEndpointsTestsBase<PutDatamodelTests>, 
         };
 
         var response = await HttpClient.SendAsync(request);
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
         string content = await response.Content.ReadAsStringAsync();
 
         var errorResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(content, new JsonSerializerOptions()
@@ -141,7 +142,7 @@ public class PutDatamodelTests : DesignerEndpointsTestsBase<PutDatamodelTests>, 
         {
             var pointerObject = JsonPointer.Parse(pointer);
             Assert.Single(errorResponse.Errors.Keys, p => JsonPointer.Parse(p) == pointerObject);
-            errorResponse.Errors[pointerObject.ToString(JsonPointerStyle.UriEncoded)].Contains(errorCode).Should().BeTrue();
+            Assert.Contains(errorCode, errorResponse.Errors[pointerObject.ToString(JsonPointerStyle.UriEncoded)]);
         }
     }
 
@@ -164,10 +165,10 @@ public class PutDatamodelTests : DesignerEndpointsTestsBase<PutDatamodelTests>, 
         };
 
         HttpResponseMessage response = await HttpClient.SendAsync(putRequest);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         DataType dataTypeResponse = await response.Content.ReadFromJsonAsync<DataType>();
-        dataTypeResponse.Should().NotBeNull();
-        dataTypeResponse.Should().BeEquivalentTo(dataType);
+        Assert.NotNull(dataTypeResponse);
+        AssertionUtil.AssertEqualTo(dataType, dataTypeResponse);
     }
 
     [Theory]
@@ -189,7 +190,7 @@ public class PutDatamodelTests : DesignerEndpointsTestsBase<PutDatamodelTests>, 
         };
 
         HttpResponseMessage response = await HttpClient.SendAsync(putRequest);
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
 
@@ -234,7 +235,7 @@ public class PutDatamodelTests : DesignerEndpointsTestsBase<PutDatamodelTests>, 
     private static void VerifyFileContent(string path, string expectedContent)
     {
         var fileContent = File.ReadAllText(path);
-        expectedContent.Should().Be(fileContent);
+        Assert.Equal(expectedContent, fileContent);
     }
 
     public static IEnumerable<object[]> IncompatibleSchemasTestData => new List<object[]>

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/UseXsdFromRepoTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/UseXsdFromRepoTests.cs
@@ -28,6 +28,6 @@ public class UseXsdFromRepoTests : DesignerEndpointsTestsBase<UseXsdFromRepoTest
         using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, url);
 
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/UseXsdFromRepoTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/UseXsdFromRepoTests.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/Utils/FileContentVerifier.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/Utils/FileContentVerifier.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using SharedResources.Tests;
+using Xunit;
 
 namespace Designer.Tests.Controllers.DataModelsController.Utils
 {
@@ -9,7 +10,7 @@ namespace Designer.Tests.Controllers.DataModelsController.Utils
         public static void VerifyJsonFileContent(string path, string json)
         {
             string fileContent = File.ReadAllText(path);
-            JsonUtils.DeepEquals(fileContent, json).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(fileContent, json));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/DataModelsController/Utils/FileContentVerifier.cs
+++ b/backend/tests/Designer.Tests/Controllers/DataModelsController/Utils/FileContentVerifier.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using FluentAssertions;
 using SharedResources.Tests;
 
 namespace Designer.Tests.Controllers.DataModelsController.Utils

--- a/backend/tests/Designer.Tests/Controllers/FeedbackFormController/SendMessageToSlackTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/FeedbackFormController/SendMessageToSlackTests.cs
@@ -54,7 +54,7 @@ public class SendMessageToSlackTests : FeedbackFormControllerTestBase<SendMessag
 
 
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class SendMessageToSlackTests : FeedbackFormControllerTestBase<SendMessag
         };
 
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
@@ -83,6 +83,6 @@ public class SendMessageToSlackTests : FeedbackFormControllerTestBase<SendMessag
         };
 
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/FeedbackFormController/SendMessageToSlackTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/FeedbackFormController/SendMessageToSlackTests.cs
@@ -8,7 +8,6 @@ using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.FeedbackFormController.Base;
 using Designer.Tests.Controllers.FeedbackFormController.Utils;
 using Designer.Tests.Fixtures;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/OptionsController/GetOptionsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OptionsController/GetOptionsTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Altinn.AccessManagement.Tests.Utils;
 using Altinn.Studio.Designer.Filters;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.Dto;
@@ -90,18 +92,18 @@ public class GetOptionsTests : DesignerEndpointsTestsBase<GetOptionsTests>, ICla
 
         // Assert
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
-        responseList.Should().BeEquivalentTo(new List<OptionListData>
-        {
-            new () { Title = "options-with-null-fields", Data = null, HasError = true },
-            new () { Title = "other-options", HasError = false },
-            new () { Title = "test-options", HasError = false },
-            new () { Title = "optionListMissingValue", Data = null, HasError = true },
-            new () { Title = "optionListMissingLabel", Data = null, HasError = true },
-            new () { Title = "optionListTrailingComma", Data = null, HasError = true },
-            new () { Title = "optionListLabelWithObject", Data = null, HasError = true },
-            new () { Title = "optionListLabelWithNumber", Data = null, HasError = true },
-            new () { Title = "optionListLabelWithBool", Data = null, HasError = true }
-        }, options => options.Excluding(x => x.Data));
+
+        Assert.Equal(9, responseList.Count);
+        Assert.Single(responseList, o => o.Title == "options-with-null-fields" && o.HasError == true);
+        Assert.Single(responseList, o => o.Title == "other-options" && o.HasError == false);
+        Assert.Single(responseList, o => o.Title == "test-options" && o.HasError == false);
+        Assert.Single(responseList, o => o.Title == "optionListMissingValue" && o.HasError == true);
+        Assert.Single(responseList, o => o.Title == "optionListMissingLabel" && o.HasError == true);
+        Assert.Single(responseList, o => o.Title == "optionListTrailingComma" && o.HasError == true);
+        Assert.Single(responseList, o => o.Title == "optionListLabelWithObject" && o.HasError == true);
+        Assert.Single(responseList, o => o.Title == "optionListLabelWithNumber" && o.HasError == true);
+        Assert.Single(responseList, o => o.Title == "optionListLabelWithBool" && o.HasError == true);
+
     }
 
     [Fact]
@@ -164,8 +166,8 @@ public class GetOptionsTests : DesignerEndpointsTestsBase<GetOptionsTests>, ICla
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
 
         var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(await response.Content.ReadAsStringAsync());
-        problemDetails.Should().NotBeNull();
+        Assert.NotNull(problemDetails);
         JsonElement errorCode = (JsonElement)problemDetails.Extensions[ProblemDetailsExtensionsCodes.ErrorCode];
-        errorCode.ToString().Should().Be("InvalidOptionsFormat");
+        Assert.Equal("InvalidOptionsFormat", errorCode.ToString());
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/OptionsController/GetOptionsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OptionsController/GetOptionsTests.cs
@@ -9,7 +9,6 @@ using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;

--- a/backend/tests/Designer.Tests/Controllers/OptionsController/UpdateOptionsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OptionsController/UpdateOptionsTests.cs
@@ -7,7 +7,6 @@ using Altinn.Studio.Designer.Filters;
 using Altinn.Studio.Designer.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;

--- a/backend/tests/Designer.Tests/Controllers/OptionsController/UpdateOptionsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OptionsController/UpdateOptionsTests.cs
@@ -199,9 +199,9 @@ public class UpdateOptionsTests : DesignerEndpointsTestsBase<UpdateOptionsTests>
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
 
-        problemDetails.Should().NotBeNull();
+        Assert.NotNull(problemDetails);
         JsonElement errorCode = (JsonElement)problemDetails.Extensions[ProblemDetailsExtensionsCodes.ErrorCode];
-        errorCode.ToString().Should().Be("InvalidOptionsFormat");
+        Assert.Equal("InvalidOptionsFormat", errorCode.ToString());
     }
 
     [Fact]

--- a/backend/tests/Designer.Tests/Controllers/OptionsController/UploadOptionsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OptionsController/UploadOptionsTests.cs
@@ -8,7 +8,6 @@ using Altinn.Studio.Designer.Filters;
 using Altinn.Studio.Designer.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -105,7 +104,7 @@ public class UploadOptionsTests : DesignerEndpointsTestsBase<UploadOptionsTests>
 
         string optionsFileName = "missing-fields-options.json";
         string jsonOptions = @"[
-        {""value"": """" }, 
+        {""value"": """" },
         {""label"": """" },
     ]";
 

--- a/backend/tests/Designer.Tests/Controllers/OptionsController/UploadOptionsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OptionsController/UploadOptionsTests.cs
@@ -188,8 +188,8 @@ public class UploadOptionsTests : DesignerEndpointsTestsBase<UploadOptionsTests>
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
 
         var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(await response.Content.ReadAsStringAsync());
-        problemDetails.Should().NotBeNull();
+        Assert.NotNull(problemDetails);
         JsonElement errorCode = (JsonElement)problemDetails.Extensions[ProblemDetailsExtensionsCodes.ErrorCode];
-        errorCode.ToString().Should().Be("InvalidOptionsFormat");
+        Assert.Equal("InvalidOptionsFormat", errorCode.ToString());
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/AnonymousTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/AnonymousTests.cs
@@ -2,7 +2,6 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/AnonymousTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/AnonymousTests.cs
@@ -25,7 +25,7 @@ namespace Designer.Tests.Controllers.PreviewController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals("{}", responseBody).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals("{}", responseBody));
         }
 
     }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/ApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/ApplicationMetadataTests.cs
@@ -10,7 +10,6 @@ using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Mocks;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/ApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/ApplicationMetadataTests.cs
@@ -53,7 +53,7 @@ namespace Designer.Tests.Controllers.PreviewController
             ApplicationMetadata expectedApplicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(expectedApplicationMetadataString, JsonSerializerOptions);
             expectedApplicationMetadata.AltinnNugetVersion = string.Empty;
             string expectedJson = JsonSerializer.Serialize(expectedApplicationMetadata, JsonSerializerOptions);
-            JsonUtils.DeepEquals(expectedJson, responseBody).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedJson, responseBody));
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace Designer.Tests.Controllers.PreviewController
             ApplicationMetadata expectedApplicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(expectedApplicationMetadataString, JsonSerializerOptions);
             expectedApplicationMetadata.AltinnNugetVersion = "8.0.0.0";
             string expectedJson = JsonSerializer.Serialize(expectedApplicationMetadata, JsonSerializerOptions);
-            JsonUtils.DeepEquals(expectedJson, responseBody).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedJson, responseBody));
         }
 
         [Fact]
@@ -82,10 +82,11 @@ namespace Designer.Tests.Controllers.PreviewController
         {
             string originalApplicationMetadataString = TestDataHelper.GetFileFromRepo(Org, AppV4, Developer, "App/config/applicationmetadata.json");
             ApplicationMetadata originalApplicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(originalApplicationMetadataString, JsonSerializerOptions);
-            originalApplicationMetadata.PartyTypesAllowed.Person.Should().BeTrue();
-            originalApplicationMetadata.PartyTypesAllowed.Organisation.Should().BeTrue();
-            originalApplicationMetadata.PartyTypesAllowed.SubUnit.Should().BeTrue();
-            originalApplicationMetadata.PartyTypesAllowed.BankruptcyEstate.Should().BeTrue();
+
+            Assert.True(originalApplicationMetadata.PartyTypesAllowed.Person);
+            Assert.True(originalApplicationMetadata.PartyTypesAllowed.Organisation);
+            Assert.True(originalApplicationMetadata.PartyTypesAllowed.SubUnit);
+            Assert.True(originalApplicationMetadata.PartyTypesAllowed.BankruptcyEstate);
 
             _appDevelopmentServiceMock
                 .Setup(rs => rs.GetAppLibVersion(It.IsAny<AltinnRepoEditingContext>()))
@@ -101,10 +102,11 @@ namespace Designer.Tests.Controllers.PreviewController
             string responseBody = await response.Content.ReadAsStringAsync();
 
             ApplicationMetadata responseApplicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(responseBody, JsonSerializerOptions);
-            responseApplicationMetadata.PartyTypesAllowed.Person.Should().BeFalse();
-            responseApplicationMetadata.PartyTypesAllowed.Organisation.Should().BeFalse();
-            responseApplicationMetadata.PartyTypesAllowed.SubUnit.Should().BeFalse();
-            responseApplicationMetadata.PartyTypesAllowed.BankruptcyEstate.Should().BeFalse();
+
+            Assert.False(responseApplicationMetadata.PartyTypesAllowed.Person);
+            Assert.False(responseApplicationMetadata.PartyTypesAllowed.Organisation);
+            Assert.False(responseApplicationMetadata.PartyTypesAllowed.SubUnit);
+            Assert.False(responseApplicationMetadata.PartyTypesAllowed.BankruptcyEstate);
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/DatamodelTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/DatamodelTests.cs
@@ -28,7 +28,7 @@ namespace Designer.Tests.Controllers.PreviewController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedDatamodel, responseBody).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedDatamodel, responseBody));
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace Designer.Tests.Controllers.PreviewController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedDatamodel, responseBody).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedDatamodel, responseBody));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/DatamodelTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/DatamodelTests.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Services.Implementation;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetFooterTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetFooterTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Altinn.AccessManagement.Tests.Utils;
 using Altinn.Studio.Designer.Models;
 using Designer.Tests.Utils;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -32,7 +33,7 @@ namespace Designer.Tests.Controllers.PreviewController
             string responseString = await response.Content.ReadAsStringAsync();
             FooterFile responseFooterFile = JsonSerializer.Deserialize<FooterFile>(responseString);
 
-            responseFooterFile.Footer.Should().BeEquivalentTo(actualFooterFile.Footer);
+            AssertionUtil.AssertEqualTo(actualFooterFile.Footer, responseFooterFile.Footer);
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetFooterTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetFooterTests.cs
@@ -6,9 +6,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
-using SharedResources.Tests;
 using Xunit;
 
 namespace Designer.Tests.Controllers.PreviewController

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormLayoutsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormLayoutsTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormLayoutsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormLayoutsTests.cs
@@ -28,7 +28,7 @@ namespace Designer.Tests.Controllers.PreviewController
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedFormLayouts, responseBody).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedFormLayouts, responseBody));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormLayoutsV4Tests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormLayoutsV4Tests.cs
@@ -2,7 +2,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormLayoutsV4Tests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetFormLayoutsV4Tests.cs
@@ -29,7 +29,7 @@ namespace Designer.Tests.Controllers.PreviewController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedFormLayouts, responseBody).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedFormLayouts, responseBody));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleConfigurationTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleConfigurationTests.cs
@@ -2,7 +2,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleConfigurationTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleConfigurationTests.cs
@@ -28,7 +28,7 @@ namespace Designer.Tests.Controllers.PreviewController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedRuleConfig, responseBody).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedRuleConfig, responseBody));
         }
 
         [Fact]

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleConfigurationV4Tests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleConfigurationV4Tests.cs
@@ -2,7 +2,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleConfigurationV4Tests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/GetRuleConfigurationV4Tests.cs
@@ -37,7 +37,7 @@ namespace Designer.Tests.Controllers.PreviewController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedRuleConfig, responseBody).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedRuleConfig, responseBody));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSettingsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSettingsTests.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSettingsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSettingsTests.cs
@@ -26,7 +26,7 @@ namespace Designer.Tests.Controllers.PreviewController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedLayoutSettings, responseBody).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedLayoutSettings, responseBody));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSettingsV4Tests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSettingsV4Tests.cs
@@ -2,7 +2,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSettingsV4Tests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/LayoutSettingsV4Tests.cs
@@ -26,7 +26,7 @@ namespace Designer.Tests.Controllers.PreviewController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedLayoutSettings, responseBody).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedLayoutSettings, responseBody));
         }
 
     }

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/ValidateInstantiationTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/ValidateInstantiationTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/PreviewController/ValidateInstantiationTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/PreviewController/ValidateInstantiationTests.cs
@@ -24,7 +24,7 @@ namespace Designer.Tests.Controllers.PreviewController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(@"{""valid"": true}", responseBody).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(@"{""valid"": true}", responseBody));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/AddDataTypeToApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/AddDataTypeToApplicationMetadataTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/AddDataTypeToApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/AddDataTypeToApplicationMetadataTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Altinn.AccessManagement.Tests.Utils;
 using Altinn.Platform.Storage.Interface.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
@@ -29,7 +30,7 @@ namespace Designer.Tests.Controllers.ProcessModelingController
 
             using var request = new HttpRequestMessage(HttpMethod.Post, url);
             using var response = await HttpClient.SendAsync(request);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string appMetadataString = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
             Application appMetadata = JsonSerializer.Deserialize<Application>(appMetadataString, new JsonSerializerOptions
@@ -50,9 +51,9 @@ namespace Designer.Tests.Controllers.ProcessModelingController
                 EnabledFileValidators = new List<string>()
             };
 
-            appMetadata.DataTypes.Count.Should().Be(2);
-            appMetadata.DataTypes.Find(dataType => dataType.Id == dataTypeId).Should().BeEquivalentTo(expectedDataType);
-            appMetadata.DataTypes.Find(dataType => dataType.Id == dataTypeId).TaskId.Should().Be(taskId);
+            Assert.Equal(2, appMetadata.DataTypes.Count);
+            AssertionUtil.AssertEqualTo(expectedDataType, appMetadata.DataTypes.Find(dataType => dataType.Id == dataTypeId));
+            Assert.Equal(taskId, appMetadata.DataTypes.Find(dataType => dataType.Id == dataTypeId).TaskId);
         }
 
         [Theory]
@@ -65,7 +66,7 @@ namespace Designer.Tests.Controllers.ProcessModelingController
             using var request = new HttpRequestMessage(HttpMethod.Post, url);
             using var response = await HttpClient.SendAsync(request);
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string appMetadataString = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
             Application appMetadata = JsonSerializer.Deserialize<Application>(appMetadataString, new JsonSerializerOptions
@@ -73,7 +74,7 @@ namespace Designer.Tests.Controllers.ProcessModelingController
                 PropertyNameCaseInsensitive = true
             });
 
-            appMetadata.DataTypes.Count.Should().Be(1);
+            Assert.Single(appMetadata.DataTypes);
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/DeleteDataTypeFromApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/DeleteDataTypeFromApplicationMetadataTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/DeleteDataTypeFromApplicationMetadataTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/DeleteDataTypeFromApplicationMetadataTests.cs
@@ -28,7 +28,7 @@ namespace Designer.Tests.Controllers.ProcessModelingController
 
             using var request = new HttpRequestMessage(HttpMethod.Delete, url);
             using var response = await HttpClient.SendAsync(request);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string appMetadataString = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
             Application appMetadata = JsonSerializer.Deserialize<Application>(appMetadataString, new JsonSerializerOptions
@@ -36,7 +36,7 @@ namespace Designer.Tests.Controllers.ProcessModelingController
                 PropertyNameCaseInsensitive = true
             });
 
-            appMetadata.DataTypes.Count.Should().Be(0);
+            Assert.Empty(appMetadata.DataTypes);
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/DataTypesChangeTests/ApplicationMetadataFileSyncDataTypesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/DataTypesChangeTests/ApplicationMetadataFileSyncDataTypesTests.cs
@@ -9,7 +9,6 @@ using Altinn.App.Core.Models;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/DataTypesChangeTests/ApplicationMetadataFileSyncDataTypesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/DataTypesChangeTests/ApplicationMetadataFileSyncDataTypesTests.cs
@@ -41,13 +41,13 @@ public class ApplicationMetadataFileSyncDataTypesTests : DesignerEndpointsTestsB
             Content = new StringContent(dataTypeChangeString, Encoding.UTF8, "application/json")
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string applicationMetadataFromRepo = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
 
         ApplicationMetadata applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataFromRepo, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
-        applicationMetadata.DataTypes.Should().NotContain(dataType => dataType.AppLogic != null && dataType.TaskId == dataTypesChange.ConnectedTaskId); // No data type connected to Task_1
+        Assert.DoesNotContain(applicationMetadata.DataTypes, dataType => dataType.AppLogic != null && dataType.TaskId == dataTypesChange.ConnectedTaskId); // Task_1 is not connected to any data type
     }
 
     [Theory]
@@ -72,13 +72,14 @@ public class ApplicationMetadataFileSyncDataTypesTests : DesignerEndpointsTestsB
             Content = new StringContent(dataTypesChangeString, Encoding.UTF8, "application/json")
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string applicationMetadataFromRepo = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
 
         ApplicationMetadata applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataFromRepo, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
-        applicationMetadata.DataTypes.Find(type => type.Id == dataTypeToConnect).TaskId.Should().Be(task); // Data type 'message' is now connected to Task_5
+        Assert.Equal(task, applicationMetadata.DataTypes.Find(type => type.Id == dataTypeToConnect).TaskId); // Data type 'message' is now connected to Task_5;
+
     }
 
     [Theory]
@@ -104,14 +105,15 @@ public class ApplicationMetadataFileSyncDataTypesTests : DesignerEndpointsTestsB
             Content = new StringContent(dataTypesChangeString, Encoding.UTF8, "application/json")
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string applicationMetadataFromRepo = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
 
         ApplicationMetadata applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataFromRepo, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-        applicationMetadata.DataTypes.FindAll(type => type.TaskId == task).Count.Should().Be(2); // Original connected data type 'datalist' should be disconnected
-        applicationMetadata.DataTypes.Find(type => type.Id == dataTypeToConnect1).TaskId.Should().Be(task); // Data type 'message' is now connected to Task_5
-        applicationMetadata.DataTypes.Find(type => type.Id == dataTypeToConnect2).TaskId.Should().Be(task); // Data type 'likert' is now connected to Task_5
+
+        Assert.Equal(2, applicationMetadata.DataTypes.FindAll(type => type.TaskId == task).Count); // Original connected data type 'datalist' should be disconnected
+        Assert.Equal(task, applicationMetadata.DataTypes.Find(type => type.Id == dataTypeToConnect1).TaskId); // Data type 'message' is now connected to Task_5
+        Assert.Equal(task, applicationMetadata.DataTypes.Find(type => type.Id == dataTypeToConnect2).TaskId); // Data type 'likert' is now connected to Task_5
     }
 
     [Theory]
@@ -136,12 +138,12 @@ public class ApplicationMetadataFileSyncDataTypesTests : DesignerEndpointsTestsB
             Content = new StringContent(dataTypesChangeString, Encoding.UTF8, "application/json")
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string applicationMetadataFromRepo = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
 
         ApplicationMetadata applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataFromRepo, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-        applicationMetadata.DataTypes.Find(type => type.Id == dataTypeToConnect).TaskId.Should().NotBe(task); // CustomReceipt has not been added to the dataType
+        Assert.DoesNotContain(applicationMetadata.DataTypes, dataType => dataType.AppLogic != null && dataType.TaskId == dataTypesChange.ConnectedTaskId); // No data type connected to Task_1
     }
 
     public static IEnumerable<object[]> ProcessDataTypeChangedNotifyTestData()

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/DataTypesChangeTests/LayoutSetsFileSyncDataTypesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/DataTypesChangeTests/LayoutSetsFileSyncDataTypesTests.cs
@@ -9,7 +9,6 @@ using Altinn.App.Core.Models;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/DataTypesChangeTests/LayoutSetsFileSyncDataTypesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/DataTypesChangeTests/LayoutSetsFileSyncDataTypesTests.cs
@@ -43,14 +43,14 @@ public class LayoutSetsFileSyncDataTypesTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(dataTypesChangeString, Encoding.UTF8, "application/json")
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string layoutSetsFromRepo =
             TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/ui/layout-sets.json");
 
         LayoutSets layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsFromRepo, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
-        layoutSets.Sets.Find(set => set.Tasks[0] == dataTypesChange.ConnectedTaskId).DataType.Should().BeNull();
+        Assert.Null(layoutSets.Sets.Find(set => set.Tasks[0] == dataTypesChange.ConnectedTaskId).DataType);
     }
 
     [Theory]
@@ -75,14 +75,14 @@ public class LayoutSetsFileSyncDataTypesTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(dataTypesChangeString, Encoding.UTF8, "application/json")
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string layoutSetsFromRepo =
             TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/ui/layout-sets.json");
 
         LayoutSets layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsFromRepo, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
-        layoutSets.Sets.Find(set => set.Tasks[0] == task).DataType.Should().Be(dataTypeToConnect);
+        Assert.Equal(dataTypeToConnect, layoutSets.Sets.Find(set => set.Tasks[0] == task).DataType);
     }
 
     [Theory]
@@ -107,14 +107,14 @@ public class LayoutSetsFileSyncDataTypesTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(dataTypesChangeString, Encoding.UTF8, "application/json")
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string layoutSetsFromRepo =
             TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/ui/layout-sets.json");
 
         LayoutSets layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsFromRepo, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
-        layoutSets.Sets.Find(set => set.Tasks[0] == task).DataType.Should().Be(dataTypeToConnect1);
+        Assert.Equal(dataTypeToConnect1, layoutSets.Sets.Find(set => set.Tasks[0] == task).DataType);
     }
 
     [Theory]
@@ -139,14 +139,14 @@ public class LayoutSetsFileSyncDataTypesTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(dataTypesChangeString, Encoding.UTF8, "application/json")
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string layoutSetsFromRepo =
             TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/ui/layout-sets.json");
 
         LayoutSets layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsFromRepo, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
-        layoutSets.Sets.Find(set => set.Tasks[0] == task).DataType.Should().Be(dataTypeToConnect2);
+        Assert.Equal(dataTypeToConnect2, layoutSets.Sets.Find(set => set.Tasks[0] == task).DataType);
     }
 
     [Theory]
@@ -170,14 +170,14 @@ public class LayoutSetsFileSyncDataTypesTests : DesignerEndpointsTestsBase<Layou
             Content = new StringContent(dataTypeChangeString, Encoding.UTF8, "application/json")
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string layoutSetsFromRepo =
             TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/ui/layout-sets.json");
 
         LayoutSets layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsFromRepo, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
-        layoutSets.Sets.Find(set => set.Tasks[0] == task).DataType.Should().Be(dataTypeToConnect);
+        Assert.Equal(dataTypeToConnect, layoutSets.Sets.Find(set => set.Tasks[0] == task).DataType);
     }
 
     private async Task AddFileToRepo(string fileToCopyPath, string relativeCopyRepoLocation)

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/ApplicationMetadataFileSyncTaskIdTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/ApplicationMetadataFileSyncTaskIdTests.cs
@@ -48,14 +48,14 @@ public class ApplicationMetadataFileSyncTaskIdTests : DesignerEndpointsTestsBase
         form.Add(new StringContent(metadataString, Encoding.UTF8, MediaTypeNames.Application.Json), "metadata");
 
         using var response = await HttpClient.PutAsync(url, form);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string applicationMetadataFromRepo = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/applicationmetadata.json");
 
         ApplicationMetadata applicationMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(applicationMetadataFromRepo, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
-        applicationMetadata.DataTypes.Should().NotContain(dataType => dataType.TaskId == metadata.TaskIdChange.OldId);
-        applicationMetadata.DataTypes.Should().Contain(dataType => dataType.TaskId == metadata.TaskIdChange.NewId);
+        Assert.DoesNotContain(applicationMetadata.DataTypes, dataType => dataType.TaskId == metadata.TaskIdChange.OldId);
+        Assert.Contains(applicationMetadata.DataTypes, dataType => dataType.TaskId == metadata.TaskIdChange.NewId);
     }
 
     public static IEnumerable<object[]> UpsertProcessDefinitionAndNotifyTestData()

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/ApplicationMetadataFileSyncTaskIdTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/ApplicationMetadataFileSyncTaskIdTests.cs
@@ -11,7 +11,6 @@ using Altinn.Studio.Designer.Models.App;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/LayoutFileSyncTaskIdTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/LayoutFileSyncTaskIdTests.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/LayoutFileSyncTaskIdTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/LayoutFileSyncTaskIdTests.cs
@@ -58,7 +58,7 @@ public class LayoutFileSyncTaskIdTests : DesignerEndpointsTestsBase<LayoutFileSy
         using var response = await HttpClient.PutAsync(url, form);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string layoutFilePath = "App/ui/layoutSet2/layouts/layoutFile2InSet2.json";
         string layoutContent = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, layoutFilePath);
@@ -66,8 +66,8 @@ public class LayoutFileSyncTaskIdTests : DesignerEndpointsTestsBase<LayoutFileSy
         JsonNode layout = JsonSerializer.Deserialize<JsonNode>(layoutContent);
         string newTaskId = layout["data"]?["layout"]?[0]?["target"]?["taskId"]?.ToString();
 
-        newTaskId.Should().Be(metadata.TaskIdChange.NewId);
-        newTaskId.Should().NotBe(metadata.TaskIdChange.OldId);
+        Assert.Equal(newTaskId, metadata.TaskIdChange.NewId);
+        Assert.NotEqual(newTaskId, metadata.TaskIdChange.OldId);
     }
 
     [Theory]
@@ -104,10 +104,10 @@ public class LayoutFileSyncTaskIdTests : DesignerEndpointsTestsBase<LayoutFileSy
         using var response = await HttpClient.PutAsync(url, form);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string layoutAfterUpdate = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, layoutPath);
-        layoutAfterUpdate.Should().Be(layoutBeforeUpdate);
+        Assert.Equal(layoutBeforeUpdate, layoutAfterUpdate);
     }
 
     public static IEnumerable<object[]> GetReferencedTaskIdTestData()

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/LayoutSetsFileSyncTaskIdTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/LayoutSetsFileSyncTaskIdTests.cs
@@ -11,7 +11,6 @@ using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/LayoutSetsFileSyncTaskIdTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/LayoutSetsFileSyncTaskIdTests.cs
@@ -49,15 +49,15 @@ public class LayoutSetsFileSyncTaskIdTests : DesignerEndpointsTestsBase<LayoutSe
         form.Add(new StringContent(metadataString, Encoding.UTF8, MediaTypeNames.Application.Json), "metadata");
 
         using var response = await HttpClient.PutAsync(url, form);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string layoutSetsFromRepo =
             TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/ui/layout-sets.json");
 
         LayoutSets layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsFromRepo, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
-        layoutSets.Sets.Should().NotContain(layout => layout.Tasks.Contains(metadata.TaskIdChange.OldId));
-        layoutSets.Sets.Should().Contain(layout => layout.Tasks.Contains(metadata.TaskIdChange.NewId));
+        Assert.DoesNotContain(layoutSets.Sets, layout => layout.Tasks.Contains(metadata.TaskIdChange.OldId));
+        Assert.Contains(layoutSets.Sets, layout => layout.Tasks.Contains(metadata.TaskIdChange.NewId));
     }
 
     public static IEnumerable<object[]> UpsertProcessDefinitionAndNotifyTestData()

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/PolicyFileSyncTaskIdTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/PolicyFileSyncTaskIdTests.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/PolicyFileSyncTaskIdTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/FileSync/TaskIdChangeTests/PolicyFileSyncTaskIdTests.cs
@@ -50,13 +50,13 @@ public class PolicyFileSyncTaskIdTests : DesignerEndpointsTestsBase<PolicyFileSy
         form.Add(new StringContent(metadataString, Encoding.UTF8, MediaTypeNames.Application.Json), "metadata");
 
         using var response = await HttpClient.PutAsync(url, form);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string policyFileFromRepo =
             TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/authorization/policy.xml");
 
-        policyFileFromRepo.Should().NotContain(metadata.TaskIdChange.OldId);
-        policyFileFromRepo.Should().Contain(metadata.TaskIdChange.NewId);
+        Assert.DoesNotContain(metadata.TaskIdChange.OldId, policyFileFromRepo);
+        Assert.Contains(metadata.TaskIdChange.NewId, policyFileFromRepo);
 
     }
 

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/GetProcessDefinitionTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/GetProcessDefinitionTests.cs
@@ -31,13 +31,13 @@ namespace Designer.Tests.Controllers.ProcessModelingController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseContent = await response.Content.ReadAsStringAsync();
 
             XDocument responseXml = XDocument.Parse(responseContent);
             XDocument expectedXml = XDocument.Parse(fileContent);
-            XNode.DeepEquals(responseXml, expectedXml).Should().BeTrue();
+            Assert.True(XNode.DeepEquals(responseXml, expectedXml));
         }
 
         [Theory]
@@ -48,7 +48,7 @@ namespace Designer.Tests.Controllers.ProcessModelingController
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
             using var response = await HttpClient.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         private async Task<string> AddFileToRepo(string fileToCopyPath, string relativeCopyRepoLocation)

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/GetProcessDefinitionTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/GetProcessDefinitionTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/GetTemplatesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/GetTemplatesTests.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/GetTemplatesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/GetTemplatesTests.cs
@@ -26,14 +26,14 @@ namespace Designer.Tests.Controllers.ProcessModelingController
             string url = VersionPrefix(org, app, version);
 
             using var response = await HttpClient.GetAsync(url);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             List<string> responseContent = await response.Content.ReadAsAsync<List<string>>();
 
-            responseContent.Count.Should().Be(expectedTemplates.Length);
+            Assert.Equal(expectedTemplates.Length, responseContent.Count);
             foreach (string expectedTemplate in expectedTemplates)
             {
-                responseContent.Should().Contain(expectedTemplate);
+                Assert.Contains(expectedTemplate, responseContent);
             }
         }
     }

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/ProcessDataTypesChangedNotifyTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/ProcessDataTypesChangedNotifyTests.cs
@@ -37,7 +37,7 @@ public class ProcessDataTypesChangedNotifyTests : DesignerEndpointsTestsBase<Pro
             Content = new StringContent(metadataString, Encoding.UTF8, "application/json")
         };
         using var response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
     }
 
     public static IEnumerable<object[]> ProcessDataTypeChangedNotifyTestData()

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/ProcessDataTypesChangedNotifyTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/ProcessDataTypesChangedNotifyTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/SaveProcessDefinitionFromTemplateTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/SaveProcessDefinitionFromTemplateTests.cs
@@ -27,7 +27,7 @@ namespace Designer.Tests.Controllers.ProcessModelingController
             string url = VersionPrefix(org, targetRepository, version, templateName);
 
             using var response = await HttpClient.PutAsync(url, null);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [Theory]
@@ -41,7 +41,7 @@ namespace Designer.Tests.Controllers.ProcessModelingController
             string url = VersionPrefix(org, targetRepository, version, templateName);
 
             using var response = await HttpClient.PutAsync(url, null);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string responseContent = await response.Content.ReadAsStringAsync();
 
@@ -49,7 +49,7 @@ namespace Designer.Tests.Controllers.ProcessModelingController
 
             XDocument responseXml = XDocument.Parse(responseContent);
             XDocument savedXml = XDocument.Parse(savedFile);
-            XNode.DeepEquals(savedXml, responseXml).Should().BeTrue();
+            Assert.True(XNode.DeepEquals(savedXml, responseXml));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/SaveProcessDefinitionFromTemplateTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/SaveProcessDefinitionFromTemplateTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/UpsertProcessDefinitionAndNotifyTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/UpsertProcessDefinitionAndNotifyTests.cs
@@ -45,13 +45,13 @@ public class UpsertProcessDefinitionAndNotifyTests : DesignerEndpointsTestsBase<
         form.Add(new StringContent(metadataString, Encoding.UTF8, MediaTypeNames.Application.Json), "metadata");
 
         using var response = await HttpClient.PutAsync(url, form);
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         string savedFile = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, "App/config/process/process.bpmn");
 
         XDocument expectedXml = XDocument.Parse(processContent);
         XDocument savedXml = XDocument.Parse(savedFile);
-        XNode.DeepEquals(savedXml, expectedXml).Should().BeTrue();
+        Assert.True(XNode.DeepEquals(savedXml, expectedXml));
     }
 
     public static IEnumerable<object[]> UpsertProcessDefinitionAndNotifyTestData()

--- a/backend/tests/Designer.Tests/Controllers/ProcessModelingController/UpsertProcessDefinitionAndNotifyTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ProcessModelingController/UpsertProcessDefinitionAndNotifyTests.cs
@@ -11,7 +11,6 @@ using System.Xml.Linq;
 using Altinn.Studio.Designer.Models.Dto;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/TextController/DeleteLanguageTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TextController/DeleteLanguageTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Controllers/TextController/DeleteLanguageTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TextController/DeleteLanguageTests.cs
@@ -21,16 +21,15 @@ namespace Designer.Tests.Controllers.TextController
             string targetRepository = TestDataHelper.GenerateTestRepoName();
             await CopyRepositoryForTest(org, app, developer, targetRepository);
             string url = $"{VersionPrefix(org, targetRepository)}/language/{language}";
-            TestDataHelper.FileExistsInRepo(org, targetRepository, developer, $"App/config/texts/resource.{language}.json")
-                .Should().BeTrue();
+            Assert.True(TestDataHelper.FileExistsInRepo(org, targetRepository, developer, $"App/config/texts/resource.{language}.json"));
 
             // Act
             using var response = await HttpClient.DeleteAsync(url);
 
             // Assert
             Assert.Equal(200, (int)response.StatusCode);
-            TestDataHelper.FileExistsInRepo(org, targetRepository, developer, $"App/config/texts/resource.{language}.json")
-                .Should().BeFalse();
+            Assert.False(TestDataHelper.FileExistsInRepo(org, targetRepository, developer,
+                $"App/config/texts/resource.{language}.json"));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/TextController/GetLanguagesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TextController/GetLanguagesTests.cs
@@ -30,7 +30,7 @@ namespace Designer.Tests.Controllers.TextController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string content = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedContent, content).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedContent, content));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/TextController/GetLanguagesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TextController/GetLanguagesTests.cs
@@ -2,7 +2,6 @@
 using System.Text.Json;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/TextController/GetResourceTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TextController/GetResourceTests.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/TextController/GetResourceTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TextController/GetResourceTests.cs
@@ -29,7 +29,7 @@ namespace Designer.Tests.Controllers.TextController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string content = await response.Content.ReadAsStringAsync();
-            JsonUtils.DeepEquals(expectedContent, content).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(expectedContent, content));
         }
 
         [Theory]

--- a/backend/tests/Designer.Tests/Controllers/TextController/SaveResourceTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TextController/SaveResourceTests.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/TextController/SaveResourceTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TextController/SaveResourceTests.cs
@@ -35,8 +35,8 @@ namespace Designer.Tests.Controllers.TextController
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            TestDataHelper.FileExistsInRepo(org, targetRepository, developer, $"App/config/texts/resource.{lang}.json").Should().BeTrue();
-            JsonUtils.DeepEquals(payload, TestDataHelper.GetFileFromRepo(org, targetRepository, developer, $"App/config/texts/resource.{lang}.json")).Should().BeTrue();
+            Assert.True(TestDataHelper.FileExistsInRepo(org, targetRepository, developer, $"App/config/texts/resource.{lang}.json"));
+            Assert.True(JsonUtils.DeepEquals(payload, TestDataHelper.GetFileFromRepo(org, targetRepository, developer, $"App/config/texts/resource.{lang}.json")));
         }
 
 

--- a/backend/tests/Designer.Tests/Controllers/TextController/UpdateTextsForKeysTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TextController/UpdateTextsForKeysTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Controllers/TextController/UpdateTextsForKeysTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TextController/UpdateTextsForKeysTests.cs
@@ -52,7 +52,7 @@ namespace Designer.Tests.Controllers.TextController
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string actualContent = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, $"App/config/texts/resource.{lang}.json");
-            JsonUtils.DeepEquals(JsonSerializer.Serialize(expectedResource, _jsonOptions), actualContent).Should().BeTrue();
+            Assert.True(JsonUtils.DeepEquals(JsonSerializer.Serialize(expectedResource, _jsonOptions), actualContent));
         }
 
         [Theory]
@@ -73,7 +73,7 @@ namespace Designer.Tests.Controllers.TextController
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string actualContent = TestDataHelper.GetFileFromRepo(org, targetRepository, developer, $"App/config/texts/resource.{lang}.json");
             TextResource actualResource = JsonSerializer.Deserialize<TextResource>(actualContent, _jsonOptions);
-            actualResource.Resources.Find(el => el.Id == "TextUsingVariables").Variables.Should().NotBeNull();
+            Assert.NotNull(actualResource.Resources.Find(el => el.Id == "TextUsingVariables").Variables);
         }
 
         private static void PrepareExpectedResourceWithoutVariables(TextResource resource, Dictionary<string, string> updateDictionary)

--- a/backend/tests/Designer.Tests/DbIntegrationTests/AppScopesRepository/GetAppScopesAsyncTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/AppScopesRepository/GetAppScopesAsyncTests.cs
@@ -21,7 +21,7 @@ public class GetAppScopesAsyncTests : DbIntegrationTestsBase
         var repository = new Altinn.Studio.Designer.Repository.ORMImplementation.AppScopesRepository(DbFixture.DbContext);
         var result = await repository.GetAppScopesAsync(AltinnRepoContext.FromOrgRepo(org, app));
 
-        result.Should().BeNull();
+        Assert.Null(result);
     }
 
 
@@ -33,7 +33,7 @@ public class GetAppScopesAsyncTests : DbIntegrationTestsBase
         await DbFixture.PrepareAppScopesEntityInDatabaseAsync(entity);
         var repository = new Altinn.Studio.Designer.Repository.ORMImplementation.AppScopesRepository(DbFixture.DbContext);
         AppScopesEntity result = await repository.GetAppScopesAsync(AltinnRepoContext.FromOrgRepo(org, app));
-        result.Version.Should().BeGreaterThan(0);
+        Assert.True(result.Version > 0);
         entity.Version = result.Version;
         EntityAssertions.AssertEqual(result, entity);
     }

--- a/backend/tests/Designer.Tests/DbIntegrationTests/AppScopesRepository/GetAppScopesAsyncTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/AppScopesRepository/GetAppScopesAsyncTests.cs
@@ -4,7 +4,6 @@ using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Repository.Models.AppScope;
 using Designer.Tests.Fixtures;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.DbIntegrationTests.AppScopesRepository;

--- a/backend/tests/Designer.Tests/DbIntegrationTests/AppScopesRepository/UpsertAppScopesAsyncIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/AppScopesRepository/UpsertAppScopesAsyncIntegrationTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Designer.Tests.Fixtures;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/DbIntegrationTests/AppScopesRepository/UpsertAppScopesAsyncIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/AppScopesRepository/UpsertAppScopesAsyncIntegrationTests.cs
@@ -25,7 +25,7 @@ public class UpsertAppScopesAsyncIntegrationTests : DbIntegrationTestsBase
             d.Org == org &&
             d.App == app);
 
-        dbRecord.Version.Should().BeGreaterThan(0);
+        Assert.True(dbRecord.Version > 0);
         entity.Version = dbRecord.Version;
 
         EntityAssertions.AssertEqual(entity, dbRecord);
@@ -42,7 +42,7 @@ public class UpsertAppScopesAsyncIntegrationTests : DbIntegrationTestsBase
             d.Org == org &&
             d.App == app);
 
-        dbRecord.Version.Should().BeGreaterThan(0);
+        Assert.True(dbRecord.Version > 0);
         entity.Version = dbRecord.Version;
         EntityAssertions.AssertEqual(entity, dbRecord);
 
@@ -50,7 +50,7 @@ public class UpsertAppScopesAsyncIntegrationTests : DbIntegrationTestsBase
         var repository = new Altinn.Studio.Designer.Repository.ORMImplementation.AppScopesRepository(DbFixture.DbContext);
 
         var result = await repository.UpsertAppScopesAsync(entity);
-        result.Version.Should().NotBe(entity.Version);
+        Assert.NotEqual(entity.Version, result.Version);
         entity.Version = result.Version;
         EntityAssertions.AssertEqual(entity, result);
 

--- a/backend/tests/Designer.Tests/DbIntegrationTests/AppScopesRepository/Utils/AppScopesEntityAsserts.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/AppScopesRepository/Utils/AppScopesEntityAsserts.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
+using Altinn.AccessManagement.Tests.Utils;
 using Altinn.Studio.Designer.Repository.Models.AppScope;
+using Xunit;
 
 namespace Designer.Tests.DbIntegrationTests;
 
@@ -9,28 +11,28 @@ public partial class EntityAssertions
 {
     public static void AssertEqual(AppScopesEntity appScopesEntity, Altinn.Studio.Designer.Repository.ORMImplementation.Models.AppScopesDbModel dbRecord)
     {
-        dbRecord.App.Should().BeEquivalentTo(appScopesEntity.App);
-        dbRecord.Org.Should().BeEquivalentTo(appScopesEntity.Org);
-        dbRecord.CreatedBy.Should().BeEquivalentTo(appScopesEntity.CreatedBy);
-        dbRecord.LastModifiedBy.Should().BeEquivalentTo(appScopesEntity.LastModifiedBy);
-        dbRecord.Created.Should().BeCloseTo(appScopesEntity.Created, TimeSpan.FromMilliseconds(100));
+        Assert.Equal(dbRecord.App, appScopesEntity.App);
+        Assert.Equal(dbRecord.Org, appScopesEntity.Org);
+        Assert.Equal(dbRecord.CreatedBy, appScopesEntity.CreatedBy);
+        Assert.Equal(dbRecord.LastModifiedBy, appScopesEntity.LastModifiedBy);
+        AssertionUtil.AssertCloseTo(dbRecord.Created, appScopesEntity.Created, TimeSpan.FromMilliseconds(100));
 
-        dbRecord.Version.Should().Be(appScopesEntity.Version);
+        Assert.Equal(dbRecord.Version, appScopesEntity.Version);
         var scopesFromDb = JsonSerializer.Deserialize<ISet<MaskinPortenScopeEntity>>(dbRecord.Scopes, JsonOptions);
-        scopesFromDb.Should().BeEquivalentTo(appScopesEntity.Scopes);
-        dbRecord.Version.Should().Be(appScopesEntity.Version);
+        AssertionUtil.AssertEqualTo(scopesFromDb, appScopesEntity.Scopes);
+        Assert.Equal(dbRecord.Version, appScopesEntity.Version);
     }
 
     public static void AssertEqual(AppScopesEntity expected, AppScopesEntity actual)
     {
-        actual.App.Should().Be(expected.App);
-        actual.Org.Should().Be(expected.Org);
-        actual.CreatedBy.Should().Be(expected.CreatedBy);
-        actual.LastModifiedBy.Should().Be(expected.LastModifiedBy);
-        actual.Created.Should().BeCloseTo(expected.Created, TimeSpan.FromMilliseconds(100));
+        Assert.Equal(expected.App, actual.App);
+        Assert.Equal(expected.Org, actual.Org);
+        Assert.Equal(expected.CreatedBy, actual.CreatedBy);
+        Assert.Equal(expected.LastModifiedBy, actual.LastModifiedBy);
+        AssertionUtil.AssertCloseTo(expected.Created, actual.Created, TimeSpan.FromMilliseconds(100));
 
-        actual.Version.Should().Be(expected.Version);
-        actual.Scopes.Should().BeEquivalentTo(expected.Scopes);
+        Assert.Equal(expected.Version, actual.Version);
+        AssertionUtil.AssertEqualTo(expected.Scopes, actual.Scopes);
     }
 
 }

--- a/backend/tests/Designer.Tests/DbIntegrationTests/AppScopesRepository/Utils/AppScopesEntityAsserts.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/AppScopesRepository/Utils/AppScopesEntityAsserts.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Altinn.Studio.Designer.Repository.Models.AppScope;
-using FluentAssertions;
 
 namespace Designer.Tests.DbIntegrationTests;
 

--- a/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/Base/DeploymentEntityIntegrationTestsBase.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/Base/DeploymentEntityIntegrationTestsBase.cs
@@ -47,6 +47,7 @@ public class DeploymentEntityIntegrationTestsBase : DbIntegrationTestsBase
             App = entity.App,
             Buildresult = entity.Build.Result.ToEnumMemberAttributeValue(),
             Created = entity.Created,
+            CreatedBy = entity.CreatedBy,
             Entity = JsonSerializer.Serialize(entity, JsonOptions),
             EnvName = entity.EnvName,
             Build = MapBuildToDbModel(entity.Build)

--- a/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/CreateIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/CreateIntegrationTests.cs
@@ -4,7 +4,6 @@ using Altinn.Studio.Designer.Repository.ORMImplementation;
 using Altinn.Studio.Designer.Repository.ORMImplementation.Models;
 using Designer.Tests.DbIntegrationTests.DeploymentEntityRepository.Base;
 using Designer.Tests.Fixtures;
-using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/CreateIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/CreateIntegrationTests.cs
@@ -28,8 +28,7 @@ public class CreateIntegrationTests : DeploymentEntityIntegrationTestsBase
             d.App == deploymentEntity.App &&
             d.Buildid == buildId.ToString());
 
-
-        dbRecord.DeploymentType.Should().Be(DeploymentType.Deploy);
+        Assert.Equal(DeploymentType.Deploy, dbRecord.DeploymentType);
 
         EntityAssertions.AssertEqual(deploymentEntity, dbRecord);
     }

--- a/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/GetIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/GetIntegrationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Altinn.Studio.Designer.Repository.Models;
 using Altinn.Studio.Designer.Repository.ORMImplementation;
 using Altinn.Studio.Designer.ViewModels.Request;
 using Altinn.Studio.Designer.ViewModels.Request.Enums;
@@ -35,11 +36,18 @@ public class GetIntegrationTests : DeploymentEntityIntegrationTestsBase
             .Take(top)
             .ToList();
 
-        result.Count.Should().Be(top);
-        result.Should().BeEquivalentTo(expectedEntities, options =>
-            options.Using<DateTime>(ctx =>
-                ctx.Subject.Should().BeCloseTo(ctx.Expectation, TimeSpan.FromMilliseconds(200))
-            ).WhenTypeIs<DateTime>());
+        Assert.Equal(top, result.Count);
+        Assert.Equal(top, result.Count);
+
+
+        expectedEntities.ToHashSet().SetEquals(result.ToHashSet());
+        var compareList = expectedEntities.Zip(result, (expected, actual) =>
+        {
+            EntityAssertions.AssertEqual(expected, actual, TimeSpan.FromMilliseconds(200));
+            return true;
+        }).ToList();
+
+        Assert.All(compareList, Assert.True);
     }
 
     [Theory]
@@ -64,11 +72,15 @@ public class GetIntegrationTests : DeploymentEntityIntegrationTestsBase
                 : deploymentEntities.OrderByDescending(d => d.Created))
             .ToList();
 
-        result.Count.Should().Be(allEntitiesCount);
-        result.Should().BeEquivalentTo(expectedEntities, options =>
-            options.Using<DateTime>(ctx =>
-                ctx.Subject.Should().BeCloseTo(ctx.Expectation, TimeSpan.FromMilliseconds(200))
-            ).WhenTypeIs<DateTime>());
+        Assert.Equal(allEntitiesCount, result.Count);
+
+        var compareList = expectedEntities.Zip(result, (expected, actual) =>
+        {
+            EntityAssertions.AssertEqual(expected, actual, TimeSpan.FromMilliseconds(200));
+            return true;
+        }).ToList();
+
+        Assert.All(compareList, Assert.True);
 
     }
 

--- a/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/GetIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/GetIntegrationTests.cs
@@ -7,7 +7,6 @@ using Altinn.Studio.Designer.ViewModels.Request;
 using Altinn.Studio.Designer.ViewModels.Request.Enums;
 using Designer.Tests.DbIntegrationTests.DeploymentEntityRepository.Base;
 using Designer.Tests.Fixtures;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.DbIntegrationTests.DeploymentEntityRepository;

--- a/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/GetSingleIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/GetSingleIntegrationTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Repository.ORMImplementation;
 using Designer.Tests.DbIntegrationTests.DeploymentEntityRepository.Base;
 using Designer.Tests.Fixtures;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.DbIntegrationTests.DeploymentEntityRepository;

--- a/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/GetSingleIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/GetSingleIntegrationTests.cs
@@ -23,9 +23,6 @@ public class GetSingleIntegrationTests : DeploymentEntityIntegrationTestsBase
         var repository = new DeploymentRepository(DbFixture.DbContext);
         var result = await repository.Get(deploymentEntity.Org, deploymentEntity.Build.Id);
 
-        result.Should().BeEquivalentTo(deploymentEntity, options =>
-            options.Using<DateTime>(ctx =>
-                ctx.Subject.Should().BeCloseTo(ctx.Expectation, TimeSpan.FromMilliseconds(200))
-            ).WhenTypeIs<DateTime>());
+        EntityAssertions.AssertEqual(deploymentEntity, result, TimeSpan.FromMilliseconds(200));
     }
 }

--- a/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/Utils/DeploymentEntityAsserts.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/Utils/DeploymentEntityAsserts.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Text.Json;
+using Altinn.AccessManagement.Tests.Utils;
 using Altinn.Studio.Designer.Repository.Models;
 using Altinn.Studio.Designer.Repository.ORMImplementation.Models;
+using Altinn.Studio.Designer.TypedHttpClients.AzureDevOps.Enums;
+using Xunit;
 
 namespace Designer.Tests.DbIntegrationTests;
 
@@ -9,30 +12,64 @@ public static partial class EntityAssertions
 {
     public static void AssertEqual(DeploymentEntity deploymentEntity, Altinn.Studio.Designer.Repository.ORMImplementation.Models.DeploymentDbModel dbRecord)
     {
-        dbRecord.App.Should().BeEquivalentTo(deploymentEntity.App);
-        dbRecord.Org.Should().BeEquivalentTo(deploymentEntity.Org);
-        dbRecord.Buildid.Should().BeEquivalentTo(deploymentEntity.Build.Id);
-        dbRecord.Buildresult.Should().BeEquivalentTo(deploymentEntity.Build.Result.ToString());
-        dbRecord.Tagname.Should().BeEquivalentTo(deploymentEntity.TagName);
-        dbRecord.EnvName.Should().BeEquivalentTo(deploymentEntity.EnvName);
+        Assert.Equal(dbRecord.App, deploymentEntity.App);
+        Assert.Equal(dbRecord.Org, deploymentEntity.Org);
+        Assert.Equal(dbRecord.CreatedBy, deploymentEntity.CreatedBy);
+        Assert.Equal(dbRecord.Buildid, deploymentEntity.Build.Id);
+        Assert.Equal(dbRecord.Buildresult, deploymentEntity.Build.Result.ToEnumMemberAttributeValue());
+        Assert.Equal(dbRecord.Tagname, deploymentEntity.TagName);
+        Assert.Equal(dbRecord.EnvName, deploymentEntity.EnvName);
         var entityFromColumn = JsonSerializer.Deserialize<DeploymentEntity>(dbRecord.Entity, JsonOptions);
-        entityFromColumn.Should().BeEquivalentTo(deploymentEntity);
+        AssertionUtil.AssertEqualTo(deploymentEntity, entityFromColumn);
 
         Altinn.Studio.Designer.Repository.ORMImplementation.Models.BuildDbModel buildDbModel = dbRecord.Build;
-        buildDbModel.ExternalId.Should().BeEquivalentTo(deploymentEntity.Build.Id);
-        buildDbModel.Status.Should().BeEquivalentTo(deploymentEntity.Build.Status.ToString());
-        buildDbModel.Result.Should().BeEquivalentTo(deploymentEntity.Build.Result.ToString());
-        buildDbModel.BuildType.Should().Be(BuildType.Deployment);
+        Assert.Equal(buildDbModel.ExternalId, deploymentEntity.Build.Id);
+        Assert.Equal(buildDbModel.Status, deploymentEntity.Build.Status.ToString());
+        Assert.Equal(buildDbModel.Result, deploymentEntity.Build.Result.ToString());
+        Assert.Equal(BuildType.Deployment, buildDbModel.BuildType);
 
-        buildDbModel.Started!.Value.UtcDateTime.Should().BeCloseTo(deploymentEntity.Build.Started!.Value, TimeSpan.FromMilliseconds(100));
+        AssertionUtil.AssertCloseTo(buildDbModel.Started!.Value.UtcDateTime, deploymentEntity.Build.Started!.Value, TimeSpan.FromMilliseconds(100));
 
         if (!buildDbModel.Finished.HasValue)
         {
-            deploymentEntity.Build.Finished.Should().BeNull();
+            Assert.Null(deploymentEntity.Build.Finished);
         }
         else
         {
-            buildDbModel.Finished!.Value.UtcDateTime.Should().BeCloseTo(deploymentEntity.Build.Finished!.Value, TimeSpan.FromMilliseconds(100));
+            AssertionUtil.AssertCloseTo(buildDbModel.Finished!.Value.UtcDateTime, deploymentEntity.Build.Finished!.Value, TimeSpan.FromMilliseconds(100));
+        }
+    }
+
+    public static void AssertEqual(DeploymentEntity expected, DeploymentEntity actual, TimeSpan datesTolerance)
+    {
+        Assert.Equal(expected.App, actual.App);
+        Assert.Equal(expected.Org, actual.Org);
+        Assert.Equal(expected.CreatedBy, actual.CreatedBy);
+        AssertionUtil.AssertCloseTo(expected.Created, actual.Created, datesTolerance);
+        Assert.Equal(expected.TagName, actual.TagName);
+        Assert.Equal(expected.EnvName, actual.EnvName);
+        Assert.Equal(expected.Build.Id, actual.Build.Id);
+        Assert.Equal(expected.Build.Status, actual.Build.Status);
+        Assert.Equal(expected.Build.Result, actual.Build.Result);
+
+        if (!expected.Build.Started.HasValue)
+        {
+            Assert.Null(expected.Build.Started);
+            Assert.Null(actual.Build.Started);
+        }
+        else
+        {
+            AssertionUtil.AssertCloseTo(expected.Build.Started.Value, actual.Build.Started.Value, datesTolerance);
+        }
+
+        if (!expected.Build.Finished.HasValue)
+        {
+            Assert.Null(expected.Build.Finished);
+            Assert.Null(actual.Build.Finished);
+        }
+        else
+        {
+            AssertionUtil.AssertCloseTo(expected.Build.Finished.Value, actual.Build.Finished.Value, datesTolerance);
         }
     }
 }

--- a/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/Utils/DeploymentEntityAsserts.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/Utils/DeploymentEntityAsserts.cs
@@ -2,7 +2,6 @@ using System;
 using System.Text.Json;
 using Altinn.Studio.Designer.Repository.Models;
 using Altinn.Studio.Designer.Repository.ORMImplementation.Models;
-using FluentAssertions;
 
 namespace Designer.Tests.DbIntegrationTests;
 

--- a/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/Utils/EntityGenerationUtils.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/DeploymentEntityRepository/Utils/EntityGenerationUtils.cs
@@ -22,6 +22,7 @@ public static partial class EntityGenerationUtils
                 TagName = tagname ?? Guid.NewGuid().ToString(),
                 EnvName = Guid.NewGuid().ToString(),
                 Created = DateTime.UtcNow,
+                CreatedBy = "testUser"
             };
         }
 

--- a/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetBuildStatusAndResultsFilterIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetBuildStatusAndResultsFilterIntegrationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Altinn.AccessManagement.Tests.Utils;
 using Altinn.Studio.Designer.Repository.ORMImplementation;
 using Altinn.Studio.Designer.TypedHttpClients.AzureDevOps.Enums;
 using Designer.Tests.DbIntegrationTests.ReleaseEntityRepository.Base;
@@ -41,8 +42,8 @@ public class GetBuildStatusAndResultsFilterIntegrationTests : ReleaseEntityInteg
 
         var results = (await repository.Get(org, app, tagName, buildStatuses, buildResults)).ToList();
 
-        results.Should().HaveCount(expectedFoundNumber);
-        results.Should().BeEquivalentTo(exptectedEntities);
+        Assert.Equal(expectedFoundNumber, results.Count);
+        AssertionUtil.AssertEqualTo(exptectedEntities, results);
     }
 
     public static IEnumerable<object[]> TestData()

--- a/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetBuildStatusAndResultsFilterIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetBuildStatusAndResultsFilterIntegrationTests.cs
@@ -6,7 +6,6 @@ using Altinn.Studio.Designer.Repository.ORMImplementation;
 using Altinn.Studio.Designer.TypedHttpClients.AzureDevOps.Enums;
 using Designer.Tests.DbIntegrationTests.ReleaseEntityRepository.Base;
 using Designer.Tests.Fixtures;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.DbIntegrationTests.ReleaseEntityRepository;

--- a/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetSingleIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetSingleIntegrationTests.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Repository.ORMImplementation;
 using Designer.Tests.DbIntegrationTests.ReleaseEntityRepository.Base;
 using Designer.Tests.Fixtures;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.DbIntegrationTests.ReleaseEntityRepository;

--- a/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetSingleIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetSingleIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Altinn.AccessManagement.Tests.Utils;
 using Altinn.Studio.Designer.Repository.ORMImplementation;
 using Designer.Tests.DbIntegrationTests.ReleaseEntityRepository.Base;
 using Designer.Tests.Fixtures;
@@ -24,6 +25,6 @@ public class GetSingleIntegrationTests : ReleaseEntityIntegrationTestsBase
         await PrepareEntityInDatabase(releaseEntity);
 
         var result = (await repository.Get(releaseEntity.Org, buildId.ToString())).Single();
-        result.Should().BeEquivalentTo(releaseEntity);
+        AssertionUtil.AssertEqualTo(releaseEntity, result);
     }
 }

--- a/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetSucceededReleaseFromDbIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetSucceededReleaseFromDbIntegrationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Altinn.AccessManagement.Tests.Utils;
 using Altinn.Studio.Designer.Repository.ORMImplementation;
 using Altinn.Studio.Designer.TypedHttpClients.AzureDevOps.Enums;
 using Designer.Tests.DbIntegrationTests.ReleaseEntityRepository.Base;
@@ -40,7 +41,7 @@ public class GetSucceededReleaseFromDbIntegrationTests : ReleaseEntityIntegratio
             r.Build.Result == BuildResult.Succeeded);
 
         var result = await repository.GetSucceededReleaseFromDb(org, app, tagName);
-        result.Should().BeEquivalentTo(exptectedEntity);
+        AssertionUtil.AssertEqualTo(exptectedEntity, result);
     }
 
     public static IEnumerable<object[]> TestData()

--- a/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetSucceededReleaseFromDbIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetSucceededReleaseFromDbIntegrationTests.cs
@@ -6,7 +6,6 @@ using Altinn.Studio.Designer.Repository.ORMImplementation;
 using Altinn.Studio.Designer.TypedHttpClients.AzureDevOps.Enums;
 using Designer.Tests.DbIntegrationTests.ReleaseEntityRepository.Base;
 using Designer.Tests.Fixtures;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.DbIntegrationTests.ReleaseEntityRepository;

--- a/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetTopAndSortedIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetTopAndSortedIntegrationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Altinn.AccessManagement.Tests.Utils;
 using Altinn.Studio.Designer.Repository.ORMImplementation;
 using Altinn.Studio.Designer.ViewModels.Request;
 using Altinn.Studio.Designer.ViewModels.Request.Enums;
@@ -35,8 +36,8 @@ public class GetTopAndSortedIntegrationTests : ReleaseEntityIntegrationTestsBase
             .Take(top)
             .ToList();
 
-        result.Count.Should().Be(top);
-        result.Should().BeEquivalentTo(expectedEntities);
+        Assert.Equal(top, result.Count);
+        AssertionUtil.AssertEqualTo(expectedEntities, result);
     }
 
     [Theory]
@@ -57,12 +58,12 @@ public class GetTopAndSortedIntegrationTests : ReleaseEntityIntegrationTestsBase
         var result = (await repository.Get(org, app, query)).ToList();
 
         var expectedEntities = (sortDirection == SortDirection.Ascending
-                ? releaseEntities.OrderBy(d => d.Created)
-                : releaseEntities.OrderByDescending(d => d.Created))
+                ? releaseEntities.OrderBy(r => r.Created)
+                : releaseEntities.OrderByDescending(r => r.Created))
             .ToList();
 
-        result.Count().Should().Be(allEntitiesCount);
-        result.Should().BeEquivalentTo(expectedEntities);
+        Assert.Equal(allEntitiesCount, result.Count);
+        AssertionUtil.AssertEqualTo(expectedEntities, result);
 
     }
 

--- a/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetTopAndSortedIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/GetTopAndSortedIntegrationTests.cs
@@ -7,7 +7,6 @@ using Altinn.Studio.Designer.ViewModels.Request;
 using Altinn.Studio.Designer.ViewModels.Request.Enums;
 using Designer.Tests.DbIntegrationTests.ReleaseEntityRepository.Base;
 using Designer.Tests.Fixtures;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.DbIntegrationTests.ReleaseEntityRepository;

--- a/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/Utils/EntityGenerationUtils.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/Utils/EntityGenerationUtils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Altinn.Studio.Designer.Repository.Models;
 using Altinn.Studio.Designer.TypedHttpClients.AzureDevOps.Enums;
 
@@ -28,6 +29,10 @@ public static partial class EntityGenerationUtils
 
         public static IEnumerable<ReleaseEntity> GenerateReleaseEntities(string org, string app, int count) =>
             Enumerable.Range(0, count)
-                .Select(x => GenerateReleaseEntity(org, app)).ToList();
+                .Select(x =>
+                {
+                    Thread.Sleep(1); // To ensure unique timestamps
+                    return GenerateReleaseEntity(org, app);
+                }).ToList();
     }
 }

--- a/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/Utils/ReleaseEntityAsserts.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/Utils/ReleaseEntityAsserts.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Text.Json;
 using Altinn.Studio.Designer.Repository.Models;
-using FluentAssertions;
 
 namespace Designer.Tests.DbIntegrationTests;
 

--- a/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/Utils/ReleaseEntityAsserts.cs
+++ b/backend/tests/Designer.Tests/DbIntegrationTests/ReleaseEntityRepository/Utils/ReleaseEntityAsserts.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Text.Json;
+using Altinn.AccessManagement.Tests.Utils;
 using Altinn.Studio.Designer.Repository.Models;
+using Altinn.Studio.Designer.TypedHttpClients.AzureDevOps.Enums;
+using Xunit;
 
 namespace Designer.Tests.DbIntegrationTests;
 
@@ -9,14 +12,14 @@ public static partial class EntityAssertions
 
     public static void AssertEqual(ReleaseEntity releaseEntity, Altinn.Studio.Designer.Repository.ORMImplementation.Models.ReleaseDbModel dbRecord)
     {
-        dbRecord.App.Should().BeEquivalentTo(releaseEntity.App);
-        dbRecord.Org.Should().BeEquivalentTo(releaseEntity.Org);
-        dbRecord.Buildid.Should().BeEquivalentTo(releaseEntity.Build.Id);
-        dbRecord.Buildresult.Should().BeEquivalentTo(releaseEntity.Build.Result.ToString());
-        dbRecord.Tagname.Should().BeEquivalentTo(releaseEntity.TagName);
+        Assert.Equal(dbRecord.App, releaseEntity.App);
+        Assert.Equal(dbRecord.Org, releaseEntity.Org);
+        Assert.Equal(dbRecord.Buildid, releaseEntity.Build.Id);
+        Assert.Equal(dbRecord.Buildresult, releaseEntity.Build.Result.ToEnumMemberAttributeValue());
+        Assert.Equal(dbRecord.Tagname, releaseEntity.TagName);
         var entityFromColumn = JsonSerializer.Deserialize<ReleaseEntity>(dbRecord.Entity, JsonOptions);
-        entityFromColumn.Should().BeEquivalentTo(releaseEntity);
+        AssertionUtil.AssertEqualTo(entityFromColumn, releaseEntity);
 
-        dbRecord.Created.Should().BeCloseTo(releaseEntity.Created, TimeSpan.FromMilliseconds(100));
+        AssertionUtil.AssertCloseTo(dbRecord.Created, releaseEntity.Created, TimeSpan.FromMilliseconds(100));
     }
 }

--- a/backend/tests/Designer.Tests/Designer.Tests.csproj
+++ b/backend/tests/Designer.Tests/Designer.Tests.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Altinn.ApiClients.Maskinporten" />
     <PackageReference Include="Basic.Reference.Assemblies" />
     <PackageReference Include="DistributedLock.FileSystem" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/GiteaIntegrationTestsBase.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/GiteaIntegrationTestsBase.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Fixtures;
 using DotNet.Testcontainers.Builders;
-using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing.Handlers;
 using Microsoft.AspNetCore.TestHost;

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/GiteaIntegrationTestsBase.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/GiteaIntegrationTestsBase.cs
@@ -181,7 +181,7 @@ public abstract class GiteaIntegrationTestsBase<TControllerTest> : ApiTestsBase<
             $"designer/api/repos/create-app?org={org}&repository={repoName}");
 
         using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
     protected static string GetCommitInfoJson(string text, string org, string repository) =>

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/CopyAppGiteaIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/CopyAppGiteaIntegrationTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Designer.Tests.Fixtures;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.GiteaIntegrationTests.RepositoryController

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/CopyAppGiteaIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/CopyAppGiteaIntegrationTests.cs
@@ -30,13 +30,13 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
 
             CopyRepoName = TestDataHelper.GenerateTestRepoName("-gitea-copy");
 
-            // Copy app
+            // Copy app1
             using HttpResponseMessage commitResponse = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/copy-app?sourceRepository={targetRepo}&targetRepository={CopyRepoName}&targetOrg={TargetCopyOrg}", null);
-            commitResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.Equal(HttpStatusCode.Created, commitResponse.StatusCode);
 
             // Check if repo exists in git
             using HttpResponseMessage response = await GiteaFixture.GiteaClient.Value.GetAsync($"repos/{TargetCopyOrg}/{CopyRepoName}");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
         protected override void Dispose(bool disposing)

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/GitDiffIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/GitDiffIntegrationTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Designer.Tests.Fixtures;
 using Designer.Tests.Services;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using SharedResources.Tests;
 using Xunit;
 using Xunit.Abstractions;

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/GitDiffIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/GitDiffIntegrationTests.cs
@@ -42,14 +42,15 @@ public class GitDiffIntegrationTests : GiteaIntegrationTestsBase<GitDiffIntegrat
             Content = new StringContent($"\"{newLayoutSetName}\"", Encoding.UTF8, MediaTypeNames.Application.Json)
         };
         var updateLayoutSetNameResponse = await HttpClient.SendAsync(httpRequestMessageWithNewLayoutSetName);
-        updateLayoutSetNameResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, updateLayoutSetNameResponse.StatusCode);
 
         string getGitDiffUrl = $"designer/api/repos/repo/{org}/{targetRepo}/diff";
         using var httpRequestMessageGetGitDiff = new HttpRequestMessage(HttpMethod.Get, getGitDiffUrl);
         var gitDiffResponse = await HttpClient.SendAsync(httpRequestMessageGetGitDiff);
         string responseContent = await gitDiffResponse.Content.ReadAsStringAsync();
-        gitDiffResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        JsonUtils.DeepEquals(expectedGitDiffResponse, responseContent).Should().BeTrue();
+
+        Assert.Equal(HttpStatusCode.OK, gitDiffResponse.StatusCode);
+        Assert.True(JsonUtils.DeepEquals(expectedGitDiffResponse, responseContent));
     }
 
 }

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/GitNotesGiteaIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/GitNotesGiteaIntegrationTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models;
 using Designer.Tests.Fixtures;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.GiteaIntegrationTests.RepositoryController

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/GitNotesGiteaIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/GitNotesGiteaIntegrationTests.cs
@@ -29,10 +29,10 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
             await File.WriteAllTextAsync($"{CreatedFolderPath}/test3.txt", "I am a new file");
             using var commitContent = new StringContent(GetCommitInfoJson("test commit", org, targetRepo), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage commitResponse = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/{targetRepo}/commit", commitContent);
-            commitResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, commitResponse.StatusCode);
 
             using HttpResponseMessage pushResponse = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/{targetRepo}/push", null);
-            pushResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, pushResponse.StatusCode);
 
             await VerifyStudioNoteAddedToLatestCommit(org, targetRepo);
         }
@@ -49,7 +49,7 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
 
             using var commitAndPushContent = new StringContent(GetCommitInfoJson("test commit", org, targetRepo), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage commitAndPushResponse = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/{targetRepo}/commit-and-push", commitAndPushContent);
-            commitAndPushResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, commitAndPushResponse.StatusCode);
 
             await VerifyStudioNoteAddedToLatestCommit(org, targetRepo);
         }
@@ -66,24 +66,24 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
 
             using var commitAndPushContent = new StringContent(GetCommitInfoJson("test commit", org, targetRepo), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage commitAndPushResponse = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/{targetRepo}/commit-and-push", commitAndPushContent);
-            commitAndPushResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, commitAndPushResponse.StatusCode);
 
             await VerifyStudioNoteAddedToLatestCommit(org, targetRepo);
 
             // reset repo
             using HttpResponseMessage resetResponse = await HttpClient.GetAsync($"designer/api/repos/repo/{org}/{targetRepo}/reset");
-            resetResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, resetResponse.StatusCode);
 
             // this ensures local clone
             using HttpResponseMessage appDevelopmentIndes = await HttpClient.GetAsync($"editor/{org}/{targetRepo}");
-            appDevelopmentIndes.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, appDevelopmentIndes.StatusCode);
 
             // Try to create a new commit
             await File.WriteAllTextAsync($"{CreatedFolderPath}/newFile.txt", "I am a new file");
 
             using var commitAndPushContent2 = new StringContent(GetCommitInfoJson("test commit", org, targetRepo), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage commitAndPushResponse2 = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/{targetRepo}/commit-and-push", commitAndPushContent2);
-            commitAndPushResponse2.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, commitAndPushResponse2.StatusCode);
 
             await VerifyStudioNoteAddedToLatestCommit(org, targetRepo);
         }
@@ -99,17 +99,17 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
             // Create a file using gitea client
             using var createFileContent = new StringContent(GenerateCommitJsonPayload("I am a new file created in gitea", "test gitea commit"), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage createFileResponse = await GiteaFixture.GiteaClient.Value.PostAsync($"repos/{org}/{targetRepo}/contents/test2.txt", createFileContent);
-            createFileResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.Equal(HttpStatusCode.Created, createFileResponse.StatusCode);
 
             // Try pull file with designer endpoint
             using HttpResponseMessage pullResponse = await HttpClient.GetAsync($"designer/api/repos/repo/{org}/{targetRepo}/pull");
-            pullResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, pullResponse.StatusCode);
 
             // Add a new file and try to push with designer
             await File.WriteAllTextAsync($"{CreatedFolderPath}/test3.txt", "I am a new file created directly with gitea");
             using var commitAndPushContent = new StringContent(GetCommitInfoJson("test commit", org, targetRepo), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage commitAndPushResponse = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/{targetRepo}/commit-and-push", commitAndPushContent);
-            commitAndPushResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, commitAndPushResponse.StatusCode);
             await VerifyStudioNoteAddedToLatestCommit(org, targetRepo);
         }
 
@@ -124,19 +124,19 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
             // Create a file using gitea client
             using var createFileContent = new StringContent(GenerateCommitJsonPayload("I am a new file created in gitea", "test gitea commit"), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage createFileResponse = await GiteaFixture.GiteaClient.Value.PostAsync($"repos/{org}/{targetRepo}/contents/test2.txt", createFileContent);
-            createFileResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.Equal(HttpStatusCode.Created, createFileResponse.StatusCode);
 
             // Add a new file and try to push with designer
             await File.WriteAllTextAsync($"{CreatedFolderPath}/test3.txt", "I am a new file created directly with gitea");
 
             // Try pull file with designer endpoint
             using HttpResponseMessage pullResponse = await HttpClient.GetAsync($"designer/api/repos/repo/{org}/{targetRepo}/pull");
-            pullResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, pullResponse.StatusCode);
 
 
             using var commitAndPushContent = new StringContent(GetCommitInfoJson("test commit", org, targetRepo), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage commitAndPushResponse = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/{targetRepo}/commit-and-push", commitAndPushContent);
-            commitAndPushResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, commitAndPushResponse.StatusCode);
             await VerifyStudioNoteAddedToLatestCommit(org, targetRepo);
         }
 
@@ -149,7 +149,7 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
             var noteResponse = await GiteaFixture.GiteaClient.Value.GetAsync($"repos/{org}/{targetRepo}/git/notes/{commit.Sha}");
 
             var notesNode = JsonNode.Parse(await noteResponse.Content.ReadAsStringAsync());
-            notesNode!["message"]!.ToString().Should().Be("studio-commit");
+            Assert.Equal("studio-commit", notesNode!["message"]!.ToString());
         }
     }
 }

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/RepositoryControllerGiteaIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/RepositoryControllerGiteaIntegrationTests.cs
@@ -38,7 +38,7 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
 
             // Check if repo is created in gitea
             var giteaResponse = await GiteaFixture.GiteaClient.Value.GetAsync($"repos/{org}/{targetRepo}");
-            giteaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, giteaResponse.StatusCode);
         }
 
         [Theory]
@@ -53,15 +53,15 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
 
             using var commitAndPushContent = new StringContent(GetCommitInfoJson("test commit", org, targetRepo), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage commitAndPushResponse = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/{targetRepo}/commit-and-push", commitAndPushContent);
-            commitAndPushResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, commitAndPushResponse.StatusCode);
 
             // Check if file is pushed to gitea
             var giteaFileResponse = await GiteaFixture.GiteaClient.Value.GetAsync($"repos/{org}/{targetRepo}/contents/test.txt");
-            giteaFileResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, giteaFileResponse.StatusCode);
 
             // Check contents with designer endpoint
             using HttpResponseMessage contentsResponse = await HttpClient.GetAsync($"designer/api/repos/repo/{org}/{targetRepo}/contents?path=test.txt");
-            contentsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, contentsResponse.StatusCode);
         }
 
         [Theory]
@@ -75,14 +75,14 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
             await File.WriteAllTextAsync($"{CreatedFolderPath}/test3.txt", "I am a new file");
             using var commitContent = new StringContent(GetCommitInfoJson("test commit", org, targetRepo), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage commitResponse = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/{targetRepo}/commit", commitContent);
-            commitResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, commitResponse.StatusCode);
 
             using HttpResponseMessage pushResponse = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/{targetRepo}/push", null);
-            pushResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, pushResponse.StatusCode);
 
             // Check if file is pushed to gitea
             var giteaFileResponse2 = await GiteaFixture.GiteaClient.Value.GetAsync($"repos/{org}/{targetRepo}/contents/test3.txt");
-            giteaFileResponse2.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, giteaFileResponse2.StatusCode);
         }
 
         [Theory]
@@ -95,14 +95,14 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
             // Create a file in gitea
             using var createFileContent = new StringContent(GenerateCommitJsonPayload("I am a new file created in gitea", "test commit"), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage createFileResponse = await GiteaFixture.GiteaClient.Value.PostAsync($"repos/{org}/{targetRepo}/contents/test2.txt", createFileContent);
-            createFileResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.Equal(HttpStatusCode.Created, createFileResponse.StatusCode);
 
             // Try pull file with designer endpoint
             using HttpResponseMessage pullResponse = await HttpClient.GetAsync($"designer/api/repos/repo/{org}/{targetRepo}/pull");
-            pullResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, pullResponse.StatusCode);
 
             // Check if file exists locally
-            File.Exists($"{CreatedFolderPath}/test2.txt").Should().BeTrue();
+            Assert.True(File.Exists($"{CreatedFolderPath}/test2.txt"));
         }
 
         [Theory]
@@ -114,9 +114,9 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
 
             // Check initial-commit endpoint
             using HttpResponseMessage initialCommitResponse = await HttpClient.GetAsync($"designer/api/repos/repo/{org}/{targetRepo}/initial-commit");
-            initialCommitResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, initialCommitResponse.StatusCode);
             var commit = await initialCommitResponse.Content.ReadAsAsync<Commit>();
-            commit.Message.Should().Contain("App created");
+            Assert.Contains("App created", commit.Message);
         }
 
         [Theory]
@@ -128,15 +128,15 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
 
             // Call metadata endpoint
             using HttpResponseMessage metadataResponse = await HttpClient.GetAsync($"designer/api/repos/repo/{org}/{targetRepo}/metadata");
-            metadataResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, metadataResponse.StatusCode);
             var deserializedRepositoryModel = await metadataResponse.Content.ReadAsAsync<Repository>();
-            deserializedRepositoryModel.Name.Should().Be(targetRepo);
+            Assert.Equal(targetRepo, deserializedRepositoryModel.Name);
 
             // Call status endpoint
             using HttpResponseMessage statusResponse = await HttpClient.GetAsync($"designer/api/repos/repo/{org}/{targetRepo}/status");
-            statusResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, statusResponse.StatusCode);
             var deserializedRepoStatusModel = await statusResponse.Content.ReadAsAsync<RepoStatus>();
-            deserializedRepoStatusModel.RepositoryStatus.Should().Be(RepositoryStatus.Ok);
+            Assert.Equal(RepositoryStatus.Ok, deserializedRepoStatusModel.RepositoryStatus);
         }
 
         [Theory]
@@ -145,7 +145,7 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
         {
             // Call status endpoint
             using HttpResponseMessage statusResponse = await HttpClient.GetAsync($"designer/api/repos/repo/{org}/123/status");
-            statusResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, statusResponse.StatusCode);
         }
 
         [Theory]
@@ -157,10 +157,11 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
 
             // Call getOrgRepos endpoint
             using HttpResponseMessage getOrgReposResponse = await HttpClient.GetAsync($"designer/api/repos/org/{org}");
-            getOrgReposResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, getOrgReposResponse.StatusCode);
             var deserializedRepositoryModel = await getOrgReposResponse.Content.ReadAsAsync<List<Repository>>();
-            deserializedRepositoryModel.Should().NotBeEmpty();
-            deserializedRepositoryModel.Should().Contain(x => x.Name == targetRepo);
+
+            Assert.NotEmpty(deserializedRepositoryModel);
+            Assert.Contains(deserializedRepositoryModel, x => x.Name == targetRepo);
         }
 
         // Get branch endpoint test
@@ -173,14 +174,14 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
 
             // Call branches endpoint
             using HttpResponseMessage branchesResponse = await _giteaRetryPolicy.ExecuteAsync(async () => await HttpClient.GetAsync($"designer/api/repos/repo/{org}/{targetRepo}/branches"));
-            branchesResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, branchesResponse.StatusCode);
             var deserializedBranchesModel = await branchesResponse.Content.ReadAsAsync<List<Branch>>();
-            deserializedBranchesModel.Count.Should().Be(1);
-            deserializedBranchesModel.First().Name.Should().Be("master");
+            Assert.Single(deserializedBranchesModel);
+            Assert.Equal("master", deserializedBranchesModel.First().Name);
 
             // Call branch endpoint
             using HttpResponseMessage branchResponse = await _giteaRetryPolicy.ExecuteAsync(async () => await HttpClient.GetAsync($"designer/api/repos/repo/{org}/{targetRepo}/branches/branch?branch=master"));
-            branchResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, branchResponse.StatusCode);
         }
 
 
@@ -194,13 +195,13 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
             // Create a file in gitea
             using var createFileContent = new StringContent(GenerateCommitJsonPayload("I am a new file created in gitea", "test commit"), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage createFileResponse = await GiteaFixture.GiteaClient.Value.PostAsync($"repos/{org}/{targetRepo}/contents/fileAlreadyInRepository.txt", createFileContent);
-            createFileResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.Equal(HttpStatusCode.Created, createFileResponse.StatusCode);
 
             // Add a file to local repo and try to push with designer
             await File.WriteAllTextAsync($"{CreatedFolderPath}/fileAlreadyInRepository.txt", "I am a new file from studio.");
             using var commitAndPushContent = new StringContent(GetCommitInfoJson("test commit", org, targetRepo), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage commitAndPushResponse = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/{targetRepo}/commit-and-push", commitAndPushContent);
-            commitAndPushResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+            Assert.Equal(HttpStatusCode.Conflict, commitAndPushResponse.StatusCode);
         }
     }
 }

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/RepositoryControllerGiteaIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/RepositoryControllerGiteaIntegrationTests.cs
@@ -12,7 +12,6 @@ using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.RepositoryClient.Model;
 using Designer.Tests.Fixtures;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Polly;
 using Polly.Retry;
 using Xunit;

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/UserControllerGiteaIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/UserControllerGiteaIntegrationTests.cs
@@ -4,11 +4,9 @@ using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Altinn.Studio.Designer.Models.Dto;
 using Altinn.Studio.Designer.RepositoryClient.Model;
 using Designer.Tests.Fixtures;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.GiteaIntegrationTests

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/UserControllerGiteaIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/UserControllerGiteaIntegrationTests.cs
@@ -28,14 +28,14 @@ namespace Designer.Tests.GiteaIntegrationTests
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Headers.First(h => h.Key == "Set-Cookie").Value.Should().Contain(e => e.Contains("XSRF-TOKEN"));
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains("XSRF-TOKEN", response.Headers.GetValues("Set-Cookie").First());
             string content = await response.Content.ReadAsStringAsync();
             var user = JsonSerializer.Deserialize<User>(content,
                 new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
-            user.Login.Should().Be(expectedUserName);
-            user.Email.Should().Be(expectedEmail);
+            Assert.Equal(expectedUserName, user.Login);
+            Assert.Equal(expectedEmail, user.Email);
         }
 
         [Theory]
@@ -47,10 +47,11 @@ namespace Designer.Tests.GiteaIntegrationTests
 
             string requestUrl = "designer/api/user/repos";
             using var response = await HttpClient.GetAsync(requestUrl);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var content = await response.Content.ReadAsAsync<List<Repository>>();
-            content.Should().NotBeNull();
-            content.Should().Contain(r => r.Name == targetRepo);
+
+            Assert.NotNull(content);
+            Assert.Contains(content, r => r.Name == targetRepo);
         }
 
         [Theory]
@@ -62,12 +63,12 @@ namespace Designer.Tests.GiteaIntegrationTests
 
             using var putStarredResponse =
                 await HttpClient.PutAsync($"designer/api/user/starred/{org}/{targetRepo}", null);
-            putStarredResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.Equal(HttpStatusCode.NoContent, putStarredResponse.StatusCode);
             await GetAndVerifyStarredRepos(targetRepo);
 
             using var deleteStarredResponse =
                 await HttpClient.DeleteAsync($"designer/api/user/starred/{org}/{targetRepo}");
-            deleteStarredResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.Equal(HttpStatusCode.NoContent, deleteStarredResponse.StatusCode);
 
             await GetAndVerifyStarredRepos();
         }
@@ -81,7 +82,7 @@ namespace Designer.Tests.GiteaIntegrationTests
 
             using var response = await HttpClient.GetAsync(requestUrl);
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string content = await response.Content.ReadAsStringAsync();
             var deserializeOptions = new JsonSerializerOptions
             {
@@ -90,19 +91,20 @@ namespace Designer.Tests.GiteaIntegrationTests
 
             var userOrgPermission = JsonSerializer.Deserialize<Team>(content, deserializeOptions);
 
-            userOrgPermission.Should().NotBeNull();
-            userOrgPermission.CanCreateOrgRepo.Should().Be(expectedCanCreate);
+            Assert.NotNull(userOrgPermission);
+            Assert.Equal(expectedCanCreate, userOrgPermission.CanCreateOrgRepo);
         }
 
         private async Task GetAndVerifyStarredRepos(params string[] expectedStarredRepos)
         {
             using var response = await HttpClient.GetAsync("designer/api/user/starred");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var content = await response.Content.ReadAsAsync<List<Repository>>();
-            content.Should().NotBeNull().And.HaveCount(expectedStarredRepos.Length);
+            Assert.NotNull(content);
+            Assert.Equal(expectedStarredRepos.Length, content.Count);
             foreach (string expectedStarredRepo in expectedStarredRepos)
             {
-                content.Should().Contain(r => r.Name == expectedStarredRepo);
+                Assert.Contains(content, r => r.Name == expectedStarredRepo);
             }
         }
     }

--- a/backend/tests/Designer.Tests/Helpers/AltinnStudioRepositoryScannerTests.cs
+++ b/backend/tests/Designer.Tests/Helpers/AltinnStudioRepositoryScannerTests.cs
@@ -10,6 +10,6 @@ public class AltinnStudioRepositoryScannerTests
     public void ShouldBeAbleToFindRootDirectoryOfRepository()
     {
         string actual = AltinnStudioRepositoryScanner.FindRootDotEnvFilePath();
-        actual.Replace(Path.DirectorySeparatorChar, '/').Should().EndWith("altinn-studio/.env");
+        Assert.EndsWith("altinn-studio/.env", actual.Replace(Path.DirectorySeparatorChar, '/'));
     }
 }

--- a/backend/tests/Designer.Tests/Helpers/AltinnStudioRepositoryScannerTests.cs
+++ b/backend/tests/Designer.Tests/Helpers/AltinnStudioRepositoryScannerTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using Altinn.Studio.Designer.Helpers;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.Helpers;

--- a/backend/tests/Designer.Tests/Helpers/PackageVersionHelperTests.cs
+++ b/backend/tests/Designer.Tests/Helpers/PackageVersionHelperTests.cs
@@ -21,11 +21,11 @@ namespace Designer.Tests.Helpers
             {
                 bool result = PackageVersionHelper.TryGetPackageVersionFromCsprojFile(testTemplateCsProjPath, input, out var version);
 
-                result.Should().Be(expectedResult);
+                Assert.Equal(expectedResult, result);
 
                 if (result)
                 {
-                    version.ToString().Should().Be(expectedVersion);
+                    Assert.Equal(expectedVersion, version.ToString());
                 }
             }
         }

--- a/backend/tests/Designer.Tests/Helpers/PackageVersionHelperTests.cs
+++ b/backend/tests/Designer.Tests/Helpers/PackageVersionHelperTests.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using Altinn.Studio.Designer.Helpers;
 using DotNet.Testcontainers.Builders;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.Helpers

--- a/backend/tests/Designer.Tests/Hubs/SyncHub/SyncHubConnectionTests.cs
+++ b/backend/tests/Designer.Tests/Hubs/SyncHub/SyncHubConnectionTests.cs
@@ -21,10 +21,11 @@ public class SyncHubConnectionTests : DesignerEndpointsTestsBase<SyncHubConnecti
     {
         await When.ConnectionStarted();
 
-        Then.HubConnection.State.Should().Be(HubConnectionState.Connected);
+        Assert.True(HubConnection.State == HubConnectionState.Connected);
 
         await And.When.HubConnection.StopAsync();
-        Then.HubConnection.State.Should().Be(HubConnectionState.Disconnected);
+
+        Assert.True(HubConnection.State == HubConnectionState.Disconnected);
     }
 
     private async Task ConnectionStarted()

--- a/backend/tests/Designer.Tests/Hubs/SyncHub/SyncHubConnectionTests.cs
+++ b/backend/tests/Designer.Tests/Hubs/SyncHub/SyncHubConnectionTests.cs
@@ -2,7 +2,6 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using Designer.Tests.Controllers.ApiTests;
-using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.SignalR.Client;
 using Xunit;

--- a/backend/tests/Designer.Tests/Infrastructure/GitRepository/AltinnAppGitRepositoryTests.cs
+++ b/backend/tests/Designer.Tests/Infrastructure/GitRepository/AltinnAppGitRepositoryTests.cs
@@ -42,36 +42,38 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
             ApplicationMetadata applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
 
-            applicationMetadata.Id.Should().Be("yabbin/hvem-er-hvem");
-            applicationMetadata.Org.Should().Be("yabbin");
-            applicationMetadata.Title.Should().ContainValues("Hvem er hvem?", "who-is-who");
-            applicationMetadata.Title.Should().ContainKeys("nb", "en");
+            Assert.Equal("yabbin/hvem-er-hvem", applicationMetadata.Id);
+            Assert.Equal("yabbin", applicationMetadata.Org);
+            Assert.Contains("Hvem er hvem?", applicationMetadata.Title.Values);
+            Assert.Contains("who-is-who", applicationMetadata.Title.Values);
+            Assert.Contains("nb", applicationMetadata.Title.Keys);
+            Assert.Contains("en", applicationMetadata.Title.Keys);
 
-            applicationMetadata.DataTypes.Should().HaveCount(2);
-            applicationMetadata.DataTypes.First(d => d.Id == "ref-data-as-pdf").AllowedContentTypes.First().Should().Be("application/pdf");
+            Assert.Equal(2, applicationMetadata.DataTypes.Count);
+            Assert.Equal("application/pdf", applicationMetadata.DataTypes.First(d => d.Id == "ref-data-as-pdf").AllowedContentTypes.First());
 
             DataType mainDataType = applicationMetadata.DataTypes.First(d => d.Id == "Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES");
-            mainDataType.AllowedContentTypes.First().Should().Be("application/xml");
-            mainDataType.AppLogic.ClassRef.Should().Be("Altinn.App.Models.HvemErHvem_M");
-            mainDataType.AppLogic.AutoCreate.Should().BeTrue();
-            mainDataType.MinCount.Should().Be(1);
-            mainDataType.MaxCount.Should().Be(1);
-            mainDataType.TaskId.Should().Be("Task_1");
+            Assert.Equal("application/xml", mainDataType.AllowedContentTypes.First());
+            Assert.Equal("Altinn.App.Models.HvemErHvem_M", mainDataType.AppLogic.ClassRef);
+            Assert.True(mainDataType.AppLogic.AutoCreate);
+            Assert.Equal(1, mainDataType.MinCount);
+            Assert.Equal(1, mainDataType.MaxCount);
+            Assert.Equal("Task_1", mainDataType.TaskId);
 
-            applicationMetadata.PartyTypesAllowed.Person.Should().BeFalse();
-            applicationMetadata.PartyTypesAllowed.Organisation.Should().BeFalse();
-            applicationMetadata.PartyTypesAllowed.SubUnit.Should().BeFalse();
-            applicationMetadata.PartyTypesAllowed.BankruptcyEstate.Should().BeFalse();
+            Assert.False(applicationMetadata.PartyTypesAllowed.Person);
+            Assert.False(applicationMetadata.PartyTypesAllowed.Organisation);
+            Assert.False(applicationMetadata.PartyTypesAllowed.SubUnit);
+            Assert.False(applicationMetadata.PartyTypesAllowed.BankruptcyEstate);
 
             DataField dataField = applicationMetadata.DataFields.First(d => d.Id == "GeekType");
-            dataField.Path.Should().Be("InnrapporterteData.geekType");
-            dataField.DataTypeId.Should().Be("Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES");
+            Assert.Equal("InnrapporterteData.geekType", dataField.Path);
+            Assert.Equal("Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES", dataField.DataTypeId);
 
-            applicationMetadata.AutoDeleteOnProcessEnd.Should().BeFalse();
-            applicationMetadata.Created.Should().BeSameDateAs(DateTime.Parse("2021-04-08T17:42:09.0883842Z"));
-            applicationMetadata.CreatedBy.Should().Be("Ronny");
-            applicationMetadata.LastChanged.Should().BeSameDateAs(DateTime.Parse("2021-04-08T17:42:09.08847Z"));
-            applicationMetadata.LastChangedBy.Should().Be("Ronny");
+            Assert.False(applicationMetadata.AutoDeleteOnProcessEnd);
+            Assert.Equal(DateTime.Parse("2021-04-08T17:42:09.0883842Z"), applicationMetadata.Created);
+            Assert.Equal("Ronny", applicationMetadata.CreatedBy);
+            Assert.Equal(DateTime.Parse("2021-04-08T17:42:09.08847Z"), applicationMetadata.LastChanged);
+            Assert.Equal("Ronny", applicationMetadata.LastChangedBy);
         }
 
         [Fact]
@@ -84,8 +86,8 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
             var textResource = await altinnAppGitRepository.GetTextV1("nb");
 
-            textResource.Should().NotBeNull();
-            textResource.Resources.First(r => r.Id == "ServiceName").Value.Should().Be("Hvem er hvem?");
+            Assert.NotNull(textResource);
+            Assert.Equal("Hvem er hvem?", textResource.Resources.First(r => r.Id == "ServiceName").Value);
         }
 
         [Fact]
@@ -98,8 +100,10 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
             var languages = altinnAppGitRepository.GetLanguages();
 
-            languages.Should().NotBeNull();
-            languages.ToArray().Should().Equal("en", "nb");
+            Assert.NotNull(languages);
+            Assert.Equal(2, languages.Count());
+            Assert.Equal("en", languages.First());
+            Assert.Equal("nb", languages.Last());
         }
 
         [Fact]
@@ -112,8 +116,8 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
             string[] layoutSetNames = altinnAppGitRepository.GetLayoutSetNames();
 
-            layoutSetNames.Should().NotBeNull();
-            layoutSetNames.Should().HaveCount(2);
+            Assert.NotNull(layoutSetNames);
+            Assert.Equal(2, layoutSetNames.Length);
         }
 
         [Fact]
@@ -126,8 +130,8 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
             string[] layoutSetNames = altinnAppGitRepository.GetLayoutSetNames();
 
-            layoutSetNames.Should().NotBeNull();
-            layoutSetNames.Should().HaveCount(1);
+            Assert.NotNull(layoutSetNames);
+            Assert.Single(layoutSetNames);
         }
 
         [Fact]
@@ -140,7 +144,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
             bool appUsesLayoutSets = altinnAppGitRepository.AppUsesLayoutSets();
 
-            appUsesLayoutSets.Should().BeTrue();
+            Assert.True(appUsesLayoutSets);
             return Task.CompletedTask;
         }
 
@@ -154,7 +158,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
             bool appUsesLayoutSets = altinnAppGitRepository.AppUsesLayoutSets();
 
-            appUsesLayoutSets.Should().BeFalse();
+            Assert.False(appUsesLayoutSets);
             return Task.CompletedTask;
         }
 
@@ -169,8 +173,8 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
             string[] layoutNames = altinnAppGitRepository.GetLayoutNames(layoutSetName);
 
-            layoutNames.Should().NotBeNull();
-            layoutNames.Should().HaveCount(2);
+            Assert.NotNull(layoutSetName);
+            Assert.Equal(2, layoutNames.Length);
             return Task.CompletedTask;
         }
 
@@ -184,8 +188,8 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
             string[] layoutNames = altinnAppGitRepository.GetLayoutNames(null);
 
-            layoutNames.Should().NotBeNull();
-            layoutNames.Should().HaveCount(2);
+            Assert.NotNull(layoutNames);
+            Assert.Equal(2, layoutNames.Length);
             return Task.CompletedTask;
         }
 
@@ -201,8 +205,9 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
             JsonNode formLayout = await altinnAppGitRepository.GetLayout(layoutSetName, layoutName);
 
-            formLayout.Should().NotBeNull();
-            formLayout["data"]["layout"].Should().NotBeNull();
+            Assert.NotNull(formLayout);
+            Assert.NotNull(formLayout["data"]);
+            Assert.NotNull(formLayout["data"]["layout"]);
         }
 
         [Fact]
@@ -216,8 +221,9 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
             JsonNode formLayout = await altinnAppGitRepository.GetLayout(null, layoutName);
 
-            formLayout.Should().NotBeNull();
-            formLayout["data"]["layout"].Should().NotBeNull();
+            Assert.NotNull(formLayout);
+            Assert.NotNull(formLayout["data"]);
+            Assert.NotNull(formLayout["data"]["layout"]);
         }
 
         [Fact]
@@ -239,9 +245,10 @@ namespace Designer.Tests.Infrastructure.GitRepository
                 await altinnAppGitRepository.SaveLayout(layoutSetName, layoutName, formLayoutToSave);
                 JsonNode formLayoutSaved = await altinnAppGitRepository.GetLayout(layoutSetName, layoutName);
 
-                formLayoutSaved.Should().NotBeNull();
-                formLayoutSaved["data"]["layout"].Should().NotBeNull();
-                (formLayoutSaved["data"]["layout"] as JsonArray).Should().HaveCount(1);
+                Assert.NotNull(formLayoutSaved);
+                Assert.NotNull(formLayoutSaved["data"]);
+                Assert.NotNull(formLayoutSaved["data"]["layout"]);
+                Assert.Single(formLayoutSaved["data"]["layout"] as JsonArray);
             }
             finally
             {
@@ -260,11 +267,12 @@ namespace Designer.Tests.Infrastructure.GitRepository
             AltinnAppGitRepository altinnAppGitRepository = PrepareRepositoryForTest(org, repository, developer);
 
             string options = await altinnAppGitRepository.GetOptionsList(optionsId);
-            options.Should().NotBeNull();
+
+            Assert.NotNull(options);
             var optionsArray = JsonNode.Parse(options).AsArray();
-            optionsArray.Count.Should().Be(2);
-            optionsArray[0]["label"].ToString().Should().Be("label1");
-            optionsArray[1]["label"].ToString().Should().Be("label2");
+            Assert.Equal(2, optionsArray.Count);
+            Assert.Equal("label1", optionsArray[0]["label"].ToString());
+            Assert.Equal("label2", optionsArray[1]["label"].ToString());
         }
 
         [Fact]
@@ -289,8 +297,8 @@ namespace Designer.Tests.Infrastructure.GitRepository
 
             string[] optionListIds = altinnAppGitRepository.GetOptionsListIds();
 
-            optionListIds.Should().NotBeNull();
-            optionListIds.Should().HaveCount(3);
+            Assert.NotNull(optionListIds);
+            Assert.Equal(3, optionListIds.Length);
             return Task.CompletedTask;
         }
 

--- a/backend/tests/Designer.Tests/Infrastructure/GitRepository/AltinnAppGitRepositoryTests.cs
+++ b/backend/tests/Designer.Tests/Infrastructure/GitRepository/AltinnAppGitRepositoryTests.cs
@@ -9,7 +9,6 @@ using Altinn.Studio.Designer.Infrastructure.GitRepository;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.App;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests.Infrastructure.GitRepository

--- a/backend/tests/Designer.Tests/Models/AltinnCoreFileTests.cs
+++ b/backend/tests/Designer.Tests/Models/AltinnCoreFileTests.cs
@@ -26,7 +26,7 @@ namespace Designer.Tests
             Assert.Equal(@"/App/models/0678.xsd", altinnCoreFile.RepositoryRelativeUrl);
             Assert.Equal(directory, altinnCoreFile.Directory);
             Assert.Equal(filePath, altinnCoreFile.FilePath);
-            altinnCoreFile.LastChanged.Should().BeOnOrBefore(DateTime.Now);
+            Assert.True(altinnCoreFile.LastChanged < DateTime.Now);
         }
 
         [Theory]

--- a/backend/tests/Designer.Tests/Models/AltinnCoreFileTests.cs
+++ b/backend/tests/Designer.Tests/Models/AltinnCoreFileTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using Altinn.Studio.Designer.Models;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Xunit;
 
 namespace Designer.Tests

--- a/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
+++ b/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
@@ -10,7 +10,6 @@ using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Moq;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
+++ b/backend/tests/Designer.Tests/Services/AppDevelopmentServiceTest.cs
@@ -44,7 +44,7 @@ public class AppDevelopmentServiceTest : IDisposable
         CreatedTestRepoPath = await TestDataHelper.CopyRepositoryForTest(_org, repository, _developer, targetRepository);
         var layoutSettings = await _appDevelopmentService.GetLayoutSettings(AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, targetRepository, _developer), null);
 
-        layoutSettings.Should().NotBeNull();
+        Assert.NotNull(layoutSettings);
     }
 
     [Fact]
@@ -72,8 +72,9 @@ public class AppDevelopmentServiceTest : IDisposable
         await _appDevelopmentService.SaveLayoutSettings(AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, targetRepository, _developer), layoutSettingsUpdated, layoutSetName);
         var layoutSettings = await _appDevelopmentService.GetLayoutSettings(AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, targetRepository, _developer), layoutSetName);
 
-        layoutSettings.Should().NotBeNull();
-        (layoutSettings["pages"]["order"] as JsonArray).Should().HaveCount(3);
+        Assert.NotNull(layoutSettings);
+
+        Assert.Equal(3, ((JsonArray)layoutSettings!["pages"]!["order"]!).Count);
     }
 
     [Fact]
@@ -85,7 +86,7 @@ public class AppDevelopmentServiceTest : IDisposable
         CreatedTestRepoPath = await TestDataHelper.CopyRepositoryForTest(_org, _repository, _developer, targetRepository);
         var layoutSettings = await _appDevelopmentService.GetLayoutSettings(AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, targetRepository, _developer), layoutSetName);
 
-        layoutSettings.Should().NotBeNull();
+        Assert.NotNull(layoutSettings);
     }
 
 
@@ -98,8 +99,9 @@ public class AppDevelopmentServiceTest : IDisposable
         CreatedTestRepoPath = await TestDataHelper.CopyRepositoryForTest(_org, _repository, _developer, targetRepository);
         var layoutSettings = await _appDevelopmentService.GetLayoutSettings(AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, targetRepository, _developer), layoutSetName);
 
-        layoutSettings.Should().NotBeNull();
-        (layoutSettings["pages"]["order"] as JsonArray).Should().HaveCount(2);
+        Assert.NotNull(layoutSettings);
+
+        Assert.Equal(2, ((JsonArray)layoutSettings!["pages"]!["order"]!).Count);
     }
 
     [Fact]
@@ -138,9 +140,10 @@ public class AppDevelopmentServiceTest : IDisposable
         List<string> layoutSetFileNamesAfterUpdate = GetFileNamesInLayoutSet(newLayoutSetName);
 
         // Assert
-        updatedLayoutSets.Sets.Should().HaveCount(4);
-        updatedLayoutSets.Sets.Find(set => set.Id == newLayoutSetName).Should().NotBeNull();
-        layoutSetFileNamesBeforeUpdate.Should().BeEquivalentTo(layoutSetFileNamesAfterUpdate);
+        Assert.Equal(4, updatedLayoutSets.Sets.Count);
+        Assert.NotNull(updatedLayoutSets.Sets.Find(set => set.Id == newLayoutSetName));
+        Assert.Equal(layoutSetFileNamesBeforeUpdate.Count, layoutSetFileNamesAfterUpdate.Count);
+
     }
 
     [Fact]
@@ -156,9 +159,9 @@ public class AppDevelopmentServiceTest : IDisposable
         var updatedLayoutSets = await _appDevelopmentService.AddLayoutSet(AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, targetRepository, _developer), newLayoutSet);
 
         // Assert
-        updatedLayoutSets.Should().NotBeNull();
-        updatedLayoutSets.Sets.Should().HaveCount(5);
-        updatedLayoutSets.Sets.Should().Contain(newLayoutSet);
+        Assert.NotNull(updatedLayoutSets);
+        Assert.Equal(5, updatedLayoutSets.Sets.Count);
+        Assert.Contains(newLayoutSet, updatedLayoutSets.Sets);
     }
 
     [Fact]
@@ -190,7 +193,7 @@ public class AppDevelopmentServiceTest : IDisposable
         Func<Task> act = async () => await _appDevelopmentService.UpdateLayoutSetName(AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, targetRepository, _developer), "layoutSet1", "someName");
 
         // Assert
-        await act.Should().ThrowAsync<NoLayoutSetsFileFoundException>();
+        await Assert.ThrowsAsync<NoLayoutSetsFileFoundException>(act);
     }
 
     [Fact]
@@ -206,7 +209,7 @@ public class AppDevelopmentServiceTest : IDisposable
         Func<Task> act = async () => await _appDevelopmentService.AddLayoutSet(AltinnRepoEditingContext.FromOrgRepoDeveloper(_org, targetRepository, _developer), new() { Id = "layoutSet1" });
 
         // Assert
-        await act.Should().ThrowAsync<NoLayoutSetsFileFoundException>();
+        await Assert.ThrowsAsync<NoLayoutSetsFileFoundException>(act);
     }
 
     private List<string> GetFileNamesInLayoutSet(string layoutSetName)

--- a/backend/tests/Designer.Tests/Services/ProcessModelingServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/ProcessModelingServiceTests.cs
@@ -37,11 +37,11 @@ namespace Designer.Tests.Services
 
             var result = processModelingService.GetProcessDefinitionTemplates(version).ToList();
 
-            result.Count.Should().Be(expectedTemplates.Length);
+            Assert.Equal(expectedTemplates.Length, result.Count);
 
             foreach (string expectedTemplate in expectedTemplates)
             {
-                result.Should().Contain(expectedTemplate);
+                Assert.Contains(expectedTemplate, result);
             }
         }
 
@@ -59,7 +59,7 @@ namespace Designer.Tests.Services
             string taskType = await processModelingService.GetTaskTypeFromProcessDefinition(AltinnRepoEditingContext.FromOrgRepoDeveloper(org, targetRepository, developer), "layoutSet1");
 
             // Assert
-            taskType.Should().Be("data");
+            Assert.Equal("data", taskType);
         }
 
         public static IEnumerable<object[]> TemplatesTestData => new List<object[]>

--- a/backend/tests/Designer.Tests/Services/ProcessModelingServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/ProcessModelingServiceTests.cs
@@ -7,7 +7,6 @@ using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Implementation.ProcessModeling;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Moq;
 using NuGet.Versioning;
 using SharedResources.Tests;

--- a/backend/tests/Designer.Tests/Services/RepositorySITests.cs
+++ b/backend/tests/Designer.Tests/Services/RepositorySITests.cs
@@ -121,7 +121,7 @@ namespace Designer.Tests.Services
             {
                 await repositoryService.CreateService(org, new ServiceConfiguration() { RepositoryName = repositoryName, ServiceName = repositoryName });
                 var altinnStudioSettings = await new AltinnGitRepositoryFactory(repositoriesRootDirectory).GetAltinnGitRepository(org, repositoryName, developer).GetAltinnStudioSettings();
-                altinnStudioSettings.RepoType.Should().Be(AltinnRepositoryType.App);
+                Assert.Equal(AltinnRepositoryType.App, altinnStudioSettings.RepoType);
             }
             finally
             {

--- a/backend/tests/Designer.Tests/Services/RepositorySITests.cs
+++ b/backend/tests/Designer.Tests/Services/RepositorySITests.cs
@@ -19,7 +19,6 @@ using Altinn.Studio.Designer.TypedHttpClients.AltinnStorage;
 
 using Designer.Tests.Mocks;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;

--- a/backend/tests/Designer.Tests/Services/SchemaModelServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/SchemaModelServiceTests.cs
@@ -14,7 +14,6 @@ using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Moq;
 using SharedResources.Tests;
 using Xunit;

--- a/backend/tests/Designer.Tests/Services/SchemaModelServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/SchemaModelServiceTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -47,11 +46,11 @@ namespace Designer.Tests.Services
             try
             {
                 var schemaFiles = _schemaModelService.GetSchemaFiles(editingContext);
-                schemaFiles.Should().HaveCount(7);
+                Assert.Equal(7, schemaFiles.Count);
 
                 var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
                 var applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
-                applicationMetadata.DataTypes.Should().HaveCount(2);
+                Assert.Equal(2, applicationMetadata.DataTypes.Count);
 
                 // Act
                 var schemaToDelete = schemaFiles.First(s => s.FileName == "Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES.schema.json");
@@ -59,9 +58,9 @@ namespace Designer.Tests.Services
 
                 // Assert
                 schemaFiles = _schemaModelService.GetSchemaFiles(editingContext);
-                schemaFiles.Should().HaveCount(6);
+                Assert.Equal(6, schemaFiles.Count);
                 applicationMetadata = await altinnAppGitRepository.GetApplicationMetadata();
-                applicationMetadata.DataTypes.Should().HaveCount(1);
+                Assert.Single(applicationMetadata.DataTypes);
             }
             finally
             {
@@ -85,7 +84,7 @@ namespace Designer.Tests.Services
                 string dataModelName = "datamodel";
 
                 var schemaFiles = _schemaModelService.GetSchemaFiles(editingContext);
-                schemaFiles.Should().HaveCount(1);
+                Assert.Single(schemaFiles);
 
                 var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
                 var applicationMetadataBefore = await altinnAppGitRepository.GetApplicationMetadata();
@@ -97,12 +96,13 @@ namespace Designer.Tests.Services
 
                 // Assert
                 schemaFiles = _schemaModelService.GetSchemaFiles(editingContext);
-                schemaFiles.Should().HaveCount(0);
+                Assert.Empty(schemaFiles);
                 var applicationMetadataAfter = await altinnAppGitRepository.GetApplicationMetadata();
-                applicationMetadataAfter.DataTypes.Should().HaveCount(applicationMetadataBefore.DataTypes.Count - 1);
+                Assert.Equal(applicationMetadataBefore.DataTypes.Count - 1, applicationMetadataAfter.DataTypes.Count);
                 var layoutSetsAfter = await altinnAppGitRepository.GetLayoutSetsFile();
-                layoutSetsBefore.Sets.Exists(set => set.DataType == dataModelName).Should().BeTrue();
-                layoutSetsAfter.Sets.Exists(set => set.DataType == dataModelName).Should().BeFalse();
+
+                Assert.True(layoutSetsBefore.Sets.Exists(set => set.DataType == dataModelName));
+                Assert.False(layoutSetsAfter.Sets.Exists(set => set.DataType == dataModelName));
             }
             finally
             {
@@ -125,7 +125,7 @@ namespace Designer.Tests.Services
             {
 
                 var schemaFiles = _schemaModelService.GetSchemaFiles(editingContext);
-                schemaFiles.Should().HaveCount(6);
+                Assert.Equal(6, schemaFiles.Count);
 
                 // Act
                 var schemaToDelete = schemaFiles.First(s => s.FileName == "Kursdomene_HvemErHvem_M_2021-04-08_5742_34627_SERES.schema.json");
@@ -133,7 +133,7 @@ namespace Designer.Tests.Services
 
                 // Assert
                 schemaFiles = _schemaModelService.GetSchemaFiles(editingContext);
-                schemaFiles.Should().HaveCount(5);
+                Assert.Equal(5, schemaFiles.Count);
             }
             finally
             {
@@ -164,7 +164,7 @@ namespace Designer.Tests.Services
 
                 var updatedSchema = await altinnGitRepository.ReadTextByRelativePathAsync("App/models/HvemErHvem_SERES.schema.json");
                 string serializedExpectedSchemaUpdates = FormatJsonString(updatedSchema);
-                updatedSchema.Should().BeEquivalentTo(serializedExpectedSchemaUpdates);
+                Assert.Equal(serializedExpectedSchemaUpdates, updatedSchema);
 
                 var xsd = await altinnGitRepository.ReadTextByRelativePathAsync("App/models/HvemErHvem_SERES.xsd");
 
@@ -179,8 +179,8 @@ namespace Designer.Tests.Services
                 //   </xsd:complexType>
                 // </xsd:schema>
                 var xsdSchema = XDocument.Parse(xsd);
-                xsdSchema.Root.Should().NotBeNull();
-                xsdSchema.Root.Elements().First().Attributes().First(a => a.Name.LocalName == "name").Should().HaveValue("root");
+                Assert.NotNull(xsdSchema.Root);
+                Assert.Equal("root", xsdSchema.Root.Elements().First().Attributes().First(a => a.Name.LocalName == "name").Value);
             }
             finally
             {
@@ -235,7 +235,7 @@ namespace Designer.Tests.Services
                 Assert.False(altinnGitRepository.FileExistsByRelativePath("App/models/HvemErHvem_SERES.metadata.json"));
                 var updatedSchema = await altinnGitRepository.ReadTextByRelativePathAsync("App/models/HvemErHvem_SERES.schema.json");
                 string serializedExpectedSchemaUpdates = FormatJsonString(updatedSchema);
-                updatedSchema.Should().BeEquivalentTo(serializedExpectedSchemaUpdates);
+                Assert.Equal(serializedExpectedSchemaUpdates, updatedSchema);
             }
             finally
             {
@@ -264,7 +264,7 @@ namespace Designer.Tests.Services
             });
 
             Assert.NotNull(exception.CustomErrorMessages);
-            exception.CustomErrorMessages.Should().ContainSingle(c => c.Contains("root': member names cannot be the same as their enclosing type"));
+            Assert.Single(exception.CustomErrorMessages, c => c.Contains("root': member names cannot be the same as their enclosing type"));
         }
 
         [Fact]
@@ -287,7 +287,8 @@ namespace Designer.Tests.Services
                 Func<Task> action = () => _schemaModelService.BuildSchemaFromXsd(editingContext, fileName, xsdStream);
 
                 // Act/assert
-                await action.Should().ThrowAsync<XmlSchemaException>();
+                await Assert.ThrowsAsync<XmlSchemaException>(action);
+
             }
             finally
             {
@@ -321,9 +322,10 @@ namespace Designer.Tests.Services
 
                 // Assert
                 var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
-                altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.metadata.json").Should().BeFalse();
-                altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.schema.json").Should().BeTrue();
-                altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.cs").Should().BeTrue();
+
+                Assert.False(altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.metadata.json"));
+                Assert.True(altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.schema.json"));
+                Assert.True(altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.cs"));
             }
             finally
             {
@@ -357,10 +359,11 @@ namespace Designer.Tests.Services
 
                 // Assert
                 var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
-                altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.metadata.json").Should().BeFalse();
-                altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.schema.json").Should().BeTrue();
-                altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.xsd").Should().BeTrue();
-                altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.cs").Should().BeTrue();
+
+                Assert.False(altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.metadata.json"));
+                Assert.True(altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.schema.json"));
+                Assert.True(altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.xsd"));
+                Assert.True(altinnAppGitRepository.FileExistsByRelativePath($"{relativeDirectory}/{schemaName}.cs"));
             }
             finally
             {

--- a/backend/tests/Designer.Tests/Services/SourceControlLoggingDecoratorTests.cs
+++ b/backend/tests/Designer.Tests/Services/SourceControlLoggingDecoratorTests.cs
@@ -37,7 +37,7 @@ namespace Designer.Tests.Services
 
             var service = serviceProvider.GetService<ISourceControl>();
 
-            service.Should().BeOfType<SourceControlLoggingDecorator>();
+            Assert.IsType<SourceControlLoggingDecorator>(service);
         }
 
         [Fact]

--- a/backend/tests/Designer.Tests/Services/SourceControlLoggingDecoratorTests.cs
+++ b/backend/tests/Designer.Tests/Services/SourceControlLoggingDecoratorTests.cs
@@ -5,7 +5,6 @@ using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.RepositoryClient.Model;
 using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
-using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;

--- a/backend/tests/Designer.Tests/Services/TextsServiceTest.cs
+++ b/backend/tests/Designer.Tests/Services/TextsServiceTest.cs
@@ -11,7 +11,6 @@ using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.TypedHttpClients.AltinnStorage;
 using Designer.Tests.Mocks;
 using Designer.Tests.Utils;
-using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;

--- a/backend/tests/Designer.Tests/Services/TextsServiceTest.cs
+++ b/backend/tests/Designer.Tests/Services/TextsServiceTest.cs
@@ -53,8 +53,8 @@ public class TextsServiceTest : IDisposable
         AltinnAppGitRepository altinnAppGitRepository = altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
         JsonNode formLayout = await altinnAppGitRepository.GetLayout(layoutSetName1, layoutName1);
 
-        formLayout.Should().NotBeNull();
-        (formLayout["data"]["layout"] as JsonArray)[0]["textResourceBindings"]["title"].ToString().Should().Be("new-id");
+        Assert.NotNull(formLayout);
+        Assert.Equal("new-id", (formLayout["data"]["layout"] as JsonArray)[0]["textResourceBindings"]["title"].ToString());
     }
 
     [Fact]
@@ -69,10 +69,10 @@ public class TextsServiceTest : IDisposable
         JsonNode formLayout1 = await altinnAppGitRepository.GetLayout(layoutSetName1, layoutName1);
         JsonNode formLayout2 = await altinnAppGitRepository.GetLayout(layoutSetName2, layoutName2);
 
-        formLayout1.Should().NotBeNull();
-        formLayout2.Should().NotBeNull();
-        (formLayout1["data"]["layout"] as JsonArray)[0]["textResourceBindings"]["title"].ToString().Should().Be("new-id");
-        (formLayout2["data"]["layout"] as JsonArray)[0]["textResourceBindings"]["title"].ToString().Should().Be("new-id");
+        Assert.NotNull(formLayout1);
+        Assert.NotNull(formLayout2);
+        Assert.Equal("new-id", (formLayout1["data"]["layout"] as JsonArray)[0]["textResourceBindings"]["title"].ToString());
+        Assert.Equal("new-id", (formLayout2["data"]["layout"] as JsonArray)[0]["textResourceBindings"]["title"].ToString());
     }
 
     [Fact]
@@ -85,8 +85,8 @@ public class TextsServiceTest : IDisposable
         AltinnAppGitRepository altinnAppGitRepository = altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
         JsonNode formLayout = await altinnAppGitRepository.GetLayout(layoutSetName1, layoutName1);
 
-        formLayout.Should().NotBeNull();
-        (formLayout["data"]["layout"] as JsonArray)[0]["textResourceBindings"]["title"].ToString().Should().Be("new-id");
+        Assert.NotNull(formLayout);
+        Assert.Equal("new-id", (formLayout["data"]["layout"] as JsonArray)[0]["textResourceBindings"]["title"].ToString());
     }
 
     [Fact]
@@ -99,8 +99,8 @@ public class TextsServiceTest : IDisposable
         AltinnAppGitRepository altinnAppGitRepository = altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
         JsonNode formLayout = await altinnAppGitRepository.GetLayout(layoutSetName1, layoutName1);
 
-        formLayout.Should().NotBeNull();
-        (formLayout["data"]["layout"] as JsonArray)[0]["textResourceBindings"]["title"].ToString().Should().Be("some-old-id");
+        Assert.NotNull(formLayout);
+        Assert.Equal("some-old-id", (formLayout["data"]["layout"] as JsonArray)[0]["textResourceBindings"]["title"].ToString());
     }
 
     [Fact]
@@ -113,8 +113,8 @@ public class TextsServiceTest : IDisposable
         AltinnAppGitRepository altinnAppGitRepository = altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
         JsonNode formLayout = await altinnAppGitRepository.GetLayout(layoutSetName1, layoutName1);
 
-        formLayout.Should().NotBeNull();
-        formLayout.ToString().Should().NotContain("some-old-key");
+        Assert.NotNull(formLayout);
+        Assert.DoesNotContain("some-old-key", formLayout.ToString());
     }
 
     [Fact]
@@ -127,10 +127,10 @@ public class TextsServiceTest : IDisposable
         AltinnAppGitRepository altinnAppGitRepository = altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
         JsonNode formLayout = await altinnAppGitRepository.GetLayout(layoutSetName1, layoutName1);
 
-        formLayout.Should().NotBeNull();
-        (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["label"].ToString().Should().Be("new-id");
-        (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["helpText"].ToString().Should().Be("help-text-used-by-options");
-        (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["description"].ToString().Should().Be("description-used-by-options");
+        Assert.NotNull(formLayout);
+        Assert.Equal("new-id", (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["label"].ToString());
+        Assert.Equal("help-text-used-by-options", (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["helpText"].ToString());
+        Assert.Equal("description-used-by-options", (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["description"].ToString());
     }
 
     [Fact]
@@ -143,10 +143,10 @@ public class TextsServiceTest : IDisposable
         AltinnAppGitRepository altinnAppGitRepository = altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
         JsonNode formLayout = await altinnAppGitRepository.GetLayout(layoutSetName1, layoutName1);
 
-        formLayout.Should().NotBeNull();
-        (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["label"].ToString().Should().Be("id-used-by-options");
-        (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["helpText"].ToString().Should().Be("new-id");
-        (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["description"].ToString().Should().Be("new-id");
+        Assert.NotNull(formLayout);
+        Assert.Equal("id-used-by-options", (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["label"].ToString());
+        Assert.Equal("new-id", (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["helpText"].ToString());
+        Assert.Equal("new-id", (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["description"].ToString());
     }
 
     [Fact]
@@ -159,8 +159,8 @@ public class TextsServiceTest : IDisposable
         AltinnAppGitRepository altinnAppGitRepository = altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
         JsonNode formLayout = await altinnAppGitRepository.GetLayout(layoutSetName1, layoutName1);
 
-        formLayout.Should().NotBeNull();
-        (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["label"].ToString().Should().Be("id-used-by-options");
+        Assert.NotNull(formLayout);
+        Assert.Equal("id-used-by-options", (formLayout["data"]["layout"] as JsonArray)[2]["options"][0]["label"].ToString());
     }
 
     [Fact]
@@ -174,9 +174,9 @@ public class TextsServiceTest : IDisposable
         string raw = await altinnAppGitRepository.GetOptionsList("test-options");
         JsonNode optionsList = JsonNode.Parse(raw);
 
-        optionsList.Should().NotBeNull();
-        (optionsList as JsonArray)[0]["label"].ToString().Should().Be("label1new");
-        (optionsList as JsonArray)[1]["label"].ToString().Should().Be("label2");
+        Assert.NotNull(optionsList);
+        Assert.Equal("label1new", (optionsList as JsonArray)[0]["label"].ToString());
+        Assert.Equal("label2", (optionsList as JsonArray)[1]["label"].ToString());
     }
 
     [Fact]
@@ -190,9 +190,9 @@ public class TextsServiceTest : IDisposable
         string raw = await altinnAppGitRepository.GetOptionsList("test-options");
         JsonNode optionsList = JsonNode.Parse(raw);
 
-        optionsList.Should().NotBeNull();
-        (optionsList as JsonArray)[0]["label"].ToString().Should().Be("label1");
-        (optionsList as JsonArray)[1]["label"].ToString().Should().Be("label2");
+        Assert.NotNull(optionsList);
+        Assert.Equal("label1", (optionsList as JsonArray)[0]["label"].ToString());
+        Assert.Equal("label2", (optionsList as JsonArray)[1]["label"].ToString());
     }
 
     [Fact]
@@ -205,8 +205,8 @@ public class TextsServiceTest : IDisposable
         AltinnAppGitRepository altinnAppGitRepository = altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
         JsonNode formLayout = await altinnAppGitRepository.GetLayout(layoutSetName1, layoutName1);
 
-        formLayout.Should().NotBeNull();
-        (formLayout["data"]["layout"] as JsonArray)[3]["source"]["label"].ToString().Should().Be("source-label-new");
+        Assert.NotNull(formLayout);
+        Assert.Equal("source-label-new", (formLayout["data"]["layout"] as JsonArray)[3]["source"]["label"].ToString());
     }
 
     [Fact]
@@ -219,8 +219,8 @@ public class TextsServiceTest : IDisposable
         AltinnAppGitRepository altinnAppGitRepository = altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, targetRepository, developer);
         JsonNode formLayout = await altinnAppGitRepository.GetLayout(layoutSetName1, layoutName1);
 
-        formLayout.Should().NotBeNull();
-        (formLayout["data"]["layout"] as JsonArray)[3]["source"]["label"].ToString().Should().Be("source-label");
+        Assert.NotNull(formLayout);
+        Assert.Equal("source-label", (formLayout["data"]["layout"] as JsonArray)[3]["source"]["label"].ToString());
     }
 
     public void Dispose()

--- a/backend/tests/Designer.Tests/TypedHttpClients/DelegatingHandlers/CachingDelegatingHandlerTests.cs
+++ b/backend/tests/Designer.Tests/TypedHttpClients/DelegatingHandlers/CachingDelegatingHandlerTests.cs
@@ -2,7 +2,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.TypedHttpClients.DelegatingHandlers;
-using FluentAssertions;
 using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 

--- a/backend/tests/Designer.Tests/TypedHttpClients/DelegatingHandlers/CachingDelegatingHandlerTests.cs
+++ b/backend/tests/Designer.Tests/TypedHttpClients/DelegatingHandlers/CachingDelegatingHandlerTests.cs
@@ -36,10 +36,11 @@ namespace Designer.Tests.TypedHttpClients.DelegatingHandlers
             _memoryCache.Set($"{HttpMethod.Get}_http://nonexistingurl1234.no/", cacheResponseDataEntry);
 
             var response = await client.GetAsync("http://nonexistingurl1234.no/");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             byte[] responseArray = await response.Content.ReadAsByteArrayAsync();
-            responseArray.Should().BeEquivalentTo(expectedResponse);
+            Assert.Equal(expectedResponse, responseArray);
         }
 
         [Fact]
@@ -51,7 +52,7 @@ namespace Designer.Tests.TypedHttpClients.DelegatingHandlers
 
             var response = await client.PostAsync("https://docs.altinn.studio/", null);
 
-            response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
         }
 
         [Fact]
@@ -63,7 +64,7 @@ namespace Designer.Tests.TypedHttpClients.DelegatingHandlers
 
             var response = await client.GetAsync("https://docs.altinn.studio/nonexisting");
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [Fact]
@@ -75,10 +76,10 @@ namespace Designer.Tests.TypedHttpClients.DelegatingHandlers
 
             var response = await client.GetAsync("https://docs.altinn.studio/");
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            _memoryCache.TryGetValue($"{HttpMethod.Get}_https://docs.altinn.studio/", out CachingDelegatingHandler.CacheResponseDataEntry _).Should().BeTrue();
+            Assert.True(_memoryCache.TryGetValue($"{HttpMethod.Get}_https://docs.altinn.studio/", out CachingDelegatingHandler.CacheResponseDataEntry _));
         }
     }
 }

--- a/backend/tests/Designer.Tests/Utils/AssertionUtil.cs
+++ b/backend/tests/Designer.Tests/Utils/AssertionUtil.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using Microsoft.AspNetCore.Mvc;
+using SharedResources.Tests;
 using Xunit;
 
 namespace Altinn.AccessManagement.Tests.Utils
@@ -194,6 +196,28 @@ namespace Altinn.AccessManagement.Tests.Utils
             {
                 Assert.Equal(expected.Errors[expectedKey], actual.Errors[expectedKey]);
             }
+        }
+
+        public static void AssertEqualTo<TType>(TType expected, TType actual)
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
+            Assert.True(JsonUtils.DeepEquals(JsonSerializer.Serialize(expected, options),
+                JsonSerializer.Serialize(actual, options)));
+        }
+
+        public static void AssertCloseTo(DateTimeOffset expected, DateTimeOffset actual, TimeSpan tolerance)
+        {
+            TimeSpan difference = (expected - actual).Duration();
+            Assert.True(difference <= tolerance);
+        }
+
+        public static void AssertCloseTo(DateTime expected, DateTime actual, TimeSpan tolerance)
+        {
+            TimeSpan difference = (expected - actual).Duration();
+            Assert.True(difference <= tolerance);
         }
 
         private static void AssertEqual(XacmlJsonResult expected, XacmlJsonResult actual)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pr removes usage of FluentAssertion library.
In addition if fixes the bug of having null value for createdby property on the deployment table.

<!--- Describe your changes in detail -->

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
