### PR TITLE
refactor: Use new props for StudioCodeListEditor in Library (2)

### DIFF
--- a/frontend/libs/studio-components-legacy/src/components/StudioCodelistEditor/index.ts
+++ b/frontend/libs/studio-components-legacy/src/components/StudioCodelistEditor/index.ts
@@ -3,5 +3,5 @@ export type { CodeListEditorTexts } from './types/CodeListEditorTexts';
 export type { CodeListItem } from './types/CodeListItem';
 export type { CodeListItemTextProperty } from './types/CodeListItemTextProperty';
 export type { CodeListItemValue } from './types/CodeListItemValue';
-export type { StudioCodeListEditorProps } from './StudioCodeListEditor';
+export type { StudioCodeListEditorProps, CreateTextResourceArgs } from './StudioCodeListEditor';
 export { StudioCodeListEditor } from './StudioCodeListEditor';

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/EditCodeList/EditCodeList.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/EditCodeList/EditCodeList.tsx
@@ -1,4 +1,9 @@
-import type { CodeList, CodeListEditorTexts, TextResource } from '@studio/components-legacy';
+import type {
+  CodeList,
+  CodeListEditorTexts,
+  TextResource,
+  CreateTextResourceArgs,
+} from '@studio/components-legacy';
 import {
   StudioDeleteButton,
   StudioModal,
@@ -13,9 +18,9 @@ import { useCodeListEditorTexts } from '../../hooks/useCodeListEditorTexts';
 import { EyeIcon, KeyVerticalIcon } from '@studio/icons';
 import { ArrayUtils, FileNameUtils } from '@studio/pure-functions';
 import { useInputCodeListNameErrorMessage } from '../../hooks/useInputCodeListNameErrorMessage';
-import classes from './EditCodeList.module.css';
 import type { CodeListIdSource } from '../../types/CodeListReference';
 import { CodeListUsages } from './CodeListUsages/CodeListUsages';
+import classes from './EditCodeList.module.css';
 
 export type EditCodeListProps = {
   codeList: CodeList;
@@ -42,12 +47,24 @@ export function EditCodeList({
 }: EditCodeListProps): React.ReactElement {
   const editorTexts: CodeListEditorTexts = useCodeListEditorTexts();
 
-  const handleCodeListChange = (updatedCodeList: CodeList): void => {
+  const handleUpdateCodeList = (updatedCodeList: CodeList): void => {
     const updatedCodeListWithMetadata = updateCodeListWithMetadata(
       { title: codeListTitle, codeList: codeList },
       updatedCodeList,
     );
     onUpdateCodeList(updatedCodeListWithMetadata);
+  };
+
+  const handleUpdateTextResource = (newTextResource: TextResource): void => {
+    onBlurTextResource && onBlurTextResource(newTextResource);
+  };
+
+  const handleCreateTextResource = ({
+    codeList: newCodeList,
+    textResource: newTextResource,
+  }: CreateTextResourceArgs): void => {
+    handleUpdateCodeList(newCodeList);
+    onBlurTextResource && onBlurTextResource(newTextResource);
   };
 
   const handleDeleteCodeList = (): void => onDeleteCodeList(codeListTitle);
@@ -65,9 +82,9 @@ export function EditCodeList({
       />
       <StudioCodeListEditor
         codeList={codeList}
-        onAddOrDeleteItem={handleCodeListChange}
-        onBlurAny={handleCodeListChange}
-        onBlurTextResource={onBlurTextResource}
+        onCreateTextResource={handleCreateTextResource}
+        onUpdateTextResource={handleUpdateTextResource}
+        onUpdateCodeList={handleUpdateCodeList}
         texts={editorTexts}
         textResources={textResources}
       />


### PR DESCRIPTION
## Description
New props for easier management of when to update both the code list and text resources have been made in these 2 PRs:
- #15276
- #15219

This PR takes use of the new props and removes the usage of the old props, for both Org and App Library.

## Related Issue
- #15047

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
