### PR TITLE
fix(resource-adm): validate org set in resource json when publishing resource

### DIFF
--- a/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -605,6 +605,12 @@ namespace Altinn.Studio.Designer.Controllers
         {
             if (repository == $"{org}-resources")
             {
+                ServiceResource resource = _repository.GetServiceResourceById(org, repository, id);
+                if (resource.HasCompetentAuthority.Orgcode != org)
+                {
+                    return new StatusCodeResult(400);
+                }
+
                 string xacmlPolicyPath = _repository.GetPolicyPath(org, repository, id);
                 ActionResult publishResult = await _repository.PublishResource(org, repository, id, env, xacmlPolicyPath);
                 _memoryCache.Remove($"resourcelist_${env}");

--- a/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -605,12 +605,6 @@ namespace Altinn.Studio.Designer.Controllers
         {
             if (repository == $"{org}-resources")
             {
-                ServiceResource resource = _repository.GetServiceResourceById(org, repository, id);
-                if (resource.HasCompetentAuthority.Orgcode != org)
-                {
-                    return new StatusCodeResult(400);
-                }
-
                 string xacmlPolicyPath = _repository.GetPolicyPath(org, repository, id);
                 ActionResult publishResult = await _repository.PublishResource(org, repository, id, env, xacmlPolicyPath);
                 _memoryCache.Remove($"resourcelist_${env}");

--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -514,6 +514,11 @@ namespace Altinn.Studio.Designer.Services.Implementation
         public async Task<ActionResult> PublishResource(string org, string repository, string id, string env, string policy = null)
         {
             ServiceResource resource = GetServiceResourceById(org, repository, id);
+            if (resource.HasCompetentAuthority.Orgcode != org)
+            {
+                return new StatusCodeResult(400);
+            }
+
             return await _resourceRegistryService.PublishServiceResource(resource, env, policy);
         }
 

--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -516,7 +516,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             ServiceResource resource = GetServiceResourceById(org, repository, id);
             if (resource.HasCompetentAuthority == null || resource.HasCompetentAuthority.Orgcode != org)
             {
-                _logger.LogWarning("Org mismatch for resource {repo} for org {org}.", id, org);
+                _logger.LogWarning("Org mismatch for resource");
                 return new StatusCodeResult(400);
             }
 

--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -514,8 +514,9 @@ namespace Altinn.Studio.Designer.Services.Implementation
         public async Task<ActionResult> PublishResource(string org, string repository, string id, string env, string policy = null)
         {
             ServiceResource resource = GetServiceResourceById(org, repository, id);
-            if (resource.HasCompetentAuthority.Orgcode != org)
+            if (resource.HasCompetentAuthority == null || resource.HasCompetentAuthority.Orgcode != org)
             {
+                _logger.LogWarning("Org mismatch for resource {repo} for org {org}.", id, org);
                 return new StatusCodeResult(400);
             }
 


### PR DESCRIPTION
## Description

- Validate that org code set in resource json file matches org code in url when publishing resource

## Related Issue(s)

- this PR

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Added enhanced verification during resource publishing, ensuring that only authorized organization codes proceed. Invalid codes now prompt an immediate error response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->