### PR TITLE
feat(taskNavigation): Cards link to utforming

### DIFF
--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.test.tsx
@@ -4,8 +4,8 @@ import type { LayoutSetModel } from 'app-shared/types/api/dto/LayoutSetModel';
 import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';
 import { app, org, studioIconCardPopoverTrigger } from '@studio/testing/testids';
-import { renderWithProviders } from '../../testing/mocks';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { renderWithProviders, type ExtendedRenderOptions } from '../../testing/mocks';
 
 describe('taskCard', () => {
   let confirmSpy: jest.SpyInstance;
@@ -50,14 +50,23 @@ describe('taskCard', () => {
     expect(queriesMock.deleteLayoutSet).toHaveBeenCalledTimes(1);
     expect(queriesMock.deleteLayoutSet).toHaveBeenCalledWith(org, app, 'test');
   });
+
+  it('should set selected form layout set name when clicking on navigation button', async () => {
+    const user = userEvent.setup();
+    const setSelectedFormLayoutSetName = jest.fn();
+
+    render({ appContextProps: { setSelectedFormLayoutSetName } });
+    await user.click(screen.getByRole('button', { name: /ux_editor.task_card.ux_editor/ }));
+    expect(setSelectedFormLayoutSetName).toHaveBeenCalledWith('test');
+  });
 });
 
-const render = () => {
+const render = (extendedRenderOptions?: Partial<ExtendedRenderOptions>) => {
   const layoutSet: LayoutSetModel = {
     id: 'test',
     dataType: 'datamodell123',
     type: 'subform',
     task: { id: null, type: null },
   };
-  renderWithProviders(<TaskCard layoutSetModel={layoutSet} />);
+  renderWithProviders(<TaskCard layoutSetModel={layoutSet} />, extendedRenderOptions);
 };

--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.tsx
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.tsx
@@ -7,6 +7,7 @@ import { StudioButton, StudioDeleteButton, StudioParagraph } from '@studio/compo
 import { useLayoutSetIcon } from '../../hooks/useLayoutSetIcon';
 import { useDeleteLayoutSetMutation } from 'app-development/hooks/mutations/useDeleteLayoutSetMutation';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
+import { useAppContext } from '../../hooks/useAppContext';
 
 type TaskCardProps = {
   layoutSetModel: LayoutSetModel;
@@ -16,6 +17,7 @@ export const TaskCard = ({ layoutSetModel }: TaskCardProps) => {
   const { t } = useTranslation();
   const { org, app } = useStudioEnvironmentParams();
   const { mutate: deleteLayoutSet } = useDeleteLayoutSetMutation(org, app);
+  const { setSelectedFormLayoutSetName } = useAppContext();
 
   const taskName = getLayoutSetTypeTranslationKey(layoutSetModel);
   const taskIcon = useLayoutSetIcon(layoutSetModel);
@@ -32,6 +34,10 @@ export const TaskCard = ({ layoutSetModel }: TaskCardProps) => {
     </StudioDeleteButton>
   );
 
+  const goToFormEditor = () => {
+    setSelectedFormLayoutSetName(layoutSetModel.id);
+  };
+
   return (
     <StudioIconCard
       icon={taskIcon.icon}
@@ -44,7 +50,7 @@ export const TaskCard = ({ layoutSetModel }: TaskCardProps) => {
         {t('ux_editor.task_card.datamodel')}
         {layoutSetModel.dataType && ' ' + layoutSetModel.dataType}
       </StudioParagraph>
-      <StudioButton color='second' variant='primary'>
+      <StudioButton color='second' onClick={goToFormEditor} variant='primary'>
         {t('ux_editor.task_card.ux_editor')}
       </StudioButton>
     </StudioIconCard>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update task cards to navigate to utforming when clicking the 'utform' button.

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced task navigation: Clicking the navigation button now automatically updates your selected form layout set and directs you to the appropriate form editor view. This streamlined interaction provides a more intuitive and efficient user experience when managing your form layouts.
  - Added a new test case to ensure the button interaction correctly sets the selected form layout set name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->