### PR TITLE
fix: Add ArrayUtils.extractKeyValuePairs

### DIFF
--- a/frontend/libs/studio-pure-functions/src/ArrayUtils/ArrayUtils.test.ts
+++ b/frontend/libs/studio-pure-functions/src/ArrayUtils/ArrayUtils.test.ts
@@ -352,4 +352,25 @@ describe('ArrayUtils', () => {
       expect(ArrayUtils.getArrayFromString(' a, b, c ')).toEqual(['a', 'b', 'c']);
     });
   });
+
+  describe('extractKeyValuePairs', () => {
+    it('Returns an empty object when the input array is empty', () => {
+      expect(ArrayUtils.extractKeyValuePairs([], 'key', 'value')).toEqual({});
+    });
+
+    it('Returns an object with key-value pairs from the input array', () => {
+      type TestObject = { key: string; value: string };
+      const array: TestObject[] = [
+        { key: 'a', value: '1' },
+        { key: 'b', value: '2' },
+        { key: 'c', value: '3' },
+      ];
+      const result = ArrayUtils.extractKeyValuePairs<TestObject, 'key', 'value'>(
+        array,
+        'key',
+        'value',
+      );
+      expect(result).toEqual({ a: '1', b: '2', c: '3' });
+    });
+  });
 });

--- a/frontend/libs/studio-pure-functions/src/ArrayUtils/ArrayUtils.ts
+++ b/frontend/libs/studio-pure-functions/src/ArrayUtils/ArrayUtils.ts
@@ -221,4 +221,19 @@ export class ArrayUtils {
   static hasSingleType = (array: unknown[]): boolean => {
     return ArrayUtils.extractUniqueTypes(array).length === 1;
   };
+
+  public static extractKeyValuePairs<
+    O extends Record<string | number | symbol, any>,
+    K extends keyof O,
+    V extends keyof O,
+  >(array: O[], keyProperty: K, valueProperty: V): Record<O[K], O[V]> {
+    return array.reduce(
+      (acc: Record<O[K], O[V]>, item: O) => {
+        const key = item[keyProperty];
+        acc[key] = item[valueProperty];
+        return acc;
+      },
+      {} as Record<O[K], O[V]>,
+    );
+  }
 }


### PR DESCRIPTION
## Description
We are doing a lot of conversions from arrays to objects in the code, where the object is a key-value pair based on the content of the array. I have therefore created a new `ArrayUtils` function to handle this kind of conversion. The function will for example be useful for handling text resource data in the content library. Here is an example:

Input parameters:
<table>
<thead>
<tr>
<th>Data</th>
<th>Key property</th>
<th>Value property</th>
</tr>
</thead>
<tbody>
<tr>
<td>

```typescript
[
  {
    language: 'nb',
    resources: nbTexts
  },
  {
    language: 'en',
    resources: enTexts
  }
]
```

</td>
<td>

`"language"`

</td>
<td>

`"resources"`

</td>
</tr>
</tbody>
</table>

Output:
```typescript
{
  nb: nbTexts,
  en: enTexts
}
```

I'll appreciate any suggestions on how to simplify the typing or the function itself.

I have added the `skip-manual-testing` label since the function is not yet in use.

## Related Issue
- #14870

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
