### PR TITLE
chore: turn off project status for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    project: off


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add repository codecov config, turning off status reporting for project level codecov. Coverage will still be visible in codecov comment currently. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated internal configuration settings to disable test coverage reporting. This adjustment streamlines our internal processes and aligns our setup with current development practices. There are no visible changes to your experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->