### PR TITLE
feat: make the 'three-dot' menu always visible

### DIFF
--- a/frontend/libs/studio-components-legacy/src/components/StudioIconCard/StudioIconCard.module.css
+++ b/frontend/libs/studio-components-legacy/src/components/StudioIconCard/StudioIconCard.module.css
@@ -59,10 +59,6 @@
   height: 100%;
 }
 
-.card:not(:hover) .editIcon {
-  display: none;
-}
-
 .editIcon {
   padding: var(--fds-sizing-0);
   position: absolute;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<img width="809" alt="image" src="https://github.com/user-attachments/assets/f8862dce-bdf2-4e0c-89bd-c70ba047324c" />


<!--- Describe your changes in detail -->

## Related Issue(s)

- #15123 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - The edit icon is now always visible on cards, rather than only appearing on hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->