### PR TITLE
fix: popover bug

### DIFF
--- a/frontend/packages/shared/src/components/RemindChoiceDialog/RemindChoiceDialog.module.css
+++ b/frontend/packages/shared/src/components/RemindChoiceDialog/RemindChoiceDialog.module.css
@@ -13,6 +13,10 @@
   max-width: unset;
 }
 
+.closed {
+  display: none;
+}
+
 .buttons {
   display: flex;
   gap: var(--ds-size-4);

--- a/frontend/packages/shared/src/components/RemindChoiceDialog/RemindChoiceDialog.tsx
+++ b/frontend/packages/shared/src/components/RemindChoiceDialog/RemindChoiceDialog.tsx
@@ -3,6 +3,7 @@ import classes from './RemindChoiceDialog.module.css';
 import { useTranslation } from 'react-i18next';
 import { XMarkIcon } from '@studio/icons';
 import { StudioButton, StudioParagraph, StudioPopover } from '@studio/components';
+import cn from 'classnames';
 
 export type RemindChoiceDialogProps = {
   closeDialog: (permanentlyDismiss: boolean) => void;
@@ -24,9 +25,9 @@ export const RemindChoiceDialog = ({ closeDialog }: RemindChoiceDialogProps) => 
       <StudioPopover
         placement='bottom'
         data-color='info'
-        className={classes.popover}
         onOpen={() => setOpened(true)}
         onClose={() => setOpened(false)}
+        className={cn(classes.popover, { [classes.closed]: !opened })}
       >
         {opened && (
           <>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hide popover, it is always in the html by design of designsystemet. 
Since we added flex, it would be displayed in the top corner as the issue describe.

See https://github.com/Altinn/altinn-studio/issues/15774


<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Introduced a new style to hide elements when needed.
- **Refactor**
  - Updated the popover component to dynamically apply styles based on its open or closed state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->