### PR TITLE
refactor: use new studio components in NavigationMenu

### DIFF
--- a/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.test.tsx
@@ -7,18 +7,13 @@ import {
 import { layoutSet1NameMock } from '../../../../testing/layoutSetsMock';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import { app, org } from '@studio/testing/testids';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import React from 'react';
-import { useFormLayoutSettingsQuery } from '../../../../hooks/queries/useFormLayoutSettingsQuery';
-import {
-  formLayoutSettingsMock,
-  renderHookWithProviders,
-  renderWithProviders,
-} from '../../../../testing/mocks';
+import { renderWithProviders } from '../../../../testing/mocks';
 import type { NavigationMenuProps } from './NavigationMenu';
 import { NavigationMenu } from './NavigationMenu';
 import type { PagesModel } from 'app-shared/types/api/dto/PagesModel';
@@ -46,102 +41,22 @@ const defaultProps: NavigationMenuProps = {
 describe('NavigationMenu', () => {
   afterEach(jest.clearAllMocks);
 
-  it('should open the menu when clicking the menu icon', async () => {
-    const user = userEvent.setup();
-    await render({});
-
-    const elementInMenu = screen.queryByText(textMock('ux_editor.page_menu_up'));
-    expect(elementInMenu).not.toBeInTheDocument();
-
-    const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
-    await user.click(menuButtons[0]);
-
-    const elementInMenuAfter = screen.getByRole('menuitem', {
-      name: textMock('ux_editor.page_menu_up'),
-    });
-    expect(elementInMenuAfter).toBeInTheDocument();
-  });
-  it('should close the menu when clicking the menu icon twice', async () => {
-    const user = userEvent.setup();
-    await render({});
-
-    const elementInMenu = screen.queryByText(textMock('ux_editor.page_menu_up'));
-    expect(elementInMenu).not.toBeInTheDocument();
-
-    const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
-    await user.click(menuButtons[0]);
-
-    const elementInMenuAfter = screen.getByRole('menuitem', {
-      name: textMock('ux_editor.page_menu_up'),
-    });
-    expect(elementInMenuAfter).toBeInTheDocument();
-
-    await user.click(menuButtons[0]);
-
-    const elementInMenuAfterClose = screen.queryByRole('menuitem', {
-      name: textMock('ux_editor.page_menu_up'),
-    });
-    expect(elementInMenuAfterClose).not.toBeInTheDocument();
-  });
-
-  it('should close the menu when clicking outside the menu', async () => {
-    const user = userEvent.setup();
-    await render({});
-
-    const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
-    await user.click(menuButtons[0]);
-
-    const elementInMenu = screen.getByRole('menuitem', {
-      name: textMock('ux_editor.page_menu_up'),
-    });
-    expect(elementInMenu).toBeInTheDocument();
-
-    await user.click(document.body);
-
-    const elementInMenuAfterClose = screen.queryByRole('menuitem', {
-      name: textMock('ux_editor.page_menu_up'),
-    });
-    expect(elementInMenuAfterClose).not.toBeInTheDocument();
-  });
-
-  it('shows the up and down button by default', async () => {
-    const user = userEvent.setup();
-    await render({});
-    const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
-    await user.click(menuButtons[0]);
-
-    const upButton = screen.getByRole('menuitem', { name: textMock('ux_editor.page_menu_up') });
-    const downButton = screen.getByRole('menuitem', {
-      name: textMock('ux_editor.page_menu_down'),
-    });
-
-    expect(upButton).toBeInTheDocument();
-    expect(downButton).toBeInTheDocument();
-  });
-
   describe('when the pages are in page order configuration', () => {
     it('should toggle the page order using up and down buttons', async () => {
       const user = userEvent.setup();
       await render({});
 
-      const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
-      await user.click(menuButtons[0]);
-      const menuItemDown = screen.getByRole('menuitem', {
-        name: textMock('ux_editor.page_menu_down'),
-      });
-      await user.click(menuItemDown);
+      const menuButtons = contextMenuTriggerButton();
+      await user.click(menuButtons);
+      await user.click(movePageDownButton());
 
       expect(queriesMock.changePageOrder).toHaveBeenCalledTimes(1);
       expect(queriesMock.changePageOrder).toHaveBeenCalledWith(org, app, mockSelectedLayoutSet, {
         pages: [{ id: layout2NameMock }, { id: layout1NameMock }],
       });
-      expect(menuItemDown).not.toBeInTheDocument();
 
-      await user.click(menuButtons[1]);
-      const menuItemUp = screen.getByRole('menuitem', {
-        name: textMock('ux_editor.page_menu_up'),
-      });
-      await user.click(menuItemUp);
+      await user.click(menuButtons);
+      await user.click(movePageUpButton());
       expect(queriesMock.changePageOrder).toHaveBeenCalledTimes(2);
       expect(queriesMock.changePageOrder).toHaveBeenCalledWith(org, app, mockSelectedLayoutSet, {
         pages: [{ id: layout1NameMock }, { id: layout2NameMock }],
@@ -155,12 +70,8 @@ describe('NavigationMenu', () => {
       await render({
         pagesModel: pageGroupsMultiplePagesMock,
       });
-      const menuButtons = screen.getAllByRole('button', { name: textMock('general.options') });
-      await user.click(menuButtons[0]);
-      const menuItemDown = screen.getByRole('menuitem', {
-        name: textMock('ux_editor.page_menu_down'),
-      });
-      await user.click(menuItemDown);
+      await user.click(contextMenuTriggerButton());
+      await user.click(movePageDownButton());
 
       const updatedPagesModel = {
         ...pageGroupsMultiplePagesMock,
@@ -173,22 +84,15 @@ describe('NavigationMenu', () => {
         mockSelectedLayoutSet,
         updatedPagesModel,
       );
-      expect(menuItemDown).not.toBeInTheDocument();
     });
   });
 });
 
-const waitForData = async () => {
-  const getFormLayoutSettings = jest
-    .fn()
-    .mockImplementation(() => Promise.resolve(formLayoutSettingsMock));
-  const settingsResult = renderHookWithProviders(
-    () => useFormLayoutSettingsQuery(org, app, mockSelectedLayoutSet),
-    { queries: { getFormLayoutSettings } },
-  ).result;
-
-  await waitFor(() => expect(settingsResult.current.isSuccess).toBe(true));
-};
+const contextMenuTriggerButton = () => screen.getByRole('button', { name: '' });
+const movePageDownButton = () =>
+  screen.getByRole('button', { name: textMock('ux_editor.page_menu_down') });
+const movePageUpButton = () =>
+  screen.getByRole('button', { name: textMock('ux_editor.page_menu_up') });
 
 type renderParams = {
   props?: Partial<NavigationMenuProps>;
@@ -199,12 +103,5 @@ const render = async ({ props = {}, pagesModel = pagesModelMock }: renderParams)
   const queryClient = createQueryClientMock();
   queryClient.invalidateQueries = jest.fn();
   queryClient.setQueryData([QueryKey.Pages, org, app, mockSelectedLayoutSet], pagesModel);
-  await waitForData();
-  return renderWithProviders(
-    <>
-      <NavigationMenu {...defaultProps} {...props} />
-      <NavigationMenu {...defaultProps} {...props} />
-    </>,
-    { queryClient },
-  );
+  return renderWithProviders(<NavigationMenu {...defaultProps} {...props} />, { queryClient });
 };

--- a/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/NavigationMenu/NavigationMenu.tsx
@@ -1,10 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { DropdownMenu } from '@digdir/designsystemet-react';
 import { MenuElipsisVerticalIcon, ArrowUpIcon, ArrowDownIcon } from '@studio/icons';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { useAppContext } from '../../../../hooks';
-import { StudioButton } from '@studio/components-legacy';
+import { StudioDropdown } from '@studio/components';
 import { usePagesQuery } from '../../../../hooks/queries/usePagesQuery';
 import { useChangePageOrderMutation } from '../../../../hooks/mutations/useChangePageOrderMutation';
 import { useChangePageGroupOrder } from '@altinn/ux-editor/hooks/mutations/useChangePageGroupOrder';
@@ -33,8 +32,6 @@ export const NavigationMenu = ({ pageName }: NavigationMenuProps): JSX.Element =
   );
   const { mutate: changePageGroups } = useChangePageGroupOrder(org, app, selectedFormLayoutSetName);
 
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-
   const isUsingGroups = !!pagesModel.groups;
   const groupModel = pagesModel.groups?.find((group) =>
     group.order.some((page) => page.id === pageName),
@@ -61,7 +58,6 @@ export const NavigationMenu = ({ pageName }: NavigationMenuProps): JSX.Element =
       pagesModel.pages?.splice(pageIndex - 1, 0, page);
       changePageOrder(pagesModel);
     }
-    setDropdownOpen(false);
   };
 
   const moveLayoutDown = () => {
@@ -79,42 +75,34 @@ export const NavigationMenu = ({ pageName }: NavigationMenuProps): JSX.Element =
       pagesModel.pages?.splice(pageIndex + 1, 0, page);
       changePageOrder(pagesModel);
     }
-    setDropdownOpen(false);
   };
 
   return (
     <div>
-      <DropdownMenu open={dropdownOpen} onClose={() => setDropdownOpen(false)} portal size='small'>
-        <DropdownMenu.Trigger asChild>
-          <StudioButton
-            icon={<MenuElipsisVerticalIcon />}
-            onClick={() => setDropdownOpen((prev) => !prev)}
-            aria-haspopup='menu'
-            variant='tertiary'
-            title={t('general.options')}
-          />
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content>
-          <DropdownMenu.Group>
-            <DropdownMenu.Item
+      <StudioDropdown icon={<MenuElipsisVerticalIcon />} triggerButtonVariant='tertiary'>
+        <StudioDropdown.List>
+          <StudioDropdown.Item>
+            <StudioDropdown.Button
               onClick={() => !disableUp && moveLayoutUp()}
               disabled={disableUp}
               id='move-page-up-button'
             >
               <ArrowUpIcon />
               {t('ux_editor.page_menu_up')}
-            </DropdownMenu.Item>
-            <DropdownMenu.Item
+            </StudioDropdown.Button>
+          </StudioDropdown.Item>
+          <StudioDropdown.Item>
+            <StudioDropdown.Button
               onClick={() => !disableDown && moveLayoutDown()}
               disabled={disableDown}
               id='move-page-down-button'
             >
               <ArrowDownIcon />
               {t('ux_editor.page_menu_down')}
-            </DropdownMenu.Item>
-          </DropdownMenu.Group>
-        </DropdownMenu.Content>
-      </DropdownMenu>
+            </StudioDropdown.Button>
+          </StudioDropdown.Item>
+        </StudioDropdown.List>
+      </StudioDropdown>
     </div>
   );
 };

--- a/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/PageAccordion/PageAccordion.test.tsx
@@ -51,20 +51,6 @@ describe('PageAccordion', () => {
     expect(mockOnClick).toHaveBeenCalledTimes(1);
   });
 
-  it('opens the NavigationMenu when the menu icon is clicked', async () => {
-    const user = userEvent.setup();
-    await render();
-
-    const elementInMenu = screen.queryByText(textMock('ux_editor.page_menu_up'));
-    expect(elementInMenu).not.toBeInTheDocument();
-
-    const menuButton = screen.getByRole('button', { name: textMock('general.options') });
-    await user.click(menuButton);
-
-    const elementInMenuAfter = screen.getByText(textMock('ux_editor.page_menu_up'));
-    expect(elementInMenuAfter).toBeInTheDocument();
-  });
-
   it('Calls deleteLayout with pageName when delete button is clicked and deletion is confirmed', async () => {
     const user = userEvent.setup();
     jest.spyOn(window, 'confirm').mockImplementation(jest.fn(() => true));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Refactors `NavigationMenu.tsx` to use the updated studio components.
Part of a stack:

- #15701
- #15702 👈 This PR

## Related Issue(s)

- #{issue number}

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the navigation menu with a new dropdown component for a more streamlined and modern user interface.
- **Tests**
  - Simplified tests to focus on core page order changes, removing tests related to menu opening, closing, and item visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->