### PR TITLE
fix(resource-adm): Rename resource type ConsentResource to Consent

### DIFF
--- a/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -633,7 +633,7 @@ namespace Altinn.Studio.Designer.Controllers
                 }
             }
 
-            if (resource.ResourceType == ResourceType.ConsentResource)
+            if (resource.ResourceType == ResourceType.Consent)
             {
                 if (string.IsNullOrWhiteSpace(resource.ConsentTemplate))
                 {

--- a/backend/src/Designer/Enums/ResourceType.cs
+++ b/backend/src/Designer/Enums/ResourceType.cs
@@ -22,5 +22,5 @@ public enum ResourceType
 
     CorrespondenceService = 1 << 6,
 
-    ConsentResource = 1 << 7,
+    Consent = 1 << 7,
 }

--- a/frontend/packages/shared/src/types/ResourceAdm.ts
+++ b/frontend/packages/shared/src/types/ResourceAdm.ts
@@ -48,7 +48,7 @@ export type ResourceTypeOption =
   | 'MaskinportenSchema'
   | 'BrokerService'
   | 'CorrespondenceService'
-  | 'ConsentResource';
+  | 'Consent';
 
 export type ResourceStatusOption = 'Completed' | 'Deprecated' | 'UnderDevelopment' | 'Withdrawn';
 

--- a/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
+++ b/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
@@ -56,7 +56,7 @@ const mockResource2: Resource = {
 };
 const mockConsentResource: Resource = {
   ...mockResource1,
-  resourceType: 'ConsentResource',
+  resourceType: 'Consent',
   consentText: {
     nb: 'Du samtykker til å dele dine data med {org}',
     nn: 'consentNn',
@@ -578,13 +578,13 @@ describe('AboutResourcePage', () => {
     ).toBeInTheDocument();
   });
 
-  it('should display correct fields for resourceType ConsentResource', () => {
+  it('should display correct fields for resourceType consent resource', () => {
     render(
       <AboutResourcePage
         {...defaultProps}
         validationErrors={[]}
         consentTemplates={[]}
-        resourceData={{ ...mockResource1, resourceType: 'ConsentResource' }}
+        resourceData={{ ...mockResource1, resourceType: 'Consent' }}
       />,
     );
 

--- a/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
+++ b/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
@@ -68,7 +68,7 @@ export const AboutResourcePage = ({
    */
   const resourceTypeOptions = Object.entries(resourceTypeMap)
     .filter(([key]) =>
-      key === 'ConsentResource' ? shouldDisplayFeature(FeatureFlag.ConsentResource) : true,
+      key === 'Consent' ? shouldDisplayFeature(FeatureFlag.ConsentResource) : true,
     )
     .map(([key, value]) => ({
       value: key,
@@ -185,7 +185,7 @@ export const AboutResourcePage = ({
           required
           errors={validationErrors.filter((error) => error.field === 'description')}
         />
-        {resourceData.resourceType === 'ConsentResource' && (
+        {resourceData.resourceType === 'Consent' && (
           <>
             <ResourceRadioGroup
               id='consentTemplate'
@@ -370,7 +370,7 @@ export const AboutResourcePage = ({
           onChange={(isChecked: boolean) => handleSave({ ...resourceData, visible: isChecked })}
           toggleTextTranslationKey='resourceadm.about_resource_visible_show_text'
         />
-        {resourceData.resourceType !== 'ConsentResource' && (
+        {resourceData.resourceType !== 'Consent' && (
           <ResourceSwitchInput
             id='accessListMode'
             label={t('resourceadm.about_resource_limited_by_rrr_label')}

--- a/frontend/resourceadm/pages/PolicyEditorPage/PolicyEditorPage.test.tsx
+++ b/frontend/resourceadm/pages/PolicyEditorPage/PolicyEditorPage.test.tsx
@@ -125,7 +125,7 @@ describe('PolicyEditorPage', () => {
           nn: '',
           en: '',
         },
-        resourceType: 'ConsentResource',
+        resourceType: 'Consent',
       }),
     );
 

--- a/frontend/resourceadm/pages/PolicyEditorPage/PolicyEditorPage.tsx
+++ b/frontend/resourceadm/pages/PolicyEditorPage/PolicyEditorPage.tsx
@@ -52,7 +52,7 @@ export const PolicyEditorPage = ({
     app,
     resourceId,
   );
-  const isConsentResource = resourceData?.resourceType === 'ConsentResource';
+  const isConsentResource = resourceData?.resourceType === 'Consent';
   const { data: accessLists, isPending: isLoadingAccessLists } = useGetAllAccessListsQuery(
     org,
     isConsentResource,

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.test.tsx
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.test.tsx
@@ -110,7 +110,7 @@ describe('ResourcePage', () => {
     const getResource = jest
       .fn()
       .mockImplementation(() =>
-        Promise.resolve<Resource>({ ...mockResource1, resourceType: 'ConsentResource' }),
+        Promise.resolve<Resource>({ ...mockResource1, resourceType: 'Consent' }),
       );
 
     renderResourcePage({ getResource });
@@ -273,8 +273,8 @@ describe('ResourcePage', () => {
     await waitFor(() => expect(queriesMock.updateResource).toHaveBeenCalledTimes(1));
   });
 
-  it('fetches consent templates when resource is ConsentResource', async () => {
-    const resource = { ...mockResource1, resourceType: 'ConsentResource' as ResourceTypeOption };
+  it('fetches consent templates when resource is consent resource', async () => {
+    const resource = { ...mockResource1, resourceType: 'Consent' as ResourceTypeOption };
     const getResource = jest.fn().mockImplementation(() => Promise.resolve<Resource>(resource));
 
     renderResourcePage({ getResource });

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
@@ -68,7 +68,7 @@ export const ResourcePage = (): React.JSX.Element => {
   const { data: accessList } = useGetAccessListQuery(org, accessListId, env);
   const { data: consentTemplates } = useGetConsentTemplates(
     org,
-    resourceData?.resourceType === 'ConsentResource',
+    resourceData?.resourceType === 'Consent',
   );
 
   // Mutation function for editing a resource

--- a/frontend/resourceadm/utils/resourceUtils/resourceUtils.test.tsx
+++ b/frontend/resourceadm/utils/resourceUtils/resourceUtils.test.tsx
@@ -214,10 +214,10 @@ describe('deepCompare', () => {
       expect(validationErrors.length).toBe(13);
     });
 
-    it('should return all possible errors for consentResource', () => {
+    it('should return all possible errors for consent resource', () => {
       const resource: Resource = {
         identifier: 'res',
-        resourceType: 'ConsentResource',
+        resourceType: 'Consent',
         title: null,
         description: null,
         delegable: true,
@@ -248,7 +248,7 @@ describe('deepCompare', () => {
       it('should return error for nb consentText field', () => {
         const resource: Resource = {
           identifier: 'res',
-          resourceType: 'ConsentResource',
+          resourceType: 'Consent',
           title: null,
           consentMetadata: {
             org: { optional: false },
@@ -276,7 +276,7 @@ describe('deepCompare', () => {
       it('should return error for nn consentText field', () => {
         const resource: Resource = {
           identifier: 'res',
-          resourceType: 'ConsentResource',
+          resourceType: 'Consent',
           title: null,
           consentMetadata: {
             org: { optional: false },
@@ -313,7 +313,7 @@ describe('deepCompare', () => {
       it('should return errors for nn and en consentText field', () => {
         const resource: Resource = {
           identifier: 'res',
-          resourceType: 'ConsentResource',
+          resourceType: 'Consent',
           title: null,
           consentMetadata: {
             org: { optional: false },

--- a/frontend/resourceadm/utils/resourceUtils/resourceUtils.ts
+++ b/frontend/resourceadm/utils/resourceUtils/resourceUtils.ts
@@ -385,7 +385,7 @@ export const validateResource = (
   }
 
   // validate consentTemplate
-  if (resourceData.resourceType === 'ConsentResource') {
+  if (resourceData.resourceType === 'Consent') {
     if (!resourceData.consentTemplate) {
       errors.push({
         field: 'consentTemplate',

--- a/frontend/resourceadm/utils/resourceUtils/resourceUtils.ts
+++ b/frontend/resourceadm/utils/resourceUtils/resourceUtils.ts
@@ -26,7 +26,7 @@ export const resourceTypeMap: Record<ResourceTypeOption, string> = {
   MaskinportenSchema: 'resourceadm.about_resource_resource_type_maskinporten',
   BrokerService: 'resourceadm.about_resource_resource_type_brokerservice',
   CorrespondenceService: 'resourceadm.about_resource_resource_type_correspondenceservice',
-  ConsentResource: 'resourceadm.about_resource_resource_type_consentresource',
+  Consent: 'resourceadm.about_resource_resource_type_consentresource',
 };
 
 /**


### PR DESCRIPTION
## Description
- Rename resource type ConsentResource to Consent

## Related Issue(s)

- this PR

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the resource type from "ConsentResource" to "Consent" across the application for consistency.
- **Tests**
  - Updated all relevant test cases to use the new "Consent" resource type name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->