### PR TITLE
feat: Add new `StudioHelpText` component

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioHelpText/StudioHelpText.module.css
+++ b/frontend/libs/studio-components/src/components/StudioHelpText/StudioHelpText.module.css
@@ -1,0 +1,48 @@
+.helpText {
+  --dsc-helptext-icon-size: 65%;
+  --dsc-helptext-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 8 14'%3E%3Cpath fill='%23000' fill-rule='evenodd' d='M4 11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM4 0c2.2 0 4 1.66 4 3.7 0 .98-.42 1.9-1.17 2.6l-.6.54-.29.29c-.48.46-.87.93-.94 1.41V9.5H3v-.81c0-1.26.84-2.22 1.68-3L5.42 5C5.8 4.65 6 4.2 6 3.7 6 2.66 5.1 1.83 4 1.83c-1.06 0-1.92.75-2 1.7v.15H0C0 1.66 1.8 0 4 0Z' clip-rule='evenodd'/%3E%3C/svg%3E");
+  --dsc-helptext-size: var(--ds-size-7);
+
+  border-radius: var(--ds-border-radius-full);
+  border: max(1px, calc(var(--ds-size-1) / 2)) solid; /* Allow border-width to grow with font-size */
+  box-sizing: border-box;
+  height: var(--dsc-helptext-size);
+  min-height: 0;
+  min-width: 0;
+  padding: 0;
+  position: relative;
+  width: var(--dsc-helptext-size);
+
+  @media (forced-colors: active) {
+    color: ButtonText;
+  }
+
+  &::before {
+    content: '';
+    border-radius: inherit;
+    background: currentcolor;
+    mask-composite: exclude;
+    mask-image: var(--dsc-helptext-icon-url);
+    mask-position: center;
+    mask-repeat: no-repeat;
+    mask-size:
+      var(--dsc-helptext-icon-size) var(--dsc-helptext-icon-size),
+      cover;
+    scale: 1.1; /* Hide tiny half pixel rendeing bug */
+    width: 100%;
+    height: 100%;
+
+    @media (forced-colors: active) {
+      background: ButtonText;
+    }
+  }
+
+  &:has(+ :popover-open)::before {
+    mask-image:
+      var(--dsc-helptext-icon-url), linear-gradient(currentcolor, currentcolor); /* Cut icon out of currentcolor surface */
+  }
+
+  @media print {
+    display: none;
+  }
+}

--- a/frontend/libs/studio-components/src/components/StudioHelpText/StudioHelpText.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioHelpText/StudioHelpText.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { RenderResult } from '@testing-library/react';
+import { StudioHelpText } from './StudioHelpText';
+import type { StudioHelpTextProps } from './StudioHelpText';
+import { testRootClassNameAppending } from '../../test-utils/testRootClassNameAppending';
+import { testCustomAttributes } from '../../test-utils/testCustomAttributes';
+import userEvent from '@testing-library/user-event';
+
+const mockText: string = 'Test Text';
+
+const defaultProps: StudioHelpTextProps = {
+  placement: 'right',
+  'aria-label': 'test-label',
+};
+
+describe('StudioHelpText', () => {
+  it('renders children correctly', () => {
+    renderField();
+    expect(screen.getByText(mockText)).toBeInTheDocument();
+  });
+
+  it('applies custom placement correctly', async () => {
+    const user = userEvent.setup();
+    renderField({ placement: 'left' });
+    await user.click(screen.getByText(mockText));
+    expect(screen.getByRole('dialog').getAttribute('data-placement')).toBe('left');
+  });
+
+  it('Appends given classname to internal classname', () => {
+    testRootClassNameAppending((className) => renderField({ className }));
+  });
+
+  it('Appends custom attributes to the field element', () => {
+    testCustomAttributes(renderField);
+  });
+});
+
+const renderField = (props: Partial<StudioHelpTextProps> = {}): RenderResult => {
+  return render(
+    <StudioHelpText {...defaultProps} {...props}>
+      {mockText}
+    </StudioHelpText>,
+  );
+};

--- a/frontend/libs/studio-components/src/components/StudioHelpText/StudioHelpText.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioHelpText/StudioHelpText.test.tsx
@@ -1,45 +1,38 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import type { RenderResult } from '@testing-library/react';
-import { StudioHelpText } from './StudioHelpText';
-import type { StudioHelpTextProps } from './StudioHelpText';
+import { StudioHelpText, type StudioHelpTextProps } from './StudioHelpText';
 import { testRootClassNameAppending } from '../../test-utils/testRootClassNameAppending';
 import { testCustomAttributes } from '../../test-utils/testCustomAttributes';
-import userEvent from '@testing-library/user-event';
 
-const mockText: string = 'Test Text';
+const mockTitle: string = 'Test title';
+const mockText: string = 'Test text';
 
 const defaultProps: StudioHelpTextProps = {
-  placement: 'right',
-  'aria-label': 'test-label',
+  'aria-label': mockTitle,
 };
 
 describe('StudioHelpText', () => {
   it('renders children correctly', () => {
-    renderField();
-    expect(screen.getByText(mockText)).toBeInTheDocument();
-  });
-
-  it('applies custom placement correctly', async () => {
-    const user = userEvent.setup();
-    renderField({ placement: 'left' });
-    await user.click(screen.getByText(mockText));
-    expect(screen.getByRole('dialog').getAttribute('data-placement')).toBe('left');
+    renderStudioHelpText();
+    expect(getText(mockText)).toBeInTheDocument();
   });
 
   it('Appends given classname to internal classname', () => {
-    testRootClassNameAppending((className) => renderField({ className }));
+    testRootClassNameAppending((className) => renderStudioHelpText({ className }));
   });
 
-  it('Appends custom attributes to the field element', () => {
-    testCustomAttributes(renderField);
+  it('Appends custom attributes to the help text element', () => {
+    testCustomAttributes(renderStudioHelpText);
   });
 });
 
-const renderField = (props: Partial<StudioHelpTextProps> = {}): RenderResult => {
+const renderStudioHelpText = (props: Partial<StudioHelpTextProps> = {}): RenderResult => {
   return render(
     <StudioHelpText {...defaultProps} {...props}>
       {mockText}
     </StudioHelpText>,
   );
 };
+
+const getText = (text: string): HTMLElement => screen.getByText(text) as HTMLElement;

--- a/frontend/libs/studio-components/src/components/StudioHelpText/StudioHelpText.tsx
+++ b/frontend/libs/studio-components/src/components/StudioHelpText/StudioHelpText.tsx
@@ -28,7 +28,7 @@ export const StudioHelpText = forwardRef<HTMLButtonElement, StudioHelpTextProps>
         data-color='info'
         {...rest}
       />
-      <Popover placement={placement} data-color='info'>
+      <Popover placement={placement} data-color='info' variant='tinted'>
         {children}
       </Popover>
     </Popover.TriggerContext>

--- a/frontend/libs/studio-components/src/components/StudioHelpText/StudioHelpText.tsx
+++ b/frontend/libs/studio-components/src/components/StudioHelpText/StudioHelpText.tsx
@@ -1,0 +1,36 @@
+import type { ButtonHTMLAttributes } from 'react';
+import React, { forwardRef } from 'react';
+import classes from './StudioHelpText.module.css';
+import { Popover } from '@digdir/designsystemet-react';
+
+export type StudioHelpTextProps = {
+  /**
+   * Required descriptive label for screen readers.
+   **/
+  'aria-label': string;
+  /**
+   * Placement of the Popover.
+   * @default 'right'
+   */
+  placement?: 'right' | 'bottom' | 'left' | 'top';
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'color'>;
+
+export const StudioHelpText = forwardRef<HTMLButtonElement, StudioHelpTextProps>(function HelpText(
+  { placement = 'right', children, ...rest },
+  ref,
+) {
+  return (
+    <Popover.TriggerContext>
+      <Popover.Trigger
+        className={classes.helpText}
+        ref={ref}
+        variant='tertiary'
+        data-color='info'
+        {...rest}
+      />
+      <Popover placement={placement} data-color='info'>
+        {children}
+      </Popover>
+    </Popover.TriggerContext>
+  );
+});

--- a/frontend/libs/studio-components/src/components/StudioHelpText/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioHelpText/index.ts
@@ -1,0 +1,1 @@
+export { StudioHelpText } from './StudioHelpText';

--- a/frontend/libs/studio-components/src/components/index.ts
+++ b/frontend/libs/studio-components/src/components/index.ts
@@ -5,6 +5,7 @@ import '@digdir/designsystemet-theme/altinn.css';
 export { StudioDropdown } from './StudioDropdown';
 export { StudioButton } from './StudioButton';
 export { StudioHeading } from './StudioHeading';
+export { StudioHelpText } from './StudioHelpText';
 export { StudioParagraph } from './StudioParagraph';
 export { StudioField } from './StudioField';
 export { StudioLabel } from './StudioLabel';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add new `StudioHelpText` component based on https://www.designsystemet.no/bloggen/2025/helptext-blir-fjerna-kva-gjer-du

## Related Issue(s)

- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new help text component that displays an informational icon with a popover for additional guidance.
- **Style**
  - Added new styles for the help text icon, including accessibility improvements and print mode support.
- **Tests**
  - Added tests to verify rendering, class name handling, and custom attribute support for the help text component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->