### PR TITLE
feat(page-groups): create layout files when new pages are added to pagegroup

### DIFF
--- a/backend/src/Designer/Services/Implementation/LayoutService.cs
+++ b/backend/src/Designer/Services/Implementation/LayoutService.cs
@@ -256,6 +256,10 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 );
             }
             var createdPages = order.Except(originalOrder).ToList();
+            LayoutSetConfig layoutSetConfig = await appDevelopmentService.GetLayoutSetConfig(
+                editingContext,
+                layoutSetId
+            );
             foreach (string pageId in createdPages)
             {
                 AltinnPageLayout altinnPageLayout = new();
@@ -264,6 +268,15 @@ namespace Altinn.Studio.Designer.Services.Implementation
                     altinnPageLayout = altinnPageLayout.WithNavigationButtons();
                 }
                 await appRepository.CreatePageLayoutFile(layoutSetId, pageId, altinnPageLayout);
+
+                await mediatr.Publish(
+                    new LayoutPageAddedEvent
+                    {
+                        EditingContext = editingContext,
+                        LayoutName = pageId,
+                        LayoutSetConfig = layoutSetConfig,
+                    }
+                );
             }
             originalLayoutSettings.Pages = pagesWithGroups;
             await appRepository.SaveLayoutSettings(layoutSetId, originalLayoutSettings);

--- a/backend/src/Designer/Services/Implementation/LayoutService.cs
+++ b/backend/src/Designer/Services/Implementation/LayoutService.cs
@@ -255,6 +255,16 @@ namespace Altinn.Studio.Designer.Services.Implementation
                     }
                 );
             }
+            var createdPages = order.Except(originalOrder).ToList();
+            foreach (string pageId in createdPages)
+            {
+                AltinnPageLayout altinnPageLayout = new();
+                if (originalOrder.Any())
+                {
+                    altinnPageLayout = altinnPageLayout.WithNavigationButtons();
+                }
+                await appRepository.CreatePageLayoutFile(layoutSetId, pageId, altinnPageLayout);
+            }
             originalLayoutSettings.Pages = pagesWithGroups;
             await appRepository.SaveLayoutSettings(layoutSetId, originalLayoutSettings);
         }

--- a/backend/tests/Designer.Tests/Services/LayoutServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/LayoutServiceTests.cs
@@ -245,16 +245,26 @@ public class LayoutServiceTests
 
         int newGroupCount = (updatedLayoutSettings.Pages as PagesWithGroups).Groups.Count;
         Assert.Equal(originalGroupCount + 1, newGroupCount);
-        foreach (PageDto page in allPages)
+        foreach (
+            string fileContent in allPages.Select(page =>
+                TestDataHelper.GetFileFromRepo(
+                    editingContext.Org,
+                    editingContext.Repo,
+                    editingContext.Developer,
+                    $"App/ui/form/layouts/{page.Id}.json"
+                )
+            )
+        )
         {
-            string fileContent = TestDataHelper.GetFileFromRepo(
-                editingContext.Org,
-                editingContext.Repo,
-                editingContext.Developer,
-                $"App/ui/form/layouts/{page.Id}.json"
-            );
             Assert.NotEqual(string.Empty, fileContent);
         }
+        Assert.Equal(
+            2,
+            mediatr.Invocations.Count(i =>
+                i.Method.Name == nameof(IPublisher.Publish)
+                && i.Arguments[0] is LayoutPageAddedEvent
+            )
+        );
     }
 
     [Fact]

--- a/backend/tests/Designer.Tests/Services/LayoutServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/LayoutServiceTests.cs
@@ -209,6 +209,55 @@ public class LayoutServiceTests
     }
 
     [Fact]
+    public async Task PageGroupAddingPages_ShouldCreateLayouts()
+    {
+        const string repo = "app-with-groups-and-taskNavigation";
+        (
+            AltinnRepoEditingContext editingContext,
+            LayoutService layoutService,
+            Mock<IPublisher> mediatr
+        ) = await PrepareTestForRepo(repo);
+
+        LayoutSettings layoutSettings = await layoutService.GetLayoutSettings(
+            editingContext,
+            "form"
+        );
+
+        PagesDto pagesDto = PagesDto.From(layoutSettings);
+        int originalGroupCount = pagesDto.Groups.Count;
+        List<PageDto> allPages = [.. pagesDto.Groups.SelectMany((group) => group.Pages)];
+        pagesDto.Groups.Add(
+            new GroupDto
+            {
+                Name = "newGroup",
+                Pages = [new() { Id = "newPage" }, new() { Id = "newPage2" }],
+            }
+        );
+        await layoutService.UpdatePageGroups(
+            editingContext,
+            "form",
+            (PagesWithGroups)pagesDto.ToBusiness()
+        );
+        LayoutSettings updatedLayoutSettings = await layoutService.GetLayoutSettings(
+            editingContext,
+            "form"
+        );
+
+        int newGroupCount = (updatedLayoutSettings.Pages as PagesWithGroups).Groups.Count;
+        Assert.Equal(originalGroupCount + 1, newGroupCount);
+        foreach (PageDto page in allPages)
+        {
+            string fileContent = TestDataHelper.GetFileFromRepo(
+                editingContext.Org,
+                editingContext.Repo,
+                editingContext.Developer,
+                $"App/ui/form/layouts/{page.Id}.json"
+            );
+            Assert.NotEqual(string.Empty, fileContent);
+        }
+    }
+
+    [Fact]
     public async Task PageGroupToOrderConversion_ShouldThrowException_IfInvalid()
     {
         const string repo = "app-with-groups-and-taskNavigation";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using the `update page order` endpoint, adding new pages should also create the layout files needed.

## Related Issue(s)

- #14957 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured new pages added to page groups are properly initialized and saved, with corresponding layout files created automatically.

- **Tests**
  - Added a test to verify layout files are correctly created when new pages are introduced within a new page group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->