### PR TITLE
feat: markAsCompleted and type backend support for page groups

### DIFF
--- a/backend/src/Designer/Models/Dto/GroupDto.cs
+++ b/backend/src/Designer/Models/Dto/GroupDto.cs
@@ -12,4 +12,12 @@ public class GroupDto
 
     [JsonPropertyName("order")]
     public required List<PageDto> Pages { get; set; }
+
+    [JsonPropertyName("markWhenCompleted")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool? MarkWhenCompleted { get; set; }
+
+    [JsonPropertyName("type")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public GroupType? Type { get; set; }
 }

--- a/backend/src/Designer/Models/Dto/PagesDto.cs
+++ b/backend/src/Designer/Models/Dto/PagesDto.cs
@@ -35,6 +35,8 @@ public class PagesDto
                     {
                         Name = group.Name,
                         Pages = group.Order.Select(pageId => new PageDto { Id = pageId }).ToList(),
+                        MarkWhenCompleted = group.MarkWhenCompleted,
+                        Type = group.Type,
                     })
                     .ToList(),
             },
@@ -67,6 +69,8 @@ public class PagesDto
                     {
                         Name = group.Name,
                         Order = [.. group.Pages.Select(page => page.Id)],
+                        MarkWhenCompleted = group.MarkWhenCompleted,
+                        Type = group.Type,
                     })
                     .ToList(),
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`markAsCompleted` and `type` properties on page groups will now be saved and sent from pagegroup endpoints.
ref. https://github.com/Altinn/app-frontend-react/pull/2831

## Related Issue(s)

- #14785 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional fields for "Mark When Completed" and "Type" to groups, allowing these properties to be included and transferred as part of group data.

- **Bug Fixes**
  - Ensured that the new group properties are correctly preserved when converting between different data formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->