### PR TITLE
feat: Extend the GET endpoint for task navigation to include the total number of pages

### DIFF
--- a/backend/src/Designer/Controllers/TaskNavigationController.cs
+++ b/backend/src/Designer/Controllers/TaskNavigationController.cs
@@ -40,11 +40,10 @@ namespace Altinn.Studio.Designer.Controllers
             IEnumerable<TaskNavigationGroup> taskNavigationGroupList = await taskNavigationService.GetTaskNavigation(editingContext, cancellationToken);
             IEnumerable<App.Core.Internal.Process.Elements.ProcessTask> tasks = taskNavigationService.GetTasks(editingContext, cancellationToken);
 
+            LayoutSets layoutSets = await appDevelopmentService.GetLayoutSets(editingContext, cancellationToken);
             IEnumerable<TaskNavigationGroupDto> taskNavigationGroupDto = await Task.WhenAll(taskNavigationGroupList.Select(async taskNavigationGroup =>
             {
                 TaskNavigationGroupDto taskNavigationGroupDto = taskNavigationGroup.ToDto((taskId) => tasks.FirstOrDefault(task => task.Id == taskId)?.ExtensionElements?.TaskExtension?.TaskType);
-
-                LayoutSets layoutSets = await appDevelopmentService.GetLayoutSets(editingContext, cancellationToken);
                 if (taskNavigationGroupDto.TaskId != null)
                 {
                     LayoutSetConfig layoutSet = layoutSets.Sets?.FirstOrDefault(layoutSet => layoutSet.Tasks?.Contains(taskNavigationGroupDto.TaskId) ?? false);

--- a/backend/src/Designer/Controllers/TaskNavigationController.cs
+++ b/backend/src/Designer/Controllers/TaskNavigationController.cs
@@ -21,7 +21,7 @@ namespace Altinn.Studio.Designer.Controllers
     [Authorize]
     [AutoValidateAntiforgeryToken]
     [Route("designer/api/{org}/{app:regex(^(?!datamodels$)[[a-z]][[a-z0-9-]]{{1,28}}[[a-z0-9]]$)}/task-navigation")]
-    public class TaskNavigationController(ITaskNavigationService taskNavigationService) : ControllerBase
+    public class TaskNavigationController(ITaskNavigationService taskNavigationService, IAppDevelopmentService appDevelopmentService, ILayoutService layoutService) : ControllerBase
     {
         /// <summary>
         /// Get task navigation
@@ -39,7 +39,29 @@ namespace Altinn.Studio.Designer.Controllers
 
             IEnumerable<TaskNavigationGroup> taskNavigationGroupList = await taskNavigationService.GetTaskNavigation(editingContext, cancellationToken);
             IEnumerable<App.Core.Internal.Process.Elements.ProcessTask> tasks = taskNavigationService.GetTasks(editingContext, cancellationToken);
-            IEnumerable<TaskNavigationGroupDto> taskNavigationGroupDto = taskNavigationGroupList.Select(taskNavigationGroup => taskNavigationGroup.ToDto((taskId) => tasks.FirstOrDefault(task => task.Id == taskId)?.ExtensionElements?.TaskExtension?.TaskType));
+
+            IEnumerable<TaskNavigationGroupDto> taskNavigationGroupDto = await Task.WhenAll(taskNavigationGroupList.Select(async taskNavigationGroup =>
+            {
+                TaskNavigationGroupDto taskNavigationGroupDto = taskNavigationGroup.ToDto((taskId) => tasks.FirstOrDefault(task => task.Id == taskId)?.ExtensionElements?.TaskExtension?.TaskType);
+
+                LayoutSets layoutSets = await appDevelopmentService.GetLayoutSets(editingContext, cancellationToken);
+                if (taskNavigationGroupDto.TaskId != null)
+                {
+                    LayoutSetConfig layoutSet = layoutSets.Sets?.FirstOrDefault(layoutSet => layoutSet.Tasks?.Contains(taskNavigationGroupDto.TaskId) ?? false);
+                    if (layoutSet != null)
+                    {
+                        string layoutSetId = layoutSet?.Id;
+                        LayoutSettings layoutSettings = await layoutService.GetLayoutSettings(
+                            editingContext,
+                            layoutSetId
+                        );
+                        PagesDto pages = PagesDto.From(layoutSettings);
+                        taskNavigationGroupDto.PageCount = pages.Groups != null ? pages.Groups.Sum(group => group.Pages.Count) : pages.Pages.Count;
+                    }
+                }
+
+                return taskNavigationGroupDto;
+            }));
 
             return Ok(taskNavigationGroupDto);
         }

--- a/backend/src/Designer/Models/Dto/TaskNavigationGroupDto.cs
+++ b/backend/src/Designer/Models/Dto/TaskNavigationGroupDto.cs
@@ -17,5 +17,6 @@ public class TaskNavigationGroupDto
     public string Name { get; set; }
 
     [JsonPropertyName("pageCount")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int PageCount { get; set; }
 }

--- a/backend/src/Designer/Models/Dto/TaskNavigationGroupDto.cs
+++ b/backend/src/Designer/Models/Dto/TaskNavigationGroupDto.cs
@@ -15,4 +15,7 @@ public class TaskNavigationGroupDto
     [JsonPropertyName("name")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string Name { get; set; }
+
+    [JsonPropertyName("pageCount")]
+    public int PageCount { get; set; }
 }

--- a/backend/tests/Designer.Tests/Controllers/TaskNavigationController/GetTaskNavigationTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/TaskNavigationController/GetTaskNavigationTests.cs
@@ -33,7 +33,8 @@ public class GetTaskNavigationTests(WebApplicationFactory<Program> factory) : De
             {
                 TaskId = "Task_1",
                 TaskType = "data",
-                Name = "tasks.form"
+                Name = "tasks.form",
+                PageCount = 12
             },
             new ()
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Extend the GET endpoint for task navigation to include the total number of pages

## Related Issue(s)

- #15090

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Task navigation groups now display a page count, providing users with information on the total number of pages associated with each group.

- **Bug Fixes**
  - Improved accuracy and completeness of task navigation details by including page count information.

- **Tests**
  - Updated tests to verify the presence and correctness of the new page count property in task navigation groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->