### PR TITLE
refactor: change design of settings page

### DIFF
--- a/frontend/app-development/features/appSettings/AppSettings.module.css
+++ b/frontend/app-development/features/appSettings/AppSettings.module.css
@@ -1,15 +1,32 @@
 .settingsWrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.settingsHeading {
+  display: flex;
+  align-items: center;
+  padding-left: var(--ds-size-4);
+  padding-block: var(--ds-size-4);
+}
+
+.pageContentWrapper {
   display: flex;
   flex: 1;
 }
 
 .leftNavWrapper {
-  overflow-y: auto;
   width: 250px;
+  top: 0;
+  position: sticky;
+  align-self: flex-start;
+  height: 100vh;
 }
 
 .contentWrapper {
   flex: 1;
+  padding: var(--ds-size-6);
+  border-top: 1px solid var(--ds-color-neutral-surface-tinted);
   overflow-y: auto;
-  padding: var(--studio-modal-spacing);
 }

--- a/frontend/app-development/features/appSettings/AppSettings.tsx
+++ b/frontend/app-development/features/appSettings/AppSettings.tsx
@@ -17,12 +17,16 @@ export function AppSettings(): ReactElement {
 
   return (
     <div className={classes.settingsWrapper}>
-      <div className={classes.leftNavWrapper}>
-        <ContentMenu currentTab={currentTab} onChangeTab={handleTabChange} />
-      </div>
-      <div className={classes.contentWrapper}>
-        <StudioHeading level={1}>{t('settings_modal.heading')}</StudioHeading>
-        <TabsContent currentTab={currentTab} />
+      <StudioHeading level={2} className={classes.settingsHeading}>
+        {t('app_settings.heading')}
+      </StudioHeading>
+      <div className={classes.pageContentWrapper}>
+        <div className={classes.leftNavWrapper}>
+          <ContentMenu currentTab={currentTab} onChangeTab={handleTabChange} />
+        </div>
+        <div className={classes.contentWrapper}>
+          <TabsContent currentTab={currentTab} />
+        </div>
       </div>
     </div>
   );

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -160,6 +160,7 @@
   "app_release.release_title": "Appen bygges basert på",
   "app_release.release_title_link": "siste endringstransaksjon til master",
   "app_release.release_version": "Versjon:",
+  "app_settings.heading": "Innstillinger",
   "code_list_editor.add_button_disabled": "Du kan ikke ha flere enn to alternativer i en boolsk kodeliste",
   "code_list_editor.add_option": "Legg til alternativ",
   "code_list_editor.column_title_delete": "Slett",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Moving `Innstillinger` to the top of the page after meeting with UX.

![image](https://github.com/user-attachments/assets/14281ff9-46f7-4f1b-b65f-18cde9bd805d)

## Related Issue(s)
- PR itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x]  Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new heading for the app settings page with updated styling and layout.
  - Added Norwegian Bokmål translation for the new app settings heading.

- **Style**
  - Improved layout and visual structure of the app settings page, including updated navigation and content wrappers, sticky sidebar, and enhanced padding and borders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->