### PR TITLE
refactor: Split tests for OptionListEditor and move into child components (1)

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.test.tsx
@@ -13,7 +13,7 @@ import userEvent from '@testing-library/user-event';
 import type { OptionList } from 'app-shared/types/OptionList';
 import type { Option } from 'app-shared/types/Option';
 import type { QueryClient } from '@tanstack/react-query';
-import { LibraryOptionsEditor, LibraryOptionsEditorProps } from './LibraryOptionsEditor';
+import { LibraryOptionsEditor, type LibraryOptionsEditorProps } from './LibraryOptionsEditor';
 
 // Test data:
 const mockComponent = componentMocks[ComponentType.RadioButtons];

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { app, org } from '@studio/testing/testids';
+import { componentMocks } from '../../../../../../../../testing/componentMocks';
+import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { textMock } from '@studio/testing/mocks/i18nMock';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { renderWithProviders } from '../../../../../../../../testing/mocks';
+import { ComponentType } from 'app-shared/types/ComponentType';
+import { ObjectUtils } from '@studio/pure-functions';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import userEvent from '@testing-library/user-event';
+import type { OptionList } from 'app-shared/types/OptionList';
+import type { Option } from 'app-shared/types/Option';
+import type { QueryClient } from '@tanstack/react-query';
+import { LibraryOptionsEditor, LibraryOptionsEditorProps } from './LibraryOptionsEditor';
+
+// Test data:
+const mockComponent = componentMocks[ComponentType.RadioButtons];
+const optionListId = 'someId';
+const componentWithOptionsId = { ...mockComponent, options: undefined, optionsId: optionListId };
+const handleDelete = jest.fn();
+const doReloadPreview = jest.fn();
+const optionList: OptionList = [
+  { value: 'value 1', label: 'label 1', description: 'description', helpText: 'help text' },
+  { value: 'value 2', label: 'label 2', description: null, helpText: null },
+  { value: 'value 3', label: '', description: null, helpText: null },
+];
+
+describe('LibraryOptionEditor', () => {
+  afterEach(jest.clearAllMocks);
+
+  it('should render the open Dialog button', async () => {
+    renderLibraryOptionsEditorWithData();
+    expect(getOptionModalButton()).toBeInTheDocument();
+  });
+
+  it('should open Dialog', async () => {
+    const user = userEvent.setup();
+    renderLibraryOptionsEditorWithData();
+
+    await user.click(getOptionModalButton());
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('ux_editor.options.modal_header_library_code_list')),
+    ).toBeInTheDocument();
+  });
+
+  it('should close Dialog', async () => {
+    const user = userEvent.setup();
+    renderLibraryOptionsEditorWithData();
+    await user.click(getOptionModalButton());
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should call doReloadPreview when editing', async () => {
+    const user = userEvent.setup();
+    renderLibraryOptionsEditorWithData();
+
+    await user.click(getOptionModalButton());
+    const textBox = getDescriptionInput(2);
+    await user.type(textBox, 'test');
+    await user.tab();
+
+    await waitFor(() => expect(doReloadPreview).toHaveBeenCalledTimes(1));
+  });
+
+  it('should call updateOptionList with correct parameters when closing Dialog', async () => {
+    const user = userEvent.setup();
+    renderLibraryOptionsEditorWithData();
+    const expectedResultAfterEdit: Option[] = ObjectUtils.deepCopy(optionList);
+    expectedResultAfterEdit[1].description = 'test';
+
+    await user.click(getOptionModalButton());
+    const textBox = getDescriptionInput(2);
+    await user.type(textBox, 'test');
+    await user.tab();
+
+    await waitFor(() => expect(queriesMock.updateOptionList).toHaveBeenCalledTimes(1));
+    expect(queriesMock.updateOptionList).toHaveBeenCalledWith(
+      org,
+      app,
+      componentWithOptionsId.optionsId,
+      expectedResultAfterEdit,
+    );
+  });
+
+  it('should show placeholder for option label when option list label is empty', async () => {
+    renderLibraryOptionsEditorWithData();
+
+    expect(
+      screen.getByText(textMock('general.empty_string'), { exact: false }),
+    ).toBeInTheDocument();
+  });
+
+  it('should call handleDelete when removing chosen options', async () => {
+    const user = userEvent.setup();
+    renderLibraryOptionsEditorWithData();
+
+    await user.click(getDeleteButton());
+
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+  });
+});
+
+function getOptionModalButton() {
+  return screen.getByRole('button', {
+    name: textMock('general.edit'),
+  });
+}
+
+function getDescriptionInput(number: number) {
+  return screen.getByRole('textbox', {
+    name: textMock('code_list_editor.description_item', { number }),
+  });
+}
+
+function getDeleteButton() {
+  return screen.getByRole('button', {
+    name: textMock('general.delete'),
+  });
+}
+
+const defaultProps: LibraryOptionsEditorProps = {
+  handleDelete: handleDelete,
+  optionListId: optionListId,
+};
+
+function renderLibraryOptionsEditor({
+  queries = {},
+  props = {},
+  queryClient = createQueryClientMock(),
+} = {}) {
+  renderWithProviders(<LibraryOptionsEditor {...defaultProps} {...props} />, {
+    queries,
+    queryClient,
+    previewContextProps: { doReloadPreview },
+  });
+}
+
+function renderLibraryOptionsEditorWithData({ queries = {}, props = {} } = {}) {
+  const queryClient = createQueryClientWithData();
+  renderLibraryOptionsEditor({ queries, props, queryClient });
+}
+
+function createQueryClientWithData(): QueryClient {
+  const queryClient = createQueryClientMock();
+  queryClient.setQueryData([QueryKey.OptionList, org, app, optionListId], optionList);
+  return queryClient;
+}

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.test.tsx
@@ -32,14 +32,14 @@ describe('LibraryOptionEditor', () => {
 
   it('should render the open Dialog button', async () => {
     renderLibraryOptionsEditorWithData();
-    expect(getOptionModalButton()).toBeInTheDocument();
+    expect(getEditButton()).toBeInTheDocument();
   });
 
   it('should open Dialog', async () => {
     const user = userEvent.setup();
     renderLibraryOptionsEditorWithData();
 
-    await user.click(getOptionModalButton());
+    await user.click(getEditButton());
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(
@@ -50,7 +50,7 @@ describe('LibraryOptionEditor', () => {
   it('should close Dialog', async () => {
     const user = userEvent.setup();
     renderLibraryOptionsEditorWithData();
-    await user.click(getOptionModalButton());
+    await user.click(getEditButton());
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
@@ -61,7 +61,7 @@ describe('LibraryOptionEditor', () => {
     const user = userEvent.setup();
     renderLibraryOptionsEditorWithData();
 
-    await user.click(getOptionModalButton());
+    await user.click(getEditButton());
     const textBox = getDescriptionInput(2);
     await user.type(textBox, 'test');
     await user.tab();
@@ -75,7 +75,7 @@ describe('LibraryOptionEditor', () => {
     const expectedResultAfterEdit: Option[] = ObjectUtils.deepCopy(optionList);
     expectedResultAfterEdit[1].description = 'test';
 
-    await user.click(getOptionModalButton());
+    await user.click(getEditButton());
     const textBox = getDescriptionInput(2);
     await user.type(textBox, 'test');
     await user.tab();
@@ -107,7 +107,7 @@ describe('LibraryOptionEditor', () => {
   });
 });
 
-function getOptionModalButton() {
+function getEditButton() {
   return screen.getByRole('button', {
     name: textMock('general.edit'),
   });

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/LibraryOptionsEditor/LibraryOptionsEditor.tsx
@@ -13,7 +13,7 @@ import { useOptionListQuery } from 'app-shared/hooks/queries';
 import classes from './LibraryOptionsEditor.module.css';
 import type { OptionList } from 'app-shared/types/OptionList';
 
-type LibraryOptionsEditorProps = {
+export type LibraryOptionsEditorProps = {
   handleDelete: () => void;
   optionListId: string;
 };

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
@@ -14,96 +14,93 @@ const mockComponent = componentMocks[ComponentType.RadioButtons];
 const handleDelete = jest.fn();
 const handleComponentChange = jest.fn();
 
-describe('OptionListEditor', () => {
+describe('ManualOptionEditor', () => {
   afterEach(jest.clearAllMocks);
 
-  describe('ManualOptionEditor', () => {
-    it('should render the open Dialog button', () => {
-      renderManualOptionsEditor();
+  it('should render the open Dialog button', () => {
+    renderManualOptionsEditor();
+    expect(getEditButton()).toBeInTheDocument();
+  });
 
-      expect(getOptionModalButton()).toBeInTheDocument();
+  it('should open Dialog', async () => {
+    const user = userEvent.setup();
+    renderManualOptionsEditor();
+
+    await user.click(getEditButton());
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('ux_editor.options.modal_header_manual_code_list')),
+    ).toBeInTheDocument();
+  });
+
+  it('should close Dialog', async () => {
+    const user = userEvent.setup();
+    renderManualOptionsEditor();
+    await user.click(getEditButton());
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should call handleComponentChange with correct parameters when closing Dialog and options is empty', async () => {
+    const user = userEvent.setup();
+    renderManualOptionsEditor({
+      props: { component: { ...mockComponent, options: [], optionsId: undefined } },
     });
+    const expectedArgs = ObjectUtils.deepCopy(mockComponent);
+    expectedArgs.options = undefined;
+    expectedArgs.optionsId = undefined;
 
-    it('should open Dialog', async () => {
-      const user = userEvent.setup();
-      renderManualOptionsEditor();
+    await user.click(getEditButton());
+    await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
 
-      await user.click(getOptionModalButton());
+    expect(handleComponentChange).toHaveBeenCalledTimes(1);
+    expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
+  });
 
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-      expect(
-        screen.getByText(textMock('ux_editor.options.modal_header_manual_code_list')),
-      ).toBeInTheDocument();
-    });
+  it('should call handleComponentChange with correct parameters when editing', async () => {
+    const user = userEvent.setup();
+    renderManualOptionsEditor();
+    const text = 'test';
+    const expectedArgs = ObjectUtils.deepCopy(mockComponent);
+    expectedArgs.optionsId = undefined;
+    expectedArgs.options[0].description = text;
 
-    it('should close Dialog', async () => {
-      const user = userEvent.setup();
-      renderManualOptionsEditor();
-      await user.click(getOptionModalButton());
+    await user.click(getEditButton());
+    const textBox = getDescriptionInput(1);
+    await user.type(textBox, text);
+    await user.tab();
 
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-      await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    });
+    expect(handleComponentChange).toHaveBeenCalledTimes(1);
+    expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
+  });
 
-    it('should call handleComponentChange with correct parameters when closing Dialog and options is empty', async () => {
-      const user = userEvent.setup();
-      renderManualOptionsEditor({
-        props: { component: { ...mockComponent, options: [], optionsId: undefined } },
-      });
-      const expectedArgs = ObjectUtils.deepCopy(mockComponent);
-      expectedArgs.options = undefined;
-      expectedArgs.optionsId = undefined;
-
-      await user.click(getOptionModalButton());
-      await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
-
-      expect(handleComponentChange).toHaveBeenCalledTimes(1);
-      expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
-    });
-
-    it('should call handleComponentChange with correct parameters when editing', async () => {
-      const user = userEvent.setup();
-      renderManualOptionsEditor();
-      const text = 'test';
-      const expectedArgs = ObjectUtils.deepCopy(mockComponent);
-      expectedArgs.optionsId = undefined;
-      expectedArgs.options[0].description = text;
-
-      await user.click(getOptionModalButton());
-      const textBox = getDescriptionInput(1);
-      await user.type(textBox, text);
-      await user.tab();
-
-      expect(handleComponentChange).toHaveBeenCalledTimes(1);
-      expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
-    });
-
-    it('should show placeholder for option label when option list label is empty', () => {
-      renderManualOptionsEditor({
-        props: {
-          component: {
-            ...mockComponent,
-            options: [{ value: 1, label: '' }],
-          },
+  it('should show placeholder for option label when option list label is empty', () => {
+    renderManualOptionsEditor({
+      props: {
+        component: {
+          ...mockComponent,
+          options: [{ value: 1, label: '' }],
         },
-      });
-
-      expect(screen.getByText(textMock('general.empty_string'))).toBeInTheDocument();
+      },
     });
 
-    it('should call handleDelete when removing chosen options', async () => {
-      const user = userEvent.setup();
-      renderManualOptionsEditor();
+    expect(screen.getByText(textMock('general.empty_string'))).toBeInTheDocument();
+  });
 
-      await user.click(getDeleteButton());
+  it('should call handleDelete when removing chosen options', async () => {
+    const user = userEvent.setup();
+    renderManualOptionsEditor();
 
-      expect(handleDelete).toHaveBeenCalledTimes(1);
-    });
+    await user.click(getDeleteButton());
+
+    expect(handleDelete).toHaveBeenCalledTimes(1);
   });
 });
 
-function getOptionModalButton() {
+function getEditButton() {
   return screen.getByRole('button', {
     name: textMock('general.edit'),
   });

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { ComponentType } from 'app-shared/types/ComponentType';
+import { ObjectUtils } from '@studio/pure-functions';
+import { textMock } from '@studio/testing/mocks/i18nMock';
+import { renderWithProviders } from '../../../../../../../../testing/mocks';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import userEvent from '@testing-library/user-event';
+import { componentMocks } from '../../../../../../../../testing/componentMocks';
+import { ManualOptionsEditor, ManualOptionsEditorProps } from './ManualOptionsEditor';
+
+// Test data:
+const mockComponent = componentMocks[ComponentType.RadioButtons];
+const handleDelete = jest.fn();
+const handleComponentChange = jest.fn();
+
+describe('OptionListEditor', () => {
+  afterEach(jest.clearAllMocks);
+
+  describe('ManualOptionEditor', () => {
+    it('should render the open Dialog button', () => {
+      renderManualOptionsEditor();
+
+      expect(getOptionModalButton()).toBeInTheDocument();
+    });
+
+    it('should open Dialog', async () => {
+      const user = userEvent.setup();
+      renderManualOptionsEditor();
+
+      await user.click(getOptionModalButton());
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(
+        screen.getByText(textMock('ux_editor.options.modal_header_manual_code_list')),
+      ).toBeInTheDocument();
+    });
+
+    it('should close Dialog', async () => {
+      const user = userEvent.setup();
+      renderManualOptionsEditor();
+      await user.click(getOptionModalButton());
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('should call handleComponentChange with correct parameters when closing Dialog and options is empty', async () => {
+      const user = userEvent.setup();
+      renderManualOptionsEditor({
+        props: { component: { ...mockComponent, options: [], optionsId: undefined } },
+      });
+      const expectedArgs = ObjectUtils.deepCopy(mockComponent);
+      expectedArgs.options = undefined;
+      expectedArgs.optionsId = undefined;
+
+      await user.click(getOptionModalButton());
+      await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
+
+      expect(handleComponentChange).toHaveBeenCalledTimes(1);
+      expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
+    });
+
+    it('should call handleComponentChange with correct parameters when editing', async () => {
+      const user = userEvent.setup();
+      renderManualOptionsEditor();
+      const text = 'test';
+      const expectedArgs = ObjectUtils.deepCopy(mockComponent);
+      expectedArgs.optionsId = undefined;
+      expectedArgs.options[0].description = text;
+
+      await user.click(getOptionModalButton());
+      const textBox = getDescriptionInput(1);
+      await user.type(textBox, text);
+      await user.tab();
+
+      expect(handleComponentChange).toHaveBeenCalledTimes(1);
+      expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
+    });
+
+    it('should show placeholder for option label when option list label is empty', () => {
+      renderManualOptionsEditor({
+        props: {
+          component: {
+            ...mockComponent,
+            options: [{ value: 1, label: '' }],
+          },
+        },
+      });
+
+      expect(screen.getByText(textMock('general.empty_string'))).toBeInTheDocument();
+    });
+
+    it('should call handleDelete when removing chosen options', async () => {
+      const user = userEvent.setup();
+      renderManualOptionsEditor();
+
+      await user.click(getDeleteButton());
+
+      expect(handleDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+function getOptionModalButton() {
+  return screen.getByRole('button', {
+    name: textMock('general.edit'),
+  });
+}
+
+function getDescriptionInput(number: number) {
+  return screen.getByRole('textbox', {
+    name: textMock('code_list_editor.description_item', { number }),
+  });
+}
+
+function getDeleteButton() {
+  return screen.getByRole('button', {
+    name: textMock('general.delete'),
+  });
+}
+
+const defaultProps: ManualOptionsEditorProps = {
+  handleDelete: handleDelete,
+  handleComponentChange: handleComponentChange,
+  component: mockComponent,
+};
+
+function renderManualOptionsEditor({ queries = {}, props = {} } = {}) {
+  renderWithProviders(<ManualOptionsEditor {...defaultProps} {...props} />, {
+    queries,
+    queryClient: createQueryClientMock(),
+  });
+}

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.test.tsx
@@ -7,7 +7,7 @@ import { renderWithProviders } from '../../../../../../../../testing/mocks';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import userEvent from '@testing-library/user-event';
 import { componentMocks } from '../../../../../../../../testing/componentMocks';
-import { ManualOptionsEditor, ManualOptionsEditorProps } from './ManualOptionsEditor';
+import { ManualOptionsEditor, type ManualOptionsEditorProps } from './ManualOptionsEditor';
 
 // Test data:
 const mockComponent = componentMocks[ComponentType.RadioButtons];

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/ManualOptionsEditor/ManualOptionsEditor.tsx
@@ -15,7 +15,7 @@ import { OptionListButtons } from '../OptionListButtons';
 import type { Option } from 'app-shared/types/Option';
 import classes from './ManualOptionsEditor.module.css';
 
-type ManualOptionsEditorProps = {
+export type ManualOptionsEditorProps = {
   handleDelete: () => void;
 } & Pick<IGenericEditComponent<SelectionComponentType>, 'component' | 'handleComponentChange'>;
 

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.test.tsx
@@ -1,252 +1,101 @@
 import React from 'react';
-import { screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import type { OptionList } from 'app-shared/types/OptionList';
-import type { Option } from 'app-shared/types/Option';
 import { ComponentType } from 'app-shared/types/ComponentType';
 import type { OptionListEditorProps } from './OptionListEditor';
-import { ObjectUtils } from '@studio/pure-functions';
 import { OptionListEditor } from './OptionListEditor';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import { renderWithProviders } from '../../../../../../../testing/mocks';
 import userEvent from '@testing-library/user-event';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
-import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { app, org } from '@studio/testing/testids';
 import { componentMocks } from '../../../../../../../testing/componentMocks';
+import { QueryClient } from '@tanstack/react-query';
+import { QueryKey } from 'app-shared/types/QueryKey';
 
 // Test data:
 const mockComponent = componentMocks[ComponentType.RadioButtons];
+const optionListId = 'someId';
+const componentWithOptionsId = { ...mockComponent, options: undefined, optionsId: optionListId };
 const handleComponentChange = jest.fn();
-const apiResult: OptionList = [
+const optionList: OptionList = [
   { value: 'value 1', label: 'label 1', description: 'description', helpText: 'help text' },
   { value: 'value 2', label: 'label 2', description: null, helpText: null },
   { value: 'value 3', label: 'label 3', description: null, helpText: null },
 ];
-const getOptionListMock = jest
-  .fn()
-  .mockImplementation(() => Promise.resolve<OptionList>(apiResult));
-const componentWithOptionsId = { ...mockComponent, options: undefined, optionsId: 'some-id' };
 
 describe('OptionListEditor', () => {
-  afterEach(() => jest.clearAllMocks());
+  afterEach(jest.clearAllMocks);
 
-  describe('ManualOptionEditor', () => {
-    it('should render the open Dialog button', () => {
-      renderOptionListEditor();
-      expect(getOptionModalButton()).toBeInTheDocument();
-    });
-
-    it('should open Dialog', async () => {
-      const user = userEvent.setup();
-      renderOptionListEditor();
-
-      await user.click(getOptionModalButton());
-
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-      expect(
-        screen.getByText(textMock('ux_editor.options.modal_header_manual_code_list')),
-      ).toBeInTheDocument();
-    });
-
-    it('should close Dialog', async () => {
-      const user = userEvent.setup();
-      renderOptionListEditor();
-      await user.click(getOptionModalButton());
-
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-      await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    });
-
-    it('should call handleComponentChange with correct parameters when closing Dialog and options is empty', async () => {
-      const user = userEvent.setup();
-      renderOptionListEditor({
-        props: { component: { ...mockComponent, options: [], optionsId: undefined } },
-      });
-      const expectedArgs = ObjectUtils.deepCopy(mockComponent);
-      expectedArgs.options = undefined;
-      expectedArgs.optionsId = undefined;
-
-      await user.click(getOptionModalButton());
-      await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
-
-      expect(handleComponentChange).toHaveBeenCalledTimes(1);
-      expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
-    });
-
-    it('should call handleComponentChange with correct parameters when editing', async () => {
-      const user = userEvent.setup();
-      renderOptionListEditor();
-      const text = 'test';
-      const expectedArgs = ObjectUtils.deepCopy(mockComponent);
-      expectedArgs.optionsId = undefined;
-      expectedArgs.options[0].description = text;
-
-      await user.click(getOptionModalButton());
-      const textBox = getDescriptionInput(1);
-      await user.type(textBox, text);
-      await user.tab();
-
-      expect(handleComponentChange).toHaveBeenCalledTimes(1);
-      expect(handleComponentChange).toHaveBeenCalledWith(expectedArgs);
-    });
-
-    it('should show placeholder for option label when option list label is empty', () => {
-      renderOptionListEditor({
-        props: {
-          component: {
-            ...mockComponent,
-            options: [{ value: 2, label: '', description: 'test', helpText: null }],
-          },
-        },
-      });
-
-      expect(screen.getByText(textMock('general.empty_string'))).toBeInTheDocument();
-    });
-
-    it('should call handleComponentChange with correct parameters when removing chosen options', async () => {
-      const user = userEvent.setup();
-      renderOptionListEditor();
-      const expectedResult = ObjectUtils.deepCopy(mockComponent);
-      expectedResult.options = undefined;
-      expectedResult.optionsId = undefined;
-
-      await user.click(getDeleteButton());
-
-      expect(handleComponentChange).toHaveBeenCalledTimes(1);
-      expect(handleComponentChange).toHaveBeenCalledWith(expectedResult);
-    });
+  it('should render the open Dialog button', () => {
+    renderOptionListEditor();
+    expect(getOptionModalButton()).toBeInTheDocument();
   });
 
-  describe('LibraryOptionEditor', () => {
-    it('should render a spinner when there is no data', () => {
-      renderOptionListEditor({
-        queries: {
-          getOptionList: jest.fn().mockImplementation(() => Promise.resolve<OptionList>([])),
-        },
-        props: { component: componentWithOptionsId },
-      });
+  it('should render ManualOptionsEditor', async () => {
+    const user = userEvent.setup();
+    renderOptionListEditor();
 
-      expect(
-        screen.getByText(textMock('ux_editor.modal_properties_code_list_spinner_title')),
-      ).toBeInTheDocument();
+    await user.click(getOptionModalButton());
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('ux_editor.options.modal_header_manual_code_list')),
+    ).toBeInTheDocument();
+  });
+
+  it('should render LibraryOptionsEditor when data has loaded', async () => {
+    const user = userEvent.setup();
+    renderOptionListEditorWithData();
+
+    await user.click(getOptionModalButton());
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(textMock('ux_editor.options.modal_header_library_code_list')),
+    ).toBeInTheDocument();
+  });
+
+  it('should render a spinner when there is no data', () => {
+    renderOptionListEditor({
+      queries: {
+        getOptionList: jest.fn().mockImplementation(() => Promise.resolve<OptionList>([])),
+      },
+      props: { component: componentWithOptionsId },
     });
 
-    it('should render an error message when getOptionList throws an error', async () => {
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved({
-        queries: {
-          getOptionList: jest.fn().mockImplementation(() => Promise.reject()),
-        },
-      });
+    expect(
+      screen.getByText(textMock('ux_editor.modal_properties_code_list_spinner_title')),
+    ).toBeInTheDocument();
+  });
 
-      expect(
-        screen.getByText(textMock('ux_editor.modal_properties_fetch_option_list_error_message')),
-      ).toBeInTheDocument();
+  it('should render an error message when getOptionList throws an error', async () => {
+    renderOptionListEditor({
+      queries: {
+        getOptionList: jest.fn().mockImplementation(() => Promise.reject()),
+      },
+      props: { component: componentWithOptionsId },
+    });
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText(textMock('ux_editor.modal_properties_code_list_spinner_title')),
+    );
+
+    expect(
+      screen.getByText(textMock('ux_editor.modal_properties_fetch_option_list_error_message')),
+    ).toBeInTheDocument();
+  });
+
+  it('should be able to remove binding to optionList if getOptionList throws an error', async () => {
+    const user = userEvent.setup();
+    renderOptionListEditorWithData({
+      queries: {
+        getOptionList: jest.fn().mockImplementation(() => Promise.reject()),
+      },
     });
 
-    it('should be able to remove binding to optionList if getOptionList throws an error', async () => {
-      const user = userEvent.setup();
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved({
-        queries: {
-          getOptionList: jest.fn().mockImplementation(() => Promise.reject()),
-        },
-      });
-
-      expect(getDeleteButton()).toBeInTheDocument();
-      await user.click(getDeleteButton());
-      expect(handleComponentChange).toHaveBeenCalledTimes(1);
-    });
-
-    it('should render the open Dialog button', async () => {
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved();
-      expect(getOptionModalButton()).toBeInTheDocument();
-    });
-
-    it('should open Dialog', async () => {
-      const user = userEvent.setup();
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved();
-
-      await user.click(getOptionModalButton());
-
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-    });
-
-    it('should close Dialog', async () => {
-      const user = userEvent.setup();
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved();
-      await user.click(getOptionModalButton());
-
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-      await user.click(screen.getByRole('button', { name: 'close modal' })); // Todo: Replace "close modal" with defaultDialogProps.closeButtonTitle when we upgrade to Designsystemet v1
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    });
-
-    it('should call doReloadPreview when editing', async () => {
-      const user = userEvent.setup();
-      const doReloadPreview = jest.fn();
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved({
-        previewContextProps: { doReloadPreview },
-      });
-
-      await user.click(getOptionModalButton());
-      const textBox = getDescriptionInput(2);
-      await user.type(textBox, 'test');
-      await user.tab();
-
-      await waitFor(() => expect(doReloadPreview).toHaveBeenCalledTimes(1));
-    });
-
-    it('should call updateOptionList with correct parameters when closing Dialog', async () => {
-      const user = userEvent.setup();
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved();
-      const expectedResultAfterEdit: Option[] = [
-        { value: 'value 1', label: 'label 1', description: 'description', helpText: 'help text' },
-        { value: 'value 2', label: 'label 2', description: 'test', helpText: null },
-        { value: 'value 3', label: 'label 3', description: null, helpText: null },
-      ];
-
-      await user.click(getOptionModalButton());
-      const textBox = getDescriptionInput(2);
-      await user.type(textBox, 'test');
-      await user.tab();
-
-      await waitFor(() => expect(queriesMock.updateOptionList).toHaveBeenCalledTimes(1));
-      expect(queriesMock.updateOptionList).toHaveBeenCalledWith(
-        org,
-        app,
-        componentWithOptionsId.optionsId,
-        expectedResultAfterEdit,
-      );
-    });
-
-    it('should show placeholder for option label when option list label is empty', async () => {
-      const apiResultWithEmptyLabel: OptionList = [
-        { value: true, label: '', description: null, helpText: null },
-      ];
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved({
-        queries: {
-          getOptionList: jest
-            .fn()
-            .mockImplementation(() => Promise.resolve<OptionList>(apiResultWithEmptyLabel)),
-        },
-      });
-
-      expect(screen.getByText(textMock('general.empty_string'))).toBeInTheDocument();
-    });
-
-    it('should call handleComponentChange with correct parameters when removing chosen options', async () => {
-      const user = userEvent.setup();
-      await renderOptionListEditorAndWaitForSpinnerToBeRemoved();
-
-      await user.click(getDeleteButton());
-
-      expect(handleComponentChange).toHaveBeenCalledTimes(1);
-      expect(handleComponentChange).toHaveBeenCalledWith({
-        ...mockComponent,
-        options: undefined,
-        optionsId: undefined,
-      });
-    });
+    expect(getDeleteButton()).toBeInTheDocument();
+    await user.click(getDeleteButton());
+    expect(handleComponentChange).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -256,43 +105,38 @@ function getOptionModalButton() {
   });
 }
 
-function getDescriptionInput(number: number) {
-  return screen.getByRole('textbox', {
-    name: textMock('code_list_editor.description_item', { number }),
-  });
-}
-
 function getDeleteButton() {
   return screen.getByRole('button', {
     name: textMock('general.delete'),
   });
 }
 
-const renderOptionListEditor = ({ previewContextProps = {}, queries = {}, props = {} } = {}) => {
-  const defaultProps: OptionListEditorProps = {
-    component: mockComponent,
-    handleComponentChange,
-  };
-
-  return renderWithProviders(<OptionListEditor {...defaultProps} {...props} />, {
-    queries: { getOptionList: getOptionListMock, ...queries },
-    queryClient: createQueryClientMock(),
-    previewContextProps,
-  });
+const defaultProps: OptionListEditorProps = {
+  component: mockComponent,
+  handleComponentChange,
 };
 
-const renderOptionListEditorAndWaitForSpinnerToBeRemoved = async ({
-  previewContextProps = {},
+function renderOptionListEditor({
+  queries = {},
+  props = {},
+  queryClient = createQueryClientMock(),
+} = {}) {
+  renderWithProviders(<OptionListEditor {...defaultProps} {...props} />, {
+    queries,
+    queryClient,
+  });
+}
+
+function renderOptionListEditorWithData({
   queries = {},
   props = { component: componentWithOptionsId },
-} = {}) => {
-  const view = renderOptionListEditor({
-    previewContextProps,
-    queries,
-    props,
-  });
-  await waitForElementToBeRemoved(() =>
-    screen.queryByText(textMock('ux_editor.modal_properties_code_list_spinner_title')),
-  );
-  return view;
-};
+} = {}) {
+  const queryClient = createQueryClientWithData();
+  renderOptionListEditor({ queries, props, queryClient });
+}
+
+function createQueryClientWithData(): QueryClient {
+  const queryClient = createQueryClientMock();
+  queryClient.setQueryData([QueryKey.OptionList, org, app, optionListId], optionList);
+  return queryClient;
+}

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.test.tsx
@@ -10,7 +10,7 @@ import userEvent from '@testing-library/user-event';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { app, org } from '@studio/testing/testids';
 import { componentMocks } from '../../../../../../../testing/componentMocks';
-import { QueryClient } from '@tanstack/react-query';
+import type { QueryClient } from '@tanstack/react-query';
 import { QueryKey } from 'app-shared/types/QueryKey';
 
 // Test data:

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.test.tsx
@@ -27,16 +27,11 @@ const optionList: OptionList = [
 describe('OptionListEditor', () => {
   afterEach(jest.clearAllMocks);
 
-  it('should render the open Dialog button', () => {
-    renderOptionListEditor();
-    expect(getOptionModalButton()).toBeInTheDocument();
-  });
-
-  it('should render ManualOptionsEditor', async () => {
+  it('should render ManualOptionsEditor when component has options property', async () => {
     const user = userEvent.setup();
     renderOptionListEditor();
 
-    await user.click(getOptionModalButton());
+    await user.click(getEditButton());
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(
@@ -44,11 +39,11 @@ describe('OptionListEditor', () => {
     ).toBeInTheDocument();
   });
 
-  it('should render LibraryOptionsEditor when data has loaded', async () => {
+  it('should render LibraryOptionsEditor when component has optionId property', async () => {
     const user = userEvent.setup();
     renderOptionListEditorWithData();
 
-    await user.click(getOptionModalButton());
+    await user.click(getEditButton());
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(
@@ -99,7 +94,7 @@ describe('OptionListEditor', () => {
   });
 });
 
-function getOptionModalButton() {
+function getEditButton() {
   return screen.getByRole('button', {
     name: textMock('general.edit'),
   });


### PR DESCRIPTION
## Description
This PR refactors tests which were in the parent component `OptionListEditor`. New changes are coming to both child components, and therefore it's good to split up these tests. It was a mistake to use a common test file to begin with.

## Related Issue
- #14835

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive test suites for the `LibraryOptionsEditor` and `ManualOptionsEditor` components, ensuring smooth interactions like opening and closing dialogs, editing entries, and handling deletions.
  - Restructured tests in the `OptionListEditor` component to focus on essential functionality and improve clarity.

- **Refactor**
  - Updated exported type declarations for `LibraryOptionsEditorProps` and `ManualOptionsEditorProps` to enhance accessibility and maintainability.
  
- **Chore**
  - Streamlined test cases and rendering logic for a more consistent and reliable option editing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->