### PR TITLE
fix: disabled delete button

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/ExpressionContent/ExpressionContent.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/ExpressionContent/ExpressionContent.test.tsx
@@ -58,11 +58,23 @@ describe('ExpressionContent', () => {
     const user = userEvent.setup();
     jest.spyOn(window, 'confirm').mockImplementation(() => true);
     const onDelete = jest.fn();
-    renderExpressionContent({ onDelete });
+    renderExpressionContent({ onDelete, expression: parsableLogicalExpression });
     const deleteButtonName = textMock('right_menu.expression_delete');
     const deleteButton = screen.getByRole('button', { name: deleteButtonName });
     await user.click(deleteButton);
     expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('Show delete button when existing an expression', async () => {
+    renderExpressionContent({ expression: parsableLogicalExpression });
+    screen.getByRole('button', { name: textMock('right_menu.expression_delete') });
+  });
+
+  it('Do not show delete button if there is no expression', async () => {
+    renderExpressionContent();
+    expect(
+      screen.queryByRole('button', { name: textMock('right_menu.expression_delete') }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/packages/ux-editor/src/components/config/ExpressionContent/ExpressionContent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/ExpressionContent/ExpressionContent.tsx
@@ -48,13 +48,15 @@ export const ExpressionContent = ({
           {heading}
         </Paragraph>
       </legend>
-      <StudioDeleteButton
-        className={classes.deleteButton}
-        confirmMessage={t('right_menu.expressions_delete_confirm')}
-        onDelete={onDelete}
-        size='small'
-        title={t('right_menu.expression_delete')}
-      />
+      {expression && (
+        <StudioDeleteButton
+          className={classes.deleteButton}
+          confirmMessage={t('right_menu.expressions_delete_confirm')}
+          onDelete={onDelete}
+          size='small'
+          title={t('right_menu.expression_delete')}
+        />
+      )}
       <div className={classes.expressionWrapper}>
         <ExpressionWithTexts
           expression={expression}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Disabled delete button in dynamic when there is no expression added. 
- Added test for it. 

## Related Issue(s)

- #14775

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The delete button now appears only when a valid expression is present, resulting in a cleaner, more intuitive interface by reducing unnecessary options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->