### PR TITLE
fix(resource-adm): add IsOneTimeConsent field to consent resource

### DIFF
--- a/backend/src/Designer/Models/ServiceResource.cs
+++ b/backend/src/Designer/Models/ServiceResource.cs
@@ -129,7 +129,7 @@ namespace Altinn.Studio.Designer.Models
         public string? ConsentTemplate { get; set; }
 
         /// <summary>
-        /// Consent text is markdown? text used if resource is a consent resource
+        /// Consent text is markdown text used if resource is a consent resource
         /// </summary>
         public Dictionary<string, string>? ConsentText { get; set; }
 
@@ -137,6 +137,11 @@ namespace Altinn.Studio.Designer.Models
         /// Defines consentmetadata for consent resources
         /// </summary>
         public Dictionary<string, ConsentMetadata>? ConsentMetadata { get; set; }
+
+        /// <summary>
+        /// If consent resource is used for one time consents, or consents with an expiry date
+        /// </summary>
+        public bool IsOneTimeConsent { get; set; }
 
         /// <summary>
         /// Writes key information when this object is written to Log.

--- a/frontend/packages/shared/src/types/ResourceAdm.ts
+++ b/frontend/packages/shared/src/types/ResourceAdm.ts
@@ -30,6 +30,7 @@ export interface Resource {
   consentTemplate?: string;
   consentText?: SupportedLanguage;
   consentMetadata?: ConsentMetadata;
+  isOneTimeConsent?: boolean;
 }
 
 export type ResourceAccessListMode = 'Disabled' | 'Enabled';

--- a/frontend/resourceadm/language/src/nb.json
+++ b/frontend/resourceadm/language/src/nb.json
@@ -22,6 +22,8 @@
   "resourceadm.about_resource_contact_remove_button": "Slett kontakt",
   "resourceadm.about_resource_delegable_label": "Delegerbar ressurs",
   "resourceadm.about_resource_delegable_show_text": "Ressursen er {{shouldText}} delegerbar.",
+  "resourceadm.about_resource_one_time_consent_label": "Engangssamtykke",
+  "resourceadm.about_resource_one_time_consent_show_text": "Samtykket gjelder {{shouldText}} kun én gang.",
   "resourceadm.about_resource_edit_rrr": "Administrer tilgangslister i {{env}}",
   "resourceadm.about_resource_enterprise_label": "Virksomhetsbruker",
   "resourceadm.about_resource_enterprise_show_text": "Ressursen har {{shouldText}} virksomhetsbruker aktivert.",

--- a/frontend/resourceadm/language/src/nb.json
+++ b/frontend/resourceadm/language/src/nb.json
@@ -23,7 +23,7 @@
   "resourceadm.about_resource_delegable_label": "Delegerbar ressurs",
   "resourceadm.about_resource_delegable_show_text": "Ressursen er {{shouldText}} delegerbar.",
   "resourceadm.about_resource_one_time_consent_label": "Engangssamtykke",
-  "resourceadm.about_resource_one_time_consent_show_text": "Samtykket gjelder {{shouldText}} kun én gang.",
+  "resourceadm.about_resource_one_time_consent_show_text": "Samtykket gjelder kun én gang.",
   "resourceadm.about_resource_edit_rrr": "Administrer tilgangslister i {{env}}",
   "resourceadm.about_resource_enterprise_label": "Virksomhetsbruker",
   "resourceadm.about_resource_enterprise_show_text": "Ressursen har {{shouldText}} virksomhetsbruker aktivert.",

--- a/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
+++ b/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
@@ -62,6 +62,7 @@ const mockConsentResource: Resource = {
     nn: 'consentNn',
     en: 'consentEn',
   },
+  isOneTimeConsent: true,
 };
 
 const mockResourceType: ResourceTypeOption = textMock(
@@ -404,6 +405,23 @@ describe('AboutResourcePage', () => {
     });
   });
 
+  it('handles isOneTimeConsent switch changes', async () => {
+    const user = userEvent.setup();
+    render(<AboutResourcePage {...defaultProps} resourceData={mockConsentResource} />);
+
+    const isOneTimeConsentInput = screen.getByLabelText(
+      textMock('resourceadm.about_resource_one_time_consent_label'),
+    );
+    expect(isOneTimeConsentInput).toBeChecked();
+
+    await user.click(isOneTimeConsentInput);
+
+    expect(mockOnSaveResource).toHaveBeenCalledWith({
+      ...mockConsentResource,
+      isOneTimeConsent: false,
+    });
+  });
+
   it('displays field errors for consent fields', () => {
     const consentTemplateError = 'CONSENT_TEMPLATE_ERROR';
     const consentTextError = 'CONSENT_TEXT_ERROR';
@@ -576,6 +594,10 @@ describe('AboutResourcePage', () => {
 
     expect(
       screen.getByText(textMock('resourceadm.about_resource_consent_template_label')),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(textMock('resourceadm.about_resource_one_time_consent_label')),
     ).toBeInTheDocument();
 
     expect(

--- a/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
+++ b/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
@@ -233,6 +233,16 @@ export const AboutResourcePage = ({
               required
               errors={validationErrors.filter((error) => error.field === 'consentText')}
             />
+            <ResourceSwitchInput
+              id='isOneTimeConsent'
+              label={t('resourceadm.about_resource_one_time_consent_label')}
+              value={resourceData.isOneTimeConsent ?? true}
+              onFocus={() => setTranslationType('none')}
+              onChange={(isChecked: boolean) =>
+                handleSave({ ...resourceData, isOneTimeConsent: isChecked })
+              }
+              toggleTextTranslationKey='resourceadm.about_resource_one_time_consent_show_text'
+            />
           </>
         )}
         <ResourceTextField


### PR DESCRIPTION
## Description

In consent resources, service owner can define whether the consent resource is used for one time consents, or whether the consent can be used multiple times before an expiry date. So whether a consent is a one time consent or not is set on the resource by the service owner, *not* by the party requesting a consent.

![image](https://github.com/user-attachments/assets/dc929c73-5b08-4a9a-b85f-9946626d4b2b)


## Related Issue(s)

- https://github.com/Altinn/altinn-authorization-tmp/issues/592

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "one-time consent" option for consent resources, allowing users to specify if a consent is valid only once or can have an expiry date.
  - Added a toggle switch in the resource administration interface for setting the one-time consent option.
- **Localization**
  - Added Norwegian language support for labels and descriptions related to the one-time consent feature.
- **Tests**
  - Enhanced test coverage to verify the new one-time consent toggle and its behavior in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->