### PR TITLE
feat: Add GetLanguages endpoint in OrgTextController

### DIFF
--- a/backend/src/Designer/Controllers/Organisation/OrgTextController.cs
+++ b/backend/src/Designer/Controllers/Organisation/OrgTextController.cs
@@ -113,4 +113,26 @@ public class OrgTextController : ControllerBase
             return BadRequest($"The text resource, resource.{languageCode}.json, could not be updated.");
         }
     }
+
+    /// <summary>
+    /// Gets all languages available for the given organisation.
+    /// </summary>
+    /// <param name="org">The organisation name</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
+    /// <returns>List of language codes</returns>
+    [HttpGet]
+    [Route("languages")]
+    public ActionResult<List<string>> GetLanguages(string org, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
+
+        List<string> languages = _orgTextsService.GetLanguages(org, developer, cancellationToken);
+
+        if (languages.Count > 0)
+        {
+            return Ok(languages);
+        }
+        return NoContent();
+    }
 }

--- a/backend/src/Designer/Services/Implementation/Organisation/OrgTextsService.cs
+++ b/backend/src/Designer/Services/Implementation/Organisation/OrgTextsService.cs
@@ -88,14 +88,13 @@ public class OrgTextsService : IOrgTextsService
         await altinnOrgGitRepository.SaveText(languageCode, textResourceObject, cancellationToken);
     }
 
+    /// <inheritdoc />
     public async Task<List<string>> GetTextIds(string org, string developer, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        string repo = GetStaticContentRepo(org);
-        AltinnOrgGitRepository altinnOrgGitRepository = _altinnGitRepositoryFactory.GetAltinnOrgGitRepository(org, repo, developer);
 
         List<string> textKeys = [];
-        List<string> languages = altinnOrgGitRepository.GetLanguages();
+        List<string> languages = GetLanguages(org, developer, cancellationToken);
         foreach (string languageCode in languages)
         {
             TextResource textResource = await GetText(org, developer, languageCode, cancellationToken);
@@ -104,6 +103,17 @@ public class OrgTextsService : IOrgTextsService
         }
 
         return textKeys.Distinct().ToList();
+    }
+
+    /// <inheritdoc />
+    public List<string> GetLanguages(string org, string developer, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string repo = GetStaticContentRepo(org);
+        AltinnOrgGitRepository altinnOrgGitRepository = _altinnGitRepositoryFactory.GetAltinnOrgGitRepository(org, repo, developer);
+
+        return altinnOrgGitRepository.GetLanguages();
     }
 
     private static string GetStaticContentRepo(string org)

--- a/backend/src/Designer/Services/Interfaces/Organisation/IOrgTextsService.cs
+++ b/backend/src/Designer/Services/Interfaces/Organisation/IOrgTextsService.cs
@@ -47,4 +47,13 @@ public interface IOrgTextsService
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
     /// <returns></returns>
     public Task<List<string>> GetTextIds(string org, string developer, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets languages based on the text resource file names.
+    /// </summary>
+    /// <param name="org">Organisation</param>
+    /// <param name="developer">Username of developer</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
+    /// <returns></returns>
+    public List<string> GetLanguages(string org, string developer, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Designer/Services/Interfaces/Organisation/IOrgTextsService.cs
+++ b/backend/src/Designer/Services/Interfaces/Organisation/IOrgTextsService.cs
@@ -25,7 +25,6 @@ public interface IOrgTextsService
     /// <param name="textResource">The text resource to be saved</param>
     /// <param name="languageCode">LanguageCode</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    /// <returns></returns>
     public Task SaveText(string org, string developer, TextResource textResource, string languageCode, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -36,7 +35,6 @@ public interface IOrgTextsService
     /// <param name="keysTexts">KeysTexts</param>
     /// <param name="languageCode">LanguageCode</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    /// <returns></returns>
     public Task UpdateTextsForKeys(string org, string developer, Dictionary<string, string> keysTexts, string languageCode, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -45,15 +43,15 @@ public interface IOrgTextsService
     /// <param name="org">Organisation</param>
     /// <param name="developer">Username of developer</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    /// <returns></returns>
+    /// <returns>A list of text IDs.</returns>
     public Task<List<string>> GetTextIds(string org, string developer, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets languages based on the text resource file names.
     /// </summary>
-    /// <param name="org">Organisation</param>
-    /// <param name="developer">Username of developer</param>
+    /// <param name="org">Organisation.</param>
+    /// <param name="developer">Username of developer.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    /// <returns></returns>
+    /// <returns>A list of language codes.</returns>
     public List<string> GetLanguages(string org, string developer, CancellationToken cancellationToken = default);
 }

--- a/backend/tests/Designer.Tests/Controllers/OrgTextController/GetLanguagesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OrgTextController/GetLanguagesTests.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Designer.Tests.Controllers.ApiTests;
+using Designer.Tests.Utils;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Designer.Tests.Controllers.OrgTextController;
+
+public class GetLanguagesTests : DesignerEndpointsTestsBase<GetLanguagesTests>, IClassFixture<WebApplicationFactory<Program>>
+{
+    public GetLanguagesTests(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    private const string DeveloperName = "testUser";
+    private const string OrgName = "ttd";
+
+    [Fact]
+    public async Task GetLanguages_ReturnsOk_WithAllLanguages()
+    {
+        // Arrange
+        const string repoName = "org-content";
+        string targetOrgName = TestDataHelper.GenerateTestOrgName();
+        string targetRepoName = TestDataHelper.GetOrgContentRepoName(targetOrgName);
+        await CopyOrgRepositoryForTest(DeveloperName, OrgName, repoName, targetOrgName, targetRepoName);
+
+        string apiUrl = ApiUrl(targetOrgName);
+        using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, apiUrl);
+
+        // Act
+        using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
+
+        // Assert
+        List<string> languages = await response.Content.ReadAsAsync<List<string>>();
+        Assert.Equal(2, languages.Count);
+        Assert.Contains("nb", languages);
+        Assert.Contains("en", languages);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetLanguages_ReturnsNoContent_WhenThereAreNoLanguages()
+    {
+        // Arrange
+        const string repoName = "org-content-empty";
+        string targetOrgName = TestDataHelper.GenerateTestOrgName();
+        string targetRepoName = TestDataHelper.GetOrgContentRepoName(targetOrgName);
+        await CopyOrgRepositoryForTest(DeveloperName, OrgName, repoName, targetOrgName, targetRepoName);
+
+        string apiUrl = ApiUrl(targetOrgName);
+        using HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, apiUrl);
+
+        // Act
+        using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    private static string ApiUrl(string org) => $"/designer/api/{org}/text/languages";
+}

--- a/backend/tests/Designer.Tests/Controllers/OrgTextController/GetLanguagesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OrgTextController/GetLanguagesTests.cs
@@ -19,7 +19,7 @@ public class GetLanguagesTests : DesignerEndpointsTestsBase<GetLanguagesTests>, 
     private const string OrgName = "ttd";
 
     [Fact]
-    public async Task GetLanguages_ReturnsOk_WithAllLanguages()
+    public async Task GetLanguages_Returns200Ok_WithAllLanguages()
     {
         // Arrange
         const string repoName = "org-content";
@@ -34,15 +34,16 @@ public class GetLanguagesTests : DesignerEndpointsTestsBase<GetLanguagesTests>, 
         using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
 
         // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
         List<string> languages = await response.Content.ReadAsAsync<List<string>>();
         Assert.Equal(2, languages.Count);
         Assert.Contains("nb", languages);
         Assert.Contains("en", languages);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
-    public async Task GetLanguages_ReturnsNoContent_WhenThereAreNoLanguages()
+    public async Task GetLanguages_Returns204NoContent_WhenThereAreNoLanguages()
     {
         // Arrange
         const string repoName = "org-content-empty";


### PR DESCRIPTION
## Description
**Changes**
- Introduces a new GET endpoint `/designer/api/{org}/text/languages`:
  - Returns a list of language codes based on an organisation's text resource files.
  - Returns `204 No Content` if there are no text resource files.
- Adds new `GetLanguages` method to `IOrgTextsService`.
- Reuses existing `GetLanguages` method from `AltinnOrgGitRepository`.
- Includes new tests for validation.

## Related Issue(s)

- Closes #15163 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint to retrieve available language codes for an organisation’s text resources.

- **Tests**
  - Introduced new tests to verify the correct behavior of the languages retrieval endpoint, including scenarios with and without available languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->