### PR TITLE
fix: size of preview button

### DIFF
--- a/frontend/packages/ux-editor/src/components/TasksTable/TasksTable.module.css
+++ b/frontend/packages/ux-editor/src/components/TasksTable/TasksTable.module.css
@@ -34,8 +34,8 @@
 }
 
 .previewLink svg {
-  width: var(--icon-size);
-  height: var(--icon-size);
+  width: 1.25em;
+  height: 1.25em;
 }
 
 .disabledPreviewLink {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The root icon size has changed, so needed to adjust the css class for preview link icon. 

Before:
![image](https://github.com/user-attachments/assets/4501838b-0a3b-4e62-81bf-825f44432e35)


After:
![image](https://github.com/user-attachments/assets/67a7e78b-fd6e-4089-a78a-327a4d9d36a6)


<!--- Describe your changes in detail -->

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated SVG icon sizing in task table preview links for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->