### PR TITLE
fix(resource-adm): add authorize attribute to GET resource policy endpoint

### DIFF
--- a/backend/src/Designer/Controllers/PolicyController.cs
+++ b/backend/src/Designer/Controllers/PolicyController.cs
@@ -6,6 +6,7 @@ using Altinn.Studio.Designer.Services.Interfaces;
 using Altinn.Studio.Designer.TypedHttpClients.AltinnAuthorization;
 using Altinn.Studio.PolicyAdmin;
 using Altinn.Studio.PolicyAdmin.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PolicyAdmin.Models;
 
@@ -55,6 +56,7 @@ namespace Altinn.Studio.Designer.Controllers
         /// <param name="resourceid">The resource Id for the connected policy</param>
         /// <returns>The updated application metadata</returns>
         [HttpGet]
+        [Authorize]
         [Route("{resourceid}")]
         public ActionResult GetResourcePolicy(string org, string app, string resourceid)
         {


### PR DESCRIPTION
## Description
- Since GET resource policy will attempt to get policy based on developer name deeper down, calling GET resource policy without being authorized will return an empty policy file

## Related Issue(s)

- this PR

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
