### PR TITLE
fix: Trigger text resource updates with blur instead of change in code list editor (2)

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditor.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditor.test.tsx
@@ -30,7 +30,6 @@ import { emptyBooleanItem, emptyNumberItem, emptyStringItem } from './utils';
 const onAddOrDeleteItem = jest.fn();
 const onBlurAny = jest.fn();
 const onChange = jest.fn();
-const onChangeTextResource = jest.fn();
 const onInvalid = jest.fn();
 const defaultProps: StudioCodeListEditorProps = {
   codeList: codeListWithoutTextResources,
@@ -38,7 +37,6 @@ const defaultProps: StudioCodeListEditorProps = {
   onAddOrDeleteItem,
   onBlurAny,
   onChange,
-  onChangeTextResource,
   onInvalid,
 };
 const propsWithTextResources: Partial<StudioCodeListEditorProps> = {
@@ -242,7 +240,8 @@ describe('StudioCodeListEditor', () => {
 
     it('Calls the onChangeTextResource callback with the new text resource when a label is changed', async () => {
       const user = userEvent.setup();
-      renderCodeListEditor(propsWithTextResources);
+      const onChangeTextResource = jest.fn();
+      renderCodeListEditor({ ...propsWithTextResources, onChangeTextResource });
       const propertyCoords: TextPropertyCoords = [testRowNumber, CodeListItemTextProperty.Label];
       const newValue = 'new text';
       await user.type(getTextResourceValueInput(propertyCoords), newValue);
@@ -255,7 +254,8 @@ describe('StudioCodeListEditor', () => {
 
     it('Calls the onChangeTextResource callback with the new text resource when a description is changed', async () => {
       const user = userEvent.setup();
-      renderCodeListEditor(propsWithTextResources);
+      const onChangeTextResource = jest.fn();
+      renderCodeListEditor({ ...propsWithTextResources, onChangeTextResource });
       const propertyCoords: TextPropertyCoords = [
         testRowNumber,
         CodeListItemTextProperty.Description,
@@ -271,12 +271,65 @@ describe('StudioCodeListEditor', () => {
 
     it('Calls the onChangeTextResource callback with the new text resource when a help text is changed', async () => {
       const user = userEvent.setup();
-      renderCodeListEditor(propsWithTextResources);
+      const onChangeTextResource = jest.fn();
+      renderCodeListEditor({ ...propsWithTextResources, onChangeTextResource });
       const propertyCoords: TextPropertyCoords = [testRowNumber, CodeListItemTextProperty.HelpText];
       const newValue = 'new text';
       await user.type(getTextResourceValueInput(propertyCoords), newValue);
       expect(onChangeTextResource).toHaveBeenCalledTimes(newValue.length);
       expect(onChangeTextResource).toHaveBeenLastCalledWith({
+        ...helpText1Resource,
+        value: expect.stringContaining(newValue),
+      });
+    });
+  });
+
+  describe('onBlurTextResource', () => {
+    const testRowNumber = 1;
+
+    it('Calls the onBlurTextResource callback with the new text resource when a label is changed', async () => {
+      const user = userEvent.setup();
+      const onBlurTextResource = jest.fn();
+      renderCodeListEditor({ ...propsWithTextResources, onBlurTextResource });
+      const propertyCoords: TextPropertyCoords = [testRowNumber, CodeListItemTextProperty.Label];
+      const newValue = 'new text';
+      await user.type(getTextResourceValueInput(propertyCoords), newValue);
+      await user.tab();
+      expect(onBlurTextResource).toHaveBeenCalledTimes(1);
+      expect(onBlurTextResource).toHaveBeenCalledWith({
+        ...label1Resource,
+        value: expect.stringContaining(newValue),
+      });
+    });
+
+    it('Calls the onBlurTextResource callback with the new text resource when a description is changed', async () => {
+      const user = userEvent.setup();
+      const onBlurTextResource = jest.fn();
+      renderCodeListEditor({ ...propsWithTextResources, onBlurTextResource });
+      const propertyCoords: TextPropertyCoords = [
+        testRowNumber,
+        CodeListItemTextProperty.Description,
+      ];
+      const newValue = 'new text';
+      await user.type(getTextResourceValueInput(propertyCoords), newValue);
+      await user.tab();
+      expect(onBlurTextResource).toHaveBeenCalledTimes(1);
+      expect(onBlurTextResource).toHaveBeenCalledWith({
+        ...description1Resource,
+        value: expect.stringContaining(newValue),
+      });
+    });
+
+    it('Calls the onBlurTextResource callback with the new text resource when a help text is changed', async () => {
+      const user = userEvent.setup();
+      const onBlurTextResource = jest.fn();
+      renderCodeListEditor({ ...propsWithTextResources, onBlurTextResource });
+      const propertyCoords: TextPropertyCoords = [testRowNumber, CodeListItemTextProperty.HelpText];
+      const newValue = 'new text';
+      await user.type(getTextResourceValueInput(propertyCoords), newValue);
+      await user.tab();
+      expect(onBlurTextResource).toHaveBeenCalledTimes(1);
+      expect(onBlurTextResource).toHaveBeenCalledWith({
         ...helpText1Resource,
         value: expect.stringContaining(newValue),
       });

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditor.tsx
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditor.tsx
@@ -36,6 +36,7 @@ export type StudioCodeListEditorProps = {
   codeList: CodeList;
   onAddOrDeleteItem?: (codeList: CodeList) => void;
   onBlurAny?: (codeList: CodeList) => void;
+  onBlurTextResource?: (textResource: TextResource) => void;
   onChange?: (codeList: CodeList) => void;
   onChangeTextResource?: (textResource: TextResource) => void;
   onInvalid?: () => void;
@@ -57,6 +58,7 @@ function StatefulCodeListEditor({
   codeList: defaultCodeList,
   onAddOrDeleteItem,
   onBlurAny,
+  onBlurTextResource,
   onChange,
   onChangeTextResource,
   onInvalid,
@@ -88,6 +90,7 @@ function StatefulCodeListEditor({
       codeList={codeList}
       onAddOrDeleteItem={handleAddOrDeleteAny}
       onBlurAny={handleBlurAny}
+      onBlurTextResource={onBlurTextResource}
       onChange={handleChange}
       onChangeTextResource={onChangeTextResource}
       textResources={textResources}
@@ -104,6 +107,7 @@ function ControlledCodeListEditor({
   codeList,
   onAddOrDeleteItem,
   onBlurAny,
+  onBlurTextResource,
   onChange,
   onChangeTextResource,
   textResources,
@@ -127,6 +131,7 @@ function ControlledCodeListEditor({
         errorMap={errorMap}
         onAddOrDeleteItem={onAddOrDeleteItem}
         onBlurAny={onBlurAny}
+        onBlurTextResource={onBlurTextResource}
         onChange={onChange}
         onChangeCodeType={setCodeType}
         onChangeTextResource={onChangeTextResource}
@@ -200,6 +205,7 @@ function TableHeadings(): ReactElement {
 function TableBody({
   codeList,
   onAddOrDeleteItem,
+  onBlurTextResource,
   onChange,
   onChangeTextResource,
   errorMap,
@@ -230,6 +236,7 @@ function TableBody({
           item={item}
           key={index}
           number={index + 1}
+          onBlurTextResource={onBlurTextResource}
           onChange={(newItem) => handleChange(index, newItem)}
           onChangeTextResource={onChangeTextResource}
           onDeleteButtonClick={() => handleDeleteButtonClick(index)}

--- a/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditorRow/StudioCodeListEditorRow.tsx
+++ b/frontend/libs/studio-components/src/components/StudioCodelistEditor/StudioCodeListEditorRow/StudioCodeListEditorRow.tsx
@@ -15,6 +15,7 @@ type StudioCodeListEditorRowProps = {
   error: ValueError | null;
   item: CodeListItem;
   number: number;
+  onBlurTextResource: (newTextResource: TextResource) => void;
   onChange: (newItem: CodeListItem) => void;
   onChangeTextResource: (newTextResource: TextResource) => void;
   onDeleteButtonClick: () => void;
@@ -25,6 +26,7 @@ export function StudioCodeListEditorRow({
   error,
   item,
   number,
+  onBlurTextResource,
   onChange,
   onChangeTextResource,
   onDeleteButtonClick,
@@ -77,6 +79,7 @@ export function StudioCodeListEditorRow({
         currentId={item.label}
         label={texts.itemLabel(number)}
         number={number}
+        onBlurTextResource={onBlurTextResource}
         onChangeCurrentId={handleLabelChange}
         onChangeTextResource={onChangeTextResource}
         property={CodeListItemTextProperty.Label}
@@ -87,6 +90,7 @@ export function StudioCodeListEditorRow({
         currentId={item.description}
         label={texts.itemDescription(number)}
         number={number}
+        onBlurTextResource={onBlurTextResource}
         onChangeCurrentId={handleDescriptionChange}
         onChangeTextResource={onChangeTextResource}
         property={CodeListItemTextProperty.Description}
@@ -97,6 +101,7 @@ export function StudioCodeListEditorRow({
         currentId={item.helpText}
         label={texts.itemHelpText(number)}
         number={number}
+        onBlurTextResource={onBlurTextResource}
         onChangeCurrentId={handleHelpTextChange}
         onChangeTextResource={onChangeTextResource}
         property={CodeListItemTextProperty.HelpText}
@@ -213,6 +218,7 @@ type TextResourceIdCellProps = {
   currentId: string;
   label: string;
   number: number;
+  onBlurTextResource: (newTextResource: TextResource) => void;
   onChangeCurrentId: (newId: string) => void;
   onChangeTextResource: (newTextResource: TextResource) => void;
   property: CodeListItemTextProperty;
@@ -232,6 +238,7 @@ function TextResourceIdCell(props: TextResourceIdCellProps): ReactElement {
 function TextResourceSelectorCell({
   currentId,
   number,
+  onBlurTextResource,
   onChangeCurrentId,
   onChangeTextResource,
   property,
@@ -244,6 +251,7 @@ function TextResourceSelectorCell({
   return (
     <StudioInputTable.Cell.TextResource
       currentId={currentId}
+      onBlurTextResource={onBlurTextResource}
       onChangeCurrentId={onChangeCurrentId}
       onChangeTextResource={onChangeTextResource}
       required={required}

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.test.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.test.tsx
@@ -174,14 +174,15 @@ describe('CodeListPage', () => {
     renderCodeListPage({ textResources, codeListsData: codeListDataList, onUpdateTextResource });
     const labelField = await openAndGetFirstLabelField(user, codeList1Data.title);
     await user.type(labelField, newLabel);
+    await user.tab();
 
     const expectedLanguage = 'nb';
     const expectedObject: TextResourceWithLanguage = {
       language: expectedLanguage,
       textResource: { ...label1ResourceNb, value: newLabel },
     };
-    expect(onUpdateTextResource).toHaveBeenCalledTimes(newLabel.length);
-    expect(onUpdateTextResource).toHaveBeenLastCalledWith(expectedObject);
+    expect(onUpdateTextResource).toHaveBeenCalledTimes(1);
+    expect(onUpdateTextResource).toHaveBeenCalledWith(expectedObject);
   });
 
   it('Renders with text resources in the input fields of the create dialog when given', async () => {
@@ -209,14 +210,15 @@ describe('CodeListPage', () => {
     await user.click(getTextResourceOption(label1ResourceNb));
     await openEditModeForFirstLabel(user, dialog);
     await user.type(getFirstLabelField(dialog), newLabel);
+    await user.tab();
 
     const expectedLanguage = 'nb';
     const expectedObject: TextResourceWithLanguage = {
       language: expectedLanguage,
       textResource: { ...label1ResourceNb, value: newLabel },
     };
-    expect(onUpdateTextResource).toHaveBeenCalledTimes(newLabel.length);
-    expect(onUpdateTextResource).toHaveBeenLastCalledWith(expectedObject);
+    expect(onUpdateTextResource).toHaveBeenCalledTimes(1);
+    expect(onUpdateTextResource).toHaveBeenCalledWith(expectedObject);
   });
 });
 

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.tsx
@@ -62,7 +62,7 @@ export function CodeListPage({
     [textResources],
   );
 
-  const handleChangeTextResource = useCallback(
+  const handleBlurTextResource = useCallback(
     (textResource: TextResource) => {
       const updatedTextResource = createTextResourceWithLanguage(language, textResource);
       onUpdateTextResource?.(updatedTextResource);
@@ -87,7 +87,7 @@ export function CodeListPage({
       <StudioHeading size='small'>{t('app_content_library.code_lists.page_name')}</StudioHeading>
       <CodeListsCounterMessage codeListsCount={codeListsData.length} />
       <CodeListsActionsBar
-        onChangeTextResource={handleChangeTextResource}
+        onBlurTextResource={handleBlurTextResource}
         onUploadCodeList={handleUploadCodeList}
         onUpdateCodeList={onUpdateCodeList}
         codeListNames={codeListTitles}
@@ -96,7 +96,7 @@ export function CodeListPage({
       />
       <CodeLists
         codeListsData={filteredCodeLists}
-        onChangeTextResource={handleChangeTextResource}
+        onBlurTextResource={handleBlurTextResource}
         onDeleteCodeList={onDeleteCodeList}
         onUpdateCodeListId={handleUpdateCodeListId}
         onUpdateCodeList={onUpdateCodeList}

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
@@ -11,7 +11,7 @@ import type { TextResource } from '@studio/components';
 
 export type CodeListsProps = {
   codeListsData: CodeListData[];
-  onChangeTextResource?: (textResource: TextResource) => void;
+  onBlurTextResource?: (textResource: TextResource) => void;
   onDeleteCodeList: (codeListId: string) => void;
   onUpdateCodeListId: (codeListId: string, newCodeListId: string) => void;
   onUpdateCodeList: (updatedCodeList: CodeListWithMetadata) => void;

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/EditCodeList/EditCodeList.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/EditCodeList/EditCodeList.tsx
@@ -20,7 +20,7 @@ import { CodeListUsages } from './CodeListUsages/CodeListUsages';
 export type EditCodeListProps = {
   codeList: CodeList;
   codeListTitle: string;
-  onChangeTextResource?: (textResource: TextResource) => void;
+  onBlurTextResource?: (textResource: TextResource) => void;
   onDeleteCodeList: (codeListId: string) => void;
   onUpdateCodeListId: (codeListId: string, newCodeListId: string) => void;
   onUpdateCodeList: (updatedCodeList: CodeListWithMetadata) => void;
@@ -32,7 +32,7 @@ export type EditCodeListProps = {
 export function EditCodeList({
   codeList,
   codeListTitle,
-  onChangeTextResource,
+  onBlurTextResource,
   onDeleteCodeList,
   onUpdateCodeListId,
   onUpdateCodeList,
@@ -67,7 +67,7 @@ export function EditCodeList({
         codeList={codeList}
         onAddOrDeleteItem={handleCodeListChange}
         onBlurAny={handleCodeListChange}
-        onChangeTextResource={onChangeTextResource}
+        onBlurTextResource={onBlurTextResource}
         texts={editorTexts}
         textResources={textResources}
       />

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListsActionsBar/CodeListsActionsBar.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListsActionsBar/CodeListsActionsBar.tsx
@@ -11,7 +11,7 @@ import { useUploadCodeListNameErrorMessage } from '../hooks/useUploadCodeListNam
 import { toast } from 'react-toastify';
 
 export type CodeListsActionsBarProps = {
-  onChangeTextResource?: (textResource: TextResource) => void;
+  onBlurTextResource?: (textResource: TextResource) => void;
   onUploadCodeList: (updatedCodeList: File) => void;
   onUpdateCodeList: (updatedCodeList: CodeListWithMetadata) => void;
   codeListNames: string[];
@@ -20,7 +20,7 @@ export type CodeListsActionsBarProps = {
 };
 
 export function CodeListsActionsBar({
-  onChangeTextResource,
+  onBlurTextResource,
   onUploadCodeList,
   onUpdateCodeList,
   codeListNames,
@@ -56,7 +56,7 @@ export function CodeListsActionsBar({
       />
       <CreateNewCodeListModal
         codeListNames={codeListNames}
-        onChangeTextResource={onChangeTextResource}
+        onBlurTextResource={onBlurTextResource}
         onUpdateCodeList={onUpdateCodeList}
         textResources={textResources}
       />

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListsActionsBar/CreateNewCodeListModal/CreateNewCodeListModal.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListsActionsBar/CreateNewCodeListModal/CreateNewCodeListModal.tsx
@@ -15,14 +15,14 @@ import { FileNameUtils } from '@studio/pure-functions';
 import { useInputCodeListNameErrorMessage } from '../../hooks/useInputCodeListNameErrorMessage';
 
 type CreateNewCodeListModalProps = {
-  onChangeTextResource?: (textResource: TextResource) => void;
+  onBlurTextResource?: (textResource: TextResource) => void;
   onUpdateCodeList: (codeListWithMetadata: CodeListWithMetadata) => void;
   codeListNames: string[];
   textResources?: TextResource[];
 };
 
 export function CreateNewCodeListModal({
-  onChangeTextResource,
+  onBlurTextResource,
   onUpdateCodeList,
   codeListNames,
   textResources,
@@ -50,7 +50,7 @@ export function CreateNewCodeListModal({
         <CreateNewCodeList
           codeList={newCodeList}
           codeListNames={codeListNames}
-          onChangeTextResource={onChangeTextResource}
+          onBlurTextResource={onBlurTextResource}
           onUpdateCodeList={onUpdateCodeList}
           onCloseModal={handleCloseModal}
           textResources={textResources}
@@ -63,7 +63,7 @@ export function CreateNewCodeListModal({
 type CreateNewCodeListProps = {
   codeList: CodeList;
   codeListNames: string[];
-  onChangeTextResource?: (textResource: TextResource) => void;
+  onBlurTextResource?: (textResource: TextResource) => void;
   onUpdateCodeList: (codeListWithMetadata: CodeListWithMetadata) => void;
   onCloseModal: () => void;
   textResources?: TextResource[];
@@ -72,7 +72,7 @@ type CreateNewCodeListProps = {
 function CreateNewCodeList({
   codeList,
   codeListNames,
-  onChangeTextResource,
+  onBlurTextResource,
   onUpdateCodeList,
   onCloseModal,
   textResources,
@@ -133,8 +133,8 @@ function CreateNewCodeList({
       <div className={classes.codeListEditor}>
         <StudioCodeListEditor
           codeList={currentCodeListWithMetadata.codeList}
+          onBlurTextResource={onBlurTextResource}
           onChange={handleCodeListChange}
-          onChangeTextResource={onChangeTextResource}
           onInvalid={handleInvalidCodeList}
           texts={editorTexts}
           textResources={textResources}


### PR DESCRIPTION
## Description
This pull request makes text resources in the code list editor in the content library become updated on the `blur` event instead of the `change` event, so that only one request is sent to the backend. The video below demonstrates that no requests are sent before the user leaves the text field.

https://github.com/user-attachments/assets/c4e25fe3-4a19-4009-bde1-af5663ddfdfa

This pull request is stacked upon #14868, which should be merged first.

## Related Issue(s)
- #13739

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test adjusted
