### PR TITLE
feat: gitea log level and version bump

### DIFF
--- a/gitea/Dockerfile
+++ b/gitea/Dockerfile
@@ -1,4 +1,4 @@
-ARG GITEA_VERSION=1.23.5
+ARG GITEA_VERSION=1.23.7
 
 # Grab the locale files from the gitea binary in the image
 FROM gitea/gitea:${GITEA_VERSION}-rootless AS locale_source

--- a/gitea/files/conf/app.ini
+++ b/gitea/files/conf/app.ini
@@ -44,7 +44,7 @@ PATH = /var/lib/gitea/attachments
 
 [log]
 MODE      = console
-LEVEL     = Trace
+LEVEL     = Warn
 
 [log.console]
 STDERR    = true

--- a/gitea/files/conf/app.ini
+++ b/gitea/files/conf/app.ini
@@ -44,7 +44,7 @@ PATH = /var/lib/gitea/attachments
 
 [log]
 MODE      = console
-LEVEL     = Error
+LEVEL     = Debug
 
 [log.console]
 STDERR    = true

--- a/gitea/files/conf/app.ini
+++ b/gitea/files/conf/app.ini
@@ -44,7 +44,7 @@ PATH = /var/lib/gitea/attachments
 
 [log]
 MODE      = console
-LEVEL     = Debug
+LEVEL     = Trace
 
 [log.console]
 STDERR    = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Updates gitea version and sets log level to Warn

## Related Issue(s)

- N/A

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the application’s container to a newer version for improved maintenance.
  - Adjusted the logging configuration to capture a broader range of warning messages for enhanced system feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->