### PR TITLE
fix: update DATA_MODEL_NAME_REGEX to disallow hyphens and adjust validation tests

### DIFF
--- a/frontend/packages/shared/src/constants.js
+++ b/frontend/packages/shared/src/constants.js
@@ -20,4 +20,4 @@ export const PROTECTED_TASK_NAME_CUSTOM_RECEIPT = 'CustomReceipt';
 export const PREVIEW_MOCK_PARTY_ID = '51001';
 export const PREVIEW_MOCK_INSTANCE_GUID = 'f1e23d45-6789-1bcd-8c34-56789abcdef0';
 export const MEDIA_QUERY_MAX_WIDTH = '(max-width: 1024px)';
-export const DATA_MODEL_NAME_REGEX = /^[a-zA-Z][a-zA-Z0-9_\-]*$/;
+export const DATA_MODEL_NAME_REGEX = /^[a-zA-Z][a-zA-Z0-9_]*$/;

--- a/frontend/packages/shared/src/hooks/useValidateSchemaName.test.ts
+++ b/frontend/packages/shared/src/hooks/useValidateSchemaName.test.ts
@@ -147,14 +147,29 @@ describe('useValidateSchemaName', () => {
       });
     });
 
-    it('should allow "-" and "_" in rest of name', () => {
+    it('should allow "_" in rest of name', () => {
       const { result } = renderUseValidateSchemaName();
 
       act(() => {
-        result.current.validateName('a-_');
+        result.current.validateName('a_');
       });
 
       expect(result.current.nameError).toBe('');
+    });
+
+    it('should disallow "-" in rest of name', () => {
+      const { result } = renderUseValidateSchemaName();
+      const invalidNames = ['a-', 'a-b'];
+
+      invalidNames.forEach((name) => {
+        act(() => {
+          result.current.validateName(name);
+        });
+
+        expect(result.current.nameError).toBe(
+          textMock('schema_editor.error_invalid_datamodel_name'),
+        );
+      });
     });
 
     it('should disallow " " and "." in name', () => {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated `DATA_MODEL_NAME_REGEX` in `constants.js` to disallow hyphens, so it throws an error when user is trying to create datamodel with `-`. 

Also removed tests for **allowing** `-` and instead replaced with tests for **disallowing** `-`

## Related Issue(s)

- #14121

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
