### PR TITLE
fix: broken codelist links in Studio to Altinn docs

### DIFF
--- a/frontend/packages/ux-editor-v3/src/components/config/editModal/EditCodeList.tsx
+++ b/frontend/packages/ux-editor-v3/src/components/config/editModal/EditCodeList.tsx
@@ -82,7 +82,7 @@ export function EditCodeList({ component, handleComponentChange }: IGenericEditC
       <p style={{ marginBottom: 0 }}>
         <Trans i18nKey={'ux_editor.modal_properties_code_list_read_more'}>
           <a
-            href={altinnDocsUrl({ relativeUrl: 'altinn-studio/reference/data/options/' })}
+            href={altinnDocsUrl({ relativeUrl: 'altinn-studio/guides/development/options/' })}
             target='_newTab'
             rel='noopener noreferrer'
           />

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/ReferenceTab/ReferenceTab.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/ReferenceTab/ReferenceTab.tsx
@@ -64,7 +64,9 @@ export function ReferenceTab({
       <p>
         <Trans i18nKey={'ux_editor.modal_properties_code_list_read_more'}>
           <a
-            href={altinnDocsUrl({ relativeUrl: 'altinn-studio/guides/options/dynamic-codelists/' })}
+            href={altinnDocsUrl({
+              relativeUrl: 'altinn-studio/guides/development/options/sources/dynamic/',
+            })}
             target='_newTab'
             rel='noopener noreferrer'
           />

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/SelectTab/SelectTab.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/SelectTab/SelectTab.tsx
@@ -83,7 +83,7 @@ export function SelectTab<T extends SelectionComponentType>({
         <a
           className={classes.linkStaticCodeLists}
           href={altinnDocsUrl({
-            relativeUrl: 'altinn-studio/reference/data/options/static-codelists/',
+            relativeUrl: 'altinn-studio/guides/development/options/sources/static/',
           })}
           target='_newTab'
           rel='noopener noreferrer'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated some links in Studio that were supposed to point to docs about codelists. 

<!--- Describe your changes in detail -->

## Related Issue(s)

- itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation links in multiple components:
		- Changed URL for dynamic code lists guide
		- Updated link for static code lists reference
		- Redirected users to new development option sources documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->