### PR TITLE
fix: Playwright issue in staging when codelists are not deleted

### DIFF
--- a/frontend/testing/playwright/pages/OrgLibraryPage/CodeLists.ts
+++ b/frontend/testing/playwright/pages/OrgLibraryPage/CodeLists.ts
@@ -94,6 +94,16 @@ export class CodeLists extends BasePage {
     await expect(codeList).toBeVisible();
   }
 
+  public async getIfCodeListTitleExists(title: string): Promise<boolean> {
+    const codeList = this.page.getByTitle(
+      this.textMock('app_content_library.code_lists.code_list_accordion_title', {
+        codeListTitle: title,
+      }),
+    );
+
+    return codeList.isVisible();
+  }
+
   public async clickOnAddItemButton(): Promise<void> {
     await this.page
       .getByRole('button', {

--- a/frontend/testing/playwright/pages/OrgLibraryPage/CodeLists.ts
+++ b/frontend/testing/playwright/pages/OrgLibraryPage/CodeLists.ts
@@ -94,7 +94,7 @@ export class CodeLists extends BasePage {
     await expect(codeList).toBeVisible();
   }
 
-  public async getIfCodeListTitleExists(title: string): Promise<boolean> {
+  public async codeListTitleExists(title: string): Promise<boolean> {
     const codeList = this.page.getByTitle(
       this.textMock('app_content_library.code_lists.code_list_accordion_title', {
         codeListTitle: title,

--- a/frontend/testing/playwright/tests/org-library/codelists.spec.ts
+++ b/frontend/testing/playwright/tests/org-library/codelists.spec.ts
@@ -121,6 +121,16 @@ test('that it is possible to add a new row to an existing codelist and modify th
 test('that it is possible to upload a new codelist', async ({ page, testAppName }) => {
   const orgLibraryPage: OrgLibraryPage = await setupAndVerifyCodeListPage(page, testAppName);
 
+  const codeListTitleAlreadyExists: boolean =
+    await orgLibraryPage.codeLists.getIfCodeListTitleExists(CODELIST_TITLE_UPLOADED);
+
+  // If for some reason the code list was not deleted in the tests in staging, we delete it before testing the creation.
+  // This situation might happen if a test is cancelled right after the creation of the code list.
+  if (codeListTitleAlreadyExists) {
+    await orgLibraryPage.codeLists.clickOnCodeListAccordion(CODELIST_TITLE_UPLOADED);
+    await deleteAndVerifyDeletionOfCodeList(orgLibraryPage, CODELIST_TITLE_UPLOADED);
+  }
+
   const codelistFileName: string = `${CODELIST_TITLE_UPLOADED}.json`;
   await orgLibraryPage.codeLists.clickOnUploadButtonAndSelectFileToUpload(codelistFileName);
   await orgLibraryPage.codeLists.verifyThatCodeListIsVisible(CODELIST_TITLE_UPLOADED);

--- a/frontend/testing/playwright/tests/org-library/codelists.spec.ts
+++ b/frontend/testing/playwright/tests/org-library/codelists.spec.ts
@@ -50,9 +50,20 @@ const setupAndVerifyCodeListPage = async (
 test('that it is possible to create a new codelist', async ({ page, testAppName }) => {
   const orgLibraryPage: OrgLibraryPage = await setupAndVerifyCodeListPage(page, testAppName);
 
+  const codeListTitleAlreadyExists: boolean =
+    await orgLibraryPage.codeLists.getIfCodeListTitleExists(CODELIST_TITLE_MANUALLY);
+
+  // If for some reason the code list was not deleted in the tests in staging, we delete it before testing the creation.
+  // This situation might happen if a test is cancelled right after the creation of the code list.
+  if (codeListTitleAlreadyExists) {
+    await orgLibraryPage.codeLists.clickOnCodeListAccordion(CODELIST_TITLE_MANUALLY);
+    await deleteAndVerifyDeletionOfCodeList(orgLibraryPage, CODELIST_TITLE_MANUALLY);
+  }
+
   await orgLibraryPage.codeLists.clickOnCreateNewCodelistButton();
   await orgLibraryPage.codeLists.verifyNewCodelistModalIsOpen();
   await orgLibraryPage.codeLists.writeCodelistTitle(CODELIST_TITLE_MANUALLY);
+
   await orgLibraryPage.codeLists.clickOnAddAlternativeButton();
 
   await orgLibraryPage.codeLists.verifyNewItemValueFieldIsVisible(
@@ -152,18 +163,18 @@ test('that it is possible to search for and delete the new codelists', async ({
   const orgLibraryPage: OrgLibraryPage = await setupAndVerifyCodeListPage(page, testAppName);
 
   await searchForAndOpenCodeList(orgLibraryPage, CODELIST_TITLE_MANUALLY);
-  await deleteAndVerifyDeletionOfCodeList(
-    orgLibraryPage,
-    CODELIST_TITLE_MANUALLY,
+  await orgLibraryPage.codeLists.verifyNumberOfItemsInTheCodelist(
     EXPECTED_NUMBER_OF_ROWS_IN_MANUALLY_CREATED_CODELIST_AFTER_ADDING_ROW,
+    CODELIST_TITLE_MANUALLY,
   );
+  await deleteAndVerifyDeletionOfCodeList(orgLibraryPage, CODELIST_TITLE_MANUALLY);
 
   await searchForAndOpenCodeList(orgLibraryPage, CODELIST_TITLE_UPLOADED);
-  await deleteAndVerifyDeletionOfCodeList(
-    orgLibraryPage,
-    CODELIST_TITLE_UPLOADED,
+  await orgLibraryPage.codeLists.verifyNumberOfItemsInTheCodelist(
     EXPECTED_NUMBER_OF_ROWS_IN_UPLOADED_CODELIST_AFTER_DELETE,
+    CODELIST_TITLE_UPLOADED,
   );
+  await deleteAndVerifyDeletionOfCodeList(orgLibraryPage, CODELIST_TITLE_UPLOADED);
 });
 
 const searchForAndOpenCodeList = async (
@@ -178,12 +189,7 @@ const searchForAndOpenCodeList = async (
 const deleteAndVerifyDeletionOfCodeList = async (
   orgLibraryPage: OrgLibraryPage,
   codelistTitle: string,
-  expectedNumberOfRowsInCodeList: number,
 ): Promise<void> => {
-  await orgLibraryPage.codeLists.verifyNumberOfItemsInTheCodelist(
-    expectedNumberOfRowsInCodeList,
-    codelistTitle,
-  );
   await orgLibraryPage.codeLists.listenToAndWaitForConfirmDeleteCodeList(codelistTitle);
   await orgLibraryPage.codeLists.clickOnDeleteCodelistButton();
   await orgLibraryPage.codeLists.verifyThatCodeListIsNotVisible(codelistTitle);

--- a/frontend/testing/playwright/tests/org-library/codelists.spec.ts
+++ b/frontend/testing/playwright/tests/org-library/codelists.spec.ts
@@ -51,7 +51,7 @@ test('that it is possible to create a new codelist', async ({ page, testAppName 
   const orgLibraryPage: OrgLibraryPage = await setupAndVerifyCodeListPage(page, testAppName);
 
   const codeListTitleAlreadyExists: boolean =
-    await orgLibraryPage.codeLists.getIfCodeListTitleExists(CODELIST_TITLE_MANUALLY);
+    await orgLibraryPage.codeLists.codeListTitleExists(CODELIST_TITLE_MANUALLY);
 
   // If for some reason the code list was not deleted in the tests in staging, we delete it before testing the creation.
   // This situation might happen if a test is cancelled right after the creation of the code list.
@@ -122,7 +122,7 @@ test('that it is possible to upload a new codelist', async ({ page, testAppName 
   const orgLibraryPage: OrgLibraryPage = await setupAndVerifyCodeListPage(page, testAppName);
 
   const codeListTitleAlreadyExists: boolean =
-    await orgLibraryPage.codeLists.getIfCodeListTitleExists(CODELIST_TITLE_UPLOADED);
+    await orgLibraryPage.codeLists.codeListTitleExists(CODELIST_TITLE_UPLOADED);
 
   // If for some reason the code list was not deleted in the tests in staging, we delete it before testing the creation.
   // This situation might happen if a test is cancelled right after the creation of the code list.


### PR DESCRIPTION
## Description
The issue with Playwright was that there already existed a codelist with the same title as the one the test tried to create. 
The reason for this might be because a test was cancelled just after a codelist was created, and therefore the test deleting the codelist was never executed. 
The issue has been solved by adding a check for if the title already exists, and if it does, the codelist is deleted before attempting to create a new.

## Video of the test locally

https://github.com/user-attachments/assets/29ec6621-be27-4060-b9f6-e9c3f125205a



## Related Issue(s)

- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced code list verification with updated method naming for better clarity and consistency.
  
- **Bug Fixes**
  - Updated package references to newer versions, potentially improving performance and stability.

- **Tests**
  - Improved the upload process by ensuring any duplicate code list entries are automatically cleared, promoting more reliable interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->