### PR TITLE
fix: orgTextLanguagesPath

### DIFF
--- a/frontend/packages/shared/src/api/paths.js
+++ b/frontend/packages/shared/src/api/paths.js
@@ -95,7 +95,7 @@ export const orgCodeListsPath = (org) => `${basePath}/${org}/code-lists`; // Get
 export const orgCodeListPath = (org, codeListId) => `${basePath}/${org}/code-lists/${codeListId}`; // Post, Put, Delete
 export const orgCodeListUploadPath = (org) => `${basePath}/${org}/code-lists/upload`; // Post
 export const orgTextResourcesPath = (org, language) => `${basePath}/${org}/text/language/${language}`; // Get, patch, post
-export const orgTextLanguagesPath = (org) => `${basePath}/${org}/text/language/languages`; // Get
+export const orgTextLanguagesPath = (org) => `${basePath}/${org}/text/languages`; // Get
 export const availableResourcesInOrgLibraryPath = (org, contentType) => `${basePath}/${org}/content?${s({ contentType })}`; // Get
 
 // Organizations


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed wrong path to correct path.

Correct path as shown in Rider:
![bilde](https://github.com/user-attachments/assets/6a0cd81e-a9fb-463f-8822-1957911ab647)

The path is unused per now.

## Related Issue(s)

- This PR

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with the organization text languages endpoint, ensuring the correct URL path is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->