### PR TITLE
fix: Remove dashes from class names to make them work with css-loader

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioBreadcrumbs/StudioBreadcrumbs.module.css
+++ b/frontend/libs/studio-components/src/components/StudioBreadcrumbs/StudioBreadcrumbs.module.css
@@ -1,9 +1,10 @@
-.ds-breadcrumbs {
+.dsBreadcrumbs {
   --dsc-breadcrumbs-spacing: var(--fds-spacing-2);
   --dsc-breadcrumbs-chevron-size: var(--fds-sizing-6);
   --dsc-breadcrumbs-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24'%3E%3Cpath d='M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06'/%3E%3C/svg%3E");
 
   & > :is(ol, ul) {
+    align-items: center;
     display: flex;
     flex-wrap: wrap;
     list-style-type: none;
@@ -17,6 +18,7 @@
   }
 
   & a[aria-current='page'] {
+    vertical-align: middle;
     text-decoration: none;
   }
 

--- a/frontend/libs/studio-components/src/components/StudioBreadcrumbs/StudioBreadcrumbs.tsx
+++ b/frontend/libs/studio-components/src/components/StudioBreadcrumbs/StudioBreadcrumbs.tsx
@@ -12,7 +12,7 @@ const StudioBreadcrumbs = forwardRef<HTMLElement, StudioBreadcrumbsProps>(
   ({ 'aria-label': ariaLabel = defaultAriaLabel, className, ...rest }, ref) => (
     <nav
       aria-label={ariaLabel}
-      className={`${classes['ds-breadcrumbs']} ${className}`}
+      className={`${classes.dsBreadcrumbs} ${className}`}
       ref={ref}
       {...rest}
     />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Remove dashes from class names to make them work with css-loader

## Related Issue(s)

- PR itself

<table>
<tr>
<th>BEFORE</th>
<th>AFTER</th>
</tr>
<tr>
<td>

![breadcrumbs-before](https://github.com/user-attachments/assets/41f9473c-2555-44eb-9c5f-00bf619d7939)

</td>
<td>

![breadcrumbs-after](https://github.com/user-attachments/assets/5473ed69-4d2b-4005-8c16-ff3f136abade)

</td>
</tr>
</table>

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the breadcrumb navigation appearance by centering list items and aligning the current page indicator, resulting in a more balanced and visually consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->