### PR TITLE
feat(policy editor): app policy summary component

### DIFF
--- a/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleSubjectSummary.module.css
+++ b/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleSubjectSummary.module.css
@@ -1,0 +1,5 @@
+.limitationsCell {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--fds-spacing-1);
+}

--- a/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleSubjectSummary.test.tsx
+++ b/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleSubjectSummary.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import {
+  PolicyRuleSubjectSummary,
+  type PolicyRuleSubjectSummaryProps,
+} from './PolicyRuleSubjectSummary';
+import {
+  PolicyEditorContext,
+  type PolicyEditorContextProps,
+} from '../../../contexts/PolicyEditorContext';
+import {
+  mockSubject1,
+  mockSubjectId1,
+  mockSubjectBackendString1,
+} from '../../../../test/mocks/policySubjectMocks';
+import { mockAction1, mockAction2 } from '../../../../test/mocks/policyActionMocks';
+import type { PolicySubject } from '../../../types';
+
+const mockSubjects: PolicySubject[] = [
+  {
+    subjectId: 's1',
+    subjectTitle: 'Subject 1',
+    subjectDescription: 'Subject 1 description',
+    subjectSource: 'altinn:rolecode',
+  },
+  {
+    subjectId: 's2',
+    subjectTitle: '[ORG]',
+    subjectDescription: 'Subject 2 description',
+    subjectSource: 'altinn:org',
+  },
+];
+const mockPolicyEditorContextValue: PolicyEditorContextProps = {
+  policyRules: [
+    {
+      ruleId: 'r1',
+      description: '',
+      subject: ['s1'],
+      actions: [mockAction1.actionId, mockAction2.actionId],
+      accessPackages: [],
+      resources: [
+        [
+          { type: 'urn:altinn:org', id: '[org]' },
+          { type: 'urn:altinn:app', id: '[app]' },
+        ],
+      ],
+    },
+  ],
+  setPolicyRules: jest.fn(),
+  actions: [mockAction1, mockAction2],
+  subjects: mockSubjects,
+  accessPackages: [],
+  usageType: 'app',
+  resourceType: 'urn',
+  resourceId: '[app]',
+  showAllErrors: false,
+  savePolicy: jest.fn(),
+};
+describe('PolicyRuleSubjectSummary', () => {
+  it('should render', () => {
+    const actions = [mockAction1.actionId, mockAction2.actionId];
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    renderPolicyRuleSubjectSummary({ subject: 's1', actions }, {});
+    expect(screen.getByText('Subject 1')).toBeInTheDocument();
+    // We are rendering a table row independently of table, so we expect a console error
+    expect(consoleError).toHaveBeenCalled();
+  });
+});
+
+const renderPolicyRuleSubjectSummary = (
+  props: Partial<PolicyRuleSubjectSummaryProps>,
+  policyEditorContextProps: Partial<PolicyEditorContextProps> = {},
+) => {
+  const defaultProps = {
+    subject: 'subject',
+    actions: ['action1', 'action2'],
+  };
+  render(
+    <PolicyEditorContext.Provider
+      value={{ ...mockPolicyEditorContextValue, ...policyEditorContextProps }}
+    >
+      <PolicyRuleSubjectSummary {...defaultProps} {...props} />
+    </PolicyEditorContext.Provider>,
+  );
+};

--- a/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleSubjectSummary.tsx
+++ b/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleSubjectSummary.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { usePolicyEditorContext } from '../../../contexts/PolicyEditorContext';
+import { StudioTable, StudioTag } from '@studio/components';
+import {
+  getSubjectCategoryTextKey,
+  getSubjectDisplayName,
+  mapActionsForRole,
+} from '../../../utils/AppPolicyUtils';
+import { useTranslation } from 'react-i18next';
+import classes from './PolicyRuleSubjectSummary.module.css';
+
+export type PolicyRuleSubjectSummaryProps = {
+  subject: string;
+  actions: string[];
+};
+
+export const PolicyRuleSubjectSummary = ({
+  subject,
+  actions,
+}: PolicyRuleSubjectSummaryProps): React.ReactNode => {
+  const { usageType, subjects, policyRules } = usePolicyEditorContext();
+  const { t } = useTranslation();
+
+  const actionsForRole = mapActionsForRole(policyRules, subject, usageType, t);
+
+  return (
+    <StudioTable.Row>
+      <StudioTable.Cell>{subject}</StudioTable.Cell>
+      <StudioTable.Cell>{getSubjectDisplayName(subject, subjects)}</StudioTable.Cell>
+      <StudioTable.Cell>{t(getSubjectCategoryTextKey(subject, subjects))}</StudioTable.Cell>
+      {actions.map((action, index) => {
+        return (
+          <StudioTable.Cell key={index}>
+            <div className={classes.limitationsCell}>
+              {actionsForRole[action]
+                ? actionsForRole[action].split(', ').map((r, i) => {
+                    return (
+                      <StudioTag size='small' key={i} color='info'>
+                        {r}
+                      </StudioTag>
+                    );
+                  })
+                : '-'}
+            </div>
+          </StudioTable.Cell>
+        );
+      })}
+    </StudioTable.Row>
+  );
+};

--- a/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleSummary.tsx
+++ b/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleSummary.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import type { PolicyRuleCard } from '../../../types';
+import { useTranslation } from 'react-i18next';
+import { usePolicyEditorContext } from '../../../contexts/PolicyEditorContext';
+import { StudioTable, StudioTag } from '@studio/components';
+import { getSubjectDisplayName, getSubResourceDisplayText } from '../../../utils/AppPolicyUtils';
+
+export type PolicyRuleSummaryProps = {
+  policyRule: PolicyRuleCard;
+  showErrors: boolean;
+  ruleIndex?: number;
+};
+
+export const PolicyRuleSummary = ({ policyRule }: PolicyRuleSummaryProps): React.ReactNode => {
+  const { t } = useTranslation();
+  const { usageType, subjects } = usePolicyEditorContext();
+
+  const getActionsDisplayNames = (actionList: string[]): string => {
+    return actionList
+      .map((a) => {
+        return t(`policy_editor.action_${a}`);
+      })
+      .join(', ');
+  };
+
+  return (
+    <StudioTable.Row>
+      <StudioTable.Cell>{policyRule.ruleId}</StudioTable.Cell>
+      <StudioTable.Cell>
+        {policyRule.resources
+          .map((r) => {
+            return getSubResourceDisplayText(r, usageType, t);
+          })
+          .join(', ')}
+      </StudioTable.Cell>
+      <StudioTable.Cell>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+          {policyRule.subject.map((s) => {
+            return (
+              <StudioTag size='small' key={s} color='info'>
+                {getSubjectDisplayName(s, subjects)}
+              </StudioTag>
+            );
+          })}
+        </div>
+      </StudioTable.Cell>
+      <StudioTable.Cell>{getActionsDisplayNames(policyRule.actions)}</StudioTable.Cell>
+    </StudioTable.Row>
+  );
+};

--- a/frontend/packages/policy-editor/src/components/PolicySummary/PolicySummary.test.tsx
+++ b/frontend/packages/policy-editor/src/components/PolicySummary/PolicySummary.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { PolicySummary } from './PolicySummary';
+import {
+  PolicyEditorContext,
+  type PolicyEditorContextProps,
+} from '../../contexts/PolicyEditorContext';
+import { mockAction1, mockAction2, mockAction3 } from '../../../test/mocks/policyActionMocks';
+import type { PolicySubject } from '../../types';
+import { textMock } from '@studio/testing/mocks/i18nMock';
+
+const mockSubjects: PolicySubject[] = [
+  {
+    subjectId: 's1',
+    subjectTitle: 'Subject 1',
+    subjectDescription: 'Subject 1 description',
+    subjectSource: 'altinn:rolecode',
+  },
+  {
+    subjectId: '[org]',
+    subjectTitle: '[ORG]',
+    subjectDescription: 'Subject 2 description',
+    subjectSource: 'altinn:org',
+  },
+];
+const mockPolicyEditorContextValue: PolicyEditorContextProps = {
+  policyRules: [
+    {
+      ruleId: 'r1',
+      description: '',
+      subject: ['s1', '[org]'],
+      actions: [mockAction1.actionId, mockAction2.actionId],
+      accessPackages: [],
+      resources: [
+        [
+          { type: 'urn:altinn:org', id: '[org]' },
+          { type: 'urn:altinn:app', id: '[app]' },
+        ],
+      ],
+    },
+  ],
+  setPolicyRules: jest.fn(),
+  actions: [mockAction1, mockAction2],
+  subjects: mockSubjects,
+  accessPackages: [],
+  usageType: 'app',
+  resourceType: 'urn',
+  resourceId: '[app]',
+  showAllErrors: false,
+  savePolicy: jest.fn(),
+};
+
+describe('PolicySummary', () => {
+  it('should render', () => {
+    renderPolicyRuleSubjectSummary({});
+    expect(screen.getByText(textMock('policy_editor.summary_heading'))).toBeInTheDocument();
+  });
+
+  it('should render subject summary for each subject in policy rule', () => {
+    renderPolicyRuleSubjectSummary({});
+    expect(screen.getByText('Subject 1')).toBeInTheDocument();
+    expect(screen.getByText('Tjenesteeier')).toBeInTheDocument();
+  });
+
+  it('should render action heading for each unique action in policy rule', () => {
+    renderPolicyRuleSubjectSummary({});
+    expect(
+      screen.getByText(textMock(`policy_editor.action_${mockAction1.actionId}`)),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock(`policy_editor.action_${mockAction2.actionId}`)),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render action heading for actions that are not in policy rule', () => {
+    renderPolicyRuleSubjectSummary({});
+    expect(
+      screen.queryByText(textMock(`policy_editor.action_${mockAction3.actionId}`)),
+    ).not.toBeInTheDocument();
+  });
+});
+
+const renderPolicyRuleSubjectSummary = (
+  policyEditorContextProps: Partial<PolicyEditorContextProps> = {},
+) => {
+  render(
+    <PolicyEditorContext.Provider
+      value={{ ...mockPolicyEditorContextValue, ...policyEditorContextProps }}
+    >
+      <PolicySummary />
+    </PolicyEditorContext.Provider>,
+  );
+};

--- a/frontend/packages/policy-editor/src/components/PolicySummary/PolicySummary.tsx
+++ b/frontend/packages/policy-editor/src/components/PolicySummary/PolicySummary.tsx
@@ -1,0 +1,54 @@
+import { usePolicyEditorContext } from '../../contexts/PolicyEditorContext';
+import React from 'react';
+import { StudioHeading, StudioParagraph, StudioTable } from '@studio/components';
+import { PolicyRuleSubjectSummary } from './PolicyRuleSummary/PolicyRuleSubjectSummary';
+import { useTranslation } from 'react-i18next';
+import { extractAllUniqueActions, extractAllUniqueSubjects } from '../../utils/AppPolicyUtils';
+
+export function PolicySummary() {
+  const { policyRules } = usePolicyEditorContext();
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <StudioHeading spacing={true} level={4} size='xs'>
+        {t('policy_editor.summary_heading')}
+      </StudioHeading>
+      <StudioParagraph spacing={true}>{t('policy_editor.summary_info_about')}</StudioParagraph>
+      <StudioParagraph spacing={true}>{t('policy_editor.summary_info_edit')}</StudioParagraph>
+      <StudioTable>
+        <StudioTable.Head>
+          <StudioTable.Row>
+            <StudioTable.HeaderCell>
+              {t('policy_editor.summary_table.header_rolecode')}
+            </StudioTable.HeaderCell>
+            <StudioTable.HeaderCell>
+              {t('policy_editor.summary_table.header_rolename')}
+            </StudioTable.HeaderCell>
+            <StudioTable.HeaderCell>
+              {t('policy_editor.summary_table.header_rolecategory')}
+            </StudioTable.HeaderCell>
+            {extractAllUniqueActions(policyRules).map((action, index) => {
+              return (
+                <StudioTable.HeaderCell key={index}>
+                  {t(`policy_editor.action_${action}`)}
+                </StudioTable.HeaderCell>
+              );
+            })}
+          </StudioTable.Row>
+        </StudioTable.Head>
+        <StudioTable.Body>
+          {extractAllUniqueSubjects(policyRules).map((subject, index) => {
+            return (
+              <PolicyRuleSubjectSummary
+                subject={subject}
+                actions={extractAllUniqueActions(policyRules)}
+                key={index}
+              />
+            );
+          })}
+        </StudioTable.Body>
+      </StudioTable>
+    </div>
+  );
+}

--- a/frontend/packages/policy-editor/src/types/index.ts
+++ b/frontend/packages/policy-editor/src/types/index.ts
@@ -1,3 +1,7 @@
+export type AppPolicyActionMap = {
+  [key: string]: string;
+};
+
 export interface PolicyRuleCard {
   ruleId: string;
   description: string;

--- a/frontend/packages/policy-editor/src/types/index.ts
+++ b/frontend/packages/policy-editor/src/types/index.ts
@@ -2,6 +2,8 @@ export type AppPolicyActionMap = {
   [key: string]: string;
 };
 
+export type AppSubResourceDefaultLimitationType = 'urn:altinn:org' | 'urn:altinn:app';
+
 export interface PolicyRuleCard {
   ruleId: string;
   description: string;

--- a/frontend/packages/policy-editor/src/utils/AppPolicyUtils/AppPolicyUtils.test.ts
+++ b/frontend/packages/policy-editor/src/utils/AppPolicyUtils/AppPolicyUtils.test.ts
@@ -1,3 +1,4 @@
+import { textMock } from '@studio/testing/mocks/i18nMock';
 import type { PolicyRuleCard, PolicyRuleResource } from '../../types';
 import {
   extractAllUniqueActions,
@@ -219,8 +220,8 @@ describe('AppPolicyUtils', () => {
           id: '[app]',
         },
       ];
-      const displayText = getSubResourceDisplayText(resource, 'app');
-      expect(displayText).toEqual('Hele tjenesten');
+      const displayText = getSubResourceDisplayText(resource, 'app', textMock);
+      expect(displayText).toEqual('[mockedText(policy_editor._subresource_covers.whole_service)]');
     });
 
     it('should return the display text for an app sub-resource with limitations', () => {
@@ -238,7 +239,7 @@ describe('AppPolicyUtils', () => {
           id: 'task_1',
         },
       ];
-      const displayText = getSubResourceDisplayText(resource, 'app');
+      const displayText = getSubResourceDisplayText(resource, 'app', textMock);
       expect(displayText).toEqual('task_1');
     });
 
@@ -257,7 +258,7 @@ describe('AppPolicyUtils', () => {
           id: 'task_1',
         },
       ];
-      const displayText = getSubResourceDisplayText(resource, 'resource');
+      const displayText = getSubResourceDisplayText(resource, 'resource', textMock);
       expect(displayText).toEqual('[org] - [app] - task_1');
     });
   });
@@ -360,11 +361,12 @@ describe('AppPolicyUtils', () => {
           description: 'test',
         },
       ];
-      const mappedActions = mapActionsForRole(rules, 'subject1', 'app');
+      const mappedActions = mapActionsForRole(rules, 'subject1', 'app', textMock);
       expect(mappedActions).toEqual({
-        read: 'Hele tjenesten (1)',
-        write: 'Hele tjenesten (1), Hele tjenesten (3)',
-        start: 'Hele tjenesten (3)',
+        read: '[mockedText(policy_editor._subresource_covers.whole_service)] (1)',
+        write:
+          '[mockedText(policy_editor._subresource_covers.whole_service)] (1), [mockedText(policy_editor._subresource_covers.whole_service)] (3)',
+        start: '[mockedText(policy_editor._subresource_covers.whole_service)] (3)',
       });
     });
 
@@ -443,17 +445,17 @@ describe('AppPolicyUtils', () => {
           description: 'test',
         },
       ];
-      const mappedActions = mapActionsForRole(rules, 'subject1', 'app');
+      const mappedActions = mapActionsForRole(rules, 'subject1', 'app', textMock);
       expect(mappedActions).toEqual({
         read: 'task_1 (1), task_2 (1)',
-        write: 'Hele tjenesten (3)',
-        instantiate: 'Hele tjenesten (2)',
+        write: '[mockedText(policy_editor._subresource_covers.whole_service)] (3)',
+        instantiate: '[mockedText(policy_editor._subresource_covers.whole_service)] (2)',
       });
     });
 
     it('should return an empty map if the list of rules is empty', () => {
       const rules: PolicyRuleCard[] = [];
-      const mappedActions = mapActionsForRole(rules, 'subject1', 'app');
+      const mappedActions = mapActionsForRole(rules, 'subject1', 'app', textMock);
       expect(mappedActions).toEqual({});
     });
 
@@ -482,7 +484,7 @@ describe('AppPolicyUtils', () => {
           description: 'test',
         },
       ];
-      const mappedActions = mapActionsForRole(rules, 'subject2', 'app');
+      const mappedActions = mapActionsForRole(rules, 'subject2', 'app', textMock);
       expect(mappedActions).toEqual({});
     });
   });

--- a/frontend/packages/policy-editor/src/utils/AppPolicyUtils/AppPolicyUtils.test.ts
+++ b/frontend/packages/policy-editor/src/utils/AppPolicyUtils/AppPolicyUtils.test.ts
@@ -1,0 +1,489 @@
+import type { PolicyRuleCard, PolicyRuleResource } from '../../types';
+import {
+  extractAllUniqueActions,
+  extractAllUniqueSubjects,
+  filterDefaultAppLimitations,
+  filterRulesWithSubject,
+  getSubResourceDisplayText,
+  getSubjectCategoryTextKey,
+  mapActionsForRole,
+} from './AppPolicyUtils';
+
+describe('AppPolicyUtils', () => {
+  describe('extractAllUniqueActions', () => {
+    it('should return a list of unique actions from a list of policy rules', () => {
+      const rules: PolicyRuleCard[] = [
+        {
+          ruleId: '1',
+          actions: ['read', 'write'],
+          resources: [],
+          subject: [],
+          description: 'test',
+        },
+        {
+          ruleId: '2',
+          actions: ['read'],
+          resources: [],
+          subject: [],
+          description: 'test',
+        },
+        {
+          ruleId: '3',
+          actions: ['write'],
+          resources: [],
+          subject: [],
+          description: 'test',
+        },
+      ];
+      const actions = extractAllUniqueActions(rules);
+      expect(actions).toEqual(['read', 'write']);
+    });
+
+    it('should return an empty list if the list of policy rules is empty', () => {
+      const rules: PolicyRuleCard[] = [];
+      const actions = extractAllUniqueActions(rules);
+      expect(actions).toEqual([]);
+    });
+  });
+
+  describe('filterRulesWithSubject', () => {
+    it('should return a list of rules with the provided subject', () => {
+      const rules: PolicyRuleCard[] = [
+        {
+          ruleId: '1',
+          actions: ['read', 'write'],
+          resources: [],
+          subject: ['subject1'],
+          description: 'test',
+        },
+        {
+          ruleId: '2',
+          actions: ['read'],
+          resources: [],
+          subject: ['subject2'],
+          description: 'test',
+        },
+        {
+          ruleId: '3',
+          actions: ['write'],
+          resources: [],
+          subject: ['subject1'],
+          description: 'test',
+        },
+      ];
+      const filteredRules = filterRulesWithSubject(rules, 'subject1');
+      expect(filteredRules).toEqual([
+        {
+          ruleId: '1',
+          actions: ['read', 'write'],
+          resources: [],
+          subject: ['subject1'],
+          description: 'test',
+        },
+        {
+          ruleId: '3',
+          actions: ['write'],
+          resources: [],
+          subject: ['subject1'],
+          description: 'test',
+        },
+      ]);
+    });
+
+    it('should return an empty list if no rules have the provided subject', () => {
+      const rules: PolicyRuleCard[] = [
+        {
+          ruleId: '1',
+          actions: ['read', 'write'],
+          resources: [],
+          subject: ['subject1'],
+          description: 'test',
+        },
+        {
+          ruleId: '2',
+          actions: ['read'],
+          resources: [],
+          subject: ['subject2'],
+          description: 'test',
+        },
+        {
+          ruleId: '3',
+          actions: ['write'],
+          resources: [],
+          subject: ['subject1'],
+          description: 'test',
+        },
+      ];
+      const filteredRules = filterRulesWithSubject(rules, 'subject3');
+      expect(filteredRules).toEqual([]);
+    });
+  });
+
+  describe('filterDefaultAppLimitations', () => {
+    it('should filter out all default app limitations', () => {
+      const appResources = [
+        {
+          type: 'urn:altinn:org',
+          id: 'org',
+        },
+        {
+          type: 'urn:altinn:app',
+          id: 'app',
+        },
+        {
+          type: 'urn:altinn:appresource',
+          id: 'resource',
+        },
+      ];
+      const filteredResources = filterDefaultAppLimitations(appResources);
+      expect(filteredResources).toEqual([
+        {
+          type: 'urn:altinn:appresource',
+          id: 'resource',
+        },
+      ]);
+    });
+
+    it('should return undefined if no default app limitations are present', () => {
+      const appResources = [
+        {
+          type: 'urn:altinn:appresource',
+          id: 'resource',
+        },
+      ];
+      const filteredResources = filterDefaultAppLimitations(appResources);
+      expect(filteredResources).toBeUndefined();
+    });
+
+    it('should return an empty list if only default app limitations are present', () => {
+      const appResources = [
+        {
+          type: 'urn:altinn:org',
+          id: 'org',
+        },
+        {
+          type: 'urn:altinn:app',
+          id: 'app',
+        },
+      ];
+      const filteredResources = filterDefaultAppLimitations(appResources);
+      expect(filteredResources).toEqual([]);
+    });
+  });
+
+  describe('extractAllUniqueSubjects', () => {
+    it('should return a list of unique subjects from a list of policy rules', () => {
+      const rules: PolicyRuleCard[] = [
+        {
+          ruleId: '1',
+          actions: ['read', 'write'],
+          resources: [],
+          subject: ['subject1'],
+          description: 'test',
+        },
+        {
+          ruleId: '2',
+          actions: ['read'],
+          resources: [],
+          subject: ['subject2'],
+          description: 'test',
+        },
+        {
+          ruleId: '3',
+          actions: ['write'],
+          resources: [],
+          subject: ['subject1'],
+          description: 'test',
+        },
+      ];
+      const subjects = extractAllUniqueSubjects(rules);
+      expect(subjects).toEqual(['subject1', 'subject2']);
+    });
+
+    it('should return an empty list if the list of policy rules is empty', () => {
+      const rules: PolicyRuleCard[] = [];
+      const subjects = extractAllUniqueSubjects(rules);
+      expect(subjects).toEqual([]);
+    });
+  });
+
+  describe('getSubResourceDisplayText', () => {
+    it('should return the display text for an app sub-resource with no limitations', () => {
+      const resource: PolicyRuleResource[] = [
+        {
+          type: 'urn:altinn:org',
+          id: '[org]',
+        },
+        {
+          type: 'urn:altinn:app',
+          id: '[app]',
+        },
+      ];
+      const displayText = getSubResourceDisplayText(resource, 'app');
+      expect(displayText).toEqual('Hele tjenesten');
+    });
+
+    it('should return the display text for an app sub-resource with limitations', () => {
+      const resource: PolicyRuleResource[] = [
+        {
+          type: 'urn:altinn:org',
+          id: '[org]',
+        },
+        {
+          type: 'urn:altinn:app',
+          id: '[app]',
+        },
+        {
+          type: 'urn:altinn:task',
+          id: 'task_1',
+        },
+      ];
+      const displayText = getSubResourceDisplayText(resource, 'app');
+      expect(displayText).toEqual('task_1');
+    });
+
+    it('should return the display text for a generic sub-resource with limitations', () => {
+      const resource: PolicyRuleResource[] = [
+        {
+          type: 'urn:altinn:org',
+          id: '[org]',
+        },
+        {
+          type: 'urn:altinn:app',
+          id: '[app]',
+        },
+        {
+          type: 'urn:altinn:task',
+          id: 'task_1',
+        },
+      ];
+      const displayText = getSubResourceDisplayText(resource, 'resource');
+      expect(displayText).toEqual('[org] - [app] - task_1');
+    });
+  });
+
+  describe('getSubjectCategoryTextKey', () => {
+    it('should return the text key for the subject category', () => {
+      const subjects = [
+        {
+          subjectId: 'subject1',
+          subjectSource: 'altinn:role',
+          subjectTitle: 'Role 1',
+          subjectDescription: 'Role 1 description',
+        },
+        {
+          subjectId: 'subject2',
+          subjectSource: 'altinn:role',
+          subjectTitle: 'Role 2',
+          subjectDescription: 'Role 2 description',
+        },
+      ];
+      const textKey = getSubjectCategoryTextKey('subject1', subjects);
+      expect(textKey).toEqual('policy_editor.role_category.altinn_role');
+    });
+
+    it('should return undefined if the subject is not found', () => {
+      const subjects = [
+        {
+          subjectId: 'subject1',
+          subjectSource: 'urn:altinn:role',
+          subjectTitle: 'Role 1',
+          subjectDescription: 'Role 1 description',
+        },
+        {
+          subjectId: 'subject2',
+          subjectSource: 'urn:altinn:role',
+          subjectTitle: 'Role 2',
+          subjectDescription: 'Role 2 description',
+        },
+      ];
+      const textKey = getSubjectCategoryTextKey('subject3', subjects);
+      expect(textKey).toBeUndefined();
+    });
+  });
+
+  describe('mapActionsForRole', () => {
+    it('should return a list of actions mapped to a role', () => {
+      const rules: PolicyRuleCard[] = [
+        {
+          ruleId: '1',
+          actions: ['read', 'write'],
+          resources: [
+            [
+              {
+                type: 'urn:altinn:org',
+                id: '[org]',
+              },
+              {
+                type: 'urn:altinn:app',
+                id: '[app]',
+              },
+            ],
+          ],
+          subject: ['subject1'],
+          description: 'test',
+        },
+        {
+          ruleId: '2',
+          actions: ['start'],
+          resources: [
+            [
+              {
+                type: 'urn:altinn:org',
+                id: '[org]',
+              },
+              {
+                type: 'urn:altinn:app',
+                id: '[app]',
+              },
+            ],
+          ],
+          subject: ['subject2'],
+          description: 'test',
+        },
+        {
+          ruleId: '3',
+          actions: ['write', 'start'],
+          resources: [
+            [
+              {
+                type: 'urn:altinn:org',
+                id: '[org]',
+              },
+              {
+                type: 'urn:altinn:app',
+                id: '[app]',
+              },
+            ],
+          ],
+          subject: ['subject1'],
+          description: 'test',
+        },
+      ];
+      const mappedActions = mapActionsForRole(rules, 'subject1', 'app');
+      expect(mappedActions).toEqual({
+        read: 'Hele tjenesten (1)',
+        write: 'Hele tjenesten (1), Hele tjenesten (3)',
+        start: 'Hele tjenesten (3)',
+      });
+    });
+
+    it('should return a map of actions to the sub-resources they cover', () => {
+      const rules: PolicyRuleCard[] = [
+        {
+          ruleId: '1',
+          actions: ['read'],
+          resources: [
+            [
+              {
+                type: 'urn:altinn:org',
+                id: '[org]',
+              },
+              {
+                type: 'urn:altinn:app',
+                id: '[app]',
+              },
+              {
+                type: 'urn:altinn:task',
+                id: 'task_1',
+              },
+            ],
+            [
+              {
+                type: 'urn:altinn:org',
+                id: '[org]',
+              },
+              {
+                type: 'urn:altinn:app',
+                id: '[app]',
+              },
+              {
+                type: 'urn:altinn:task',
+                id: 'task_2',
+              },
+            ],
+          ],
+          subject: ['subject1'],
+          description: 'test',
+        },
+        {
+          ruleId: '2',
+          actions: ['instantiate'],
+          resources: [
+            [
+              {
+                type: 'urn:altinn:org',
+                id: '[org]',
+              },
+              {
+                type: 'urn:altinn:app',
+                id: '[app]',
+              },
+            ],
+          ],
+          subject: ['subject1'],
+          description: 'test',
+        },
+        {
+          ruleId: '3',
+          actions: ['write'],
+          resources: [
+            [
+              {
+                type: 'urn:altinn:org',
+                id: '[org]',
+              },
+              {
+                type: 'urn:altinn:app',
+                id: '[app]',
+              },
+            ],
+          ],
+          subject: ['subject1'],
+          description: 'test',
+        },
+      ];
+      const mappedActions = mapActionsForRole(rules, 'subject1', 'app');
+      expect(mappedActions).toEqual({
+        read: 'task_1 (1), task_2 (1)',
+        write: 'Hele tjenesten (3)',
+        instantiate: 'Hele tjenesten (2)',
+      });
+    });
+
+    it('should return an empty map if the list of rules is empty', () => {
+      const rules: PolicyRuleCard[] = [];
+      const mappedActions = mapActionsForRole(rules, 'subject1', 'app');
+      expect(mappedActions).toEqual({});
+    });
+
+    it('should return an empty map if the subject does not match any rules', () => {
+      const rules: PolicyRuleCard[] = [
+        {
+          ruleId: '1',
+          actions: ['read'],
+          resources: [
+            [
+              {
+                type: 'urn:altinn:org',
+                id: '[org]',
+              },
+              {
+                type: 'urn:altinn:app',
+                id: '[app]',
+              },
+              {
+                type: 'urn:altinn:task',
+                id: 'task_1',
+              },
+            ],
+          ],
+          subject: ['subject1'],
+          description: 'test',
+        },
+      ];
+      const mappedActions = mapActionsForRole(rules, 'subject2', 'app');
+      expect(mappedActions).toEqual({});
+    });
+  });
+});

--- a/frontend/packages/policy-editor/src/utils/AppPolicyUtils/AppPolicyUtils.ts
+++ b/frontend/packages/policy-editor/src/utils/AppPolicyUtils/AppPolicyUtils.ts
@@ -1,0 +1,160 @@
+import type {
+  AppPolicyActionMap,
+  PolicyEditorUsage,
+  PolicyRuleCard,
+  PolicyRuleResource,
+  PolicySubject,
+} from '../../types';
+
+/**
+ * Get the display name for a subject
+ * @param subject The subject to get the display name for
+ * @param allSubjects
+ * @returns The display name for the subject, or the subject itself if no display name is found
+ */
+export const getSubjectDisplayName = (subject: string, allSubjects: PolicySubject[]): string => {
+  if (subject.toLowerCase() === '[org]') {
+    return 'Tjenesteeier';
+  }
+  return (
+    allSubjects.find((sub) => sub.subjectId.toLowerCase() === subject.toLowerCase())
+      ?.subjectTitle || subject
+  );
+};
+
+/**
+ *
+ * @param rules Filters out only the rules that have the provided subject (case-insensitive)
+ * @param subject
+ * @returns The filtered rules
+ */
+export const filterRulesWithSubject = (
+  rules: PolicyRuleCard[],
+  subject: string,
+): PolicyRuleCard[] => {
+  return rules.filter((rule) =>
+    rule.subject.map((s) => s.toLowerCase()).includes(subject.toLowerCase()),
+  );
+};
+
+/**
+ * Filters out all default app limitations from a list of sub-resource limitations
+ * @param appResources The resources to filter
+ * @returns The filtered resources
+ */
+export const filterDefaultAppLimitations = (
+  appResources: PolicyRuleResource[],
+): PolicyRuleResource[] => {
+  if (
+    !appResources.find((r) => r.type === 'urn:altinn:app') ||
+    !appResources.find((r) => r.type === 'urn:altinn:org')
+  ) {
+    return undefined;
+  }
+
+  return appResources.filter((r) => r.type !== 'urn:altinn:org' && r.type !== 'urn:altinn:app');
+};
+
+/**
+ * Extracts all unique subjects from a list of policy rules
+ * @param rules The policy rules to extract subjects from
+ * @returns The list of unique subjects
+ */
+export const extractAllUniqueSubjects = (rules: PolicyRuleCard[]): string[] => {
+  const subjects: string[] = [];
+  rules.forEach((rule) => {
+    rule.subject.forEach((s) => {
+      if (!subjects.includes(s.toLowerCase())) {
+        subjects.push(s.toLowerCase());
+      }
+    });
+  });
+  return subjects;
+};
+
+/**
+ * Extracts all unique actions from a list of policy rules
+ * @param rules The policy rules to extract actions from
+ * @returns The list of unique actions
+ */
+export const extractAllUniqueActions = (rules: PolicyRuleCard[]): string[] => {
+  const actions: string[] = [];
+  rules.forEach((rule) => {
+    rule.actions.forEach((a) => {
+      if (!actions.includes(a)) {
+        actions.push(a);
+      }
+    });
+  });
+  return actions;
+};
+
+/**
+ * Get the display text key for a subject category
+ * @param subject The subject to get the category text key for
+ * @param subjects The list of all subjects
+ * @returns The text key for the subject category
+ */
+export const getSubjectCategoryTextKey = (
+  subject: string,
+  subjects: PolicySubject[],
+): string | undefined => {
+  const source = subjects.find(
+    (sub) => sub.subjectId.toLowerCase() === subject.toLowerCase(),
+  )?.subjectSource;
+  if (!source) {
+    return undefined;
+  }
+  return `policy_editor.role_category.${source.replace(':', '_')}`;
+};
+
+/**
+ * Get complete sub-resource display text, including limitations
+ * @param resources The resources to get the display text for
+ * @param usageType The usage type for the policy editor
+ * @returns The display text
+ */
+export const getSubResourceDisplayText = (
+  resources: PolicyRuleResource[],
+  usageType: PolicyEditorUsage,
+): string => {
+  if (usageType === 'app') {
+    const limitations = filterDefaultAppLimitations(resources)
+      .map((r) => r.id)
+      .join(' - ');
+    if (limitations && limitations.length > 0) {
+      return limitations;
+    }
+    return 'Hele tjenesten';
+  }
+  return resources.map((r) => r.id).join(' - ');
+};
+
+/**
+ * Maps actions to the resources they cover for a specific role
+ * @param policyRules The policy rules to map actions for
+ * @param subject The subject to map actions for
+ * @param usageType The usage type for the policy editor
+ * @returns A map of actions to the resources they cover
+ */
+export const mapActionsForRole = (
+  policyRules: PolicyRuleCard[],
+  subject: string,
+  usageType: PolicyEditorUsage,
+): AppPolicyActionMap => {
+  const result = {};
+  filterRulesWithSubject(policyRules, subject).forEach((rule) => {
+    const covers = rule.resources
+      .map((r) => getSubResourceDisplayText(r, usageType).concat(` (${rule.ruleId})`))
+      .join(', ');
+
+    rule.actions.forEach((action) => {
+      if (!result[action]) {
+        result[action] = `${covers}`;
+      } else {
+        result[action] += `, ${covers}`;
+      }
+    });
+  });
+  return result;
+};

--- a/frontend/packages/policy-editor/src/utils/AppPolicyUtils/index.ts
+++ b/frontend/packages/policy-editor/src/utils/AppPolicyUtils/index.ts
@@ -1,0 +1,10 @@
+export {
+  filterRulesWithSubject,
+  filterDefaultAppLimitations,
+  extractAllUniqueSubjects,
+  extractAllUniqueActions,
+  getSubResourceDisplayText,
+  getSubjectCategoryTextKey,
+  getSubjectDisplayName,
+  mapActionsForRole,
+} from './AppPolicyUtils';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Created a summary component for app policy, that can be used to create an overview of the roles, actions and resources set in the policy.

Example with the default app policy:
<img width="981" alt="Screenshot 2025-02-20 at 15 36 35" src="https://github.com/user-attachments/assets/5f4505de-a404-44c4-934d-55427d90d997" />

Implementing the component in the policy editor will be done in a separate PR.

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
