### PR TITLE
refactor: codeListService

### DIFF
--- a/backend/src/Designer/Services/Interfaces/Organisation/ICodeListService.cs
+++ b/backend/src/Designer/Services/Interfaces/Organisation/ICodeListService.cs
@@ -10,87 +10,67 @@ namespace Altinn.Studio.Designer.Services.Interfaces.Organisation;
 public interface ICodeListService
 {
     /// <summary>
-    /// Gets a list of file names from the Options folder representing the available options lists.
-    /// </summary>
-    /// <param name="org">Organisation</param>
-    /// <param name="repo">Repository</param>
-    /// <param name="developer">Username of developer</param>
-    /// <returns>Options lists</returns>
-    public string[] GetCodeListIds(string org, string repo, string developer);
-
-    /// <summary>
-    /// Gets an options list from the app repository with the specified optionListId.
-    /// </summary>
-    /// <param name="org">Organisation</param>
-    /// <param name="repo">Repository</param>
-    /// <param name="developer">Username of developer</param>
-    /// <param name="optionsListId">Name of the options list to fetch</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    /// <returns>The options list</returns>
-    public Task<List<Option>> GetCodeList(string org, string repo, string developer, string optionsListId, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Gets an options list from the app repository with the specified optionListId.
+    /// Gets a code-list from the app repository with the specified codeListId.
     /// </summary>
     /// <param name="org">Organisation</param>
     /// <param name="repo">Repository</param>
     /// <param name="developer">Username of developer</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    /// <returns>The options list</returns>
+    /// <returns>The code-list</returns>
     public Task<List<OptionListData>> GetCodeLists(string org, string repo, string developer, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Creates a new options list in the app repository.
+    /// Creates a new code-list in the app repository.
     /// If the file already exists, it will be overwritten.
     /// </summary>
     /// <param name="org">Organisation</param>
     /// <param name="repo">Repository</param>
     /// <param name="developer">Username of developer</param>
-    /// <param name="optionsListId">Name of the new options list</param>
-    /// <param name="payload">The options list contents</param>
+    /// <param name="codeListId">Name of the new code-list</param>
+    /// <param name="codeList">The code-list contents</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    public Task<List<Option>> CreateCodeList(string org, string repo, string developer, string optionsListId, List<Option> payload, CancellationToken cancellationToken = default);
+    public Task<List<Option>> CreateCodeList(string org, string repo, string developer, string codeListId, List<Option> codeList, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Adds a new option to the option list.
+    /// Adds a new option to the code-list.
     /// If the file already exists, it will be overwritten.
     /// </summary>
     /// <param name="org">Organisation</param>
     /// <param name="repo">Repository</param>
     /// <param name="developer">Username of developer</param>
-    /// <param name="optionsListId">Name of the new options list</param>
-    /// <param name="payload">The options list contents</param>
+    /// <param name="codeListId">Name of the new code-list</param>
+    /// <param name="codeList">The code-list contents</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    public Task<List<Option>> UpdateCodeList(string org, string repo, string developer, string optionsListId, List<Option> payload, CancellationToken cancellationToken = default);
+    public Task<List<Option>> UpdateCodeList(string org, string repo, string developer, string codeListId, List<Option> codeList, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Adds a new option to the option list.
+    /// Adds a new option to the code-list.
     /// If the file already exists, it will be overwritten.
     /// </summary>
     /// <param name="org">Organisation</param>
     /// <param name="repo">Repository</param>
     /// <param name="developer">Username of developer</param>
-    /// <param name="optionsListId">Name of the new options list</param>
-    /// <param name="payload">The options list contents</param>
+    /// <param name="codeListId">Name of the new code-list</param>
+    /// <param name="payload">The code-list contents</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    public Task<List<Option>> UploadCodeList(string org, string repo, string developer, string optionsListId, IFormFile payload, CancellationToken cancellationToken = default);
+    public Task<List<Option>> UploadCodeList(string org, string repo, string developer, string codeListId, IFormFile payload, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Deletes an options list from the app repository.
+    /// Deletes an code-list from the org repository.
     /// </summary>
     /// <param name="org">Organisation</param>
     /// <param name="repo">Repository</param>
     /// <param name="developer">Username of developer</param>
-    /// <param name="optionsListId">Name of the options list</param>
-    public void DeleteCodeList(string org, string repo, string developer, string optionsListId);
+    /// <param name="codeListId">Name of the code-list</param>
+    public void DeleteCodeList(string org, string repo, string developer, string codeListId);
 
     /// <summary>
-    /// Checks if an options list exists in the app repository.
+    /// Checks if an code-list exists in the org repository.
     /// </summary>
     /// <param name="org">Organisation</param>
     /// <param name="repo">Repository</param>
     /// <param name="developer">Username of developer</param>
-    /// <param name="optionsListId">Name of the options list</param>
+    /// <param name="codeListId">Name of the code-list</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    public Task<bool> CodeListExists(string org, string repo, string developer, string optionsListId, CancellationToken cancellationToken = default);
+    public Task<bool> CodeListExists(string org, string repo, string developer, string codeListId, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Description
Refactor CodeListService
- Rename variables to use `codeList` and not `option`.
- Make `GetCodeListIds` and `GetCodeList` into private methods

## Related Issue(s)
- #14482

## Additional information
There are no tests in this PR as we're missing required setup for testing endpoints on org level. It will be done in a different PR.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
