### PR TITLE
feat: add fileuploader item to StudioDropdownMenu

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioDropdownMenu/StudioDropdownMenu.stories.tsx
+++ b/frontend/libs/studio-components/src/components/StudioDropdownMenu/StudioDropdownMenu.stories.tsx
@@ -6,6 +6,9 @@ const ComposedComponent = (args): React.ReactElement => (
   <StudioDropdownMenu anchorButtonProps={{ children: args.label }}>
     <StudioDropdownMenu.Group heading='My heading'>
       <StudioDropdownMenu.Item {...args} />
+      <StudioDropdownMenu.FileUploaderItem label='Upload File'>
+        Upload File
+      </StudioDropdownMenu.FileUploaderItem>
     </StudioDropdownMenu.Group>
   </StudioDropdownMenu>
 );

--- a/frontend/libs/studio-components/src/components/StudioDropdownMenu/StudioDropdownMenu.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioDropdownMenu/StudioDropdownMenu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { StudioDropdownMenu } from './';
 import React, { createRef } from 'react';
 import userEvent from '@testing-library/user-event';
@@ -66,6 +66,31 @@ describe('StudioDropdownMenu', () => {
     expect(referredElement).toBe(group1Item2Ref.current);
   });
 
+  it('Renders the file uploader item with the correct text and icon', async () => {
+    const user = userEvent.setup();
+    renderTestDropdownMenu();
+    await openDropdown(user);
+
+    const fileUploaderItem = screen.getByRole('menuitem', { name: fileUploaderText });
+    expect(fileUploaderItem).toBeInTheDocument();
+    expect(screen.getByTestId(icon4TestId)).toBeInTheDocument();
+  });
+
+  it('Triggers onFileUpload when a file is selected', async () => {
+    const user = userEvent.setup();
+    const fileNameMock = 'fileNameMock';
+    renderTestDropdownMenu();
+    await openDropdown(user);
+
+    const file = new File(['test'], `${fileNameMock}.json`, { type: 'application/json' });
+    const fileInputElement = screen.getByLabelText(fileUploaderText);
+
+    await user.upload(fileInputElement, file);
+
+    expect(onFileUpload).toHaveBeenCalledTimes(1);
+    expect(onFileUpload).toHaveBeenCalledWith(expect.any(Object));
+  });
+
   const openDropdown = (user: UserEvent) =>
     user.click(screen.getByRole('button', { name: buttonLabel }));
 });
@@ -78,13 +103,17 @@ const group1Item2Text = 'Group 1 Item 2';
 const group2Item1Text = 'Group 2 Item 1';
 const group2Item2Text = 'Group 2 Item 2';
 const group2Item3Text = 'Group 2 Item 3';
+const fileUploaderText = 'Upload file';
+const onFileUpload = jest.fn();
 const group1Item1Action = jest.fn();
 const icon1TestId = 'Icon 1';
 const icon2TestId = 'Icon 2';
 const icon3TestId = 'Icon 3';
+const icon4TestId = 'Icon 4';
 const icon1 = <span data-testid={icon1TestId} />;
 const icon2 = <span data-testid={icon2TestId} />;
 const icon3 = <span data-testid={icon3TestId} />;
+const icon4 = <span data-testid={icon4TestId} />;
 const group1Item2Ref = createRef<HTMLButtonElement>();
 
 const renderTestDropdownMenu = () =>
@@ -104,6 +133,13 @@ const renderTestDropdownMenu = () =>
         <StudioDropdownMenu.Item icon={icon3} iconPlacement='right'>
           {group2Item3Text}
         </StudioDropdownMenu.Item>
+        <StudioDropdownMenu.FileUploaderItem
+          icon={icon4}
+          iconPlacement='right'
+          onFileUpload={onFileUpload}
+        >
+          {fileUploaderText}
+        </StudioDropdownMenu.FileUploaderItem>
       </StudioDropdownMenu.Group>
     </StudioDropdownMenu>,
   );

--- a/frontend/libs/studio-components/src/components/StudioDropdownMenu/StudioDropdownMenu.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioDropdownMenu/StudioDropdownMenu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { StudioDropdownMenu } from './';
 import React, { createRef } from 'react';
 import userEvent from '@testing-library/user-event';
@@ -76,6 +76,21 @@ describe('StudioDropdownMenu', () => {
     expect(screen.getByTestId(icon4TestId)).toBeInTheDocument();
   });
 
+  it('Triggers onFileUpload when a file is selected', async () => {
+    const user = userEvent.setup();
+    const fileNameMock = 'fileNameMock';
+    renderTestDropdownMenu();
+    await openDropdown(user);
+
+    const file = new File(['test'], `${fileNameMock}.json`, { type: 'application/json' });
+    const fileInputElement = screen.getByLabelText(fileUploaderText);
+
+    await user.upload(fileInputElement, file);
+
+    expect(onFileUpload).toHaveBeenCalledTimes(1);
+    expect(onFileUpload).toHaveBeenCalledWith(expect.any(Object));
+  });
+
   const openDropdown = (user: UserEvent) =>
     user.click(screen.getByRole('button', { name: buttonLabel }));
 });
@@ -89,6 +104,7 @@ const group2Item1Text = 'Group 2 Item 1';
 const group2Item2Text = 'Group 2 Item 2';
 const group2Item3Text = 'Group 2 Item 3';
 const fileUploaderText = 'Upload file';
+const onFileUpload = jest.fn();
 const group1Item1Action = jest.fn();
 const icon1TestId = 'Icon 1';
 const icon2TestId = 'Icon 2';
@@ -117,7 +133,11 @@ const renderTestDropdownMenu = () =>
         <StudioDropdownMenu.Item icon={icon3} iconPlacement='right'>
           {group2Item3Text}
         </StudioDropdownMenu.Item>
-        <StudioDropdownMenu.FileUploaderItem icon={icon4} iconPlacement='right'>
+        <StudioDropdownMenu.FileUploaderItem
+          icon={icon4}
+          iconPlacement='right'
+          onFileUpload={onFileUpload}
+        >
           {fileUploaderText}
         </StudioDropdownMenu.FileUploaderItem>
       </StudioDropdownMenu.Group>

--- a/frontend/libs/studio-components/src/components/StudioDropdownMenu/StudioDropdownMenu.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioDropdownMenu/StudioDropdownMenu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { StudioDropdownMenu } from './';
 import React, { createRef } from 'react';
 import userEvent from '@testing-library/user-event';
@@ -76,21 +76,6 @@ describe('StudioDropdownMenu', () => {
     expect(screen.getByTestId(icon4TestId)).toBeInTheDocument();
   });
 
-  it('Triggers onFileUpload when a file is selected', async () => {
-    const user = userEvent.setup();
-    const fileNameMock = 'fileNameMock';
-    renderTestDropdownMenu();
-    await openDropdown(user);
-
-    const file = new File(['test'], `${fileNameMock}.json`, { type: 'application/json' });
-    const fileInputElement = screen.getByLabelText(fileUploaderText);
-
-    await user.upload(fileInputElement, file);
-
-    expect(onFileUpload).toHaveBeenCalledTimes(1);
-    expect(onFileUpload).toHaveBeenCalledWith(expect.any(Object));
-  });
-
   const openDropdown = (user: UserEvent) =>
     user.click(screen.getByRole('button', { name: buttonLabel }));
 });
@@ -104,7 +89,6 @@ const group2Item1Text = 'Group 2 Item 1';
 const group2Item2Text = 'Group 2 Item 2';
 const group2Item3Text = 'Group 2 Item 3';
 const fileUploaderText = 'Upload file';
-const onFileUpload = jest.fn();
 const group1Item1Action = jest.fn();
 const icon1TestId = 'Icon 1';
 const icon2TestId = 'Icon 2';
@@ -133,11 +117,7 @@ const renderTestDropdownMenu = () =>
         <StudioDropdownMenu.Item icon={icon3} iconPlacement='right'>
           {group2Item3Text}
         </StudioDropdownMenu.Item>
-        <StudioDropdownMenu.FileUploaderItem
-          icon={icon4}
-          iconPlacement='right'
-          onFileUpload={onFileUpload}
-        >
+        <StudioDropdownMenu.FileUploaderItem icon={icon4} iconPlacement='right'>
           {fileUploaderText}
         </StudioDropdownMenu.FileUploaderItem>
       </StudioDropdownMenu.Group>

--- a/frontend/libs/studio-components/src/components/StudioDropdownMenu/StudioDropdownMenuFileUploaderItem.module.css
+++ b/frontend/libs/studio-components/src/components/StudioDropdownMenu/StudioDropdownMenuFileUploaderItem.module.css
@@ -1,0 +1,19 @@
+.studioDropdownMenuFileUploaderItem {
+  display: flex;
+}
+
+.fileUploaderLabel {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  cursor: pointer;
+  gap: var(--fds-spacing-1);
+}
+
+.iconWrapper {
+  display: contents;
+}
+
+.fileInput {
+  display: none;
+}

--- a/frontend/libs/studio-components/src/components/StudioDropdownMenu/StudioDropdownMenuFileUploaderItem.tsx
+++ b/frontend/libs/studio-components/src/components/StudioDropdownMenu/StudioDropdownMenuFileUploaderItem.tsx
@@ -1,0 +1,56 @@
+import type { ChangeEvent, ReactNode } from 'react';
+import React, { forwardRef, useContext } from 'react';
+import { DropdownMenu } from '@digdir/designsystemet-react';
+import type { DropdownMenuItemProps } from '@digdir/designsystemet-react';
+import type { IconPlacement } from '../../types/IconPlacement';
+import type { OverridableComponent } from '../../types/OverridableComponent';
+import cn from 'classnames';
+import classes from './StudioDropdownMenuFileUploaderItem.module.css';
+import { StudioDropdownMenuContext } from './StudioDropdownMenuContext';
+
+export type StudioDropdownMenuFileUploaderItemProps = {
+  icon?: ReactNode;
+  iconPlacement?: IconPlacement;
+  onFileUpload?: (file: File) => void;
+} & Omit<DropdownMenuItemProps, 'icon'>;
+
+const StudioDropdownMenuFileUploaderItem: OverridableComponent<
+  StudioDropdownMenuFileUploaderItemProps,
+  HTMLLabelElement
+> = forwardRef<HTMLLabelElement, StudioDropdownMenuFileUploaderItemProps>(
+  ({ children, icon, iconPlacement = 'left', className, onFileUpload, ...rest }, ref) => {
+    const { setOpen } = useContext(StudioDropdownMenuContext);
+
+    const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file) {
+        onFileUpload?.(file);
+        setOpen(false);
+      }
+    };
+
+    const iconComponent = (
+      <span aria-hidden className={classes.iconWrapper}>
+        {icon}
+      </span>
+    );
+
+    return (
+      <DropdownMenu.Item
+        className={cn(className, classes.studioDropdownMenuFileUploaderItem)}
+        {...rest}
+      >
+        <label className={classes.fileUploaderLabel} ref={ref}>
+          {icon && iconPlacement === 'left' && iconComponent}
+          {children}
+          {icon && iconPlacement === 'right' && iconComponent}
+          <input type='file' className={classes.fileInput} onChange={handleFileChange} />
+        </label>
+      </DropdownMenu.Item>
+    );
+  },
+);
+
+StudioDropdownMenuFileUploaderItem.displayName = 'StudioDropdownMenu.FileUploaderItem';
+
+export { StudioDropdownMenuFileUploaderItem };

--- a/frontend/libs/studio-components/src/components/StudioDropdownMenu/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioDropdownMenu/index.ts
@@ -1,16 +1,19 @@
 import { StudioDropdownMenu as Root } from './StudioDropdownMenu';
 import { DropdownMenuGroup } from '@digdir/designsystemet-react';
 import { StudioDropdownMenuItem } from './StudioDropdownMenuItem';
+import { StudioDropdownMenuFileUploaderItem } from './StudioDropdownMenuFileUploaderItem';
 
 type StudioDropdownMenuComponent = typeof Root & {
   Group: typeof DropdownMenuGroup;
   Item: typeof StudioDropdownMenuItem;
+  FileUploaderItem: typeof StudioDropdownMenuFileUploaderItem;
 };
 
 const StudioDropdownMenu = Root as StudioDropdownMenuComponent;
 
 StudioDropdownMenu.Group = DropdownMenuGroup;
 StudioDropdownMenu.Item = StudioDropdownMenuItem;
+StudioDropdownMenu.FileUploaderItem = StudioDropdownMenuFileUploaderItem;
 
 StudioDropdownMenu.Group.displayName = 'StudioDropdownMenu.Group';
 StudioDropdownMenu.Item.displayName = 'StudioDropdownMenu.Item';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adding an item to the StudioDropdownMenu to upload files. It looks the same as a normal item, but when clicked it opens the file explorer on your machine,

## Related Issue(s)

- #14887 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a file uploader option within the dropdown menu, allowing users to upload files directly via the "Upload File" label and accompanying icon.
- **Tests**
  - Enhanced testing to confirm the correct display and interactive behavior of the new file uploader.
- **Style**
  - Applied dedicated styles for improved layout, alignment, and click feedback for the file uploader option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->