### PR TITLE
feat: Show warning when previewing a subform

### DIFF
--- a/frontend/app-preview/src/views/LandingPage.test.tsx
+++ b/frontend/app-preview/src/views/LandingPage.test.tsx
@@ -6,7 +6,7 @@ import { userEvent } from '@testing-library/user-event';
 import { useMediaQuery } from '@studio/components/src/hooks/useMediaQuery';
 import { renderWithProviders } from 'app-development/test/mocks';
 import { app, org } from '@studio/testing/testids';
-import { type ServicesContextProps } from 'app-shared/contexts/ServicesContext';
+import type { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
 import { userMock } from 'app-development/test/userMock';
 
 jest.mock('@studio/components/src/hooks/useMediaQuery');
@@ -60,7 +60,6 @@ describe('LandingPage', () => {
 
   it('should display the user profile menu', async () => {
     const user = userEvent.setup();
-
     (useMediaQuery as jest.Mock).mockReturnValue(false);
     renderLandingPage({
       getUser: jest.fn().mockImplementation(() => Promise.resolve(userMock)),
@@ -89,6 +88,20 @@ describe('LandingPage', () => {
 
     const iframe = screen.getByTitle(textMock('preview.title'));
     expect(iframe).toHaveAttribute('src', `/app-specific-preview/${org}/${app}?`);
+  });
+
+  it('should display a warning message when previewing a subform', async () => {
+    renderLandingPage({
+      getLayoutSets: jest
+        .fn()
+        .mockImplementation(() => Promise.resolve({ sets: [{ id: '', type: 'subform' }] })),
+    });
+
+    await waitForElementToBeRemoved(screen.queryByTitle(textMock('preview.loading_page')));
+
+    expect(
+      screen.getByText(textMock('ux_editor.preview.subform_unsupported_warning')),
+    ).toBeInTheDocument();
   });
 });
 

--- a/frontend/app-preview/src/views/LandingPage.tsx
+++ b/frontend/app-preview/src/views/LandingPage.tsx
@@ -8,7 +8,12 @@ import { AppPreviewSubMenu } from '../components/AppPreviewSubMenu';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { previewPage } from 'app-shared/api/paths';
 import { PreviewLimitationsInfo } from 'app-shared/components/PreviewLimitationsInfo/PreviewLimitationsInfo';
-import { StudioPageHeader, StudioPageSpinner, useMediaQuery } from '@studio/components';
+import {
+  StudioAlert,
+  StudioPageHeader,
+  StudioPageSpinner,
+  useMediaQuery,
+} from '@studio/components';
 import { UserProfileMenu } from '../components/UserProfileMenu';
 import { PreviewControlHeader } from '../components/PreviewControlHeader';
 import { MEDIA_QUERY_MAX_WIDTH } from 'app-shared/constants';
@@ -41,6 +46,9 @@ export const LandingPage = () => {
     data: instance,
     isPending: instanceIsPending,
   } = useCreatePreviewInstanceMutation(org, app);
+
+  const currentLayoutSet = layoutSets?.sets?.find((set) => set.id === selectedFormLayoutSetName);
+  const isSubform = currentLayoutSet?.type === 'subform';
 
   useEffect(() => {
     if (user && taskId) createInstance({ partyId: user?.id, taskId: taskId });
@@ -90,6 +98,11 @@ export const LandingPage = () => {
         </StudioPageHeader.Main>
         <StudioPageHeader.Sub>
           <AppPreviewSubMenu />
+          {isSubform && (
+            <StudioAlert severity='warning'>
+              {t('ux_editor.preview.subform_unsupported_warning')}
+            </StudioAlert>
+          )}
         </StudioPageHeader.Sub>
       </StudioPageHeader>
       <div className={classes.previewArea}>

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1844,7 +1844,7 @@
   "ux_editor.pages_error_empty": "Navnet kan ikke være tomt.",
   "ux_editor.pages_error_unique": "Det finnes allerede en side med dette navnet. Bruk et annet navn.",
   "ux_editor.preview": "Forhåndsvisning",
-  "ux_editor.preview.subform_unsupported_warning": "Underskjema er ikke støttet i forhåndsvisningen ennå.",
+  "ux_editor.preview.subform_unsupported_warning": "Foreløpig støtter vi ikke å forhåndsvise underskjemaer. Vi jobber med å få dette på plass!",
   "ux_editor.properties_panel.images.add_image_tab_title": "Legg til bilde",
   "ux_editor.properties_panel.images.cancel_image_upload": "Avbryt opplastning",
   "ux_editor.properties_panel.images.choose_from_library": "Velg fra biblioteket",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1844,7 +1844,7 @@
   "ux_editor.pages_error_empty": "Navnet kan ikke være tomt.",
   "ux_editor.pages_error_unique": "Det finnes allerede en side med dette navnet. Bruk et annet navn.",
   "ux_editor.preview": "Forhåndsvisning",
-  "ux_editor.preview.subform_unsupported_warning": "Foreløpig støtter vi ikke å forhåndsvise underskjemaer. Vi jobber med å få dette på plass!",
+  "ux_editor.preview.subform_unsupported_warning": "Vi kan foreløpig ikke forhåndvise underskjema, men vi jobber med å få det på plass.",
   "ux_editor.properties_panel.images.add_image_tab_title": "Legg til bilde",
   "ux_editor.properties_panel.images.cancel_image_upload": "Avbryt opplastning",
   "ux_editor.properties_panel.images.choose_from_library": "Velg fra biblioteket",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1844,6 +1844,7 @@
   "ux_editor.pages_error_empty": "Navnet kan ikke være tomt.",
   "ux_editor.pages_error_unique": "Det finnes allerede en side med dette navnet. Bruk et annet navn.",
   "ux_editor.preview": "Forhåndsvisning",
+  "ux_editor.preview.subform_unsupported_warning": "Underskjema er ikke støttet i forhåndsvisningen ennå.",
   "ux_editor.properties_panel.images.add_image_tab_title": "Legg til bilde",
   "ux_editor.properties_panel.images.cancel_image_upload": "Avbryt opplastning",
   "ux_editor.properties_panel.images.choose_from_library": "Velg fra biblioteket",

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.module.css
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.module.css
@@ -41,3 +41,7 @@
   width: 100%;
   height: 100%;
 }
+
+.alert {
+  margin: var(--fds-spacing-4);
+}

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.test.tsx
@@ -9,6 +9,7 @@ import { appContextMock } from '../../testing/appContextMock';
 import { previewPage } from 'app-shared/api/paths';
 import { TASKID_FOR_STATELESS_APPS } from 'app-shared/constants';
 import { app, org } from '@studio/testing/testids';
+import { subformLayoutMock } from '../../testing/subformLayoutMock';
 
 describe('Preview', () => {
   it('Renders an iframe with the ref from AppContext', async () => {
@@ -132,6 +133,16 @@ describe('Preview', () => {
         ),
     );
   });
+
+  it('should show a warning that subform is unsupported in preview', async () => {
+    appContextMock.selectedFormLayoutSetName = subformLayoutMock.layoutSetName;
+    render();
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTitle(textMock('preview.loading_preview_controller')),
+    );
+
+    expect(screen.getByText(/ux_editor.preview.subform_unsupported_warning/i)).toBeInTheDocument();
+  });
 });
 
 const collapseToggle = jest.fn();
@@ -141,6 +152,11 @@ export const render = (options: Partial<ExtendedRenderOptions> = {}) => {
   options = {
     ...options,
     queries: {
+      getLayoutSets: jest
+        .fn()
+        .mockImplementation(() =>
+          Promise.resolve({ sets: [{ id: subformLayoutMock.layoutSetName, type: 'subform' }] }),
+        ),
       createPreviewInstance: jest
         .fn()
         .mockImplementation(() => Promise.resolve({ id: mockInstanceId })),

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
@@ -141,7 +141,7 @@ const PreviewFrame = () => {
     <div className={classes.root}>
       <ViewToggler onChange={setViewportToSimulate} />
       {isSubform ? (
-        <StudioAlert severity='warning'>
+        <StudioAlert className={classes.alert} severity='warning'>
           {t('ux_editor.preview.subform_unsupported_warning')}
         </StudioAlert>
       ) : (

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
@@ -3,11 +3,17 @@ import classes from './Preview.module.css';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import cn from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { useAppContext } from '../../hooks';
+import { useAppContext, useGetLayoutSetByName } from '../../hooks';
 import { useChecksum } from '../../hooks/useChecksum.ts';
 import { previewPage } from 'app-shared/api/paths';
 import { Paragraph } from '@digdir/designsystemet-react';
-import { StudioButton, StudioCenter, StudioErrorMessage, StudioSpinner } from '@studio/components';
+import {
+  StudioAlert,
+  StudioButton,
+  StudioCenter,
+  StudioErrorMessage,
+  StudioSpinner,
+} from '@studio/components';
 import type { SupportedView } from './ViewToggler/ViewToggler';
 import { ViewToggler } from './ViewToggler/ViewToggler';
 import { ShrinkIcon } from '@studio/icons';
@@ -98,6 +104,9 @@ const PreviewFrame = () => {
     isPending: createInstancePending,
   } = useCreatePreviewInstanceMutation(org, app);
 
+  const currentLayoutSet = useGetLayoutSetByName({ name: selectedFormLayoutSetName, org, app });
+  const isSubform = currentLayoutSet?.type === 'subform';
+
   useEffect(() => {
     if (user && taskId) createInstance({ partyId: user?.id, taskId: taskId });
   }, [createInstance, user, taskId]);
@@ -131,6 +140,11 @@ const PreviewFrame = () => {
   return (
     <div className={classes.root}>
       <ViewToggler onChange={setViewportToSimulate} />
+      {isSubform && (
+        <StudioAlert severity='warning'>
+          {t('ux_editor.preview.subform_unsupported_warning')}
+        </StudioAlert>
+      )}
       <div className={classes.previewArea}>
         <div className={classes.iframeContainer}>
           <iframe

--- a/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
+++ b/frontend/packages/ux-editor/src/components/Preview/Preview.tsx
@@ -140,24 +140,25 @@ const PreviewFrame = () => {
   return (
     <div className={classes.root}>
       <ViewToggler onChange={setViewportToSimulate} />
-      {isSubform && (
+      {isSubform ? (
         <StudioAlert severity='warning'>
           {t('ux_editor.preview.subform_unsupported_warning')}
         </StudioAlert>
-      )}
-      <div className={classes.previewArea}>
-        <div className={classes.iframeContainer}>
-          <iframe
-            key={checksum}
-            ref={previewIframeRef}
-            className={cn(classes.iframe, classes[viewportToSimulate])}
-            title={t('ux_editor.preview')}
-            src={previewURL}
-            onLoad={previewHasLoaded}
-          />
+      ) : (
+        <div className={classes.previewArea}>
+          <div className={classes.iframeContainer}>
+            <iframe
+              key={checksum}
+              ref={previewIframeRef}
+              className={cn(classes.iframe, classes[viewportToSimulate])}
+              title={t('ux_editor.preview')}
+              src={previewURL}
+              onLoad={previewHasLoaded}
+            />
+          </div>
+          <PreviewLimitationsInfo />
         </div>
-        <PreviewLimitationsInfo />
-      </div>
+      )}
     </div>
   );
 };

--- a/frontend/packages/ux-editor/src/hooks/useGetLayoutSetByName.ts
+++ b/frontend/packages/ux-editor/src/hooks/useGetLayoutSetByName.ts
@@ -13,5 +13,5 @@ export const useGetLayoutSetByName = ({
   app,
 }: UseGetLayoutSetByName): LayoutSet | null => {
   const { data: layoutSetsResponse } = useLayoutSetsQuery(org, app);
-  return layoutSetsResponse.sets.find((set) => set.id === name);
+  return layoutSetsResponse?.sets.find((set) => set.id === name);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

![image](https://github.com/user-attachments/assets/e81f19c8-b513-4a70-8958-e1dc8d0ae997)
![image](https://github.com/user-attachments/assets/7c16c65a-b841-4dce-8fb3-3fd134c4493f)


## Related Issue(s)

- #14483 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added warning for unsupported subform previews in the UI.
  
- **Bug Fixes**
  - Improved error handling in layout set retrieval to prevent potential runtime errors.

- **Localization**
  - Added Norwegian translation for subform preview warning.

These updates enhance user communication regarding layout compatibility and improve the overall stability of the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->