### PR TITLE
chore: team-studio as CODEOWNERS for CODEOWNERS file only (no wildcard)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
+/.github/CODEOWNERS                         @altinn/team-studio
 src/Altinn.Platform/Altinn.Platform.PDF/**  @altinn/team-core
 src/test/K6/**                              @altinn/team-core
 frontend/resourceadm/**                     @altinn/team-access-info


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Re-added altinn/team-studio as CODEOWNERS, but only for the .github/CODEOWNERS file itself, without using the * wildcard.
This ensures that the team only receives notifications when changes are made to the CODEOWNERS file directly.

This is a workaround to reduce unnecessary notifications, while still allowing the security team to utilize CODEOWNERS for tracking purposes (e.g. Dependabot findings in the security dashboard).

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
