### PR TITLE
fix: Explicit width on create code list dialog

### DIFF
--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListsActionsBar/CreateNewCodeListModal/CreateNewCodeListModal.module.css
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListsActionsBar/CreateNewCodeListModal/CreateNewCodeListModal.module.css
@@ -1,6 +1,6 @@
 .createNewCodeListModal[open] {
   max-width: unset;
-  width: min(80vw, 64rem);
+  width: 80vw;
 }
 
 .createNewCodeList {


### PR DESCRIPTION
## Description
Made the create code list dialog always fill the same amount of the window width.

Current:
![image](https://github.com/user-attachments/assets/6df8c2a5-2a0b-47df-93cf-9863f6d1588f)

This branch:
![image](https://github.com/user-attachments/assets/dccd8a4c-32df-4389-ac15-5898a430b978)

## Related Issue(s)
- #13739

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated modal styling to use a fixed width of 80% viewport width, allowing a broader display on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->