### PR TITLE
feat: frontend mock endpoint to edit org codelist

### DIFF
--- a/frontend/packages/shared/src/api/mutations.ts
+++ b/frontend/packages/shared/src/api/mutations.ts
@@ -169,11 +169,12 @@ export const updateProcessDataTypes = (org: string, app: string, dataTypesChange
 // Maskinporten
 export const updateSelectedMaskinportenScopes = (org: string, app: string, appScopesUpsertRequest: MaskinportenScopes) => put(selectedMaskinportenScopesPath(org, app), appScopesUpsertRequest);
 
-// Org level code lists - TODO: Replace mocks with correct paths.
+// Org level code lists
 export const editOrgLevelCodeList = async (codeListItem: OptionListsResponse): Promise<void> =>
+  // TODO: Replace with endpoint when it is ready in backend. https://github.com/Altinn/altinn-studio/issues/14482
   new Promise((resolve) => {
     setTimeout(() => {
       console.log('Code list edited:', codeListItem);
       resolve();
-    }, 1000);
+    }, 200);
   });

--- a/frontend/packages/shared/src/api/mutations.ts
+++ b/frontend/packages/shared/src/api/mutations.ts
@@ -75,6 +75,7 @@ import type { FormLayoutRequest } from 'app-shared/types/api/FormLayoutRequest';
 import type { Option } from 'app-shared/types/Option';
 import type { MaskinportenScopes } from 'app-shared/types/MaskinportenScope';
 import type { DataType } from '../types/DataType';
+import type { OptionListsResponse } from 'app-shared/types/api/OptionListsResponse';
 
 const headers = {
   Accept: 'application/json',
@@ -167,3 +168,12 @@ export const updateProcessDataTypes = (org: string, app: string, dataTypesChange
 
 // Maskinporten
 export const updateSelectedMaskinportenScopes = (org: string, app: string, appScopesUpsertRequest: MaskinportenScopes) => put(selectedMaskinportenScopesPath(org, app), appScopesUpsertRequest);
+
+// Org level code lists - TODO: Replace mocks with correct paths.
+export const editOrgLevelCodeList = async (codeListItem: OptionListsResponse): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(() => {
+      console.log('Code list edited:', codeListItem);
+      resolve();
+    }, 1000);
+  });

--- a/frontend/packages/shared/src/hooks/mutations/useEditOrgCodeListMutation.test.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useEditOrgCodeListMutation.test.ts
@@ -1,0 +1,46 @@
+import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { renderHookWithProviders } from 'app-development/test/mocks';
+import { useEditOrgCodeListMutation } from './useEditOrgCodeListMutation';
+import { waitFor } from '@testing-library/react';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import type { OptionListsResponse } from 'app-shared/types/api/OptionListsResponse';
+
+const codeListToEdit: OptionListsResponse = [
+  {
+    title: 'title',
+    data: [
+      { label: 'label1', value: 'value1' },
+      { label: 'label2', value: 'value2' },
+    ],
+    hasError: false,
+  },
+];
+
+describe('useEditOrgCodeListMutation', () => {
+  it('Calls editOrgLevelCodeList with correct arguments and payload', async () => {
+    const result = renderHookWithProviders()(() => useEditOrgCodeListMutation()).renderHookResult
+      .result;
+
+    result.current.mutate(codeListToEdit);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(queriesMock.editOrgLevelCodeList).toHaveBeenCalledTimes(1);
+    expect(queriesMock.editOrgLevelCodeList).toHaveBeenCalledWith(codeListToEdit);
+  });
+
+  it('Invalidates query key', async () => {
+    const client = createQueryClientMock();
+    const invalidateQueriesSpy = jest.spyOn(client, 'invalidateQueries');
+    const result = renderHookWithProviders({}, client)(() => useEditOrgCodeListMutation())
+      .renderHookResult.result;
+
+    result.current.mutate(codeListToEdit);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledTimes(1);
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: [QueryKey.OrgLevelCodeLists],
+    });
+  });
+});

--- a/frontend/packages/shared/src/hooks/mutations/useEditOrgCodeListMutation.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useEditOrgCodeListMutation.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
+import type { OptionListsResponse } from 'app-shared/types/api/OptionListsResponse';
+import { QueryKey } from 'app-shared/types/QueryKey';
+
+export const useEditOrgCodeListMutation = () => {
+  const q = useQueryClient();
+  const { editOrgLevelCodeList } = useServicesContext();
+  return useMutation({
+    mutationFn: (codeListItem: OptionListsResponse) => editOrgLevelCodeList(codeListItem),
+    onSuccess: () => Promise.all([q.invalidateQueries({ queryKey: [QueryKey.OrgLevelCodeLists] })]),
+  });
+};

--- a/frontend/packages/shared/src/mocks/queriesMock.ts
+++ b/frontend/packages/shared/src/mocks/queriesMock.ts
@@ -203,6 +203,7 @@ export const queriesMock: ServicesContextProps = {
     .mockImplementation(() => Promise.resolve({ belongsToOrg: true })),
 
   // Mutations
+  editOrgLevelCodeList: jest.fn().mockImplementation(() => Promise.resolve()),
   addAppAttachmentMetadata: jest.fn().mockImplementation(() => Promise.resolve()),
   addDataTypeToAppMetadata: jest.fn().mockImplementation(() => Promise.resolve()),
   addImage: jest.fn().mockImplementation(() => Promise.resolve()),

--- a/frontend/packages/shared/src/types/QueryKey.ts
+++ b/frontend/packages/shared/src/types/QueryKey.ts
@@ -48,8 +48,8 @@ export enum QueryKey {
   IsLoggedInWithAnsattporten = 'IsLoggedInWithAnsattporten',
   AppScopes = 'AppScopes',
   SelectedAppScopes = 'SelectedAppScopes',
-  UserOrgPermissions = 'UserOrgPermissions',
   DataType = 'DataType',
+  OrgLevelCodeLists = 'OrgLevelCodeLists',
 
   // Resourceadm
   ResourceList = 'ResourceList',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Creating mock endpoint in frontend for edit org code list

## Related Issue(s)

- #14501 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added functionality to edit organization-level code lists
  - Introduced a new custom mutation hook for managing code list updates

- **Improvements**
  - Enhanced query key management for better data synchronization
  - Improved type definitions for API interactions

- **Testing**
  - Added comprehensive unit tests for the new code list mutation hook

<!-- end of auto-generated comment: release notes by coderabbit.ai -->