### PR TITLE
fix: use built in provider declaration for previewContext in render function for mocks

### DIFF
--- a/frontend/app-development/test/mocks.tsx
+++ b/frontend/app-development/test/mocks.tsx
@@ -9,8 +9,7 @@ import { PreviewConnectionContextProvider } from 'app-shared/providers/PreviewCo
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 import type { QueryClient } from '@tanstack/react-query';
 import { queryClientConfigMock } from 'app-shared/mocks/queryClientMock';
-import type { PreviewContextProps } from '../contexts/PreviewContext';
-import { PreviewContextProvider } from '../contexts/PreviewContext';
+import { PreviewContext, type PreviewContextProps } from '../contexts/PreviewContext';
 
 export const renderWithProviders =
   (
@@ -27,9 +26,11 @@ export const renderWithProviders =
         clientConfig={queryClientConfigMock}
       >
         <PreviewConnectionContextProvider>
-          <PreviewContextProvider {...defaultPreviewContextProps} {...previewContextProps}>
+          <PreviewContext.Provider
+            value={{ ...defaultPreviewContextProps, ...previewContextProps }}
+          >
             <BrowserRouter>{component}</BrowserRouter>
-          </PreviewContextProvider>
+          </PreviewContext.Provider>
         </PreviewConnectionContextProvider>
       </ServicesContextProvider>,
     );
@@ -42,9 +43,11 @@ export const renderWithProviders =
           clientConfig={queryClientConfigMock}
         >
           <PreviewConnectionContextProvider>
-            <PreviewContextProvider {...defaultPreviewContextProps} {...previewContextProps}>
+            <PreviewContext.Provider
+              value={{ ...defaultPreviewContextProps, ...previewContextProps }}
+            >
               <BrowserRouter>{rerenderedComponent}</BrowserRouter>
-            </PreviewContextProvider>
+            </PreviewContext.Provider>
           </PreviewConnectionContextProvider>
         </ServicesContextProvider>,
       );


### PR DESCRIPTION
## Description

Use built in provider declaration for previewContext in render function for mocks, instead of the custom prover component. The custom provider component does not allow setting the context-value from outside.

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated context provider implementation in test mocking utility
	- Modified how preview context is passed during component rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->