### PR TITLE
refactor: Rename codeListsData to codeListDataList

### DIFF
--- a/frontend/app-development/features/appContentLibrary/AppContentLibrary.test.tsx
+++ b/frontend/app-development/features/appContentLibrary/AppContentLibrary.test.tsx
@@ -72,7 +72,7 @@ describe('AppContentLibrary', () => {
 
   it('Renders with the given code lists', () => {
     renderAppContentLibraryWithData();
-    const codeListDataList = retrieveConfig().codeList.props.codeListsData;
+    const codeListDataList = retrieveConfig().codeList.props.codeListDataList;
     const expectedData: CodeListData[] = optionListDataList;
     expect(codeListDataList).toEqual(expectedData);
   });

--- a/frontend/app-development/features/appContentLibrary/AppContentLibrary.tsx
+++ b/frontend/app-development/features/appContentLibrary/AppContentLibrary.tsx
@@ -132,7 +132,7 @@ function AppContentLibraryWithData({
     pages: {
       codeList: {
         props: {
-          codeListsData: codeListDataList,
+          codeListDataList,
           onCreateCodeList: handleCreate,
           onDeleteCodeList: deleteOptionList,
           onUpdateCodeListId: handleUpdateCodeListId,

--- a/frontend/dashboard/pages/OrgContentLibraryPage/OrgContentLibraryPage.test.tsx
+++ b/frontend/dashboard/pages/OrgContentLibraryPage/OrgContentLibraryPage.test.tsx
@@ -90,7 +90,7 @@ describe('OrgContentLibraryPage', () => {
 
   it('Renders with the given code lists', () => {
     renderOrgContentLibraryWithData();
-    const renderedList = retrieveConfig().codeList.props.codeListsData;
+    const renderedList = retrieveConfig().codeList.props.codeListDataList;
     expect(renderedList).toEqual(codeListDataList);
   });
 

--- a/frontend/dashboard/pages/OrgContentLibraryPage/OrgContentLibraryPage.tsx
+++ b/frontend/dashboard/pages/OrgContentLibraryPage/OrgContentLibraryPage.tsx
@@ -137,7 +137,7 @@ function OrgContentLibraryWithContextAndData({
     pages: {
       codeList: {
         props: {
-          codeListsData: codeListDataList,
+          codeListDataList,
           onCreateCodeList: handleCreate,
           onCreateTextResource: handleUpdateTextResource,
           onDeleteCodeList: deleteCodeList,

--- a/frontend/libs/studio-content-library/mocks/mockPagesConfig.ts
+++ b/frontend/libs/studio-content-library/mocks/mockPagesConfig.ts
@@ -12,7 +12,7 @@ export const codeListsDataMock: CodeListData[] = [codeListData];
 export const mockPagesConfig: PagesConfig = {
   codeList: {
     props: {
-      codeListsData: codeListsDataMock,
+      codeListDataList: codeListsDataMock,
       onCreateCodeList: () => {},
       onDeleteCodeList: () => {},
       onUpdateCodeListId: () => {},

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.test.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.test.tsx
@@ -22,7 +22,7 @@ const onUpdateCodeListId = jest.fn();
 const onUpdateCodeList = jest.fn();
 const onUploadCodeList = jest.fn();
 const defaultCodeListPageProps: CodeListPageProps = {
-  codeListsData: codeListDataList,
+  codeListDataList,
   onDeleteCodeList,
   onUpdateCodeListId,
   onUpdateCodeList,
@@ -106,12 +106,12 @@ describe('CodeListPage', () => {
       data: [{ value: 'value', label: 'label' }],
     };
     const newCodeListDataList: CodeListData[] = [
-      ...defaultCodeListPageProps.codeListsData,
+      ...defaultCodeListPageProps.codeListDataList,
       newCodeListData,
     ];
 
     await uploadCodeList(user, newCodeListData.title);
-    rerender(<CodeListPage {...defaultCodeListPageProps} codeListsData={newCodeListDataList} />);
+    rerender(<CodeListPage {...defaultCodeListPageProps} codeListDataList={newCodeListDataList} />);
 
     const openItem = screen.getByRole('button', { name: newCodeListData.title, expanded: true });
     expect(openItem).toBeInTheDocument();
@@ -164,7 +164,7 @@ describe('CodeListPage', () => {
 
   it('Renders with text resources in the input fields when given', async () => {
     const user = userEvent.setup();
-    renderCodeListPage({ textResources, codeListsData: codeListDataList });
+    renderCodeListPage({ textResources, codeListDataList: codeListDataList });
     const labelField = await openAndGetFirstLabelField(user, codeList1Data.title);
     expect(labelField).toHaveValue(label1ResourceNb.value);
   });
@@ -174,7 +174,7 @@ describe('CodeListPage', () => {
     const onUpdateTextResource = jest.fn();
     const newLabel = 'Ny ledetekst';
 
-    renderCodeListPage({ textResources, codeListsData: codeListDataList, onUpdateTextResource });
+    renderCodeListPage({ textResources, codeListDataList: codeListDataList, onUpdateTextResource });
     const labelField = await openAndGetFirstLabelField(user, codeList1Data.title);
     await user.type(labelField, newLabel);
     await user.tab();
@@ -193,7 +193,7 @@ describe('CodeListPage', () => {
     const onCreateTextResource = jest.fn();
     const newDescription = 'Ny beskrivelse';
 
-    renderCodeListPage({ textResources, codeListsData: codeListDataList, onCreateTextResource });
+    renderCodeListPage({ textResources, codeListDataList: codeListDataList, onCreateTextResource });
     const emptyDescriptionField = await openAndGetFirstDescriptionField(user, codeList2Data.title);
     await user.type(emptyDescriptionField, newDescription);
     await user.tab();
@@ -264,7 +264,7 @@ describe('CodeListPage', () => {
   });
 
   it('renders an info box when no code lists are passed', () => {
-    renderCodeListPage({ codeListsData: [] });
+    renderCodeListPage({ codeListDataList: [] });
     const alert = screen.getByText(textMock('app_content_library.code_lists.info_box.title'));
     expect(alert).toBeInTheDocument();
   });

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeListPage.tsx
@@ -26,7 +26,7 @@ export type CodeListData = {
 };
 
 export type CodeListPageProps = {
-  codeListsData: CodeListData[];
+  codeListDataList: CodeListData[];
   onCreateCodeList: (newCodeList: CodeListWithMetadata) => void;
   onCreateTextResource?: (textResource: TextResourceWithLanguage) => void;
   onDeleteCodeList: (codeListId: string) => void;
@@ -41,7 +41,7 @@ export type CodeListPageProps = {
 };
 
 export function CodeListPage({
-  codeListsData,
+  codeListDataList,
   onCreateCodeList,
   onCreateTextResource,
   onDeleteCodeList,
@@ -58,11 +58,11 @@ export function CodeListPage({
   const [searchString, setSearchString] = useState<string>('');
   const [codeListInEditMode, setCodeListInEditMode] = useState<string>(undefined);
 
-  const codeListIsEmpty: boolean = codeListsData.length === 0;
+  const codeListIsEmpty: boolean = codeListDataList.length === 0;
 
   const filteredCodeLists: CodeListData[] = useMemo(
-    () => filterCodeLists(codeListsData, searchString),
-    [codeListsData, searchString],
+    () => filterCodeLists(codeListDataList, searchString),
+    [codeListDataList, searchString],
   );
 
   const textResourcesForLanguage = useMemo(
@@ -86,7 +86,7 @@ export function CodeListPage({
     [onUpdateTextResource],
   );
 
-  const codeListTitles = ArrayUtils.mapByKey<CodeListData, 'title'>(codeListsData, 'title');
+  const codeListTitles = ArrayUtils.mapByKey<CodeListData, 'title'>(codeListDataList, 'title');
 
   const handleUploadCodeList = (uploadedCodeList: File) => {
     setCodeListInEditMode(FileNameUtils.removeExtension(uploadedCodeList.name));
@@ -101,7 +101,7 @@ export function CodeListPage({
   return (
     <div className={classes.codeListsContainer}>
       <StudioHeading size='small'>{t('app_content_library.code_lists.page_name')}</StudioHeading>
-      <CodeListsCounterMessage codeListsCount={codeListsData.length} />
+      <CodeListsCounterMessage codeListsCount={codeListDataList.length} />
       <CodeListsActionsBar
         onCreateCodeList={onCreateCodeList}
         onCreateTextResource={handleCreateTextResource}
@@ -114,7 +114,7 @@ export function CodeListPage({
         onImportCodeListFromOrg={onImportCodeListFromOrg}
       />
       <CodeLists
-        codeListsData={filteredCodeLists}
+        codeListDataList={filteredCodeLists}
         onCreateTextResource={handleCreateTextResource}
         onDeleteCodeList={onDeleteCodeList}
         onUpdateCodeListId={handleUpdateCodeListId}

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.test.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.test.tsx
@@ -239,7 +239,9 @@ describe('CodeLists', () => {
   });
 
   it('renders error message if option list has format error', () => {
-    renderCodeLists({ codeListsData: [{ ...codeListsDataMock[0], hasError: true, data: null }] });
+    renderCodeLists({
+      codeListDataList: [{ ...codeListsDataMock[0], hasError: true, data: null }],
+    });
     const errorMessage = screen.getByText(textMock('app_content_library.code_lists.format_error'));
     expect(errorMessage).toBeInTheDocument();
   });
@@ -294,7 +296,7 @@ const changeCodeListId = async (user: UserEvent, oldCodeListId: string, newCodeL
 };
 
 const defaultProps: CodeListsProps = {
-  codeListsData: codeListsDataMock,
+  codeListDataList: codeListsDataMock,
   onDeleteCodeList: onDeleteCodeListMock,
   onUpdateCodeListId: onUpdateCodeListIdMock,
   onUpdateCodeList: onUpdateCodeListMock,

--- a/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
+++ b/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
@@ -11,7 +11,7 @@ import { getCodeListSourcesById, getCodeListUsageCount } from '../utils';
 import type { TextResource } from '@studio/components-legacy';
 
 export type CodeListsProps = {
-  codeListsData: CodeListData[];
+  codeListDataList: CodeListData[];
   onCreateTextResource?: (textResource: TextResource) => void;
   onDeleteCodeList: (codeListId: string) => void;
   onUpdateCodeListId: (codeListId: string, newCodeListId: string) => void;
@@ -24,11 +24,11 @@ export type CodeListsProps = {
 };
 
 export function CodeLists({
-  codeListsData,
+  codeListDataList,
   codeListsUsages,
   ...rest
 }: CodeListsProps): React.ReactElement[] {
-  return codeListsData.map((codeListData) => {
+  return codeListDataList.map((codeListData) => {
     const codeListSources = getCodeListSourcesById(codeListsUsages, codeListData.title);
     return (
       <CodeList
@@ -41,7 +41,7 @@ export function CodeLists({
   });
 }
 
-type CodeListProps = Omit<CodeListsProps, 'codeListsData' | 'codeListsUsages'> & {
+type CodeListProps = Omit<CodeListsProps, 'codeListDataList' | 'codeListsUsages'> & {
   codeListData: CodeListData;
   codeListSources: CodeListIdSource[];
 };


### PR DESCRIPTION
## Description
This pull request renames the `codeListsData` property of `CodeListPage` in the content library to `codeListDataList`, according to our naming conventions. The name `codeListsData` implies that the variable holds one data object for a list of code lists, but it is in fact a list of `CodeListData` objects.

This also removes the workarounds we have made due to inconsistent naming. With this change, we can write `{codeListDataList}` instead of `{codeListsData: codeListDataList}`.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the prop for code list data from `codeListsData` to `codeListDataList` throughout the application for improved consistency and clarity.
- **Tests**
  - Updated all related tests to use the new prop name, ensuring alignment with the updated naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->