### PR TITLE
refactor: create useListenToMergeConflictInRepo

### DIFF
--- a/frontend/app-development/layout/App.tsx
+++ b/frontend/app-development/layout/App.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import postMessages from 'app-shared/utils/postMessages';
 import './App.css';
 import { Outlet, matchPath, useLocation } from 'react-router-dom';
 import classes from './App.module.css';
@@ -8,8 +7,8 @@ import { initReactI18next } from 'react-i18next';
 import nb from '../../language/src/nb.json';
 import en from '../../language/src/en.json';
 import { DEFAULT_LANGUAGE } from 'app-shared/constants';
-import { useRepoStatusQuery } from 'app-shared/hooks/queries';
 import { appContentWrapperId } from '@studio/testing/testids';
+import { useListenToMergeConflictInRepo } from 'app-shared/hooks/useListenToMergeConflictInRepo';
 
 i18next.use(initReactI18next).init({
   ns: 'translation',
@@ -33,24 +32,11 @@ export function App() {
   const org = match?.params?.org ?? '';
   const app = match?.params?.app ?? '';
 
-  const { refetch: reFetchRepoStatus } = useRepoStatusQuery(org, app);
-
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [pathname]);
 
-  useEffect(() => {
-    const windowEventReceived = async (event: any) => {
-      if (event.data === postMessages.forceRepoStatusCheck) {
-        await reFetchRepoStatus();
-      }
-    };
-
-    window.addEventListener('message', windowEventReceived);
-    return function cleanup() {
-      window.removeEventListener('message', windowEventReceived);
-    };
-  }, [reFetchRepoStatus]);
+  useListenToMergeConflictInRepo(org, app);
 
   return (
     <div className={classes.container}>

--- a/frontend/packages/shared/src/hooks/useListenToMergeConflictInRepo.test.tsx
+++ b/frontend/packages/shared/src/hooks/useListenToMergeConflictInRepo.test.tsx
@@ -54,7 +54,7 @@ describe('useListenToMergeConflictInRepo', () => {
 });
 
 const renderHookRepoStatusEventListenerHook = () => {
-  return renderHook(() => useRepoStatusEventListener(org, app), {
+  return renderHook(() => useListenToMergeConflictInRepo(org, app), {
     wrapper: ({ children }) => (
       <ServicesContextProvider {...queriesMock}>{children}</ServicesContextProvider>
     ),

--- a/frontend/packages/shared/src/hooks/useListenToMergeConflictInRepo.test.tsx
+++ b/frontend/packages/shared/src/hooks/useListenToMergeConflictInRepo.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useListenToMergeConflictInRepo } from './useListenToMergeConflictInRepo';
+import { useRepoStatusQuery } from 'app-shared/hooks/queries';
+import postMessages from 'app-shared/utils/postMessages';
+import { app, org } from '@studio/testing/testids';
+import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
+import { queriesMock } from 'app-shared/mocks/queriesMock';
+
+jest.mock('app-shared/hooks/queries', () => ({
+  useRepoStatusQuery: jest.fn(),
+}));
+
+describe('useListenToMergeConflictInRepo', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should add and remove event listener on mount and unmount', () => {
+    const refetchMock = jest.fn();
+    (useRepoStatusQuery as jest.Mock).mockReturnValue({ refetch: refetchMock });
+
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHookRepoStatusEventListenerHook();
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+    unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+  });
+
+  it('should call refetch when receiving the correct message', async () => {
+    const refetchMock = jest.fn();
+    (useRepoStatusQuery as jest.Mock).mockReturnValue({ refetch: refetchMock });
+    renderHookRepoStatusEventListenerHook();
+
+    const event = new MessageEvent('message', { data: postMessages.forceRepoStatusCheck });
+    window.dispatchEvent(event);
+
+    await waitFor(() => expect(refetchMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('should not call refetch when receiving an incorrect message', () => {
+    const refetchMock = jest.fn();
+    (useRepoStatusQuery as jest.Mock).mockReturnValue({ refetch: refetchMock });
+    renderHookRepoStatusEventListenerHook();
+
+    const event = new MessageEvent('message', { data: 'WRONG_MESSAGE' });
+    window.dispatchEvent(event);
+
+    expect(refetchMock).not.toHaveBeenCalled();
+  });
+});
+
+const renderHookRepoStatusEventListenerHook = () => {
+  return renderHook(() => useRepoStatusEventListener(org, app), {
+    wrapper: ({ children }) => (
+      <ServicesContextProvider {...queriesMock}>{children}</ServicesContextProvider>
+    ),
+  });
+};

--- a/frontend/packages/shared/src/hooks/useListenToMergeConflictInRepo.ts
+++ b/frontend/packages/shared/src/hooks/useListenToMergeConflictInRepo.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useRepoStatusQuery } from 'app-shared/hooks/queries';
+import postMessages from 'app-shared/utils/postMessages';
+
+export function useListenToMergeConflictInRepo(org: string, app: string) {
+  const { refetch: reFetchRepoStatus } = useRepoStatusQuery(org, app);
+
+  useEffect(() => {
+    const handleMessage = async (event: MessageEvent) => {
+      if (event.data === postMessages.forceRepoStatusCheck) {
+        await reFetchRepoStatus();
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [reFetchRepoStatus]);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Creating shared hook for listening to repoStatus to know when to refetch when there is a merge conflict

## Related Issue(s)
- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Replaced the repository status check with a new mechanism that listens for merge conflict events.
  
- **Tests**
  - Introduced tests to validate that merge conflict event listeners are properly added and removed, ensuring reliable detection and refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->