### PR TITLE
feat(app-deploy): ensure to disable undeploy button when undeploy is in pending

### DIFF
--- a/frontend/app-development/features/appPublish/components/ConfirmUndeployDialog/ConfirmUndeployDialog.test.tsx
+++ b/frontend/app-development/features/appPublish/components/ConfirmUndeployDialog/ConfirmUndeployDialog.test.tsx
@@ -60,7 +60,6 @@ describe('ConfirmUndeployDialog', () => {
       undeployAppFromEnvMock: undeployMock,
     });
     await openDialog();
-
     const confirmTextField = getConfirmTextField();
     await user.type(confirmTextField, app);
     await user.click(getUndeployButton());
@@ -79,7 +78,6 @@ describe('ConfirmUndeployDialog', () => {
     await openDialog();
 
     const errorMessageKey = 'app_deployment.error_unknown.message';
-
     const confirmTextField = getConfirmTextField();
     await user.type(confirmTextField, app);
 

--- a/frontend/app-development/features/appPublish/components/ConfirmUndeployDialog/ConfirmUndeployDialog.test.tsx
+++ b/frontend/app-development/features/appPublish/components/ConfirmUndeployDialog/ConfirmUndeployDialog.test.tsx
@@ -3,7 +3,7 @@ import { APP_DEVELOPMENT_BASENAME } from 'app-shared/constants';
 import { app, org } from '@studio/testing/testids';
 import React from 'react';
 import { textMock } from '@studio/testing/mocks/i18nMock';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ConfirmUndeployDialog } from './ConfirmUndeployDialog';
 
@@ -93,7 +93,7 @@ describe('ConfirmUndeployDialog', () => {
 
   it('should disable the undeploy-button while undeploy isPending', async () => {
     const user = userEvent.setup();
-    const undeployMock = jest.fn(() => new Promise((resolve) => setTimeout(resolve, 300)));
+    const undeployMock = jest.fn(() => new Promise((resolve) => setTimeout(resolve, 100)));
 
     renderConfirmUndeployDialog({
       undeployAppFromEnvMock: undeployMock,
@@ -106,7 +106,7 @@ describe('ConfirmUndeployDialog', () => {
     const undeployButton = getUndeployButton();
     await user.click(undeployButton);
 
-    await waitFor(() => expect(undeployButton).toBeDisabled());
+    expect(undeployButton).toBeDisabled();
   });
 });
 

--- a/frontend/app-development/features/appPublish/components/ConfirmUndeployDialog/ConfirmUndeployDialog.tsx
+++ b/frontend/app-development/features/appPublish/components/ConfirmUndeployDialog/ConfirmUndeployDialog.tsx
@@ -24,7 +24,10 @@ export const ConfirmUndeployDialog = ({
   const dialogRef = useRef<HTMLDialogElement>();
   const [isAppNameConfirmed, setIsAppNameConfirmed] = useState<boolean>(false);
   const [undeployError, setUndeployError] = useState<string | null>(null);
-  const mutation = useUndeployMutation(org, appName);
+  const { mutate: mutateUndeploy, isPending: isPendingUndeploy } = useUndeployMutation(
+    org,
+    appName,
+  );
   const onAppNameInputChange = (event: React.FormEvent<HTMLInputElement>): void => {
     setIsAppNameConfirmed(isAppNameConfirmedForDelete(event.currentTarget.value, appName));
   };
@@ -33,7 +36,7 @@ export const ConfirmUndeployDialog = ({
   const closeDialog = () => dialogRef.current.close();
 
   const onUndeployClicked = (): void => {
-    mutation.mutate(
+    mutateUndeploy(
       {
         environment,
       },
@@ -83,7 +86,7 @@ export const ConfirmUndeployDialog = ({
           </StudioAlert>
         )}
         <StudioButton
-          disabled={!isAppNameConfirmed}
+          disabled={!isAppNameConfirmed || isPendingUndeploy}
           color='danger'
           size='sm'
           className={classes.confirmUndeployButton}

--- a/frontend/app-development/features/appPublish/components/ConfirmUndeployDialog/ConfirmUndeployDialog.tsx
+++ b/frontend/app-development/features/appPublish/components/ConfirmUndeployDialog/ConfirmUndeployDialog.tsx
@@ -23,11 +23,11 @@ export const ConfirmUndeployDialog = ({
   const { org, app: appName } = useStudioEnvironmentParams();
   const dialogRef = useRef<HTMLDialogElement>();
   const [isAppNameConfirmed, setIsAppNameConfirmed] = useState<boolean>(false);
-  const [undeployError, setUndeployError] = useState<string | null>(null);
-  const { mutate: mutateUndeploy, isPending: isPendingUndeploy } = useUndeployMutation(
-    org,
-    appName,
-  );
+  const {
+    mutate: mutateUndeploy,
+    isPending: isPendingUndeploy,
+    error: undeployError,
+  } = useUndeployMutation(org, appName);
   const onAppNameInputChange = (event: React.FormEvent<HTMLInputElement>): void => {
     setIsAppNameConfirmed(isAppNameConfirmedForDelete(event.currentTarget.value, appName));
   };
@@ -42,11 +42,7 @@ export const ConfirmUndeployDialog = ({
       },
       {
         onSuccess: (): void => {
-          setUndeployError(null);
           closeDialog();
-        },
-        onError: (): void => {
-          setUndeployError('app_deployment.error_unknown.message');
         },
       },
     );
@@ -77,7 +73,7 @@ export const ConfirmUndeployDialog = ({
           <StudioAlert severity='danger' className={classes.errorContainer}>
             <StudioParagraph size='sm'>
               <Trans
-                i18nKey={undeployError}
+                i18nKey={'app_deployment.error_unknown.message'}
                 components={{
                   a: <StudioLink href='/contact'> </StudioLink>,
                 }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)

- PR itslf

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the undeploy confirmation interface to dynamically disable the action button during processing, providing clear feedback to users.

- **Refactor**
  - Streamlined the undeploy process and error alert handling for a more consistent and responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->