### PR TITLE
chore: Add beta tag to Library header element and reorder header elements

### DIFF
--- a/frontend/dashboard/pages/PageLayout/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/dashboard/pages/PageLayout/DashboardHeader/DashboardHeader.tsx
@@ -75,6 +75,7 @@ function TopNavigationMenuItem({ menuItem }: TopNavigationMenuProps): ReactEleme
     <StudioPageHeader.HeaderLink
       color='dark'
       variant='regular'
+      isBeta={menuItem.isBeta}
       renderLink={(props) => (
         <NavLink to={path} {...props}>
           <span

--- a/frontend/dashboard/types/HeaderMenuItem.ts
+++ b/frontend/dashboard/types/HeaderMenuItem.ts
@@ -6,4 +6,5 @@ export type HeaderMenuItem = {
   link: string;
   name: string;
   group: HeaderMenuGroupKey;
+  isBeta?: boolean;
 };

--- a/frontend/dashboard/utils/headerUtils/headerUtils.ts
+++ b/frontend/dashboard/utils/headerUtils/headerUtils.ts
@@ -8,16 +8,17 @@ import { type StudioProfileMenuGroup } from '@studio/components-legacy';
 
 export const dashboardHeaderMenuItems: HeaderMenuItem[] = [
   {
-    key: HeaderMenuItemKey.OrgLibrary,
-    link: Subroute.OrgLibrary,
-    name: 'dashboard.header_item_library',
-    group: HeaderMenuGroupKey.Tools,
-  },
-  {
     key: HeaderMenuItemKey.AppDashboard,
     link: Subroute.AppDashboard,
     name: 'dashboard.header_item_dashboard',
     group: HeaderMenuGroupKey.Tools,
+  },
+  {
+    key: HeaderMenuItemKey.OrgLibrary,
+    link: Subroute.OrgLibrary,
+    name: 'dashboard.header_item_library',
+    group: HeaderMenuGroupKey.Tools,
+    isBeta: true,
   },
 ];
 


### PR DESCRIPTION
## Description
This pull request reorders header elements on the dashboard page, and adds a beta tag for the `Bibliotek` menu item.

## Related Issue
- #15529

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "OrgLibrary" menu item in the dashboard header is now marked as "Beta" to indicate its beta status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->