### PR TITLE
fix: ensure org is updated during copying of app

### DIFF
--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -289,6 +289,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
             ApplicationMetadata appMetadata = await targetAppRepository.GetApplicationMetadata();
             appMetadata.Id = $"{targetOrg}/{targetRepository}";
+            appMetadata.Org = targetOrg;
             appMetadata.CreatedBy = developer;
             appMetadata.LastChangedBy = developer;
             appMetadata.Created = DateTime.UtcNow;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It seems only app `id` in applicationMetadata is updated when copying an app, and not `org`. This results in a mismatch which may cause problems.
Added a line explicitly setting the (updated) org to ensure it is correct.

## Related Issue(s)

https://altinn.slack.com/archives/C02EJ9HKQA3/p1744015767895519?thread_ts=1744006691.648009&cid=C02EJ9HKQA3

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Application metadata now consistently includes complete organization information, ensuring more relevant and accurate settings for enhanced overall context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->