### PR TITLE
test: add using statement to dispose of test cancellation token

### DIFF
--- a/backend/tests/Designer.Tests/Services/OrgContentServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/OrgContentServiceTests.cs
@@ -118,7 +118,7 @@ public class OrgContentServiceTests
     public async Task GetOrgContentReferences_WithCancellationToken_PassesTokenToServices()
     {
         // Arrange
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         var token = cts.Token;
         var textIds = new List<string> { "text1" };
 


### PR DESCRIPTION
## Description

Added the `using` keyword to the `CancellationTokenSource` declaration. This ensures that the `CancellationTokenSource` object is properly disposed of when it goes out of scope at the end of the test method, even if an exception occurs during the test execution.

This is important because `CancellationTokenSource` implements the `IDisposable` interface, and failing to dispose of it properly can lead to resource leaks, especially when running many tests.

## Related Issue(s)

- #15234 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)