### PR TITLE
feat: add editing-mode to task cards

### DIFF
--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.test.tsx
@@ -8,8 +8,8 @@ import { renderWithProviders } from '../../testing/mocks';
 
 describe('taskCard', () => {
   it('should display popover when clicking ellipsis button', async () => {
-    render();
     const user = userEvent.setup();
+    render();
     await user.click(screen.getByTestId(studioIconCardPopoverTrigger));
     expect(screen.getByRole('button', { name: /general.delete/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /ux_editor.task_card.edit/ })).toBeInTheDocument();
@@ -23,6 +23,37 @@ describe('taskCard', () => {
   it('should display task type', async () => {
     render();
     expect(screen.getByText(/ux_editor.subform/)).toBeInTheDocument();
+  });
+
+  it('should open edit mode when clicking edit button', async () => {
+    const user = userEvent.setup();
+    render();
+    await user.click(screen.getByTestId(studioIconCardPopoverTrigger));
+    await user.click(screen.getByRole('button', { name: /ux_editor.task_card.edit/ }));
+
+    expect(screen.getByRole('button', { name: /general.save/ })).toBeInTheDocument();
+  });
+
+  it('should exit save mode when closing', async () => {
+    const user = userEvent.setup();
+    render();
+    await user.click(screen.getByTestId(studioIconCardPopoverTrigger));
+    await user.click(screen.getByRole('button', { name: /ux_editor.task_card.edit/ }));
+    await user.click(screen.getByRole('button', { name: /general.close/ }));
+    expect(screen.queryByRole('button', { name: /general.save/ })).not.toBeInTheDocument();
+  });
+
+  it('should exit save mode when saving', async () => {
+    const user = userEvent.setup();
+    render();
+    await user.click(screen.getByTestId(studioIconCardPopoverTrigger));
+    await user.click(screen.getByRole('button', { name: /ux_editor.task_card.edit/ }));
+    await user.type(
+      screen.getByRole('textbox', { name: /ux_editor.component_properties.layoutSet/ }),
+      'test',
+    );
+    await user.click(screen.getByRole('button', { name: /general.save/ }));
+    expect(screen.queryByRole('button', { name: /general.save/ })).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.tsx
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.tsx
@@ -1,4 +1,4 @@
-import React, { type MouseEvent } from 'react';
+import React, { useState, type MouseEvent } from 'react';
 import type { LayoutSetModel } from 'app-shared/types/api/dto/LayoutSetModel';
 import { StudioIconCard } from '@studio/components/src/components/StudioIconCard/StudioIconCard';
 import { PencilIcon } from '@studio/icons';
@@ -6,6 +6,9 @@ import { getLayoutSetTypeTranslationKey } from 'app-shared/utils/layoutSetsUtils
 import { useTranslation } from 'react-i18next';
 import { StudioButton, StudioDeleteButton, StudioParagraph } from '@studio/components';
 import { useLayoutSetIcon } from '../../hooks/useLayoutSetIcon';
+import { useDeleteLayoutSetMutation } from 'app-development/hooks/mutations/useDeleteLayoutSetMutation';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
+import { TaskCardEditing } from './TaskCardEditing';
 
 type TaskCardProps = {
   layoutSetModel: LayoutSetModel;
@@ -13,29 +16,39 @@ type TaskCardProps = {
 
 export const TaskCard = ({ layoutSetModel }: TaskCardProps) => {
   const { t } = useTranslation();
+  const { org, app } = useStudioEnvironmentParams();
+  const { mutate: deleteLayoutSet } = useDeleteLayoutSetMutation(org, app);
 
   const taskName = getLayoutSetTypeTranslationKey(layoutSetModel);
   const taskIcon = useLayoutSetIcon(layoutSetModel);
+
+  const [editing, setEditing] = useState(false);
+
   const contextButtons = (
     <>
       <StudioButton
         variant='tertiary'
-        onClick={(event: MouseEvent<HTMLButtonElement>) => {
-          /* TODO: Implement editing mode */
+        onClick={(_: MouseEvent<HTMLButtonElement>) => {
+          setEditing(true);
         }}
       >
         <PencilIcon /> {t('ux_editor.task_card.edit')}
       </StudioButton>
       <StudioDeleteButton
         variant='tertiary'
+        confirmMessage='Er du sikker?'
         onDelete={() => {
-          /* TODO: Call delete on task */
+          deleteLayoutSet({ layoutSetIdToUpdate: layoutSetModel.id });
         }}
       >
         {t('general.delete')}
       </StudioDeleteButton>
     </>
   );
+
+  if (editing) {
+    return <TaskCardEditing layoutSetModel={layoutSetModel} onClose={() => setEditing(false)} />;
+  }
 
   return (
     <StudioIconCard

--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.module.css
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.module.css
@@ -1,0 +1,6 @@
+.card {
+  width: 350px;
+  min-height: 250px;
+  margin: 0;
+  padding: 0;
+}

--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import type { LayoutSetModel } from 'app-shared/types/api/dto/LayoutSetModel';
+import userEvent from '@testing-library/user-event';
+import { act, screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../testing/mocks';
+import { TaskCardEditing, type TaskCardEditingProps } from './TaskCardEditing';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import { app, org } from '@studio/testing/testids';
+
+const updateProcessDataTypesMutation = jest.fn().mockImplementation((params, options) => {
+  console.log('updateProcessDataTypesMutation');
+  console.log(params);
+  console.log(options);
+  options.onSettled();
+});
+const updateLayoutSetIdMutation = jest.fn().mockImplementation((params, options) => {
+  console.log('updateLayoutSetIdMutation');
+  console.log(params);
+  console.log(options);
+  options.onSettled();
+});
+jest.mock('app-development/hooks/mutations/useUpdateProcessDataTypesMutation', () => ({
+  useUpdateProcessDataTypesMutation: () => ({ mutate: updateProcessDataTypesMutation }),
+}));
+jest.mock('app-development/hooks/mutations/useUpdateLayoutSetIdMutation', () => ({
+  useUpdateLayoutSetIdMutation: () => ({ mutate: updateLayoutSetIdMutation }),
+}));
+
+describe('taskCard', () => {
+  it('should render with disabled save button without changes', () => {
+    render();
+    expect(screen.getByRole('button', { name: /general.save/ })).toBeDisabled();
+  });
+
+  it('should call onClose when clicking close button', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render({ onClose });
+    await user.click(screen.getByRole('button', { name: /general.close/ }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call updateLayoutSetidMutation when layout set id is changed', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render({ onClose });
+    await user.clear(
+      screen.getByRole('textbox', { name: /ux_editor.component_properties.layoutSet/ }),
+    );
+    const newLayoutSetId = 'CoolLayoutName';
+    await user.type(
+      screen.getByRole('textbox', { name: /ux_editor.component_properties.layoutSet/ }),
+      newLayoutSetId,
+    );
+    await user.click(screen.getByRole('button', { name: /general.save/ }));
+    expect(updateLayoutSetIdMutation).toHaveBeenCalledTimes(1);
+    expect(updateLayoutSetIdMutation).toHaveBeenCalledWith(
+      {
+        layoutSetIdToUpdate: mockLayoutSet.id,
+        newLayoutSetId: newLayoutSetId,
+      },
+      expect.anything(),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call updateProcessDataTypesMutation when datamodel id is changed', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render({ onClose });
+    await act(async () => {
+      await user.selectOptions(
+        screen.getByRole('combobox', { name: /ux_editor.modal_properties_data_model_binding/ }),
+        'unuseddatamodel',
+      );
+    });
+    await user.click(screen.getByRole('button', { name: /general.save/ }));
+    expect(updateProcessDataTypesMutation).toHaveBeenCalledTimes(1);
+    expect(updateProcessDataTypesMutation).toHaveBeenCalledWith(
+      {
+        layoutSetIdToUpdate: mockLayoutSet.id,
+        newLayoutSetId: '',
+      },
+      expect.anything(),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show validation error when inputting invalid id', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render({ onClose });
+    await user.type(
+      screen.getByRole('textbox', { name: /ux_editor.component_properties.layoutSet/ }),
+      ' test4! &',
+    );
+    expect(
+      screen.getByRole('textbox', { name: /ux_editor.component_properties.layoutSet/ }),
+    ).toBeInvalid();
+    expect(screen.getByRole('button', { name: /general.save/ })).toBeDisabled();
+  });
+});
+
+const mockLayoutSet: LayoutSetModel = {
+  id: 'test',
+  dataType: 'datamodell123',
+  type: 'subform',
+  task: { id: null, type: null },
+};
+
+const render = (props?: Partial<TaskCardEditingProps>) => {
+  const queryClient = createQueryClientMock();
+  queryClient.setQueryData(
+    [QueryKey.AppMetadataModelIds, org, app, true],
+    ['datamodell123', 'unuseddatamodel'],
+  );
+  renderWithProviders(
+    <TaskCardEditing layoutSetModel={mockLayoutSet} onClose={jest.fn()} {...props} />,
+    { queryClient },
+  );
+};

--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.tsx
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.tsx
@@ -1,0 +1,113 @@
+import {
+  StudioButton,
+  StudioCard,
+  StudioHeading,
+  StudioNativeSelect,
+  StudioSpinner,
+  StudioTextfield,
+} from '@studio/components';
+import { useUpdateLayoutSetIdMutation } from 'app-development/hooks/mutations/useUpdateLayoutSetIdMutation';
+import { useUpdateProcessDataTypesMutation } from 'app-development/hooks/mutations/useUpdateProcessDataTypesMutation';
+import { useAppMetadataModelIdsQuery } from 'app-shared/hooks/queries/useAppMetadataModelIdsQuery';
+import { useLayoutSetsQuery } from 'app-shared/hooks/queries/useLayoutSetsQuery';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
+import { useValidateLayoutSetName } from 'app-shared/hooks/useValidateLayoutSetName';
+import type { LayoutSetModel } from 'app-shared/types/api/dto/LayoutSetModel';
+import React, { type ChangeEvent } from 'react';
+import classes from './TaskCardEditing.module.css';
+import { getLayoutSetTypeTranslationKey } from 'app-shared/utils/layoutSetsUtils';
+import { useTranslation } from 'react-i18next';
+
+export type TaskCardEditingProps = {
+  layoutSetModel: LayoutSetModel;
+  onClose: () => void;
+};
+
+export const TaskCardEditing = ({ layoutSetModel, onClose }: TaskCardEditingProps) => {
+  const { org, app } = useStudioEnvironmentParams();
+  const { t } = useTranslation();
+
+  const { mutate: updateProcessDataType, isPending: updateProcessDataTypePending } =
+    useUpdateProcessDataTypesMutation(org, app);
+  const { mutate: mutateLayoutSetId, isPending: mutateLayoutSetIdPending } =
+    useUpdateLayoutSetIdMutation(org, app);
+  const { validateLayoutSetName } = useValidateLayoutSetName();
+  const { data: dataModels } = useAppMetadataModelIdsQuery(org, app, true);
+  const { data: layoutSets } = useLayoutSetsQuery(org, app);
+
+  const taskName = getLayoutSetTypeTranslationKey(layoutSetModel);
+  const [id, setId] = React.useState(layoutSetModel.id);
+  const [dataType, setDataType] = React.useState(layoutSetModel.dataType);
+
+  const idChanged = id !== layoutSetModel.id;
+  const dataTypeChanged = dataType !== layoutSetModel.dataType;
+  const fieldChanged = idChanged || dataTypeChanged;
+
+  const idValidationError = validateLayoutSetName(id, layoutSets, layoutSetModel.id);
+  const pendingMutation = updateProcessDataTypePending || mutateLayoutSetIdPending;
+  const disableSaveButton = !fieldChanged || Boolean(idValidationError) || pendingMutation;
+
+  const onSettled = () => {
+    if (!pendingMutation) onClose();
+  };
+
+  const saveChanges = () => {
+    if (idChanged) {
+      mutateLayoutSetId(
+        { layoutSetIdToUpdate: layoutSetModel.id, newLayoutSetId: id },
+        { onSettled },
+      );
+    }
+    if (dataTypeChanged) {
+      // TODO: implement subform datamodel change, maybe a common mutation
+      updateProcessDataType(
+        {
+          newDataTypes: [dataType],
+          connectedTaskId: layoutSetModel.task?.id,
+        },
+        { onSettled },
+      );
+    }
+  };
+
+  return (
+    <StudioCard className={classes.card}>
+      <StudioCard.Header>
+        <StudioHeading size='xs'>{t(taskName)}</StudioHeading>
+      </StudioCard.Header>
+      <StudioCard.Content style={{ paddingLeft: 10, paddingRight: 10, padding: 10 }}>
+        <StudioTextfield
+          label={t('ux_editor.component_properties.layoutSet')}
+          size='sm'
+          value={id}
+          error={idValidationError}
+          onKeyUp={(event) => {
+            if (event.key === 'Enter' && !disableSaveButton) saveChanges();
+          }}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => setId(event.target.value)}
+        ></StudioTextfield>
+        <StudioNativeSelect
+          label={t('ux_editor.modal_properties_data_model_binding')}
+          size='sm'
+          disabled={layoutSetModel.type === 'subform'}
+          value={dataType}
+          onChange={(event) => setDataType(event.target.value)}
+        >
+          {/* TODO: filter or validate this */}
+          <option value=''>Ingen datamodell</option>
+          {dataModels?.map((dataModel) => (
+            <option key={dataModel} value={dataModel}>
+              {dataModel}
+            </option>
+          ))}
+        </StudioNativeSelect>
+        <StudioButton disabled={disableSaveButton} onClick={() => saveChanges()} variant='primary'>
+          {pendingMutation ? <StudioSpinner size='xs' spinnerTitle='' /> : t('general.save')}
+        </StudioButton>
+        <StudioButton disabled={pendingMutation} onClick={() => onClose()} variant='secondary'>
+          {t('general.close')}
+        </StudioButton>
+      </StudioCard.Content>
+    </StudioCard>
+  );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add editing mode to task cards allowing editing of default datamodel and
name for the layoutset.

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an interactive editing mode for tasks, allowing users to modify details directly and save changes with responsive UI feedback.
	- Implemented a deletion process that includes a confirmation prompt to help prevent accidental removals.
- **Style**
	- Refined the visual layout of task elements for a more consistent and streamlined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->