### PR TITLE
test: Improve tests for organisation content library

### DIFF
--- a/frontend/dashboard/pages/OrgContentLibrary/test-data/codeListDataList.ts
+++ b/frontend/dashboard/pages/OrgContentLibrary/test-data/codeListDataList.ts
@@ -1,0 +1,36 @@
+import type { CodeList } from 'app-shared/types/CodeList';
+import type { CodeListData } from 'app-shared/types/CodeListData';
+
+const codeList1: CodeList = [
+  {
+    value: 'item1',
+    label: 'item1-text-key',
+  },
+  {
+    value: 'item2',
+    label: 'item2-text-key',
+  },
+];
+const codeList1Name = 'codeList1';
+export const codeList1Data: CodeListData = {
+  title: codeList1Name,
+  data: codeList1,
+};
+
+const codeList2: CodeList = [
+  {
+    value: 'itemA',
+    label: 'itemA-text-key',
+  },
+  {
+    value: 'itemB',
+    label: 'itemB-text-key',
+  },
+];
+const codeList2Name = 'codeList2';
+export const codeList2Data: CodeListData = {
+  title: codeList2Name,
+  data: codeList2,
+};
+
+export const codeListDataList = [codeList1Data, codeList2Data];

--- a/frontend/dashboard/testing/mocks.tsx
+++ b/frontend/dashboard/testing/mocks.tsx
@@ -1,4 +1,4 @@
-import { queryClientMock } from 'app-shared/mocks/queryClientMock';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import type { Queries, RenderHookOptions, RenderOptions } from '@testing-library/react';
 import { render, renderHook } from '@testing-library/react';
 import React from 'react';
@@ -18,7 +18,7 @@ type WrapperArgs = {
 } & Pick<MemoryRouterProps, 'initialEntries'>;
 
 const wrapper =
-  ({ queries = {}, queryClient = queryClientMock, initialEntries }: WrapperArgs) =>
+  ({ queries = {}, queryClient = createQueryClientMock(), initialEntries }: WrapperArgs) =>
   // eslint-disable-next-line react/display-name
   (component: ReactNode) => (
     <MemoryRouter initialEntries={initialEntries}>
@@ -34,7 +34,7 @@ export interface ProviderData extends Partial<WrapperArgs> {
 
 export function renderWithProviders(
   component: ReactNode,
-  { queries = {}, queryClient = queryClientMock, initialEntries }: ProviderData = {},
+  { queries = {}, queryClient = createQueryClientMock(), initialEntries }: ProviderData = {},
 ) {
   const renderOptions: RenderOptions = {
     wrapper: ({ children }) =>
@@ -51,7 +51,7 @@ export function renderHookWithProviders<HookResult, Props>(
   hook: (props: Props) => HookResult,
   {
     queries = {},
-    queryClient = queryClientMock,
+    queryClient = createQueryClientMock(),
     externalWrapper = (children) => children,
     initialEntries,
   }: ProviderData = {},


### PR DESCRIPTION
## Description
The tests for the organisation library are overly complicated, making them difficult to work with. Since we are mocking the library component, it doesn't make sense to simulate user events. All we need to verify is that data and functions are correctly dispatced inside the `OrgContentLibrary` component. Therefore I have simplified the mock and removed the dependency on the `userEvent` utility. I have also extended the test data.

This change doesn't only simplify the tests - it also makes the test suite run five times as fast. When running on my own computer, it currently takes 1404 millisendonds on the main branch, while it takes 275 milliseconds on this one.
 
## Related Issue(s)
- #14870

## Verification
- [x] **Your** code builds clean without any errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced testing of the content library interface to validate proper handling of different states such as loading, errors, and notifications.
  - Streamlined test data for code list scenarios to ensure a more accurate reflection of component behavior.
  - Updated testing utilities to better simulate user interactions, contributing to a more reliable and maintainable testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->