### PR TITLE
refactor: make OptionListReferences instance variable

### DIFF
--- a/backend/src/Designer/Controllers/OptionsController.cs
+++ b/backend/src/Designer/Controllers/OptionsController.cs
@@ -137,7 +137,7 @@ public class OptionsController : ControllerBase
     }
 
     /// <summary>
-    /// Gets all usages of all optionListIds in the layouts as <see cref="RefToOptionListSpecifier"/>.
+    /// Gets all usages of all optionListIds in the layouts as <see cref="OptionListReference"/>.
     /// </summary>
     /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
     /// <param name="repo">Application identifier which is unique within an organisation.</param>
@@ -146,12 +146,12 @@ public class OptionsController : ControllerBase
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [Route("usage")]
-    public async Task<ActionResult<List<RefToOptionListSpecifier>>> GetOptionListsReferences(string org, string repo, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<List<OptionListReference>>> GetOptionListsReferences(string org, string repo, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         string developer = AuthenticationHelper.GetDeveloperUserName(HttpContext);
 
-        List<RefToOptionListSpecifier> optionListReferences = await _optionListReferenceService.GetAllOptionListReferences(AltinnRepoEditingContext.FromOrgRepoDeveloper(org, repo, developer), cancellationToken);
+        List<OptionListReference> optionListReferences = await _optionListReferenceService.GetAllOptionListReferences(AltinnRepoEditingContext.FromOrgRepoDeveloper(org, repo, developer), cancellationToken);
         return Ok(optionListReferences);
     }
 

--- a/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/AltinnAppGitRepository.cs
@@ -945,7 +945,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
             return OpenStreamByRelativePath(ProcessDefinitionFilePath);
         }
 
-        public Definitions GetDefinitions()
+        public Definitions GetProcessDefinitions()
         {
             using Stream processDefinitionStream = GetProcessDefinitionFile();
             XmlSerializer serializer = new(typeof(Definitions));

--- a/backend/src/Designer/Models/Dto/OptionListReferences.cs
+++ b/backend/src/Designer/Models/Dto/OptionListReferences.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace Altinn.Studio.Designer.Models.Dto;
 
-public class RefToOptionListSpecifier
+public class OptionListReference
 {
     [JsonPropertyName("optionListId")]
     public string OptionListId { get; set; }

--- a/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
+++ b/backend/src/Designer/Services/Implementation/AppDevelopmentService.cs
@@ -276,7 +276,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             AltinnAppGitRepository altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(altinnRepoEditingContext.Org, altinnRepoEditingContext.Repo, altinnRepoEditingContext.Developer);
 
             LayoutSets layoutSetsFile = await altinnAppGitRepository.GetLayoutSetsFile(cancellationToken);
-            Definitions definitions = altinnAppGitRepository.GetDefinitions();
+            Definitions definitions = altinnAppGitRepository.GetProcessDefinitions();
 
             LayoutSetsModel layoutSetsModel = new();
             layoutSetsFile.Sets.ForEach(set =>

--- a/backend/src/Designer/Services/Implementation/OptionListReferenceService.cs
+++ b/backend/src/Designer/Services/Implementation/OptionListReferenceService.cs
@@ -93,20 +93,25 @@ public class OptionListReferenceService : IOptionListReferenceService
 
     private void AddComponentReference(string layoutSetName, string layoutName, string componentId, string optionListId)
     {
-        if (OptionListIdAlreadyReferenced(_optionListReferences, optionListId, out var existingRef))
+        if (OptionListIdAlreadyReferenced(optionListId, out var existingRef))
         {
-            if (OptionListIdAlreadyReferencedInLayout(existingRef, layoutSetName, layoutName, out var existingSource))
-            {
-                AddComponentIdToExistingSource(componentId, existingSource);
-            }
-            else
-            {
-                AddNewOptionListIdSource(existingRef, layoutSetName, layoutName, componentId);
-            }
+            AppendOptionListReference(existingRef, layoutSetName, layoutName, componentId);
         }
         else
         {
-            AddNewOptionListReference(_optionListReferences, optionListId, layoutSetName, layoutName, componentId);
+            AddNewOptionListReference(optionListId, layoutSetName, layoutName, componentId);
+        }
+    }
+
+    private static void AppendOptionListReference(OptionListReference existingRef, string layoutSetName, string layoutName, string componentId)
+    {
+        if (OptionListIdAlreadyReferencedInLayout(existingRef, layoutSetName, layoutName, out var existingSource))
+        {
+            AddComponentIdToExistingSource(componentId, existingSource);
+        }
+        else
+        {
+            AddNewOptionListIdSource(existingRef, layoutSetName, layoutName, componentId);
         }
     }
 
@@ -136,9 +141,9 @@ public class OptionListReferenceService : IOptionListReferenceService
         return repoOptionListIds.Contains(optionListId);
     }
 
-    private static bool OptionListIdAlreadyReferenced(List<OptionListReference> optionListReferences, string optionListId, out OptionListReference existingRef)
+    private bool OptionListIdAlreadyReferenced(string optionListId, out OptionListReference existingRef)
     {
-        existingRef = optionListReferences.FirstOrDefault(reference => reference.OptionListId == optionListId);
+        existingRef = _optionListReferences.FirstOrDefault(reference => reference.OptionListId == optionListId);
         return existingRef != null;
     }
 
@@ -169,9 +174,9 @@ public class OptionListReferenceService : IOptionListReferenceService
         );
     }
 
-    private static void AddNewOptionListReference(List<OptionListReference> optionListReferences, string optionListId, string layoutSetName, string layoutName, string componentId)
+    private void AddNewOptionListReference(string optionListId, string layoutSetName, string layoutName, string componentId)
     {
-        optionListReferences.Add(
+        _optionListReferences.Add(
             new()
             {
                 OptionListId = optionListId,

--- a/backend/src/Designer/Services/Implementation/OptionListReferenceService.cs
+++ b/backend/src/Designer/Services/Implementation/OptionListReferenceService.cs
@@ -15,7 +15,7 @@ namespace Altinn.Studio.Designer.Services.Implementation;
 /// </summary>
 public class OptionListReferenceService : IOptionListReferenceService
 {
-    private readonly List<RefToOptionListSpecifier> _optionListReferences;
+    private readonly List<OptionListReference> _optionListReferences;
     private readonly IAppDevelopmentService _appDevelopmentService;
     private readonly IAltinnGitRepositoryFactory _altinnGitRepositoryFactory;
     private AltinnAppGitRepository _altinnAppGitRepository;
@@ -33,7 +33,7 @@ public class OptionListReferenceService : IOptionListReferenceService
     }
 
     /// <inheritdoc />
-    public async Task<List<RefToOptionListSpecifier>> GetAllOptionListReferences(AltinnRepoEditingContext editingContext, CancellationToken cancellationToken = default)
+    public async Task<List<OptionListReference>> GetAllOptionListReferences(AltinnRepoEditingContext editingContext, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         _altinnAppGitRepository = _altinnGitRepositoryFactory.GetAltinnAppGitRepository(editingContext.Org, editingContext.Repo, editingContext.Developer);
@@ -78,12 +78,12 @@ public class OptionListReferenceService : IOptionListReferenceService
     }
 
     /// <summary>
-    /// Finds all <see cref="RefToOptionListSpecifier"/> in a given layout.
+    /// Finds all <see cref="OptionListReference"/> in a given layout.
     /// </summary>
     /// <param name="layoutSetName">The layoutSetName the layout belongs to.</param>
     /// <param name="layoutName">The name of the given layout.</param>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> that observes if a call is cancelled.</param>
-    /// <returns>A list of <see cref="RefToOptionListSpecifier"/>.</returns>
+    /// <returns>A list of <see cref="OptionListReference"/>.</returns>
     private async Task FindOptionListReferencesInLayout(string layoutSetName, string layoutName, CancellationToken cancellationToken = default)
     {
         string[] repoOptionListIds = _altinnAppGitRepository.GetOptionsListIds();
@@ -129,7 +129,7 @@ public class OptionListReferenceService : IOptionListReferenceService
         }
         else
         {
-            AddNewRefToOptionListSpecifier(_optionListReferences, optionListId, layoutSetName, layoutName, componentId);
+            AddNewOptionListReference(_optionListReferences, optionListId, layoutSetName, layoutName, componentId);
         }
     }
 
@@ -154,15 +154,15 @@ public class OptionListReferenceService : IOptionListReferenceService
         return repoOptionListIds.Contains(optionListId);
     }
 
-    private static bool OptionListIdAlreadyReferenced(List<RefToOptionListSpecifier> refToOptionListSpecifiers, string optionListId, out RefToOptionListSpecifier existingRef)
+    private static bool OptionListIdAlreadyReferenced(List<OptionListReference> optionListReferences, string optionListId, out OptionListReference existingRef)
     {
-        existingRef = refToOptionListSpecifiers.FirstOrDefault(refToOptionList => refToOptionList.OptionListId == optionListId);
+        existingRef = optionListReferences.FirstOrDefault(reference => reference.OptionListId == optionListId);
         return existingRef != null;
     }
 
-    private static bool OptionListIdAlreadyReferencedInLayout(RefToOptionListSpecifier refToOptionListSpecifier, string layoutSetName, string layoutName, out OptionListIdSource existingSource)
+    private static bool OptionListIdAlreadyReferencedInLayout(OptionListReference optionListReference, string layoutSetName, string layoutName, out OptionListIdSource existingSource)
     {
-        existingSource = refToOptionListSpecifier.OptionListIdSources.FirstOrDefault(
+        existingSource = optionListReference.OptionListIdSources.FirstOrDefault(
             optionListIdSource =>
                 optionListIdSource.LayoutSetId == layoutSetName
                 && optionListIdSource.LayoutName == layoutName
@@ -175,9 +175,9 @@ public class OptionListReferenceService : IOptionListReferenceService
         existingSource.ComponentIds.Add(componentId);
     }
 
-    private static void AddNewOptionListIdSource(RefToOptionListSpecifier refToOptionListSpecifier, string layoutSetName, string layoutName, string componentId)
+    private static void AddNewOptionListIdSource(OptionListReference optionListReference, string layoutSetName, string layoutName, string componentId)
     {
-        refToOptionListSpecifier.OptionListIdSources.Add(
+        optionListReference.OptionListIdSources.Add(
             new OptionListIdSource
             {
                 LayoutSetId = layoutSetName,
@@ -187,9 +187,9 @@ public class OptionListReferenceService : IOptionListReferenceService
         );
     }
 
-    private static void AddNewRefToOptionListSpecifier(List<RefToOptionListSpecifier> refToOptionListSpecifiers, string optionListId, string layoutSetName, string layoutName, string componentId)
+    private static void AddNewOptionListReference(List<OptionListReference> optionListReferences, string optionListId, string layoutSetName, string layoutName, string componentId)
     {
-        refToOptionListSpecifiers.Add(
+        optionListReferences.Add(
             new()
             {
                 OptionListId = optionListId,
@@ -216,7 +216,7 @@ public class OptionListReferenceService : IOptionListReferenceService
         }
     }
 
-    private static void AddTaskDataToOptionListReferences(List<RefToOptionListSpecifier> optionListReferences, LayoutSetsModel layoutSetsModel)
+    private static void AddTaskDataToOptionListReferences(List<OptionListReference> optionListReferences, LayoutSetsModel layoutSetsModel)
     {
         foreach (var reference in optionListReferences)
         {
@@ -224,7 +224,7 @@ public class OptionListReferenceService : IOptionListReferenceService
         }
     }
 
-    private static void AddTaskDataToOptionListReference(RefToOptionListSpecifier reference, LayoutSetsModel layoutSetsModel)
+    private static void AddTaskDataToOptionListReference(OptionListReference reference, LayoutSetsModel layoutSetsModel)
     {
         foreach (var source in reference.OptionListIdSources)
         {

--- a/backend/src/Designer/Services/Implementation/OptionListReferenceService.cs
+++ b/backend/src/Designer/Services/Implementation/OptionListReferenceService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
@@ -71,6 +70,7 @@ public class OptionListReferenceService : IOptionListReferenceService
 
     private async Task FindOptionListReferencesInGivenLayouts(string layoutSetName, string[] layoutNames, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         foreach (string layoutName in layoutNames)
         {
             var layout = await _altinnAppGitRepository.GetLayout(layoutSetName, layoutName, cancellationToken);
@@ -174,14 +174,11 @@ public class OptionListReferenceService : IOptionListReferenceService
     private async Task AddTaskReferences(AltinnRepoEditingContext editingContext, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-
-        LayoutSetsModel layoutSetsModel = await _appDevelopmentService.GetLayoutSetsExtended(editingContext, cancellationToken);
-        if (_optionListReferences.Count == 0 || layoutSetsModel.Sets.Count == 0)
+        if (_optionListReferences.Count > 0)
         {
-            return;
+            LayoutSetsModel layoutSetsModel = await _appDevelopmentService.GetLayoutSetsExtended(editingContext, cancellationToken);
+            AddTaskDataToOptionListReferences(_optionListReferences, layoutSetsModel);
         }
-
-        AddTaskDataToOptionListReferences(_optionListReferences, layoutSetsModel);
     }
 
     private static void AddTaskDataToOptionListReferences(List<RefToOptionListSpecifier> optionListReferences, LayoutSetsModel layoutSetsModel)

--- a/backend/src/Designer/Services/Implementation/OptionListReferenceService.cs
+++ b/backend/src/Designer/Services/Implementation/OptionListReferenceService.cs
@@ -47,13 +47,8 @@ public class OptionListReferenceService : IOptionListReferenceService
     private async Task AddLayoutSetReferences(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+
         string[] layoutSetNames = _altinnAppGitRepository.GetLayoutSetNames();
-
-        await FindOptionListReferencesInGivenLayoutSets(layoutSetNames, cancellationToken);
-    }
-
-    private async Task FindOptionListReferencesInGivenLayoutSets(string[] layoutSetNames, CancellationToken cancellationToken = default)
-    {
         foreach (string layoutSetName in layoutSetNames)
         {
             await FindOptionListReferencesInLayoutSet(layoutSetName, cancellationToken);
@@ -63,27 +58,14 @@ public class OptionListReferenceService : IOptionListReferenceService
     private async Task FindOptionListReferencesInLayoutSet(string layoutSetName, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+
         string[] layoutNames = _altinnAppGitRepository.GetLayoutNames(layoutSetName);
-
-        await FindOptionListReferencesInGivenLayouts(layoutSetName, layoutNames, cancellationToken);
-    }
-
-    private async Task FindOptionListReferencesInGivenLayouts(string layoutSetName, string[] layoutNames, CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
         foreach (string layoutName in layoutNames)
         {
             await FindOptionListReferencesInLayout(layoutSetName, layoutName, cancellationToken);
         }
     }
 
-    /// <summary>
-    /// Finds all <see cref="OptionListReference"/> in a given layout.
-    /// </summary>
-    /// <param name="layoutSetName">The layoutSetName the layout belongs to.</param>
-    /// <param name="layoutName">The name of the given layout.</param>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> that observes if a call is cancelled.</param>
-    /// <returns>A list of <see cref="OptionListReference"/>.</returns>
     private async Task FindOptionListReferencesInLayout(string layoutSetName, string layoutName, CancellationToken cancellationToken = default)
     {
         string[] repoOptionListIds = _altinnAppGitRepository.GetOptionsListIds();
@@ -93,11 +75,6 @@ public class OptionListReferenceService : IOptionListReferenceService
         {
             FindOptionListReferencesInComponents(layoutSetName, layoutName, components, repoOptionListIds);
         }
-    }
-
-    private static JsonArray GetComponentArray(JsonNode layout)
-    {
-        return layout["data"]?["layout"] as JsonArray;
     }
 
     private void FindOptionListReferencesInComponents(string layoutSetName, string layoutName, JsonArray components, string[] repoOptionListIds)
@@ -131,6 +108,11 @@ public class OptionListReferenceService : IOptionListReferenceService
         {
             AddNewOptionListReference(_optionListReferences, optionListId, layoutSetName, layoutName, componentId);
         }
+    }
+
+    private static JsonArray GetComponentArray(JsonNode layout)
+    {
+        return layout["data"]?["layout"] as JsonArray;
     }
 
     private static string GetComponentId(JsonNode component)

--- a/backend/src/Designer/Services/Implementation/TaskNavigationService.cs
+++ b/backend/src/Designer/Services/Implementation/TaskNavigationService.cs
@@ -30,7 +30,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             cancellationToken.ThrowIfCancellationRequested();
             AltinnAppGitRepository altinnAppGitRepository = altinnGitRepositoryFactory.GetAltinnAppGitRepository(altinnRepoEditingContext.Org, altinnRepoEditingContext.Repo, altinnRepoEditingContext.Developer);
 
-            Definitions definitions = altinnAppGitRepository.GetDefinitions();
+            Definitions definitions = altinnAppGitRepository.GetProcessDefinitions();
             return definitions.Process.Tasks;
         }
 

--- a/backend/src/Designer/Services/Interfaces/IOptionListReferenceService.cs
+++ b/backend/src/Designer/Services/Interfaces/IOptionListReferenceService.cs
@@ -16,6 +16,6 @@ public interface IOptionListReferenceService
     /// </summary>
     /// <param name="editingContext">An <see cref="AltinnRepoEditingContext"/>.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that observes if operation is cancelled.</param>
-    /// <returns>A list of <see cref="RefToOptionListSpecifier"/> with task data.</returns>
-    Task<List<RefToOptionListSpecifier>> GetAllOptionListReferences(AltinnRepoEditingContext editingContext, CancellationToken cancellationToken = default);
+    /// <returns>A list of <see cref="OptionListReference"/> with task data.</returns>
+    Task<List<OptionListReference>> GetAllOptionListReferences(AltinnRepoEditingContext editingContext, CancellationToken cancellationToken = default);
 }

--- a/backend/tests/Designer.Tests/Controllers/OptionsController/GetOptionListsReferencesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OptionsController/GetOptionListsReferencesTests.cs
@@ -30,11 +30,11 @@ public class GetOptionListsReferencesTests : DesignerEndpointsTestsBase<GetOptio
 
         using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
         string responseBody = await response.Content.ReadAsStringAsync();
-        List<RefToOptionListSpecifier> responseList = JsonSerializer.Deserialize<List<RefToOptionListSpecifier>>(responseBody);
+        List<OptionListReference> responseList = JsonSerializer.Deserialize<List<OptionListReference>>(responseBody);
 
-        List<RefToOptionListSpecifier> expectedResponseList = new()
+        List<OptionListReference> expectedResponseList = new()
         {
-            new RefToOptionListSpecifier
+            new OptionListReference
             {
                 OptionListId = "test-options", OptionListIdSources =
                 [

--- a/backend/tests/Designer.Tests/Services/OptionListReferenceServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/OptionListReferenceServiceTests.cs
@@ -28,107 +28,11 @@ public class OptionListReferenceServiceTests
         List<RefToOptionListSpecifier> optionListsReferences = await optionListReferenceService.GetAllOptionListReferences(AltinnRepoEditingContext.FromOrgRepoDeveloper(OrgName, RepoName, DeveloperName));
 
         // Assert
-        List<RefToOptionListSpecifier> expectedResponseList = OptionListReferenceTestDataWithTaskData();
+        List<RefToOptionListSpecifier> expectedResponseList = OptionListReferenceTestData();
         Assert.Equivalent(optionListsReferences, expectedResponseList);
     }
 
-    [Fact]
-    public async Task AddTaskDataToOptionListReferences_ShouldAddCorrectTaskData_WhenReferencesExist()
-    {
-        // Arrange
-        const string RepoName = "app-with-options";
-        var optionListReferenceService = GetOptionListReferenceServiceForTest();
-        var repoEditingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(OrgName, RepoName, DeveloperName);
-        List<RefToOptionListSpecifier> referencesWithoutTaskData = OptionListReferenceTestDataWithoutTaskData();
-
-        // Act
-        List<RefToOptionListSpecifier> result = await optionListReferenceService.AddTaskDataToOptionListReferences(repoEditingContext, referencesWithoutTaskData);
-
-        // Assert
-        List<RefToOptionListSpecifier> expectedResult = OptionListReferenceTestDataWithTaskData();
-        Assert.Equivalent(result, expectedResult);
-    }
-
-    [Fact]
-    public async Task AddTaskDataToOptionListReferences_ShouldReturnSameReferenceList_WhenGivenListIsEmpty()
-    {
-        // Arrange
-        const string RepoName = "app-with-options";
-        var optionListReferenceService = GetOptionListReferenceServiceForTest();
-        var repoEditingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(OrgName, RepoName, DeveloperName);
-        List<RefToOptionListSpecifier> emptyReferenceList = [];
-
-        // Act
-        List<RefToOptionListSpecifier> result = await optionListReferenceService.AddTaskDataToOptionListReferences(repoEditingContext, emptyReferenceList);
-
-        // Assert
-        Assert.Same(result, emptyReferenceList);
-    }
-
-    [Fact]
-    public async Task AddTaskDataToOptionListReferences_ShouldReturnSameReferenceList_WhenLayoutSetsModelIsEmpty()
-    {
-        // Arrange
-        const string RepoName = "app-with-options";
-        var repoEditingContext = AltinnRepoEditingContext.FromOrgRepoDeveloper(OrgName, RepoName, DeveloperName);
-        var appDevelopmentServiceMock = new Mock<IAppDevelopmentService>();
-        appDevelopmentServiceMock.Setup(s => s.GetLayoutSetsExtended(repoEditingContext, new CancellationToken())).ReturnsAsync(new LayoutSetsModel());
-        var optionListReferenceService = GetOptionListReferenceServiceForTestWithMockedAppDevelopmentService(appDevelopmentServiceMock);
-        List<RefToOptionListSpecifier> referencesWithoutTaskData = OptionListReferenceTestDataWithoutTaskData();
-
-        // Act
-        List<RefToOptionListSpecifier> result = await optionListReferenceService.AddTaskDataToOptionListReferences(repoEditingContext, referencesWithoutTaskData);
-
-        // Assert
-        Assert.Same(result, referencesWithoutTaskData);
-    }
-
-    private List<RefToOptionListSpecifier> OptionListReferenceTestDataWithoutTaskData()
-    {
-        return new List<RefToOptionListSpecifier>
-        {
-            new RefToOptionListSpecifier
-            {
-                OptionListId = "test-options",
-                OptionListIdSources =
-                [
-                    new OptionListIdSource
-                    {
-                        ComponentIds = ["component-using-same-options-id-in-same-set-and-another-layout"],
-                        LayoutName = "layoutWithOneOptionListIdRef",
-                        LayoutSetId = "layoutSet1",
-                    },
-                    new OptionListIdSource
-                    {
-                        ComponentIds = ["component-using-test-options-id", "component-using-test-options-id-again"],
-                        LayoutName = "layoutWithFourCheckboxComponentsAndThreeOptionListIdRefs",
-                        LayoutSetId = "layoutSet1",
-                    },
-                    new OptionListIdSource
-                    {
-                        ComponentIds = ["component-using-same-options-id-in-another-set"],
-                        LayoutName = "layoutWithTwoOptionListIdRefs",
-                        LayoutSetId = "layoutSet2",
-                    }
-                ]
-            },
-            new RefToOptionListSpecifier
-            {
-                OptionListId = "other-options",
-                OptionListIdSources =
-                [
-                    new OptionListIdSource
-                    {
-                        ComponentIds = ["component-using-other-options-id"],
-                        LayoutName = "layoutWithFourCheckboxComponentsAndThreeOptionListIdRefs",
-                        LayoutSetId = "layoutSet1",
-                    }
-                ]
-            }
-        };
-    }
-
-    private List<RefToOptionListSpecifier> OptionListReferenceTestDataWithTaskData()
+    private List<RefToOptionListSpecifier> OptionListReferenceTestData()
     {
         return new List<RefToOptionListSpecifier>
         {
@@ -187,14 +91,6 @@ public class OptionListReferenceServiceTests
         var schemaModelServiceMock = new Mock<ISchemaModelService>().Object;
         AppDevelopmentService appDevelopmentService = new(altinnGitRepositoryFactory, schemaModelServiceMock);
         OptionListReferenceService optionListReferenceService = new(altinnGitRepositoryFactory, appDevelopmentService);
-
-        return optionListReferenceService;
-    }
-
-    private static OptionListReferenceService GetOptionListReferenceServiceForTestWithMockedAppDevelopmentService(Mock<IAppDevelopmentService> appDevelopmentServiceMock)
-    {
-        AltinnGitRepositoryFactory altinnGitRepositoryFactory = new(TestDataHelper.GetTestDataRepositoriesRootDirectory());
-        OptionListReferenceService optionListReferenceService = new(altinnGitRepositoryFactory, appDevelopmentServiceMock.Object);
 
         return optionListReferenceService;
     }

--- a/backend/tests/Designer.Tests/Services/OptionListReferenceServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/OptionListReferenceServiceTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Factories;
 using Altinn.Studio.Designer.Models;
@@ -25,18 +24,18 @@ public class OptionListReferenceServiceTests
         var optionListReferenceService = GetOptionListReferenceServiceForTest();
 
         // Act
-        List<RefToOptionListSpecifier> optionListsReferences = await optionListReferenceService.GetAllOptionListReferences(AltinnRepoEditingContext.FromOrgRepoDeveloper(OrgName, RepoName, DeveloperName));
+        List<OptionListReference> optionListsReferences = await optionListReferenceService.GetAllOptionListReferences(AltinnRepoEditingContext.FromOrgRepoDeveloper(OrgName, RepoName, DeveloperName));
 
         // Assert
-        List<RefToOptionListSpecifier> expectedResponseList = OptionListReferenceTestData();
+        List<OptionListReference> expectedResponseList = OptionListReferenceTestData();
         Assert.Equivalent(optionListsReferences, expectedResponseList);
     }
 
-    private List<RefToOptionListSpecifier> OptionListReferenceTestData()
+    private List<OptionListReference> OptionListReferenceTestData()
     {
-        return new List<RefToOptionListSpecifier>
+        return new List<OptionListReference>
         {
-            new RefToOptionListSpecifier
+            new OptionListReference
             {
                 OptionListId = "test-options",
                 OptionListIdSources =
@@ -67,7 +66,7 @@ public class OptionListReferenceServiceTests
                     }
                 ]
             },
-            new RefToOptionListSpecifier
+            new OptionListReference
             {
                 OptionListId = "other-options",
                 OptionListIdSources =


### PR DESCRIPTION
## Description

This PR attempts to make the `OptionListReferencesService` class more readable by:
1. Extracting the `optionListReferences` array into an instance variable, so that it does not have to be passed as a parameter into many different methods, as suggested in #15511.
2. Dividing long methods into separate ones, with more specific names.

Note that the unit tests for `AddTaskReferences` have been removed, since the only reason for the method being public was to allow testing. The method should already be sufficiently covered through other tests.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)