### PR TITLE
chore: Move `StudioLabelWrapper` to new `@studio/components`

### DIFF
--- a/frontend/libs/studio-components-legacy/src/components/StudioLabelWrapper/StudioLabelWrapper.tsx
+++ b/frontend/libs/studio-components-legacy/src/components/StudioLabelWrapper/StudioLabelWrapper.tsx
@@ -7,6 +7,9 @@ export type StudioLabelWrapperProps = HTMLAttributes<HTMLSpanElement> & {
   withAsterisk?: boolean;
 };
 
+/**
+ * @deprecated use `StudioLabelWrapper` from `@studio/components` instead
+ */
 const StudioLabelWrapper = forwardRef<HTMLSpanElement, StudioLabelWrapperProps>(
   ({ children, className, withAsterisk, ...rest }, ref) => {
     const finalClassName = cn(

--- a/frontend/libs/studio-components/src/components/StudioLabelWrapper/StudioLabelWrapper.mdx
+++ b/frontend/libs/studio-components/src/components/StudioLabelWrapper/StudioLabelWrapper.mdx
@@ -1,0 +1,14 @@
+import { Canvas, Meta } from '@storybook/blocks';
+import { Heading, Paragraph } from '@digdir/designsystemet-react';
+import * as StudioLabelWrapperStories from './StudioLabelWrapper.stories';
+
+<Meta of={StudioLabelWrapperStories} />
+
+<Heading level={1} size='small'>
+  StudioLabelWrapper
+</Heading>
+<Paragraph>
+  StudioLabelWrapper is a wrapper component to add asterisk to label if required.
+</Paragraph>
+
+<Canvas of={StudioLabelWrapperStories.Preview} />

--- a/frontend/libs/studio-components/src/components/StudioLabelWrapper/StudioLabelWrapper.module.css
+++ b/frontend/libs/studio-components/src/components/StudioLabelWrapper/StudioLabelWrapper.module.css
@@ -1,0 +1,5 @@
+.studioLabelWrapper.withAsterisk::after {
+  content: '*';
+  color: var(--ds-color-warning-text-default);
+  margin-left: var(--ds-size-1);
+}

--- a/frontend/libs/studio-components/src/components/StudioLabelWrapper/StudioLabelWrapper.stories.tsx
+++ b/frontend/libs/studio-components/src/components/StudioLabelWrapper/StudioLabelWrapper.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { StudioLabelWrapper } from './StudioLabelWrapper';
+
+type Story = StoryFn<typeof StudioLabelWrapper>;
+
+const meta: Meta = {
+  title: 'Components/StudioLabelWrapper',
+  component: StudioLabelWrapper,
+};
+export const Preview: Story = (args): React.ReactElement => <StudioLabelWrapper {...args} />;
+
+Preview.args = {
+  withAsterisk: true,
+  children: 'Label',
+};
+export default meta;

--- a/frontend/libs/studio-components/src/components/StudioLabelWrapper/StudioLabelWrapper.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioLabelWrapper/StudioLabelWrapper.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { StudioLabelWrapper } from './StudioLabelWrapper';
+import { render, screen } from '@testing-library/react';
+import { testRootClassNameAppending } from '../../test-utils/testRootClassNameAppending';
+import { testRefForwarding } from '../../test-utils/testRefForwarding';
+
+jest.mock('./StudioLabelWrapper.module.css', () => ({
+  studioLabelWrapper: 'studioLabelWrapper',
+  withAsterisk: 'withAsterisk',
+}));
+
+/* eslint-disable testing-library/no-node-access */
+describe('StudioLabelWrapper', () => {
+  it('Renders with given label', () => {
+    const label = 'test-label';
+    render(<StudioLabelWrapper>{label}</StudioLabelWrapper>);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it('Renders with withAsterisk class when "withAsterisk" is set', () => {
+    const { container } = render(<StudioLabelWrapper withAsterisk>Test</StudioLabelWrapper>);
+    expect(container.firstChild).toHaveClass('withAsterisk');
+  });
+
+  it.each([false, undefined])(
+    'Renders without withAsterisk class when "withAsterisk" is %s',
+    (withAsterisk) => {
+      const { container } = render(
+        <StudioLabelWrapper withAsterisk={withAsterisk}>Test</StudioLabelWrapper>,
+      );
+      expect(container.firstChild).not.toHaveClass('withAsterisk');
+    },
+  );
+
+  it('Appends given classname to internal classname', () => {
+    testRootClassNameAppending((className) => render(<StudioLabelWrapper className={className} />));
+  });
+
+  it('Forwards the ref object to the span element if given', () => {
+    testRefForwarding<HTMLSpanElement>((ref) => render(<StudioLabelWrapper ref={ref} />));
+  });
+});

--- a/frontend/libs/studio-components/src/components/StudioLabelWrapper/StudioLabelWrapper.tsx
+++ b/frontend/libs/studio-components/src/components/StudioLabelWrapper/StudioLabelWrapper.tsx
@@ -1,0 +1,29 @@
+import type { HTMLAttributes, Ref, ReactElement } from 'react';
+import React, { forwardRef } from 'react';
+import classes from './StudioLabelWrapper.module.css';
+import cn from 'classnames';
+
+export type StudioLabelWrapperProps = HTMLAttributes<HTMLSpanElement> & {
+  withAsterisk?: boolean;
+};
+
+function StudioLabelWrapper(
+  { children, className, withAsterisk, ...rest }: StudioLabelWrapperProps,
+  ref: Ref<HTMLSpanElement>,
+): ReactElement {
+  const finalClassName = cn(
+    classes.studioLabelWrapper,
+    withAsterisk && classes.withAsterisk,
+    className,
+  );
+
+  return (
+    <span className={finalClassName} {...rest} ref={ref}>
+      {children}
+    </span>
+  );
+}
+
+const ForwardedStudioLabelWrapper = forwardRef(StudioLabelWrapper);
+
+export { ForwardedStudioLabelWrapper as StudioLabelWrapper };

--- a/frontend/libs/studio-components/src/components/StudioLabelWrapper/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioLabelWrapper/index.ts
@@ -1,0 +1,2 @@
+export { StudioLabelWrapper } from './StudioLabelWrapper';
+export type { StudioLabelWrapperProps } from './StudioLabelWrapper';

--- a/frontend/libs/studio-components/src/components/index.ts
+++ b/frontend/libs/studio-components/src/components/index.ts
@@ -16,3 +16,4 @@ export { StudioSelect } from './StudioSelect';
 export { StudioTable } from './StudioTable';
 export { StudioTag } from './StudioTag';
 export { StudioValidationMessage } from './StudioValidationMessage';
+export { StudioLabelWrapper } from './StudioLabelWrapper';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Creating new `StudioLabelWrapper` in `@studio/components`
- Adding `@deprecated` to `StudioLabelWrapper` in `@studio/components-legacy`

## Related Issue(s)
- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `StudioLabelWrapper` component for wrapping labels and optionally displaying an asterisk for required fields.
- **Documentation**
	- Added comprehensive documentation and interactive Storybook examples for the new component.
- **Style**
	- Implemented CSS styling to display a warning-colored asterisk when applicable.
- **Tests**
	- Added unit tests to ensure correct rendering, class name handling, and ref forwarding.
- **Chores**
	- Marked the legacy `StudioLabelWrapper` as deprecated and recommended migration to the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->