### PR TITLE
fix: dotnet test workflow functioning correctly in all enviorments

### DIFF
--- a/.github/workflows/designer-dotnet-test.yaml
+++ b/.github/workflows/designer-dotnet-test.yaml
@@ -35,11 +35,11 @@ jobs:
           dotnet build backend/Designer.sln -v m
       - name: Test
         run: |
-          dotnet test backend/Designer.sln --filter FullyQualifiedName~AppDevelopmentController --no-build;
-          dotnet test backend/Designer.sln --filter FullyQualifiedName~PolicyControllerTests --no-build;
-          dotnet test backend/Designer.sln --filter FullyQualifiedName~PreviewController --no-build;
-          dotnet test backend/Designer.sln --filter FullyQualifiedName~DataModelsController --no-build;
-          dotnet test backend/Designer.sln --filter FullyQualifiedName~ResourceAdminController --no-build;
-          dotnet test backend/Designer.sln --filter FullyQualifiedName~TextController --no-build;
-          dotnet test backend/Designer.sln --filter "(Category!=GiteaIntegrationTest)&(FullyQualifiedName~RepositoryController)" --no-build;
+          dotnet test backend/Designer.sln --filter FullyQualifiedName~AppDevelopmentController --no-build || exit 1;
+          dotnet test backend/Designer.sln --filter FullyQualifiedName~PolicyControllerTests --no-build || exit 1;
+          dotnet test backend/Designer.sln --filter FullyQualifiedName~PreviewController --no-build || exit 1;
+          dotnet test backend/Designer.sln --filter FullyQualifiedName~DataModelsController --no-build || exit 1;
+          dotnet test backend/Designer.sln --filter FullyQualifiedName~ResourceAdminController --no-build || exit 1;
+          dotnet test backend/Designer.sln --filter FullyQualifiedName~TextController --no-build || exit 1;
+          dotnet test backend/Designer.sln --filter "(Category!=GiteaIntegrationTest)&(FullyQualifiedName~RepositoryController)" --no-build || exit 1;
           dotnet test backend/Designer.sln --filter "(Category!=GiteaIntegrationTest)&(Category!=DbIntegrationTest)&(FullyQualifiedName!~AppDevelopmentController)&(FullyQualifiedName!~PreviewController)&(FullyQualifiedName!~PolicyControllerTests)&(FullyQualifiedName!~DataModelsController)&(FullyQualifiedName!~ResourceAdminController)&(FullyQualifiedName!~TextController)&(FullyQualifiedName!~RepositoryController)" -v m --no-build


### PR DESCRIPTION
## Description
This PR includes a change to the dotnet-test workflow.
The reason for this change is to force Powershell (windows) to exit with the correct exit code if any test fails.

## Related Issue(s)
- #14857

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced test execution to promptly catch and report failures, ensuring a more robust and reliable release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->