### PR TITLE
refactor: rename Playwright Header to AppDevelopmentHeader

### DIFF
--- a/frontend/testing/playwright/components/AppDevelopmentHeader.ts
+++ b/frontend/testing/playwright/components/AppDevelopmentHeader.ts
@@ -10,7 +10,7 @@ const ALTINN_LOGO_TITLE: string = 'Altinn logo';
 
 const TIMEOUT_FOR_GITEA_TO_DO_THE_PUSH: number = 10000;
 
-export class Header extends BasePage {
+export class AppDevelopmentHeader extends BasePage {
   constructor(page: Page, environment?: Environment) {
     super(page, environment);
   }

--- a/frontend/testing/playwright/tests/git-sync/git-sync.spec.ts
+++ b/frontend/testing/playwright/tests/git-sync/git-sync.spec.ts
@@ -3,7 +3,7 @@ import type { Download, Page } from '@playwright/test';
 import { test } from '../../extenders/testExtend';
 import { DesignerApi } from '../../helpers/DesignerApi';
 import type { StorageState } from '../../types/StorageState';
-import { Header } from '../../components/Header';
+import { AppDevelopmentHeader } from '../../components/AppDevelopmentHeader';
 import { LocalChangesModal } from '../../components/LocalChangesModal';
 import { UiEditorPage } from '../../pages/UiEditorPage';
 import { GiteaPage } from '../../pages/GiteaPage';
@@ -39,7 +39,7 @@ test('That new changes are pushed to gitea and are visible on Gitea after they h
   testAppName,
 }) => {
   const uiEditorPage = await setupAndVerifyUiEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const giteaPage = new GiteaPage(page, { app: testAppName });
 
   const newPageName: string = 'Side2';
@@ -61,7 +61,7 @@ test('That new changes are pushed to gitea and are visible on Gitea after they h
 
 test('That it is possible to delete local changes', async ({ page, testAppName }) => {
   const uiEditorPage = await setupAndVerifyUiEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const localChangesModal = new LocalChangesModal(page, { app: testAppName });
 
   const newPageName: string = 'Side2';
@@ -102,7 +102,10 @@ const makeChangesOnUiEditorPage = async (uiEditorPage: UiEditorPage, newPageName
   await uiEditorPage.waitForDraggableToolbarItemToBeVisible(ComponentType.NavigationButtons);
 };
 
-const goToGiteaAndNavigateToUiLayoutFiles = async (header: Header, giteaPage: GiteaPage) => {
+const goToGiteaAndNavigateToUiLayoutFiles = async (
+  header: AppDevelopmentHeader,
+  giteaPage: GiteaPage,
+) => {
   await header.clickOnThreeDotsMenu();
   await header.clickOnGoToGiteaRepository();
 
@@ -116,9 +119,9 @@ const goToGiteaAndNavigateToUiLayoutFiles = async (header: Header, giteaPage: Gi
 const makeUiEditorChangesAndOpenLocalChangesModal = async (
   page: Page,
   testAppName: string,
-): Promise<Header> => {
+): Promise<AppDevelopmentHeader> => {
   const uiEditorPage = await setupAndVerifyUiEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
 
   const newPageName: string = 'Side2';
   await makeChangesOnUiEditorPage(uiEditorPage, newPageName);

--- a/frontend/testing/playwright/tests/main-navigation-between-sub-apps/main-navigation-between-sub-apps.spec.ts
+++ b/frontend/testing/playwright/tests/main-navigation-between-sub-apps/main-navigation-between-sub-apps.spec.ts
@@ -11,7 +11,7 @@ import { ProcessEditorPage } from '../../pages/ProcessEditorPage';
 import { DashboardPage } from '../../pages/DashboardPage';
 import { PreviewPage } from '../../pages/PreviewPage';
 import { DeployPage } from '../../pages/DeployPage';
-import { Header } from '../../components/Header';
+import { AppDevelopmentHeader } from '../../components/AppDevelopmentHeader';
 import { Gitea } from '../../helpers/Gitea';
 
 const getTtdApp = (appName: string) => `ttd-app-${appName}`;
@@ -51,7 +51,7 @@ test('That it is possible to navigate from overview to the app builder page and 
 }) => {
   const overviewPage = await setupAndVerifyOverviewPage(page, testAppName);
   const uiEditorPage = new UiEditorPage(page, { app: testAppName });
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
 
   await header.verifyNoGeneralErrorMessage();
   await header.clickOnNavigateToPageInTopMenuHeader('create');
@@ -68,7 +68,7 @@ test('That it is possible to navigate from overview to the data model page and b
 }) => {
   const overviewPage = await setupAndVerifyOverviewPage(page, testAppName);
   const dataModelPage = new DataModelPage(page, { app: testAppName });
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
 
   await header.verifyNoGeneralErrorMessage();
   await header.clickOnNavigateToPageInTopMenuHeader('data_model');
@@ -85,7 +85,7 @@ test('That it is possible to navigate from overview to the text editor page and 
 }) => {
   const overviewPage = await setupAndVerifyOverviewPage(page, testAppName);
   const textEditorPage = new TextEditorPage(page, { app: testAppName });
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
 
   await header.verifyNoGeneralErrorMessage();
   await header.clickOnNavigateToPageInTopMenuHeader('texts');
@@ -102,7 +102,7 @@ test('That it is possible to navigate from overview to the process editor page a
 }) => {
   const overviewPage = await setupAndVerifyOverviewPage(page, testAppName);
   const processEditorPage = new ProcessEditorPage(page, { app: testAppName });
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
 
   await header.verifyNoGeneralErrorMessage();
   await header.clickOnNavigateToPageInTopMenuHeader('process_editor');
@@ -119,7 +119,7 @@ test('That it is possible to navigate from overview to the dashboard page by cli
 }) => {
   await setupAndVerifyOverviewPage(page, testAppName);
   const dashboardPage = new DashboardPage(page, { app: testAppName });
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
 
   await header.clickOnNavigateToDashboard();
   await dashboardPage.verifyDashboardPage();
@@ -132,7 +132,7 @@ test('That it is possible to navigate from overview to the preview page and back
   await setupAndVerifyOverviewPage(page, testAppName);
   const previewPage = new PreviewPage(page, { app: testAppName });
   const uiEditor = new UiEditorPage(page, { app: testAppName });
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
 
   await header.clickOnPreviewButton();
   await previewPage.verifyPreviewPage();
@@ -161,7 +161,7 @@ test('That it is possible to navigate from overview to the deploy page and back 
   const dashboardPage = new DashboardPage(page, { app: appName });
   const overviewPage = new OverviewPage(page, { app: appName });
   const deployPage = new DeployPage(page, { app: appName });
-  const header = new Header(page, { app: appName });
+  const header = new AppDevelopmentHeader(page, { app: appName });
 
   await dashboardPage.loadDashboardPage();
   await dashboardPage.verifyDashboardPage();

--- a/frontend/testing/playwright/tests/process-editor/add-new-bpmn-task.spec.ts
+++ b/frontend/testing/playwright/tests/process-editor/add-new-bpmn-task.spec.ts
@@ -6,7 +6,7 @@ import { DesignerApi } from '../../helpers/DesignerApi';
 import type { StorageState } from '../../types/StorageState';
 import { ProcessEditorPage } from '../../pages/ProcessEditorPage';
 import { BpmnJSQuery } from '../../helpers/BpmnJSQuery';
-import { Header } from '../../components/Header';
+import { AppDevelopmentHeader } from '../../components/AppDevelopmentHeader';
 import { DataModelPage } from '../../pages/DataModelPage';
 import { GiteaPage } from '../../pages/GiteaPage';
 import { type BpmnTaskType } from '../../types/BpmnTaskType';
@@ -49,7 +49,7 @@ test('that the user can drag a new task in to the data model, and assign a data 
 }) => {
   const processEditorPage = await setupAndVerifyProcessEditorPage(page, testAppName);
   const bpmnJSQuery = new BpmnJSQuery(page);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const dataModelPage = new DataModelPage(page, { app: testAppName });
 
   const svgSelector = await bpmnJSQuery.getTaskByIdAndType('SingleDataTask', 'svg');
@@ -113,7 +113,7 @@ test('that the changes made to the bpmn process are uploaded to Gitea', async ({
   testAppName,
 }) => {
   await setupAndVerifyProcessEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const giteaPage = new GiteaPage(page, { app: testAppName });
   await commitAndPushToGitea(header);
 
@@ -129,7 +129,7 @@ test('that the changes made to the bpmn process are uploaded to Gitea', async ({
 
 // --------------------- Helper Functions ---------------------
 const goToGiteaAndNavigateToProcessBpmnFile = async (
-  header: Header,
+  header: AppDevelopmentHeader,
   giteaPage: GiteaPage,
 ): Promise<void> => {
   await header.clickOnThreeDotsMenu();
@@ -142,7 +142,7 @@ const goToGiteaAndNavigateToProcessBpmnFile = async (
   await giteaPage.clickOnProcessBpmnFile();
 };
 
-const commitAndPushToGitea = async (header: Header): Promise<void> => {
+const commitAndPushToGitea = async (header: AppDevelopmentHeader): Promise<void> => {
   await header.clickOnUploadLocalChangesButton();
   await header.clickOnValidateChanges();
   await header.checkThatUploadSuccessMessageIsVisible();
@@ -151,7 +151,7 @@ const commitAndPushToGitea = async (header: Header): Promise<void> => {
 const navigateToDataModelAndCreateNewDataModel = async (
   dataModelPage: DataModelPage,
   processEditorPage: ProcessEditorPage,
-  header: Header,
+  header: AppDevelopmentHeader,
   newDataModelName: string,
 ): Promise<void> => {
   await header.verifyNoGeneralErrorMessage();

--- a/frontend/testing/playwright/tests/process-editor/process-editor.spec.ts
+++ b/frontend/testing/playwright/tests/process-editor/process-editor.spec.ts
@@ -6,7 +6,7 @@ import { DesignerApi } from '../../helpers/DesignerApi';
 import type { StorageState } from '../../types/StorageState';
 import { ProcessEditorPage } from '../../pages/ProcessEditorPage';
 import { BpmnJSQuery } from '../../helpers/BpmnJSQuery';
-import { Header } from '../../components/Header';
+import { AppDevelopmentHeader } from '../../components/AppDevelopmentHeader';
 import { DataModelPage } from '../../pages/DataModelPage';
 import { GiteaPage } from '../../pages/GiteaPage';
 import { type BpmnTaskType } from '../../types/BpmnTaskType';
@@ -98,7 +98,7 @@ test('Opening the settings modal from the header after the user has opened it fr
   const processEditorPage = await setupAndVerifyProcessEditorPage(page, testAppName);
   const bpmnJSQuery = new BpmnJSQuery(page);
   const settingsModal = new SettingsModal(page, { app: testAppName });
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
 
   const initialTaskDataElementIdSelector: string = await bpmnJSQuery.getTaskByIdAndType(
     'Task_1',
@@ -128,7 +128,7 @@ test('that the user can edit the id of a task and add data-types to sign', async
   testAppName,
 }) => {
   const processEditorPage = await setupAndVerifyProcessEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const giteaPage = new GiteaPage(page, { app: testAppName });
 
   const signingTask = await addNewSigningTaskToProcessEditor(page);
@@ -152,7 +152,7 @@ test('That it is possible to create a custom receipt', async ({ page, testAppNam
   const processEditorPage = await setupAndVerifyProcessEditorPage(page, testAppName);
   const dataModelPage = new DataModelPage(page, { app: testAppName });
   const bpmnJSQuery = new BpmnJSQuery(page);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const giteaPage = new GiteaPage(page, { app: testAppName });
 
   // --------------------- Create new data model ---------------------
@@ -233,7 +233,7 @@ const editRandomGeneratedId = async (
 };
 
 const goToGiteaAndNavigateToProcessBpmnFile = async (
-  header: Header,
+  header: AppDevelopmentHeader,
   giteaPage: GiteaPage,
 ): Promise<void> => {
   await header.clickOnThreeDotsMenu();
@@ -246,7 +246,7 @@ const goToGiteaAndNavigateToProcessBpmnFile = async (
   await giteaPage.clickOnProcessBpmnFile();
 };
 
-const commitAndPushToGitea = async (header: Header): Promise<void> => {
+const commitAndPushToGitea = async (header: AppDevelopmentHeader): Promise<void> => {
   await header.clickOnUploadLocalChangesButton();
   await header.clickOnValidateChanges();
   await header.checkThatUploadSuccessMessageIsVisible();
@@ -255,7 +255,7 @@ const commitAndPushToGitea = async (header: Header): Promise<void> => {
 const navigateToDataModelAndCreateNewDataModel = async (
   dataModelPage: DataModelPage,
   processEditorPage: ProcessEditorPage,
-  header: Header,
+  header: AppDevelopmentHeader,
   newDataModelName: string,
 ): Promise<void> => {
   await header.verifyNoGeneralErrorMessage();
@@ -275,7 +275,7 @@ const navigateToDataModelAndCreateNewDataModel = async (
 };
 
 const goToGiteaAndNavigateToApplicationMetadataFile = async (
-  header: Header,
+  header: AppDevelopmentHeader,
   giteaPage: GiteaPage,
 ): Promise<void> => {
   await header.clickOnThreeDotsMenu();

--- a/frontend/testing/playwright/tests/process-editor/task-actions.spec.ts
+++ b/frontend/testing/playwright/tests/process-editor/task-actions.spec.ts
@@ -2,7 +2,7 @@ import { test } from '../../extenders/testExtend';
 import { ProcessEditorPage } from '../../pages/ProcessEditorPage';
 import { BpmnJSQuery } from '@studio/testing/playwright/helpers/BpmnJSQuery';
 import { expect, type Page } from '@playwright/test';
-import { Header } from '@studio/testing/playwright/components/Header';
+import { AppDevelopmentHeader } from '@studio/testing/playwright/components/AppDevelopmentHeader';
 import { DesignerApi } from '@studio/testing/playwright/helpers/DesignerApi';
 import type { StorageState } from '@studio/testing/playwright/types/StorageState';
 import { Gitea } from '@studio/testing/playwright/helpers/Gitea';
@@ -90,14 +90,14 @@ const setupProcessEditorActionConfigPanel = async (
 };
 
 const commitAndPushToGitea = async (page: Page, testAppName: string): Promise<void> => {
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   await header.clickOnUploadLocalChangesButton();
   await header.clickOnValidateChanges();
   await header.checkThatUploadSuccessMessageIsVisible();
 };
 
 const goToProcessFileInGitea = async (page: Page, testAppName: string) => {
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const giteaPage = new GiteaPage(page, { app: testAppName });
 
   await header.clickOnThreeDotsMenu();

--- a/frontend/testing/playwright/tests/settings-modal/settings-modal.spec.ts
+++ b/frontend/testing/playwright/tests/settings-modal/settings-modal.spec.ts
@@ -3,7 +3,7 @@ import type { Page } from '@playwright/test';
 import { test } from '../../extenders/testExtend';
 import { DesignerApi } from '../../helpers/DesignerApi';
 import type { StorageState } from '../../types/StorageState';
-import { Header } from '../../components/Header';
+import { AppDevelopmentHeader } from '../../components/AppDevelopmentHeader';
 import { UiEditorPage } from '../../pages/UiEditorPage';
 import type { SettingsModalTab } from '../../components/SettingsModal';
 import { SettingsModal } from '../../components/SettingsModal';
@@ -36,7 +36,7 @@ const setUpAndOpenSettingsModal = async (
   tabToStartAt: SettingsModalTab = 'about',
 ): Promise<SettingsModal> => {
   const settingsModal = new SettingsModal(page, { app: testAppName });
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
 
   await setupAndVerifyUiEditorPage(page, testAppName);
 

--- a/frontend/testing/playwright/tests/text-editor/text-editor.spec.ts
+++ b/frontend/testing/playwright/tests/text-editor/text-editor.spec.ts
@@ -5,7 +5,7 @@ import { DesignerApi } from '../../helpers/DesignerApi';
 import type { StorageState } from '../../types/StorageState';
 import { TextEditorPage } from '../../pages/TextEditorPage';
 import { Gitea } from '../../helpers/Gitea';
-import { Header } from '../../components/Header';
+import { AppDevelopmentHeader } from '../../components/AppDevelopmentHeader';
 import { UiEditorPage } from '../../pages/UiEditorPage';
 import { ComponentType } from '../../enum/ComponentType';
 import { LanguageCode } from '../../enum/LanguageCode';
@@ -53,7 +53,7 @@ test('That it is possible to create a text at the ui-editor page, and that the t
   testAppName,
 }) => {
   const textEditorPage = await setupAndVerifyTextEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const uiEditorPage = new UiEditorPage(page, { app: testAppName });
 
   await navigateToUiEditorAndVerifyPage(header, uiEditorPage);
@@ -87,7 +87,7 @@ test('That it is possible to edit a textkey, and that the key is updated on the 
   testAppName,
 }) => {
   const textEditorPage = await setupAndVerifyTextEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const uiEditorPage = new UiEditorPage(page, { app: testAppName });
 
   await textEditorPage.verifyThatTextKeyIsVisible(INITIAL_TEXT_KEY);
@@ -144,7 +144,7 @@ test('That the newly added language with key is updated on ui-editor page', asyn
   testAppName,
 }) => {
   await setupAndVerifyTextEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const uiEditorPage = new UiEditorPage(page, { app: testAppName });
 
   await navigateToUiEditorAndVerifyPage(header, uiEditorPage);
@@ -159,7 +159,7 @@ test('That it is possible to push the changes to Gitea and verify that the chang
   testAppName,
 }) => {
   await setupAndVerifyTextEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const giteaPage = new GiteaPage(page, { app: testAppName });
 
   await header.clickOnUploadLocalChangesButton();
@@ -210,7 +210,7 @@ const updateTextKey = async (
 };
 
 const navigateToUiEditorAndVerifyPage = async (
-  header: Header,
+  header: AppDevelopmentHeader,
   uiEditorPage: UiEditorPage,
 ): Promise<void> => {
   await header.verifyNoGeneralErrorMessage();

--- a/frontend/testing/playwright/tests/ui-editor/ui-editor-data-model-binding-and-gitea.spec.ts
+++ b/frontend/testing/playwright/tests/ui-editor/ui-editor-data-model-binding-and-gitea.spec.ts
@@ -6,7 +6,7 @@ import type { StorageState } from '../../types/StorageState';
 import { UiEditorPage } from '../../pages/UiEditorPage';
 import { Gitea } from '../../helpers/Gitea';
 import { ComponentType } from '../../enum/ComponentType';
-import { Header } from '../../components/Header';
+import { AppDevelopmentHeader } from '../../components/AppDevelopmentHeader';
 import { DataModelPage } from '../../pages/DataModelPage';
 import { GiteaPage } from '../../pages/GiteaPage';
 
@@ -77,7 +77,7 @@ test('That it is possible to navigate to Gitea and that data model bindings are 
   testAppName,
 }): Promise<void> => {
   const uiEditorPage = await setupAndVerifyUiEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const giteaPage = new GiteaPage(page, { app: testAppName });
 
   await header.clickOnThreeDotsMenu();
@@ -95,7 +95,7 @@ test('That it is possible to navigate to datamodel page and create a new data mo
   testAppName,
 }): Promise<void> => {
   await setupAndVerifyUiEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const dataModelPage = new DataModelPage(page, { app: testAppName });
 
   await header.verifyNoGeneralErrorMessage();
@@ -111,7 +111,7 @@ test('That it is possible to navigate back to ui-editor page and add the data mo
   testAppName,
 }): Promise<void> => {
   const uiEditorPage = await setupAndVerifyUiEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
 
   await header.verifyNoGeneralErrorMessage();
   await header.clickOnNavigateToPageInTopMenuHeader('create');
@@ -135,7 +135,7 @@ test('That it is possible to upload the changes to Gitea and view the changes in
   testAppName,
 }): Promise<void> => {
   await setupAndVerifyUiEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const giteaPage = new GiteaPage(page, { app: testAppName });
 
   await header.clickOnUploadLocalChangesButton();
@@ -156,7 +156,7 @@ test('That it is possible to navigate to data model page and create another data
   testAppName,
 }): Promise<void> => {
   await setupAndVerifyUiEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const dataModelPage = new DataModelPage(page, { app: testAppName });
 
   await header.verifyNoGeneralErrorMessage();
@@ -169,7 +169,7 @@ test('That it is possible to navigate back to ui-editor page and add the newly a
   testAppName,
 }): Promise<void> => {
   const uiEditorPage = await setupAndVerifyUiEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
 
   await header.verifyNoGeneralErrorMessage();
   await header.clickOnNavigateToPageInTopMenuHeader('create');
@@ -193,7 +193,7 @@ test('That it is possible to upload to Gitea and that files are updated correctl
   testAppName,
 }): Promise<void> => {
   await setupAndVerifyUiEditorPage(page, testAppName);
-  const header = new Header(page, { app: testAppName });
+  const header = new AppDevelopmentHeader(page, { app: testAppName });
   const giteaPage = new GiteaPage(page, { app: testAppName });
 
   await header.clickOnUploadLocalChangesButton();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Renaming `Header` component in Playwright to `AppDevelopmentHeader`. This header is only used with files from `app-development` and as [`Domain1` is currently working on Playwright tests for `org-library`](https://github.com/Altinn/altinn-studio/issues/14609), we need to rename this file to make sure we can create a `DashboardHeader` component so that the naming is easier to understand.

## Related Issue(s)
- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)