### PR TITLE
feat(policy-editor): include access package rows in policy summary

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -719,6 +719,7 @@
   "policy_editor.policy_rule_missing_actions": "rettigheter",
   "policy_editor.policy_rule_missing_sub_resource": "sub-ressurs",
   "policy_editor.policy_rule_missing_subjects": "roller",
+  "policy_editor.role_category.access_package": "Tilgangspakke",
   "policy_editor.role_category.altinn_org": "Organisasjon",
   "policy_editor.role_category.altinn_rolecode": "Rolle",
   "policy_editor.role_category.unknown": "Ukjent",

--- a/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleAccessPackageSummary.test.tsx
+++ b/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleAccessPackageSummary.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import {
+  PolicyEditorContext,
+  type PolicyEditorContextProps,
+} from '../../../contexts/PolicyEditorContext';
+import { mockAction1, mockAction2 } from '../../../../test/mocks/policyActionMocks';
+import type {
+  PolicyAccessPackage,
+  PolicyAccessPackageArea,
+  PolicyAccessPackageAreaGroup,
+} from 'app-shared/types/PolicyAccessPackages';
+import {
+  PolicyRuleAccessPackageSummary,
+  type PolicyRuleAccessPackageSummaryProps,
+} from './PolicyRuleAccessPackageSummary';
+
+const package1: PolicyAccessPackage = {
+  id: 'package1',
+  urn: 'urn:package1',
+  name: 'Package Alpha',
+  description: 'First package',
+};
+const package2: PolicyAccessPackage = {
+  id: 'package2',
+  urn: 'urn:package2',
+  name: 'Package Beta',
+  description: 'Second package',
+};
+const package3: PolicyAccessPackage = {
+  id: 'package3',
+  urn: 'urn:package3',
+  name: 'Package Gamma',
+  description: 'Third package',
+};
+
+const groupedAccessPackagesByArea: PolicyAccessPackageArea[] = [
+  {
+    id: 'area1',
+    name: 'Area 1',
+    urn: 'urn:area1',
+    description: '',
+    icon: '',
+    areaGroup: '',
+    packages: [package1, package2],
+  },
+  {
+    id: 'area2',
+    name: 'Area 2',
+    urn: 'urn:area2',
+    description: '',
+    icon: '',
+    areaGroup: '',
+    packages: [package3],
+  },
+];
+
+const mockAccessPackageAreaGroup: PolicyAccessPackageAreaGroup = {
+  id: 'group1',
+  name: 'Group 1',
+  urn: 'urn:group1',
+  description: '',
+  areas: groupedAccessPackagesByArea,
+  type: 'group',
+};
+const mockPolicyEditorContextValue: PolicyEditorContextProps = {
+  policyRules: [
+    {
+      ruleId: 'r1',
+      description: '',
+      subject: ['s1'],
+      actions: [mockAction1.actionId, mockAction2.actionId],
+      accessPackages: [],
+      resources: [
+        [
+          { type: 'urn:altinn:org', id: '[org]' },
+          { type: 'urn:altinn:app', id: '[app]' },
+        ],
+      ],
+    },
+  ],
+  setPolicyRules: jest.fn(),
+  actions: [mockAction1, mockAction2],
+  subjects: [],
+  accessPackages: [mockAccessPackageAreaGroup],
+  usageType: 'app',
+  resourceType: 'urn',
+  resourceId: '[app]',
+  showAllErrors: false,
+  savePolicy: jest.fn(),
+};
+describe('PolicyRuleAccessPackageSummary', () => {
+  it('should render', () => {
+    const actions = [mockAction1.actionId, mockAction2.actionId];
+    renderPolicyRuleAccessPackageSummary({ accessPackage: 'urn:package1', actions }, {}, true);
+    expect(screen.getByText('Package Alpha')).toBeInTheDocument();
+  });
+});
+
+const renderPolicyRuleAccessPackageSummary = (
+  props: Partial<PolicyRuleAccessPackageSummaryProps>,
+  policyEditorContextProps: Partial<PolicyEditorContextProps> = {},
+  withTable: boolean = false,
+) => {
+  const defaultProps: PolicyRuleAccessPackageSummaryProps = {
+    accessPackage: 'urn:package1',
+    actions: ['action1', 'action2'],
+  };
+
+  const component = <PolicyRuleAccessPackageSummary {...defaultProps} {...props} />;
+  render(
+    <PolicyEditorContext.Provider
+      value={{ ...mockPolicyEditorContextValue, ...policyEditorContextProps }}
+    >
+      {withTable ? (
+        <table>
+          <tbody>{component}</tbody>
+        </table>
+      ) : (
+        component
+      )}
+    </PolicyEditorContext.Provider>,
+  );
+};

--- a/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleAccessPackageSummary.tsx
+++ b/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleAccessPackageSummary.tsx
@@ -6,7 +6,7 @@ import {
   mapActionsForRoleOrAccessPackage,
 } from '../../../utils/AppPolicyUtils';
 import { useTranslation } from 'react-i18next';
-import classes from './PolicyRuleAccessPackageSummary.module.css';
+import classes from './PolicyRuleSubjectSummary.module.css';
 import { ArrayUtils } from '@studio/pure-functions';
 import { groupAccessPackagesByArea } from '../../PolicyCardRules/PolicyRule/PolicyAccessPackages/policyAccessPackageUtils';
 
@@ -30,6 +30,7 @@ export const PolicyRuleAccessPackageSummary = ({
     accessPackage,
     usageType,
     t,
+    true,
   );
 
   const displayName = getAccessPackageDisplayName(accessPackage, groupedAccessPackagesByArea);

--- a/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleAccessPackageSummary.tsx
+++ b/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleAccessPackageSummary.tsx
@@ -1,0 +1,67 @@
+import React, { useMemo } from 'react';
+import { usePolicyEditorContext } from '../../../contexts/PolicyEditorContext';
+import { StudioTable, StudioTag } from '@studio/components-legacy';
+import {
+  getAccessPackageDisplayName,
+  mapActionsForRoleOrAccessPackage,
+} from '../../../utils/AppPolicyUtils';
+import { useTranslation } from 'react-i18next';
+import classes from './PolicyRuleAccessPackageSummary.module.css';
+import { ArrayUtils } from '@studio/pure-functions';
+import { groupAccessPackagesByArea } from '../../PolicyCardRules/PolicyRule/PolicyAccessPackages/policyAccessPackageUtils';
+
+export type PolicyRuleAccessPackageSummaryProps = {
+  accessPackage: string;
+  actions: string[];
+};
+
+export const PolicyRuleAccessPackageSummary = ({
+  accessPackage,
+  actions,
+}: PolicyRuleAccessPackageSummaryProps): React.ReactNode => {
+  const { usageType, accessPackages, policyRules } = usePolicyEditorContext();
+  const { t } = useTranslation();
+  const groupedAccessPackagesByArea = useMemo(() => {
+    return groupAccessPackagesByArea(accessPackages);
+  }, [accessPackages]);
+
+  const actionsForAccessPackage = mapActionsForRoleOrAccessPackage(
+    policyRules,
+    accessPackage,
+    usageType,
+    t,
+  );
+
+  const displayName = getAccessPackageDisplayName(accessPackage, groupedAccessPackagesByArea);
+
+  return (
+    <StudioTable.Row>
+      <StudioTable.Cell>{accessPackage}</StudioTable.Cell>
+      <StudioTable.Cell>{displayName}</StudioTable.Cell>
+      <StudioTable.Cell>{t('policy_editor.role_category.access_package')}</StudioTable.Cell>
+      {actions.map((action) => {
+        return (
+          <StudioTable.Cell key={action}>
+            <div className={classes.limitationsCell}>
+              {actionsForAccessPackage[action]
+                ? ArrayUtils.getArrayFromString(actionsForAccessPackage[action]).map(
+                    (subResource) => {
+                      return (
+                        <StudioTag
+                          size='sm'
+                          key={`${accessPackage}-${action}-${subResource}`}
+                          color='info'
+                        >
+                          {subResource}
+                        </StudioTag>
+                      );
+                    },
+                  )
+                : '-'}
+            </div>
+          </StudioTable.Cell>
+        );
+      })}
+    </StudioTable.Row>
+  );
+};

--- a/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleSubjectSummary.tsx
+++ b/frontend/packages/policy-editor/src/components/PolicySummary/PolicyRuleSummary/PolicyRuleSubjectSummary.tsx
@@ -4,7 +4,7 @@ import { StudioTable, StudioTag } from '@studio/components-legacy';
 import {
   getSubjectCategoryTextKey,
   getSubjectDisplayName,
-  mapActionsForRole,
+  mapActionsForRoleOrAccessPackage,
 } from '../../../utils/AppPolicyUtils';
 import { useTranslation } from 'react-i18next';
 import classes from './PolicyRuleSubjectSummary.module.css';
@@ -22,13 +22,15 @@ export const PolicyRuleSubjectSummary = ({
   const { usageType, subjects, policyRules } = usePolicyEditorContext();
   const { t } = useTranslation();
 
-  const actionsForRole = mapActionsForRole(policyRules, subject, usageType, t);
+  const actionsForRole = mapActionsForRoleOrAccessPackage(policyRules, subject, usageType, t);
+  const displayName = getSubjectDisplayName(subject, subjects);
+  const subjectCategoryTextKey = getSubjectCategoryTextKey(subject, subjects);
 
   return (
     <StudioTable.Row>
       <StudioTable.Cell>{subject}</StudioTable.Cell>
-      <StudioTable.Cell>{getSubjectDisplayName(subject, subjects)}</StudioTable.Cell>
-      <StudioTable.Cell>{t(getSubjectCategoryTextKey(subject, subjects))}</StudioTable.Cell>
+      <StudioTable.Cell>{displayName}</StudioTable.Cell>
+      <StudioTable.Cell>{t(subjectCategoryTextKey)}</StudioTable.Cell>
       {actions.map((action) => {
         return (
           <StudioTable.Cell key={action}>

--- a/frontend/packages/policy-editor/src/components/PolicySummary/PolicySummary.test.tsx
+++ b/frontend/packages/policy-editor/src/components/PolicySummary/PolicySummary.test.tsx
@@ -8,6 +8,11 @@ import {
 import { mockAction1, mockAction2, mockAction3 } from '../../../test/mocks/policyActionMocks';
 import type { PolicySubject } from '../../types';
 import { textMock } from '@studio/testing/mocks/i18nMock';
+import type {
+  PolicyAccessPackage,
+  PolicyAccessPackageArea,
+  PolicyAccessPackageAreaGroup,
+} from 'app-shared/types/PolicyAccessPackages';
 
 const mockSubjects: PolicySubject[] = [
   {
@@ -52,18 +57,18 @@ const mockPolicyEditorContextValue: PolicyEditorContextProps = {
 
 describe('PolicySummary', () => {
   it('should render', () => {
-    renderPolicyRuleSubjectSummary({});
+    renderPolicySummary({});
     expect(screen.getByText(textMock('policy_editor.summary_heading'))).toBeInTheDocument();
   });
 
   it('should render subject summary for each subject in policy rule', () => {
-    renderPolicyRuleSubjectSummary({});
+    renderPolicySummary({});
     expect(screen.getByText('Subject 1')).toBeInTheDocument();
     expect(screen.getByText('Tjenesteeier')).toBeInTheDocument();
   });
 
   it('should render action heading for each unique action in policy rule', () => {
-    renderPolicyRuleSubjectSummary({});
+    renderPolicySummary({});
     expect(
       screen.getByText(textMock(`policy_editor.action_${mockAction1.actionId}`)),
     ).toBeInTheDocument();
@@ -73,16 +78,77 @@ describe('PolicySummary', () => {
   });
 
   it('should not render action heading for actions that are not in policy rule', () => {
-    renderPolicyRuleSubjectSummary({});
+    renderPolicySummary({});
     expect(
       screen.queryByText(textMock(`policy_editor.action_${mockAction3.actionId}`)),
     ).not.toBeInTheDocument();
   });
+
+  it('should render access package summary for each access package in policy rule', () => {
+    const package1: PolicyAccessPackage = {
+      id: 'package1',
+      urn: 'urn:package1',
+      name: 'Package Alpha',
+      description: 'First package',
+    };
+    const package2: PolicyAccessPackage = {
+      id: 'package2',
+      urn: 'urn:package2',
+      name: 'Package Beta',
+      description: 'Second package',
+    };
+    const package3: PolicyAccessPackage = {
+      id: 'package3',
+      urn: 'urn:package3',
+      name: 'Package Gamma',
+      description: 'Third package',
+    };
+
+    const groupedAccessPackagesByArea: PolicyAccessPackageArea[] = [
+      {
+        id: 'area1',
+        name: 'Area 1',
+        urn: 'urn:area1',
+        description: '',
+        icon: '',
+        areaGroup: '',
+        packages: [package1, package2],
+      },
+      {
+        id: 'area2',
+        name: 'Area 2',
+        urn: 'urn:area2',
+        description: '',
+        icon: '',
+        areaGroup: '',
+        packages: [package3],
+      },
+    ];
+
+    const accessPackages: PolicyAccessPackageAreaGroup[] = [
+      {
+        id: 'group1',
+        name: 'Group 1',
+        urn: 'urn:group1',
+        description: '',
+        areas: groupedAccessPackagesByArea,
+        type: 'group',
+      },
+    ];
+
+    const mockRules = [...mockPolicyEditorContextValue.policyRules];
+    mockRules[0].accessPackages = [package1.urn, package2.urn];
+
+    renderPolicySummary({
+      accessPackages,
+      policyRules: [...mockPolicyEditorContextValue.policyRules],
+    });
+    expect(screen.getByText(package1.name)).toBeInTheDocument();
+    expect(screen.getByText(package2.name)).toBeInTheDocument();
+  });
 });
 
-const renderPolicyRuleSubjectSummary = (
-  policyEditorContextProps: Partial<PolicyEditorContextProps> = {},
-) => {
+const renderPolicySummary = (policyEditorContextProps: Partial<PolicyEditorContextProps> = {}) => {
   render(
     <PolicyEditorContext.Provider
       value={{ ...mockPolicyEditorContextValue, ...policyEditorContextProps }}

--- a/frontend/packages/policy-editor/src/components/PolicySummary/PolicySummary.tsx
+++ b/frontend/packages/policy-editor/src/components/PolicySummary/PolicySummary.tsx
@@ -8,9 +8,15 @@ import {
 } from '@studio/components-legacy';
 import { PolicyRuleSubjectSummary } from './PolicyRuleSummary/PolicyRuleSubjectSummary';
 import { useTranslation } from 'react-i18next';
-import { extractAllUniqueActions, extractAllUniqueSubjects } from '../../utils/AppPolicyUtils';
+import {
+  extractAllUniqueActions,
+  extractAllUniqueAccessPackages,
+  extractAllUniqueSubjects,
+} from '../../utils/AppPolicyUtils';
 import { FeedbackForm } from './FeedbackForm/FeedbackForm';
 import classes from './PolicySummary.module.css';
+import { PolicyRuleAccessPackageSummary } from './PolicyRuleSummary/PolicyRuleAccessPackageSummary';
+import type { PolicyRuleCard } from '../../types';
 
 export function PolicySummary(): React.ReactElement {
   const { policyRules } = usePolicyEditorContext();
@@ -32,38 +38,103 @@ export function PolicySummary(): React.ReactElement {
       <StudioParagraph spacing={true}>{t('policy_editor.summary_info_about')}</StudioParagraph>
       <StudioParagraph spacing={true}>{t('policy_editor.summary_info_edit')}</StudioParagraph>
       <StudioTable>
-        <StudioTable.Head>
-          <StudioTable.Row>
-            <StudioTable.HeaderCell>
-              {t('policy_editor.summary_table.header_rolecode')}
-            </StudioTable.HeaderCell>
-            <StudioTable.HeaderCell>
-              {t('policy_editor.summary_table.header_rolename')}
-            </StudioTable.HeaderCell>
-            <StudioTable.HeaderCell>
-              {t('policy_editor.summary_table.header_rolecategory')}
-            </StudioTable.HeaderCell>
-            {extractAllUniqueActions(policyRules).map((action) => {
-              return (
-                <StudioTable.HeaderCell key={action}>
-                  {t(`policy_editor.action_${action}`)}
-                </StudioTable.HeaderCell>
-              );
-            })}
-          </StudioTable.Row>
-        </StudioTable.Head>
-        <StudioTable.Body>
-          {extractAllUniqueSubjects(policyRules).map((subject) => {
-            return (
-              <PolicyRuleSubjectSummary
-                subject={subject}
-                actions={extractAllUniqueActions(policyRules)}
-                key={subject}
-              />
-            );
-          })}
-        </StudioTable.Body>
+        <PolicySummaryTableHead uniqueActions={extractAllUniqueActions(policyRules)} />
+        <PolicySummaryTableBody
+          policyRules={policyRules}
+          uniqueActions={extractAllUniqueActions(policyRules)}
+        />
       </StudioTable>
     </div>
+  );
+}
+
+function PolicySummaryTableHead({
+  uniqueActions,
+}: {
+  uniqueActions: string[];
+}): React.ReactElement {
+  const { t } = useTranslation();
+  return (
+    <StudioTable.Head>
+      <StudioTable.Row>
+        <StudioTable.HeaderCell>
+          {t('policy_editor.summary_table.header_rolecode')}
+        </StudioTable.HeaderCell>
+        <StudioTable.HeaderCell>
+          {t('policy_editor.summary_table.header_rolename')}
+        </StudioTable.HeaderCell>
+        <StudioTable.HeaderCell>
+          {t('policy_editor.summary_table.header_rolecategory')}
+        </StudioTable.HeaderCell>
+        {uniqueActions.map((action) => {
+          return (
+            <StudioTable.HeaderCell key={action}>
+              {t(`policy_editor.action_${action}`)}
+            </StudioTable.HeaderCell>
+          );
+        })}
+      </StudioTable.Row>
+    </StudioTable.Head>
+  );
+}
+
+type PolicySummaryTableBodyProps = {
+  policyRules: PolicyRuleCard[];
+  uniqueActions: string[];
+};
+
+function PolicySummaryTableBody({
+  policyRules,
+  uniqueActions,
+}: PolicySummaryTableBodyProps): React.ReactElement {
+  return (
+    <StudioTable.Body>
+      <PolicySummaryAccessPackageRows
+        uniqueAccessPackages={extractAllUniqueAccessPackages(policyRules)}
+        uniqueActions={uniqueActions}
+      />
+      <PolicySummarySubjectRows
+        uniqueSubjects={extractAllUniqueSubjects(policyRules)}
+        uniqueActions={uniqueActions}
+      />
+    </StudioTable.Body>
+  );
+}
+
+function PolicySummarySubjectRows({
+  uniqueSubjects,
+  uniqueActions,
+}: {
+  uniqueSubjects: string[];
+  uniqueActions: string[];
+}): React.ReactElement {
+  return (
+    <>
+      {uniqueSubjects.map((subject) => {
+        return <PolicyRuleSubjectSummary subject={subject} actions={uniqueActions} key={subject} />;
+      })}
+    </>
+  );
+}
+
+function PolicySummaryAccessPackageRows({
+  uniqueAccessPackages,
+  uniqueActions,
+}: {
+  uniqueAccessPackages: string[];
+  uniqueActions: string[];
+}): React.ReactElement {
+  return (
+    <>
+      {uniqueAccessPackages.map((accessPackage) => {
+        return (
+          <PolicyRuleAccessPackageSummary
+            accessPackage={accessPackage}
+            actions={uniqueActions}
+            key={accessPackage}
+          />
+        );
+      })}
+    </>
   );
 }

--- a/frontend/packages/policy-editor/src/utils/AppPolicyUtils/index.ts
+++ b/frontend/packages/policy-editor/src/utils/AppPolicyUtils/index.ts
@@ -3,8 +3,10 @@ export {
   filterDefaultAppLimitations,
   extractAllUniqueSubjects,
   extractAllUniqueActions,
+  extractAllUniqueAccessPackages,
+  getAccessPackageDisplayName,
   getSubResourceDisplayText,
   getSubjectCategoryTextKey,
   getSubjectDisplayName,
-  mapActionsForRole,
+  mapActionsForRoleOrAccessPackage,
 } from './AppPolicyUtils';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a separate component handling summary rows for access packages, to be shown together with summary rows for role/serviceowner.

Refactored PolicySummary by splitting the large table into smaller chunks rendered by separate functions.

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
