### PR TITLE
fix: tablecolumns saving/deleting a column affects other columns

### DIFF
--- a/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/ColumnElement/ColumnElement.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/ColumnElement/ColumnElement.test.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import { ColumnElement, type ColumnElementProps } from './ColumnElement';
 import { textMock } from '@studio/testing/mocks/i18nMock';
-import { renderWithProviders } from 'dashboard/testing/mocks';
+import { renderWithProviders } from '../../../../testing/mocks';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 import userEvent from '@testing-library/user-event';
-import { type TableColumn } from '../types/TableColumn';
+import type { TableColumn } from '../types/TableColumn';
 import { layoutSet3SubformNameMock } from '../../../../testing/layoutSetsMock';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { app, org } from '@studio/testing/testids';
@@ -30,21 +30,25 @@ const defaultProps: ColumnElementProps = {
   columnNumber: columnNumberMock,
   isInitialOpenForEdit: false,
   onDeleteColumn: jest.fn(),
-  onEdit: jest.fn(),
+  onChange: jest.fn(),
   subformLayout: layoutSet3SubformNameMock,
 };
 
 describe('ColumnElement', () => {
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should call onEdit with updated header content when click on save button', async () => {
-    const onEditMock = jest.fn();
+  it('should call onChange with component values when selecting component', async () => {
+    const onChangeMock = jest.fn();
 
     const user = userEvent.setup();
     renderColumnElement({
-      onEdit: onEditMock,
+      onChange: onChangeMock,
+      tableColumn: {
+        headerContent: subformLayoutMock.component4.textResourceBindings.title,
+        cellContent: { query: subformLayoutMock.component4.dataModelBindings.address },
+      },
     });
 
     const editButton = screen.getByRole('button', {
@@ -58,35 +62,18 @@ describe('ColumnElement', () => {
 
     await user.click(componentSelect);
     await user.click(
-      screen.getByRole('option', { name: new RegExp(`${subformLayoutMock.component3Id}`) }),
-    );
-
-    await screen.findByText(
-      textMock(
-        'ux_editor.properties_panel.subform_table_columns.column_multiple_data_model_bindings_label',
-      ),
-    );
-
-    await user.click(
-      await screen.findByText(
-        textMock('ux_editor.properties_panel.subform_table_columns.column_title_unedit'),
-      ),
-    );
-    await user.type(
-      screen.getByText(
-        textMock('ux_editor.properties_panel.subform_table_columns.column_title_edit'),
-      ),
-      'New Title',
+      screen.getByRole('option', { name: new RegExp(`${subformLayoutMock.component4Id}`) }),
     );
 
     const saveButton = await screen.findByRole('button', { name: textMock('general.save') });
     await user.click(saveButton);
 
-    expect(onEditMock).toHaveBeenCalledTimes(1);
-    expect(onEditMock).toHaveBeenCalledWith({
+    expect(onChangeMock).toHaveBeenCalledWith({
       ...mockTableColumn,
-      headerContent: expect.stringContaining('subform_table_column_title_'),
-      cellContent: { query: subformLayoutMock.component3.dataModelBindings.simpleBinding },
+      cellContent: {
+        query: subformLayoutMock.component4.dataModelBindings.address,
+      },
+      headerContent: subformLayoutMock.component4.textResourceBindings.title,
     });
   });
 
@@ -133,6 +120,7 @@ const renderColumnElement = (props: Partial<ColumnElementProps> = {}) => {
     [QueryKey.FormLayouts, org, app, layoutSet3SubformNameMock],
     subformLayoutMock.layoutSet,
   );
+
   return renderWithProviders(<ColumnElement {...defaultProps} {...props} />, {
     ...queriesMock,
     queryClient,

--- a/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/ColumnElement/ColumnElement.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/ColumnElement/ColumnElement.tsx
@@ -1,12 +1,13 @@
 import React, { useState, type ReactElement } from 'react';
 import classes from './ColumnElement.module.css';
-import { type TableColumn } from '../types/TableColumn';
+import type { TableColumn } from '../types/TableColumn';
 import { useTranslation } from 'react-i18next';
 import { StudioProperty } from '@studio/components';
 import { EditColumnElement } from './EditColumnElement';
 import { useTextResourcesQuery } from 'app-shared/hooks/queries';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { textResourceByLanguageAndIdSelector } from '../../../../selectors/textResourceSelectors';
+import { DEFAULT_LANGUAGE } from 'app-shared/constants';
 
 export type ColumnElementProps = {
   subformLayout: string;
@@ -14,7 +15,7 @@ export type ColumnElementProps = {
   columnNumber: number;
   isInitialOpenForEdit: boolean;
   onDeleteColumn: () => void;
-  onEdit: (tableColumn: TableColumn) => void;
+  onChange: (tableColumn: TableColumn) => void;
 };
 
 export const ColumnElement = ({
@@ -22,7 +23,7 @@ export const ColumnElement = ({
   columnNumber,
   isInitialOpenForEdit,
   onDeleteColumn,
-  onEdit,
+  onChange,
   subformLayout,
 }: ColumnElementProps): ReactElement => {
   const { t } = useTranslation();
@@ -30,21 +31,20 @@ export const ColumnElement = ({
   const { org, app } = useStudioEnvironmentParams();
   const { data: textResources } = useTextResourcesQuery(org, app);
 
-  const textKeyValue = textResourceByLanguageAndIdSelector(
-    'nb',
-    tableColumn.headerContent,
-  )(textResources)?.value;
+  const textKeyValue =
+    textResourceByLanguageAndIdSelector(DEFAULT_LANGUAGE, tableColumn?.headerContent)(textResources)
+      ?.value || tableColumn?.headerContent;
 
   if (editing) {
     return (
       <EditColumnElement
         subformLayout={subformLayout}
-        sourceColumn={tableColumn}
+        tableColumn={tableColumn}
         columnNumber={columnNumber}
         onDeleteColumn={onDeleteColumn}
-        onEdit={(col) => {
+        onChange={onChange}
+        onClose={() => {
           setEditing(false);
-          onEdit(col);
         }}
       />
     );

--- a/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/ColumnElement/EditColumnElement/EditColumnElementContent.module.css
+++ b/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/ColumnElement/EditColumnElement/EditColumnElementContent.module.css
@@ -1,15 +1,7 @@
-.componentTitleButton,
-.componentCellContent {
-  padding-left: var(--fds-spacing-1);
-}
-
-.componentTitleButton > span:first-child {
-  display: flex;
-  gap: var(--fds-spacing-1);
-}
-
-.componentTitleButton {
-  margin-bottom: var(--fds-spacing-1);
+.textResource > button,
+.textResource > fieldset {
+  margin-inline: 0px;
+  padding-inline: 0px;
 }
 
 .componentCellContent {

--- a/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/ColumnElement/EditColumnElement/EditColumnElementContent.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/ColumnElement/EditColumnElement/EditColumnElementContent.tsx
@@ -1,52 +1,48 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-import { StudioCodeFragment, StudioProperty, StudioTextfield } from '@studio/components';
+import { StudioCodeFragment } from '@studio/components';
 import { Trans, useTranslation } from 'react-i18next';
+import { TextResource } from '../../../../TextResource/TextResource';
+import type { TableColumn } from '../../types/TableColumn';
 import classes from './EditColumnElementContent.module.css';
+import { generateRandomId } from 'app-shared/utils/generateRandomId';
 
 type EditColumnElementContentProps = {
-  title: string;
-  setTitle: (title: string) => void;
-  cellContent: string;
+  subformLayout: string;
+  tableColumn: TableColumn;
+  onChange: (updatedTableColumn: TableColumn) => void;
 };
 
 export const EditColumnElementContent = ({
-  title,
-  setTitle,
-  cellContent,
+  subformLayout,
+  tableColumn,
+  onChange,
 }: EditColumnElementContentProps) => {
-  const [isEditingTitle, setIsEditingTitle] = useState<boolean>(false);
   const { t } = useTranslation();
 
-  const errorMessage = t('ux_editor.properties_panel.subform_table_columns.column_title_error');
-
   return (
-    <div>
-      {isEditingTitle ? (
-        <StudioTextfield
+    <>
+      <div className={classes.textResource}>
+        <TextResource
           label={t('ux_editor.properties_panel.subform_table_columns.column_title_edit')}
-          size='sm'
-          value={title}
-          autoFocus={true}
-          onChange={(e) => setTitle(e.target.value)}
-          error={!title?.trim() && errorMessage}
+          textResourceId={tableColumn.headerContent}
+          handleIdChange={(newTextKey) => onChange({ ...tableColumn, headerContent: newTextKey })}
+          handleRemoveTextResource={() => onChange({ ...tableColumn, headerContent: '' })}
+          generateIdOptions={{
+            layoutId: subformLayout,
+            componentId: 'tableColumn',
+            textResourceKey: generateRandomId(6),
+          }}
         />
-      ) : (
-        <StudioProperty.Button
-          className={classes.componentTitleButton}
-          onClick={() => setIsEditingTitle(true)}
-          property={t('ux_editor.properties_panel.subform_table_columns.column_title_unedit')}
-          value={title}
-        />
-      )}
+      </div>
 
       <div className={classes.componentCellContent}>
         <Trans
           i18nKey='ux_editor.properties_panel.subform_table_columns.column_cell_content'
-          values={{ cellContent }}
+          values={{ cellContent: tableColumn.cellContent?.query }}
           components={[<StudioCodeFragment key='0' />]}
         />
       </div>
-    </div>
+    </>
   );
 };

--- a/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/EditSubformTableColumns.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/EditSubformTableColumns.test.tsx
@@ -91,7 +91,9 @@ describe('EditSubformTableColumns', () => {
     expect(handleComponentChangeMock).toHaveBeenCalledTimes(1);
 
     const columnTitleKey = getUpdatedTableColumns(handleComponentChangeMock)[0].headerContent;
-    expect(columnTitleKey).toEqual(expect.stringContaining('subform_table_column_title_'));
+    expect(columnTitleKey).toEqual(
+      expect.stringContaining(subformLayoutMock.component1.textResourceBindings.title),
+    );
   });
 
   it('should call handleComponentChange when a column is deleted', async () => {

--- a/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/EditSubformTableColumns.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/EditSubformTableColumns.tsx
@@ -67,7 +67,7 @@ export const EditSubformTableColumns = ({
             columnNumber={index + 1}
             isInitialOpenForEdit={newColumnNumber === index + 1}
             onDeleteColumn={() => deleteColumn(tableColumn, index)}
-            onEdit={(updatedTableColumn: TableColumn) => editColumn(updatedTableColumn, index)}
+            onChange={(updatedTableColumn: TableColumn) => editColumn(updatedTableColumn, index)}
           />
         ))}
       <StudioButton

--- a/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/utils/editSubformTableColumnsUtils.test.ts
+++ b/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/utils/editSubformTableColumnsUtils.test.ts
@@ -2,13 +2,12 @@ import {
   updateComponentWithSubform,
   filterOutTableColumn,
   getComponentsForSubformTable,
-  getTitleIdForColumn,
 } from './editSubformTableColumnsUtils';
-import { type FormItem } from '@altinn/ux-editor/types/FormItem';
+import type { FormItem } from '@altinn/ux-editor/types/FormItem';
 import { ComponentType } from 'app-shared/types/ComponentType';
-import { type TableColumn } from '../types/TableColumn';
+import type { TableColumn } from '../types/TableColumn';
 import { componentMocks } from '../../../../testing/componentMocks';
-import { type IFormLayouts } from '@altinn/ux-editor/types/global';
+import type { IFormLayouts } from '@altinn/ux-editor/types/global';
 import { layoutMock } from '@altinn/ux-editor/testing/layoutMock';
 
 // Mock data for testing
@@ -155,42 +154,6 @@ describe('editSubformTableColumnsUtils', () => {
         defaultDataModel,
       );
       expect(availableComponents.length).toEqual(0);
-    });
-  });
-
-  describe('getTitleIdForColumn', () => {
-    it('should return a titleId with the correct prefix', () => {
-      const titleId = getTitleIdForColumn({
-        titleId: 'subform_table_column_title_subformId',
-        subformId: 'subformId',
-        textResources: {},
-      });
-      expect(titleId).toEqual('subform_table_column_title_subformId');
-    });
-
-    it('should return a titleId with a random number if the input does not have the correct prefix', () => {
-      const titleId = getTitleIdForColumn({
-        titleId: 'not_correct_prefix',
-        subformId: 'subformId',
-        textResources: {},
-      });
-      expect(titleId.startsWith('subform_table_column_title_')).toBeTruthy();
-    });
-
-    it('should return a titleId with a random number if the input is not unique', () => {
-      const textResources = {
-        nb: [{ id: 'subform_table_column_title_123', value: 'title' }],
-      };
-
-      const titleId = getTitleIdForColumn({
-        titleId: 'subform_table_column_title_subformId',
-        subformId: 'subformId',
-        textResources,
-      });
-
-      const isUnique = (id: string): boolean =>
-        !textResources.nb.some((resource) => resource.id === id);
-      expect(isUnique(titleId)).toBeTruthy();
     });
   });
 });

--- a/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/utils/editSubformTableColumnsUtils.ts
+++ b/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/utils/editSubformTableColumnsUtils.ts
@@ -2,10 +2,7 @@ import { type FormItem } from '@altinn/ux-editor/types/FormItem';
 import { type ComponentType } from 'app-shared/types/ComponentType';
 import { type TableColumn } from '../types/TableColumn';
 import type { IInternalLayout, IFormLayouts } from '@altinn/ux-editor/types/global';
-import { type ITextResources } from 'app-shared/types/global';
 import { getAllLayoutComponents } from '@altinn/ux-editor/utils/formLayoutUtils';
-import { textResourceByLanguageAndIdSelector } from '@altinn/ux-editor/selectors/textResourceSelectors';
-import { getRandNumber } from '@altinn/text-editor/utils';
 import { type LayoutSets } from 'app-shared/types/api/LayoutSetsResponse';
 import { convertDataBindingToInternalFormat } from '@altinn/ux-editor/utils/dataModelUtils';
 
@@ -54,36 +51,4 @@ export const getDefaultDataModel = (layoutSets: LayoutSets, subformLayout: strin
   const layoutSet = layoutSets?.sets.find((layoutSet) => layoutSet.id === subformLayout);
 
   return layoutSet?.dataType ?? '';
-};
-
-export const getValueOfTitleId = (titleId: string, textResources: ITextResources): string => {
-  return textResourceByLanguageAndIdSelector('nb', titleId)(textResources)?.value;
-};
-
-type TitleIdForColumn = {
-  titleId: string;
-  subformId: string;
-  textResources: ITextResources;
-};
-
-export const getTitleIdForColumn = ({
-  titleId,
-  subformId,
-  textResources,
-}: TitleIdForColumn): string => {
-  const prefixTitleId = 'subform_table_column_title_';
-
-  if (titleId.startsWith(prefixTitleId)) {
-    return titleId;
-  }
-
-  const resourcesArray = Object.values(textResources).flat();
-  const isUnique = (id: string): boolean => !resourcesArray.some((resource) => resource.id === id);
-
-  let uniqueTitleId = prefixTitleId + subformId;
-  while (!isUnique(uniqueTitleId)) {
-    uniqueTitleId = prefixTitleId + subformId + getRandNumber();
-  }
-
-  return uniqueTitleId;
 };


### PR DESCRIPTION
Removes unecessary state, and dependence on custom text resource key for headerContent.

`headerContent` now uses the `TextResource` component for editing and lookup of text resources.


https://github.com/user-attachments/assets/79c0b3b2-0278-4f35-9531-4506f326c17a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Streamlined table column editing by updating interaction callbacks from `onEdit` to `onChange` and simplifying state management.
  - Renamed and restructured component properties to improve clarity and consistency.
  - Removed several functions and type definitions related to title ID management for subform table columns.

- **Tests**
  - Revised test scenarios to ensure the updated editing behavior triggers the appropriate callbacks with accurate data.
  - Updated assertions in tests for better specificity regarding column title checks.

- **Style**
  - Adjusted styling rules to refine spacing and layout for enhanced visual consistency, including the removal of outdated CSS rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->