### PR TITLE
fix: GetLanguage not checking or creating directory in absolute path.

### DIFF
--- a/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -275,9 +275,9 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
         {
             List<string> languages = new();
             string pathToTexts = GetPathToTexts();
-            if (!Directory.Exists(pathToTexts))
+            if (!DirectoryExistsByRelativePath(pathToTexts))
             {
-                Directory.CreateDirectory(pathToTexts);
+                Directory.CreateDirectory(GetAbsoluteFileOrDirectoryPathSanitized(pathToTexts));
             }
 
             string[] directoryFiles = GetFilesByRelativeDirectory(


### PR DESCRIPTION
## Description
Use absolute paths for if check and creation of directory. This aims to make it possible to create tests for the import endpoint.

## Related Issue
- #15658

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of directory checks and creation for language resources, ensuring more robust and consistent file operations. No visible changes to end-user features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->