### PR TITLE
refactor: Rename OrgContentController to OrgResourceController

### DIFF
--- a/backend/src/Designer/Controllers/Organisation/OrgResourceController.cs
+++ b/backend/src/Designer/Controllers/Organisation/OrgResourceController.cs
@@ -14,19 +14,19 @@ namespace Altinn.Studio.Designer.Controllers.Organisation;
 [ApiController]
 [Authorize]
 [Route("designer/api/{orgName}")]
-public class OrgContentController : ControllerBase
+public class OrgResourceController : ControllerBase
 {
     private readonly IOrgCodeListService _orgCodeListService;
     private readonly IOrgTextsService _orgTextsService;
     private readonly IOrgService _orgService;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="OrgContentController"/> class.
+    /// Initializes a new instance of the <see cref="OrgResourceController"/> class.
     /// </summary>
     /// <param name="orgCodeListService">The code list service</param>
     /// <param name="orgTextsService">The texts service</param>
     /// <param name="orgService">The org service</param>
-    public OrgContentController(IOrgCodeListService orgCodeListService, IOrgTextsService orgTextsService, IOrgService orgService)
+    public OrgResourceController(IOrgCodeListService orgCodeListService, IOrgTextsService orgTextsService, IOrgService orgService)
     {
         _orgCodeListService = orgCodeListService;
         _orgTextsService = orgTextsService;
@@ -37,11 +37,11 @@ public class OrgContentController : ControllerBase
     /// Returns names of available resources from an organisation, based on the requested type.
     /// </summary>
     /// <param name="orgName">Unique identifier of the organisation.</param>
-    /// <param name="contentType">The type of resource to return the names of. For example code lists or text resources. </param>
+    /// <param name="resourceType">The type of resource to return the names of. For example code lists or text resources. </param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
     [HttpGet]
-    [Route("content/{contentType}")]
-    public async Task<ActionResult<List<string>>> GetOrgContentIds([FromRoute] string orgName, [FromRoute] string contentType, CancellationToken cancellationToken = default)
+    [Route("content/{resourceType}")]
+    public async Task<ActionResult<List<string>>> GetOrgResourceIds([FromRoute] string orgName, [FromRoute] string resourceType, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         if (!await _orgService.IsOrg(orgName))
@@ -50,21 +50,21 @@ public class OrgContentController : ControllerBase
             return NoContent();
         }
 
-        ActionResult badRequestResponse = BadRequest($"Invalid content type '{contentType}'.");
-        bool didParse = Enum.TryParse<LibraryContentType>(contentType, ignoreCase: true, out var parsedContentType);
+        ActionResult badRequestResponse = BadRequest($"Invalid resource type '{resourceType}'.");
+        bool didParse = Enum.TryParse<LibraryResourceType>(resourceType, ignoreCase: true, out var parsedResourceType);
         if (!didParse)
         {
             return badRequestResponse;
         }
 
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
-        switch (parsedContentType)
+        switch (parsedResourceType)
         {
-            case LibraryContentType.CodeList:
+            case LibraryResourceType.CodeList:
                 List<string> codeListResult = _orgCodeListService.GetCodeListIds(orgName, developer, cancellationToken);
                 return Ok(codeListResult);
 
-            case LibraryContentType.TextResource:
+            case LibraryResourceType.TextResource:
                 List<string> textResourceResult = await _orgTextsService.GetTextIds(orgName, developer, cancellationToken);
                 return Ok(textResourceResult);
 

--- a/backend/src/Designer/Controllers/Organisation/OrgResourceController.cs
+++ b/backend/src/Designer/Controllers/Organisation/OrgResourceController.cs
@@ -40,7 +40,7 @@ public class OrgResourceController : ControllerBase
     /// <param name="resourceType">The type of resource to return the names of. For example code lists or text resources. </param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
     [HttpGet]
-    [Route("resource/{resourceType}")]
+    [Route("resources/{resourceType}")]
     public async Task<ActionResult<List<string>>> GetOrgResourceIds([FromRoute] string orgName, [FromRoute] string resourceType, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/backend/src/Designer/Controllers/Organisation/OrgResourceController.cs
+++ b/backend/src/Designer/Controllers/Organisation/OrgResourceController.cs
@@ -40,7 +40,7 @@ public class OrgResourceController : ControllerBase
     /// <param name="resourceType">The type of resource to return the names of. For example code lists or text resources. </param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
     [HttpGet]
-    [Route("content/{resourceType}")]
+    [Route("resource/{resourceType}")]
     public async Task<ActionResult<List<string>>> GetOrgResourceIds([FromRoute] string orgName, [FromRoute] string resourceType, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/backend/src/Designer/Enums/LibraryResourceType.cs
+++ b/backend/src/Designer/Enums/LibraryResourceType.cs
@@ -1,6 +1,6 @@
 namespace Altinn.Studio.Designer.Enums
 {
-    public enum LibraryContentType
+    public enum LibraryResourceType
     {
         CodeList,
         TextResource

--- a/backend/tests/Designer.Tests/Controllers/OrgResourceController/GetOrgResourceIdsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OrgResourceController/GetOrgResourceIdsTests.cs
@@ -175,6 +175,6 @@ public class GetOrgResourceIdsTests : DesignerEndpointsTestsBase<GetOrgResourceI
     private class Organisation(string name)
     {
         public string Name { get; } = name;
-        public string ApiBaseUrl => $"designer/api/{Name}/content";
+        public string ApiBaseUrl => $"designer/api/{Name}/resources";
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/OrgResourceController/GetOrgResourceIdsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OrgResourceController/GetOrgResourceIdsTests.cs
@@ -11,13 +11,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
-namespace Designer.Tests.Controllers.OrgContentController;
+namespace Designer.Tests.Controllers.OrgResourceController;
 
-public class GetOrgContentIdsTests : DesignerEndpointsTestsBase<GetOrgContentIdsTests>, IClassFixture<WebApplicationFactory<Program>>
+public class GetOrgResourceIdsTests : DesignerEndpointsTestsBase<GetOrgResourceIdsTests>, IClassFixture<WebApplicationFactory<Program>>
 {
     private readonly Mock<IOrgService> _orgServiceMock;
 
-    public GetOrgContentIdsTests(WebApplicationFactory<Program> factory) : base(factory)
+    public GetOrgResourceIdsTests(WebApplicationFactory<Program> factory) : base(factory)
     {
         _orgServiceMock = new Mock<IOrgService>();
     }
@@ -29,14 +29,14 @@ public class GetOrgContentIdsTests : DesignerEndpointsTestsBase<GetOrgContentIds
     }
 
     [Fact]
-    public async Task GetOrgContentIds_GivenCodeListParameter_ShouldReturnOkWithCodeListIds()
+    public async Task GetOrgResourceIds_GivenCodeListParameter_ShouldReturnOkWithCodeListIds()
     {
         // Arrange
         _orgServiceMock.Setup(s => s.IsOrg(It.IsAny<string>())).ReturnsAsync(true);
 
         OrgAndRepoName orgAndRepoName = await CreateOrgWithRepository();
         string apiBaseUrl = orgAndRepoName.Org.ApiBaseUrl;
-        const LibraryContentType resourceType = LibraryContentType.CodeList;
+        const LibraryResourceType resourceType = LibraryResourceType.CodeList;
         string apiUrlWithCodeListParameter = $"{apiBaseUrl}/{resourceType}";
         using var request = new HttpRequestMessage(HttpMethod.Get, apiUrlWithCodeListParameter);
 
@@ -52,14 +52,14 @@ public class GetOrgContentIdsTests : DesignerEndpointsTestsBase<GetOrgContentIds
     }
 
     [Fact]
-    public async Task GetOrgContentIds_GivenTextResourceParameter_ShouldReturnOkWithTextResourceIds()
+    public async Task GetOrgResourceIds_GivenTextResourceParameter_ShouldReturnOkWithTextResourceIds()
     {
         // Arrange
         _orgServiceMock.Setup(s => s.IsOrg(It.IsAny<string>())).ReturnsAsync(true);
 
         OrgAndRepoName orgAndRepoName = await CreateOrgWithRepository();
         string apiBaseUrl = orgAndRepoName.Org.ApiBaseUrl;
-        const LibraryContentType resourceType = LibraryContentType.TextResource;
+        const LibraryResourceType resourceType = LibraryResourceType.TextResource;
         string apiUrlWithTextResourceParameter = $"{apiBaseUrl}/{resourceType}";
         using var request = new HttpRequestMessage(HttpMethod.Get, apiUrlWithTextResourceParameter);
 
@@ -75,7 +75,7 @@ public class GetOrgContentIdsTests : DesignerEndpointsTestsBase<GetOrgContentIds
     }
 
     [Fact]
-    public async Task GetOrgContentIds_GivenValidTypeParameterInMixedCaseString_ShouldReturnOkWithContent()
+    public async Task GetOrgResourceIds_GivenValidTypeParameterInMixedCaseString_ShouldReturnOkWithResource()
     {
         // Arrange
         _orgServiceMock.Setup(s => s.IsOrg(It.IsAny<string>())).ReturnsAsync(true);
@@ -97,14 +97,14 @@ public class GetOrgContentIdsTests : DesignerEndpointsTestsBase<GetOrgContentIds
     }
 
     [Fact]
-    public async Task GetOrgContentIds_GivenInvalidOrg_ShouldReturnNoContentWithHeaderMessage()
+    public async Task GetOrgResourceIds_GivenInvalidOrg_ShouldReturnNoContentWithHeaderMessage()
     {
         // Arrange
         _orgServiceMock.Setup(s => s.IsOrg(It.IsAny<string>())).ReturnsAsync(false);
 
         const string orgName = "invalidOrgName";
         string apiBaseUrl = new Organisation(orgName).ApiBaseUrl;
-        const LibraryContentType resourceType = LibraryContentType.CodeList;
+        const LibraryResourceType resourceType = LibraryResourceType.CodeList;
         string apiUrlWithTextInvalidOrg = $"{apiBaseUrl}/{resourceType}";
         using var request = new HttpRequestMessage(HttpMethod.Get, apiUrlWithTextInvalidOrg);
 
@@ -118,7 +118,7 @@ public class GetOrgContentIdsTests : DesignerEndpointsTestsBase<GetOrgContentIds
     }
 
     [Fact]
-    public async Task GetOrgContentIds_GivenInvalidTypeParameter_ShouldReturnBadRequest()
+    public async Task GetOrgResourceIds_GivenInvalidTypeParameter_ShouldReturnBadRequest()
     {
         // Arrange
         _orgServiceMock.Setup(s => s.IsOrg(It.IsAny<string>())).ReturnsAsync(true);

--- a/frontend/app-development/features/appContentLibrary/AppContentLibrary.tsx
+++ b/frontend/app-development/features/appContentLibrary/AppContentLibrary.tsx
@@ -35,7 +35,7 @@ import { mergeQueryStatuses } from 'app-shared/utils/tanstackQueryUtils';
 import type { ITextResources } from 'app-shared/types/global';
 import { convertTextResourceToMutationArgs } from './utils/convertTextResourceToMutationArgs';
 import { useGetAvailableCodeListsFromOrgQuery } from 'app-development/hooks/queries/useGetAvailableCodeListsFromOrgQuery';
-import { LibraryContentType } from 'app-shared/enums/LibraryContentType';
+import { LibraryResourceType } from 'app-shared/enums/LibraryResourceType';
 import { useImportCodeListFromOrgToAppMutation } from 'app-development/hooks/mutations/useImportCodeListFromOrgToAppMutation';
 
 export function AppContentLibrary(): React.ReactElement {
@@ -53,7 +53,7 @@ export function AppContentLibrary(): React.ReactElement {
   const {
     data: availableCodeListsToImportFromOrg,
     status: availableCodeListsToImportFromOrgStatus,
-  } = useGetAvailableCodeListsFromOrgQuery(org, LibraryContentType.CodeList);
+  } = useGetAvailableCodeListsFromOrgQuery(org, LibraryResourceType.CodeList);
 
   const status = mergeQueryStatuses(
     optionListDataListStatus,

--- a/frontend/app-development/hooks/queries/useGetAvailableCodeListsFromOrgQuery.test.ts
+++ b/frontend/app-development/hooks/queries/useGetAvailableCodeListsFromOrgQuery.test.ts
@@ -2,7 +2,7 @@ import { waitFor } from '@testing-library/react';
 import { useGetAvailableCodeListsFromOrgQuery } from './useGetAvailableCodeListsFromOrgQuery';
 import { org } from '@studio/testing/testids';
 import { renderHookWithProviders } from 'app-shared/mocks/renderHookWithProviders';
-import { LibraryContentType } from 'app-shared/enums/LibraryContentType';
+import { LibraryResourceType } from 'app-shared/enums/LibraryResourceType';
 
 const title1: string = 'title1';
 const title2: string = 'title2';
@@ -16,14 +16,14 @@ describe('useGetAvailableCodeListsFromOrgQuery', () => {
       .mockImplementation(() => Promise.resolve(listOfAvailableCodeListTitlesToImport));
 
     const result = renderHookWithProviders(
-      () => useGetAvailableCodeListsFromOrgQuery(org, LibraryContentType.CodeList),
+      () => useGetAvailableCodeListsFromOrgQuery(org, LibraryResourceType.CodeList),
       {
         queries: { getAvailableResourcesFromOrg },
       },
     ).result;
 
     await waitFor(() => result.current.isSuccess);
-    expect(getAvailableResourcesFromOrg).toHaveBeenCalledWith(org, LibraryContentType.CodeList);
+    expect(getAvailableResourcesFromOrg).toHaveBeenCalledWith(org, LibraryResourceType.CodeList);
     expect(result.current.data).toEqual(listOfAvailableCodeListTitlesToImport);
   });
 });

--- a/frontend/app-development/hooks/queries/useGetAvailableCodeListsFromOrgQuery.ts
+++ b/frontend/app-development/hooks/queries/useGetAvailableCodeListsFromOrgQuery.ts
@@ -6,11 +6,11 @@ import type { LibraryResourceType } from 'app-shared/enums/LibraryResourceType';
 
 export const useGetAvailableCodeListsFromOrgQuery = (
   org: string,
-  contentType: LibraryResourceType,
+  resourceType: LibraryResourceType,
 ): UseQueryResult<string[], Error> => {
   const { getAvailableResourcesFromOrg } = useServicesContext();
   return useQuery<string[]>({
     queryKey: [QueryKey.CodeListTitles, org],
-    queryFn: () => getAvailableResourcesFromOrg(org, contentType),
+    queryFn: () => getAvailableResourcesFromOrg(org, resourceType),
   });
 };

--- a/frontend/app-development/hooks/queries/useGetAvailableCodeListsFromOrgQuery.ts
+++ b/frontend/app-development/hooks/queries/useGetAvailableCodeListsFromOrgQuery.ts
@@ -2,11 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { useServicesContext } from 'app-shared/contexts/ServicesContext';
-import type { LibraryContentType } from 'app-shared/enums/LibraryContentType';
+import type { LibraryResourceType } from 'app-shared/enums/LibraryResourceType';
 
 export const useGetAvailableCodeListsFromOrgQuery = (
   org: string,
-  contentType: LibraryContentType,
+  contentType: LibraryResourceType,
 ): UseQueryResult<string[], Error> => {
   const { getAvailableResourcesFromOrg } = useServicesContext();
   return useQuery<string[]>({

--- a/frontend/packages/shared/src/api/paths.js
+++ b/frontend/packages/shared/src/api/paths.js
@@ -55,7 +55,7 @@ export const optionListUploadPath = (org, app) => `${basePath}/${org}/${app}/opt
 export const importCodeListFromOrgPath = (org, app, codeListId) => `${basePath}/${org}/${app}/options/import/${codeListId}`; // Post
 export const ruleConfigPath = (org, app, layoutSetName) => `${basePath}/${org}/${app}/app-development/rule-config?${s({ layoutSetName })}`; // Get, Post
 export const appMetadataModelIdsPath = (org, app, onlyUnReferenced) => `${basePath}/${org}/${app}/app-development/model-ids?${s({ onlyUnReferenced })}`; // Get
-export const availableResourcesInOrgLibraryPath = (org, resourceType) => `${basePath}/${org}/resource/${resourceType}`; // Get
+export const availableResourcesInOrgLibraryPath = (org, resourceType) => `${basePath}/${org}/resources/${resourceType}`; // Get
 export const dataModelMetadataPath = (org, app, layoutSetName, dataModelName) => `${basePath}/${org}/${app}/app-development/model-metadata?${s({ layoutSetName })}&${s({ dataModelName })}`; // Get
 export const layoutNamesPath = (org, app) => `${basePath}/${org}/${app}/app-development/layout-names`; // Get
 export const layoutSetsPath = (org, app) => `${basePath}/${org}/${app}/app-development/layout-sets`; // Get

--- a/frontend/packages/shared/src/api/paths.js
+++ b/frontend/packages/shared/src/api/paths.js
@@ -55,7 +55,7 @@ export const optionListUploadPath = (org, app) => `${basePath}/${org}/${app}/opt
 export const importCodeListFromOrgPath = (org, app, codeListId) => `${basePath}/${org}/${app}/options/import/${codeListId}`; // Post
 export const ruleConfigPath = (org, app, layoutSetName) => `${basePath}/${org}/${app}/app-development/rule-config?${s({ layoutSetName })}`; // Get, Post
 export const appMetadataModelIdsPath = (org, app, onlyUnReferenced) => `${basePath}/${org}/${app}/app-development/model-ids?${s({ onlyUnReferenced })}`; // Get
-export const availableResourcesInOrgLibraryPath = (org, contentType) => `${basePath}/${org}/content/${contentType}`; // Get
+export const availableResourcesInOrgLibraryPath = (org, resourceType) => `${basePath}/${org}/resource/${resourceType}`; // Get
 export const dataModelMetadataPath = (org, app, layoutSetName, dataModelName) => `${basePath}/${org}/${app}/app-development/model-metadata?${s({ layoutSetName })}&${s({ dataModelName })}`; // Get
 export const layoutNamesPath = (org, app) => `${basePath}/${org}/${app}/app-development/layout-names`; // Get
 export const layoutSetsPath = (org, app) => `${basePath}/${org}/${app}/app-development/layout-sets`; // Get

--- a/frontend/packages/shared/src/api/queries.ts
+++ b/frontend/packages/shared/src/api/queries.ts
@@ -107,7 +107,7 @@ import type { DataType } from '../types/DataType';
 import type { CodeListsResponse } from '../types/api/CodeListsResponse';
 import type { PagesModel } from '../types/api/dto/PagesModel';
 import type { TaskNavigationGroup } from 'app-shared/types/api/dto/TaskNavigationGroup';
-import type { LibraryContentType } from 'app-shared/enums/LibraryContentType';
+import type { LibraryResourceType } from 'app-shared/enums/LibraryResourceType';
 
 export const getIsLoggedInWithAnsattporten = () => get<{ isLoggedIn: boolean }>(authStatusAnsattporten());
 export const getMaskinportenScopes = (org: string, app: string) => get<MaskinportenScopes>(availableMaskinportenScopesPath(org, app));
@@ -137,7 +137,7 @@ export const getOptionList = (owner: string, app: string, optionsListId: string)
 export const getOptionLists = (owner: string, app: string) => get<OptionListsResponse>(optionListsPath(owner, app));
 export const getOptionListsReferences = (owner: string, app: string) => get<OptionListReferences>(optionListReferencesPath(owner, app));
 export const getOptionListIds = (owner: string, app: string) => get<string[]>(optionListIdsPath(owner, app));
-export const getAvailableResourcesFromOrg = (owner: string, contentType: LibraryContentType) => get<string[]>(availableResourcesInOrgLibraryPath(owner, contentType));
+export const getAvailableResourcesFromOrg = (owner: string, resourceType: LibraryResourceType) => get<string[]>(availableResourcesInOrgLibraryPath(owner, resourceType));
 
 export const getOrgList = () => get<OrgList>(orgListUrl());
 export const getOrganizations = () => get<Organization[]>(orgsListPath());

--- a/frontend/packages/shared/src/enums/LibraryResourceType.ts
+++ b/frontend/packages/shared/src/enums/LibraryResourceType.ts
@@ -1,4 +1,4 @@
-export enum LibraryContentType {
+export enum LibraryResourceType {
   CodeList = 'codeList',
   TextResource = 'textResource',
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When working with a different PR, I noticed that renaming `content` to `resource` made more sense. 
The term `resource` gives more specific meaning when used in method names like `CreateResourceList` and `GetResourceList`.

This is a pure refactoring, split out from PR https://github.com/Altinn/altinn-studio/pull/15277.

## Related Issue(s)

- #15234 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done
- [x] Relevant automated test updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated terminology from "content" to "resource" across organization library features for clearer user context.
  - Renamed enums, API endpoints, and parameters to align with the "resource" naming convention.
- **Tests**
  - Updated test names and parameters to reflect the revised "resource" terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->