### PR TITLE
feat: create frontend mock endpoint for get codelists

### DIFF
--- a/frontend/packages/shared/src/api/queries.ts
+++ b/frontend/packages/shared/src/api/queries.ts
@@ -98,6 +98,7 @@ import type { OptionListReferences } from 'app-shared/types/OptionListReferences
 import type { LayoutSetsModel } from '../types/api/dto/LayoutSetsModel';
 import type { AccessPackageResource, PolicyAccessPackageAreaGroup } from 'app-shared/types/PolicyAccessPackages';
 import type { DataType } from '../types/DataType';
+import type { CodeList } from '@studio/components';
 
 export const getIsLoggedInWithAnsattporten = () => get<{ isLoggedIn: boolean }>(authStatusAnsattporten());
 export const getMaskinportenScopes = (org: string, app: string) => get<MaskinportenScopes>(availableMaskinportenScopesPath(org, app));
@@ -174,3 +175,39 @@ export const getProcessTaskType = (org: string, app: string, taskId: string) => 
 
 // Contact Page
 export const fetchBelongsToGiteaOrg = () => get(belongsToOrg());
+
+// Org level code lists
+
+const orgLevelCodeListsMock: CodeList[] = [
+  [
+    {
+      description: 'description1',
+      helpText: 'helpText1',
+      label: 'label1',
+      value: 'value1',
+    },
+    {
+      description: 'description2',
+      helpText: 'helpText2',
+      label: 'label2',
+      value: true,
+    },
+  ],
+  [
+    {
+      description: 'description3',
+      helpText: 'helpText3',
+      label: 'label3',
+      value: 3,
+    },
+  ],
+];
+export const getOrgLevelCodeLists = async (): Promise<CodeList[]> =>
+  // TODO: Replace with endpoint when it is ready in backend.
+  new Promise((resolve) => {
+    setTimeout(() => {
+      // Replace the two resolves to test with empty list
+      // resolve([]);
+      resolve(orgLevelCodeListsMock);
+    }, 1000);
+  });

--- a/frontend/packages/shared/src/api/queries.ts
+++ b/frontend/packages/shared/src/api/queries.ts
@@ -98,7 +98,6 @@ import type { OptionListReferences } from 'app-shared/types/OptionListReferences
 import type { LayoutSetsModel } from '../types/api/dto/LayoutSetsModel';
 import type { AccessPackageResource, PolicyAccessPackageAreaGroup } from 'app-shared/types/PolicyAccessPackages';
 import type { DataType } from '../types/DataType';
-import type { CodeList } from '@studio/components';
 
 export const getIsLoggedInWithAnsattporten = () => get<{ isLoggedIn: boolean }>(authStatusAnsattporten());
 export const getMaskinportenScopes = (org: string, app: string) => get<MaskinportenScopes>(availableMaskinportenScopesPath(org, app));
@@ -177,37 +176,34 @@ export const getProcessTaskType = (org: string, app: string, taskId: string) => 
 export const fetchBelongsToGiteaOrg = () => get(belongsToOrg());
 
 // Org level code lists
-
-const orgLevelCodeListsMock: CodeList[] = [
+const orgLevelCodeListsMock: OptionListsResponse[] = [
   [
     {
-      description: 'description1',
-      helpText: 'helpText1',
-      label: 'label1',
-      value: 'value1',
+      title: 'title1',
+      data: [
+        { label: 'label1', value: 'value1' },
+        { label: 'label2', value: 'value2' },
+      ],
+      hasError: false,
     },
     {
-      description: 'description2',
-      helpText: 'helpText2',
-      label: 'label2',
-      value: true,
+      title: 'title2',
+      data: [],
+      hasError: false,
     },
   ],
   [
     {
-      description: 'description3',
-      helpText: 'helpText3',
-      label: 'label3',
-      value: 3,
+      title: 'title3',
+      data: [],
+      hasError: false,
     },
   ],
 ];
-export const getOrgLevelCodeLists = async (): Promise<CodeList[]> =>
-  // TODO: Replace with endpoint when it is ready in backend.
+export const getOrgLevelCodeLists = async (org: string): Promise<OptionListsResponse[]> =>
+  // TODO: Replace with endpoint when it is ready in backend. https://github.com/Altinn/altinn-studio/issues/14482
   new Promise((resolve) => {
     setTimeout(() => {
-      // Replace the two resolves to test with empty list
-      // resolve([]);
       resolve(orgLevelCodeListsMock);
-    }, 1000);
+    }, 200);
   });

--- a/frontend/packages/shared/src/hooks/queries/useOrgLevelCodeListsQuery.test.ts
+++ b/frontend/packages/shared/src/hooks/queries/useOrgLevelCodeListsQuery.test.ts
@@ -4,7 +4,7 @@ import { waitFor } from '@testing-library/react';
 import { useOrgLevelCodeListsQuery } from './useOrgLevelCodeListsQuery';
 
 describe('useOrgLevelCodeListsQuery', () => {
-  it('calls getOptionListsReferences with the correct parameters', () => {
+  it('calls getOrgLevelCodeLists with the correct parameters', () => {
     render();
     expect(queriesMock.getOrgLevelCodeLists).toHaveBeenCalledWith();
     expect(queriesMock.getOrgLevelCodeLists).toHaveBeenCalledTimes(1);

--- a/frontend/packages/shared/src/hooks/queries/useOrgLevelCodeListsQuery.test.ts
+++ b/frontend/packages/shared/src/hooks/queries/useOrgLevelCodeListsQuery.test.ts
@@ -1,0 +1,18 @@
+import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { renderHookWithProviders } from 'app-shared/mocks/renderHookWithProviders';
+import { waitFor } from '@testing-library/react';
+import { useOrgLevelCodeListsQuery } from './useOrgLevelCodeListsQuery';
+
+describe('useOrgLevelCodeListsQuery', () => {
+  it('calls getOptionListsReferences with the correct parameters', () => {
+    render();
+    expect(queriesMock.getOrgLevelCodeLists).toHaveBeenCalledWith();
+    expect(queriesMock.getOrgLevelCodeLists).toHaveBeenCalledTimes(1);
+  });
+});
+
+const render = async () => {
+  const { result } = renderHookWithProviders(() => useOrgLevelCodeListsQuery());
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  return result;
+};

--- a/frontend/packages/shared/src/hooks/queries/useOrgLevelCodeListsQuery.ts
+++ b/frontend/packages/shared/src/hooks/queries/useOrgLevelCodeListsQuery.ts
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
-import type { CodeList } from '@studio/components';
+import type { OptionListsResponse } from 'app-shared/types/api/OptionListsResponse';
 
 export const useOrgLevelCodeListsQuery = () => {
   const { getOrgLevelCodeLists } = useServicesContext();
-  return useQuery<CodeList[]>({
+  return useQuery<OptionListsResponse[]>({
     queryKey: [QueryKey.OrgLevelCodeLists],
     queryFn: () => getOrgLevelCodeLists(),
   });

--- a/frontend/packages/shared/src/hooks/queries/useOrgLevelCodeListsQuery.ts
+++ b/frontend/packages/shared/src/hooks/queries/useOrgLevelCodeListsQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
+import type { CodeList } from '@studio/components';
+
+export const useOrgLevelCodeListsQuery = () => {
+  const { getOrgLevelCodeLists } = useServicesContext();
+  return useQuery<CodeList[]>({
+    queryKey: [QueryKey.OrgLevelCodeLists],
+    queryFn: () => getOrgLevelCodeLists(),
+  });
+};

--- a/frontend/packages/shared/src/mocks/queriesMock.ts
+++ b/frontend/packages/shared/src/mocks/queriesMock.ts
@@ -77,6 +77,7 @@ import type { OptionListsResponse } from 'app-shared/types/api/OptionListsRespon
 
 export const queriesMock: ServicesContextProps = {
   // Queries
+  getOrgLevelCodeLists: jest.fn().mockImplementation(() => Promise.resolve([])),
   getAppMetadataModelIds: jest.fn().mockImplementation(() => Promise.resolve<string[]>([])),
   getAppReleases: jest
     .fn()

--- a/frontend/packages/shared/src/types/QueryKey.ts
+++ b/frontend/packages/shared/src/types/QueryKey.ts
@@ -49,6 +49,7 @@ export enum QueryKey {
   AppScopes = 'AppScopes',
   SelectedAppScopes = 'SelectedAppScopes',
   DataType = 'DataType',
+  OrgLevelCodeLists = 'OrgLevelCodeLists',
 
   // Resourceadm
   ResourceList = 'ResourceList',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Creating mock endpoint in frontend for get code lists

## Related Issue(s)

- #14501 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added support for fetching organizational level code lists.
	- Introduced a new custom hook for retrieving code lists.
	- Expanded query key enumeration to support new code list queries.

- **Chores**
	- Added mock implementations for testing and development purposes.

The changes enhance the application's data retrieval capabilities for organizational code lists with a new query mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->