### PR TITLE
fix: move LayoutController UseSystemTextJson attribute to method level

### DIFF
--- a/backend/src/Designer/Controllers/LayoutController.cs
+++ b/backend/src/Designer/Controllers/LayoutController.cs
@@ -16,13 +16,13 @@ namespace Altinn.Studio.Designer.Controllers
     [Authorize]
     [AutoValidateAntiforgeryToken]
     [Route("designer/api/{org}/{app}/layouts/layoutSet/{layoutSetId}/")]
-    [UseSystemTextJson]
     public class LayoutController(ILayoutService layoutService) : Controller
     {
         [EndpointSummary("Retrieve pages")]
         [ProducesResponseType<PagesDto>(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [HttpGet("pages")]
+        [UseSystemTextJson]
         public async Task<ActionResult<PagesDto>> GetPages(
             [FromRoute] string org,
             [FromRoute] string app,
@@ -43,6 +43,7 @@ namespace Altinn.Studio.Designer.Controllers
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [HttpPost("pages")]
+        [UseSystemTextJson]
         public async Task<ActionResult<PageDto>> CreatePage(
             [FromRoute] string org,
             [FromRoute] string app,
@@ -72,8 +73,9 @@ namespace Altinn.Studio.Designer.Controllers
         [EndpointSummary("Retrieve page")]
         [ProducesResponseType<PageDto>(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [HttpGet("pages/{pageId}")]
         [ProducesResponseType<PageDto>(StatusCodes.Status200OK)]
+        [HttpGet("pages/{pageId}")]
+        [UseSystemTextJson]
         public async Task<ActionResult<PageDto>> GetPage(
             [FromRoute] string org,
             [FromRoute] string app,
@@ -100,6 +102,7 @@ namespace Altinn.Studio.Designer.Controllers
         [ProducesResponseType<PageDto>(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [HttpPut("pages/{pageId}")]
+        [UseSystemTextJson]
         public async Task<ActionResult<PageDto>> ModifyPage(
             [FromRoute] string org,
             [FromRoute] string app,
@@ -129,6 +132,7 @@ namespace Altinn.Studio.Designer.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [HttpDelete("pages/{pageId}")]
+        [UseSystemTextJson]
         public async Task<ActionResult> DeletePage(
             [FromRoute] string org,
             [FromRoute] string app,
@@ -156,6 +160,7 @@ namespace Altinn.Studio.Designer.Controllers
         [EndpointSummary("Modify pages")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [HttpPut("pages")]
+        [UseSystemTextJson]
         public async Task<ActionResult> ModifyPages(
             [FromRoute] string org,
             [FromRoute] string app,
@@ -178,6 +183,7 @@ namespace Altinn.Studio.Designer.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [HttpPost("convert-to-pagegroups")]
+        [UseSystemTextJson]
         public async Task<ActionResult> ConvertToPageGroups(
             [FromRoute] string org,
             [FromRoute] string app,
@@ -206,6 +212,7 @@ namespace Altinn.Studio.Designer.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [HttpPost("convert-to-pageorder")]
+        [UseSystemTextJson]
         public async Task<ActionResult> ConvertToPageOrder(
             [FromRoute] string org,
             [FromRoute] string app,
@@ -236,6 +243,7 @@ namespace Altinn.Studio.Designer.Controllers
         )]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [HttpPut("page-groups")]
+        [UseSystemTextJson]
         public async Task<ActionResult> UpdatePageGroups(
             [FromRoute] string org,
             [FromRoute] string app,

--- a/backend/src/Designer/Controllers/LayoutController.cs
+++ b/backend/src/Designer/Controllers/LayoutController.cs
@@ -73,7 +73,6 @@ namespace Altinn.Studio.Designer.Controllers
         [EndpointSummary("Retrieve page")]
         [ProducesResponseType<PageDto>(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType<PageDto>(StatusCodes.Status200OK)]
         [HttpGet("pages/{pageId}")]
         [UseSystemTextJson]
         public async Task<ActionResult<PageDto>> GetPage(

--- a/backend/src/Designer/Models/Dto/GroupDto.cs
+++ b/backend/src/Designer/Models/Dto/GroupDto.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -7,8 +8,8 @@ public class GroupDto
 {
     [JsonPropertyName("name")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     [JsonPropertyName("order")]
-    public List<PageDto> Pages { get; set; }
+    public required List<PageDto> Pages { get; set; }
 }

--- a/backend/src/Designer/Models/Dto/PagesDto.cs
+++ b/backend/src/Designer/Models/Dto/PagesDto.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,11 +10,11 @@ public class PagesDto
 {
     [JsonPropertyName("pages")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public List<PageDto> Pages { get; set; }
+    public List<PageDto>? Pages { get; set; }
 
     [JsonPropertyName("groups")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public List<GroupDto> Groups { get; set; }
+    public List<GroupDto>? Groups { get; set; }
 
     public PagesDto() { }
 
@@ -33,7 +34,7 @@ public class PagesDto
                     .Groups?.Select(group => new GroupDto
                     {
                         Name = group.Name,
-                        Pages = group.Order?.Select(pageId => new PageDto { Id = pageId }).ToList(),
+                        Pages = group.Order.Select(pageId => new PageDto { Id = pageId }).ToList(),
                     })
                     .ToList(),
             },
@@ -53,12 +54,6 @@ public class PagesDto
                 "Cannot convert to business object: `Pages` and `Groups` are defined"
             );
         }
-        if (Pages == null && Groups == null)
-        {
-            throw new InvalidOperationException(
-                "Cannot convert to business object: `Pages` and `Groups` are not defined"
-            );
-        }
         Pages pages = this switch
         {
             { Pages: not null } => new PagesWithOrder
@@ -75,6 +70,9 @@ public class PagesDto
                     })
                     .ToList(),
             },
+            _ => throw new InvalidOperationException(
+                "Cannot convert to business object: `Pages` and `Groups` are not defined"
+            ),
         };
         return pages;
     }


### PR DESCRIPTION
## Description

This attribute did not work as expected on class level (endpoints inside did in fact not use System.Text.Json), maybe it can be reworked to work on class level, but for now i've moved the attribute onto every method in LayoutController instead.

## Related Issue(s)

- [14957](https://github.com/Altinn/altinn-studio/issues/14957)

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved support for nullable values in group and page data, enhancing flexibility in handling optional information.

- **Refactor**
  - Adjusted serialization attribute placement for layout-related endpoints to improve maintainability.
  - Updated data handling to enforce required page lists in groups and allow nullable group and page lists where appropriate.

- **Style**
  - Enabled nullable reference types for improved code reliability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->