### PR TITLE
feat: frontend mock endpoint create codelist

### DIFF
--- a/frontend/packages/shared/src/api/mutations.ts
+++ b/frontend/packages/shared/src/api/mutations.ts
@@ -75,6 +75,7 @@ import type { FormLayoutRequest } from 'app-shared/types/api/FormLayoutRequest';
 import type { Option } from 'app-shared/types/Option';
 import type { MaskinportenScopes } from 'app-shared/types/MaskinportenScope';
 import type { DataType } from '../types/DataType';
+import type { CodeList } from '@studio/components';
 
 const headers = {
   Accept: 'application/json',
@@ -167,3 +168,12 @@ export const updateProcessDataTypes = (org: string, app: string, dataTypesChange
 
 // Maskinporten
 export const updateSelectedMaskinportenScopes = (org: string, app: string, appScopesUpsertRequest: MaskinportenScopes) => put(selectedMaskinportenScopesPath(org, app), appScopesUpsertRequest);
+
+// Org level code lists - TODO: Replace mocks with correct paths.
+export const createOrgLevelCodeList = async (codeListItem: CodeList): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(() => {
+      console.log('Code list created:', codeListItem);
+      resolve();
+    }, 1000);
+  });

--- a/frontend/packages/shared/src/api/mutations.ts
+++ b/frontend/packages/shared/src/api/mutations.ts
@@ -169,11 +169,11 @@ export const updateProcessDataTypes = (org: string, app: string, dataTypesChange
 // Maskinporten
 export const updateSelectedMaskinportenScopes = (org: string, app: string, appScopesUpsertRequest: MaskinportenScopes) => put(selectedMaskinportenScopesPath(org, app), appScopesUpsertRequest);
 
-// Org level code lists - TODO: Replace mocks with correct paths.
+// Org level code lists
 export const createOrgLevelCodeList = async (codeListItem: OptionListsResponse): Promise<void> =>
+  // TODO: Replace with endpoint when it is ready in backend. https://github.com/Altinn/altinn-studio/issues/14482
   new Promise((resolve) => {
     setTimeout(() => {
-      console.log('Code list created:', codeListItem);
       resolve();
-    }, 1000);
+    }, 200);
   });

--- a/frontend/packages/shared/src/api/mutations.ts
+++ b/frontend/packages/shared/src/api/mutations.ts
@@ -75,7 +75,7 @@ import type { FormLayoutRequest } from 'app-shared/types/api/FormLayoutRequest';
 import type { Option } from 'app-shared/types/Option';
 import type { MaskinportenScopes } from 'app-shared/types/MaskinportenScope';
 import type { DataType } from '../types/DataType';
-import type { CodeList } from '@studio/components';
+import type { OptionListsResponse } from 'app-shared/types/api/OptionListsResponse';
 
 const headers = {
   Accept: 'application/json',
@@ -170,7 +170,7 @@ export const updateProcessDataTypes = (org: string, app: string, dataTypesChange
 export const updateSelectedMaskinportenScopes = (org: string, app: string, appScopesUpsertRequest: MaskinportenScopes) => put(selectedMaskinportenScopesPath(org, app), appScopesUpsertRequest);
 
 // Org level code lists - TODO: Replace mocks with correct paths.
-export const createOrgLevelCodeList = async (codeListItem: CodeList): Promise<void> =>
+export const createOrgLevelCodeList = async (codeListItem: OptionListsResponse): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(() => {
       console.log('Code list created:', codeListItem);

--- a/frontend/packages/shared/src/hooks/mutations/useCreateOrgLevelCodeListMutation.test.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useCreateOrgLevelCodeListMutation.test.ts
@@ -4,14 +4,16 @@ import { useCreateOrgLevelCodeListMutation } from './useCreateOrgLevelCodeListMu
 import { waitFor } from '@testing-library/react';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { QueryKey } from 'app-shared/types/QueryKey';
-import type { CodeList } from '@studio/components';
+import type { OptionListsResponse } from 'app-shared/types/api/OptionListsResponse';
 
-const newCodeList: CodeList = [
+const newCodeList: OptionListsResponse = [
   {
-    description: 'description1',
-    helpText: 'helpText1',
-    label: 'label1',
-    value: 'value1',
+    title: 'title',
+    data: [
+      { label: 'label1', value: 'value1' },
+      { label: 'label2', value: 'value2' },
+    ],
+    hasError: false,
   },
 ];
 
@@ -27,7 +29,7 @@ describe('useCreateOrgLevelCodeListMutation', () => {
     expect(queriesMock.createOrgLevelCodeList).toHaveBeenCalledWith(newCodeList);
   });
 
-  it('Invalidates imageFileNames when deleting an image', async () => {
+  it('Invalidates query key', async () => {
     const client = createQueryClientMock();
     const invalidateQueriesSpy = jest.spyOn(client, 'invalidateQueries');
     const result = renderHookWithProviders({}, client)(() => useCreateOrgLevelCodeListMutation())

--- a/frontend/packages/shared/src/hooks/mutations/useCreateOrgLevelCodeListMutation.test.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useCreateOrgLevelCodeListMutation.test.ts
@@ -1,0 +1,44 @@
+import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { renderHookWithProviders } from 'app-development/test/mocks';
+import { useCreateOrgLevelCodeListMutation } from './useCreateOrgLevelCodeListMutation';
+import { waitFor } from '@testing-library/react';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import type { CodeList } from '@studio/components';
+
+const newCodeList: CodeList = [
+  {
+    description: 'description1',
+    helpText: 'helpText1',
+    label: 'label1',
+    value: 'value1',
+  },
+];
+
+describe('useCreateOrgLevelCodeListMutation', () => {
+  it('Calls createOrgLevelCodeList with correct arguments and payload', async () => {
+    const result = renderHookWithProviders()(() => useCreateOrgLevelCodeListMutation())
+      .renderHookResult.result;
+
+    result.current.mutate(newCodeList);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(queriesMock.createOrgLevelCodeList).toHaveBeenCalledTimes(1);
+    expect(queriesMock.createOrgLevelCodeList).toHaveBeenCalledWith(newCodeList);
+  });
+
+  it('Invalidates imageFileNames when deleting an image', async () => {
+    const client = createQueryClientMock();
+    const invalidateQueriesSpy = jest.spyOn(client, 'invalidateQueries');
+    const result = renderHookWithProviders({}, client)(() => useCreateOrgLevelCodeListMutation())
+      .renderHookResult.result;
+
+    result.current.mutate(newCodeList);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledTimes(1);
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: [QueryKey.OrgLevelCodeLists],
+    });
+  });
+});

--- a/frontend/packages/shared/src/hooks/mutations/useCreateOrgLevelCodeListMutation.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useCreateOrgLevelCodeListMutation.ts
@@ -1,13 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
-import type { CodeList } from '@studio/components';
+import type { OptionListsResponse } from 'app-shared/types/api/OptionListsResponse';
 
 export const useCreateOrgLevelCodeListMutation = () => {
   const q = useQueryClient();
   const { createOrgLevelCodeList } = useServicesContext();
   return useMutation({
-    mutationFn: (codeListItem: CodeList) => createOrgLevelCodeList(codeListItem),
+    mutationFn: (codeListItem: OptionListsResponse) => createOrgLevelCodeList(codeListItem),
     onSuccess: () => Promise.all([q.invalidateQueries({ queryKey: [QueryKey.OrgLevelCodeLists] })]),
   });
 };

--- a/frontend/packages/shared/src/hooks/mutations/useCreateOrgLevelCodeListMutation.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useCreateOrgLevelCodeListMutation.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import type { CodeList } from '@studio/components';
+
+export const useCreateOrgLevelCodeListMutation = () => {
+  const q = useQueryClient();
+  const { createOrgLevelCodeList } = useServicesContext();
+  return useMutation({
+    mutationFn: (codeListItem: CodeList) => createOrgLevelCodeList(codeListItem),
+    onSuccess: () => Promise.all([q.invalidateQueries({ queryKey: [QueryKey.OrgLevelCodeLists] })]),
+  });
+};

--- a/frontend/packages/shared/src/mocks/queriesMock.ts
+++ b/frontend/packages/shared/src/mocks/queriesMock.ts
@@ -198,6 +198,7 @@ export const queriesMock: ServicesContextProps = {
     .mockImplementation(() => Promise.resolve({ belongsToOrg: true })),
 
   // Mutations
+  createOrgLevelCodeList: jest.fn().mockImplementation(() => Promise.resolve()),
   addAppAttachmentMetadata: jest.fn().mockImplementation(() => Promise.resolve()),
   addDataTypeToAppMetadata: jest.fn().mockImplementation(() => Promise.resolve()),
   addImage: jest.fn().mockImplementation(() => Promise.resolve()),

--- a/frontend/packages/shared/src/types/QueryKey.ts
+++ b/frontend/packages/shared/src/types/QueryKey.ts
@@ -49,6 +49,7 @@ export enum QueryKey {
   AppScopes = 'AppScopes',
   SelectedAppScopes = 'SelectedAppScopes',
   DataType = 'DataType',
+  OrgLevelCodeLists = 'OrgLevelCodeLists',
 
   // Resourceadm
   ResourceList = 'ResourceList',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Creating mock endpoint in frontend for create new code list

## Related Issue(s)

- #14501 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added functionality to create organization-level code lists.
	- Implemented a new mutation hook for creating code lists.
	- Introduced a new query key for organization-level code lists.

- **Tests**
	- Added comprehensive unit tests for the new code list creation mutation hook.

- **Chores**
	- Updated mock functions to support new code list creation functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->