### PR TITLE
test: Establish proper route mocking in OptionListEditor tests

### DIFF
--- a/frontend/packages/shared/src/hooks/useStudioEnvironmentParams.ts
+++ b/frontend/packages/shared/src/hooks/useStudioEnvironmentParams.ts
@@ -1,10 +1,6 @@
 import { useParams } from 'react-router-dom';
 import type { AppRouteParams } from 'app-shared/types/AppRouteParams';
 
-/**
- * Retrieves the org and app names from the URL.
- * @returns {StudioUrlParams} The org and app names.
- */
 export const useStudioEnvironmentParams = (): AppRouteParams => {
   const { org, app } = useParams<Partial<AppRouteParams>>();
   return { org, app };

--- a/frontend/packages/shared/src/hooks/useStudioEnvironmentParams.ts
+++ b/frontend/packages/shared/src/hooks/useStudioEnvironmentParams.ts
@@ -1,15 +1,11 @@
 import { useParams } from 'react-router-dom';
-
-interface StudioEnvironmentParams {
-  org: string;
-  app: string;
-}
+import type { AppRouteParams } from 'app-shared/types/AppRouteParams';
 
 /**
  * Retrieves the org and app names from the URL.
  * @returns {StudioUrlParams} The org and app names.
  */
-export const useStudioEnvironmentParams = (): StudioEnvironmentParams => {
-  const { org, app } = useParams<Partial<StudioEnvironmentParams>>();
+export const useStudioEnvironmentParams = (): AppRouteParams => {
+  const { org, app } = useParams<Partial<AppRouteParams>>();
   return { org, app };
 };

--- a/frontend/packages/shared/src/types/AppRouteParams.ts
+++ b/frontend/packages/shared/src/types/AppRouteParams.ts
@@ -1,0 +1,4 @@
+export type AppRouteParams = {
+  org: string;
+  app: string;
+};

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.test.tsx
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListEditor/OptionListEditor.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { screen, waitForElementToBeRemoved } from '@testing-library/react';
-import { app, org } from '@studio/testing/testids';
 import { componentMocks } from '../../../../../../../testing/componentMocks';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
@@ -13,6 +12,11 @@ import type { QueryClient } from '@tanstack/react-query';
 import type { OptionList } from 'app-shared/types/OptionList';
 import type { OptionListEditorProps } from './OptionListEditor';
 import { OptionListEditor } from './OptionListEditor';
+import type { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
+import type { AppRouteParams } from 'app-shared/types/AppRouteParams';
+
+// Mocks:
+jest.mock('react-router-dom', () => jest.requireActual('react-router-dom')); // Todo: Remove this when we have removed the global mock: https://github.com/Altinn/altinn-studio/issues/14597
 
 // Test data:
 const mockComponent = componentMocks[ComponentType.RadioButtons];
@@ -24,6 +28,9 @@ const optionList: OptionList = [
   { value: 'value 2', label: 'label 2', description: null, helpText: null },
   { value: 'value 3', label: 'label 3', description: null, helpText: null },
 ];
+const app = 'app';
+const org = 'org';
+const appRouteParams: AppRouteParams = { org, app };
 
 describe('OptionListEditor', () => {
   afterEach(jest.clearAllMocks);
@@ -115,27 +122,34 @@ const defaultProps: OptionListEditorProps = {
   handleComponentChange,
 };
 
-function renderOptionListEditor({
-  queries = {},
-  props = {},
-  queryClient = createQueryClientMock(),
-} = {}) {
-  renderWithProviders(<OptionListEditor {...defaultProps} {...props} />, {
-    queries,
-    queryClient,
-  });
-}
-
 function renderOptionListEditorWithData({
-  queries = {},
   props = { component: componentWithOptionsId },
-} = {}) {
-  const queryClient = createQueryClientWithData();
-  renderOptionListEditor({ queries, props, queryClient });
+  queryClient = createQueryClientWithData(),
+  ...rest
+}: RenderOptionListEditorArgs = {}): void {
+  renderOptionListEditor({ props, queryClient, ...rest });
 }
 
 function createQueryClientWithData(): QueryClient {
   const queryClient = createQueryClientMock();
   queryClient.setQueryData([QueryKey.OptionList, org, app, optionListId], optionList);
   return queryClient;
+}
+
+type RenderOptionListEditorArgs = {
+  queries?: Partial<ServicesContextProps>;
+  props?: Partial<OptionListEditorProps>;
+  queryClient?: QueryClient;
+};
+
+function renderOptionListEditor({
+  queries = {},
+  props = {},
+  queryClient = createQueryClientMock(),
+}: RenderOptionListEditorArgs = {}): void {
+  renderWithProviders(<OptionListEditor {...defaultProps} {...props} />, {
+    queries,
+    queryClient,
+    appRouteParams,
+  });
 }

--- a/frontend/packages/ux-editor/src/testing/mocks.tsx
+++ b/frontend/packages/ux-editor/src/testing/mocks.tsx
@@ -1,11 +1,11 @@
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import React from 'react';
 import type { RenderOptions } from '@testing-library/react';
 import { render, renderHook } from '@testing-library/react';
 import type { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
 import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import type { ILayoutSettings } from 'app-shared/types/global';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { PreviewConnectionContextProvider } from 'app-shared/providers/PreviewConnectionContext';
 import { layout1NameMock, layout2NameMock } from './layoutMock';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
@@ -15,6 +15,7 @@ import { AppContext } from '../AppContext';
 import { appContextMock } from './appContextMock';
 import { queryClientMock } from 'app-shared/mocks/queryClientMock';
 import { PreviewContext, type PreviewContextProps } from 'app-development/contexts/PreviewContext';
+import type { AppRouteParams } from 'app-shared/types/AppRouteParams';
 
 export const formLayoutSettingsMock: ILayoutSettings = {
   pages: {
@@ -25,6 +26,11 @@ export const formLayoutSettingsMock: ILayoutSettings = {
 export const textLanguagesMock = ['nb', 'nn', 'en'];
 
 export const optionListIdsMock: string[] = ['test-1', 'test-2'];
+
+const defaultAppRouteParams: AppRouteParams = {
+  org: 'defaultTestOrg',
+  app: 'defaultTestApp',
+};
 
 const defaultPreviewContextProps: PreviewContextProps = {
   shouldReloadPreview: false,
@@ -37,16 +43,18 @@ type WrapperArgs = {
   queryClient: QueryClient;
   appContextProps: Partial<AppContextProps>;
   previewContextProps?: Partial<PreviewContextProps>;
+  appRouteParams?: AppRouteParams;
 };
 
-const wrapper = ({
+function wrapper({
   queries = {},
   queryClient = queryClientMock,
   appContextProps = {},
   previewContextProps = {},
-}: WrapperArgs) => {
-  const renderComponent = (component: ReactNode) => (
-    <MemoryRouter>
+  appRouteParams = defaultAppRouteParams,
+}: WrapperArgs): (component: ReactNode) => ReactElement {
+  const renderComponent = (component: ReactNode): ReactElement => (
+    <AppRouter params={appRouteParams}>
       <ServicesContextProvider {...queriesMock} {...queries} client={queryClient}>
         <PreviewConnectionContextProvider>
           <AppContext.Provider value={{ ...appContextMock, ...appContextProps }}>
@@ -58,16 +66,35 @@ const wrapper = ({
           </AppContext.Provider>
         </PreviewConnectionContextProvider>
       </ServicesContextProvider>
+    </AppRouter>
+  );
+  renderComponent.displayName = 'renderComponent';
+  return renderComponent;
+}
+
+type AppRouterProps = {
+  params: AppRouteParams;
+  children: ReactNode;
+};
+
+function AppRouter({ params: { org, app }, children }: AppRouterProps): ReactElement {
+  const route = `/${org}/${app}`;
+  const path = '/:org/:app';
+  return (
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path={path} element={children} />
+      </Routes>
     </MemoryRouter>
   );
-  return renderComponent;
-};
+}
 
 export interface ExtendedRenderOptions extends Omit<RenderOptions, 'queries'> {
   queries?: Partial<ServicesContextProps>;
   queryClient?: QueryClient;
   appContextProps?: Partial<AppContextProps>;
   previewContextProps?: Partial<PreviewContextProps>;
+  appRouteParams?: AppRouteParams;
 }
 
 export const renderHookWithProviders = (
@@ -77,6 +104,7 @@ export const renderHookWithProviders = (
     queryClient = queryClientMock,
     appContextProps = {},
     previewContextProps = {},
+    appRouteParams = defaultAppRouteParams,
   }: ExtendedRenderOptions = {},
 ) => {
   return renderHook(hook, {
@@ -86,6 +114,7 @@ export const renderHookWithProviders = (
         queryClient,
         appContextProps,
         previewContextProps,
+        appRouteParams,
       })(children),
   });
 };
@@ -97,6 +126,7 @@ export const renderWithProviders = (
     queryClient = queryClientMock,
     appContextProps = {},
     previewContextProps = {},
+    appRouteParams = defaultAppRouteParams,
     ...renderOptions
   }: Partial<ExtendedRenderOptions> = {},
 ) => {
@@ -108,6 +138,7 @@ export const renderWithProviders = (
           queryClient,
           appContextProps,
           previewContextProps,
+          appRouteParams,
         })(children),
       ...renderOptions,
     }),


### PR DESCRIPTION
## Description
Since I need to work with the `OptionListEditor` tests, I need to fix the route mocking in this file. Currently, it gets the `org` and `app` values from the test ID file, although they are not test ID's. It also uses the global `react-router-dom` mock, which is going to be removed in #14597.

This pull request adds a route params option to the `renderWithProviders` function in the `ux-editor` package. This option can be used to mock the `org` and `app` parameters with `MemoryRouter`. It also makes use of this parameter in the `OptionListEditor` test suite. Finally, I have improved the typing in the relevant files, adding some missing return and parameter types and renaming the `StudioEnvironmentParams` type to the more precise `AppRouteParams`.

## Related Issue
- #13739

## Verification
- [x] **Your** code builds clean without any errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized route parameter typing across the codebase for improved consistency and maintainability.
  - Enhanced test utilities to support dynamic routing parameters, allowing more flexible test setups.

- **Tests**
  - Improved type safety and parameter handling in test helper functions.
  - Updated test mocks to better simulate route contexts during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->