### PR TITLE
fix: adding missing white line under active tab on dashboard

### DIFF
--- a/frontend/dashboard/pages/PageLayout/DashboardHeader/DashboardHeader.module.css
+++ b/frontend/dashboard/pages/PageLayout/DashboardHeader/DashboardHeader.module.css
@@ -1,0 +1,3 @@
+.active {
+  border-bottom: 2px solid var(--fds-semantic-surface-neutral-default);
+}

--- a/frontend/dashboard/pages/PageLayout/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/dashboard/pages/PageLayout/DashboardHeader/DashboardHeader.tsx
@@ -21,6 +21,7 @@ import { usePageHeaderTitle } from 'dashboard/hooks/usePageHeaderTitle';
 import { useSubroute } from '../../../hooks/useSubRoute';
 import type { HeaderMenuItem } from './dashboardHeaderMenuItems';
 import { dashboardHeaderMenuItems } from './dashboardHeaderMenuItems';
+import { StringUtils } from '@studio/pure-functions';
 
 export const DashboardHeader = () => {
   const pageHeaderTitle: string = usePageHeaderTitle();
@@ -60,7 +61,7 @@ function TopNavigationMenuItem({ menuItem }: TopNavigationMenuProps): React.Reac
         <NavLink to={path} {...props}>
           <span
             className={cn({
-              [classes.active]: menuItem.key === currentRoutePath,
+              [classes.active]: StringUtils.removeLeadingSlash(menuItem.link) === currentRoutePath,
             })}
           >
             {t(menuItem.name)}

--- a/frontend/dashboard/pages/PageLayout/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/dashboard/pages/PageLayout/DashboardHeader/DashboardHeader.tsx
@@ -1,4 +1,6 @@
 import React, { useContext } from 'react';
+import classes from './DashboardHeader.module.css';
+import cn from 'classnames';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -48,6 +50,7 @@ function TopNavigationMenuItem({ menuItem }: TopNavigationMenuProps): React.Reac
   const selectedContext: string = useSelectedContext();
   const { t } = useTranslation();
   const path: string = `${menuItem.link}/${selectedContext}`;
+  const currentRoutePath: string = extractSecondLastRouterParam(location.pathname);
 
   return (
     <StudioPageHeader.HeaderLink
@@ -55,11 +58,22 @@ function TopNavigationMenuItem({ menuItem }: TopNavigationMenuProps): React.Reac
       variant='regular'
       renderLink={(props) => (
         <NavLink to={path} {...props}>
-          {t(menuItem.name)}
+          <span
+            className={cn({
+              [classes.active]: menuItem.key === currentRoutePath,
+            })}
+          >
+            {t(menuItem.name)}
+          </span>
         </NavLink>
       )}
     />
   );
+}
+
+function extractSecondLastRouterParam(pathname: string): string {
+  const pathnameArray = pathname.split('/');
+  return pathnameArray[pathnameArray.length - 2];
 }
 
 const DashboardHeaderMenu = () => {

--- a/frontend/dashboard/pages/PageLayout/DashboardHeader/dashboardHeaderMenuItems.ts
+++ b/frontend/dashboard/pages/PageLayout/DashboardHeader/dashboardHeaderMenuItems.ts
@@ -1,8 +1,8 @@
 import { Subroute } from '../../../context/HeaderContext';
 
 enum HeaderMenuItemKey {
-  OrgLibrary = 'orgLibrary',
-  AppDashboard = 'appDashboard',
+  OrgLibrary = 'org-library',
+  AppDashboard = 'app-dashboard',
 }
 
 export interface HeaderMenuItem {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adding the missing white line to the active tab in the dashboard app

#### Before: 
<img width="322" alt="Skjermbilde 2025-02-10 kl  12 23 46" src="https://github.com/user-attachments/assets/0727def8-b246-436f-a69a-854c5d432fcc" />

#### After: 
<img width="212" alt="image" src="https://github.com/user-attachments/assets/b2fb0829-d6b7-45d1-ac65-c7178e821444" />

## Related Issue(s)
- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)