### PR TITLE
fix: make library content utilise full screen width

### DIFF
--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/LibraryBody.module.css
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/LibraryBody.module.css
@@ -1,9 +1,9 @@
 .libraryContent {
   display: grid;
-  grid-template-columns: 2fr 7fr 3fr;
+  grid-template-columns: 2fr 10fr;
   height: 100%;
 }
 
 .component {
-  padding: var(--padding-library) 0 var(--padding-library) var(--padding-library);
+  padding: var(--padding-library);
 }

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/LibraryBody.module.css
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/LibraryBody.module.css
@@ -1,6 +1,6 @@
 .libraryContent {
   display: grid;
-  grid-template-columns: 2fr 10fr;
+  grid-template-columns: 1fr 5fr;
   height: 100%;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After moving the information box from right to center, the CSS grid columns were not adjusted accordingly. This PR fixes that, so that there is more room for editing code lists.

### Before
![before](https://github.com/user-attachments/assets/e06b13d0-5df7-40e2-b27c-660ef6d17c84)

### After
![after](https://github.com/user-attachments/assets/88f1be5b-cf9d-41d7-9cce-e11d62121e56)


## Related Issue(s)

- #15229 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the content library layout to use two columns instead of three, providing more space for the main content area.
  - Simplified padding for components to ensure consistent spacing throughout the library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->