### PR TITLE
chore: Update cookie name for ASPX AUTH cookie in at23

### DIFF
--- a/src/test/K6/src/config.js
+++ b/src/test/K6/src/config.js
@@ -12,9 +12,9 @@ export var baseUrls = {
 // Auth cookie names in the different environments. NB: Must be updated until changes
 // are rolled out to all environments
 export var authCookieNames = {
-  at21: '.ASPXAUTH', // '.AspxAuthCloud',
+  at21: '.AspxAuthCloud',
   at22: '.AspxAuthCloud',
-  at23: '.ASPXAUTH', // '.AspxAuthCloud',
+  at23: '.AspxAuthCloud',
   at24: '.AspxAuthCloud',
   tt02: '.AspxAuthTT02',
   yt01: '.ASPXAUTH', // '.AspxAuthYt',


### PR DESCRIPTION
## Description
The latest changes in Altinn II have been deployed to AT23. This includes a change in the naming of the Auth Cookie. The cookie is referenced in the use-case tests by name. This is an update to the test code with the correct name of the cookie.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated authentication cookie names for the at21 and at23 environments to improve consistency. No changes for other environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->