### PR TITLE
fix: remove perform a different task button

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1966,7 +1966,6 @@
   "ux_editor.page_layout_add_group_division": "Grupper sidene",
   "ux_editor.page_layout_group": "Gruppe",
   "ux_editor.page_layout_header": "Oppsett",
-  "ux_editor.page_layout_perform_another_task": "Bytt til en annen oppgave",
   "ux_editor.page_layout_remove_group_division": "Fjern gruppeinndeling",
   "ux_editor.page_menu_down": "Flytt ned",
   "ux_editor.page_menu_edit": "Gi nytt navn",

--- a/frontend/packages/ux-editor/src/containers/DesignViewNavigation/DesignViewNavigation.test.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignViewNavigation/DesignViewNavigation.test.tsx
@@ -33,31 +33,15 @@ describe('DesignViewNavigation', () => {
     expect(menuButton).toHaveAttribute('aria-haspopup', 'menu');
   });
 
-  it('should open dropdown menu when clicking the menu button', async () => {
+  it('should be possible to toggle dropdown menu', async () => {
     const user = userEvent.setup();
     renderDesignViewNavigation({});
     const menuButton = screen.getByRole('button', { name: textMock('general.options') });
-    expect(
-      screen.queryByText(textMock('ux_editor.page_layout_perform_another_task')),
-    ).not.toBeInTheDocument();
+    expect(menuButton).toHaveAttribute('aria-expanded', 'false');
     await user.click(menuButton);
-    expect(
-      await screen.findByText(textMock('ux_editor.page_layout_perform_another_task')),
-    ).toBeInTheDocument();
-  });
-
-  it('should close dropdown menu when clicking outside', async () => {
-    const user = userEvent.setup();
-    renderDesignViewNavigation({});
-    const menuButton = screen.getByRole('button', { name: textMock('general.options') });
-    await user.click(menuButton);
-    expect(
-      await screen.findByText(textMock('ux_editor.page_layout_perform_another_task')),
-    ).toBeInTheDocument();
+    expect(menuButton).toHaveAttribute('aria-expanded', 'true');
     await user.click(document.body);
-    expect(
-      screen.queryByText(textMock('ux_editor.page_layout_perform_another_task')),
-    ).not.toBeInTheDocument();
+    expect(menuButton).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('should show button to convert to page groups if layout is using page order', async () => {

--- a/frontend/packages/ux-editor/src/containers/DesignViewNavigation/DesignViewNavigation.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignViewNavigation/DesignViewNavigation.tsx
@@ -1,12 +1,7 @@
 import React, { useState } from 'react';
 import { StudioButton, StudioSectionHeader } from '@studio/components-legacy';
 import classes from './DesignViewNavigation.module.css';
-import {
-  ArrowsSquarepathIcon,
-  MenuElipsisVerticalIcon,
-  MinusCircleIcon,
-  PlusCircleIcon,
-} from '@studio/icons';
+import { MenuElipsisVerticalIcon, MinusCircleIcon, PlusCircleIcon } from '@studio/icons';
 import { DropdownMenu } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import { useConvertToPageOrder } from '../../hooks/mutations/useConvertToPageOrder';
@@ -56,11 +51,6 @@ export const DesignViewNavigation = () => {
               </DropdownMenu.Trigger>
               <DropdownMenu.Content>
                 <DropdownMenu.Group>
-                  {/*Functionality and the number of items will be implemented based on the upcoming requirements.*/}
-                  <DropdownMenu.Item onClick={undefined}>
-                    <ArrowsSquarepathIcon className={classes.changeTaskIcon} />
-                    {t('ux_editor.page_layout_perform_another_task')}
-                  </DropdownMenu.Item>
                   {isUsingPageGroups ? (
                     <DropdownMenu.Item onClick={() => convertToPageOrder()}>
                       <MinusCircleIcon className={classes.deleteGroupIcon} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The perform a different task button does not function and we have agreed to remove it for now. 


![image](https://github.com/user-attachments/assets/4371e5e1-3d06-4c24-b313-346da4eae952)


<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed an unused and non-functional menu item from the dropdown menu for a cleaner user interface.

- **Tests**
  - Improved dropdown menu tests to better verify open and close behavior using accessibility attributes.

- **Chores**
  - Removed an obsolete translation key from the Norwegian language file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->