### PR TITLE
feat: Preview navigation tasks

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -2035,6 +2035,7 @@
   "ux_editor.task_table_hide_all": "Skjul alle oppgavene",
   "ux_editor.task_table_name": "Visningsnavn",
   "ux_editor.task_table_pages": "Antall sider",
+  "ux_editor.task_table_preview": "Vis med navigasjonsmeny",
   "ux_editor.task_table_show_all": "Vis alle oppgavene",
   "ux_editor.task_table_type": "Oppgave",
   "ux_editor.task_table_type.confirmation": "Bekreftelse",

--- a/frontend/packages/ux-editor/src/components/TasksTable/TasksTable.module.css
+++ b/frontend/packages/ux-editor/src/components/TasksTable/TasksTable.module.css
@@ -1,6 +1,7 @@
 .tasksTable {
   padding: var(--fds-spacing-2) 0;
   border: 1px solid var(--ds-color-neutral-border-subtle);
+  margin-bottom: var(--fds-spacing-5);
 }
 
 .tasksTable th {
@@ -14,4 +15,30 @@
 .taskFooterContent {
   text-align: end;
   border-top: 2px solid var(--ds-color-neutral-border-subtle);
+}
+
+.previewLink {
+  display: flex;
+  width: fit-content;
+  align-items: center;
+  padding: var(--ds-size-3) var(--ds-size-4);
+  color: var(--ds-color-base-contrast-default);
+  background: var(--ds-color-base-default);
+  border-radius: var(--ds-border-radius-default);
+  font-weight: var(--ds-font-weight-medium);
+}
+
+.previewLink:hover {
+  background: var(--ds-color-base-hover);
+}
+
+.previewLink svg {
+  width: var(--icon-size);
+  height: var(--icon-size);
+}
+
+.disabledPreviewLink {
+  pointer-events: none;
+  opacity: 0.5;
+  cursor: not-allowed;
 }

--- a/frontend/packages/ux-editor/src/components/TasksTable/TasksTable.module.css
+++ b/frontend/packages/ux-editor/src/components/TasksTable/TasksTable.module.css
@@ -26,6 +26,7 @@
   background: var(--ds-color-base-default);
   border-radius: var(--ds-border-radius-default);
   font-weight: var(--ds-font-weight-medium);
+  gap: var(--ds-size-1);
 }
 
 .previewLink:hover {

--- a/frontend/packages/ux-editor/src/components/TasksTable/TasksTable.test.tsx
+++ b/frontend/packages/ux-editor/src/components/TasksTable/TasksTable.test.tsx
@@ -72,6 +72,29 @@ describe('TasksTable', () => {
     renderTasksTable({ tasks: [], allTasks: [], isNavigationMode: false });
     expect(getShowAllButton()).toBeDisabled();
   });
+
+  it('should render preview link when in navigation mode', () => {
+    renderTasksTable();
+
+    const previewLink = getPreviewLink();
+    expect(previewLink).toBeInTheDocument();
+    expect(previewLink).toHaveAttribute('href', `/preview/${org}/${app}`);
+  });
+
+  it('should disable preview link when there are no tasks', () => {
+    renderTasksTable({ tasks: [] });
+
+    const previewLink = getPreviewLink();
+    expect(previewLink).toBeInTheDocument();
+    expect(previewLink).toHaveClass('disabledPreviewLink');
+  });
+
+  it('should not render preview link when not in navigation mode', () => {
+    renderTasksTable({ isNavigationMode: false });
+
+    const previewLink = getPreviewLink();
+    expect(previewLink).not.toBeInTheDocument();
+  });
 });
 
 const getHideAllButton = () => {
@@ -82,6 +105,12 @@ const getHideAllButton = () => {
 const getShowAllButton = () => {
   return screen.getByRole('button', {
     name: textMock('ux_editor.task_table_show_all'),
+  });
+};
+
+const getPreviewLink = () => {
+  return screen.queryByRole('link', {
+    name: textMock('ux_editor.task_table_preview'),
   });
 };
 

--- a/frontend/packages/ux-editor/src/components/TasksTable/TasksTable.tsx
+++ b/frontend/packages/ux-editor/src/components/TasksTable/TasksTable.tsx
@@ -84,7 +84,7 @@ export const TasksTable = ({
           data-color='neutral'
         >
           <PlayFillIcon />
-          Forhåndsvis med navigasjonsmeny
+          {t('ux_editor.task_table_preview')}
         </StudioLink>
       )}
     </div>

--- a/frontend/packages/ux-editor/src/components/TasksTable/TasksTable.tsx
+++ b/frontend/packages/ux-editor/src/components/TasksTable/TasksTable.tsx
@@ -1,13 +1,15 @@
 import React, { type ReactElement } from 'react';
-import { StudioButton, StudioTable } from '@studio/components';
+import { StudioButton, StudioLink, StudioTable } from '@studio/components';
 import classes from './TasksTable.module.css';
 import cn from 'classnames';
 import { TasksTableBody } from './TasksTableBody';
 import { useTranslation } from 'react-i18next';
-import { EyeClosedIcon, EyeIcon } from '@studio/icons';
+import { EyeClosedIcon, EyeIcon, PlayFillIcon } from '@studio/icons';
 import type { TaskNavigationGroup } from 'app-shared/types/api/dto/TaskNavigationGroup';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useTaskNavigationGroupMutation } from '@altinn/ux-editor/hooks/mutations/useTaskNavigationGroupMutation';
+import { useSearchParams } from 'react-router-dom';
+import { PackagesRouter } from 'app-shared/navigation/PackagesRouter';
 
 export type TasksTableProps = {
   tasks?: TaskNavigationGroup[];
@@ -24,6 +26,12 @@ export const TasksTable = ({
   const { org, app } = useStudioEnvironmentParams();
   const { mutate: updateTaskNavigationGroup } = useTaskNavigationGroupMutation(org, app);
 
+  const [searchParams] = useSearchParams();
+  const layout = searchParams?.get('layout');
+  const packagesRouter = new PackagesRouter({ org, app });
+  const previewLinkQueryParams = layout ? `?layout=${layout}` : '';
+  const previewLink: string = `${packagesRouter.getPackageNavigationUrl('preview')}${previewLinkQueryParams}`;
+
   const handleMoveAllTasks = () => {
     if (!isNavigationMode || confirm(t('ux_editor.task_table.remove_tasks'))) {
       const newNavigationTaskList = isNavigationMode ? [] : allTasks;
@@ -32,41 +40,53 @@ export const TasksTable = ({
   };
 
   return (
-    <StudioTable
-      border={true}
-      className={cn(classes.tasksTable, {
-        [classes.hiddenTasksTable]: !isNavigationMode,
-      })}
-    >
-      <StudioTable.Head>
-        <StudioTable.Row>
-          <StudioTable.HeaderCell>{t('ux_editor.task_table_type')}</StudioTable.HeaderCell>
-          {isNavigationMode && (
-            <StudioTable.HeaderCell>{t('ux_editor.task_table_name')}</StudioTable.HeaderCell>
-          )}
-          <StudioTable.HeaderCell>{t('ux_editor.task_table_pages')}</StudioTable.HeaderCell>
-          <StudioTable.HeaderCell />
-        </StudioTable.Row>
-      </StudioTable.Head>
-      <StudioTable.Body>
-        <TasksTableBody tasks={tasks} isNavigationMode={isNavigationMode} />
-      </StudioTable.Body>
-      <StudioTable.Foot>
-        <StudioTable.Row>
-          <StudioTable.Cell colSpan={4} className={classes.taskFooterContent}>
-            <StudioButton
-              variant='secondary'
-              onClick={handleMoveAllTasks}
-              icon={isNavigationMode ? <EyeIcon /> : <EyeClosedIcon />}
-              disabled={tasks.length === 0}
-            >
-              {isNavigationMode
-                ? t('ux_editor.task_table_hide_all')
-                : t('ux_editor.task_table_show_all')}
-            </StudioButton>
-          </StudioTable.Cell>
-        </StudioTable.Row>
-      </StudioTable.Foot>
-    </StudioTable>
+    <div>
+      <StudioTable
+        border={true}
+        className={cn(classes.tasksTable, {
+          [classes.hiddenTasksTable]: !isNavigationMode,
+        })}
+      >
+        <StudioTable.Head>
+          <StudioTable.Row>
+            <StudioTable.HeaderCell>{t('ux_editor.task_table_type')}</StudioTable.HeaderCell>
+            {isNavigationMode && (
+              <StudioTable.HeaderCell>{t('ux_editor.task_table_name')}</StudioTable.HeaderCell>
+            )}
+            <StudioTable.HeaderCell>{t('ux_editor.task_table_pages')}</StudioTable.HeaderCell>
+            <StudioTable.HeaderCell />
+          </StudioTable.Row>
+        </StudioTable.Head>
+        <StudioTable.Body>
+          <TasksTableBody tasks={tasks} isNavigationMode={isNavigationMode} />
+        </StudioTable.Body>
+        <StudioTable.Foot>
+          <StudioTable.Row>
+            <StudioTable.Cell colSpan={4} className={classes.taskFooterContent}>
+              <StudioButton
+                variant='secondary'
+                onClick={handleMoveAllTasks}
+                icon={isNavigationMode ? <EyeIcon /> : <EyeClosedIcon />}
+                disabled={tasks.length === 0}
+              >
+                {isNavigationMode
+                  ? t('ux_editor.task_table_hide_all')
+                  : t('ux_editor.task_table_show_all')}
+              </StudioButton>
+            </StudioTable.Cell>
+          </StudioTable.Row>
+        </StudioTable.Foot>
+      </StudioTable>
+      {isNavigationMode && (
+        <StudioLink
+          href={previewLink}
+          className={cn(classes.previewLink, { [classes.disabledPreviewLink]: tasks.length === 0 })}
+          data-color='neutral'
+        >
+          <PlayFillIcon />
+          Forhåndsvis med navigasjonsmeny
+        </StudioLink>
+      )}
+    </div>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds preview link below the task navigation table. Redirect user to preview page with the navigation menu. Disables the button if no tasks is added.

![image](https://github.com/user-attachments/assets/662451ec-cda0-4351-b517-3b69d3f37bd1)


<!--- Describe your changes in detail -->

## Related Issue(s)

- itself

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
