### PR TITLE
fix: Use correct auth cookie name in use-case tests

### DIFF
--- a/src/test/K6/src/config.js
+++ b/src/test/K6/src/config.js
@@ -17,8 +17,8 @@ export var authCookieNames = {
   at23: '.AspxAuthCloud',
   at24: '.AspxAuthCloud',
   tt02: '.AspxAuthTT02',
-  yt01: '.ASPXAUTH', // '.AspxAuthYt',
-  prod: '.ASPXAUTH', // '.AspxAuthProd'
+  yt01: '.AspxAuthYt',
+  prod: '.AspxAuthProd',
 };
 
 //Get values from environment


### PR DESCRIPTION
## Description
Update use-case tests to reference the auth cookie used when signing into the Altinn (ii) portal.
