### PR TITLE
fix: Reset of local clone when app is copied

### DIFF
--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -298,6 +298,9 @@ namespace Altinn.Studio.Designer.Services.Implementation
             CommitInfo commitInfo = new() { Org = targetOrg, Repository = targetRepository, Message = $"App cloned from {sourceRepository} {DateTime.Now.Date.ToShortDateString()}" };
             await _sourceControl.PushChangesForRepository(commitInfo);
 
+            // Ensure that developers local repository is up to date
+            await ResetLocalRepository(AltinnRepoEditingContext.FromOrgRepoDeveloper(org, targetRepository, developer));
+
             // Final changes are made in a seperate branch to be reviewed by developer
             string branchName = "complete_copy_of_app";
             string branchCloneName = $"{targetRepository}_{branchName}_{Guid.NewGuid()}";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There seems to be an issue with the .git files in the newly copied repo. Our code updates the refs in git config to match the new repo name, but it's likely that some other file (maybe index) is not updated and causes issues.

It's possible we've had this problem before without noticing. F.ex. if we swallowed the error message, or if some change in a new version of Gitea has made the issue more obvious. 

Triggering a full reset of the developers local repo after all necessary copy changes are made seems to fix the problem, and we ensure that the developers local repo is up to date with the apps git repo.

## Related Issue(s)

- #14698 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

## Documentation

~~- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the repository cloning process so that local repositories automatically update to reflect remote changes, ensuring greater consistency and reliability in repository management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->