### PR TITLE
fix: add layout queries invalidation to `useAddGroupMutation`

### DIFF
--- a/frontend/packages/ux-editor/src/hooks/mutations/useAddGroupMutation.ts
+++ b/frontend/packages/ux-editor/src/hooks/mutations/useAddGroupMutation.ts
@@ -25,6 +25,12 @@ export const useAddGroupMutation = (org: string, app: string) => {
       queryClient.invalidateQueries({
         queryKey: [QueryKey.Pages, org, app, selectedFormLayoutSetName],
       });
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.FormLayouts, org, app, selectedFormLayoutSetName],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.FormLayoutSettings, org, app, selectedFormLayoutSetName],
+      });
     },
   });
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Small fix to avoid stale queries when adding a new page group to a layout. Without this, newly added page groups will have stale page data.

## Related Issue(s)

- this PR

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data freshness by ensuring that form layouts and their settings are updated automatically when a new group is added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->