### PR TITLE
refactor: remove redundant parameter in SaveText

### DIFF
--- a/backend/src/Designer/Infrastructure/GitRepository/AltinnOrgGitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/AltinnOrgGitRepository.cs
@@ -76,14 +76,14 @@ public class AltinnOrgGitRepository : AltinnGitRepository
     }
 
     /// <summary>
-    /// Saves the text resource based on language code.
+    /// Saves the text resource.
     /// </summary>
-    /// <param name="languageCode">Language code</param>
     /// <param name="jsonTexts">text resource</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    public async Task SaveText(string languageCode, TextResource jsonTexts, CancellationToken cancellationToken = default)
+    public async Task SaveText(TextResource jsonTexts, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        string languageCode = jsonTexts.Language;
         string fileName = $"resource.{languageCode}.json";
         string textsFileRelativeFilePath = GetPathToJsonTextsFile(fileName);
         string texts = JsonSerializer.Serialize(jsonTexts, s_jsonOptions);

--- a/backend/src/Designer/Services/Implementation/Organisation/OrgTextsService.cs
+++ b/backend/src/Designer/Services/Implementation/Organisation/OrgTextsService.cs
@@ -49,7 +49,7 @@ public class OrgTextsService : IOrgTextsService
                 $"Text keys must be unique. Please review keys: {string.Join(", ", duplicateKeys)}");
         }
 
-        await altinnOrgGitRepository.SaveText(languageCode, textResource, cancellationToken);
+        await altinnOrgGitRepository.SaveText(textResource, cancellationToken);
     }
 
 
@@ -85,7 +85,7 @@ public class OrgTextsService : IOrgTextsService
             }
         }
 
-        await altinnOrgGitRepository.SaveText(languageCode, textResourceObject, cancellationToken);
+        await altinnOrgGitRepository.SaveText(textResourceObject, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/backend/tests/Designer.Tests/Infrastructure/GitRepository/AltinnOrgGitRepositoryTests.cs
+++ b/backend/tests/Designer.Tests/Infrastructure/GitRepository/AltinnOrgGitRepositoryTests.cs
@@ -68,7 +68,7 @@ public class AltinnOrgGitRepositoryTests : IDisposable
         TextResource textResource = new() { Language = language, Resources = [new() { Id = "someId", Value = "someValue" }] };
 
         // Act
-        await altinnOrgGitRepository.SaveText(language, textResource);
+        await altinnOrgGitRepository.SaveText(textResource);
 
         // Assert
         string fileContent = TestDataHelper.GetFileFromRepo(TargetOrg, targetRepository, Developer, RelativePathText(language));


### PR DESCRIPTION
## Description

Removes `languageCode` parameter from `AltinnOrgGitRepository.SaveText`, since it can be extracted from the text resource object instead.

## Related Issue(s)

- This PR

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)