### PR TITLE
test: Isolate text editor tests (1)

### DIFF
--- a/frontend/app-development/features/textEditor/TextEditor.test.tsx
+++ b/frontend/app-development/features/textEditor/TextEditor.test.tsx
@@ -6,15 +6,21 @@ import { TextEditor } from './TextEditor';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import type { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
 import userEvent from '@testing-library/user-event';
-import { org, app, deleteButtonId } from '@studio/testing/testids';
+import { deleteButtonId } from '@studio/testing/testids';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
-import { queryClientMock } from 'app-shared/mocks/queryClientMock';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { QueryKey } from 'app-shared/types/QueryKey';
+import type { QueryClient } from '@tanstack/react-query';
+import type { ITextResources } from 'app-shared/types/global';
 
 // Test data
+const org = 'test-org';
+const app = 'test-app';
 const testTextResourceKey = 'test-key';
 const testTextResourceValue = 'test-value';
-const languages = ['nb', 'en'];
+const language1 = 'nb';
+const language2 = 'en';
+const languages = [language1, language2];
 
 const getTextResources = jest.fn().mockImplementation(() =>
   Promise.resolve({
@@ -52,7 +58,7 @@ describe('TextEditor', () => {
   it('updates search query when searching text', async () => {
     const user = userEvent.setup();
 
-    renderTextEditor();
+    renderTextEditorWithData();
 
     const search = '1';
     const searchInput = screen.getByRole('searchbox', {
@@ -66,7 +72,7 @@ describe('TextEditor', () => {
   it('adds new text resource when clicking add button', async () => {
     const user = userEvent.setup();
 
-    renderTextEditor();
+    renderTextEditorWithData();
 
     const addButton = screen.getByRole('button', { name: textMock('text_editor.new_text') });
     await user.click(addButton);
@@ -77,7 +83,7 @@ describe('TextEditor', () => {
   it('updates text resource when editing text', async () => {
     const user = userEvent.setup();
 
-    renderTextEditor();
+    renderTextEditorWithData();
 
     const textarea = screen.getByRole('textbox', {
       name: textMock('text_editor.table_row_input_label', {
@@ -95,9 +101,10 @@ describe('TextEditor', () => {
   });
 
   it('updates text id when editing text id', async () => {
-    queryClientMock.setQueryData([QueryKey.LayoutNames, org, app], []);
+    const queryClient = createQueryClientWithData();
+    queryClient.setQueryData([QueryKey.LayoutNames, org, app], []);
     const user = userEvent.setup();
-    renderTextEditor();
+    renderTextEditor({}, queryClient);
 
     const editButton = screen.getByRole('button', {
       name: textMock('text_editor.toggle_edit_mode', { textKey: testTextResourceKey }),
@@ -119,7 +126,7 @@ describe('TextEditor', () => {
   it('deletes text id when clicking delete button', async () => {
     const user = userEvent.setup();
 
-    renderTextEditor();
+    renderTextEditorWithData();
 
     const deleteButton = screen.getByRole('button', { name: textMock('schema_editor.delete') });
     await waitFor(() => deleteButton.click());
@@ -137,7 +144,7 @@ describe('TextEditor', () => {
   it('adds new language when clicking add button', async () => {
     const user = userEvent.setup();
 
-    renderTextEditor();
+    renderTextEditorWithData();
 
     const addBtn = screen.getByRole('button', {
       name: textMock('general.add'),
@@ -159,7 +166,7 @@ describe('TextEditor', () => {
   it('deletes a language when clicking delete button', async () => {
     const user = userEvent.setup();
 
-    renderTextEditor();
+    renderTextEditorWithData();
 
     const deleteButton = screen.getByTestId(deleteButtonId('en'));
     await user.click(deleteButton);
@@ -182,9 +189,12 @@ describe('TextEditor', () => {
   });
 });
 
-const renderTextEditor = (queries: Partial<ServicesContextProps> = {}) => {
+const renderTextEditor = (
+  queries: Partial<ServicesContextProps> = {},
+  queryClient: QueryClient = createQueryClientMock(),
+) => {
   return renderWithProviders(<TextEditor />, {
-    queryClient: queryClientMock,
+    queryClient,
     queries: {
       getTextResources,
       getTextLanguages,
@@ -193,3 +203,19 @@ const renderTextEditor = (queries: Partial<ServicesContextProps> = {}) => {
     startUrl: `${APP_DEVELOPMENT_BASENAME}/${org}/${app}`,
   });
 };
+
+function renderTextEditorWithData(): void {
+  const queryClient = createQueryClientWithData();
+  renderTextEditor({}, queryClient);
+}
+
+function createQueryClientWithData(): QueryClient {
+  const data: ITextResources = {
+    [language1]: [{ id: testTextResourceKey, value: testTextResourceValue }],
+    [language2]: [],
+  };
+  const queryClient: QueryClient = createQueryClientMock();
+  queryClient.setQueryData([QueryKey.TextResources, org, app], data);
+  queryClient.setQueryData([QueryKey.TextLanguages, org, app], languages);
+  return queryClient;
+}

--- a/frontend/packages/shared/src/mocks/queryClientMock.ts
+++ b/frontend/packages/shared/src/mocks/queryClientMock.ts
@@ -10,4 +10,4 @@ export const queryClientConfigMock: QueryClientConfig = {
 
 export const createQueryClientMock = () => new QueryClient(queryClientConfigMock);
 
-export const queryClientMock = createQueryClientMock();
+export const queryClientMock = createQueryClientMock(); // Todo: Remove this when all usages are replaced with createQueryClientMock: https://github.com/Altinn/altinn-studio/issues/15513


### PR DESCRIPTION
## Description
When working on optismistic updates for text resource mutations, I ran into issues with the text editor tests. It turned out this was because the query client was not reinstantiated between each test. Actually, many of these tests will fail when they are executed alone, regardless of the changes I was working on, because they depend on the first test to populate the cache.

This pull request fixes that by using the `createQueryClientMock` function to create a new client for each test and the `setQueryData` method to populate it. It also makes the `org` and `app` variables being declared loacally instead of importing them from the `testids` file, which should only store test IDs.

## Related Issues
- #15044
- #15513

## Verification
- [x] **Your** code builds clean without any errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved and standardized test setup for the TextEditor component, using a query client with preset data for more consistent and isolated testing.
  - Introduced new helper functions to streamline rendering and data preparation in tests.

- **Chores**
  - Added a comment indicating the planned removal of a mock utility in the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->