### PR TITLE
fix: 14718 add confirm when deleting row in codelist

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -158,6 +158,7 @@
   "code_list_editor.column_title_label": "Ledetekst",
   "code_list_editor.column_title_value": "Verdi",
   "code_list_editor.delete_code_list_item": "Slett alternativ {{number}}",
+  "code_list_editor.delete_code_list_item_confirm": "Er du sikker på at du vil slette rad {{number}}?",
   "code_list_editor.description_item": "Beskrivelse for alternativ {{number}}",
   "code_list_editor.empty": "Kodelisten er tom.",
   "code_list_editor.error_duplicate_values": "Alle verdier må være unike.",

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditor.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditor.test.tsx
@@ -268,6 +268,8 @@ describe('StudioCodeListEditor', () => {
 
   it('Calls the onChange callback with the new code list when an item is removed', async () => {
     const user = userEvent.setup();
+    jest.spyOn(window, 'confirm').mockImplementation(jest.fn(() => true));
+
     renderCodeListEditor();
     const deleteButton = screen.getByRole('button', { name: texts.deleteItem(1) });
     await user.click(deleteButton);
@@ -276,6 +278,16 @@ describe('StudioCodeListEditor', () => {
       codeListWithoutTextResources[1],
       codeListWithoutTextResources[2],
     ]);
+  });
+
+  it('Does not call onchange method when deletion is not confirmed', async () => {
+    const user = userEvent.setup();
+    renderCodeListEditor();
+    jest.spyOn(window, 'confirm').mockImplementation(jest.fn(() => false));
+
+    const deleteButton = screen.getByRole('button', { name: texts.deleteItem(1) });
+    await user.click(deleteButton);
+    expect(onChange).toHaveBeenCalledTimes(0);
   });
 
   it('Calls the onChange callback with the new code list when an item is added', async () => {
@@ -325,6 +337,8 @@ describe('StudioCodeListEditor', () => {
 
   it('Calls the onAddOrDeleteItem callback with the new code list when an item is removed', async () => {
     const user = userEvent.setup();
+    jest.spyOn(window, 'confirm').mockImplementation(jest.fn(() => true));
+
     renderCodeListEditor();
     const deleteButton = screen.getByRole('button', { name: texts.deleteItem(1) });
     await user.click(deleteButton);
@@ -333,6 +347,15 @@ describe('StudioCodeListEditor', () => {
       codeListWithoutTextResources[1],
       codeListWithoutTextResources[2],
     ]);
+  });
+
+  it('Does not call the onAddOrDeleteItem callback when it is not confirmed', async () => {
+    const user = userEvent.setup();
+    jest.spyOn(window, 'confirm').mockImplementation(jest.fn(() => false));
+    renderCodeListEditor();
+    const deleteButton = screen.getByRole('button', { name: texts.deleteItem(1) });
+    await user.click(deleteButton);
+    expect(onAddOrDeleteItem).toHaveBeenCalledTimes(0);
   });
 
   it('Updates itself when the user changes something', async () => {
@@ -494,6 +517,8 @@ describe('StudioCodeListEditor', () => {
 
   it('Renders without errors when removing an item and no callbacks are provided', async () => {
     const user = userEvent.setup();
+    jest.spyOn(window, 'confirm').mockImplementation(jest.fn(() => true));
+
     renderCodeListEditor({
       onAddOrDeleteItem: undefined,
       onBlurAny: undefined,

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditorRow/StudioCodeListEditorRow.tsx
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditorRow/StudioCodeListEditorRow.tsx
@@ -254,11 +254,20 @@ type DeleteButtonCellProps = {
 
 function DeleteButtonCell({ onClick, number }: DeleteButtonCellProps) {
   const { texts } = useStudioCodeListEditorContext();
+
+  const delteConfirmationText: string = texts.deleteItemConfirmation(number);
+
+  const handleClick = () => {
+    if (confirm(delteConfirmationText)) {
+      onClick();
+    }
+  };
+
   return (
     <StudioInputTable.Cell.Button
       icon={<TrashIcon />}
       color='danger'
-      onClick={onClick}
+      onClick={handleClick}
       title={texts.deleteItem(number)}
     />
   );

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/test-data/texts.ts
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/test-data/texts.ts
@@ -13,6 +13,7 @@ export const texts: CodeListEditorTexts = {
   codeList: 'Code list',
   delete: 'Delete',
   deleteItem: (number) => `Delete item number ${number}`,
+  deleteItemConfirmation: (number) => `Are you sure you want to delete row ${number}?`,
   description: 'Description',
   emptyCodeList: 'The code list is empty.',
   generalError: 'The code list cannot be saved because it is not valid.',

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/types/CodeListEditorTexts.ts
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/types/CodeListEditorTexts.ts
@@ -7,6 +7,7 @@ export type CodeListEditorTexts = {
   codeList: string;
   delete: string;
   deleteItem: (number: number) => string;
+  deleteItemConfirmation: (number: number) => string;
   description: string;
   emptyCodeList: string;
   generalError: string;

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/hooks/useCodeListEditorTexts.ts
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/hooks/useCodeListEditorTexts.ts
@@ -14,6 +14,8 @@ export function useCodeListEditorTexts(): CodeListEditorTexts {
     codeList: t('code_list_editor.legend'),
     delete: t('code_list_editor.column_title_delete'),
     deleteItem: (number: number) => t('code_list_editor.delete_code_list_item', { number }),
+    deleteItemConfirmation: (number: number) =>
+      t('code_list_editor.delete_code_list_item_confirm', { number }),
     description: t('code_list_editor.column_title_description'),
     emptyCodeList: t('code_list_editor.empty'),
     generalError: t('code_list_editor.general_error'),

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/hooks/useOptionListEditorTexts.ts
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/hooks/useOptionListEditorTexts.ts
@@ -14,6 +14,8 @@ export function useOptionListEditorTexts(): CodeListEditorTexts {
     codeList: t('code_list_editor.legend'),
     delete: t('code_list_editor.column_title_delete'),
     deleteItem: (number: number) => t('code_list_editor.delete_code_list_item', { number }),
+    deleteItemConfirmation: (number: number) =>
+      t('code_list_editor.delete_code_list_item_confirm', { number }),
     description: t('code_list_editor.column_title_description'),
     emptyCodeList: t('code_list_editor.empty'),
     generalError: t('code_list_editor.general_error'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adding confirm for when deleting a row in a codelist

https://github.com/user-attachments/assets/642ccd07-96ff-416b-b528-d30a7b188915


## Related Issue(s)

- #14718 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)