### PR TITLE
ci: Remove branch filter for pull request checks

### DIFF
--- a/.github/workflows/designer-dotnet-test.yaml
+++ b/.github/workflows/designer-dotnet-test.yaml
@@ -6,7 +6,6 @@ on:
       - 'testdata/**'
       - 'backend/**'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened]
     paths:
       - 'backend/**'

--- a/.github/workflows/dotnet-format.yaml
+++ b/.github/workflows/dotnet-format.yaml
@@ -5,7 +5,6 @@ on:
     paths:
       - 'backend/**'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened]
     paths:
       - 'backend/**'

--- a/.github/workflows/run-playwright-on-pr.yaml
+++ b/.github/workflows/run-playwright-on-pr.yaml
@@ -1,7 +1,6 @@
 name: Playwright tests on pr
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
     paths:
       - 'frontend/**'


### PR DESCRIPTION
## Description
Removed the branch filter from Playwright and backend test workflows, so that they also run on pull request to other branches, like the organisation library proof of concept branch.

## Verification
- [x] **Your** code builds clean without any errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflows so that pull request checks now run on any target branch instead of only the main branch, ensuring consistent validation across all branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->