### PR TITLE
refactor: move dashboardHeaderMenuItems

### DIFF
--- a/frontend/dashboard/pages/PageLayout/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/dashboard/pages/PageLayout/DashboardHeader/DashboardHeader.tsx
@@ -20,8 +20,8 @@ import { useProfileMenuTriggerButtonText } from 'dashboard/hooks/useProfileMenuT
 import { useRepoPath } from 'dashboard/hooks/useRepoPath';
 import { usePageHeaderTitle } from 'dashboard/hooks/usePageHeaderTitle';
 import { useSubroute } from '../../../hooks/useSubRoute';
-import type { HeaderMenuItem } from './dashboardHeaderMenuItems';
-import { dashboardHeaderMenuItems } from './dashboardHeaderMenuItems';
+import type { HeaderMenuItem } from '../../../types/HeaderMenuItem';
+import { dashboardHeaderMenuItems } from '../../../utils/headerUtils/headerUtils';
 import { StringUtils } from '@studio/pure-functions';
 import { FeatureFlag, shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
 

--- a/frontend/dashboard/types/HeaderMenuItem.ts
+++ b/frontend/dashboard/types/HeaderMenuItem.ts
@@ -1,0 +1,7 @@
+import type { HeaderMenuItemKey } from '../enums/HeaderMenuItemKey';
+
+export type HeaderMenuItem = {
+  key: HeaderMenuItemKey;
+  link: string;
+  name: string;
+};

--- a/frontend/dashboard/utils/headerUtils/headerUtils.ts
+++ b/frontend/dashboard/utils/headerUtils/headerUtils.ts
@@ -1,10 +1,6 @@
-import { Subroute } from '../../../enums/Subroute';
-import { HeaderMenuItemKey } from '../../../enums/HeaderMenuItemKey';
-export interface HeaderMenuItem {
-  key: HeaderMenuItemKey;
-  link: string;
-  name: string;
-}
+import type { HeaderMenuItem } from '../../types/HeaderMenuItem';
+import { Subroute } from '../../enums/Subroute';
+import { HeaderMenuItemKey } from '../../enums/HeaderMenuItemKey';
 
 export const dashboardHeaderMenuItems: HeaderMenuItem[] = [
   {

--- a/frontend/dashboard/utils/headerUtils/index.ts
+++ b/frontend/dashboard/utils/headerUtils/index.ts
@@ -1,0 +1,1 @@
+export { dashboardHeaderMenuItems } from './headerUtils';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Moving `dashboardHeaderMenuItems` to utils and `HeaderMenuItem` to types folders to make it ready for the dashboard header refactor

## Related Issue(s)

- #14852 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)