### PR TITLE
fix: prevent EnvStatus UI from breaking on long version numbers

### DIFF
--- a/frontend/app-development/features/appPublish/components/DeploymentEnvironmentStatus.module.css
+++ b/frontend/app-development/features/appPublish/components/DeploymentEnvironmentStatus.module.css
@@ -16,3 +16,7 @@
 .loadingSpinner * {
   font-size: inherit !important;
 }
+
+.content {
+  word-break: break-all;
+}

--- a/frontend/app-development/features/appPublish/components/DeploymentEnvironmentStatus.tsx
+++ b/frontend/app-development/features/appPublish/components/DeploymentEnvironmentStatus.tsx
@@ -52,7 +52,7 @@ export const DeploymentEnvironmentStatus = ({
           <DeployMoreOptionsMenu linkToEnv={urlToApp} environment={envName} />
         )}
 
-        <Paragraph size='small' spacing={!!footer}>
+        <Paragraph size='small' spacing={!!footer} className={classes.content}>
           {content}
         </Paragraph>
         {footer && <Paragraph size='xsmall'>{footer}</Paragraph>}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved text wrapping for deployment environment status content to prevent overflow and enhance readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->