### PR TITLE
feat: implement and use mutation for updating code list id on organisation level.

### DIFF
--- a/frontend/dashboard/pages/OrgContentLibraryPage/OrgContentLibraryPage.test.tsx
+++ b/frontend/dashboard/pages/OrgContentLibraryPage/OrgContentLibraryPage.test.tsx
@@ -121,7 +121,7 @@ describe('OrgContentLibraryPage', () => {
     expect(updateOrgCodeList).toHaveBeenCalledWith(orgName, title, data);
   });
 
-  it('calls updateORgCodeListId with correct data when onUpdateCodeListId is triggered', async () => {
+  it('calls updateOrgCodeListId with correct data when onUpdateCodeListId is triggered', async () => {
     const updateOrgCodeListId = jest.fn();
     renderOrgContentLibraryWithData({ queries: { updateOrgCodeListId } });
     const codeListId: string = codeList1Data.title;

--- a/frontend/dashboard/pages/OrgContentLibraryPage/OrgContentLibraryPage.test.tsx
+++ b/frontend/dashboard/pages/OrgContentLibraryPage/OrgContentLibraryPage.test.tsx
@@ -121,6 +121,19 @@ describe('OrgContentLibraryPage', () => {
     expect(updateOrgCodeList).toHaveBeenCalledWith(orgName, title, data);
   });
 
+  it('calls updateORgCodeListId with correct data when onUpdateCodeListId is triggered', async () => {
+    const updateOrgCodeListId = jest.fn();
+    renderOrgContentLibraryWithData({ queries: { updateOrgCodeListId } });
+    const codeListId: string = codeList1Data.title;
+    const newCodeListId: string = 'new-id';
+
+    retrieveConfig().codeList.props.onUpdateCodeListId(codeListId, newCodeListId);
+    await waitFor(expect(updateOrgCodeListId).toHaveBeenCalled);
+
+    expect(updateOrgCodeListId).toHaveBeenCalledTimes(1);
+    expect(updateOrgCodeListId).toHaveBeenCalledWith(orgName, codeListId, newCodeListId);
+  });
+
   it('calls createOrgCodeList with correct data when onCreateCodeList is triggered', async () => {
     const createOrgCodeList = jest.fn();
     renderOrgContentLibraryWithData({ queries: { createOrgCodeList } });

--- a/frontend/dashboard/pages/OrgContentLibraryPage/OrgContentLibraryPage.tsx
+++ b/frontend/dashboard/pages/OrgContentLibraryPage/OrgContentLibraryPage.tsx
@@ -38,6 +38,7 @@ import { DEFAULT_LANGUAGE } from 'app-shared/constants';
 import { mergeQueryStatuses } from 'app-shared/utils/tanstackQueryUtils';
 import type { ITextResourcesWithLanguage } from 'app-shared/types/global';
 import { useUpdateOrgTextResourcesMutation } from 'app-shared/hooks/mutations/useUpdateOrgTextResourcesMutation';
+import { useUpdateOrgCodeListIdMutation } from 'app-shared/hooks/mutations/useUpdateOrgCodeListIdMutation';
 
 export function OrgContentLibraryPage(): ReactElement {
   const selectedContext = useSelectedContext();
@@ -106,9 +107,10 @@ function OrgContentLibraryWithContextAndData({
   orgName,
   textResources: textResourcesWithLanguage,
 }: OrgContentLibraryWithContextAndDataProps): ReactElement {
-  const { mutate: updateCodeList } = useUpdateOrgCodeListMutation(orgName);
-  const { mutate: deleteCodeList } = useDeleteOrgCodeListMutation(orgName);
   const { mutate: createCodeList } = useCreateOrgCodeListMutation(orgName);
+  const { mutate: deleteCodeList } = useDeleteOrgCodeListMutation(orgName);
+  const { mutate: updateCodeList } = useUpdateOrgCodeListMutation(orgName);
+  const { mutate: updateCodeListId } = useUpdateOrgCodeListIdMutation(orgName);
   const { mutate: updateTextResources } = useUpdateOrgTextResourcesMutation(orgName);
 
   const handleUpload = useUploadCodeList(orgName);
@@ -124,6 +126,10 @@ function OrgContentLibraryWithContextAndData({
     },
     [updateTextResources],
   );
+
+  const handleUpdateCodeListId = (codeListId: string, newCodeListId: string): void => {
+    updateCodeListId({ codeListId, newCodeListId });
+  };
 
   const handleUpdate = ({ title, codeList }: CodeListWithMetadata): void => {
     updateCodeList({ title, data: codeList });
@@ -141,7 +147,7 @@ function OrgContentLibraryWithContextAndData({
           onCreateCodeList: handleCreate,
           onCreateTextResource: handleUpdateTextResource,
           onDeleteCodeList: deleteCodeList,
-          onUpdateCodeListId: () => {},
+          onUpdateCodeListId: handleUpdateCodeListId,
           onUpdateCodeList: handleUpdate,
           onUpdateTextResource: handleUpdateTextResource,
           onUploadCodeList: handleUpload,

--- a/frontend/packages/shared/src/api/mutations.ts
+++ b/frontend/packages/shared/src/api/mutations.ts
@@ -58,6 +58,7 @@ import {
   layoutConvertToPageGroupsPath,
   layoutConvertToPageOrderPath,
   taskNavigationGroupPath,
+  orgCodeListUpdateIdPath,
 } from 'app-shared/api/paths';
 import type { AddLanguagePayload } from 'app-shared/types/api/AddLanguagePayload';
 import type { AddRepoParams } from 'app-shared/types/api';
@@ -196,6 +197,7 @@ export const updateSelectedMaskinportenScopes = (org: string, app: string, appSc
 // Organisation library code lists:
 export const createOrgCodeList = async (org: string, codeListId: string, payload: CodeList): Promise<CodeListsResponse> => post(orgCodeListPath(org, codeListId), payload);
 export const updateOrgCodeList = async (org: string, codeListId: string, payload: CodeList): Promise<CodeListsResponse> => put(orgCodeListPath(org, codeListId), payload);
+export const updateOrgCodeListId = async (org: string, codeListId: string, payload: string) => put(orgCodeListUpdateIdPath(org, codeListId), payload, { headers: { 'Content-Type': 'application/json' } });
 export const deleteOrgCodeList = async (org: string, codeListId: string): Promise<CodeListsResponse> => del(orgCodeListPath(org, codeListId));
 export const uploadOrgCodeList = async (org: string, payload: FormData): Promise<CodeListsResponse> => post(orgCodeListUploadPath(org), payload);
 

--- a/frontend/packages/shared/src/api/mutations.ts
+++ b/frontend/packages/shared/src/api/mutations.ts
@@ -197,7 +197,7 @@ export const updateSelectedMaskinportenScopes = (org: string, app: string, appSc
 // Organisation library code lists:
 export const createOrgCodeList = async (org: string, codeListId: string, payload: CodeList): Promise<CodeListsResponse> => post(orgCodeListPath(org, codeListId), payload);
 export const updateOrgCodeList = async (org: string, codeListId: string, payload: CodeList): Promise<CodeListsResponse> => put(orgCodeListPath(org, codeListId), payload);
-export const updateOrgCodeListId = async (org: string, codeListId: string, payload: string) => put<void, string>(orgCodeListUpdateIdPath(org, codeListId), payload, { headers: { 'Content-Type': 'application/json' } });
+export const updateOrgCodeListId = async (org: string, codeListId: string, payload: string): Promise<void> => put<void, string>(orgCodeListUpdateIdPath(org, codeListId), payload, { headers: { 'Content-Type': 'application/json' } });
 export const deleteOrgCodeList = async (org: string, codeListId: string): Promise<CodeListsResponse> => del(orgCodeListPath(org, codeListId));
 export const uploadOrgCodeList = async (org: string, payload: FormData): Promise<CodeListsResponse> => post(orgCodeListUploadPath(org), payload);
 

--- a/frontend/packages/shared/src/api/mutations.ts
+++ b/frontend/packages/shared/src/api/mutations.ts
@@ -197,7 +197,7 @@ export const updateSelectedMaskinportenScopes = (org: string, app: string, appSc
 // Organisation library code lists:
 export const createOrgCodeList = async (org: string, codeListId: string, payload: CodeList): Promise<CodeListsResponse> => post(orgCodeListPath(org, codeListId), payload);
 export const updateOrgCodeList = async (org: string, codeListId: string, payload: CodeList): Promise<CodeListsResponse> => put(orgCodeListPath(org, codeListId), payload);
-export const updateOrgCodeListId = async (org: string, codeListId: string, payload: string) => put(orgCodeListUpdateIdPath(org, codeListId), payload, { headers: { 'Content-Type': 'application/json' } });
+export const updateOrgCodeListId = async (org: string, codeListId: string, payload: string) => put<void, string>(orgCodeListUpdateIdPath(org, codeListId), payload, { headers: { 'Content-Type': 'application/json' } });
 export const deleteOrgCodeList = async (org: string, codeListId: string): Promise<CodeListsResponse> => del(orgCodeListPath(org, codeListId));
 export const uploadOrgCodeList = async (org: string, payload: FormData): Promise<CodeListsResponse> => post(orgCodeListUploadPath(org), payload);
 

--- a/frontend/packages/shared/src/api/paths.js
+++ b/frontend/packages/shared/src/api/paths.js
@@ -94,6 +94,7 @@ export const getImageFileNamesPath = (org, app) => `${basePath}/${org}/${app}/im
 // Library - org-level
 export const orgCodeListsPath = (org) => `${basePath}/${org}/code-lists`; // Get
 export const orgCodeListPath = (org, codeListId) => `${basePath}/${org}/code-lists/${codeListId}`; // Post, Put, Delete
+export const orgCodeListUpdateIdPath = (org, codeListId) => `${basePath}/${org}/code-lists/change-name/${codeListId}`;
 export const orgCodeListUploadPath = (org) => `${basePath}/${org}/code-lists/upload`; // Post
 export const orgTextResourcesPath = (org, language) => `${basePath}/${org}/text/language/${language}`; // Get, patch, post
 export const orgTextLanguagesPath = (org) => `${basePath}/${org}/text/languages`; // Get

--- a/frontend/packages/shared/src/hooks/mutations/useUpdateOrgCodeListIdMutation.test.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useUpdateOrgCodeListIdMutation.test.ts
@@ -15,7 +15,7 @@ const codeListMock: CodeList = [{ value: 'value', label: 'label' }];
 describe('useUpdateOrgCodeListIdMutation', () => {
   afterEach(jest.clearAllMocks);
 
-  it('Calls useUpdateCodeListId with correct parameters', async () => {
+  it('Calls updateOrgCodeListId with correct parameters', async () => {
     const renderUpdateCodeListIdMutationResult = renderHookWithProviders(() =>
       useUpdateOrgCodeListIdMutation(org),
     ).result;

--- a/frontend/packages/shared/src/hooks/mutations/useUpdateOrgCodeListIdMutation.test.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useUpdateOrgCodeListIdMutation.test.ts
@@ -1,0 +1,48 @@
+import { org } from '@studio/testing/testids';
+import { queriesMock } from 'app-shared/mocks/queriesMock';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { renderHookWithProviders } from 'app-shared/mocks/renderHookWithProviders';
+import { useUpdateOrgCodeListIdMutation } from './useUpdateOrgCodeListIdMutation';
+import type { CodeList } from 'app-shared/types/CodeList';
+import type { CodeListsResponse } from 'app-shared/types/api/CodeListsResponse';
+
+// Test data:
+const codeListId: string = 'codeListId';
+const newCodeListId: string = 'newCodeListId';
+const codeListMock: CodeList = [{ value: 'value', label: 'label' }];
+
+describe('useUpdateOrgCodeListIdMutation', () => {
+  afterEach(jest.clearAllMocks);
+
+  it('Calls useUpdateCodeListId with correct parameters', async () => {
+    const renderUpdateCodeListIdMutationResult = renderHookWithProviders(() =>
+      useUpdateOrgCodeListIdMutation(org),
+    ).result;
+    await renderUpdateCodeListIdMutationResult.current.mutateAsync({ codeListId, newCodeListId });
+    expect(queriesMock.updateOrgCodeListId).toHaveBeenCalledTimes(1);
+    expect(queriesMock.updateOrgCodeListId).toHaveBeenCalledWith(org, codeListId, newCodeListId);
+  });
+
+  it('Sets the code lists cache with new id', async () => {
+    const codeListA = 'codeListA';
+    const codeListB = 'codeListB';
+    const queryClient = createQueryClientMock();
+    const oldData: CodeListsResponse = [
+      { title: codeListA, data: codeListMock },
+      { title: codeListB, data: codeListMock },
+    ];
+    queryClient.setQueryData([QueryKey.OrgCodeLists, org], oldData);
+    const renderUpdateCodeListIdMutationResult = renderHookWithProviders(
+      () => useUpdateOrgCodeListIdMutation(org),
+      { queryClient },
+    ).result;
+    await renderUpdateCodeListIdMutationResult.current.mutateAsync({
+      codeListId: codeListA,
+      newCodeListId,
+    });
+    const cacheData: CodeListsResponse = queryClient.getQueryData([QueryKey.OrgCodeLists, org]);
+    expect(cacheData[0].title).toEqual(newCodeListId);
+    expect(cacheData[1].title).toEqual(codeListB);
+  });
+});

--- a/frontend/packages/shared/src/hooks/mutations/useUpdateOrgCodeListIdMutation.test.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useUpdateOrgCodeListIdMutation.test.ts
@@ -1,4 +1,3 @@
-import { org } from '@studio/testing/testids';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
@@ -8,18 +7,21 @@ import type { CodeList } from 'app-shared/types/CodeList';
 import type { CodeListsResponse } from 'app-shared/types/api/CodeListsResponse';
 
 // Test data:
+const org = 'organisation';
 const codeListId: string = 'codeListId';
 const newCodeListId: string = 'newCodeListId';
 const codeListMock: CodeList = [{ value: 'value', label: 'label' }];
+
+// Mocks
+jest.mock('react-router-dom', () => jest.requireActual('react-router-dom')); // Todo: Remove this when we have removed the global mock: https://github.com/Altinn/altinn-studio/issues/14597
 
 describe('useUpdateOrgCodeListIdMutation', () => {
   afterEach(jest.clearAllMocks);
 
   it('Calls updateOrgCodeListId with correct parameters', async () => {
-    const renderUpdateCodeListIdMutationResult = renderHookWithProviders(() =>
-      useUpdateOrgCodeListIdMutation(org),
-    ).result;
-    await renderUpdateCodeListIdMutationResult.current.mutateAsync({ codeListId, newCodeListId });
+    const { result } = renderHookWithProviders(() => useUpdateOrgCodeListIdMutation(org));
+    await result.current.mutateAsync({ codeListId, newCodeListId });
+
     expect(queriesMock.updateOrgCodeListId).toHaveBeenCalledTimes(1);
     expect(queriesMock.updateOrgCodeListId).toHaveBeenCalledWith(org, codeListId, newCodeListId);
   });
@@ -33,14 +35,12 @@ describe('useUpdateOrgCodeListIdMutation', () => {
       { title: codeListB, data: codeListMock },
     ];
     queryClient.setQueryData([QueryKey.OrgCodeLists, org], oldData);
-    const renderUpdateCodeListIdMutationResult = renderHookWithProviders(
-      () => useUpdateOrgCodeListIdMutation(org),
-      { queryClient },
-    ).result;
-    await renderUpdateCodeListIdMutationResult.current.mutateAsync({
-      codeListId: codeListA,
-      newCodeListId,
+
+    const { result } = renderHookWithProviders(() => useUpdateOrgCodeListIdMutation(org), {
+      queryClient,
     });
+    await result.current.mutateAsync({ codeListId: codeListA, newCodeListId });
+
     const cacheData: CodeListsResponse = queryClient.getQueryData([QueryKey.OrgCodeLists, org]);
     expect(cacheData[0].title).toEqual(newCodeListId);
     expect(cacheData[1].title).toEqual(codeListB);

--- a/frontend/packages/shared/src/hooks/mutations/useUpdateOrgCodeListIdMutation.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useUpdateOrgCodeListIdMutation.ts
@@ -13,14 +13,12 @@ export const useUpdateOrgCodeListIdMutation = (org: string) => {
 
   return useMutation({
     mutationFn: async ({ codeListId, newCodeListId }: UpdateOrgCodeListIdMutationArgs) =>
-      updateOrgCodeListId(org, codeListId, newCodeListId).then(() => ({
-        codeListId,
-        newCodeListId,
-      })),
-    onSuccess: ({ codeListId, newCodeListId }) => {
-      const oldData: CodeListsResponse = queryClient.getQueryData([QueryKey.OrgCodeLists, org]);
-      const newData: CodeListsResponse = updateId(codeListId, newCodeListId, oldData);
-      queryClient.setQueryData([QueryKey.OrgCodeLists, org], newData);
+      updateOrgCodeListId(org, codeListId, newCodeListId),
+
+    onSuccess: (_, { codeListId, newCodeListId }) => {
+      queryClient.setQueryData([QueryKey.OrgCodeLists, org], (oldData: CodeListsResponse) =>
+        updateId(codeListId, newCodeListId, oldData),
+      );
     },
   });
 };

--- a/frontend/packages/shared/src/hooks/mutations/useUpdateOrgCodeListIdMutation.ts
+++ b/frontend/packages/shared/src/hooks/mutations/useUpdateOrgCodeListIdMutation.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useServicesContext } from 'app-shared/contexts/ServicesContext';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import { ArrayUtils } from '@studio/pure-functions';
+import type { CodeListsResponse } from 'app-shared/types/api/CodeListsResponse';
+import type { CodeListData } from '@studio/content-library';
+
+type UpdateOrgCodeListIdMutationArgs = { codeListId: string; newCodeListId: string };
+
+export const useUpdateOrgCodeListIdMutation = (org: string) => {
+  const queryClient = useQueryClient();
+  const { updateOrgCodeListId } = useServicesContext();
+
+  return useMutation({
+    mutationFn: async ({ codeListId, newCodeListId }: UpdateOrgCodeListIdMutationArgs) =>
+      updateOrgCodeListId(org, codeListId, newCodeListId).then(() => ({
+        codeListId,
+        newCodeListId,
+      })),
+    onSuccess: ({ codeListId, newCodeListId }) => {
+      const oldData: CodeListsResponse = queryClient.getQueryData([QueryKey.OrgCodeLists, org]);
+      const newData: CodeListsResponse = updateId(codeListId, newCodeListId, oldData);
+      queryClient.setQueryData([QueryKey.OrgCodeLists, org], newData);
+    },
+  });
+};
+
+const updateId = (oldId: string, newId: string, oldData: CodeListsResponse): CodeListsResponse => {
+  if (!oldData) return [];
+
+  const oldCodeList: CodeListData = oldData.find(
+    (codeList: CodeListData): boolean => codeList.title === oldId,
+  );
+
+  return ArrayUtils.replaceByPredicate(
+    oldData,
+    (codeList: CodeListData): boolean => codeList.title === oldId,
+    { ...oldCodeList, title: newId },
+  );
+};

--- a/frontend/packages/shared/src/mocks/queriesMock.ts
+++ b/frontend/packages/shared/src/mocks/queriesMock.ts
@@ -271,6 +271,7 @@ export const queriesMock: ServicesContextProps = {
   updateAppConfig: jest.fn().mockImplementation(() => Promise.resolve()),
   updateOptionList: jest.fn().mockImplementation(() => Promise.resolve()),
   updateOptionListId: jest.fn().mockImplementation(() => Promise.resolve()),
+  updateOrgCodeListId: jest.fn().mockImplementation(() => Promise.resolve()),
   updateOrgCodeList: jest.fn().mockImplementation(() => Promise.resolve()),
   updateOrgTextResources: jest.fn().mockImplementation(() => Promise.resolve()),
   uploadOrgCodeList: jest.fn().mockImplementation(() => Promise.resolve()),


### PR DESCRIPTION
## Description
This pull request implements the frontend portion for updating the ID for a code list on organisation level.

We have decided to not implement alphabetical sorting of the cache in the `onSuccess` method for the mutation. 
There will be a follow up PR to remove it from the mutation named `useUpdateOptionListIdMutation`.

## Related Issue(s)
- #15528

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to update the ID of a code list within an organization from the content library interface.

- **Tests**
  - Introduced new tests to verify the update functionality for code list IDs and ensure cache consistency after updates.

- **Chores**
  - Added new mock functions to support testing of code list ID updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->