### PR TITLE
fix: Rewrite useCreateTextResourcesForOrgMutation

### DIFF
--- a/frontend/packages/shared/src/api/mutations.ts
+++ b/frontend/packages/shared/src/api/mutations.ts
@@ -193,5 +193,5 @@ export const uploadCodeListForOrg = async (org: string, payload: FormData): Prom
 
 // Organisation text resources:
 // Todo: Replace these with real API calls when endpoints are ready. https://github.com/Altinn/altinn-studio/issues/14503
-export const createTextResourcesForOrg = async (org: string, language: string): Promise<ITextResourcesWithLanguage> => Promise.resolve(textResourcesMock); // Todo: Replace with real API call when endpoint is ready. https://github.com/Altinn/altinn-studio/issues/14503
+export const createTextResourcesForOrg = async (org: string, language: string, payload: ITextResourcesWithLanguage): Promise<ITextResourcesWithLanguage> => Promise.resolve(textResourcesMock); // Todo: Replace with real API call when endpoint is ready. https://github.com/Altinn/altinn-studio/issues/14503
 export const updateTextResourcesForOrg = async (org: string, language: string, payload: KeyValuePairs<string>): Promise<ITextResourcesWithLanguage> => Promise.resolve(textResourcesMock); // Todo: Replace with real API call when endpoint is ready. https://github.com/Altinn/altinn-studio/issues/14503

--- a/frontend/packages/shared/src/hooks/mutations/useCreateTextResourcesForOrgMutation.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useCreateTextResourcesForOrgMutation.ts
@@ -1,18 +1,38 @@
-import type { UseMutationResult } from '@tanstack/react-query';
+import type {
+  DefaultError,
+  QueryKey as TanstackQueryKey,
+  UseMutationResult,
+} from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useServicesContext } from '../../contexts/ServicesContext';
 import { QueryKey } from '../../types/QueryKey';
 import { type ITextResourcesWithLanguage } from '../../types/global';
 
 export const useCreateTextResourcesForOrgMutation = (
-  org: string,
-  language: string,
-): UseMutationResult<ITextResourcesWithLanguage> => {
-  const q = useQueryClient();
+  orgName: string,
+): UseMutationResult<ITextResourcesWithLanguage, DefaultError, string> => {
+  const client = useQueryClient();
   const { createTextResourcesForOrg } = useServicesContext();
-  return useMutation<ITextResourcesWithLanguage>({
-    mutationFn: () => createTextResourcesForOrg(org, language),
-    onSuccess: (textResourcesWithLanguage) =>
-      q.setQueryData([QueryKey.TextResourcesForOrg, org], textResourcesWithLanguage),
+
+  return useMutation<ITextResourcesWithLanguage, DefaultError, string>({
+    mutationFn: (language: string) => {
+      const payload: ITextResourcesWithLanguage = createPayloadWithEmptyList(language);
+      return createTextResourcesForOrg(orgName, language, payload);
+    },
+    onSuccess: (textResourcesWithLanguage: ITextResourcesWithLanguage) => {
+      const queryKey: TanstackQueryKey = [
+        QueryKey.TextResourcesForOrg,
+        orgName,
+        textResourcesWithLanguage.language,
+      ];
+      client.setQueryData(queryKey, textResourcesWithLanguage);
+    },
   });
 };
+
+function createPayloadWithEmptyList(language: string): ITextResourcesWithLanguage {
+  return {
+    language,
+    resources: [],
+  };
+}


### PR DESCRIPTION
## Description
This pull request fixes some problems with the `useCreateTextResourcesForOrgMutation` hook:
- The hook does not send any payload to the endpoint
- The language is missing in the query key
- The language is received from the root function parameter, while it should rather be a parameter to the mutation function (because it is not known before the action is triggered by the user)

I have rewritten the tests to verify that all these problems are resolved and fixed the hook accordingly (along with the `createTextResourcesForOrg` function, which should receive a payload parameter).

I have added the `skip-manual-testing` label since the hook is not yet in use.

## Related Issue
- #14870

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced text resource creation allows additional input details, improving customization and management.
- **Refactor**
  - Improved the underlying process to provide better error handling and more reliable caching for text resource data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->