### PR TITLE
fix: remove pull request when doing copy of an app

### DIFF
--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -298,22 +298,6 @@ namespace Altinn.Studio.Designer.Services.Implementation
             CommitInfo commitInfo = new() { Org = targetOrg, Repository = targetRepository, Message = $"App cloned from {sourceRepository} {DateTime.Now.Date.ToShortDateString()}" };
             await _sourceControl.PushChangesForRepository(commitInfo);
 
-            // Final changes are made in a seperate branch to be reviewed by developer
-            string branchName = "complete_copy_of_app";
-            string branchCloneName = $"{targetRepository}_{branchName}_{Guid.NewGuid()}";
-
-            await _sourceControl.CreateBranch(targetOrg, targetRepository, branchName);
-            await _sourceControl.CloneRemoteRepository(targetOrg, targetRepository, _settings.GetServicePath(targetOrg, branchCloneName, developer), branchName);
-
-            var branchAppRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(targetOrg, branchCloneName, developer);
-
-            await branchAppRepository.SearchAndReplaceInFile("App/config/authorization/policy.xml", $"{sourceRepository}", $"{targetRepository}");
-
-            await _sourceControl.CommitAndPushChanges(targetOrg, targetRepository, branchName, branchAppRepository.RepositoryDirectory, "Updated policy.xml");
-            await _sourceControl.CreatePullRequest(targetOrg, targetRepository, "master", branchName, "Auto-generated: Final changes for cloning app.");
-
-            DirectoryHelper.DeleteFilesAndDirectory(branchAppRepository.RepositoryDirectory);
-
             return repository;
         }
 

--- a/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/CopyAppGiteaIntegrationTests.cs
+++ b/backend/tests/Designer.Tests/GiteaIntegrationTests/RepositoryController/CopyAppGiteaIntegrationTests.cs
@@ -32,7 +32,7 @@ namespace Designer.Tests.GiteaIntegrationTests.RepositoryController
             string targetRepo = TestDataHelper.GenerateTestRepoName("-gitea");
             await CreateAppUsingDesigner(org, targetRepo);
 
-            // Add some commit and push to be more realistic use case
+            // Add some commit and push to be more realistic use case, this also adds notes to the commit
             await File.WriteAllTextAsync($"{CreatedFolderPath}/test.txt", "I am a new file");
             using var commitAndPushContent = new StringContent(GetCommitInfoJson("test commit", org, targetRepo), Encoding.UTF8, MediaTypeNames.Application.Json);
             using HttpResponseMessage commitAndPushResponse = await HttpClient.PostAsync($"designer/api/repos/repo/{org}/{targetRepo}/commit-and-push", commitAndPushContent);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There is no need anymore to change the policy file when copying an app.
PR removes creation of the update PR.

<!--- Describe your changes in detail -->

## Related Issue(s)

- #14698

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined repository configuration by removing redundant cloning and branch management steps, resulting in a more straightforward operation.
- **Tests**
	- Enhanced integration tests for repository copying with realistic commit simulations to ensure reliable functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->