### PR TITLE
fix: changed delete task warning message and added to nb.json

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -831,6 +831,7 @@
   "process_editor.configuration_view_panel_name_label": "Navn: ",
   "process_editor.configuration_view_panel_no_task": "Du har ikke valgt noen oppgave",
   "process_editor.configuration_view_panel_please_choose_task": "Velg en oppgave for å se detaljer om valgt oppgave.",
+  "process_editor.delete_task_warning": "Er du sikker på at du vil slette oppgaven?\n\nDen kan ha komponenter, oppsett og innstillinger som også blir slettet.",
   "process_editor.fetch_bpmn_error_message": "Kunne ikke laste inn BPMN for denne appen. Prøv igjen senere.",
   "process_editor.fetch_bpmn_error_title": "En feil oppstod ved innlasting av BPMN",
   "process_editor.help_text_and_links": "Trenger du hjelp til å oppgradere, kan du <0>lese mer om oppgradering her</0> eller <1>ta kontakt med oss</1>.",

--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedContextPadProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedContextPadProvider.js
@@ -1,3 +1,5 @@
+import i18next from 'i18next';
+
 class SupportedContextPadProvider {
   constructor(contextPad) {
     contextPad.registerProvider(this);
@@ -15,9 +17,7 @@ class SupportedContextPadProvider {
               return;
             }
 
-            const isConfirmed = confirm(
-              'Prosess-steget du vil slette kan være knyttet til en sidegruppe. Den kan inneholde visningsoppsett eller skjema du har satt opp. Hvis du sletter steget, sletter du også hele sidegruppen og alt som hører til.\nAlle Summary2-komponenter knyttet til dette prosess-steget vil også bli slettet.',
-            );
+            const isConfirmed = confirm(i18next.t('process_editor.delete_task_warning'));
 
             if (isConfirmed) {
               deleteEntry.action.click(event, element);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses issue #14850 by updating the delete confirmation message displayed when removing a task element in the process editor.

The previous implementation in `SupportedContextPadProvider.js` used a hardcoded Norwegian text string within a native `confirm()` dialog. This text was outdated and did not follow localization best practices.

**Changes:**

1.  **Identified Outdated Text:** Located the hardcoded confirmation message in `frontend/packages/process-editor/src/bpmnProviders/SupportedContextPadProvider.js`.
2.  **Added Translation Key:** Introduced a new key, `process_editor.context_pad_delete_task_confirm_combined`, into the Norwegian translation file (`frontend/language/src/nb.json`) containing the updated and correctly formatted message as specified in the issue.
3.  **Implemented i18n:** Modified `SupportedContextPadProvider.js` to:
    *   Import the `i18next` instance.
    *   Replace the hardcoded string in the `confirm()` call with `i18next.t('process_editor.context_pad_delete_task_confirm_combined')` to fetch the text from the localization file.

**Result:**

*   The delete confirmation dialog now shows the correct, updated message requested in the issue.
*   The text is no longer hardcoded, adhering to i18n best practices for maintainability and future translations.

**Good to know**
This PR covers this:

> 
> Forslag til forenkling:
> 
> **Er du sikker på at du vil slette oppgaven?** Den kan ha komponenter, oppsett og innstillinger som også blir slettet.
> 
> Bekreftende knapper: Ja, slett og Nei, avbryt.

This PR only covers the texts in existing Alert. The PR knowingly does not include a custom popup dialog, since this has been discussed earlier. In conclusion, the PR could be extended to cover a custom dialog, but does not do that yet, and there should maybe be a different discussion and solution if this wants to be implemented, because the dialog if implemented should be used other places too.

## Images
**Firefox:**
![bilde](https://github.com/user-attachments/assets/bd9449fb-30bd-49f3-b271-555f28762431)
**Chromium:**
![bilde](https://github.com/user-attachments/assets/27df09a9-8773-48fb-9bc1-95b393b5c8ec)


## Related Issue(s)

- #14850

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
