### PR TITLE
fix: Fix useTextResourcesForOrgQuery

### DIFF
--- a/frontend/packages/shared/src/hooks/queries/useTextResourcesForOrgQuery.test.ts
+++ b/frontend/packages/shared/src/hooks/queries/useTextResourcesForOrgQuery.test.ts
@@ -1,22 +1,42 @@
-import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { renderHookWithProviders } from 'app-shared/mocks/renderHookWithProviders';
 import { waitFor } from '@testing-library/react';
-import { org } from '@studio/testing/testids';
 import { useTextResourcesForOrgQuery } from './useTextResourcesForOrgQuery';
+import { textResourcesMock } from 'app-shared/mocks/textResourcesMock';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import type { QueryClient, QueryKey as TanstackQueryKey } from '@tanstack/react-query';
+import { QueryKey } from 'app-shared/types/QueryKey';
 
-const languageMock: string = 'nb';
+// Test data:
+const orgName = 'org';
+const language = 'nb';
+const textResources = textResourcesMock;
+
+// Mocks:
+const getTextResourcesForOrg = jest.fn(() => Promise.resolve(textResources));
 
 describe('useTextResourcesForOrgQuery', () => {
-  beforeEach(jest.clearAllMocks);
+  beforeEach(getTextResourcesForOrg.mockClear);
 
-  it('calls getTextResourcesForOrg with the correct parameters', () => {
-    renderAndWaitForResult();
-    expect(queriesMock.getTextResourcesForOrg).toHaveBeenCalledWith(org, languageMock);
-    expect(queriesMock.getTextResourcesForOrg).toHaveBeenCalledTimes(1);
+  it('calls getTextResourcesForOrg with the correct parameters', async () => {
+    await renderAndWaitForResult();
+    expect(getTextResourcesForOrg).toHaveBeenCalledTimes(1);
+    expect(getTextResourcesForOrg).toHaveBeenCalledWith(orgName, language);
+  });
+
+  it('Stores the result in the cache with correct keys', async () => {
+    const client = createQueryClientMock();
+    await renderAndWaitForResult(client);
+    const key: TanstackQueryKey = [QueryKey.TextResourcesForOrg, orgName, language];
+    expect(client.getQueryData(key)).toEqual(textResources);
   });
 });
 
-const renderAndWaitForResult = async (): Promise<void> => {
-  const { result } = renderHookWithProviders(() => useTextResourcesForOrgQuery(org, languageMock));
+const renderAndWaitForResult = async (
+  queryClient: QueryClient = createQueryClientMock(),
+): Promise<void> => {
+  const { result } = renderHookWithProviders(() => useTextResourcesForOrgQuery(orgName, language), {
+    queries: { getTextResourcesForOrg },
+    queryClient,
+  });
   await waitFor(() => expect(result.current.isSuccess).toBe(true));
 };

--- a/frontend/packages/shared/src/hooks/queries/useTextResourcesForOrgQuery.ts
+++ b/frontend/packages/shared/src/hooks/queries/useTextResourcesForOrgQuery.ts
@@ -4,12 +4,12 @@ import { useServicesContext } from '../../contexts/ServicesContext';
 import { type ITextResourcesWithLanguage } from '../../types/global';
 
 export const useTextResourcesForOrgQuery = (
-  org: string,
+  orgName: string,
   language: string,
 ): UseQueryResult<ITextResourcesWithLanguage> => {
   const { getTextResourcesForOrg } = useServicesContext();
   return useQuery<ITextResourcesWithLanguage>({
-    queryKey: [QueryKey.TextResourcesForOrg],
-    queryFn: () => getTextResourcesForOrg(org, language),
+    queryKey: [QueryKey.TextResourcesForOrg, orgName, language],
+    queryFn: () => getTextResourcesForOrg(orgName, language),
   });
 };

--- a/frontend/packages/shared/src/mocks/renderHookWithProviders.tsx
+++ b/frontend/packages/shared/src/mocks/renderHookWithProviders.tsx
@@ -13,11 +13,9 @@ type WrapperArgs = {
   queryClient: QueryClient;
 };
 
-const queryClientMock = createQueryClientMock();
-
 export const renderHookWithProviders = (
   hook: () => any,
-  { queries = {}, queryClient = queryClientMock }: Partial<WrapperArgs> = {},
+  { queries = {}, queryClient = createQueryClientMock() }: Partial<WrapperArgs> = {},
 ) => {
   return renderHook(hook, {
     wrapper: ({ children }) => (


### PR DESCRIPTION
## Description
This pull request fixes an issue in the `useTextResourcesForOrgQuery` hook: It does not store the text resources with proper query keys in the cache. I have added a unit test that checks that the data is stored with the expected coordinates and updated the hook accordingly.

I have also made some improvements to the test suite by defining test data locally and making the `renderHookWithProviders` function start off with a clear client by default. I also added a missing `await` keyword, a deficency that may have caused false positives.

I have added the `skip-manual-testing` label since the hook is not yet in use, and the unit tests should be sufficient for verifying that it works as expected.

## Related Issue
- #14870

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced clarity in resource query parameters to improve consistency.
- **Tests**
	- Updated test logic and assertions to verify correct parameter usage and caching.
- **Chores**
	- Refined helper utilities to generate fresh instances for isolated test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->