### PR TITLE
chore: Send Gitea logs to Azure

### DIFF
--- a/gitea/files/conf/app.ini
+++ b/gitea/files/conf/app.ini
@@ -44,7 +44,7 @@ PATH = /var/lib/gitea/attachments
 
 [log]
 MODE      = console
-LEVEL     = Warn
+LEVEL     = Error
 
 [log.console]
 STDERR    = true

--- a/gitea/files/conf/app.ini
+++ b/gitea/files/conf/app.ini
@@ -46,6 +46,9 @@ PATH = /var/lib/gitea/attachments
 MODE      = console
 LEVEL     = Warn
 
+[log.console]
+STDERR    = true
+
 [admin]
 ; Disallow regular (non-admin) users from creating organizations.
 DISABLE_REGULAR_ORG_CREATION = true

--- a/gitea/files/conf/app.ini
+++ b/gitea/files/conf/app.ini
@@ -43,9 +43,8 @@ ENABLE_FEDERATED_AVATAR = false
 PATH = /var/lib/gitea/attachments
 
 [log]
-ROOT_PATH = /var/lib/gitea/log
-MODE      = file
-LEVEL     = Info
+MODE      = console
+LEVEL     = Warn
 
 [admin]
 ; Disallow regular (non-admin) users from creating organizations.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Gitea logs are saved as files in the pod, which has two drawbacks:
- They are not available in Azure, meaning we cannot properly monitor them
- The logs are destroyed when the pod is destroyed

To address this issue, I propose in this PR to:
- Change Gitea log mode from file to console to ensure logs are captured in AKS logs
- Set STDERR to true to output error logs to stderr
- Change Gitea log level from info to error to be consistent with nginx log level and prevent flooding logs with non-critical logs like:
```
2025/03/13 00:00:32 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 19.5ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:33 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 23.9ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:34 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 21.2ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:35 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 23.3ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:36 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 23.6ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:37 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 21.6ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:38 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 22.0ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:39 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 22.7ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:40 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 25.0ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:41 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 20.3ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:42 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 19.7ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:43 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 21.9ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:44 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 21.7ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:45 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 19.4ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:46 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 21.4ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:47 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 22.9ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:48 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 21.8ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:49 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 23.8ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:50 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 25.9ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:51 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 21.2ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:52 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 21.8ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:53 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 20.2ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:54 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 20.0ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:55 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 21.4ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:56 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 20.7ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:57 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 20.6ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:58 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 28.8ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:00:59 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 26.9ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:00 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 25.9ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:01 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 19.6ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:02 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 24.5ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:03 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 20.9ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:04 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 21.1ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:05 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 20.0ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:06 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 23.0ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:07 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 24.9ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:08 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 21.5ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:09 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 25.8ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:10 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 19.8ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:11 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 28.3ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:12 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 19.2ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:13 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 20.2ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:14 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.0.116:41398, 200 OK in 24.4ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
2025/03/13 00:01:15 ...eb/routing/logger.go:102:func1() [I] router: completed POST /api/actions/runner.v1.RunnerService/FetchTask for 10.48.1.5:42652, 200 OK in 24.6ms @ <autogenerated>:1(http.Handler.ServeHTTP-fm)
```

## Related Issue(s)

- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved logging output by directing logs to the console, with messages now focused solely on errors.
  - Updated log routing to use standard error, ensuring cleaner and more relevant monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->