### PR TITLE
feat: add text resources to codelist editors in ux editor

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/EditTab.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/EditTab.test.tsx
@@ -16,12 +16,10 @@ describe('EditTab', () => {
 
   it('should render spinner', () => {
     renderEditTab();
-    expect(
-      screen.getByText(textMock('ux_editor.modal_properties_code_list_spinner_title')),
-    ).toBeInTheDocument();
+    expect(screen.getByText(textMock('general.loading'))).toBeInTheDocument();
   });
 
-  it('should render error message when query fails', async () => {
+  it('should render error message when a query fails', async () => {
     renderEditTab({
       queries: { getOptionListIds: jest.fn().mockImplementation(() => Promise.reject()) },
     });
@@ -96,9 +94,7 @@ describe('EditTab', () => {
 });
 
 async function waitForSpinnerToBeRemoved() {
-  await waitForElementToBeRemoved(() =>
-    screen.queryByText(textMock('ux_editor.modal_properties_code_list_spinner_title')),
-  );
+  await waitForElementToBeRemoved(() => screen.queryByText(textMock('general.loading')));
 }
 
 function renderEditTab({

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/EditTab.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/EditTab.tsx
@@ -23,6 +23,8 @@ import type { IGenericEditComponent } from '../../../../componentConfig';
 import { OptionListSelector } from './OptionListSelector';
 import { OptionListUploader } from './OptionListUploader';
 import { OptionListEditor } from './OptionListEditor';
+import { useTextResourcesQuery } from 'app-shared/hooks/queries';
+import { mergeQueryStatuses } from 'app-shared/utils/tanstackQueryUtils';
 import classes from './EditTab.module.css';
 
 type EditTabProps = Pick<
@@ -33,7 +35,8 @@ type EditTabProps = Pick<
 export function EditTab({ component, handleComponentChange }: EditTabProps): React.ReactElement {
   const { t } = useTranslation();
   const { org, app } = useStudioEnvironmentParams();
-  const { data: optionListIds, status } = useOptionListIdsQuery(org, app);
+  const { data: optionListIds, status: statusOptionListIds } = useOptionListIdsQuery(org, app);
+  const { status: statusTextResources } = useTextResourcesQuery(org, app);
   const previousComponent = usePrevious(component);
   const dialogRef = createRef<HTMLDialogElement>();
   const errorMessage = useComponentErrorMessage(component);
@@ -44,14 +47,9 @@ export function EditTab({ component, handleComponentChange }: EditTabProps): Rea
     }
   }, [component, previousComponent]);
 
-  switch (status) {
+  switch (mergeQueryStatuses(statusOptionListIds, statusTextResources)) {
     case 'pending':
-      return (
-        <StudioSpinner
-          showSpinnerTitle={false}
-          spinnerTitle={t('ux_editor.modal_properties_code_list_spinner_title')}
-        />
-      );
+      return <StudioSpinner spinnerTitle={t('general.loading')} />;
     case 'error':
       return (
         <StudioErrorMessage>

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.module.css
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.module.css
@@ -1,8 +1,8 @@
 .editOptionTabModal[open] {
-  --code-list-modal-min-width: min(80rem, 100%);
-  --code-list-modal-height: min(45rem, 100%);
+  --code-list-modal-height: min(50rem, 100%);
 
-  min-width: var(--code-list-modal-min-width);
+  width: 80vw;
+  max-width: unset;
   height: var(--code-list-modal-height);
 }
 

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.test.tsx
@@ -8,8 +8,8 @@ import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { renderWithProviders } from '../../../../../../../../testing/mocks';
 import { ComponentType } from 'app-shared/types/ComponentType';
 import { QueryKey } from 'app-shared/types/QueryKey';
-import type { QueryClient } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
+import type { QueryClient } from '@tanstack/react-query';
 import type { ITextResources } from 'app-shared/types/global';
 import type { OptionList } from 'app-shared/types/OptionList';
 import type { Option } from 'app-shared/types/Option';
@@ -99,7 +99,7 @@ describe('LibraryOptionEditor', () => {
     );
   });
 
-  it('should call updateTextResource with correct parameters when editing label', async () => {
+  it('should call upsertTextResources with correct parameters when editing label', async () => {
     const user = userEvent.setup();
     renderLibraryOptionsEditorWithData();
     const expectedLanguage = 'nb';

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.test.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { app, org } from '@studio/testing/testids';
+import { componentMocks } from '../../../../../../../../testing/componentMocks';
+import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { textMock } from '@studio/testing/mocks/i18nMock';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { renderWithProviders } from '../../../../../../../../testing/mocks';
+import { ComponentType } from 'app-shared/types/ComponentType';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import type { QueryClient } from '@tanstack/react-query';
+import userEvent from '@testing-library/user-event';
+import type { ITextResources } from 'app-shared/types/global';
+import type { OptionList } from 'app-shared/types/OptionList';
+import type { Option } from 'app-shared/types/Option';
+import { LibraryOptionsEditor, type LibraryOptionsEditorProps } from './LibraryOptionsEditor';
+
+// Test data:
+const mockComponent = componentMocks[ComponentType.RadioButtons];
+const optionListId = 'someId';
+const componentWithOptionsId = { ...mockComponent, options: undefined, optionsId: optionListId };
+const handleDelete = jest.fn();
+const doReloadPreview = jest.fn();
+const textResources: ITextResources = {
+  nb: [
+    { id: 'some-id', value: 'label 1' },
+    { id: 'another-id', value: 'label 2' },
+    { id: 'description-id', value: 'description' },
+  ],
+};
+const optionList: OptionList = [
+  { value: 'value 1', label: 'some-id', description: 'description-id', helpText: 'help text' },
+  { value: 'value 2', label: 'another-id', description: null, helpText: null },
+  { value: 'value 3', label: '', description: null, helpText: null },
+];
+
+describe('LibraryOptionEditor', () => {
+  afterEach(jest.clearAllMocks);
+
+  it('should render the open Dialog button', async () => {
+    renderLibraryOptionsEditorWithData();
+    expect(getOptionModalButton()).toBeInTheDocument();
+  });
+
+  it('should open Dialog', async () => {
+    const user = userEvent.setup();
+    renderLibraryOptionsEditorWithData();
+
+    await user.click(getOptionModalButton());
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('ux_editor.options.modal_header_library_code_list')),
+    ).toBeInTheDocument();
+  });
+
+  it('should close Dialog', async () => {
+    const user = userEvent.setup();
+    renderLibraryOptionsEditorWithData();
+    await user.click(getOptionModalButton());
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should call doReloadPreview when editing', async () => {
+    const user = userEvent.setup();
+    renderLibraryOptionsEditorWithData();
+
+    await user.click(getOptionModalButton());
+    const textBox = getValueInput(1);
+    await user.type(textBox, 'test');
+    await user.tab();
+
+    await waitFor(() => expect(doReloadPreview).toHaveBeenCalledTimes(1));
+  });
+
+  it('should call updateOptionList with correct parameters when editing value', async () => {
+    const user = userEvent.setup();
+    renderLibraryOptionsEditorWithData();
+    const expectedResultAfterEdit: Option[] = [
+      { value: 'test', label: 'some-id', description: 'description-id', helpText: 'help text' },
+      { value: 'value 2', label: 'another-id', description: null, helpText: null },
+      { value: 'value 3', label: '', description: null, helpText: null },
+    ];
+
+    await user.click(getOptionModalButton());
+    const textBox = getValueInput(1);
+    await user.type(textBox, 'test');
+    await user.tab();
+
+    await waitFor(() => expect(queriesMock.updateOptionList).toHaveBeenCalledTimes(1));
+    expect(queriesMock.updateOptionList).toHaveBeenCalledWith(
+      org,
+      app,
+      componentWithOptionsId.optionsId,
+      expectedResultAfterEdit,
+    );
+  });
+
+  it('should call updateTextResource with correct parameters when editing label', async () => {
+    const user = userEvent.setup();
+    renderLibraryOptionsEditorWithData();
+    const expectedLanguage = 'nb';
+    const expectedTextResource = { 'description-id': 'test' };
+
+    await user.click(getOptionModalButton());
+    const textBox = getTextResourceDescriptionInput(1);
+    await user.type(textBox, 'test');
+    await user.tab();
+
+    await waitFor(() => expect(queriesMock.upsertTextResources).toHaveBeenCalledTimes(1));
+    expect(queriesMock.upsertTextResources).toHaveBeenCalledWith(
+      org,
+      app,
+      expectedLanguage,
+      expectedTextResource,
+    );
+  });
+
+  it('should show placeholder for option label when option list label is empty', async () => {
+    renderLibraryOptionsEditorWithData();
+
+    expect(
+      screen.getByText(textMock('general.empty_string'), { exact: false }),
+    ).toBeInTheDocument();
+  });
+
+  it('should call handleDelete when removing chosen options', async () => {
+    const user = userEvent.setup();
+    renderLibraryOptionsEditorWithData();
+
+    await user.click(getDeleteButton());
+
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+  });
+});
+
+function getOptionModalButton() {
+  return screen.getByRole('button', {
+    name: textMock('general.edit'),
+  });
+}
+
+function getTextResourceDescriptionInput(number: number) {
+  return screen.getByRole('textbox', {
+    name: textMock('code_list_editor.text_resource.description.value', { number }),
+  });
+}
+
+function getValueInput(number: number) {
+  return screen.getByRole('textbox', {
+    name: textMock('code_list_editor.value_item', { number }),
+  });
+}
+
+function getDeleteButton() {
+  return screen.getByRole('button', {
+    name: textMock('general.delete'),
+  });
+}
+
+const defaultProps: LibraryOptionsEditorProps = {
+  handleDelete: handleDelete,
+  optionListId: optionListId,
+};
+
+function renderLibraryOptionsEditor({
+  queries = {},
+  props = {},
+  queryClient = createQueryClientMock(),
+} = {}) {
+  renderWithProviders(<LibraryOptionsEditor {...defaultProps} {...props} />, {
+    queries,
+    queryClient,
+    previewContextProps: { doReloadPreview },
+  });
+}
+
+function renderLibraryOptionsEditorWithData({ queries = {}, props = {} } = {}) {
+  const queryClient = createQueryClientWithData();
+  renderLibraryOptionsEditor({ queries, props, queryClient });
+}
+
+function createQueryClientWithData(): QueryClient {
+  const queryClient = createQueryClientMock();
+  queryClient.setQueryData([QueryKey.OptionList, org, app, optionListId], optionList);
+  queryClient.setQueryData([QueryKey.TextResources, org, app], textResources);
+  return queryClient;
+}

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.tsx
@@ -1,17 +1,23 @@
-import React, { createRef } from 'react';
+import React, { createRef, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StudioCodeListEditor, StudioModal, StudioAlert } from '@studio/components';
-import type { CodeListEditorTexts } from '@studio/components';
+import type { TextResourceWithLanguage } from '@studio/content-library';
+import type { CodeListEditorTexts, TextResource } from '@studio/components';
+import type { OptionList } from 'app-shared/types/OptionList';
 import { usePreviewContext } from 'app-development/contexts/PreviewContext';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
-import { useUpdateOptionListMutation } from 'app-shared/hooks/mutations';
+import {
+  useUpdateOptionListMutation,
+  useUpsertTextResourceMutation,
+} from 'app-shared/hooks/mutations';
 import { useOptionListEditorTexts } from '../../../hooks';
 import { OptionListButtons } from '../OptionListButtons';
 import { OptionListLabels } from '../OptionListLabels';
 import { hasOptionListChanged } from '../../../utils/optionsUtils';
-import { useOptionListQuery } from 'app-shared/hooks/queries';
+import { useOptionListQuery, useTextResourcesQuery } from 'app-shared/hooks/queries';
+import { getTextResourcesForLanguage, createTextResourceWithLanguage } from '../utils/utils';
+import { convertTextResourceToMutationArgs } from 'app-development/features/appContentLibrary/utils/convertTextResourceToMutationArgs';
 import classes from './LibraryOptionsEditor.module.css';
-import type { OptionList } from 'app-shared/types/OptionList';
 
 type LibraryOptionsEditorProps = {
   handleDelete: () => void;
@@ -25,10 +31,33 @@ export function LibraryOptionsEditor({
   const { t } = useTranslation();
   const { org, app } = useStudioEnvironmentParams();
   const { data: optionList } = useOptionListQuery(org, app, optionListId);
-  const { doReloadPreview } = usePreviewContext();
+  const { data: textResources } = useTextResourcesQuery(org, app);
   const { mutate: updateOptionList } = useUpdateOptionListMutation(org, app);
+  const { mutate: updateTextResource } = useUpsertTextResourceMutation(org, app);
+  const { doReloadPreview } = usePreviewContext();
   const editorTexts: CodeListEditorTexts = useOptionListEditorTexts();
   const modalRef = createRef<HTMLDialogElement>();
+
+  const textResourcesForLanguage = useMemo(
+    () => getTextResourcesForLanguage(language, textResources),
+    [textResources],
+  );
+
+  const handleUpdateTextResource = useCallback(
+    (textResourceWithLanguage: TextResourceWithLanguage): void => {
+      const mutationArgs = convertTextResourceToMutationArgs(textResourceWithLanguage);
+      updateTextResource(mutationArgs);
+    },
+    [updateTextResource],
+  );
+
+  const handleBlurTextResource = useCallback(
+    (textResource: TextResource) => {
+      const updatedTextResource = createTextResourceWithLanguage(language, textResource);
+      handleUpdateTextResource?.(updatedTextResource);
+    },
+    [handleUpdateTextResource],
+  );
 
   const handleOptionsListChange = (newOptionList: OptionList) => {
     if (hasOptionListChanged(optionList, newOptionList)) {
@@ -61,9 +90,13 @@ export function LibraryOptionsEditor({
           codeList={optionList}
           onAddOrDeleteItem={handleOptionsListChange}
           onBlurAny={handleOptionsListChange}
+          onBlurTextResource={handleBlurTextResource}
           texts={editorTexts}
+          textResources={textResourcesForLanguage}
         />
       </StudioModal.Dialog>
     </>
   );
 }
+
+const language: string = 'nb'; // Todo: Let the user choose the language: https://github.com/Altinn/altinn-studio/issues/14572

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.tsx
@@ -1,7 +1,6 @@
 import React, { createRef, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StudioCodeListEditor, StudioModal, StudioAlert } from '@studio/components';
-import type { TextResourceWithLanguage } from '@studio/content-library';
 import type { CodeListEditorTexts, TextResource } from '@studio/components';
 import type { OptionList } from 'app-shared/types/OptionList';
 import { usePreviewContext } from 'app-development/contexts/PreviewContext';
@@ -19,7 +18,7 @@ import { getTextResourcesForLanguage, createTextResourceWithLanguage } from '../
 import { convertTextResourceToMutationArgs } from 'app-development/features/appContentLibrary/utils/convertTextResourceToMutationArgs';
 import classes from './LibraryOptionsEditor.module.css';
 
-type LibraryOptionsEditorProps = {
+export type LibraryOptionsEditorProps = {
   handleDelete: () => void;
   optionListId: string;
 };
@@ -43,20 +42,14 @@ export function LibraryOptionsEditor({
     [textResources],
   );
 
-  const handleUpdateTextResource = useCallback(
-    (textResourceWithLanguage: TextResourceWithLanguage): void => {
-      const mutationArgs = convertTextResourceToMutationArgs(textResourceWithLanguage);
-      updateTextResource(mutationArgs);
-    },
-    [updateTextResource],
-  );
-
   const handleBlurTextResource = useCallback(
     (textResource: TextResource) => {
       const updatedTextResource = createTextResourceWithLanguage(language, textResource);
-      handleUpdateTextResource?.(updatedTextResource);
+      const mutationArgs = convertTextResourceToMutationArgs(updatedTextResource);
+      updateTextResource(mutationArgs);
+      doReloadPreview();
     },
-    [handleUpdateTextResource],
+    [updateTextResource, doReloadPreview],
   );
 
   const handleOptionsListChange = (newOptionList: OptionList) => {

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.module.css
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.module.css
@@ -1,8 +1,8 @@
 .editOptionTabModal[open] {
-  --code-list-modal-min-width: min(80rem, 100%);
-  --code-list-modal-height: min(45rem, 100%);
+  --code-list-modal-height: min(50rem, 100%);
 
-  min-width: var(--code-list-modal-min-width);
+  width: 80vw;
+  max-width: unset;
   height: var(--code-list-modal-height);
 }
 

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
@@ -10,8 +10,8 @@ import { ComponentType } from 'app-shared/types/ComponentType';
 import { ObjectUtils } from '@studio/pure-functions';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import type { QueryClient } from '@tanstack/react-query';
-import userEvent from '@testing-library/user-event';
 import type { ITextResources } from 'app-shared/types/global';
+import userEvent from '@testing-library/user-event';
 import { ManualOptionsEditor, type ManualOptionsEditorProps } from './ManualOptionsEditor';
 
 // Test data:
@@ -71,7 +71,7 @@ describe('ManualOptionEditor', () => {
     expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
   });
 
-  it('should call handleComponentChange with correct parameters when editing description', async () => {
+  it('should call upsertTextResource with correct parameters when editing description', async () => {
     const user = userEvent.setup();
     const expectedLanguage = 'nb';
     const expectedTextResource = { 'some-id': 'test' };
@@ -100,14 +100,12 @@ describe('ManualOptionEditor', () => {
     );
   });
 
-  it('should call useUpsertTextResourceMutation when editing label', () => {});
-
-  it('should show placeholder for option label when option list label is empty', () => {
+  it('should show placeholder for option label when label is empty', () => {
     renderManualOptionsEditorWithData({
       props: {
         component: {
           ...mockComponent,
-          options: [{ value: 2, label: '', description: 'test', helpText: null }],
+          options: [{ value: 1, label: '', description: null, helpText: null }],
         },
       },
     });

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
@@ -28,6 +28,7 @@ const textResources: ITextResources = {
 
 describe('ManualOptionEditor', () => {
   afterEach(jest.clearAllMocks);
+
   it('should render the open Dialog button', () => {
     renderManualOptionsEditorWithData();
     expect(getOptionModalButton()).toBeInTheDocument();

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { app, org } from '@studio/testing/testids';
+import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { componentMocks } from '../../../../../../../../testing/componentMocks';
+import { textMock } from '@studio/testing/mocks/i18nMock';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { renderWithProviders } from '../../../../../../../../testing/mocks';
+import { ComponentType } from 'app-shared/types/ComponentType';
+import { ObjectUtils } from '@studio/pure-functions';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import type { QueryClient } from '@tanstack/react-query';
+import userEvent from '@testing-library/user-event';
+import type { ITextResources } from 'app-shared/types/global';
+import { ManualOptionsEditor, type ManualOptionsEditorProps } from './ManualOptionsEditor';
+
+// Test data:
+const mockComponent = componentMocks[ComponentType.RadioButtons];
+const handleDelete = jest.fn();
+const handleComponentChange = jest.fn();
+const textResources: ITextResources = {
+  nb: [
+    { id: 'some-id', value: 'label 1' },
+    { id: 'another-id', value: 'label 2' },
+    { id: 'description-id', value: 'description' },
+  ],
+};
+
+describe('ManualOptionEditor', () => {
+  afterEach(jest.clearAllMocks);
+  it('should render the open Dialog button', () => {
+    renderManualOptionsEditorWithData();
+    expect(getOptionModalButton()).toBeInTheDocument();
+  });
+
+  it('should open Dialog', async () => {
+    const user = userEvent.setup();
+    renderManualOptionsEditorWithData();
+
+    await user.click(getOptionModalButton());
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('ux_editor.options.modal_header_manual_code_list')),
+    ).toBeInTheDocument();
+  });
+
+  it('should close Dialog', async () => {
+    const user = userEvent.setup();
+    renderManualOptionsEditorWithData();
+    await user.click(getOptionModalButton());
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should call handleComponentChange with correct parameters when closing Dialog and options is empty', async () => {
+    const user = userEvent.setup();
+    renderManualOptionsEditorWithData({
+      props: { component: { ...mockComponent, options: [], optionsId: undefined } },
+    });
+    const expectedArgs = ObjectUtils.deepCopy(mockComponent);
+    expectedArgs.options = undefined;
+    expectedArgs.optionsId = undefined;
+
+    await user.click(getOptionModalButton());
+    await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
+
+    expect(handleComponentChange).toHaveBeenCalledTimes(1);
+    expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
+  });
+
+  it('should call handleComponentChange with correct parameters when editing description', async () => {
+    const user = userEvent.setup();
+    const expectedLanguage = 'nb';
+    const expectedTextResource = { 'some-id': 'test' };
+    renderManualOptionsEditorWithData({
+      props: {
+        component: {
+          ...mockComponent,
+          options: [{ value: 'value', label: 'label', description: 'some-id' }],
+        },
+      },
+    });
+    const text = 'test';
+
+    await user.click(getOptionModalButton());
+    screen.logTestingPlaygroundURL();
+    const textBox = getTextResourceDescriptionInput(1);
+    await user.type(textBox, text);
+    await user.tab();
+
+    expect(queriesMock.upsertTextResources).toHaveBeenCalledTimes(1);
+    expect(queriesMock.upsertTextResources).toHaveBeenCalledWith(
+      org,
+      app,
+      expectedLanguage,
+      expectedTextResource,
+    );
+  });
+
+  it('should call useUpsertTextResourceMutation when editing label', () => {});
+
+  it('should show placeholder for option label when option list label is empty', () => {
+    renderManualOptionsEditorWithData({
+      props: {
+        component: {
+          ...mockComponent,
+          options: [{ value: 2, label: '', description: 'test', helpText: null }],
+        },
+      },
+    });
+
+    expect(screen.getByText(textMock('general.empty_string'))).toBeInTheDocument();
+  });
+
+  it('should call handleDelete when removing chosen options', async () => {
+    const user = userEvent.setup();
+    renderManualOptionsEditorWithData();
+    const expectedResult = ObjectUtils.deepCopy(mockComponent);
+    expectedResult.options = undefined;
+    expectedResult.optionsId = undefined;
+
+    await user.click(getDeleteButton());
+
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+  });
+});
+
+function getOptionModalButton() {
+  return screen.getByRole('button', {
+    name: textMock('general.edit'),
+  });
+}
+
+function getTextResourceDescriptionInput(number: number) {
+  return screen.getByRole('textbox', {
+    name: textMock('code_list_editor.text_resource.description.value', { number }),
+  });
+}
+
+function getDeleteButton() {
+  return screen.getByRole('button', {
+    name: textMock('general.delete'),
+  });
+}
+
+const defaultProps: ManualOptionsEditorProps = {
+  handleDelete: handleDelete,
+  handleComponentChange: handleComponentChange,
+  component: mockComponent,
+};
+
+function renderManualOptionsEditor({
+  queries = {},
+  props = {},
+  queryClient = createQueryClientMock(),
+} = {}) {
+  renderWithProviders(<ManualOptionsEditor {...defaultProps} {...props} />, {
+    queries,
+    queryClient,
+  });
+}
+
+function renderManualOptionsEditorWithData({ queries = {}, props = {} } = {}) {
+  const queryClient = createQueryClientWithData();
+  renderManualOptionsEditor({ queries, props, queryClient });
+}
+
+function createQueryClientWithData(): QueryClient {
+  const queryClient = createQueryClientMock();
+  queryClient.setQueryData([QueryKey.TextResources, org, app], textResources);
+  return queryClient;
+}

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
@@ -86,7 +86,6 @@ describe('ManualOptionEditor', () => {
     const text = 'test';
 
     await user.click(getOptionModalButton());
-    screen.logTestingPlaygroundURL();
     const textBox = getTextResourceDescriptionInput(1);
     await user.type(textBox, text);
     await user.tab();

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef, useCallback, useMemo } from 'react';
 import type { IGenericEditComponent } from '../../../../../../componentConfig';
 import type { SelectionComponentType } from '../../../../../../../../types/FormComponent';
 import type { Option } from 'app-shared/types/Option';
-import type { TextResourceWithLanguage } from '@studio/content-library';
 import { useTranslation } from 'react-i18next';
 import { StudioCodeListEditor, StudioModal, type TextResource } from '@studio/components';
 import { useForwardedRef } from '@studio/hooks';
@@ -42,26 +41,19 @@ export const ManualOptionsEditor = forwardRef<HTMLDialogElement, ManualOptionsEd
       [textResources],
     );
 
-    const handleOptionsListChange = (options: Option[]) => {
-      const updatedComponent = updateComponentOptions(component, options);
-      handleOptionsChange(updatedComponent, handleComponentChange);
-    };
-
-    const handleUpdateTextResource = useCallback(
-      (textResourceWithLanguage: TextResourceWithLanguage): void => {
-        const mutationArgs = convertTextResourceToMutationArgs(textResourceWithLanguage);
+    const handleBlurTextResource = useCallback(
+      (textResource: TextResource) => {
+        const updatedTextResource = createTextResourceWithLanguage(language, textResource);
+        const mutationArgs = convertTextResourceToMutationArgs(updatedTextResource);
         updateTextResource(mutationArgs);
       },
       [updateTextResource],
     );
 
-    const handleBlurTextResource = useCallback(
-      (textResource: TextResource) => {
-        const updatedTextResource = createTextResourceWithLanguage(language, textResource);
-        handleUpdateTextResource?.(updatedTextResource);
-      },
-      [handleUpdateTextResource],
-    );
+    const handleOptionsListChange = (options: Option[]) => {
+      const updatedComponent = updateComponentOptions(component, options);
+      handleOptionsChange(updatedComponent, handleComponentChange);
+    };
 
     const handleClick = () => {
       modalRef.current?.showModal();

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.tsx
@@ -1,18 +1,27 @@
+import React, { forwardRef, useCallback, useMemo } from 'react';
 import type { IGenericEditComponent } from '../../../../../../componentConfig';
 import type { SelectionComponentType } from '../../../../../../../../types/FormComponent';
-import React, { forwardRef } from 'react';
+import type { Option } from 'app-shared/types/Option';
+import type { TextResourceWithLanguage } from '@studio/content-library';
 import { useTranslation } from 'react-i18next';
-import { StudioCodeListEditor, StudioModal } from '@studio/components';
+import { StudioCodeListEditor, StudioModal, type TextResource } from '@studio/components';
 import { useForwardedRef } from '@studio/hooks';
 import { useOptionListEditorTexts } from '../../../hooks';
+import { useTextResourcesQuery } from 'app-shared/hooks/queries';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import {
   handleOptionsChange,
   resetComponentOptions,
   updateComponentOptions,
 } from '../../../utils/optionsUtils';
+import { useUpsertTextResourceMutation } from 'app-shared/hooks/mutations';
+import {
+  convertTextResourceToMutationArgs,
+  createTextResourceWithLanguage,
+  getTextResourcesForLanguage,
+} from '../utils/utils';
 import { OptionListLabels } from '../OptionListLabels';
 import { OptionListButtons } from '../OptionListButtons';
-import type { Option } from 'app-shared/types/Option';
 import classes from './ManualOptionsEditor.module.css';
 
 type ManualOptionsEditorProps = {
@@ -22,13 +31,37 @@ type ManualOptionsEditorProps = {
 export const ManualOptionsEditor = forwardRef<HTMLDialogElement, ManualOptionsEditorProps>(
   ({ component, handleComponentChange, handleDelete }, ref): React.ReactNode => {
     const { t } = useTranslation();
+    const { org, app } = useStudioEnvironmentParams();
+    const { data: textResources } = useTextResourcesQuery(org, app);
+    const { mutate: updateTextResource } = useUpsertTextResourceMutation(org, app);
     const modalRef = useForwardedRef(ref);
     const editorTexts = useOptionListEditorTexts();
+
+    const textResourcesForLanguage = useMemo(
+      () => getTextResourcesForLanguage(language, textResources),
+      [textResources],
+    );
 
     const handleOptionsListChange = (options: Option[]) => {
       const updatedComponent = updateComponentOptions(component, options);
       handleOptionsChange(updatedComponent, handleComponentChange);
     };
+
+    const handleUpdateTextResource = useCallback(
+      (textResourceWithLanguage: TextResourceWithLanguage): void => {
+        const mutationArgs = convertTextResourceToMutationArgs(textResourceWithLanguage);
+        updateTextResource(mutationArgs);
+      },
+      [updateTextResource],
+    );
+
+    const handleBlurTextResource = useCallback(
+      (textResource: TextResource) => {
+        const updatedTextResource = createTextResourceWithLanguage(language, textResource);
+        handleUpdateTextResource?.(updatedTextResource);
+      },
+      [handleUpdateTextResource],
+    );
 
     const handleClick = () => {
       modalRef.current?.showModal();
@@ -57,12 +90,16 @@ export const ManualOptionsEditor = forwardRef<HTMLDialogElement, ManualOptionsEd
             codeList={component.options}
             onAddOrDeleteItem={handleOptionsListChange}
             onBlurAny={handleOptionsListChange}
+            onBlurTextResource={handleBlurTextResource}
             texts={editorTexts}
+            textResources={textResourcesForLanguage}
           />
         </StudioModal.Dialog>
       </>
     );
   },
 );
+
+const language: string = 'nb'; // Todo: Let the user choose the language: https://github.com/Altinn/altinn-studio/issues/14572
 
 ManualOptionsEditor.displayName = 'ManualOptionsEditor';

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.tsx
@@ -24,7 +24,7 @@ import { OptionListLabels } from '../OptionListLabels';
 import { OptionListButtons } from '../OptionListButtons';
 import classes from './ManualOptionsEditor.module.css';
 
-type ManualOptionsEditorProps = {
+export type ManualOptionsEditorProps = {
   handleDelete: () => void;
 } & Pick<IGenericEditComponent<SelectionComponentType>, 'component' | 'handleComponentChange'>;
 

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.test.tsx
@@ -6,9 +6,10 @@ import { textMock } from '@studio/testing/mocks/i18nMock';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { renderWithProviders } from '../../../../../../../testing/mocks';
 import { ComponentType } from 'app-shared/types/ComponentType';
+import { ObjectUtils } from '@studio/pure-functions';
 import { QueryKey } from 'app-shared/types/QueryKey';
-import type { QueryClient } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
+import type { QueryClient } from '@tanstack/react-query';
 import type { OptionList } from 'app-shared/types/OptionList';
 import type { OptionListEditorProps } from './OptionListEditor';
 import { OptionListEditor } from './OptionListEditor';
@@ -93,10 +94,13 @@ describe('OptionListEditor', () => {
         getOptionList: jest.fn().mockImplementation(() => Promise.reject()),
       },
     });
+    const expectedArgs = ObjectUtils.deepCopy(componentWithOptionsId);
+    expectedArgs.optionsId = undefined;
 
     expect(getDeleteButton()).toBeInTheDocument();
     await user.click(getDeleteButton());
     expect(handleComponentChange).toHaveBeenCalledTimes(1);
+    expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
   });
 });
 

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.test.tsx
@@ -1,252 +1,102 @@
 import React from 'react';
-import { screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
-import type { OptionList } from 'app-shared/types/OptionList';
-import type { Option } from 'app-shared/types/Option';
-import { ComponentType } from 'app-shared/types/ComponentType';
-import type { OptionListEditorProps } from './OptionListEditor';
-import { ObjectUtils } from '@studio/pure-functions';
-import { OptionListEditor } from './OptionListEditor';
-import { textMock } from '@studio/testing/mocks/i18nMock';
-import { renderWithProviders } from '../../../../../../../testing/mocks';
-import userEvent from '@testing-library/user-event';
-import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
-import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import { app, org } from '@studio/testing/testids';
 import { componentMocks } from '../../../../../../../testing/componentMocks';
+import { textMock } from '@studio/testing/mocks/i18nMock';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { renderWithProviders } from '../../../../../../../testing/mocks';
+import { ComponentType } from 'app-shared/types/ComponentType';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import type { QueryClient } from '@tanstack/react-query';
+import userEvent from '@testing-library/user-event';
+import type { OptionList } from 'app-shared/types/OptionList';
+import type { OptionListEditorProps } from './OptionListEditor';
+import { OptionListEditor } from './OptionListEditor';
 
 // Test data:
 const mockComponent = componentMocks[ComponentType.RadioButtons];
+const optionListId = 'someId';
+const componentWithOptionsId = { ...mockComponent, options: undefined, optionsId: optionListId };
 const handleComponentChange = jest.fn();
-const apiResult: OptionList = [
-  { value: 'value 1', label: 'label 1', description: 'description', helpText: 'help text' },
-  { value: 'value 2', label: 'label 2', description: null, helpText: null },
-  { value: 'value 3', label: 'label 3', description: null, helpText: null },
+const doReloadPreview = jest.fn();
+const optionList: OptionList = [
+  { value: 'value 1', label: 'some-id', description: 'description-id', helpText: 'help text' },
+  { value: 'value 2', label: 'another-id', description: null, helpText: null },
+  { value: 'value 3', label: '', description: null, helpText: null },
 ];
-const getOptionListMock = jest
-  .fn()
-  .mockImplementation(() => Promise.resolve<OptionList>(apiResult));
-const componentWithOptionsId = { ...mockComponent, options: undefined, optionsId: 'some-id' };
 
 describe('OptionListEditor', () => {
-  afterEach(() => jest.clearAllMocks());
+  afterEach(jest.clearAllMocks);
 
-  describe('ManualOptionEditor', () => {
-    it('should render the open Dialog button', () => {
-      renderOptionListEditor();
-      expect(getOptionModalButton()).toBeInTheDocument();
-    });
-
-    it('should open Dialog', async () => {
-      const user = userEvent.setup();
-      renderOptionListEditor();
-
-      await user.click(getOptionModalButton());
-
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-      expect(
-        screen.getByText(textMock('ux_editor.options.modal_header_manual_code_list')),
-      ).toBeInTheDocument();
-    });
-
-    it('should close Dialog', async () => {
-      const user = userEvent.setup();
-      renderOptionListEditor();
-      await user.click(getOptionModalButton());
-
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-      await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    });
-
-    it('should call handleComponentChange with correct parameters when closing Dialog and options is empty', async () => {
-      const user = userEvent.setup();
-      renderOptionListEditor({
-        props: { component: { ...mockComponent, options: [], optionsId: undefined } },
-      });
-      const expectedArgs = ObjectUtils.deepCopy(mockComponent);
-      expectedArgs.options = undefined;
-      expectedArgs.optionsId = undefined;
-
-      await user.click(getOptionModalButton());
-      await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
-
-      expect(handleComponentChange).toHaveBeenCalledTimes(1);
-      expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
-    });
-
-    it('should call handleComponentChange with correct parameters when editing', async () => {
-      const user = userEvent.setup();
-      renderOptionListEditor();
-      const text = 'test';
-      const expectedArgs = ObjectUtils.deepCopy(mockComponent);
-      expectedArgs.optionsId = undefined;
-      expectedArgs.options[0].description = text;
-
-      await user.click(getOptionModalButton());
-      const textBox = getDescriptionInput(1);
-      await user.type(textBox, text);
-      await user.tab();
-
-      expect(handleComponentChange).toHaveBeenCalledTimes(1);
-      expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
-    });
-
-    it('should show placeholder for option label when option list label is empty', () => {
-      renderOptionListEditor({
-        props: {
-          component: {
-            ...mockComponent,
-            options: [{ value: 2, label: '', description: 'test', helpText: null }],
-          },
-        },
-      });
-
-      expect(screen.getByText(textMock('general.empty_string'))).toBeInTheDocument();
-    });
-
-    it('should call handleComponentChange with correct parameters when removing chosen options', async () => {
-      const user = userEvent.setup();
-      renderOptionListEditor();
-      const expectedResult = ObjectUtils.deepCopy(mockComponent);
-      expectedResult.options = undefined;
-      expectedResult.optionsId = undefined;
-
-      await user.click(getDeleteButton());
-
-      expect(handleComponentChange).toHaveBeenCalledTimes(1);
-      expect(handleComponentChange).toHaveBeenCalledWith(expectedResult);
-    });
+  it('should render the open Dialog button', () => {
+    renderOptionListEditor();
+    expect(getOptionModalButton()).toBeInTheDocument();
   });
 
-  describe('LibraryOptionEditor', () => {
-    it('should render a spinner when there is no data', () => {
-      renderOptionListEditor({
-        queries: {
-          getOptionList: jest.fn().mockImplementation(() => Promise.resolve<OptionList>([])),
-        },
-        props: { component: componentWithOptionsId },
-      });
+  it('should render ManualOptionsEditor', async () => {
+    const user = userEvent.setup();
+    renderOptionListEditor();
 
-      expect(
-        screen.getByText(textMock('ux_editor.modal_properties_code_list_spinner_title')),
-      ).toBeInTheDocument();
+    await user.click(getOptionModalButton());
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('ux_editor.options.modal_header_manual_code_list')),
+    ).toBeInTheDocument();
+  });
+
+  it('should render LibraryOptionsEditor when data loads', async () => {
+    const user = userEvent.setup();
+    renderOptionListEditorWithData();
+
+    await user.click(getOptionModalButton());
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('ux_editor.options.modal_header_library_code_list')),
+    ).toBeInTheDocument();
+  });
+
+  it('should render a spinner when there is no data', () => {
+    renderOptionListEditor({
+      queries: {
+        getOptionList: jest.fn().mockImplementation(() => Promise.resolve<OptionList>([])),
+      },
+      props: { component: componentWithOptionsId },
     });
 
-    it('should render an error message when getOptionList throws an error', async () => {
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved({
-        queries: {
-          getOptionList: jest.fn().mockImplementation(() => Promise.reject()),
-        },
-      });
+    expect(
+      screen.getByText(textMock('ux_editor.modal_properties_code_list_spinner_title')),
+    ).toBeInTheDocument();
+  });
 
-      expect(
-        screen.getByText(textMock('ux_editor.modal_properties_fetch_option_list_error_message')),
-      ).toBeInTheDocument();
+  it('should render an error message when getOptionList throws an error', async () => {
+    renderOptionListEditor({
+      queries: {
+        getOptionList: jest.fn().mockImplementation(() => Promise.reject()),
+      },
+      props: { component: componentWithOptionsId },
+    });
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText(textMock('ux_editor.modal_properties_code_list_spinner_title')),
+    );
+
+    expect(
+      screen.getByText(textMock('ux_editor.modal_properties_fetch_option_list_error_message')),
+    ).toBeInTheDocument();
+  });
+
+  it('should be able to remove binding to optionList if getOptionList throws an error', async () => {
+    const user = userEvent.setup();
+    renderOptionListEditorWithData({
+      queries: {
+        getOptionList: jest.fn().mockImplementation(() => Promise.reject()),
+      },
     });
 
-    it('should be able to remove binding to optionList if getOptionList throws an error', async () => {
-      const user = userEvent.setup();
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved({
-        queries: {
-          getOptionList: jest.fn().mockImplementation(() => Promise.reject()),
-        },
-      });
-
-      expect(getDeleteButton()).toBeInTheDocument();
-      await user.click(getDeleteButton());
-      expect(handleComponentChange).toHaveBeenCalledTimes(1);
-    });
-
-    it('should render the open Dialog button', async () => {
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved();
-      expect(getOptionModalButton()).toBeInTheDocument();
-    });
-
-    it('should open Dialog', async () => {
-      const user = userEvent.setup();
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved();
-
-      await user.click(getOptionModalButton());
-
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-    });
-
-    it('should close Dialog', async () => {
-      const user = userEvent.setup();
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved();
-      await user.click(getOptionModalButton());
-
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-      await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    });
-
-    it('should call doReloadPreview when editing', async () => {
-      const user = userEvent.setup();
-      const doReloadPreview = jest.fn();
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved({
-        previewContextProps: { doReloadPreview },
-      });
-
-      await user.click(getOptionModalButton());
-      const textBox = getDescriptionInput(2);
-      await user.type(textBox, 'test');
-      await user.tab();
-
-      await waitFor(() => expect(doReloadPreview).toHaveBeenCalledTimes(1));
-    });
-
-    it('should call updateOptionList with correct parameters when closing Dialog', async () => {
-      const user = userEvent.setup();
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved();
-      const expectedResultAfterEdit: Option[] = [
-        { value: 'value 1', label: 'label 1', description: 'description', helpText: 'help text' },
-        { value: 'value 2', label: 'label 2', description: 'test', helpText: null },
-        { value: 'value 3', label: 'label 3', description: null, helpText: null },
-      ];
-
-      await user.click(getOptionModalButton());
-      const textBox = getDescriptionInput(2);
-      await user.type(textBox, 'test');
-      await user.tab();
-
-      await waitFor(() => expect(queriesMock.updateOptionList).toHaveBeenCalledTimes(1));
-      expect(queriesMock.updateOptionList).toHaveBeenCalledWith(
-        org,
-        app,
-        componentWithOptionsId.optionsId,
-        expectedResultAfterEdit,
-      );
-    });
-
-    it('should show placeholder for option label when option list label is empty', async () => {
-      const apiResultWithEmptyLabel: OptionList = [
-        { value: true, label: '', description: null, helpText: null },
-      ];
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved({
-        queries: {
-          getOptionList: jest
-            .fn()
-            .mockImplementation(() => Promise.resolve<OptionList>(apiResultWithEmptyLabel)),
-        },
-      });
-
-      expect(screen.getByText(textMock('general.empty_string'))).toBeInTheDocument();
-    });
-
-    it('should call handleComponentChange with correct parameters when removing chosen options', async () => {
-      const user = userEvent.setup();
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved();
-
-      await user.click(getDeleteButton());
-
-      expect(handleComponentChange).toHaveBeenCalledTimes(1);
-      expect(handleComponentChange).toHaveBeenCalledWith({
-        ...mockComponent,
-        options: undefined,
-        optionsId: undefined,
-      });
-    });
+    expect(getDeleteButton()).toBeInTheDocument();
+    await user.click(getDeleteButton());
+    expect(handleComponentChange).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -256,43 +106,39 @@ function getOptionModalButton() {
   });
 }
 
-function getDescriptionInput(number: number) {
-  return screen.getByRole('textbox', {
-    name: textMock('code_list_editor.description_item', { number }),
-  });
-}
-
 function getDeleteButton() {
   return screen.getByRole('button', {
     name: textMock('general.delete'),
   });
 }
 
-const renderOptionListEditor = ({ previewContextProps = {}, queries = {}, props = {} } = {}) => {
-  const defaultProps: OptionListEditorProps = {
-    component: mockComponent,
-    handleComponentChange,
-  };
-
-  return renderWithProviders(<OptionListEditor {...defaultProps} {...props} />, {
-    queries: { getOptionList: getOptionListMock, ...queries },
-    queryClient: createQueryClientMock(),
-    previewContextProps,
-  });
+const defaultProps: OptionListEditorProps = {
+  component: mockComponent,
+  handleComponentChange,
 };
 
-const renderOptionListEditorAndWaitForSpinnerToBeRemoved = async ({
-  previewContextProps = {},
+function renderOptionListEditor({
+  queries = {},
+  props = {},
+  queryClient = createQueryClientMock(),
+} = {}) {
+  renderWithProviders(<OptionListEditor {...defaultProps} {...props} />, {
+    queries,
+    queryClient,
+    previewContextProps: { doReloadPreview },
+  });
+}
+
+function renderOptionListEditorWithData({
   queries = {},
   props = { component: componentWithOptionsId },
-} = {}) => {
-  const view = renderOptionListEditor({
-    previewContextProps,
-    queries,
-    props,
-  });
-  await waitForElementToBeRemoved(() =>
-    screen.queryByText(textMock('ux_editor.modal_properties_code_list_spinner_title')),
-  );
-  return view;
-};
+} = {}) {
+  const queryClient = createQueryClientWithData();
+  renderOptionListEditor({ queries, props, queryClient });
+}
+
+function createQueryClientWithData(): QueryClient {
+  const queryClient = createQueryClientMock();
+  queryClient.setQueryData([QueryKey.OptionList, org, app, optionListId], optionList);
+  return queryClient;
+}

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.tsx
@@ -32,7 +32,6 @@ export const OptionListEditor = forwardRef<HTMLDialogElement, OptionListEditorPr
         />
       );
     }
-
     return <OptionListResolver optionsId={component.optionsId} handleDelete={handleDelete} />;
   },
 );

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/utils/utils.test.ts
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/utils/utils.test.ts
@@ -1,0 +1,69 @@
+import {
+  getTextResourcesForLanguage,
+  createTextResourceWithLanguage,
+  convertTextResourceToMutationArgs,
+} from './utils';
+import type { TextResources, TextResourceWithLanguage } from '@studio/content-library';
+import type { TextResource } from '@studio/components';
+import type { UpsertTextResourceMutation } from 'app-shared/hooks/mutations/useUpsertTextResourceMutation';
+
+describe('utils functions', () => {
+  describe('getTextResourcesForLanguage', () => {
+    it('should return undefined if text resources input variable is undefined', () => {
+      const language = '';
+      const textResources = undefined;
+      expect(getTextResourcesForLanguage(language, textResources)).toBeUndefined();
+    });
+
+    it('should return array of text resources with correct input', () => {
+      const language = 'nb';
+      const textResource: TextResource = {
+        id: 'some-id',
+        value: 'some-value',
+      };
+      const textResources: TextResources = {
+        [language]: [textResource],
+      };
+      const expectedResult = [textResource];
+
+      expect(getTextResourcesForLanguage(language, textResources)).toEqual(expectedResult);
+    });
+  });
+
+  describe('createTextResourceWithLanguage', () => {
+    it('should return text resource with language with correct input', () => {
+      const language = 'nb';
+      const textResource: TextResource = {
+        id: 'some-id',
+        value: 'some-value',
+      };
+      const expectedResult: TextResourceWithLanguage = {
+        language: language,
+        textResource: textResource,
+      };
+
+      expect(createTextResourceWithLanguage(language, textResource)).toEqual(expectedResult);
+    });
+  });
+
+  describe('convertTextResourceToMutationArgs', () => {
+    it('should return text resources with correct input', () => {
+      const language = 'nb';
+      const textResource: TextResource = {
+        id: 'some-id',
+        value: 'some-value',
+      };
+      const textResourceWithLanguage: TextResourceWithLanguage = {
+        language: language,
+        textResource: textResource,
+      };
+      const expectedResult: UpsertTextResourceMutation = {
+        textId: textResource.id,
+        language,
+        translation: textResource.value,
+      };
+
+      expect(convertTextResourceToMutationArgs(textResourceWithLanguage)).toEqual(expectedResult);
+    });
+  });
+});

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/utils/utils.ts
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/utils/utils.ts
@@ -1,0 +1,27 @@
+import type {
+  TextResource,
+  TextResources,
+  TextResourceWithLanguage,
+} from '@studio/content-library';
+import type { UpsertTextResourceMutation } from 'app-shared/hooks/mutations/useUpsertTextResourceMutation';
+
+export const getTextResourcesForLanguage = (
+  language: string,
+  textResources?: TextResources,
+): TextResource[] | undefined => textResources?.[language];
+
+export const createTextResourceWithLanguage = (
+  language: string,
+  textResource: TextResource,
+): TextResourceWithLanguage => ({ language, textResource });
+
+export function convertTextResourceToMutationArgs({
+  textResource,
+  language,
+}: TextResourceWithLanguage): UpsertTextResourceMutation {
+  return {
+    textId: textResource.id,
+    language,
+    translation: textResource.value,
+  };
+}


### PR DESCRIPTION
## Description
This PR adds usage of text resources in ux-editor, in both `ManualOptionsEditor` and `LibraryOptionsEditor`.
It also splits tests from `OptionListEditor` into seperate files, which is why the PR is so large.

Most of the tests are the same as they were, but some are new as there needs to be tests to see if the correct mutations are called.
The new and edited tests are as follows:

**ManualOptionsEditor**
- `should call upsertTextResource with correct parameters when editing description`
- `should call handleDelete when removing chosen options`

**LibraryOptionsEditor**
- `should call updateOptionList with correct parameters when editing value`
- `should show placeholder for option label when option list label is empty`
- `should call upsertTextResources with correct parameters when editing label`

## Before
![image](https://github.com/user-attachments/assets/024398d8-120c-42eb-8d28-d90658e6e557)


## After
![image](https://github.com/user-attachments/assets/985a16a0-d9c2-44dd-bee1-4aa2208eef73)


## Related Issue
- #14835

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
