### PR TITLE
feat: frontend pagegroup conversion buttons

### DIFF
--- a/frontend/packages/shared/src/api/mutations.ts
+++ b/frontend/packages/shared/src/api/mutations.ts
@@ -54,6 +54,8 @@ import {
   layoutPagesPath,
   orgTextResourcesPath,
   importCodeListFromOrgPath,
+  layoutConvertToPageGroupsPath,
+  layoutConvertToPageOrderPath,
 } from 'app-shared/api/paths';
 import type { AddLanguagePayload } from 'app-shared/types/api/AddLanguagePayload';
 import type { AddRepoParams } from 'app-shared/types/api';
@@ -148,6 +150,8 @@ export const createPage = (org: string, app: string, layoutSetName: string, payl
 export const deletePage = (org: string, app: string, layoutSetName: string, pageName: string) => del(layoutPagesPath(org, app, layoutSetName, pageName));
 export const modifyPage = (org: string, app: string, layoutSetName: string, pageName: string, payload: PageModel) => put(layoutPagesPath(org, app, layoutSetName, pageName), payload);
 export const changePageOrder = (org: string, app: string, layoutSetName: string, pages: PagesModel) => put(layoutPagesPath(org, app, layoutSetName), pages);
+export const convertToPageGroups = (org: string, app: string, layoutSetName: string) => post(layoutConvertToPageGroupsPath(org, app, layoutSetName));
+export const convertToPageOrder = (org: string, app: string, layoutSetName: string) => post(layoutConvertToPageOrderPath(org, app, layoutSetName));
 
 // Resourceadm
 export const createResource = (org: string, payload: NewResource) => post(resourceCreatePath(org), payload);

--- a/frontend/packages/shared/src/api/paths.js
+++ b/frontend/packages/shared/src/api/paths.js
@@ -66,6 +66,8 @@ export const formLayoutNamePath = (org, app, layoutName, layoutSetName) => `${ba
 export const frontEndSettingsPath = (org, app) => `${basePath}/${org}/${app}/app-development/front-end-settings`; // Get
 export const layoutPath = (org, app, layoutSetName) => `${basePath}/${org}/${app}/layouts/layoutSet/${layoutSetName}`;
 export const layoutPagesPath = (org, app, layoutSetName, pageName) => `${layoutPath(org, app, layoutSetName)}/pages/${pageName ? pageName : ''}`;
+export const layoutConvertToPageGroupsPath = (org, app, layoutSetName) => `${layoutPath(org, app, layoutSetName)}/convert-to-pagegroups/`;
+export const layoutConvertToPageOrderPath = (org, app, layoutSetName) => `${layoutPath(org, app, layoutSetName)}/convert-to-pageorder/`;
 export const taskNavigationGroupPath = (org, app) => `${basePath}/${org}/${app}/task-navigation`; // Get, Post, Put, Delete
 
 // Gitea

--- a/frontend/packages/shared/src/mocks/queriesMock.ts
+++ b/frontend/packages/shared/src/mocks/queriesMock.ts
@@ -281,6 +281,8 @@ export const queriesMock: ServicesContextProps = {
   modifyPage: jest.fn().mockImplementation(() => Promise.resolve()),
   createPage: jest.fn().mockImplementation(() => Promise.resolve()),
   changePageOrder: jest.fn().mockImplementation(() => Promise.resolve()),
+  convertToPageGroups: jest.fn().mockImplementation(() => Promise.resolve()),
+  convertToPageOrder: jest.fn().mockImplementation(() => Promise.resolve()),
 
   // Mutations - Resourceadm
   createResource: jest.fn().mockImplementation(() => Promise.resolve()),

--- a/frontend/packages/ux-editor/src/containers/DesignViewNavigation/DesignViewNavigation.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignViewNavigation/DesignViewNavigation.test.tsx
@@ -1,31 +1,41 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { DesignViewNavigation } from './DesignViewNavigation';
-import { renderWithProviders } from 'app-development/test/mocks';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../testing/mocks';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import type { QueryClient } from '@tanstack/react-query';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import { app, org } from '@studio/testing/testids';
+import { layoutSet1NameMock } from '../../testing/layoutSetsMock';
+import type { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
 
 describe('DesignViewNavigation', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render DesignViewNavigation with correct text', async () => {
-    renderDesignViewNavigation();
+    renderDesignViewNavigation({});
     expect(await screen.findByText(textMock('ux_editor.page_layout_header'))).toBeInTheDocument();
   });
 
   it('should render menu button with correct title', () => {
-    renderDesignViewNavigation();
+    renderDesignViewNavigation({});
     const menuButton = screen.getByTitle(textMock('general.options'));
     expect(menuButton).toBeInTheDocument();
   });
 
   it('should have aria-haspopup attribute set to "menu"', () => {
-    renderDesignViewNavigation();
+    renderDesignViewNavigation({});
     const menuButton = screen.getByRole('button', { name: textMock('general.options') });
     expect(menuButton).toHaveAttribute('aria-haspopup', 'menu');
   });
 
   it('should open dropdown menu when clicking the menu button', async () => {
     const user = userEvent.setup();
-    renderDesignViewNavigation();
+    renderDesignViewNavigation({});
     const menuButton = screen.getByRole('button', { name: textMock('general.options') });
     expect(
       screen.queryByText(textMock('ux_editor.page_layout_perform_another_task')),
@@ -38,7 +48,7 @@ describe('DesignViewNavigation', () => {
 
   it('should close dropdown menu when clicking outside', async () => {
     const user = userEvent.setup();
-    renderDesignViewNavigation();
+    renderDesignViewNavigation({});
     const menuButton = screen.getByRole('button', { name: textMock('general.options') });
     await user.click(menuButton);
     expect(
@@ -49,9 +59,72 @@ describe('DesignViewNavigation', () => {
       screen.queryByText(textMock('ux_editor.page_layout_perform_another_task')),
     ).not.toBeInTheDocument();
   });
+
+  it('should show button to convert to page groups if layout is using page order', async () => {
+    const user = userEvent.setup();
+    renderDesignViewNavigation({});
+    const menuButton = screen.getByRole('button', { name: textMock('general.options') });
+    await user.click(menuButton);
+    expect(
+      screen.getByRole('menuitem', { name: textMock('ux_editor.page_layout_add_group_division') }),
+    ).toBeInTheDocument();
+  });
+
+  it('should call convertToPageGroups when clicking convertion button', async () => {
+    const user = userEvent.setup();
+    const convertToPageGroups = jest.fn();
+    renderDesignViewNavigation({ queries: { convertToPageGroups } });
+    const menuButton = screen.getByRole('button', { name: textMock('general.options') });
+    await user.click(menuButton);
+    await user.click(
+      screen.getByRole('menuitem', { name: textMock('ux_editor.page_layout_add_group_division') }),
+    );
+    expect(convertToPageGroups).toHaveBeenCalledTimes(1);
+    expect(convertToPageGroups).toHaveBeenCalledWith(org, app, layoutSet1NameMock);
+  });
+
+  it('should show button to convert to page order if layout is using page groups', async () => {
+    const user = userEvent.setup();
+    const queryClient = createQueryClientMock();
+    queryClient.setQueryData([QueryKey.Pages, org, app, layoutSet1NameMock], {
+      groups: [{ id: 'Page 1' }],
+    });
+    renderDesignViewNavigation({ queryClient });
+    const menuButton = screen.getByRole('button', { name: textMock('general.options') });
+    await user.click(menuButton);
+    expect(
+      screen.getByRole('menuitem', {
+        name: textMock('ux_editor.page_layout_remove_group_division'),
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should call convertToPageOrder when clicking convertion button', async () => {
+    const user = userEvent.setup();
+    const queryClient = createQueryClientMock();
+    queryClient.setQueryData([QueryKey.Pages, org, app, layoutSet1NameMock], {
+      groups: [{ id: 'Page 1' }],
+    });
+    const convertToPageOrder = jest.fn();
+    renderDesignViewNavigation({ queryClient, queries: { convertToPageOrder } });
+    const menuButton = screen.getByRole('button', { name: textMock('general.options') });
+    await user.click(menuButton);
+    await user.click(
+      screen.getByRole('menuitem', {
+        name: textMock('ux_editor.page_layout_remove_group_division'),
+      }),
+    );
+    expect(convertToPageOrder).toHaveBeenCalledTimes(1);
+    expect(convertToPageOrder).toHaveBeenCalledWith(org, app, layoutSet1NameMock);
+  });
 });
 
-const view = renderWithProviders();
-const renderDesignViewNavigation = () => {
-  return view(<DesignViewNavigation />);
+const renderDesignViewNavigation = ({
+  queries,
+  queryClient,
+}: {
+  queries?: Partial<ServicesContextProps>;
+  queryClient?: QueryClient;
+}) => {
+  return renderWithProviders(<DesignViewNavigation />, { queries, queryClient });
 };

--- a/frontend/packages/ux-editor/src/containers/DesignViewNavigation/DesignViewNavigation.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignViewNavigation/DesignViewNavigation.tsx
@@ -1,13 +1,29 @@
 import React, { useState } from 'react';
 import { StudioButton, StudioSectionHeader } from '@studio/components-legacy';
 import classes from './DesignViewNavigation.module.css';
-import { MenuElipsisVerticalIcon, MinusCircleIcon, PlusCircleIcon } from '@studio/icons';
+import { MenuElipsisVerticalIcon } from '@studio/icons';
 import { DropdownMenu } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
+import { useConvertToPageOrder } from '../../hooks/mutations/useConvertToPageOrder';
+import { useConvertToPageGroups } from '../../hooks/mutations/useConvertToPageGroups';
+import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
+import { useAppContext } from '../../hooks';
+import { usePagesQuery } from '../../hooks/queries/usePagesQuery';
 
 export const DesignViewNavigation = () => {
   const { t } = useTranslation();
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const { org, app } = useStudioEnvironmentParams();
+  const { selectedFormLayoutSetName } = useAppContext();
+  const { mutate: convertToPageOrder } = useConvertToPageOrder(org, app, selectedFormLayoutSetName);
+  const { mutate: convertToPageGroups } = useConvertToPageGroups(
+    org,
+    app,
+    selectedFormLayoutSetName,
+  );
+  const { data: pagesModel } = usePagesQuery(org, app, selectedFormLayoutSetName);
+
+  const isUsingPageGroups = pagesModel?.groups?.length > 0;
 
   return (
     <div data-testid='design-view-navigation'>
@@ -39,14 +55,15 @@ export const DesignViewNavigation = () => {
                   <DropdownMenu.Item onClick={undefined}>
                     {t('ux_editor.page_layout_perform_another_task')}
                   </DropdownMenu.Item>
-                  <DropdownMenu.Item onClick={undefined}>
-                    <MinusCircleIcon />
-                    {t('ux_editor.page_layout_remove_group_division')}
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item onClick={undefined}>
-                    <PlusCircleIcon />
-                    {t('ux_editor.page_layout_add_group_division')}
-                  </DropdownMenu.Item>
+                  {isUsingPageGroups ? (
+                    <DropdownMenu.Item onClick={() => convertToPageOrder()}>
+                      {t('ux_editor.page_layout_remove_group_division')}
+                    </DropdownMenu.Item>
+                  ) : (
+                    <DropdownMenu.Item onClick={() => convertToPageGroups()}>
+                      {t('ux_editor.page_layout_add_group_division')}
+                    </DropdownMenu.Item>
+                  )}
                 </DropdownMenu.Group>
               </DropdownMenu.Content>
             </DropdownMenu>

--- a/frontend/packages/ux-editor/src/hooks/mutations/useConvertToPageGroups.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useConvertToPageGroups.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
+
+import { QueryKey } from 'app-shared/types/QueryKey';
+
+export const useConvertToPageGroups = (org: string, app: string, layoutSetName: string) => {
+  const queryClient = useQueryClient();
+  const { convertToPageGroups } = useServicesContext();
+
+  return useMutation({
+    mutationFn: () => convertToPageGroups(org, app, layoutSetName),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QueryKey.Pages, org, app, layoutSetName] });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.FormLayouts, org, app, layoutSetName] });
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.FormLayoutSettings, org, app, layoutSetName],
+      });
+    },
+  });
+};

--- a/frontend/packages/ux-editor/src/hooks/mutations/useConvertToPageOrder.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useConvertToPageOrder.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
+
+import { QueryKey } from 'app-shared/types/QueryKey';
+
+export const useConvertToPageOrder = (org: string, app: string, layoutSetName: string) => {
+  const queryClient = useQueryClient();
+  const { convertToPageOrder } = useServicesContext();
+
+  return useMutation({
+    mutationFn: () => convertToPageOrder(org, app, layoutSetName),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QueryKey.Pages, org, app, layoutSetName] });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.FormLayouts, org, app, layoutSetName] });
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.FormLayoutSettings, org, app, layoutSetName],
+      });
+    },
+  });
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Makes the conversion buttons only display when current configuration(pageorder/pagegroups) is vaid.
* Added mutations for conversion calls to backend and added to the buttons.

https://github.com/user-attachments/assets/391ea525-830c-4263-9452-6f248810eece

## Related Issue(s)

- #{issue number}

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to convert layout pages between "page order" and "page groups" directly from the navigation menu.
  - The navigation menu now dynamically displays options to add or remove group divisions based on the current layout state.
- **Bug Fixes**
  - Improved cache refreshing to ensure layout changes are accurately reflected after conversion actions.
- **Tests**
  - Enhanced test coverage for the navigation menu, including new scenarios for converting between page order and page groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->