### PR TITLE
fix: dotnet test depending on third party url

### DIFF
--- a/backend/src/Designer/TypedHttpClients/ImageClient/ImageClient.cs
+++ b/backend/src/Designer/TypedHttpClients/ImageClient/ImageClient.cs
@@ -20,7 +20,7 @@ public class ImageClient
         {
             // Send a HEAD request to the URL to check if the resource exists and fetch the headers
             using var request = new HttpRequestMessage(HttpMethod.Head, url);
-            var response = await _httpClient.SendAsync(request);
+            var response = await _httpClient.SendAsync(request, cancellationToken: default);
 
             // If the response status is not successful return NotValidUrl
             if (!response.IsSuccessStatusCode)
@@ -37,7 +37,8 @@ public class ImageClient
             return ImageUrlValidationResult.Ok;
         }
         // If the request fails for some other reason return NotValidUrl
-        catch (Exception ex) when (ex is UriFormatException or InvalidOperationException or HttpRequestException)
+        catch (Exception ex)
+            when (ex is UriFormatException or InvalidOperationException or HttpRequestException)
         {
             return ImageUrlValidationResult.NotValidUrl;
         }

--- a/backend/tests/Designer.Tests/Controllers/ImageController/ValidateExternalImageUrlTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ImageController/ValidateExternalImageUrlTests.cs
@@ -1,59 +1,108 @@
 using System.Net;
 using System.Net.Http;
-using System.Text.Json;
+using System.Net.Http.Headers;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Enums;
 using Altinn.Studio.Designer.Filters;
+using Altinn.Studio.Designer.Services.Interfaces;
+using Altinn.Studio.Designer.TypedHttpClients.ImageClient;
 using Designer.Tests.Controllers.ApiTests;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Moq;
+using Moq.Protected;
 using Xunit;
 
 namespace Designer.Tests.Controllers.ImageController;
 
-public class ValidateExternalImageUrlTests : DesignerEndpointsTestsBase<ValidateExternalImageUrlTests>, IClassFixture<WebApplicationFactory<Program>>
+public class ValidateExternalImageUrlTests
+    : DesignerEndpointsTestsBase<ValidateExternalImageUrlTests>,
+        IClassFixture<WebApplicationFactory<Program>>
 {
-    private const string VersionPrefix = "designer/api";
-    private const string Org = "ttd";
-    private const string EmptyApp = "empty-app";
+    private const string NotFoundUrl = "https://nonexistingurl.no/";
+    private const string ValidNonImageUrl = "https://validurl.no/";
+    private const string ValidImageUrl = "https://validurl.no/image.png";
+    private readonly Altinn.Studio.Designer.Controllers.ImageController _imageController;
 
-    public ValidateExternalImageUrlTests(WebApplicationFactory<Program> factory) : base(factory)
+    public ValidateExternalImageUrlTests(WebApplicationFactory<Program> factory)
+        : base(factory)
     {
+        Mock<IImagesService> imagesService = new();
+        Mock<HttpClient> httpClient = new();
+        httpClient
+            .Setup(x =>
+                x.SendAsync(
+                    It.Is<HttpRequestMessage>(httpRequestMessage =>
+                        httpRequestMessage.RequestUri.AbsoluteUri == ValidImageUrl
+                    ),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("", new MediaTypeHeaderValue("image/png")),
+                }
+            );
+        httpClient
+            .Setup(x =>
+                x.SendAsync(
+                    It.Is<HttpRequestMessage>(httpRequestMessage =>
+                        httpRequestMessage.RequestUri.AbsoluteUri == NotFoundUrl
+                    ),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(
+                new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("") }
+            );
+        httpClient
+            .Setup(x =>
+                x.SendAsync(
+                    It.Is<HttpRequestMessage>(httpRequestMessage =>
+                        httpRequestMessage.RequestUri.AbsoluteUri == ValidNonImageUrl
+                    ),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("") }
+            );
+        ImageClient imageClient = new(httpClient.Object);
+        _imageController = new(imagesService.Object, imageClient);
     }
 
     [Fact]
     public async Task ValidateExternalImageUrl_WhenUrlIsPointingToAnImage_ReturnsOk()
     {
-        string urlPointingToImage = "https://img5.custompublish.com/getfile.php/4807754.2665.zq7ukqkamizuiu/Logo+Sogndal.png";
-        string path = $"{VersionPrefix}/{Org}/{EmptyApp}/images/validate?url={urlPointingToImage}";
-        using HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, path);
-        using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
-        string validationResult = await response.Content.ReadAsStringAsync();
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal(ImageUrlValidationResult.Ok.ToString(), validationResult.Trim('"'));
+        string urlPointingToImage = ValidImageUrl;
+        ImageUrlValidationResult imageUrlValidationResult =
+            await _imageController.ValidateExternalImageUrl(urlPointingToImage);
+        Assert.Equal(ImageUrlValidationResult.Ok.ToString(), imageUrlValidationResult.ToString());
     }
 
     [Fact]
     public async Task ValidateExternalImageUrl_WhenUrlIsNotFound_ReturnsNotFound()
     {
-        string unExistingUrl = "https://someNonExistingUrl.com";
-        string path = $"{VersionPrefix}/{Org}/{EmptyApp}/images/validate?url={unExistingUrl}";
-        using HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, path);
-        using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
-        string validationResult = await response.Content.ReadAsStringAsync();
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal(ImageUrlValidationResult.NotValidUrl.ToString(), validationResult.Trim('"'));
+        string unExistingUrl = NotFoundUrl;
+        ImageUrlValidationResult imageUrlValidationResult =
+            await _imageController.ValidateExternalImageUrl(unExistingUrl);
+        Assert.Equal(
+            ImageUrlValidationResult.NotValidUrl.ToString(),
+            imageUrlValidationResult.ToString()
+        );
     }
 
     [Fact]
     [UseSystemTextJson]
     public async Task ValidateExternalImageUrl_WhenUrlIsNotPointingToAnImage_ReturnsUnsupportedMediaType()
     {
-        string urlPointingToSomethingThatIsNotAnImage = "https://vg.no";
-        string path = $"{VersionPrefix}/{Org}/{EmptyApp}/images/validate?url={urlPointingToSomethingThatIsNotAnImage}";
-        using HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, path);
-        using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
-        string validationResult = await response.Content.ReadAsStringAsync();
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal(ImageUrlValidationResult.NotAnImage.ToString(), validationResult.Trim('"'));
+        string urlPointingToSomethingThatIsNotAnImage = ValidNonImageUrl;
+        ImageUrlValidationResult imageUrlValidationResult =
+            await _imageController.ValidateExternalImageUrl(urlPointingToSomethingThatIsNotAnImage);
+        Assert.Equal(
+            ImageUrlValidationResult.NotAnImage.ToString(),
+            imageUrlValidationResult.ToString()
+        );
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The test `ValidateExternalImageUrl_WhenUrlIsPointingToAnImage_ReturnsOk` fails as it points to an URL that is either down or no longer used. 
This PR changes the tests to instead use a mocked HttpClient so the tests will not depend on URLs that might change/be down.

## Related Issue(s)

- #

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
