### PR TITLE
fix: Fix navigation bug when navigating to Gitea from Dashboard using small menu

### DIFF
--- a/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.test.tsx
+++ b/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.test.tsx
@@ -8,8 +8,10 @@ import { HeaderContext, type HeaderContextProps } from '../../../../../context/H
 import { MockServicesContextWrapper } from '../../../../../dashboardTestUtils';
 import { headerContextValueMock } from '../../../../../testing/headerContextMock';
 
+const origin: string = window.location.origin;
 const menuItemName: string = 'testMenuItem';
 const menuItemLink: string = '/test-path';
+const path: string = `${origin}${menuItemLink}`;
 const mockMenuItem: NavigationMenuItem = {
   itemName: menuItemName,
   action: {
@@ -35,19 +37,7 @@ describe('SmallHeaderMenuItem', () => {
       name: textMock(menuItemName),
     });
     expect(linkElement).toBeInTheDocument();
-    expect(linkElement).toHaveAttribute('href', menuItemLink);
-  });
-
-  it('should add "active" class when the current route matches the menuItem href', () => {
-    const initialEntries = `${menuItemLink}/ttd`;
-    renderSmallHeaderMenuItem({
-      routerInitialEntries: [initialEntries],
-    });
-
-    const linkElement = screen.getByRole('menuitem', {
-      name: textMock(menuItemName),
-    });
-    expect(linkElement).toHaveClass('active');
+    expect(linkElement).toHaveAttribute('href', path);
   });
 
   it('should call onClick when the NavLink is clicked', async () => {

--- a/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.tsx
+++ b/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.tsx
@@ -1,10 +1,9 @@
 import React, { type ReactElement } from 'react';
 import classes from './SmallHeaderMenuItem.module.css';
-import { useLocation } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { DropdownMenu } from '@digdir/designsystemet-react';
 import type { NavigationMenuItem } from '../../../../../types/NavigationMenuItem';
-import { UrlUtils } from '@studio/pure-functions';
 
 export type SmallHeaderMenuItemProps = {
   menuItem: NavigationMenuItem;
@@ -16,8 +15,7 @@ export const SmallHeaderMenuItem = ({
   onClick,
 }: SmallHeaderMenuItemProps): ReactElement => {
   const { t } = useTranslation();
-  const location = useLocation();
-  const currentRoutePath: string = UrlUtils.extractSecondLastRouterParam(location.pathname);
+  const origin = window.location.origin;
 
   if (menuItem.action.type === 'button') {
     const handleClick = () => {
@@ -38,19 +36,19 @@ export const SmallHeaderMenuItem = ({
     );
   }
 
-  const linkItemClassName: string =
-    UrlUtils.extractLastRouterParam(menuItem.action.href) === currentRoutePath
-      ? classes.active
-      : '';
-
   const linkTarget: string = menuItem.action.openInNewTab ? '_blank' : '';
   const linkRel: string = menuItem.action.openInNewTab ? 'noopener noreferrer' : '';
 
   return (
-    <DropdownMenu.Item key={menuItem.itemName} asChild className={linkItemClassName}>
-      <a href={menuItem.action.href} onClick={onClick} target={linkTarget} rel={linkRel}>
+    <DropdownMenu.Item key={menuItem.itemName} asChild>
+      <NavLink
+        to={`${origin}${menuItem.action.href}`}
+        onClick={onClick}
+        target={linkTarget}
+        rel={linkRel}
+      >
         {t(menuItem.itemName)}
-      </a>
+      </NavLink>
     </DropdownMenu.Item>
   );
 };

--- a/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.tsx
+++ b/frontend/dashboard/pages/PageLayout/DashboardHeader/SmallHeaderMenu/SmallHeaderMenuItem/SmallHeaderMenuItem.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactElement } from 'react';
 import classes from './SmallHeaderMenuItem.module.css';
-import { NavLink, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { DropdownMenu } from '@digdir/designsystemet-react';
 import type { NavigationMenuItem } from '../../../../../types/NavigationMenuItem';
@@ -48,9 +48,9 @@ export const SmallHeaderMenuItem = ({
 
   return (
     <DropdownMenu.Item key={menuItem.itemName} asChild className={linkItemClassName}>
-      <NavLink to={menuItem.action.href} onClick={onClick} target={linkTarget} rel={linkRel}>
+      <a href={menuItem.action.href} onClick={onClick} target={linkTarget} rel={linkRel}>
         {t(menuItem.itemName)}
-      </NavLink>
+      </a>
     </DropdownMenu.Item>
   );
 };


### PR DESCRIPTION
## Description
- There was a problem that when you clicked on `Gå til Gitea` in the small dashboard menu, the navigation did not work. This has been fixed by replacing the `NavLink` with an `a` element. 

#### Before

https://github.com/user-attachments/assets/b7256e4e-4f1a-4865-9455-0920a20714bc



#### After

https://github.com/user-attachments/assets/78cbfa18-71e0-4adb-8a1d-f9f8e515c722


## Related Issue(s)
- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated navigation in menu items from client-side routing to standard hyperlink navigation for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->