### PR TITLE
chore: change auth cookie name for at22

### DIFF
--- a/src/test/K6/src/config.js
+++ b/src/test/K6/src/config.js
@@ -13,7 +13,7 @@ export var baseUrls = {
 // are rolled out to all environments
 export var authCookieNames = {
   at21: '.ASPXAUTH', // '.AspxAuthCloud',
-  at22: '.ASPXAUTH', // '.AspxAuthCloud',
+  at22: '.AspxAuthCloud',
   at23: '.ASPXAUTH', // '.AspxAuthCloud',
   at24: '.AspxAuthCloud',
   tt02: '.ASPXAUTH', // '.AspxAuthTT02',


### PR DESCRIPTION
## Description
The latest change in .AUTH cookie name in Altinn 2 has been deployed to AT22. Needs to fix the name used by the k6 tests.

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined authentication configuration settings to ensure consistent behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->