### PR TITLE
fix: task card styling update

### DIFF
--- a/frontend/libs/studio-components-legacy/src/components/StudioIconCard/StudioIconCard.module.css
+++ b/frontend/libs/studio-components-legacy/src/components/StudioIconCard/StudioIconCard.module.css
@@ -25,8 +25,8 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: var(--fds-spacing-4);
-  padding-bottom: var(--fds-spacing-5);
+  padding: var(--fds-spacing-6);
+  padding-bottom: var(--fds-spacing-7);
   gap: var(--fds-spacing-4);
   text-align: left;
   font-weight: normal;

--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.module.css
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.module.css
@@ -17,6 +17,5 @@
 }
 
 .editcard {
-  border: var(--fds-semantic-border-first-active) solid;
-  border-radius: var(--fds-border_radius-small);
+  border: var(--fds-border_width-active) solid var(--fds-semantic-border-first-active);
 }

--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.tsx
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.tsx
@@ -86,7 +86,7 @@ export const TaskCard = ({ layoutSetModel }: TaskCardProps) => {
       <div className={classes.details}>
         <div>
           <StudioParagraph size='sm'>{t(taskName)}</StudioParagraph>
-          <StudioHeading size='sm'>{layoutSetModel.id}</StudioHeading>
+          <StudioHeading size='xs'>{layoutSetModel.id}</StudioHeading>
         </div>
         <StudioParagraph size='sm'>
           {t('ux_editor.task_card.datamodel')}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* More spacing between card content and sides/bottom
* Heading/task name is now `xs`
* Fix edit mode border width and radius

![image](https://github.com/user-attachments/assets/58b1e179-161a-4fda-8182-ff215b2d93af)

<details><summary>Before</summary>
<p>

![image](https://github.com/user-attachments/assets/a60bf40c-f29f-41f2-a420-5200a6d894c5)


</p>
</details> 

<!--- Describe your changes in detail -->

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Increased padding in icon card components to enhance visual spacing.
	- Updated task card border styling by introducing a dynamic border width and removing rounded corners for a cleaner appearance.
	- Adjusted task card heading size to a smaller, more compact display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->