### PR TITLE
fix: Update codelist endpoint return types

### DIFF
--- a/backend/src/Designer/Controllers/Organisation/CodeListController.cs
+++ b/backend/src/Designer/Controllers/Organisation/CodeListController.cs
@@ -140,7 +140,7 @@ public class CodeListController : ControllerBase
         bool optionsListExists = await _codeListService.CodeListExists(org, Repo, developer, optionsListId, cancellationToken);
         if (optionsListExists)
         {
-            List<OptionListData> optionLists = await _codeListService.DeleteCodeList(org, Repo, developer, optionsListId);
+            List<OptionListData> optionLists = await _codeListService.DeleteCodeList(org, Repo, developer, optionsListId, cancellationToken);
             return Ok(optionLists);
         }
 

--- a/backend/src/Designer/Controllers/Organisation/CodeListController.cs
+++ b/backend/src/Designer/Controllers/Organisation/CodeListController.cs
@@ -140,7 +140,8 @@ public class CodeListController : ControllerBase
         bool optionsListExists = await _codeListService.CodeListExists(org, Repo, developer, optionsListId, cancellationToken);
         if (optionsListExists)
         {
-            _codeListService.DeleteCodeList(org, Repo, developer, optionsListId);
+            List<OptionListData> optionLists = await _codeListService.DeleteCodeList(org, Repo, developer, optionsListId);
+            return Ok(optionLists);
         }
 
         return Ok($"The options file {optionsListId}.json has been deleted.");

--- a/backend/src/Designer/Controllers/Organisation/CodeListController.cs
+++ b/backend/src/Designer/Controllers/Organisation/CodeListController.cs
@@ -47,7 +47,6 @@ public class CodeListController : ControllerBase
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
 
             List<OptionListData> optionLists = await _codeListService.GetCodeLists(org, Repo, developer);
-
             return Ok(optionLists);
         }
         catch (NotFoundException)
@@ -68,13 +67,12 @@ public class CodeListController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("{optionsListId}")]
-    public async Task<ActionResult<Dictionary<string, List<Option>>>> CreateCodeList(string org, [FromRoute] string optionsListId, [FromBody] List<Option> payload, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<List<Option>>> CreateCodeList(string org, [FromRoute] string optionsListId, [FromBody] List<Option> payload, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
 
         var newOptionsList = await _codeListService.CreateCodeList(org, Repo, developer, optionsListId, payload, cancellationToken);
-
         return Ok(newOptionsList);
     }
 
@@ -90,13 +88,12 @@ public class CodeListController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("{optionsListId}")]
-    public async Task<ActionResult<Dictionary<string, List<Option>>>> UpdateCodeList(string org, [FromRoute] string optionsListId, [FromBody] List<Option> payload, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<List<OptionListData>>> UpdateCodeList(string org, [FromRoute] string optionsListId, [FromBody] List<Option> payload, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
 
         var newOptionsList = await _codeListService.UpdateCodeList(org, Repo, developer, optionsListId, payload, cancellationToken);
-
         return Ok(newOptionsList);
     }
 
@@ -108,7 +105,7 @@ public class CodeListController : ControllerBase
     /// <param name="cancellationToken"><see cref="CancellationToken"/> that observes if operation is cancelled.</param>
     [HttpPost]
     [Route("upload")]
-    public async Task<IActionResult> UploadCodeList(string org, [FromForm] IFormFile file, CancellationToken cancellationToken)
+    public async Task<ActionResult<List<OptionListData>>> UploadCodeList(string org, [FromForm] IFormFile file, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
@@ -116,7 +113,7 @@ public class CodeListController : ControllerBase
 
         try
         {
-            List<Option> newOptionsList = await _codeListService.UploadCodeList(org, Repo, developer, fileName, file, cancellationToken);
+            List<OptionListData> newOptionsList = await _codeListService.UploadCodeList(org, Repo, developer, fileName, file, cancellationToken);
             return Ok(newOptionsList);
         }
         catch (JsonException e)

--- a/backend/src/Designer/Services/Implementation/Organisation/CodeListService.cs
+++ b/backend/src/Designer/Services/Implementation/Organisation/CodeListService.cs
@@ -108,31 +108,31 @@ public class CodeListService : ICodeListService
     }
 
     /// <inheritdoc />
-    public async Task<List<Option>> CreateCodeList(string org, string repo, string developer, string optionsListId, List<Option> payload, CancellationToken cancellationToken = default)
+    public async Task<List<OptionListData>> CreateCodeList(string org, string repo, string developer, string optionsListId, List<Option> payload, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
 
-        string updatedOptionsString = await altinnAppGitRepository.CreateOrOverwriteOptionsList(optionsListId, payload, cancellationToken);
-        var updatedOptions = JsonSerializer.Deserialize<List<Option>>(updatedOptionsString);
+        await altinnAppGitRepository.CreateOrOverwriteOptionsList(optionsListId, payload, cancellationToken);
 
-        return updatedOptions;
+        List<OptionListData> optionLists = await GetCodeLists(org, repo, developer, cancellationToken);
+        return optionLists;
     }
 
     /// <inheritdoc />
-    public async Task<List<Option>> UpdateCodeList(string org, string repo, string developer, string optionsListId, List<Option> payload, CancellationToken cancellationToken = default)
+    public async Task<List<OptionListData>> UpdateCodeList(string org, string repo, string developer, string optionsListId, List<Option> payload, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
 
-        string updatedOptionsString = await altinnAppGitRepository.CreateOrOverwriteOptionsList(optionsListId, payload, cancellationToken);
-        var updatedOptions = JsonSerializer.Deserialize<List<Option>>(updatedOptionsString);
+        await altinnAppGitRepository.CreateOrOverwriteOptionsList(optionsListId, payload, cancellationToken);
 
-        return updatedOptions;
+        List<OptionListData> optionLists = await GetCodeLists(org, repo, developer, cancellationToken);
+        return optionLists;
     }
 
     /// <inheritdoc />
-    public async Task<List<Option>> UploadCodeList(string org, string repo, string developer, string optionsListId, IFormFile payload, CancellationToken cancellationToken = default)
+    public async Task<List<OptionListData>> UploadCodeList(string org, string repo, string developer, string optionsListId, IFormFile payload, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -145,10 +145,8 @@ public class CodeListService : ICodeListService
             throw new InvalidOptionsFormatException("Uploaded file is missing one of the following attributes for an option: value or label.");
         }
 
-        var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
-        await altinnAppGitRepository.CreateOrOverwriteOptionsList(optionsListId, deserializedOptions, cancellationToken);
-
-        return deserializedOptions;
+        List<OptionListData> optionLists = await GetCodeLists(org, repo, developer, cancellationToken);
+        return optionLists;
     }
 
     /// <inheritdoc />

--- a/backend/src/Designer/Services/Implementation/Organisation/CodeListService.cs
+++ b/backend/src/Designer/Services/Implementation/Organisation/CodeListService.cs
@@ -145,16 +145,23 @@ public class CodeListService : ICodeListService
             throw new InvalidOptionsFormatException("Uploaded file is missing one of the following attributes for an option: value or label.");
         }
 
+        var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
+        await altinnAppGitRepository.CreateOrOverwriteOptionsList(optionsListId, deserializedOptions, cancellationToken);
+
         List<OptionListData> optionLists = await GetCodeLists(org, repo, developer, cancellationToken);
         return optionLists;
     }
 
     /// <inheritdoc />
-    public void DeleteCodeList(string org, string repo, string developer, string optionsListId)
+    public async Task<List<OptionListData>> DeleteCodeList(string org, string repo, string developer, string optionsListId, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(org, repo, developer);
 
         altinnAppGitRepository.DeleteOptionsList(optionsListId);
+
+        List<OptionListData> optionLists = await GetCodeLists(org, repo, developer, cancellationToken);
+        return optionLists;
     }
 
     /// <inheritdoc />

--- a/backend/src/Designer/Services/Interfaces/Organisation/ICodeListService.cs
+++ b/backend/src/Designer/Services/Interfaces/Organisation/ICodeListService.cs
@@ -49,7 +49,7 @@ public interface ICodeListService
     /// <param name="optionsListId">Name of the new options list</param>
     /// <param name="payload">The options list contents</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    public Task<List<Option>> CreateCodeList(string org, string repo, string developer, string optionsListId, List<Option> payload, CancellationToken cancellationToken = default);
+    public Task<List<OptionListData>> CreateCodeList(string org, string repo, string developer, string optionsListId, List<Option> payload, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds a new option to the option list.
@@ -61,7 +61,7 @@ public interface ICodeListService
     /// <param name="optionsListId">Name of the new options list</param>
     /// <param name="payload">The options list contents</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    public Task<List<Option>> UpdateCodeList(string org, string repo, string developer, string optionsListId, List<Option> payload, CancellationToken cancellationToken = default);
+    public Task<List<OptionListData>> UpdateCodeList(string org, string repo, string developer, string optionsListId, List<Option> payload, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds a new option to the option list.
@@ -73,7 +73,7 @@ public interface ICodeListService
     /// <param name="optionsListId">Name of the new options list</param>
     /// <param name="payload">The options list contents</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    public Task<List<Option>> UploadCodeList(string org, string repo, string developer, string optionsListId, IFormFile payload, CancellationToken cancellationToken = default);
+    public Task<List<OptionListData>> UploadCodeList(string org, string repo, string developer, string optionsListId, IFormFile payload, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes an options list from the app repository.

--- a/backend/src/Designer/Services/Interfaces/Organisation/ICodeListService.cs
+++ b/backend/src/Designer/Services/Interfaces/Organisation/ICodeListService.cs
@@ -82,7 +82,8 @@ public interface ICodeListService
     /// <param name="repo">Repository</param>
     /// <param name="developer">Username of developer</param>
     /// <param name="optionsListId">Name of the options list</param>
-    public void DeleteCodeList(string org, string repo, string developer, string optionsListId);
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
+    public Task<List<OptionListData>> DeleteCodeList(string org, string repo, string developer, string optionsListId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Checks if an options list exists in the app repository.


### PR DESCRIPTION
## Description
All endpoints now return the current version of the options lists. 
This will make it easier to use in our frontend as the cache can be set by a new copy after every sucessful update or creation and not updated/altered.

## Related Issue
- #14570

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The dashboard now supports comprehensive organization-level code list management, enabling users to create, update, delete, and upload code lists.
  - A dedicated content library view (“Bibliotek”) has been introduced to streamline resource management.

- **Improvements**
  - Dashboard navigation has been refined with dynamic routing and enhanced error handling, ensuring a smoother, more intuitive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->