### PR TITLE
refactor: remove default data-size from StudioButton

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioButton/StudioButton.tsx
+++ b/frontend/libs/studio-components/src/components/StudioButton/StudioButton.tsx
@@ -14,7 +14,7 @@ export type StudioButtonProps = {
 export const StudioButton = ({
   icon,
   iconPlacement = 'left',
-  'data-size': dataSize = 'sm',
+  'data-size': dataSize,
   className: givenClassName,
   children,
   ...rest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Remove default `data-size` from `StudioButton`. If we want to have a default size for our application, it can be set at the root of the application. 

## Related Issue(s)
- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The StudioButton component now requires an explicit size to be set. The previous automatic default has been removed, so please provide a size to ensure consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->