### PR TITLE
fix: deleting last group irrevocable state

### DIFF
--- a/frontend/packages/ux-editor/src/containers/DesignView/DesignView.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/DesignView.test.tsx
@@ -93,7 +93,6 @@ describe('DesignView', () => {
           { id: `${textMock('ux_editor.page')}${1}` },
           { id: `${textMock('ux_editor.page')}${2}` },
         ],
-        groups: [],
       },
     });
     const addButton = screen.getByRole('button', { name: textMock('ux_editor.pages_add') });

--- a/frontend/packages/ux-editor/src/containers/DesignView/DesignView.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/DesignView.tsx
@@ -145,7 +145,7 @@ export const DesignView = (): ReactNode => {
     );
   });
 
-  const hasGroups = pagesModel?.groups?.length > 0;
+  const hasGroups = !!pagesModel?.groups;
 
   const isTaskNavigationPageGroups = shouldDisplayFeature(FeatureFlag.TaskNavigationPageGroups);
   const handleAddGroup = () => addGroupMutation();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes the condition to display group editing layout from `more than 0 groups` to `has a defined group property in layout config`

## Related Issue(s)

- #15559 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced detection of group presence in the design view to correctly handle cases where groups exist but the array may be empty.
- **Tests**
  - Updated test cases to align with the revised logic for group detection in the design view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->