### PR TITLE
fix(resource-adm): Improve validation in deploy resource page

### DIFF
--- a/frontend/resourceadm/hooks/mutations/useEditResourceMutation.ts
+++ b/frontend/resourceadm/hooks/mutations/useEditResourceMutation.ts
@@ -20,6 +20,7 @@ export const useEditResourceMutation = (org: string, repo: string, id: string) =
       queryClient.invalidateQueries({ queryKey: [QueryKey.RepoStatus, org, repo] });
       queryClient.invalidateQueries({ queryKey: [QueryKey.ResourceList, org] });
       queryClient.invalidateQueries({ queryKey: [QueryKey.SingleResource, org, repo, id] });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.ValidateResource, org, repo, id] });
     },
   });
 };

--- a/frontend/resourceadm/language/src/nb.json
+++ b/frontend/resourceadm/language/src/nb.json
@@ -182,6 +182,7 @@
   "resourceadm.deploy_status_card_error_title": "Du må fikse disse feilene før du kan gå videre",
   "resourceadm.deploy_status_card_error_version": "Lokalt repo mangler versjonsnummer. Vennligst last opp et versjonnummer i feltet under.",
   "resourceadm.deploy_status_card_success": "Ressursen er klar til å publiseres",
+  "resourceadm.deploy_status_card_loading": "Laster status...",
   "resourceadm.deploy_test_env": "Testmiljø TT02",
   "resourceadm.deploy_title": "Publiser ressursen",
   "resourceadm.deploy_version_label": "Nytt versjonsnummer",

--- a/frontend/resourceadm/pages/DeployResourcePage/DeployResourcePage.test.tsx
+++ b/frontend/resourceadm/pages/DeployResourcePage/DeployResourcePage.test.tsx
@@ -67,7 +67,7 @@ describe('DeployResourcePage', () => {
   it('initially displays the spinner when loading data', () => {
     renderDeployResourcePage();
 
-    expect(screen.getByTitle(textMock('resourceadm.deploy_spinner'))).toBeInTheDocument();
+    expect(screen.getByLabelText(textMock('resourceadm.deploy_spinner'))).toBeInTheDocument();
   });
 
   it('fetches repo status data on mount', () => {
@@ -99,7 +99,7 @@ describe('DeployResourcePage', () => {
       });
 
       await waitForElementToBeRemoved(() =>
-        screen.queryByTitle(textMock('resourceadm.deploy_spinner')),
+        screen.queryByLabelText(textMock('resourceadm.deploy_spinner')),
       );
 
       expect(screen.getByText(textMock('general.fetch_error_message'))).toBeInTheDocument();
@@ -345,7 +345,7 @@ const resolveAndWaitForSpinnerToDisappear = async (
     props,
   );
   await waitForElementToBeRemoved(() =>
-    screen.queryByTitle(textMock('resourceadm.deploy_spinner')),
+    screen.queryByLabelText(textMock('resourceadm.deploy_spinner')),
   );
 };
 

--- a/frontend/resourceadm/pages/DeployResourcePage/DeployResourcePage.test.tsx
+++ b/frontend/resourceadm/pages/DeployResourcePage/DeployResourcePage.test.tsx
@@ -332,6 +332,14 @@ describe('DeployResourcePage', () => {
     expect(tt02Button).toBeDisabled();
     expect(prodButton).toBeDisabled();
   });
+
+  it('shows the spinner when isSavingResource is true', async () => {
+    await resolveAndWaitForSpinnerToDisappear({}, { isSavingResource: true });
+
+    expect(
+      screen.getByLabelText(textMock('resourceadm.deploy_status_card_loading')),
+    ).toBeInTheDocument();
+  });
 });
 
 const resolveAndWaitForSpinnerToDisappear = async (

--- a/frontend/resourceadm/pages/DeployResourcePage/DeployResourcePage.test.tsx
+++ b/frontend/resourceadm/pages/DeployResourcePage/DeployResourcePage.test.tsx
@@ -58,6 +58,7 @@ const defaultProps: DeployResourcePageProps = {
   resourceVersionText: mockResourceVersionText,
   onSaveVersion: mockOnSaveVersion,
   id: mockId,
+  isSavingResource: false,
 };
 
 describe('DeployResourcePage', () => {

--- a/frontend/resourceadm/pages/DeployResourcePage/DeployResourcePage.tsx
+++ b/frontend/resourceadm/pages/DeployResourcePage/DeployResourcePage.tsx
@@ -4,7 +4,6 @@ import { ResourceDeployStatus } from '../../components/ResourceDeployStatus';
 import { ResourceDeployEnvCard } from '../../components/ResourceDeployEnvCard';
 import {
   StudioTextfield,
-  StudioSpinner,
   StudioHeading,
   StudioLabelAsParagraph,
   StudioParagraph,
@@ -12,6 +11,7 @@ import {
   StudioAlert,
   StudioErrorMessage,
 } from '@studio/components-legacy';
+import { StudioSpinner } from '@studio/components';
 import type { NavigationBarPage } from '../../types/NavigationBarPage';
 import type { DeployError } from '../../types/DeployError';
 import {
@@ -32,6 +32,7 @@ export type DeployResourcePageProps = {
   resourceVersionText: string;
   onSaveVersion: (version: string) => void;
   id: string;
+  isSavingResource: boolean;
 };
 
 /**
@@ -50,6 +51,7 @@ export const DeployResourcePage = ({
   resourceVersionText,
   onSaveVersion,
   id,
+  isSavingResource,
 }: DeployResourcePageProps): React.JSX.Element => {
   const { t } = useTranslation();
 
@@ -58,7 +60,7 @@ export const DeployResourcePage = ({
   const [newVersionText, setNewVersionText] = useState(resourceVersionText);
 
   // Queries to get metadata
-  const { data: repoStatus } = useRepoStatusQuery(org, app);
+  const { data: repoStatus, isFetching: isLoadingRepoStatus } = useRepoStatusQuery(org, app);
   const {
     status: publishStatusStatus,
     data: publishStatusData,
@@ -87,17 +89,23 @@ export const DeployResourcePage = ({
   };
 
   /**
-   * Gets either danger or success for the card type
+   * Gets either error, pending or success for the card type
    *
-   * @returns danger or success
+   * @returns error, pending or success
    */
-  const getStatusCardType = (): 'danger' | 'success' => {
-    const hasError =
+  const getStatusCardType = (): 'error' | 'success' | 'pending' => {
+    if (isSavingResource || isLoadingRepoStatus) {
+      return 'pending';
+    } else if (
       validateResourceData.status !== 200 ||
       validatePolicyData.status !== 200 ||
       !isLocalRepoInSync ||
-      resourceVersionText === '';
-    return hasError ? 'danger' : 'success';
+      resourceVersionText === ''
+    ) {
+      return 'error';
+    }
+
+    return 'success';
   };
 
   /**
@@ -154,18 +162,26 @@ export const DeployResourcePage = ({
    * Displays a spinner when loading the status or displays the status card
    */
   const displayStatusCard = () => {
-    return getStatusCardType() === 'success' ? (
+    const statusCardType = getStatusCardType();
+    if (statusCardType === 'pending') {
+      return (
+        <StudioSpinner data-size='xl' aria-label={t('resourceadm.deploy_status_card_loading')} />
+      );
+    } else if (statusCardType === 'error') {
+      return (
+        <ResourceDeployStatus
+          title={t('resourceadm.deploy_status_card_error_title')}
+          error={getStatusError()}
+          onNavigateToPageWithError={navigateToPageWithError}
+          resourceId={resourceId}
+        />
+      );
+    }
+    return (
       <ResourceDeployStatus
         title={t('resourceadm.deploy_status_card_success')}
         error={[]}
         isSuccess
-        resourceId={resourceId}
-      />
-    ) : (
-      <ResourceDeployStatus
-        title={t('resourceadm.deploy_status_card_error_title')}
-        error={getStatusError()}
-        onNavigateToPageWithError={navigateToPageWithError}
         resourceId={resourceId}
       />
     );
@@ -199,11 +215,7 @@ export const DeployResourcePage = ({
       case 'pending': {
         return (
           <div>
-            <StudioSpinner
-              size='xl'
-              variant='interaction'
-              spinnerTitle={t('resourceadm.deploy_spinner')}
-            />
+            <StudioSpinner data-size='xl' aria-label={t('resourceadm.deploy_spinner')} />
           </div>
         );
       }

--- a/frontend/resourceadm/pages/DeployResourcePage/DeployResourcePage.tsx
+++ b/frontend/resourceadm/pages/DeployResourcePage/DeployResourcePage.tsx
@@ -197,9 +197,16 @@ export const DeployResourcePage = ({
   const isDeployPossible = (envVersion: string): boolean => {
     const policyError =
       validatePolicyData === undefined || validatePolicyData.status !== ServerCodes.Ok;
+    const isLoading =
+      mergeQueryStatuses(publishStatusStatus, validatePolicyStatus, validateResourceStatus) ===
+        'pending' ||
+      isSavingResource ||
+      isLoadingRepoStatus;
+
     const canDeploy =
       validateResourceData.status === 200 &&
       !policyError &&
+      !isLoading &&
       isLocalRepoInSync &&
       resourceVersionText !== '' &&
       envVersion !== resourceVersionText;

--- a/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
+++ b/frontend/resourceadm/pages/ResourcePage/ResourcePage.tsx
@@ -72,7 +72,11 @@ export const ResourcePage = (): React.JSX.Element => {
   );
 
   // Mutation function for editing a resource
-  const { mutateAsync: editResource } = useEditResourceMutation(org, app, resourceId);
+  const { mutateAsync: editResource, isPending: isSavingResource } = useEditResourceMutation(
+    org,
+    app,
+    resourceId,
+  );
 
   // Set resourceData when loaded from server. Should only be called once
   useEffect(() => {
@@ -269,6 +273,7 @@ export const ResourcePage = (): React.JSX.Element => {
                 })
               }
               id='page-content-deploy'
+              isSavingResource={isSavingResource}
             />
           )}
           {currentPage === migrationPageId && isMigrateEnabled() && (


### PR DESCRIPTION
## Description
- Show spinner when saving resource version number or loading new validation status. Earlier, it was possible to change version number and deploy without sharing changes (if done quickly) since we didn't show spinner or block publish buttons
- Use Spinner component from `@studio/components` instead of `@studio/components-legacy`

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a loading state to the deployment status card, displaying a spinner and "Laster status..." message when saving or fetching status.
  * Improved accessibility for the loading spinner with updated aria-labels.

* **Bug Fixes**
  * Ensured cached validation data is refreshed after editing a resource for more accurate status updates.

* **Style**
  * Updated spinner component usage for better consistency and accessibility.

* **Tests**
  * Improved test robustness by using aria-labels for querying spinner elements.

* **Documentation**
  * Added a new Norwegian Bokmål localization string for the deployment status card loading message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->