### PR TITLE
docs: remove placeholder in summary news

### DIFF
--- a/frontend/app-development/features/overview/components/News/NewsContent/news.nb.json
+++ b/frontend/app-development/features/overview/components/News/NewsContent/news.nb.json
@@ -4,7 +4,7 @@
     {
       "date": "2025-02-12",
       "title": "Ny Oppsummering-komponent!",
-      "content": "Med Oppsummering kan du trekke ut og vise opplysninger som brukere har fylt ut i et skjema. Du kan vise informasjon fra enkeltkomponenter, sider eller sidegrupper. Du kan fra nå av (eller dato) bare bruke den nye komponenten for oppsummering fra Utforming-siden, men den gamle vil fungere i apper du har fra før."
+      "content": "Med Oppsummering kan du trekke ut og vise opplysninger som brukere har fylt ut i et skjema. Du kan vise informasjon fra enkeltkomponenter, sider eller sidegrupper. Du kan fra nå av bare bruke den nye komponenten for oppsummering fra Utforming-siden, men den gamle vil fungere i apper du har fra før."
     },
     {
       "date": "2025-02-11",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I think the "(eller dato)" placeholder was included by mistake in the news for summary.

![image](https://github.com/user-attachments/assets/bef6dc17-529f-492c-9255-cab06753503d)


<!--- Describe your changes in detail -->

## Related Issue(s)

- itself

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Refined the text of a news update to simplify guidance on using the new summarization component. The updated message now provides clear instructions while maintaining support for existing applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->