### PR TITLE
fix: application insights requests

### DIFF
--- a/backend/src/Designer/Program.cs
+++ b/backend/src/Designer/Program.cs
@@ -197,25 +197,6 @@ void ConfigureServices(IServiceCollection services, IConfiguration configuration
 
     services.AddMaskinportenHttpClient<MaskinPortenClientDefinition>("MaskinportenHttpClient", maskinportenSettings);
 
-    services.RegisterServiceImplementations(configuration);
-
-    services.AddHttpContextAccessor();
-    services.AddMemoryCache();
-    services.AddResponseCompression();
-    services.AddHealthChecks().AddCheck<HealthCheck>("designer_health_check");
-
-    CreateDirectory(configuration);
-
-    services.ConfigureDataProtection(configuration, logger);
-    services.ConfigureMvc();
-    services.ConfigureNonMarkedSettings(configuration);
-
-    services.RegisterTypedHttpClients(configuration);
-    services.AddAnsattPortenAuthenticationAndAuthorization(configuration);
-    services.ConfigureAuthentication(configuration, env);
-
-    services.Configure<CacheSettings>(configuration.GetSection("CacheSettings"));
-
     // Add application insight telemetry
     if (!string.IsNullOrEmpty(applicationInsightsConnectionString))
     {
@@ -234,6 +215,25 @@ void ConfigureServices(IServiceCollection services, IConfiguration configuration
         services.AddApplicationInsightsTelemetryProcessor<HealthTelemetryFilter>();
         services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
     }
+
+    services.RegisterServiceImplementations(configuration);
+
+    services.AddHttpContextAccessor();
+    services.AddMemoryCache();
+    services.AddResponseCompression();
+    services.AddHealthChecks().AddCheck<HealthCheck>("designer_health_check");
+
+    CreateDirectory(configuration);
+
+    services.ConfigureDataProtection(configuration, logger);
+    services.ConfigureMvc();
+    services.ConfigureNonMarkedSettings(configuration);
+
+    services.RegisterTypedHttpClients(configuration);
+    services.AddAnsattPortenAuthenticationAndAuthorization(configuration);
+    services.ConfigureAuthentication(configuration, env);
+
+    services.Configure<CacheSettings>(configuration.GetSection("CacheSettings"));
 
     services.AddLocalization(options => options.ResourcesPath = "Resources");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Moves registration of application insights before calling Scrutor Decorate method.

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Restored service configurations in the application's backend setup
	- Reintegrated previously removed service registrations
	- Maintained existing logging and configuration behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->