### PR TITLE
fix: re-add row-gap to StudioIconCard .content

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioIconCard/StudioIconCard.module.css
+++ b/frontend/libs/studio-components/src/components/StudioIconCard/StudioIconCard.module.css
@@ -98,6 +98,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  row-gap: var(--fds-spacing-3);
   padding: var(--fds-spacing-2);
   text-align: center;
   font-weight: normal;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue(s)



## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the layout of the icon card component by adding vertical spacing between rows, resulting in improved alignment and visual appeal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->