### PR TITLE
fix(policy-editor): save role subject and accesspackage subject in same anyOf in xacml-policy

### DIFF
--- a/backend/PolicyAdmin/PolicyConverter.cs
+++ b/backend/PolicyAdmin/PolicyConverter.cs
@@ -198,14 +198,18 @@ namespace Altinn.Studio.PolicyAdmin
             xacmlRule.Description = policyRule.Description;
 
             List<XacmlAnyOf> ruleAnyOfs = new List<XacmlAnyOf>();
+            List<string> subjects = [];
             if (policyRule.Subject != null && policyRule.Subject.Count > 0)
             {
-                ruleAnyOfs.Add(GetSubjectAnyOfs(policyRule.Subject));
+                subjects.AddRange(policyRule.Subject);
             }
-
             if (policyRule.AccessPackages != null && policyRule.AccessPackages.Count > 0)
             {
-                ruleAnyOfs.Add(GetSubjectAnyOfs(policyRule.AccessPackages));
+                subjects.AddRange(policyRule.AccessPackages);
+            }
+            if (subjects.Count > 0)
+            {
+                ruleAnyOfs.Add(GetSubjectAnyOfs(subjects));
             }
 
             if (policyRule.Resources != null && policyRule.Resources.Count > 0)


### PR DESCRIPTION
## Description
- Role subject and access package subject must be saved in same anyOf block in XACML policy. Consider the following example rule with `utinn` role and access package `skattegrunnlag`:

✅ Correct XACML:
```
<xacml:Target>
       <xacml:AnyOf>
          <xacml:AllOf>
            <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
              <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">utinn</xacml:AttributeValue>
              <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
            </xacml:Match>
          </xacml:AllOf>
          <xacml:AllOf>
            <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
              <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">skattegrunnlag</xacml:AttributeValue>
              <xacml:AttributeDesignator AttributeId="urn:altinn:accesspackage" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
            </xacml:Match>
          </xacml:AllOf>
        </xacml:AnyOf>
        ...
</xacml:Target>
```

❌ Incorrect XACML:
```
<xacml:Target>
        <xacml:AnyOf>
          <xacml:AllOf>
            <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
              <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">utinn</xacml:AttributeValue>
              <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
            </xacml:Match>
          </xacml:AllOf>
        </xacml:AnyOf>
        <xacml:AnyOf>
          <xacml:AllOf>
            <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
              <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">skattegrunnlag</xacml:AttributeValue>
              <xacml:AttributeDesignator AttributeId="urn:altinn:accesspackage" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
            </xacml:Match>
          </xacml:AllOf>
        </xacml:AnyOf>
        ...
</xacml:Target>
```

## Related Issue(s)

- https://digdir.slack.com/archives/C079T644HQE/p1742201895010449

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined policy rule processing by unifying the handling of related entries for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->