### PR TITLE
refactor: move CodeListWithMetadata to types folder

### DIFF
--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.tsx
@@ -15,11 +15,7 @@ import {
 } from './utils';
 import type { TextResourceWithLanguage } from '../../../../types/TextResourceWithLanguage';
 import type { TextResources } from '../../../../types/TextResources';
-
-export type CodeListWithMetadata = {
-  codeList: CodeList;
-  title: string;
-};
+import type { CodeListWithMetadata } from './types/CodeListWithMetadata';
 
 export type CodeListData = {
   title: string;

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.test.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.test.tsx
@@ -4,7 +4,7 @@ import type { CodeListsProps } from './CodeLists';
 import { CodeLists } from './CodeLists';
 import { updateCodeListWithMetadata } from './EditCodeList/EditCodeList';
 import { textMock } from '@studio/testing/mocks/i18nMock';
-import type { CodeListWithMetadata } from '../CodeListPage';
+import type { CodeListWithMetadata } from '../types/CodeListWithMetadata';
 import type { RenderResult } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import userEvent from '@testing-library/user-event';

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import type { CodeListData, CodeListWithMetadata } from '../CodeListPage';
+import type { CodeListData } from '../CodeListPage';
+import type { CodeListWithMetadata } from '../types/CodeListWithMetadata';
 import { Accordion } from '@digdir/designsystemet-react';
 import { StudioAlert } from '@studio/components-legacy';
 import { EditCodeList } from './EditCodeList/EditCodeList';

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/EditCodeList/EditCodeList.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/EditCodeList/EditCodeList.tsx
@@ -8,7 +8,7 @@ import {
 } from '@studio/components-legacy';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import type { CodeListWithMetadata } from '../../CodeListPage';
+import type { CodeListWithMetadata } from '../../types/CodeListWithMetadata';
 import { useCodeListEditorTexts } from '../../hooks/useCodeListEditorTexts';
 import { EyeIcon, KeyVerticalIcon } from '@studio/icons';
 import { ArrayUtils, FileNameUtils } from '@studio/pure-functions';

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListsActionsBar/CodeListsActionsBar.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListsActionsBar/CodeListsActionsBar.tsx
@@ -4,7 +4,7 @@ import { StudioFileUploader, StudioSearch } from '@studio/components-legacy';
 import type { ChangeEvent } from 'react';
 import classes from './CodeListsActionsBar.module.css';
 import { useTranslation } from 'react-i18next';
-import type { CodeListWithMetadata } from '../CodeListPage';
+import type { CodeListWithMetadata } from '../types/CodeListWithMetadata';
 import { CreateNewCodeListModal } from './CreateNewCodeListModal/CreateNewCodeListModal';
 import { FileNameUtils } from '@studio/pure-functions';
 import { useUploadCodeListNameErrorMessage } from '../hooks/useUploadCodeListNameErrorMessage';

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListsActionsBar/CreateNewCodeListModal/CreateNewCodeListModal.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListsActionsBar/CreateNewCodeListModal/CreateNewCodeListModal.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { useCodeListEditorTexts } from '../../hooks/useCodeListEditorTexts';
 import { CheckmarkIcon } from '@studio/icons';
 import classes from './CreateNewCodeListModal.module.css';
-import type { CodeListWithMetadata } from '../../CodeListPage';
+import type { CodeListWithMetadata } from '../../types/CodeListWithMetadata';
 import { FileNameUtils } from '@studio/pure-functions';
 import { useInputCodeListNameErrorMessage } from '../../hooks/useInputCodeListNameErrorMessage';
 

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/index.ts
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/index.ts
@@ -1,3 +1,4 @@
 export { CodeListPage } from './CodeListPage';
-export type { CodeListWithMetadata, CodeListData, CodeListPageProps } from './CodeListPage';
+export type { CodeListData, CodeListPageProps } from './CodeListPage';
 export type { CodeListIdSource, CodeListReference } from './types/CodeListReference';
+export type { CodeListWithMetadata } from './types/CodeListWithMetadata';

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/types/CodeListWithMetadata.ts
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/types/CodeListWithMetadata.ts
@@ -1,0 +1,6 @@
+import type { CodeList } from '@studio/components-legacy';
+
+export type CodeListWithMetadata = {
+  codeList: CodeList;
+  title: string;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Moving the `CodeListWithMetadata` type to the types folder to follow the same structure as we do elsewhere in our code. 

## Related Issue(s)

- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Reorganized the code listing metadata definitions by centralizing them into a single module.
	- Updated all related components and tests to reference the new, consolidated definitions.
	- This streamlining enhances code maintainability and consistency without altering end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->