### PR TITLE
chore: add new StudioAlert

### DIFF
--- a/frontend/libs/studio-components-legacy/src/components/StudioAlert/StudioAlert.tsx
+++ b/frontend/libs/studio-components-legacy/src/components/StudioAlert/StudioAlert.tsx
@@ -4,6 +4,9 @@ import type { WithoutAsChild } from '../../types/WithoutAsChild';
 
 export type StudioAlertProps = WithoutAsChild<AlertProps>;
 
+/**
+ * @deprecated use `StudioAlert` from `@studio/components` instead
+ */
 const StudioAlert = forwardRef<HTMLDivElement, StudioAlertProps>(
   ({ size = 'sm', ...rest }, ref) => {
     return <Alert {...rest} size={size} ref={ref} />;

--- a/frontend/libs/studio-components/src/components/StudioAlert/StudioAlert.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioAlert/StudioAlert.test.tsx
@@ -1,0 +1,29 @@
+import React, { type ForwardedRef } from 'react';
+import { render } from '@testing-library/react';
+import type { RenderResult } from '@testing-library/react';
+import type { StudioAlertProps } from './StudioAlert';
+import { StudioAlert } from './StudioAlert';
+import { testRefForwarding } from '../../test-utils/testRefForwarding';
+import { testRootClassNameAppending } from '../../test-utils/testRootClassNameAppending';
+import { testCustomAttributes } from '../../test-utils/testCustomAttributes';
+
+describe('StudioAlert', () => {
+  it('should support forwarding the ref', () => {
+    testRefForwarding<HTMLDivElement>((ref) => renderTestAlert({}, ref));
+  });
+
+  it('should append classname to root', () => {
+    testRootClassNameAppending((className) => renderTestAlert({ className }));
+  });
+
+  it('should allow custom attributes', () => {
+    testCustomAttributes((customAttributes) => renderTestAlert({ ...customAttributes }));
+  });
+});
+
+const renderTestAlert = (
+  props: Partial<StudioAlertProps> = {},
+  ref?: ForwardedRef<HTMLDivElement>,
+): RenderResult => {
+  return render(<StudioAlert {...props} ref={ref} />);
+};

--- a/frontend/libs/studio-components/src/components/StudioAlert/StudioAlert.tsx
+++ b/frontend/libs/studio-components/src/components/StudioAlert/StudioAlert.tsx
@@ -1,0 +1,22 @@
+import React, { forwardRef } from 'react';
+import type { ReactElement, Ref } from 'react';
+import { Alert } from '@digdir/designsystemet-react';
+import type { AlertProps } from '@digdir/designsystemet-react';
+import type { WithoutAsChild } from '../../types/WithoutAsChild';
+
+export type StudioAlertProps = WithoutAsChild<AlertProps>;
+
+function StudioAlert(
+  { children, ...rest }: StudioAlertProps,
+  ref: Ref<HTMLDivElement>,
+): ReactElement {
+  return (
+    <Alert {...rest} ref={ref}>
+      {children}
+    </Alert>
+  );
+}
+
+const ForwardedStudioAlert = forwardRef(StudioAlert);
+
+export { ForwardedStudioAlert as StudioAlert };

--- a/frontend/libs/studio-components/src/components/StudioAlert/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioAlert/index.ts
@@ -1,0 +1,1 @@
+export { StudioAlert } from './StudioAlert';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Creating new `StudioAlert` in `@studio/components`
- Adding `@deprecated` to `StudioAlert` in `@studio/components-legacy`

## Related Issue(s)
- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `StudioAlert` component, providing a ref-forwarding alert based on the latest design system.
- **Tests**
  - Added tests to ensure correct ref forwarding, class name handling, and custom attribute support for the new `StudioAlert` component.
- **Documentation**
  - Marked the legacy `StudioAlert` component as deprecated and recommended using the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->