### PR TITLE
fix: simple type array edge case

### DIFF
--- a/backend/src/DataModeling/Converter/Metadata/JsonSchemaToMetamodelConverter.cs
+++ b/backend/src/DataModeling/Converter/Metadata/JsonSchemaToMetamodelConverter.cs
@@ -36,8 +36,9 @@ namespace Altinn.Studio.DataModeling.Converter.Metadata
 
             public bool XmlText { get; set; }
 
-
             public bool OrderOblivious { get; set; } = false;
+
+            public bool IsArray { get; set; }
 
             public Dictionary<string, Restriction> Restrictions { get; set; } = new();
         }
@@ -321,6 +322,7 @@ namespace Altinn.Studio.DataModeling.Converter.Metadata
 
         private void ProcessArrayType(JsonPointer path, JsonSchema subSchema, SchemaContext context)
         {
+            context.IsArray = true;
             var itemsKeyword = subSchema.GetKeywordOrNull<ItemsKeyword>();
             var singleSchema = itemsKeyword.SingleSchema;
             context.SchemaValueType = SchemaValueType.Array;
@@ -714,7 +716,7 @@ namespace Altinn.Studio.DataModeling.Converter.Metadata
         private static int GetMaxOccurs(JsonSchema subSchema, SchemaContext context)
         {
             int maxOccurs = 1;
-            if (context.SchemaValueType == SchemaValueType.Array)
+            if (context.SchemaValueType == SchemaValueType.Array || context.IsArray)
             {
                 maxOccurs = MAX_MAX_OCCURS;
             }

--- a/backend/tests/DataModeling.Tests/TestDataClasses/CSharpEnd2EndTestData.cs
+++ b/backend/tests/DataModeling.Tests/TestDataClasses/CSharpEnd2EndTestData.cs
@@ -37,6 +37,7 @@ public class CSharpEnd2EndTestData : IEnumerable<object[]>
         yield return ["Model/XmlSchema/Gitea/3430-39615.xsd", "Model/CSharp/Gitea/3430-39615.cs"];
         yield return ["Model/XmlSchema/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.xsd", "Model/CSharp/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.cs"];
         yield return ["Model/XmlSchema/Gitea/dev-nill-test.xsd", "Model/CSharp/Gitea/dev-nill-test.cs"];
+        yield return ["Model/Issue/gh14544/XmlSchema/simple-type-array.xsd", "Model/Issue/gh14544/CSharp/simple-type-array.cs"];
 
         // xs:all test cases
         yield return ["Model/XmlSchema/XsAll/ferdigattest/v4/ferdigattest.xsd", "Model/CSharp/XsAll/ferdigattest/v4/ferdigattest.cs"];

--- a/backend/tests/SharedResources.Tests/SharedResources.Tests.csproj
+++ b/backend/tests/SharedResources.Tests/SharedResources.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <Compile Remove="..\..\..\testdata\Model\CSharp\**" />
+    <Compile Remove="..\..\..\testdata\Model\Issue\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testdata/Model/Issue/gh14544/CSharp/simple-type-array.cs
+++ b/testdata/Model/Issue/gh14544/CSharp/simple-type-array.cs
@@ -1,0 +1,21 @@
+﻿#nullable disable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
+namespace Altinn.App.Models
+{
+    [XmlRoot(ElementName="melding")]
+    public class RootModel
+    {
+        [XmlElement("informasjonstype", Order = 1)]
+        [JsonProperty("informasjonstype")]
+        [JsonPropertyName("informasjonstype")]
+        public List<string> informasjonstype { get; set; }
+
+    }
+}

--- a/testdata/Model/Issue/gh14544/XmlSchema/simple-type-array.xsd
+++ b/testdata/Model/Issue/gh14544/XmlSchema/simple-type-array.xsd
@@ -3,7 +3,7 @@
   <xs:element name="melding" type="RootModel" />
   <xs:complexType name="RootModel">
     <xs:sequence>
-      <xs:element maxOccurs="1" minOccurs="0" name="informasjonstype" type="Informasjonstype" />
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="informasjonstype" type="Informasjonstype"/>
     </xs:sequence>
   </xs:complexType>
   <xs:simpleType name="Informasjonstype">

--- a/testdata/Model/Issue/gh14544/XmlSchema/simple-type-array.xsd
+++ b/testdata/Model/Issue/gh14544/XmlSchema/simple-type-array.xsd
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:altinn="www.altinn.no/infopath-extensions">
+  <xs:element name="melding" type="RootModel" />
+  <xs:complexType name="RootModel">
+    <xs:sequence>
+      <xs:element maxOccurs="1" minOccurs="0" name="informasjonstype" type="Informasjonstype" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Informasjonstype">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix the edge case for simple type ref array.

<!--- Describe your changes in detail -->

## Related Issue(s)

- #14544

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for handling array types in schema conversion, ensuring correct processing of repeated elements.
  - Introduced new test data and model files to validate array handling, including a sample XML schema and corresponding C# model.
- **Tests**
  - Added a new test case to verify correct generation and serialization of array-type fields in models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->