### PR TITLE
fix: add null handling for data type

### DIFF
--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.test.tsx
@@ -191,6 +191,12 @@ describe('taskCard', () => {
     expect(layoutSetNameTextbox()).toBeInvalid();
     expect(screen.getByRole('button', { name: /general.save/ })).toBeDisabled();
   });
+
+  it('should show default "choose model" option if layoutset dataType is null', () => {
+    render({ layoutSetModel: { ...dataTaskLayoutSet, dataType: null } });
+
+    expect(dataModelBindingCombobox()).toHaveTextContent('ux_editor.task_card.choose_datamodel');
+  });
 });
 
 const render = (props?: Partial<TaskCardEditingProps>) => {

--- a/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.tsx
+++ b/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCardEditing.tsx
@@ -38,7 +38,7 @@ export const TaskCardEditing = ({ layoutSetModel, onClose }: TaskCardEditingProp
 
   const taskName = getLayoutSetTypeTranslationKey(layoutSetModel);
   const [id, setId] = React.useState(layoutSetModel.id);
-  const [dataType, setDataType] = React.useState(layoutSetModel.dataType);
+  const [dataType, setDataType] = React.useState(layoutSetModel.dataType || '');
 
   const idChanged = id !== layoutSetModel.id;
   const dataTypeChanged = dataType !== layoutSetModel.dataType;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Handle possibility that data type in layoutset is null in task editing card. Now possible to set data model when none is set and only one option available.

https://github.com/user-attachments/assets/fef6cbde-ae44-4230-bb1a-8508e731c648

## Related Issue(s)

- #15584 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing or null data model bindings in the task card editing interface to ensure consistent display and prevent input issues.

- **Tests**
  - Added a test to verify correct behavior when the data model binding is not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->