### PR TITLE
feat: remove feature flag for page groups

### DIFF
--- a/frontend/packages/shared/src/utils/featureToggleUtils.test.ts
+++ b/frontend/packages/shared/src/utils/featureToggleUtils.test.ts
@@ -27,16 +27,6 @@ describe('featureToggle localStorage', () => {
   it('should return false if feature is not enabled in the localStorage', () => {
     expect(shouldDisplayFeature(FeatureFlag.ShouldOverrideAppLibCheck)).toBeFalsy();
   });
-
-  it('should return true if taskNavigationPageGroups is enabled in the localStorage', () => {
-    typedLocalStorage.setItem<string[]>('featureFlags', ['taskNavigationPageGroups']);
-    expect(shouldDisplayFeature(FeatureFlag.TaskNavigationPageGroups)).toBeTruthy();
-  });
-
-  it('should return false if taskNavigationPageGroups is not enabled in the localStorage', () => {
-    typedLocalStorage.setItem<string[]>('featureFlags', ['demo']);
-    expect(shouldDisplayFeature(FeatureFlag.TaskNavigationPageGroups)).toBeFalsy();
-  });
 });
 
 describe('featureToggle url', () => {
@@ -78,16 +68,6 @@ describe('featureToggle url', () => {
       'addComponentModal',
     ]);
     expect(typedLocalStorage.getItem<string[]>('featureFlags')).toBeNull();
-  });
-
-  it('should return true if taskNavigationPageGroups is enabled in the url', () => {
-    window.history.pushState({}, 'PageUrl', '/?featureFlags=taskNavigationPageGroups');
-    expect(shouldDisplayFeature(FeatureFlag.TaskNavigationPageGroups)).toBeTruthy();
-  });
-
-  it('should return false if taskNavigationPageGroups is not enabled in the url', () => {
-    window.history.pushState({}, 'PageUrl', '/?featureFlags=demo');
-    expect(shouldDisplayFeature(FeatureFlag.TaskNavigationPageGroups)).toBeFalsy();
   });
 });
 

--- a/frontend/packages/shared/src/utils/featureToggleUtils.ts
+++ b/frontend/packages/shared/src/utils/featureToggleUtils.ts
@@ -9,7 +9,6 @@ export enum FeatureFlag {
   Maskinporten = 'maskinporten',
   OrgLibrary = 'orgLibrary',
   ShouldOverrideAppLibCheck = 'shouldOverrideAppLibCheck',
-  TaskNavigationPageGroups = 'taskNavigationPageGroups',
   ConsentResource = 'consentResource',
   SettingsPage = 'settingsPage',
   AppMetadata = 'appMetadata',

--- a/frontend/packages/ux-editor/src/containers/DesignView/DesignView.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/DesignView.test.tsx
@@ -27,21 +27,9 @@ import type { FormLayoutsResponse } from 'app-shared/types/api';
 import { AppContext } from '@altinn/ux-editor/AppContext';
 import type { PagesModel } from 'app-shared/types/api/dto/PagesModel';
 
-jest.mock('app-shared/utils/featureToggleUtils', () => ({
-  shouldDisplayFeature: jest.fn(),
-  FeatureFlag: {
-    TaskNavigationPageGroups: 'TaskNavigationPageGroups',
-  },
-}));
-
 const mockSelectedLayoutSet = layoutSet1NameMock;
 const mockPageName1: string = layout1NameMock;
 const mockPageName2: string = layout2NameMock;
-
-const setupFeatureFlag = (enabled: boolean) => {
-  const { shouldDisplayFeature } = require('app-shared/utils/featureToggleUtils');
-  shouldDisplayFeature.mockReturnValue(enabled);
-};
 
 describe('DesignView', () => {
   afterEach(() => {
@@ -77,7 +65,6 @@ describe('DesignView', () => {
 
   it('increments the page name for the new page if pdfLayoutName has the next incremental page name', async () => {
     const user = userEvent.setup();
-    setupFeatureFlag(false);
     const pdfLayoutName = `${textMock('ux_editor.page')}${3}`;
     renderDesignView({
       layoutSettings: {
@@ -157,35 +144,13 @@ describe('DesignView', () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it('renders DesignViewNavigation when isTaskNavigationPageGroups is true', () => {
-    setupFeatureFlag(true);
-    renderDesignView({});
-    expect(screen.getByTestId('design-view-navigation')).toBeInTheDocument();
-  });
-
-  it('does not render DesignViewNavigation when isTaskNavigationPageGroups is false', () => {
-    setupFeatureFlag(false);
-    renderDesignView({});
-    expect(screen.queryByTestId('design-view-navigation')).not.toBeInTheDocument();
-  });
-
   it('does not render Accordion when pagesModel has no pages', () => {
-    setupFeatureFlag(false);
     renderDesignView({ layoutSettings: { ...formLayoutSettingsMock, pages: { order: [] } } });
     const accordion = screen.queryByRole('group', { name: /accordion/i });
     expect(accordion).not.toBeInTheDocument();
   });
 
-  it('renders page accordions when isTaskNavigationPageGroups is false', () => {
-    setupFeatureFlag(false);
-    renderDesignView({});
-    formLayoutSettingsMock.pages.order.forEach((page) => {
-      expect(screen.getByRole('button', { name: page })).toBeInTheDocument();
-    });
-  });
-
   it('Does not render group accordions when order is empty or undefined', () => {
-    setupFeatureFlag(true);
     renderDesignView({
       layoutSettings: {
         ...formLayoutSettingsMock,
@@ -198,7 +163,6 @@ describe('DesignView', () => {
 
   it('calls handleAddGroup and triggers addGroupMutation correctly', async () => {
     const user = userEvent.setup();
-    setupFeatureFlag(true);
     const updateLayoutsForPreviewMock = jest.fn().mockResolvedValue(undefined);
     appContextMock.updateLayoutsForPreview = updateLayoutsForPreviewMock;
     renderDesignView({ pagesModel: groupsPagesModelMock });
@@ -210,7 +174,6 @@ describe('DesignView', () => {
 
   it('calls "setSelectedFormLayoutName" with page name when clicking a closed accordion in a group', async () => {
     const user = userEvent.setup();
-    setupFeatureFlag(true);
     appContextMock.selectedFormLayoutName = layout2NameMock;
     renderDesignView({ pagesModel: groupsPagesModelMock });
     expect(screen.getByText('Sideoppsett 1')).toBeInTheDocument();
@@ -222,7 +185,6 @@ describe('DesignView', () => {
 
   it('calls "setSelectedFormLayoutName" with undefined when clicking an open accordion in a group', async () => {
     const user = userEvent.setup();
-    setupFeatureFlag(true);
     appContextMock.selectedFormLayoutName = layout1NameMock;
     renderDesignView({ pagesModel: groupsPagesModelMock });
     expect(screen.getByText('Sideoppsett 1')).toBeInTheDocument();

--- a/frontend/packages/ux-editor/src/containers/DesignView/DesignView.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/DesignView.tsx
@@ -20,7 +20,6 @@ import { usePagesQuery } from '../../hooks/queries/usePagesQuery';
 import { useAddPageMutation } from '../../hooks/mutations/useAddPageMutation';
 import type { PageModel } from 'app-shared/types/api/dto/PageModel';
 import { DesignViewNavigation } from '../DesignViewNavigation';
-import { shouldDisplayFeature, FeatureFlag } from 'app-shared/utils/featureToggleUtils';
 import { PageGroupAccordion } from './PageGroupAccordion';
 import { useAddGroupMutation } from '../../hooks/mutations/useAddGroupMutation';
 import { ItemType } from '../../../../ux-editor/src/components/Properties/ItemType';
@@ -147,15 +146,14 @@ export const DesignView = (): ReactNode => {
 
   const hasGroups = !!pagesModel?.groups;
 
-  const isTaskNavigationPageGroups = shouldDisplayFeature(FeatureFlag.TaskNavigationPageGroups);
   const handleAddGroup = () => addGroupMutation();
 
   return (
     <div className={classes.root}>
       <div className={classes.wrapper}>
-        {isTaskNavigationPageGroups && <DesignViewNavigation />}
+        <DesignViewNavigation />
         <div className={classes.accordionWrapper}>
-          {isTaskNavigationPageGroups && hasGroups ? (
+          {hasGroups ? (
             <PageGroupAccordion
               pages={pagesModel}
               layouts={layouts}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes feature flag `TaskNavigationPageGroups`

## Related Issue(s)

- #14925 

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The navigation and page group components in the design view are now always visible when applicable, without being gated by a feature flag.

- **Refactor**
  - Removed the TaskNavigationPageGroups feature flag and all related conditional logic and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->