### PR TITLE
fix: validation errors persist when switching pages

### DIFF
--- a/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/EditPageId.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/EditPageId.tsx
@@ -45,6 +45,7 @@ export const EditPageId = ({ layoutName }: EditPageIdProps) => {
   return (
     <div className={classes.changePageId}>
       <StudioToggleableTextfield
+        key={layoutName}
         customValidation={(value: string) => {
           const validationResult = getPageNameErrorKey(value, layoutName, layoutOrder);
           return validationResult ? t(validationResult) : undefined;

--- a/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/EditPageId.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/EditPageId.tsx
@@ -45,7 +45,6 @@ export const EditPageId = ({ layoutName }: EditPageIdProps) => {
   return (
     <div className={classes.changePageId}>
       <StudioToggleableTextfield
-        key={layoutName}
         customValidation={(value: string) => {
           const validationResult = getPageNameErrorKey(value, layoutName, layoutOrder);
           return validationResult ? t(validationResult) : undefined;

--- a/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { Fragment, useEffect, useRef } from 'react';
 import { Accordion } from '@digdir/designsystemet-react';
 import { FileIcon } from '@studio/icons';
 import { StudioSectionHeader } from '@studio/components';
@@ -65,7 +65,7 @@ export const PageConfigPanel = () => {
         }}
       />
       {layoutIsSelected && (
-        <span key={selectedFormLayoutName}>
+        <Fragment key={selectedFormLayoutName}>
           <EditPageId layoutName={selectedFormLayoutName} />
           <Accordion color='subtle'>
             <Accordion.Item>
@@ -91,7 +91,7 @@ export const PageConfigPanel = () => {
               </Accordion.Content>
             </Accordion.Item>
           </Accordion>
-        </span>
+        </Fragment>
       )}
       <PageConfigWarningModal modalRef={modalRef} />
     </>

--- a/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
@@ -65,7 +65,7 @@ export const PageConfigPanel = () => {
         }}
       />
       {layoutIsSelected && (
-        <>
+        <span key={selectedFormLayoutName}>
           <EditPageId layoutName={selectedFormLayoutName} />
           <Accordion color='subtle'>
             <Accordion.Item>
@@ -91,7 +91,7 @@ export const PageConfigPanel = () => {
               </Accordion.Content>
             </Accordion.Item>
           </Accordion>
-        </>
+        </span>
       )}
       <PageConfigWarningModal modalRef={modalRef} />
     </>

--- a/frontend/packages/ux-editor/src/components/Properties/Properties.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/Properties.tsx
@@ -18,7 +18,7 @@ export const Properties = () => {
 
   if (!formItem) {
     return (
-      <div className={classes.root} key={formItemId}>
+      <div className={classes.root}>
         <PageConfigPanel />
       </div>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Invalid key - The key were always undefined because `formItemId` was used as the key and is not associated with a layout.


<!--- Describe your changes in detail -->

## Related Issue(s)

- #14416 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the rendering logic for the layout section in the PageConfigPanel for improved state management.
  - Adjusted the Properties component by removing unnecessary key props, maintaining the existing functionality.
  - These refinements contribute to a more efficient user experience when managing page settings without altering core functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->