### PR TITLE
chore: Clean up props

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/EditFormComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/EditFormComponent.tsx
@@ -10,7 +10,6 @@ import { formItemConfigs } from '../../data/formItemConfig';
 import { UnknownComponentAlert } from '../UnknownComponentAlert';
 import type { FormItem } from '../../types/FormItem';
 import type { ComponentType } from 'app-shared/types/ComponentType';
-import { useAppContext } from '../../hooks';
 import type { UpdateFormMutateOptions } from '../../containers/FormItemContext';
 
 export interface IEditFormComponentProps<T extends ComponentType = ComponentType> {
@@ -24,7 +23,6 @@ export const EditFormComponent = ({
   component,
   handleComponentUpdate,
 }: IEditFormComponentProps) => {
-  const { selectedFormLayoutName } = useAppContext();
   const { t } = useTranslation();
 
   const formItemConfig = formItemConfigs[component.type];
@@ -55,7 +53,6 @@ export const EditFormComponent = ({
       <ComponentSpecificContent
         component={component}
         handleComponentChange={handleComponentUpdate}
-        layoutName={selectedFormLayoutName}
       />
     </Fieldset>
   );

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/ComponentSpecificContent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/ComponentSpecificContent.tsx
@@ -9,17 +9,10 @@ import { Summary2Component } from './Summary2';
 export function ComponentSpecificContent({
   component,
   handleComponentChange,
-  layoutName,
 }: IGenericEditComponent) {
   switch (component.type) {
     case ComponentType.Image: {
-      return (
-        <ImageComponent
-          component={component}
-          handleComponentChange={handleComponentChange}
-          layoutName={layoutName}
-        />
-      );
+      return <ImageComponent component={component} handleComponentChange={handleComponentChange} />;
     }
     case ComponentType.Map: {
       return <MapComponent component={component} handleComponentChange={handleComponentChange} />;

--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Image/ImageComponent.tsx
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Image/ImageComponent.tsx
@@ -11,7 +11,6 @@ import { altinnDocsUrl } from 'app-shared/ext-urls';
 export const ImageComponent = ({
   component,
   handleComponentChange,
-  layoutName,
 }: IGenericEditComponent<ComponentType.Image>) => {
   const t = useText();
   const alignOptions = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Removed unused `layoutName` prop from `ImageComponent`

## Related Issue(s)

- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the editing components by removing redundant layout configuration properties, contributing to a cleaner interface and improved maintainability.
  - Simplified form and image editing interactions to ensure a more predictable and robust user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->