### PR TITLE
fix: add up and down icons

### DIFF
--- a/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.tsx
+++ b/frontend/packages/ux-editor/src/containers/DesignView/PageGroupAccordion.tsx
@@ -6,7 +6,14 @@ import { PageAccordion } from './PageAccordion';
 import { FormLayout } from './FormLayout';
 import { StudioDeleteButton, StudioHeading } from '@studio/components-legacy';
 import { StudioButton, StudioPopover } from '@studio/components';
-import { MenuElipsisVerticalIcon, FolderIcon, PlusIcon, TrashIcon } from '@studio/icons';
+import {
+  MenuElipsisVerticalIcon,
+  FolderIcon,
+  PlusIcon,
+  TrashIcon,
+  ArrowUpIcon,
+  ArrowDownIcon,
+} from '@studio/icons';
 import type { IFormLayouts } from '@altinn/ux-editor/types/global';
 import {
   duplicatedIdsExistsInLayout,
@@ -115,6 +122,7 @@ export const PageGroupAccordion = ({
               <StudioPopover placement='bottom'>
                 <div className={classes.ellipsisMenuContent}>
                   <StudioButton
+                    icon={<ArrowUpIcon aria-hidden />}
                     variant='tertiary'
                     onClick={() => moveGroupUp(groupIndex)}
                     disabled={groupIndex === 0}
@@ -122,6 +130,7 @@ export const PageGroupAccordion = ({
                     {t('ux_editor.page_menu_up')}
                   </StudioButton>
                   <StudioButton
+                    icon={<ArrowDownIcon aria-hidden />}
                     variant='tertiary'
                     onClick={() => moveGroupDown(groupIndex)}
                     disabled={groupIndex === pages.groups.length - 1}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There were missing icons for the buttons moving page groups.

![image](https://github.com/user-attachments/assets/78f28b1d-0982-4549-88f0-11f63a4c9c0e)


<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
