### PR TITLE
refactor: Update state in StudioCodeListEditor regardless of validation

### DIFF
--- a/frontend/libs/studio-components-legacy/src/components/StudioCodelistEditor/StudioCodeListEditor.tsx
+++ b/frontend/libs/studio-components-legacy/src/components/StudioCodelistEditor/StudioCodeListEditor.tsx
@@ -104,11 +104,11 @@ function StatefulCodeListEditor({
 
   const handleChange = useCallback(
     (newCodeList: CodeList) => {
+      dispatch({
+        type: ReducerActionType.SetCodeList,
+        codeList: newCodeList,
+      });
       if (isCodeListValid(newCodeList)) {
-        dispatch({
-          type: ReducerActionType.SetCodeList,
-          codeList: newCodeList,
-        });
         onChange?.(newCodeList);
       } else {
         onInvalid?.();


### PR DESCRIPTION
## Description
Fix state management in StudioCodeListEditor.
The `handleChange` function was changed when the `useReducer` was introducted and with it came this flaw.

## Related Issue(s)
- PR itself

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
