### PR TITLE
chore(policy-editor): load access package list from tt02

### DIFF
--- a/backend/src/Designer/Configuration/PlatformSettings.cs
+++ b/backend/src/Designer/Configuration/PlatformSettings.cs
@@ -90,5 +90,10 @@ namespace Altinn.Studio.Designer.Configuration
         /// Base Url used in dev
         /// </summary>
         public string ResourceRegistryDefaultBaseUrl { get; set; }
+
+        /// <summary>
+        /// Url used to load access packages
+        /// </summary>
+        public string AccessPackagesUrl { get; set; }
     }
 }

--- a/backend/src/Designer/TypedHttpClients/AltinnAuthorization/PolicyOptionsClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnAuthorization/PolicyOptionsClient.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Altinn.Studio.Designer.Configuration;
 using Microsoft.Extensions.Logging;
 using PolicyAdmin.Models;
 
@@ -14,19 +15,21 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnAuthorization
     {
         private readonly HttpClient _client;
         private readonly ILogger<PolicyOptionsClient> _logger;
+        private readonly PlatformSettings _platformSettings;
         private readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions() { PropertyNameCaseInsensitive = true, };
 
-        public PolicyOptionsClient(HttpClient httpClient, ILogger<PolicyOptionsClient> logger)
+        public PolicyOptionsClient(HttpClient httpClient, ILogger<PolicyOptionsClient> logger, PlatformSettings platformSettings)
         {
             _client = httpClient;
             _logger = logger;
+            _platformSettings = platformSettings;
         }
 
         public async Task<List<AccessPackageAreaGroup>> GetAccessPackageOptions(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            // Temp location. Will be moved to CDN
-            string url = "https://raw.githubusercontent.com/Altinn/altinn-studio-docs/master/content/authorization/architecture/resourceregistry/accesspackages_hier.json";
+
+            string url = _platformSettings.AccessPackagesUrl;
 
             List<AccessPackageAreaGroup> accessPackageOptions;
 

--- a/backend/src/Designer/appsettings.json
+++ b/backend/src/Designer/appsettings.json
@@ -20,7 +20,8 @@
         "ResourceRegistryUrl": "/resourceregistry/api/v1/resource",
         "ResourceRegistryAccessListUrl": "/resourceregistry/api/v1/access-lists",
         "ResourceRegistryEnvBaseUrl": "https://platform.{0}.altinn.cloud",
-        "ResourceRegistryDefaultBaseUrl": "http://localhost:5100"
+        "ResourceRegistryDefaultBaseUrl": "http://localhost:5100",
+        "AccessPackagesUrl": "https://platform.tt02.altinn.no/accessmanagement/api/v1/meta/info/accesspackages/export"
     },
     "CacheSettings": {
         "DataNorgeApiCacheTimeout": 3600,


### PR DESCRIPTION
## Description

Now that the access package metadata API is ready in TT02, load access packages from TT02 instead of from file hosted on altinn-studio-docs.

## Related Issue(s)

- #15691 

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
