### PR TITLE
refactor: remove unused method AssertValidXmlContent

### DIFF
--- a/backend/src/Designer/Helpers/Guard.cs
+++ b/backend/src/Designer/Helpers/Guard.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using System.Xml;
-using System.Xml.Linq;
 
 namespace Altinn.Studio.Designer.Helpers
 {

--- a/backend/src/Designer/Helpers/Guard.cs
+++ b/backend/src/Designer/Helpers/Guard.cs
@@ -133,18 +133,6 @@ namespace Altinn.Studio.Designer.Helpers
             }
         }
 
-        public static void AssertValidXmlContent(string xmlContent)
-        {
-            try
-            {
-                _ = XDocument.Parse(xmlContent);
-            }
-            catch (XmlException)
-            {
-                throw new ArgumentException("Invalid xml content.");
-            }
-        }
-
         public static async Task AssertValidXmlStreamAndRewindAsync(Stream xmlStream)
         {
             XmlReaderSettings settings = new XmlReaderSettings


### PR DESCRIPTION
## Description

`AssertValidXmlContent` was replaced with `AssertValidXmlStreamAndRewindAsync` in #11310

## Related Issue(s)

- This PR

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the synchronous XML content validation method. Only the asynchronous XML validation remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->