### PR TITLE
refactor: Capitalise properties in LayoutSetModel

### DIFF
--- a/backend/src/Designer/Models/Dto/LayoutSetModel.cs
+++ b/backend/src/Designer/Models/Dto/LayoutSetModel.cs
@@ -9,7 +9,8 @@ public class LayoutSetModel
     [JsonPropertyName("dataType")]
     public string DataType { get; set; }
     [JsonPropertyName("type")]
-    public string Type { get; set; }
+    public string Type { get; set; } // Decides if layout set is subform
+
     [JsonPropertyName("task")]
     public TaskModel Task { get; set; }
 }

--- a/backend/src/Designer/Models/Dto/LayoutSetModel.cs
+++ b/backend/src/Designer/Models/Dto/LayoutSetModel.cs
@@ -10,7 +10,6 @@ public class LayoutSetModel
     public string DataType { get; set; }
     [JsonPropertyName("type")]
     public string Type { get; set; } // Decides if layout set is subform
-
     [JsonPropertyName("task")]
     public TaskModel Task { get; set; }
 }

--- a/backend/src/Designer/Models/Dto/LayoutSetModel.cs
+++ b/backend/src/Designer/Models/Dto/LayoutSetModel.cs
@@ -5,12 +5,12 @@ namespace Altinn.Studio.Designer.Models.Dto;
 public class LayoutSetModel
 {
     [JsonPropertyName("id")]
-    public string id { get; set; }
+    public string Id { get; set; }
     [JsonPropertyName("dataType")]
-    public string dataType { get; set; }
+    public string DataType { get; set; }
     [JsonPropertyName("type")]
-    public string type { get; set; }
+    public string Type { get; set; }
     [JsonPropertyName("task")]
-    public TaskModel task { get; set; }
+    public TaskModel Task { get; set; }
 }
 

--- a/backend/src/Designer/Models/Dto/LayoutSetsModel.cs
+++ b/backend/src/Designer/Models/Dto/LayoutSetsModel.cs
@@ -6,5 +6,5 @@ namespace Altinn.Studio.Designer.Models.Dto;
 public class LayoutSetsModel
 {
     [JsonPropertyName("sets")]
-    public List<LayoutSetModel> sets { get; set; } = [];
+    public List<LayoutSetModel> Sets { get; set; } = [];
 }

--- a/backend/src/Designer/Models/Dto/TaskModel.cs
+++ b/backend/src/Designer/Models/Dto/TaskModel.cs
@@ -5,8 +5,8 @@ namespace Altinn.Studio.Designer.Models.Dto;
 public class TaskModel
 {
     [JsonPropertyName("id")]
-    public string id { get; set; }
+    public string Id { get; set; }
     [JsonPropertyName("type")]
-    public string type { get; set; }
+    public string Type { get; set; }
 }
 

--- a/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
+++ b/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
@@ -284,21 +284,21 @@ namespace Altinn.Studio.Designer.Services.Implementation
             {
                 LayoutSetModel layoutSetModel = new()
                 {
-                    id = set.Id,
-                    dataType = set.DataType,
-                    type = set.Type,
+                    Id = set.Id,
+                    DataType = set.DataType,
+                    Type = set.Type,
                 };
                 string taskId = set.Tasks?[0];
                 if (taskId != null)
                 {
                     string taskType = TaskTypeFromDefinitions(definitions, taskId);
-                    layoutSetModel.task = new TaskModel
+                    layoutSetModel.Task = new TaskModel
                     {
-                        id = taskId,
-                        type = taskType
+                        Id = taskId,
+                        Type = taskType
                     };
                 }
-                layoutSetsModel.sets.Add(layoutSetModel);
+                layoutSetsModel.Sets.Add(layoutSetModel);
             });
             return layoutSetsModel;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Capitalised first letter of fields in `LayoutSetModel` and `LayoutSetsModel` in order to match the rest of our models.
* Renamed `LayoutSets.cs` to `LayoutSetsModel.cs` in order to match model name in code.

## Related Issue(s)

- This PR

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal property naming for data models to align with standard conventions.
  - These improvements enhance code consistency and maintainability while preserving existing API responses and user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->