### PR TITLE
fix(resource-adm): hide migrate resource tab if resourceType is not GenericAccessResource

### DIFF
--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.test.tsx
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.test.tsx
@@ -91,7 +91,7 @@ describe('ResourcePage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('displays migrate tab in left navigation bar when resource reference is present in resource', async () => {
+  it('displays migrate tab in left navigation bar when resource reference is present in resource and resource is GenericAccessResource', async () => {
     const getResource = jest
       .fn()
       .mockImplementation(() => Promise.resolve<Resource>(mockResource1));
@@ -104,6 +104,23 @@ describe('ResourcePage', () => {
     expect(
       screen.getByRole('tab', { name: textMock('resourceadm.left_nav_bar_migration') }),
     ).toBeInTheDocument();
+  });
+
+  it('displays migrate tab in left navigation bar when resource reference is present in resource and resource is not GenericAccessResource', async () => {
+    const getResource = jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve<Resource>({ ...mockResource1, resourceType: 'ConsentResource' }),
+      );
+
+    renderResourcePage({ getResource });
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTitle(textMock('resourceadm.about_resource_spinner')),
+    );
+
+    expect(
+      screen.queryByRole('tab', { name: textMock('resourceadm.left_nav_bar_migrate') }),
+    ).not.toBeInTheDocument();
   });
 
   it('does not display migrate tab in left navigation bar when resource reference is not in resource', async () => {

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.test.tsx
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.test.tsx
@@ -106,7 +106,7 @@ describe('ResourcePage', () => {
     ).toBeInTheDocument();
   });
 
-  it('displays migrate tab in left navigation bar when resource reference is present in resource and resource is not GenericAccessResource', async () => {
+  it('does not display migrate tab in left navigation bar when resource reference is present in resource and resource is not GenericAccessResource', async () => {
     const getResource = jest
       .fn()
       .mockImplementation(() =>
@@ -119,7 +119,7 @@ describe('ResourcePage', () => {
     );
 
     expect(
-      screen.queryByRole('tab', { name: textMock('resourceadm.left_nav_bar_migrate') }),
+      screen.queryByRole('tab', { name: textMock('resourceadm.left_nav_bar_migration') }),
     ).not.toBeInTheDocument();
   });
 
@@ -134,7 +134,7 @@ describe('ResourcePage', () => {
     );
 
     expect(
-      screen.queryByRole('tab', { name: textMock('resourceadm.left_nav_bar_migrate') }),
+      screen.queryByRole('tab', { name: textMock('resourceadm.left_nav_bar_migration') }),
     ).not.toBeInTheDocument();
   });
 

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
@@ -165,7 +165,7 @@ export const ResourcePage = (): React.JSX.Element => {
    * Decide if the migration page should be accessible or not
    */
   const isMigrateEnabled = (): boolean => {
-    return !!altinn2References;
+    return !!altinn2References && resourceData.resourceType === 'GenericAccessResource';
   };
 
   const aboutPageId = 'about';


### PR DESCRIPTION
## Description

After discussion on Slack, migrate resource tab should only be shown if resource has Altinn 2 resourceReferences (like before) and is a GenericAccessResource (new in this PR)

## Related Issue(s)

- this PR

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The migration tab in the navigation bar is now only visible when the resource type is "GenericAccessResource" and Altinn2 references are present. The tab will not appear for other resource types, even if references exist.

- **Tests**
  - Updated and added tests to ensure the migration tab is displayed only under the correct conditions based on resource type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->