### PR TITLE
feat: return to ui-editor from add new task

### DIFF
--- a/frontend/packages/ux-editor/src/containers/AddNewTask/AddNewTask.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/AddNewTask/AddNewTask.test.tsx
@@ -19,7 +19,9 @@ describe('AddNewTask', () => {
 
     renderAddNewTask();
     await user.click(screen.getByText(textMock('ux_editor.task_card_add_new_task')));
-    expect(navigate).toHaveBeenCalledWith('../' + RoutePaths.ProcessEditor);
+    expect(navigate).toHaveBeenCalledWith(
+      '../' + RoutePaths.ProcessEditor + '?returnTo=' + RoutePaths.UIEditor,
+    );
   });
 });
 

--- a/frontend/packages/ux-editor/src/containers/AddNewTask/AddNewTask.tsx
+++ b/frontend/packages/ux-editor/src/containers/AddNewTask/AddNewTask.tsx
@@ -9,7 +9,8 @@ import { useTranslation } from 'react-i18next';
 export const AddNewTask = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const handleClick = () => navigate('../' + RoutePaths.ProcessEditor);
+  const handleClick = () =>
+    navigate(`../${RoutePaths.ProcessEditor}?returnTo=${RoutePaths.UIEditor}`);
 
   return (
     <StudioCard onClick={handleClick} className={classes.card}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use the implementation of `returnTo` in URL to give user a simple way back to the Utforming page.

https://github.com/user-attachments/assets/87172b0b-6002-47ea-b8af-350df95a05ff


<!--- Describe your changes in detail -->

## Related Issue(s)

- #14736 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the redirection behavior when adding a new task. The navigation process now includes an updated return path, ensuring that after initiating task creation, you’re smoothly guided back to the UI editor. This change enhances the overall workflow and user experience when managing tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->