### PR TITLE
chore: Add missing issue templates from org

### DIFF
--- a/.github/ISSUE_TEMPLATE/analysis.yml
+++ b/.github/ISSUE_TEMPLATE/analysis.yml
@@ -1,0 +1,47 @@
+name: Analysis 🔬
+description: Create a new analysis issue for something big that needs some insight.
+labels: ["kind/analysis", "status/draft"]
+body:          
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Description of the the problem or area that is to be analysed. 
+    validations:
+      required: true
+
+  - type: textarea
+    id: in-scope
+    attributes:
+      label: In scope
+      description: What's in scope for this analysis?
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What's out of scope for this analysis?
+
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: Links to relevant resources, documentation of other issues, UX sketches, technical architecture/requirements.
+
+  - type: textarea
+    id: analysis
+    attributes:
+      label: Analysis
+      description: A description of how the analysis was done, what alternatives were considered etc
+
+  - type: textarea
+    id: conclusion
+    attributes:
+      label: Conclusion
+      description: What have we found out by doing this analysis
+
+  - type: markdown
+    attributes:
+      value: |
+        * Remember to add correct labels.
+        * Remember to link all relevant issues (bugs, user stories, chores).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,36 @@
+name: Bug Report 🐛
+description: File a bug report here
+labels: ["kind/bug", "status/triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report 🤗
+        Make sure there aren't any open/closed issues for this topic 😃
+        
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Description of the bug
+      description: Give us a brief description of what happened and what should have happened
+    validations:
+      required: true
+      
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: |
+        Provide any additional information such as logs, screenshots, likes, scenarios in which the bug occurs so that it facilitates resolving the issue.

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,40 @@
+name: Chore ✅
+description: Create a none user-story issue (chore, tech issue, backend issue)
+labels: ["kind/chore", "status/draft"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please make sure this chore hasn't been already submitted by someone by looking through other open/closed chore issues.
+          
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Give us a brief description of the work that needs to be done.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: Add more details as need like links, architecture sketches etc.
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: Add tasks to be done as part of this issue.
+
+  - type: textarea
+    id: acceptance-criterias
+    attributes:
+      label: Acceptance Criterias
+      description: Define the acceptance criterias that this user story should testet against (if relevant).
+
+  - type: markdown
+    attributes:
+      value: |
+        * Check the [Definition of Ready](https://docs.altinn.studio/community/devops/definition-of-ready/) if you need hints on what to include.
+        * Remember to add the correct labels (status/*, team/*, org/*)

--- a/.github/ISSUE_TEMPLATE/epic-security-requirements-verification.yml
+++ b/.github/ISSUE_TEMPLATE/epic-security-requirements-verification.yml
@@ -1,0 +1,18 @@
+name: Epic security requirements verification 💎✅
+description: This issue type will be used for verification of security requirements in epics
+title: Security requirements verification for (epic name)
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Context
+        The security requirements listed in this issue, are the subset of [OWASP Application Security Verification Standard (ASVS)](https://owasp.org/www-project-application-security-verification-standard/) that need to be verified by product teams upon completion of an epic.
+        ### How to use this issue type:
+        1. In the [plan phase](https://pedia.altinn.cloud/sec/security-architecture/appsec/devsecops/plan/#identify-security-requirements), go to [AltinnPedia](https://pedia.altinn.cloud/sec/security-architecture/governance/policies/asvs/per-team/) to see all security requirements that should be considered per epic.
+        2. Go through the [security requirements](https://pedia.altinn.cloud/sec/security-architecture/governance/policies/asvs/per-team/) and un-check those that aren't relevant for the epic in question. Copy the [markdown representation](https://pedia.altinn.cloud/sec/security-architecture/governance/policies/asvs/per-team/#markdown-for-issues) (bottom of the page) into this Github issue.
+        3. Before the epic is done, verify the relevant (non-struck through) requirements in this Github issue.
+  - type: textarea
+    attributes:
+        label: Verification of security requirements
+        value: |
+                (Copy from textfield in https://pedia.altinn.cloud/sec/security-architecture/governance/policies/asvs/per-team/#markdown-for-issues)

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,41 @@
+name: Epic 💎
+description: Create a new epic (very big user story)
+labels: ["Epic", "status/draft"]
+body:          
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A quick introduction to the user need. Make it clear for who, why and what. 
+    validations:
+      required: true
+
+  - type: textarea
+    id: in-scope
+    attributes:
+      label: In scope
+      description: What's in scope for this epic?
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What's out of scope for this epic?
+
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: Links to relevant resources, documentation of other issues, UX sketches, technical architecture/requirements.
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: Add tasks that are considered user story candidates.
+
+  - type: markdown
+    attributes:
+      value: |
+        * Check the [Definition of Ready](https://docs.altinn.studio/community/devops/definition-of-ready/) if you need hints on what to include.
+        * Remember to link all relevant issues (bugs, user stories, chores)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature Request ✨
+description: Request a new feature or enhancement
+labels: ["kind/feature-request", "status/triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please make sure this feature request hasn't been already submitted by someone by looking through other open/closed issues
+  
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Give us a brief description of the feature or enhancement you would like
+    validations:
+      required: true
+      
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: Give us some additional information on the feature request like proposed solutions, links, screenshots, etc.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,23 @@
+name: Question ❓
+description: Ask a question related to this product.
+labels: ["kind/question", "status/triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Unsure if you've found a bug or have a feature request? Use this template to ask us a question to find out.
+        
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: How can we help you? What do you want to know?
+    validations:
+      required: true
+      
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: |
+        Add any other context, screenshots or code that might help us understanding and answering the question.

--- a/.github/ISSUE_TEMPLATE/test_plan.md
+++ b/.github/ISSUE_TEMPLATE/test_plan.md
@@ -1,0 +1,59 @@
+---
+name: Testplan 🧪
+about: Create a new testplan 
+title: Testplan for <EPIC/FEATURE/CASE>
+labels: kind/testplan
+assignees: ''
+---
+
+| **Delivery**             | <EPIC/FEATURE/CASE>                               |
+|:-------------------------|:--------------------------------------------------|
+| **Roadmap**              |                                                   |
+| **Involved teams**       | @team-...                                         |
+| **Due date**             | xx.xx.xxxx                                        |
+| **Test period**          | xx.xx.xxxx - xx.xx.xxxx                           |
+
+
+## Dependencies
+
+| **Dependency**                     | **Owner**                  | **Status** |
+|:-----------------------------------|:---------------------------|:-----------|
+|                                    |                            |            |
+|                                    |                            |            |
+|                                    |                            |            |
+
+
+## Functional tests
+> ✅ OK, ⚠️ In progress, 🛑 Failed
+> During test period run tests covering business needs and requirements listed here
+
+| Scenario   | Test data | Done by     | Importance | Level  | Status | Comment |
+|------------|-----------|-------------|------------|---------|-------|---------|
+|            |           | @...        | High       |         | ✅     |        |
+|            |           | @...        | Low        |         | 🛑     |        |
+
+
+## Non-functional tests
+
+- Performance tests: Link to runs and documentation when needed
+- Security tests: Link to documentation when needed
+
+
+## Clarifications
+
+| **Question**                     | **Answer**                   | **Date **  |
+|:---------------------------------|:-----------------------------|:-----------|
+|                                  |                              |            |
+|                                  |                              |            |
+
+## ⚠️ Out of scope
+> List discussed functionality out of scope or that might be relevant in a later release
+
+
+## :information_source: Useful links
+
+### Sketches
+### Architecture diagrams
+### Test environment
+### Testd ata
+### Link to milestone


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since we added [a custom user story issue template](https://github.com/Altinn/altinn-studio/blob/main/.github/ISSUE_TEMPLATE/user_story.yml), GitHub now ignores the org-wide templates. To make them available again, we need to copy them into our repo.

<table>
<tr>
<th>BEFORE</th>
<th>AFTER</th>
</tr>
<tr>
<td>

<img width="811" alt="issue-template-before" src="https://github.com/user-attachments/assets/2449b85a-61df-4d7b-a77c-a4b834ba36b4" />

</td>
<td>

<img width="811" alt="issue-template-after" src="https://github.com/user-attachments/assets/15bf0aeb-06ee-4923-abe3-b4d357edc5b4" />

</td>
</tr>
</table>

## Related Issue(s)

- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced multiple GitHub issue templates for streamlined reporting and planning, including templates for analysis, bug reports, chores, epics, feature requests, questions, security requirements verification, and test plans.
  - Each template provides structured fields, automatic labeling, and guidance to improve issue clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->