### PR TITLE
feat: Remove feature flag edit cards

### DIFF
--- a/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/ConfigContent.tsx
+++ b/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/ConfigContent.tsx
@@ -18,7 +18,6 @@ import { StudioModeler } from '../../../utils/bpmnModeler/StudioModeler';
 import { RecommendedActionChangeName } from './EditLayoutSetNameRecommendedAction/RecommendedActionChangeName';
 import { ConfigContentContainer } from './ConfigContentContainer';
 import { EditLayoutSetName } from '@altinn/process-editor/components/ConfigPanel/ConfigContent/EditLayoutSetName';
-import { FeatureFlag, shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
 
 export const ConfigContent = (): React.ReactElement => {
   const { t } = useTranslation();
@@ -38,10 +37,6 @@ export const ConfigContent = (): React.ReactElement => {
   const isFirstSigningTask = tasks
     .filter((item) => item.businessObject.extensionElements?.values[0]?.taskType === 'signing')
     .some((item, index) => item.id === bpmnDetails.id && index === 0);
-
-  const isTaskNavigationEditCardsEnabled = shouldDisplayFeature(
-    FeatureFlag.TaskNavigationEditCards,
-  );
 
   if (shouldDisplayAction(bpmnDetails.id)) {
     return (
@@ -72,8 +67,7 @@ export const ConfigContent = (): React.ReactElement => {
           </>
         )}
         <Accordion color='neutral'>
-          {!isTaskNavigationEditCardsEnabled && taskHasConnectedLayoutSet && (
-            /*We just hide the accordion for now, It will be removed when we remove featureFlags*/
+          {taskHasConnectedLayoutSet && (
             <Accordion.Item>
               <Accordion.Header>
                 {t('process_editor.configuration_panel_design_title')}

--- a/frontend/packages/shared/src/utils/featureToggleUtils.test.ts
+++ b/frontend/packages/shared/src/utils/featureToggleUtils.test.ts
@@ -89,16 +89,6 @@ describe('featureToggle url', () => {
     window.history.pushState({}, 'PageUrl', '/?featureFlags=demo');
     expect(shouldDisplayFeature(FeatureFlag.TaskNavigationPageGroups)).toBeFalsy();
   });
-
-  it('should return true if TaskNavigationEditCards is enabled in the url', () => {
-    window.history.pushState({}, 'PageUrl', '/?featureFlags=taskNavigationEditCards');
-    expect(shouldDisplayFeature(FeatureFlag.TaskNavigationEditCards)).toBeTruthy();
-  });
-
-  it('should return false if TaskNavigationEditCards is not enabled in the url', () => {
-    window.history.pushState({}, 'PageUrl', '/?featureFlags=demo');
-    expect(shouldDisplayFeature(FeatureFlag.TaskNavigationEditCards)).toBeFalsy();
-  });
 });
 
 describe('addFeatureToLocalStorage', () => {

--- a/frontend/packages/shared/src/utils/featureToggleUtils.ts
+++ b/frontend/packages/shared/src/utils/featureToggleUtils.ts
@@ -13,7 +13,6 @@ export enum FeatureFlag {
   OrgLibrary = 'orgLibrary',
   ShouldOverrideAppLibCheck = 'shouldOverrideAppLibCheck',
   TaskNavigationPageGroups = 'taskNavigationPageGroups',
-  TaskNavigationEditCards = 'taskNavigationEditCards',
   TaskNavigationTabNav = 'taskNavigationTabNav',
 }
 

--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.test.tsx
@@ -6,16 +6,12 @@ import { screen } from '@testing-library/react';
 import { app, org, studioIconCardPopoverTrigger } from '@studio/testing/testids';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { renderWithProviders, type ExtendedRenderOptions } from '../../testing/mocks';
-import { typedLocalStorage } from '@studio/pure-functions';
-import { FeatureFlag } from 'app-shared/utils/featureToggleUtils';
 
 describe('taskCard', () => {
   let confirmSpy: jest.SpyInstance;
   beforeAll(() => {
     confirmSpy = jest.spyOn(window, 'confirm');
     confirmSpy.mockImplementation(jest.fn(() => true));
-
-    typedLocalStorage.setItem('featureFlags', FeatureFlag.TaskNavigationEditCards);
   });
 
   afterAll(() => {

--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.tsx
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.tsx
@@ -16,7 +16,6 @@ import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmen
 import { useAppContext } from '../../hooks/useAppContext';
 import { TaskCardEditing } from './TaskCardEditing';
 import classes from './TaskCard.module.css';
-import { FeatureFlag, shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
 
 type TaskCardProps = {
   layoutSetModel: LayoutSetModel;
@@ -27,39 +26,35 @@ export const TaskCard = ({ layoutSetModel }: TaskCardProps) => {
   const { org, app } = useStudioEnvironmentParams();
   const { mutate: deleteLayoutSet } = useDeleteLayoutSetMutation(org, app);
   const { setSelectedFormLayoutSetName } = useAppContext();
-  const editCardsFeatureFlag = shouldDisplayFeature(FeatureFlag.TaskNavigationEditCards);
 
   const taskName = getLayoutSetTypeTranslationKey(layoutSetModel);
   const taskIcon = useLayoutSetIcon(layoutSetModel);
 
   const [editing, setEditing] = useState(false);
 
-  const contextButtons =
-    editCardsFeatureFlag || layoutSetModel.type === 'subform' ? (
-      <>
-        {editCardsFeatureFlag && (
-          <StudioButton
-            variant='tertiary'
-            onClick={(_: MouseEvent<HTMLButtonElement>) => {
-              setEditing(true);
-            }}
-          >
-            <PencilIcon /> {t('ux_editor.task_card.edit')}
-          </StudioButton>
-        )}
-        {layoutSetModel.type === 'subform' && (
-          <StudioDeleteButton
-            variant='tertiary'
-            confirmMessage={t('ux_editor.delete.subform.confirm')}
-            onDelete={() => {
-              deleteLayoutSet({ layoutSetIdToUpdate: layoutSetModel.id });
-            }}
-          >
-            {t('general.delete')}
-          </StudioDeleteButton>
-        )}
-      </>
-    ) : null;
+  const contextButtons = (
+    <>
+      <StudioButton
+        variant='tertiary'
+        onClick={(_: MouseEvent<HTMLButtonElement>) => {
+          setEditing(true);
+        }}
+      >
+        <PencilIcon /> {t('ux_editor.task_card.edit')}
+      </StudioButton>
+      {layoutSetModel.type === 'subform' && (
+        <StudioDeleteButton
+          variant='tertiary'
+          confirmMessage={t('ux_editor.delete.subform.confirm')}
+          onDelete={() => {
+            deleteLayoutSet({ layoutSetIdToUpdate: layoutSetModel.id });
+          }}
+        >
+          {t('general.delete')}
+        </StudioDeleteButton>
+      )}
+    </>
+  );
 
   if (editing) {
     return <TaskCardEditing layoutSetModel={layoutSetModel} onClose={() => setEditing(false)} />;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR removes the feature flag.
We decided to keep Utforming accordion in process page instead of removing it in this deployable iteration: https://github.com/Altinn/altinn-studio/issues/14914

<!--- Describe your changes in detail -->

## Related Issue(s)

- #14918 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The edit button in task navigation is now always visible, regardless of feature flag settings.
  - Accordion items for tasks with connected layout sets are now always shown when applicable.

- **Refactor**
  - Simplified conditional rendering logic by removing feature flag checks related to task navigation editing.

- **Chores**
  - Removed obsolete feature flag and related test cases to streamline feature management and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->