### PR TITLE
fix: Display warning message when subform empty

### DIFF
--- a/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/hooks/useSubformLayoutValidation.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/hooks/useSubformLayoutValidation.test.tsx
@@ -5,6 +5,7 @@ import { QueryKey } from 'app-shared/types/QueryKey';
 import { app, org } from '@studio/testing/testids';
 import type { IFormLayouts } from '@altinn/ux-editor/types/global';
 import { ComponentType } from 'app-shared/types/ComponentType';
+import { componentMocks } from '@altinn/ux-editor/testing/componentMocks';
 
 const emptyLayout: IFormLayouts = {
   page1: {
@@ -23,12 +24,17 @@ const nonEmptyLayout: IFormLayouts = {
   page1: {
     ...emptyLayout.page1,
     components: {
-      component2: {
-        type: ComponentType.Input,
-        id: 'component2',
-        itemType: 'COMPONENT',
-        dataModelBindings: { simpleBinding: 'simpleBinding' },
-      },
+      component2: componentMocks.Input,
+    },
+  },
+};
+
+const excludedLayout: IFormLayouts = {
+  ...emptyLayout,
+  page1: {
+    ...emptyLayout.page1,
+    components: {
+      component2: componentMocks.CustomButton,
     },
   },
 };
@@ -40,9 +46,17 @@ describe('useSubformLayoutValidation', () => {
     });
     expect(result.current).toBe(true);
   });
+
   it('should return false if form layout has no components', () => {
     const { result } = renderHook({
       layout: emptyLayout,
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('should return false if form layout has only excluded components', () => {
+    const { result } = renderHook({
+      layout: excludedLayout,
     });
     expect(result.current).toBe(false);
   });

--- a/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/hooks/useSubformLayoutValidation.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/hooks/useSubformLayoutValidation.test.tsx
@@ -4,7 +4,6 @@ import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { app, org } from '@studio/testing/testids';
 import type { IFormLayouts } from '@altinn/ux-editor/types/global';
-import { ComponentType } from 'app-shared/types/ComponentType';
 import { componentMocks } from '@altinn/ux-editor/testing/componentMocks';
 
 const emptyLayout: IFormLayouts = {

--- a/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/hooks/useSubformLayoutValidation.ts
+++ b/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/hooks/useSubformLayoutValidation.ts
@@ -1,13 +1,19 @@
 import { useFormLayoutsQuery } from '@altinn/ux-editor/hooks/queries/useFormLayoutsQuery';
 import { getAllLayoutComponents } from '@altinn/ux-editor/utils/formLayoutUtils';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
+import { ComponentType } from 'app-shared/types/ComponentType';
 
 export const useSubformLayoutValidation = (subformLayoutSetName: string): boolean => {
   const { org, app } = useStudioEnvironmentParams();
   const { data: formLayout } = useFormLayoutsQuery(org, app, subformLayoutSetName);
+  console.log('useSubformLayoutValidation', formLayout);
+
+  const excludedComponents = [ComponentType.CustomButton];
 
   if (formLayout) {
-    return Object.values(formLayout).some((value) => getAllLayoutComponents(value).length > 0);
+    return Object.values(formLayout).some(
+      (value) => getAllLayoutComponents(value, excludedComponents).length > 0,
+    );
   }
   return false;
 };

--- a/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/hooks/useSubformLayoutValidation.ts
+++ b/frontend/packages/ux-editor/src/components/Properties/EditSubformTableColumns/hooks/useSubformLayoutValidation.ts
@@ -6,7 +6,6 @@ import { ComponentType } from 'app-shared/types/ComponentType';
 export const useSubformLayoutValidation = (subformLayoutSetName: string): boolean => {
   const { org, app } = useStudioEnvironmentParams();
   const { data: formLayout } = useFormLayoutsQuery(org, app, subformLayoutSetName);
-  console.log('useSubformLayoutValidation', formLayout);
 
   const excludedComponents = [ComponentType.CustomButton];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The warning message stopped appearing after we implemented the automatic addition of the "Close subform button" to subforms. This caused the content check to always return true, since the subform was never technically empty.

To fix this, an `excludedComponents` array was added to the `useSubformLayoutValidation` hook, so that certain components like the close button can be ignored during validation.


<img width="908" alt="image" src="https://github.com/user-attachments/assets/d0dd3b0f-db00-4847-b990-aa0300ceec70" />


<!--- Describe your changes in detail -->

## Related Issue(s)

- #14855 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation logic to ignore certain component types, ensuring excluded components (such as custom buttons) are not counted in subform layout validation.

- **Tests**
	- Added and updated tests to verify that layouts containing only excluded components are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->