### PR TITLE
test: add test cases for invalid pageorder and pagegroup conversions

### DIFF
--- a/backend/tests/Designer.Tests/Services/LayoutServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/LayoutServiceTests.cs
@@ -208,6 +208,30 @@ public class LayoutServiceTests
         Assert.Equal(originalGroupCount, newGroupCount);
     }
 
+    [Fact]
+    public async Task PageGroupToOrderConversion_ShouldThrowException_IfInvalid()
+    {
+        const string repo = "app-with-groups-and-taskNavigation";
+        (AltinnRepoEditingContext editingContext, LayoutService layoutService, _) =
+            await PrepareTestForRepo(repo);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await layoutService.ConvertPagesToPageGroups(editingContext, "form")
+        );
+    }
+
+    [Fact]
+    public async Task PageOrderToGroupConversion_ShouldThrowException_IfInvalid()
+    {
+        const string repo = "app-with-layoutsets";
+        (AltinnRepoEditingContext editingContext, LayoutService layoutService, _) =
+            await PrepareTestForRepo(repo);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await layoutService.ConvertPageGroupsToPages(editingContext, "layoutSet1")
+        );
+    }
+
     private static async Task<(
         AltinnRepoEditingContext editingContext,
         LayoutService layoutService,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Test cases for invalid pageorder and pagegroup conversions. Asserting that the conversion should not edit files and throws an exception if layoutsettings is already in that configuration.

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new test cases to verify that conversion operations correctly handle invalid inputs by raising appropriate errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->