### PR TITLE
fix: summary2 override combobox crash

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Summary2/Override/OverrideFields/Summary2OverrideDisplayType.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Summary2/Override/OverrideFields/Summary2OverrideDisplayType.tsx
@@ -27,8 +27,8 @@ export const Summary2OverrideDisplayType = ({
   };
 
   const checkboxOrMultipleselect =
-    override.componentId.includes(ComponentType.MultipleSelect) ||
-    override.componentId.includes(ComponentType.Checkboxes);
+    override.componentId?.includes(ComponentType.MultipleSelect) ||
+    override.componentId?.includes(ComponentType.Checkboxes);
 
   if (!checkboxOrMultipleselect) {
     return null;

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Summary2/Override/Summary2OverrideEntry.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Summary2/Override/Summary2OverrideEntry.tsx
@@ -39,9 +39,6 @@ export const Summary2OverrideEntry = ({
   onChange,
   onDelete,
 }: Summary2OverrideEntryProps) => {
-  const [currentComponentId, setCurrentComponentId] = useState<string | undefined>(
-    override.componentId,
-  );
   const { t } = useTranslation();
   const { org, app } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName } = useAppContext();
@@ -72,13 +69,6 @@ export const Summary2OverrideEntry = ({
     );
   }
 
-  const handleChangeComponent = (value: string) => {
-    setCurrentComponentId(value);
-
-    if (Boolean(value) || componentOptions.some((comp) => comp.id === value))
-      onChange({ ...override, componentId: value });
-  };
-
   return (
     <StudioCard className={classes.card}>
       <StudioCard.Content className={classes.content}>
@@ -86,7 +76,7 @@ export const Summary2OverrideEntry = ({
           label={t('ux_editor.component_properties.summary.override.choose_component')}
           value={override.componentId}
           options={componentOptions}
-          onValueChange={(value) => handleChangeComponent(value)}
+          onValueChange={(value) => onChange({ ...override, componentId: value })}
         ></Summary2ComponentReferenceSelector>
 
         <OverrideShowComponentSwitch onChange={onChange} override={override} />
@@ -111,7 +101,7 @@ export const Summary2OverrideEntry = ({
             variant='secondary'
             color='success'
             onClick={() => setOpen(false)}
-            disabled={!currentComponentId}
+            disabled={!override.componentId}
           />
           <StudioDeleteButton onDelete={onDelete}></StudioDeleteButton>
         </div>

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Summary2/Override/Summary2OverrideEntry.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Summary2/Override/Summary2OverrideEntry.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   StudioAlert,
   StudioButton,

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Summary2/Override/Summary2OverrideEntry.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Summary2/Override/Summary2OverrideEntry.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   StudioAlert,
   StudioButton,
@@ -39,6 +39,9 @@ export const Summary2OverrideEntry = ({
   onChange,
   onDelete,
 }: Summary2OverrideEntryProps) => {
+  const [currentComponentId, setCurrentComponentId] = useState<string | undefined>(
+    override.componentId,
+  );
   const { t } = useTranslation();
   const { org, app } = useStudioEnvironmentParams();
   const { selectedFormLayoutSetName } = useAppContext();
@@ -69,6 +72,13 @@ export const Summary2OverrideEntry = ({
     );
   }
 
+  const handleChangeComponent = (value: string) => {
+    setCurrentComponentId(value);
+
+    if (Boolean(value) || componentOptions.some((comp) => comp.id === value))
+      onChange({ ...override, componentId: value });
+  };
+
   return (
     <StudioCard className={classes.card}>
       <StudioCard.Content className={classes.content}>
@@ -76,7 +86,7 @@ export const Summary2OverrideEntry = ({
           label={t('ux_editor.component_properties.summary.override.choose_component')}
           value={override.componentId}
           options={componentOptions}
-          onValueChange={(value) => onChange({ ...override, componentId: value })}
+          onValueChange={(value) => handleChangeComponent(value)}
         ></Summary2ComponentReferenceSelector>
 
         <OverrideShowComponentSwitch onChange={onChange} override={override} />
@@ -101,7 +111,7 @@ export const Summary2OverrideEntry = ({
             variant='secondary'
             color='success'
             onClick={() => setOpen(false)}
-            disabled={!override.componentId}
+            disabled={!currentComponentId}
           />
           <StudioDeleteButton onDelete={onDelete}></StudioDeleteButton>
         </div>

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Summary2/Summary2ComponentReferenceSelector.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Summary2/Summary2ComponentReferenceSelector.tsx
@@ -21,6 +21,7 @@ export const Summary2ComponentReferenceSelector = ({
   const invalidMessage = invalidOption && t('ux_editor.component_properties.target_invalid');
   const requiredMessage = !value && t('ux_editor.component_properties.enum_Required');
   const errorMessage = invalidMessage || requiredMessage || false;
+
   return (
     <StudioCombobox
       size='small'
@@ -28,7 +29,6 @@ export const Summary2ComponentReferenceSelector = ({
       value={value ? [value] : []}
       onValueChange={(v) => onValueChange(v[0])}
       error={errorMessage}
-      multiple={false}
     >
       {options.map((option) => (
         <StudioCombobox.Option value={option.id} key={option.id} description={option.description}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Prevent studio crash when pressing backspace in Summary2 override combobox.

Sidenote: The combobox behavior when using backspace is not ideal. Since the combobox returns a value of undefined, it removes the entire text. I couldn't find a better solution without refactoring and introducing states. For now, I think this behavior is acceptable, but I’m open to addressing this as well. What do you think?

<!--- Describe your changes in detail -->

## Related Issue(s)

- #14477

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced error handling by adding optional chaining in component configuration checks
	- Modified component reference selector to potentially support multiple selections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->