### PR TITLE
chore: Return empty array when task navigation is missing

### DIFF
--- a/backend/src/Designer/Controllers/TaskNavigationController.cs
+++ b/backend/src/Designer/Controllers/TaskNavigationController.cs
@@ -31,13 +31,13 @@ namespace Altinn.Studio.Designer.Controllers
         /// <returns>The list of task navigation groups</returns>
         [HttpGet]
         [UseSystemTextJson]
-        public async Task<ActionResult<List<TaskNavigationGroupDto>>> GetTaskNavigation(string org, string app, CancellationToken cancellationToken)
+        public async Task<ActionResult<IEnumerable<TaskNavigationGroupDto>>> GetTaskNavigation(string org, string app, CancellationToken cancellationToken)
         {
             string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
             var editingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(org, app, developer);
 
-            List<TaskNavigationGroup> taskNavigationGroupList = await taskNavigationService.GetTaskNavigation(editingContext, cancellationToken);
-            List<App.Core.Internal.Process.Elements.ProcessTask> tasks = taskNavigationService.GetTasks(editingContext, cancellationToken);
+            IEnumerable<TaskNavigationGroup> taskNavigationGroupList = await taskNavigationService.GetTaskNavigation(editingContext, cancellationToken);
+            IEnumerable<App.Core.Internal.Process.Elements.ProcessTask> tasks = taskNavigationService.GetTasks(editingContext, cancellationToken);
             IEnumerable<TaskNavigationGroupDto> taskNavigationGroupDto = taskNavigationGroupList.Select(taskNavigationGroup => taskNavigationGroup.ToDto((taskId) => tasks.FirstOrDefault(task => task.Id == taskId)?.ExtensionElements?.TaskExtension?.TaskType));
 
             return Ok(taskNavigationGroupDto);

--- a/backend/src/Designer/Models/LayoutSets.cs
+++ b/backend/src/Designer/Models/LayoutSets.cs
@@ -44,7 +44,7 @@ public class UiSettings
 {
     [JsonPropertyName("taskNavigation")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<TaskNavigationGroup>? TaskNavigation { get; set; }
+    public IEnumerable<TaskNavigationGroup>? TaskNavigation { get; set; }
 
     [JsonExtensionData]
     public IDictionary<string, object?>? UnknownProperties { get; set; }

--- a/backend/src/Designer/Services/Implementation/TaskNavigationService.cs
+++ b/backend/src/Designer/Services/Implementation/TaskNavigationService.cs
@@ -13,7 +13,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
     /// </summary>
     public class TaskNavigationService(IAltinnGitRepositoryFactory altinnGitRepositoryFactory) : ITaskNavigationService
     {
-        public async Task<List<TaskNavigationGroup>> GetTaskNavigation(AltinnRepoEditingContext altinnRepoEditingContext, CancellationToken cancellationToken)
+        public async Task<IEnumerable<TaskNavigationGroup>> GetTaskNavigation(AltinnRepoEditingContext altinnRepoEditingContext, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -24,7 +24,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             return layoutSetsFile.UiSettings?.TaskNavigation ?? [];
         }
 
-        public List<ProcessTask> GetTasks(AltinnRepoEditingContext altinnRepoEditingContext, CancellationToken cancellationToken)
+        public IEnumerable<ProcessTask> GetTasks(AltinnRepoEditingContext altinnRepoEditingContext, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             AltinnAppGitRepository altinnAppGitRepository = altinnGitRepositoryFactory.GetAltinnAppGitRepository(altinnRepoEditingContext.Org, altinnRepoEditingContext.Repo, altinnRepoEditingContext.Developer);

--- a/backend/src/Designer/Services/Implementation/TaskNavigationService.cs
+++ b/backend/src/Designer/Services/Implementation/TaskNavigationService.cs
@@ -21,7 +21,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
             LayoutSets layoutSetsFile = await altinnAppGitRepository.GetLayoutSetsFile(cancellationToken);
 
-            return layoutSetsFile.UiSettings?.TaskNavigation;
+            return layoutSetsFile.UiSettings?.TaskNavigation ?? [];
         }
 
         public List<ProcessTask> GetTasks(AltinnRepoEditingContext altinnRepoEditingContext, CancellationToken cancellationToken)

--- a/backend/src/Designer/Services/Interfaces/ITaskNavigationService.cs
+++ b/backend/src/Designer/Services/Interfaces/ITaskNavigationService.cs
@@ -14,7 +14,7 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// <param name="altinnRepoEditingContext">An <see cref="AltinnRepoEditingContext"/>.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is canceled.</param>
         /// <returns>The list of task navigation groups</returns>
-        public Task<List<TaskNavigationGroup>> GetTaskNavigation(AltinnRepoEditingContext altinnRepoEditingContext, CancellationToken cancellationToken = default);
+        public Task<IEnumerable<TaskNavigationGroup>> GetTaskNavigation(AltinnRepoEditingContext altinnRepoEditingContext, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the tasks process definitions.
@@ -22,6 +22,6 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// <param name="altinnRepoEditingContext">An <see cref="AltinnRepoEditingContext"/>.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
         /// <returns>The tasks</returns>
-        public List<ProcessTask> GetTasks(AltinnRepoEditingContext altinnRepoEditingContext, CancellationToken cancellationToken);
+        public IEnumerable<ProcessTask> GetTasks(AltinnRepoEditingContext altinnRepoEditingContext, CancellationToken cancellationToken);
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/TaskNavigationController/GetTaskNavigationTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TaskNavigationController/GetTaskNavigationTests.cs
@@ -20,7 +20,7 @@ namespace Designer.Tests.Controllers.TaskNavigationController
 
         [Theory]
         [InlineData("ttd", "app-with-groups-and-taskNavigation", "testUser")]
-        public async Task GetTaskNavigation_ShouldReturnTaskNavigation(string org, string app, string developer)
+        public async Task GetTaskNavigation_WhenExists_ReturnsTaskNavigationArray(string org, string app, string developer)
         {
             string targetRepository = TestDataHelper.GenerateTestRepoName();
             await CopyRepositoryForTest(org, app, developer, targetRepository);
@@ -48,6 +48,24 @@ namespace Designer.Tests.Controllers.TaskNavigationController
                     TaskType = "receipt"
                 }
             });
+            string actual = await response.Content.ReadAsStringAsync();
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("ttd", "app-with-process-and-layoutsets", "testUser")]
+        public async Task GetTaskNavigation_WhenDoesNotExist_ReturnsEmptyArray(string org, string app, string developer)
+        {
+            string targetRepository = TestDataHelper.GenerateTestRepoName();
+            await CopyRepositoryForTest(org, app, developer, targetRepository);
+
+            string url = VersionPrefix(org, targetRepository);
+            using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url);
+
+            using var response = await HttpClient.SendAsync(httpRequestMessage);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            string expected = "[]";
             string actual = await response.Content.ReadAsStringAsync();
             Assert.Equal(expected, actual);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Return empty array when task navigation is missing

## Related Issue(s)

- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the task navigation experience by ensuring it consistently displays an array. Now, when no task navigation data is available, an empty list is returned instead of a null value, resulting in a more robust and reliable interface.

- **New Features**
  - Enhanced flexibility in task navigation and task retrieval by updating return types to allow for a broader range of collection types.
  - Added new test cases to cover scenarios where task navigation data may not exist, improving overall test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->