### PR TITLE
fix: add helper method to check if version is below or equal to a specific version

### DIFF
--- a/backend/src/Designer/Helpers/Preview/NugetVersionHelper.cs
+++ b/backend/src/Designer/Helpers/Preview/NugetVersionHelper.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Diagnostics.Contracts;
+using System.Linq;
+
+namespace Altinn.Studio.Designer.Helpers.Preview
+{
+    public static class NugetVersionHelper
+    {
+        private const string MINIMUM_NUGET_VERSION = "8.0.0.0";
+        private const int MINIMUM_PREVIEW_NUGET_VERSION = 15;
+
+        /// <summary>
+        /// Method to get the mocked altinn nuget build from the version
+        /// We are returnning the minimum BUILD version of the nuget package that is required for app frontend to work
+        /// from v4 and above.
+        /// </summary>
+        /// <param name="version">The version of the nuget package</param>
+        /// <returns>The minimum build version of the nuget package</returns>
+        public static string GetMockedAltinnNugetBuildFromVersion(string version)
+        {
+
+            string[] versionParts = version.Split('.');
+            if (!IsValidSemVerVersion(versionParts))
+            {
+                return string.Empty;
+            }
+
+            string normalVersion = version.Split('-').First();
+            int[] numberVersion = [.. normalVersion.Split('.').Take(3).Select((split) => Convert.ToInt32(split))];
+            if (IsVersionOrBelow(numberVersion, [8, 0, 0]) && IsPreviewVersion(versionParts) && GetPreviewVersion(versionParts) < MINIMUM_PREVIEW_NUGET_VERSION)
+            {
+                return string.Empty;
+            }
+
+            return MINIMUM_NUGET_VERSION;
+        }
+
+        private static bool IsValidSemVerVersion(string[] versionParts)
+        {
+            return versionParts.Length >= 3 && Convert.ToInt32(versionParts[0]) >= 8;
+        }
+
+        // <exception cref="FormatException"></exception>
+        // <exception cref="OverflowException"></exception>
+        private static bool IsVersionOrBelow(int[] versionParts, int[] breakpoint)
+        {
+            Contract.Requires(versionParts.Length == 3);
+            Contract.Requires(breakpoint.Length == 3);
+            for (int i = 0; i < 3; i++)
+            {
+                if (versionParts[i] > breakpoint[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static bool IsPreviewVersion(string[] versionParts)
+        {
+            return versionParts[2].Contains("-preview") && versionParts.Length == 4;
+        }
+
+        private static int GetPreviewVersion(string[] versionParts)
+        {
+            return Convert.ToInt32(versionParts[3]);
+        }
+    }
+}

--- a/backend/tests/Designer.Tests/Helpers/Preview/NugetVersionHelperTests.cs
+++ b/backend/tests/Designer.Tests/Helpers/Preview/NugetVersionHelperTests.cs
@@ -1,0 +1,23 @@
+using Xunit;
+using Altinn.Studio.Designer.Helpers;
+using Altinn.Studio.Designer.Helpers.Preview;
+
+namespace Designer.Tests.Helpers.Preview {
+
+    public class NugetVersionHelperTests {
+        [Fact]
+        public void GetMockedAltinnNugetBuildFromVersion_ShouldReturnEmptyStringForVersionsBelowBreakpoint()
+        {
+            Assert.Equal("", NugetVersionHelper.GetMockedAltinnNugetBuildFromVersion("1.1.1"));
+            Assert.Equal("", NugetVersionHelper.GetMockedAltinnNugetBuildFromVersion("1.1.1-preview.150"));
+            Assert.Equal("", NugetVersionHelper.GetMockedAltinnNugetBuildFromVersion("1.1.1-preview.0"));
+            Assert.Equal("8.0.0.0", NugetVersionHelper.GetMockedAltinnNugetBuildFromVersion("8.1.1-preview.14"));
+            Assert.Equal("8.0.0.0", NugetVersionHelper.GetMockedAltinnNugetBuildFromVersion("8.8.8-preview.0"));
+            Assert.Equal("8.0.0.0", NugetVersionHelper.GetMockedAltinnNugetBuildFromVersion("8.18.1238"));
+            Assert.Equal("8.0.0.0", NugetVersionHelper.GetMockedAltinnNugetBuildFromVersion("8.18.1238"));
+            Assert.Equal("8.0.0.0", NugetVersionHelper.GetMockedAltinnNugetBuildFromVersion("8.8.8-preview.342"));
+            Assert.Equal("8.0.0.0", NugetVersionHelper.GetMockedAltinnNugetBuildFromVersion("8.0.0-preview.15"));
+            Assert.Equal("", NugetVersionHelper.GetMockedAltinnNugetBuildFromVersion("8.0.0-preview.14"));
+        }
+    }
+}

--- a/backend/tests/Designer.Tests/Helpers/Preview/NugetVersionHelperTests.cs
+++ b/backend/tests/Designer.Tests/Helpers/Preview/NugetVersionHelperTests.cs
@@ -1,10 +1,11 @@
-using Xunit;
-using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Helpers.Preview;
+using Xunit;
 
-namespace Designer.Tests.Helpers.Preview {
+namespace Designer.Tests.Helpers.Preview
+{
 
-    public class NugetVersionHelperTests {
+    public class NugetVersionHelperTests
+    {
         [Fact]
         public void GetMockedAltinnNugetBuildFromVersion_ShouldReturnEmptyStringForVersionsBelowBreakpoint()
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a new helper function to check if semantic version is below or equal to a version, and only returns empty string for 8.0.0-preview.15 or below.

## Related Issue(s)

Issue thread from slack: https://digdir.slack.com/archives/C0760NPT2BE/p1740395650522149

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new helper that standardizes package version outputs.
- **Refactor**
  - Streamlined version handling by removing deprecated logic.
- **Tests**
  - Added comprehensive tests to validate the version output across various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->