### PR TITLE
feat: moving pages to new groups

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1969,6 +1969,7 @@
   "ux_editor.page_layout_remove_group_division": "Fjern gruppeinndeling",
   "ux_editor.page_menu_down": "Flytt ned",
   "ux_editor.page_menu_edit": "Gi nytt navn",
+  "ux_editor.page_menu_new_group": "Flytt til en ny gruppe",
   "ux_editor.page_menu_up": "Flytt opp",
   "ux_editor.pages_add": "Legg til ny side",
   "ux_editor.pages_error_empty": "Navnet kan ikke være tomt.",

--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1969,6 +1969,7 @@
   "ux_editor.page_layout_remove_group_division": "Fjern gruppeinndeling",
   "ux_editor.page_menu_down": "Flytt ned",
   "ux_editor.page_menu_edit": "Gi nytt navn",
+  "ux_editor.page_menu_group_movement_heading": "Mellom grupper",
   "ux_editor.page_menu_new_group": "Flytt til en ny gruppe",
   "ux_editor.page_menu_up": "Flytt opp",
   "ux_editor.pages_add": "Legg til ny side",

--- a/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.test.tsx
@@ -85,6 +85,23 @@ describe('NavigationMenu', () => {
         updatedPagesModel,
       );
     });
+
+    it('should be able to move a page to new group', async () => {
+      const user = userEvent.setup();
+      await render({
+        pagesModel: pageGroupsMultiplePagesMock,
+      });
+      await user.click(contextMenuTriggerButton());
+      await user.click(movePageToNewGroupButton());
+
+      expect(queriesMock.changePageGroups).toHaveBeenCalledTimes(1);
+      expect(queriesMock.changePageGroups).toHaveBeenCalledWith(
+        org,
+        app,
+        mockSelectedLayoutSet,
+        expect.objectContaining({ groups: [expect.anything(), expect.anything()] }),
+      );
+    });
   });
 });
 
@@ -93,6 +110,8 @@ const movePageDownButton = () =>
   screen.getByRole('button', { name: textMock('ux_editor.page_menu_down') });
 const movePageUpButton = () =>
   screen.getByRole('button', { name: textMock('ux_editor.page_menu_up') });
+const movePageToNewGroupButton = () =>
+  screen.getByRole('button', { name: textMock('ux_editor.page_menu_new_group') });
 
 type renderParams = {
   props?: Partial<NavigationMenuProps>;

--- a/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
@@ -7,6 +7,7 @@ import { StudioDropdown } from '@studio/components';
 import { usePagesQuery } from '../../../../hooks/queries/usePagesQuery';
 import { useChangePageOrderMutation } from '../../../../hooks/mutations/useChangePageOrderMutation';
 import { useChangePageGroupOrder } from '@altinn/ux-editor/hooks/mutations/useChangePageGroupOrder';
+import type { GroupModel } from 'app-shared/types/api/dto/PageModel';
 
 export type NavigationMenuProps = {
   pageName: string;

--- a/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { MenuElipsisVerticalIcon, ArrowUpIcon, ArrowDownIcon } from '@studio/icons';
+import { MenuElipsisVerticalIcon, ArrowUpIcon, ArrowDownIcon, FolderPlusIcon } from '@studio/icons';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../../../hooks';
-import { StudioDropdown } from '@studio/components';
+import { StudioDivider, StudioDropdown } from '@studio/components';
 import { usePagesQuery } from '../../../../hooks/queries/usePagesQuery';
 import { useChangePageOrderMutation } from '../../../../hooks/mutations/useChangePageOrderMutation';
 import { useChangePageGroupOrder } from '@altinn/ux-editor/hooks/mutations/useChangePageGroupOrder';
@@ -32,7 +32,6 @@ export const NavigationMenu = ({ pageName }: NavigationMenuProps): JSX.Element =
     selectedFormLayoutSetName,
   );
   const { mutate: changePageGroups } = useChangePageGroupOrder(org, app, selectedFormLayoutSetName);
-
   const isUsingGroups = !!pagesModel.groups;
   const groupModel = pagesModel.groups?.find((group) =>
     group.order.some((page) => page.id === pageName),
@@ -103,7 +102,53 @@ export const NavigationMenu = ({ pageName }: NavigationMenuProps): JSX.Element =
             </StudioDropdown.Button>
           </StudioDropdown.Item>
         </StudioDropdown.List>
+        <PageGroupActions pageName={pageName} />
       </StudioDropdown>
     </div>
+  );
+};
+
+type PageGroupActionProps = {
+  pageName: string;
+};
+
+const PageGroupActions = ({ pageName }: PageGroupActionProps) => {
+  const { t } = useTranslation();
+  const { org, app } = useStudioEnvironmentParams();
+  const { selectedFormLayoutSetName } = useAppContext();
+  const { data: pagesModel } = usePagesQuery(org, app, selectedFormLayoutSetName);
+  const { mutate: changePageGroups } = useChangePageGroupOrder(org, app, selectedFormLayoutSetName);
+
+  const pagesInGroup =
+    pagesModel.groups?.find((group) => group.order.some((page) => page.id === pageName))?.order
+      .length || 0;
+
+  const movePageToNewGroup = () => {
+    const newGroup: GroupModel = {
+      order: [{ id: pageName }],
+    };
+    const updatedPagesModel = {
+      ...pagesModel,
+      groups: [
+        ...pagesModel.groups.map((group) => ({
+          ...group,
+          order: group.order.filter((page) => page.id !== pageName),
+        })),
+        newGroup,
+      ],
+    };
+    changePageGroups(updatedPagesModel);
+  };
+
+  return (
+    <>
+      <StudioDivider />
+      <StudioDropdown.Item>
+        <StudioDropdown.Button onClick={movePageToNewGroup} disabled={pagesInGroup <= 1}>
+          <FolderPlusIcon />
+          {t('ux_editor.page_menu_new_group')}
+        </StudioDropdown.Button>
+      </StudioDropdown.Item>
+    </>
   );
 };

--- a/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { MenuElipsisVerticalIcon, ArrowUpIcon, ArrowDownIcon, FolderPlusIcon } from '@studio/icons';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../../../hooks';
-import { StudioDivider, StudioDropdown } from '@studio/components';
+import { StudioDropdown } from '@studio/components';
 import { usePagesQuery } from '../../../../hooks/queries/usePagesQuery';
 import { useChangePageOrderMutation } from '../../../../hooks/mutations/useChangePageOrderMutation';
 import { useChangePageGroupOrder } from '@altinn/ux-editor/hooks/mutations/useChangePageGroupOrder';
@@ -142,7 +142,9 @@ const PageGroupActions = ({ pageName }: PageGroupActionProps) => {
 
   return (
     <>
-      <StudioDivider />
+      <StudioDropdown.Heading>
+        {t('ux_editor.page_menu_group_movement_heading')}
+      </StudioDropdown.Heading>
       <StudioDropdown.Item>
         <StudioDropdown.Button onClick={movePageToNewGroup} disabled={pagesInGroup <= 1}>
           <FolderPlusIcon />

--- a/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.test.tsx
@@ -17,7 +17,6 @@ import { ItemType } from '../../components/Properties/ItemType';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 
 const pagesMock: PagesModel = {
-  pages: null,
   groups: [
     {
       name: 'Group 1',
@@ -78,10 +77,8 @@ describe('PageGroupAccordion', () => {
 
   it('should display page ID as fallback when group name is empty', async () => {
     const emptyGroupPagesMock: PagesModel = {
-      pages: null,
       groups: [
         {
-          name: '',
           order: [{ id: 'Side1' }],
         },
       ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds new button to page context menu, allowing pages to be moved to a new group.

<img width="333" alt="Screenshot 2025-06-18 at 12 28 50" src="https://github.com/user-attachments/assets/d8277737-ff98-415e-80e0-bcbc4ccc8905" />

This PR is part of a stack:
- #15701 👈 This PR
- #15702


## Related Issue(s)

- #15534

## Verification

- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to move a page into a new group from the page navigation menu in the UX editor.
  - Introduced new menu labels in Norwegian Bokmål for group-related actions.

- **Tests**
  - Added test coverage for the new "move page to new group" functionality in the navigation menu.
  - Updated test data structure in group-related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->