### PR TITLE
feat:  Policy subjects

### DIFF
--- a/backend/src/Designer/TypedHttpClients/AltinnAuthorization/AltinnAuthorizationPolicyClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnAuthorization/AltinnAuthorizationPolicyClient.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Services.Interfaces;
+using Microsoft.Extensions.Logging;
 
 namespace Altinn.Studio.Designer.TypedHttpClients.AltinnAuthorization
 {
@@ -15,6 +16,7 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnAuthorization
         private readonly HttpClient _httpClient;
         private readonly PlatformSettings _platformSettings;
         private readonly IEnvironmentsService _environmentsService;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// Constructor
@@ -22,14 +24,17 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnAuthorization
         /// <param name="httpClient">HttpClient</param>
         /// <param name="environmentsService">environmentsService</param>
         /// <param name="options">OptionsMonitor of type PlatformSettings</param>
+        /// <param name="logger">logger</param>
         public AltinnAuthorizationPolicyClient(
             HttpClient httpClient,
             IEnvironmentsService environmentsService,
-            PlatformSettings options)
+            PlatformSettings options,
+             ILogger<AltinnAuthorizationPolicyClient> logger)
         {
             _httpClient = httpClient;
             _platformSettings = options;
             _environmentsService = environmentsService;
+            _logger = logger;
         }
 
         /// <inheritdoc />
@@ -53,13 +58,13 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnAuthorization
             try 
             {
                 Uri refreshSubjectsUri = new($"{platformUri}{_platformSettings.ResourceRegistryUrl}/app_{org}_{app}/policy/subjects?reloadFromXacml=true");
-                using HttpRequestMessage getRequest = new(HttpMethod.Get, uri);
+                using HttpRequestMessage getRequest = new(HttpMethod.Get, refreshSubjectsUri);
                 await _httpClient.SendAsync(getRequest);
             }
             catch (Exception ex)
             {
                 // Log the exception
-                Console.WriteLine($"Error refreshing subjects: {ex.Message}");
+                _logger.LogError($"Error refreshing subjects: {ex.Message}", ex);
             }
         }
     }

--- a/backend/src/Designer/TypedHttpClients/AltinnAuthorization/AltinnAuthorizationPolicyClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnAuthorization/AltinnAuthorizationPolicyClient.cs
@@ -54,8 +54,11 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnAuthorization
 
             await _httpClient.SendAsync(request);
 
-            // After the deploy of the Policy to authoirzation server, we need to refresh the subjects. This is a temporary fix until policy is directly publisehd to resource registry endpoint
-            try 
+            /*
+             * After the deploy of the Policy to authoirzation server, we need to refresh the subjects. 
+             * This is a temporary fix until policy is directly publisehd to resource registry endpoint
+             */
+            try
             {
                 Uri refreshSubjectsUri = new($"{platformUri}{_platformSettings.ResourceRegistryUrl}/app_{org}_{app}/policy/subjects?reloadFromXacml=true");
                 using HttpRequestMessage getRequest = new(HttpMethod.Get, refreshSubjectsUri);

--- a/backend/src/Designer/TypedHttpClients/AltinnAuthorization/AltinnAuthorizationPolicyClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnAuthorization/AltinnAuthorizationPolicyClient.cs
@@ -48,6 +48,19 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnAuthorization
             };
 
             await _httpClient.SendAsync(request);
+
+            // After the deploy of the Policy to authoirzation server, we need to refresh the subjects. This is a temporary fix until policy is directly publisehd to resource registry endpoint
+            try 
+            {
+                Uri refreshSubjectsUri = new($"{platformUri}{_platformSettings.ResourceRegistryUrl}/app_{org}_{app}/policy/subjects?reloadFromXacml=true");
+                using HttpRequestMessage getRequest = new(HttpMethod.Get, uri);
+                await _httpClient.SendAsync(getRequest);
+            }
+            catch (Exception ex)
+            {
+                // Log the exception
+                Console.WriteLine($"Error refreshing subjects: {ex.Message}");
+            }
         }
     }
 }

--- a/backend/src/Designer/TypedHttpClients/AltinnAuthorization/AltinnAuthorizationPolicyClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnAuthorization/AltinnAuthorizationPolicyClient.cs
@@ -55,7 +55,7 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnAuthorization
             await _httpClient.SendAsync(request);
 
             /*
-             * After the deploy of the Policy to authoirzation server, we need to refresh the subjects. 
+             * After the deploy of the Policy to authorization server, we need to refresh the subjects. 
              * This is a temporary fix until policy is directly publisehd to resource registry endpoint
              */
             try

--- a/backend/src/Designer/TypedHttpClients/AltinnAuthorization/AltinnAuthorizationPolicyClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnAuthorization/AltinnAuthorizationPolicyClient.cs
@@ -56,7 +56,7 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnAuthorization
 
             /*
              * After the deploy of the Policy to authorization server, we need to refresh the subjects. 
-             * This is a temporary fix until policy is directly publisehd to resource registry endpoint
+             * This is a temporary fix until policy is directly published to resource registry endpoint
              */
             try
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Vi har en database over hvilke subjects (roller, tilgangspakker osv) som er knyttet til en APP. Dette for enklere oversikt og hurtigere behandinlig i f.eks dialogporten. 

I ressursregisteret importerer vi dette når vi importerer policy dit for ressurser, men apper er fremdeles ikke der og det er naturlig å gjøre dette der. 

Dette er en midlertidlig fix som forteller ressursregisteret at det er publisert en policy

Puttet in try catch for å sikre at man ikke tuller det til

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved policy deployment by automatically refreshing subjects after saving a policy, ensuring updates are reflected without manual intervention. Any errors during the refresh process are handled gracefully and logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->