### PR TITLE
always clear jsonschema cache when uploading data model

### DIFF
--- a/frontend/app-development/hooks/mutations/useUploadDataModelMutation.ts
+++ b/frontend/app-development/hooks/mutations/useUploadDataModelMutation.ts
@@ -22,8 +22,9 @@ export const useUploadDataModelMutation = (modelPath?: string, meta?: MutationMe
         queryClient.invalidateQueries({ queryKey: [QueryKey.DataModelsXsd, org, app] }),
         queryClient.invalidateQueries({ queryKey: [QueryKey.AppMetadataModelIds, org, app] }),
         queryClient.invalidateQueries({ queryKey: [QueryKey.AppMetadata, org, app] }),
-        modelPath &&
-          queryClient.invalidateQueries({ queryKey: [QueryKey.JsonSchema, org, app, modelPath] }),
+        queryClient.invalidateQueries({
+          queryKey: [QueryKey.JsonSchema, org, app, modelPath || ''],
+        }),
       ]);
     },
     meta,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ensure jsonschema cache is cleared when uploading data model

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
