### PR TITLE
fix: 14718 adding confirm on delete codelist

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -17,6 +17,7 @@
   "app_content_library.code_lists.code_list_accordion_usage_sub_title_plural": "Kodelisten brukes i {{codeListUsagesCount}} komponenter.",
   "app_content_library.code_lists.code_list_accordion_usage_sub_title_single": "Kodelisten brukes i {{codeListUsagesCount}} komponent.",
   "app_content_library.code_lists.code_list_delete": "Slett kodeliste",
+  "app_content_library.code_lists.code_list_delete_confirm": "Er du sikker på at du vil slette kodelisten {{codeListTitle}}? Alt innholdet i kodelisten vil bli fjernet.",
   "app_content_library.code_lists.code_list_delete_disabled_title": "Før du kan å slette kodelisten, må du fjerne den fra der den er brukt i appen.",
   "app_content_library.code_lists.code_list_delete_enabled_title": "Slett kodelisten fra biblioteket.",
   "app_content_library.code_lists.code_list_edit_id_disabled_title": "Redigering er ikke tilgjengelig når kodelisten er tatt i bruk.",

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.test.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.test.tsx
@@ -246,6 +246,8 @@ describe('CodeLists', () => {
 
   it('calls onDeleteCodeList when clicking delete button', async () => {
     const user = userEvent.setup();
+    jest.spyOn(window, 'confirm').mockImplementation(jest.fn(() => true));
+
     renderCodeLists();
     const deleteCodeListButton = screen.getByRole('button', {
       name: textMock('app_content_library.code_lists.code_list_delete'),
@@ -256,6 +258,21 @@ describe('CodeLists', () => {
     await user.click(deleteCodeListButton);
     expect(onDeleteCodeListMock).toHaveBeenCalledTimes(1);
     expect(onDeleteCodeListMock).toHaveBeenLastCalledWith(codeListName);
+  });
+
+  it('does not call onDeleteCodeList when it is not confirmed', async () => {
+    const user = userEvent.setup();
+    jest.spyOn(window, 'confirm').mockImplementation(jest.fn(() => false));
+
+    renderCodeLists();
+    const deleteCodeListButton = screen.getByRole('button', {
+      name: textMock('app_content_library.code_lists.code_list_delete'),
+    });
+    expect(deleteCodeListButton.title).toBe(
+      textMock('app_content_library.code_lists.code_list_delete_enabled_title'),
+    );
+    await user.click(deleteCodeListButton);
+    expect(onDeleteCodeListMock).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/EditCodeList/EditCodeList.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/EditCodeList/EditCodeList.tsx
@@ -75,6 +75,7 @@ export function EditCodeList({
         codeListHasUsages={codeListHasUsages}
         codeListSources={codeListSources}
         onDeleteCodeList={handleDeleteCodeList}
+        codeListTitle={codeListTitle}
       />
     </div>
   );
@@ -138,12 +139,14 @@ type CodeListButtonsProps = {
   codeListHasUsages: boolean;
   codeListSources: CodeListIdSource[];
   onDeleteCodeList: (codeListId: string) => void;
+  codeListTitle: string;
 };
 
 function CodeListButtons({
   codeListHasUsages,
   codeListSources,
   onDeleteCodeList,
+  codeListTitle,
 }: CodeListButtonsProps): React.ReactElement {
   const { t } = useTranslation();
   const deleteButtonTitle = codeListHasUsages
@@ -156,6 +159,9 @@ function CodeListButtons({
         onDelete={onDeleteCodeList}
         title={deleteButtonTitle}
         disabled={codeListHasUsages}
+        confirmMessage={t('app_content_library.code_lists.code_list_delete_confirm', {
+          codeListTitle,
+        })}
       >
         {t('app_content_library.code_lists.code_list_delete')}
       </StudioDeleteButton>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adding a confirm popup when deleting a codelist

https://github.com/user-attachments/assets/c03e7e23-5721-45e3-b01f-9e9da0f3d066



## Related Issue(s)

- #14718 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)