### PR TITLE
feat: basic page group renaming

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1965,6 +1965,7 @@
   "ux_editor.page_config_pdf_exclude_page_from_default_pdf": "Ekskluder siden fra standard PDF",
   "ux_editor.page_delete_text": "Er du sikker på at du vil slette siden?\nAlle avhengigheter til den blir også slettet.",
   "ux_editor.page_group.markAsCompleted_switch": "Vis status “ferdig utfylt” på gruppen når alle obligatoriske felt er fylt ut eller sidene er lest",
+  "ux_editor.page_group.name": "Gruppenavn",
   "ux_editor.page_group.one_page_in_group_info_message": "En gruppe må ha minst to sider. Hvis det bare er én side, vises den som en enkeltside i navigasjonsmenyen.",
   "ux_editor.page_group.select_data_type": "Oppgaver utfyller skal svare på",
   "ux_editor.page_group.select_info_type": "Informasjon til utfyller",

--- a/frontend/libs/studio-icons/src/index.ts
+++ b/frontend/libs/studio-icons/src/index.ts
@@ -6,3 +6,4 @@ export * from './react/types';
 
 export { CheckmarkIcon as StudioSaveIcon } from '@navikt/aksel-icons';
 export { XMarkIcon as StudioCancelIcon } from '@navikt/aksel-icons';
+export { PencilIcon as StudioEditIcon } from '@navikt/aksel-icons';

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.module.css
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.module.css
@@ -11,12 +11,9 @@
   align-items: center;
   padding-top: var(--fds-spacing-2);
   padding-bottom: var(--fds-spacing-2);
-}
-
-.reading:hover {
-  background-color: var(--ds-color-brand1-surface-hover);
-  margin-inline: calc(var(--fds-spacing-2) * -1);
-  padding-inline: var(--fds-spacing-2);
+  color: var(--ds-color-text-default);
+  margin-inline: calc(var(--fds-spacing-4) * -1);
+  font-weight: var(--fds-font-weight-regular);
 }
 
 .editingTextfield {

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.module.css
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.module.css
@@ -1,0 +1,24 @@
+.editing {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--fds-spacing-2);
+  align-items: end;
+}
+
+.reading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: var(--fds-spacing-2);
+  padding-bottom: var(--fds-spacing-2);
+}
+
+.reading:hover {
+  background-color: var(--ds-color-brand1-surface-hover);
+  margin-inline: calc(var(--fds-spacing-2) * -1);
+  padding-inline: var(--fds-spacing-2);
+}
+
+.editingTextfield {
+  flex-grow: 1;
+}

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.test.tsx
@@ -13,6 +13,11 @@ describe('EditGroupName', () => {
     expect(readModeButton()).toBeInTheDocument();
   });
 
+  it('should render placeholder when group name is empty', async () => {
+    renderEditGroupName({ group: { name: '', order: [{ id: 'page1' }, { id: 'page2' }] } });
+    expect(readModeButton()).toHaveTextContent(textMock('ux_editor.page_group.name'));
+  });
+
   it('should start editing when clicking on the group name', async () => {
     const user = userEvent.setup();
     renderEditGroupName({});
@@ -33,6 +38,32 @@ describe('EditGroupName', () => {
     await user.click(saveButton());
 
     expect(onChangeMock).toHaveBeenCalledWith('new name');
+    expect(readModeButton()).toBeInTheDocument();
+  });
+
+  it('should call onChange when clicking enter in the text field', async () => {
+    const user = userEvent.setup();
+    const onChangeMock = jest.fn();
+    renderEditGroupName({ onChange: onChangeMock });
+
+    await user.click(readModeButton());
+    await user.clear(nameTextField());
+    await user.type(nameTextField(), 'new name{enter}');
+
+    expect(onChangeMock).toHaveBeenCalledWith('new name');
+    expect(readModeButton()).toBeInTheDocument();
+  });
+
+  it('should cancel editing when clicking escape in the text field', async () => {
+    const user = userEvent.setup();
+    const onChangeMock = jest.fn();
+    renderEditGroupName({ onChange: onChangeMock });
+
+    await user.click(readModeButton());
+    await user.clear(nameTextField());
+    await user.type(nameTextField(), 'new name{escape}');
+
+    expect(onChangeMock).not.toHaveBeenCalled();
     expect(readModeButton()).toBeInTheDocument();
   });
 

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import type { GroupModel } from 'app-shared/types/api/dto/PageModel';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../testing/mocks';
+import { EditGroupName, type EditGroupNameProps } from './EditGroupName';
+import userEvent from '@testing-library/user-event';
+import { textMock } from '@studio/testing/mocks/i18nMock';
+
+describe('EditGroupName', () => {
+  it('should render the group name in reading mode', async () => {
+    renderEditGroupName({});
+
+    expect(readModeParagraph(mockGroupName)).toBeInTheDocument();
+  });
+
+  it('should start editing when clicking on the group name', async () => {
+    const user = userEvent.setup();
+    renderEditGroupName({});
+
+    await user.click(readModeParagraph(mockGroupName));
+
+    expect(nameTextField()).toBeInTheDocument();
+  });
+
+  it('should call onChange when saving the group name', async () => {
+    const user = userEvent.setup();
+    const onChangeMock = jest.fn();
+    renderEditGroupName({ onChange: onChangeMock });
+
+    await user.click(readModeParagraph(mockGroupName));
+    await user.clear(nameTextField());
+    await user.type(nameTextField(), 'new name');
+    await user.click(saveButton());
+
+    expect(onChangeMock).toHaveBeenCalledWith('new name');
+    expect(readModeParagraph('new name')).toBeInTheDocument();
+  });
+
+  it('should cancel editing and revert to original group name', async () => {
+    const user = userEvent.setup();
+    const onChangeMock = jest.fn();
+    renderEditGroupName({ onChange: onChangeMock });
+
+    await user.click(readModeParagraph(mockGroupName));
+    await user.clear(nameTextField());
+    await user.type(nameTextField(), 'new name');
+    await user.click(cancelButton());
+
+    expect(onChangeMock).not.toHaveBeenCalled();
+    expect(readModeParagraph(mockGroupName)).toBeInTheDocument();
+    await user.click(readModeParagraph(mockGroupName));
+    expect(nameTextField()).toHaveValue(mockGroupName);
+  });
+});
+
+const readModeParagraph = (groupName: string) => screen.getByText(groupName, { selector: 'p' });
+const nameTextField = () =>
+  screen.getByRole('textbox', { name: textMock('ux_editor.page_group.name') });
+const saveButton = () => screen.getByRole('button', { name: textMock('general.save') });
+const cancelButton = () => screen.getByRole('button', { name: textMock('general.cancel') });
+
+const mockGroupName = 'testgroup';
+
+const renderEditGroupName = (componentProps: Partial<EditGroupNameProps>) => {
+  const groupModelMock: GroupModel = {
+    name: mockGroupName,
+    order: [{ id: 'testlayout 1' }, { id: 'testlayout 2' }],
+  };
+  return renderWithProviders(
+    <EditGroupName group={groupModelMock} onChange={jest.fn()} {...componentProps} />,
+  );
+};

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.test.tsx
@@ -10,14 +10,14 @@ describe('EditGroupName', () => {
   it('should render the group name in reading mode', async () => {
     renderEditGroupName({});
 
-    expect(readModeParagraph(mockGroupName)).toBeInTheDocument();
+    expect(readModeButton()).toBeInTheDocument();
   });
 
   it('should start editing when clicking on the group name', async () => {
     const user = userEvent.setup();
     renderEditGroupName({});
 
-    await user.click(readModeParagraph(mockGroupName));
+    await user.click(readModeButton());
 
     expect(nameTextField()).toBeInTheDocument();
   });
@@ -27,13 +27,13 @@ describe('EditGroupName', () => {
     const onChangeMock = jest.fn();
     renderEditGroupName({ onChange: onChangeMock });
 
-    await user.click(readModeParagraph(mockGroupName));
+    await user.click(readModeButton());
     await user.clear(nameTextField());
     await user.type(nameTextField(), 'new name');
     await user.click(saveButton());
 
     expect(onChangeMock).toHaveBeenCalledWith('new name');
-    expect(readModeParagraph('new name')).toBeInTheDocument();
+    expect(readModeButton()).toBeInTheDocument();
   });
 
   it('should cancel editing and revert to original group name', async () => {
@@ -41,19 +41,20 @@ describe('EditGroupName', () => {
     const onChangeMock = jest.fn();
     renderEditGroupName({ onChange: onChangeMock });
 
-    await user.click(readModeParagraph(mockGroupName));
+    await user.click(readModeButton());
     await user.clear(nameTextField());
     await user.type(nameTextField(), 'new name');
     await user.click(cancelButton());
 
     expect(onChangeMock).not.toHaveBeenCalled();
-    expect(readModeParagraph(mockGroupName)).toBeInTheDocument();
-    await user.click(readModeParagraph(mockGroupName));
+    expect(readModeButton()).toBeInTheDocument();
+    await user.click(readModeButton());
     expect(nameTextField()).toHaveValue(mockGroupName);
   });
 });
 
-const readModeParagraph = (groupName: string) => screen.getByText(groupName, { selector: 'p' });
+const readModeButton = () =>
+  screen.getByRole('button', { name: textMock('ux_editor.page_group.name') });
 const nameTextField = () =>
   screen.getByRole('textbox', { name: textMock('ux_editor.page_group.name') });
 const saveButton = () => screen.getByRole('button', { name: textMock('general.save') });

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { StudioButton, StudioLabel, StudioTextfield } from '@studio/components';
+import { StudioButton, StudioParagraph, StudioTextfield } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 import type { GroupModel } from 'app-shared/types/api/dto/PageModel';
 import { StudioCancelIcon, StudioEditIcon, StudioSaveIcon } from '@studio/icons';
 import classes from './EditGroupName.module.css';
 
-type EditGroupNameProps = {
+export type EditGroupNameProps = {
   group: GroupModel;
   onChange: (name: string) => void;
 };
+
 export const EditGroupName = ({ group, onChange }: EditGroupNameProps) => {
   const { t } = useTranslation();
   const [isEditing, setIsEditing] = React.useState(false);
@@ -18,7 +19,7 @@ export const EditGroupName = ({ group, onChange }: EditGroupNameProps) => {
   if (!isEditing) {
     return (
       <div className={classes.reading} onClick={() => setIsEditing(true)}>
-        <StudioLabel>{groupName}</StudioLabel>
+        <StudioParagraph>{groupName}</StudioParagraph>
         <StudioEditIcon />
       </div>
     );
@@ -46,8 +47,17 @@ export const EditGroupName = ({ group, onChange }: EditGroupNameProps) => {
         value={groupName}
         onChange={onChangeName}
       ></StudioTextfield>
-      <StudioButton icon={<StudioSaveIcon />} onClick={saveGroupName} />
-      <StudioButton variant='tertiary' icon={<StudioCancelIcon />} onClick={cancelEditing} />
+      <StudioButton
+        aria-label={t('general.save')}
+        icon={<StudioSaveIcon />}
+        onClick={saveGroupName}
+      />
+      <StudioButton
+        aria-label={t('general.cancel')}
+        variant='tertiary'
+        icon={<StudioCancelIcon />}
+        onClick={cancelEditing}
+      />
     </div>
   );
 };

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.tsx
@@ -17,16 +17,17 @@ export const EditGroupName = ({ group, onChange }: EditGroupNameProps) => {
   const [groupName, setGroupName] = React.useState(group.name);
 
   if (!isEditing) {
+    const pageGroupNameTranslationKey = t('ux_editor.page_group.name');
     return (
       <StudioButton
         variant='tertiary'
         className={classes.reading}
         onClick={() => setIsEditing(true)}
-        aria-label={t('ux_editor.page_group.name')}
+        aria-label={pageGroupNameTranslationKey}
       >
         <div>
-          <StudioLabel>{t('ux_editor.page_group.name')}</StudioLabel>
-          <StudioParagraph>{groupName || t('ux_editor.page_group.name')}</StudioParagraph>
+          <StudioLabel>{pageGroupNameTranslationKey}</StudioLabel>
+          <StudioParagraph>{groupName || pageGroupNameTranslationKey}</StudioParagraph>
         </div>
         <StudioEditIcon />
       </StudioButton>
@@ -47,6 +48,11 @@ export const EditGroupName = ({ group, onChange }: EditGroupNameProps) => {
     setGroupName(event.target.value);
   };
 
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter') saveGroupName();
+    if (event.key === 'Escape') cancelEditing();
+  };
+
   return (
     <div className={classes.editing}>
       <StudioTextfield
@@ -55,10 +61,7 @@ export const EditGroupName = ({ group, onChange }: EditGroupNameProps) => {
         label={t('ux_editor.page_group.name')}
         value={groupName}
         onChange={onChangeName}
-        onKeyDown={(event: KeyboardEvent) => {
-          if (event.key === 'Enter') saveGroupName();
-          if (event.key === 'Escape') cancelEditing();
-        }}
+        onKeyDown={onKeyDown}
       ></StudioTextfield>
       <StudioButton
         aria-label={t('general.save')}

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { StudioButton, StudioParagraph, StudioTextfield } from '@studio/components';
+import React, { type KeyboardEvent } from 'react';
+import { StudioButton, StudioLabel, StudioParagraph, StudioTextfield } from '@studio/components';
 import { useTranslation } from 'react-i18next';
 import type { GroupModel } from 'app-shared/types/api/dto/PageModel';
 import { StudioCancelIcon, StudioEditIcon, StudioSaveIcon } from '@studio/icons';
@@ -18,10 +18,18 @@ export const EditGroupName = ({ group, onChange }: EditGroupNameProps) => {
 
   if (!isEditing) {
     return (
-      <div className={classes.reading} onClick={() => setIsEditing(true)}>
-        <StudioParagraph>{groupName}</StudioParagraph>
+      <StudioButton
+        variant='tertiary'
+        className={classes.reading}
+        onClick={() => setIsEditing(true)}
+        aria-label={t('ux_editor.page_group.name')}
+      >
+        <div>
+          <StudioLabel>{t('ux_editor.page_group.name')}</StudioLabel>
+          <StudioParagraph>{groupName || t('ux_editor.page_group.name')}</StudioParagraph>
+        </div>
         <StudioEditIcon />
-      </div>
+      </StudioButton>
     );
   }
 
@@ -42,10 +50,15 @@ export const EditGroupName = ({ group, onChange }: EditGroupNameProps) => {
   return (
     <div className={classes.editing}>
       <StudioTextfield
+        autoFocus={true}
         className={classes.editingTextfield}
         label={t('ux_editor.page_group.name')}
         value={groupName}
         onChange={onChangeName}
+        onKeyUp={(event: KeyboardEvent) => {
+          if (event.key === 'Enter') saveGroupName();
+          if (event.key === 'Escape') cancelEditing();
+        }}
       ></StudioTextfield>
       <StudioButton
         aria-label={t('general.save')}

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.tsx
@@ -55,7 +55,7 @@ export const EditGroupName = ({ group, onChange }: EditGroupNameProps) => {
         label={t('ux_editor.page_group.name')}
         value={groupName}
         onChange={onChangeName}
-        onKeyUp={(event: KeyboardEvent) => {
+        onKeyDown={(event: KeyboardEvent) => {
           if (event.key === 'Enter') saveGroupName();
           if (event.key === 'Escape') cancelEditing();
         }}

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/EditGroupName.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { StudioButton, StudioLabel, StudioTextfield } from '@studio/components';
+import { useTranslation } from 'react-i18next';
+import type { GroupModel } from 'app-shared/types/api/dto/PageModel';
+import { StudioCancelIcon, StudioEditIcon, StudioSaveIcon } from '@studio/icons';
+import classes from './EditGroupName.module.css';
+
+type EditGroupNameProps = {
+  group: GroupModel;
+  onChange: (name: string) => void;
+};
+export const EditGroupName = ({ group, onChange }: EditGroupNameProps) => {
+  const { t } = useTranslation();
+  const [isEditing, setIsEditing] = React.useState(false);
+
+  const [groupName, setGroupName] = React.useState(group.name);
+
+  if (!isEditing) {
+    return (
+      <div className={classes.reading} onClick={() => setIsEditing(true)}>
+        <StudioLabel>{groupName}</StudioLabel>
+        <StudioEditIcon />
+      </div>
+    );
+  }
+
+  const saveGroupName = () => {
+    onChange(groupName);
+    setIsEditing(false);
+  };
+
+  const cancelEditing = () => {
+    setGroupName(group.name);
+    setIsEditing(false);
+  };
+
+  const onChangeName = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setGroupName(event.target.value);
+  };
+
+  return (
+    <div className={classes.editing}>
+      <StudioTextfield
+        className={classes.editingTextfield}
+        label={t('ux_editor.page_group.name')}
+        value={groupName}
+        onChange={onChangeName}
+      ></StudioTextfield>
+      <StudioButton icon={<StudioSaveIcon />} onClick={saveGroupName} />
+      <StudioButton variant='tertiary' icon={<StudioCancelIcon />} onClick={cancelEditing} />
+    </div>
+  );
+};

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/GroupConfigPanel.module.css
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/GroupConfigPanel.module.css
@@ -1,5 +1,9 @@
 .configPanel {
-  margin: var(--fds-spacing-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--fds-spacing-4);
+  padding: var(--fds-spacing-4);
+  background-color: var(--fds-semantic-surface-neutral-default);
 }
 
 .fieldSetWrapper {

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/GroupConfigPanel.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/GroupConfigPanel.test.tsx
@@ -79,6 +79,28 @@ describe('GroupConfigPanel', () => {
       );
     },
   );
+
+  it('should render edit group name when group has multiple pages', () => {
+    const selectedItem: SelectedItem = { type: ItemType.Group, id: 0 };
+    renderGroupConfigPanel({
+      props: { selectedItem },
+      queries: { getPages: jest.fn().mockResolvedValue(groupsPagesModelMock) },
+    });
+    expect(
+      screen.getByRole('button', { name: textMock('ux_editor.page_group.name') }),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render edit group group has a single page', () => {
+    const selectedItem: SelectedItem = { type: ItemType.Group, id: 1 };
+    renderGroupConfigPanel({
+      props: { selectedItem },
+      queries: { getPages: jest.fn().mockResolvedValue(groupsPagesModelMock) },
+    });
+    expect(
+      screen.queryByRole('button', { name: textMock('ux_editor.page_group.name') }),
+    ).not.toBeInTheDocument();
+  });
 });
 
 const markAsCompletedSwitch = (): HTMLElement =>

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/GroupConfigPanel.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/GroupConfigPanel.test.tsx
@@ -91,7 +91,7 @@ describe('GroupConfigPanel', () => {
     ).toBeInTheDocument();
   });
 
-  it('should not render edit group group has a single page', () => {
+  it('should not render edit group when group has a single page', () => {
     const selectedItem: SelectedItem = { type: ItemType.Group, id: 1 };
     renderGroupConfigPanel({
       props: { selectedItem },

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/GroupConfigPanel.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/GroupConfigPanel.tsx
@@ -85,7 +85,7 @@ export const GroupConfigPanel = ({ selectedItem }: GroupConfigPanelProps) => {
         }}
       />
       <div className={classes.configPanel}>
-        {!!selectedGroup.name && (
+        {selectedGroup.order.length > 1 && (
           <EditGroupName group={selectedGroup} onChange={onChangeGroupName} />
         )}
         <div className={classes.fieldSetWrapper}>

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/GroupConfigPanel.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/GroupConfigPanel.tsx
@@ -19,6 +19,7 @@ import { useChangePageGroupOrder } from '@altinn/ux-editor/hooks/mutations/useCh
 import classes from './GroupConfigPanel.module.css';
 import { GroupType } from 'app-shared/types/api/dto/PageModel';
 import { isPagesModelWithGroups } from 'app-shared/types/api/dto/PagesModel';
+import { EditGroupName } from './EditGroupName';
 
 export type GroupConfigPanelProps = {
   selectedItem: Extract<SelectedItem, { type: ItemType.Group }>;
@@ -64,6 +65,14 @@ export const GroupConfigPanel = ({ selectedItem }: GroupConfigPanelProps) => {
     changePageGroup(updatedPages);
   };
 
+  const onChangeGroupName = (name: string) => {
+    const updatedPages = {
+      ...pages,
+    };
+    updatedPages.groups[selectedItem.id] = { ...selectedGroup, name };
+    changePageGroup(updatedPages);
+  };
+
   return (
     <>
       <StudioSectionHeader
@@ -75,6 +84,9 @@ export const GroupConfigPanel = ({ selectedItem }: GroupConfigPanelProps) => {
         }}
       />
       <div className={classes.configPanel}>
+        {!!selectedGroup.name && (
+          <EditGroupName group={selectedGroup} onChange={onChangeGroupName} />
+        )}
         <div className={classes.fieldSetWrapper}>
           <StudioSwitch
             label={t('ux_editor.page_group.markAsCompleted_switch')}

--- a/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/GroupConfigPanel.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/GroupConfigPanel/GroupConfigPanel.tsx
@@ -15,11 +15,12 @@ import type { SelectedItem } from '../../../AppContext';
 import { useAppContext } from '../../../hooks';
 import { useStudioEnvironmentParams } from 'app-shared/hooks/useStudioEnvironmentParams';
 import { usePagesQuery } from '../../../hooks/queries/usePagesQuery';
-import { useChangePageGroupOrder } from '@altinn/ux-editor/hooks/mutations/useChangePageGroupOrder';
+import { useChangePageGroupOrder } from '../../../hooks/mutations/useChangePageGroupOrder';
 import classes from './GroupConfigPanel.module.css';
 import { GroupType } from 'app-shared/types/api/dto/PageModel';
 import { isPagesModelWithGroups } from 'app-shared/types/api/dto/PagesModel';
 import { EditGroupName } from './EditGroupName';
+import { changeGroupName } from '../../../utils/pageGroupUtils';
 
 export type GroupConfigPanelProps = {
   selectedItem: Extract<SelectedItem, { type: ItemType.Group }>;
@@ -29,7 +30,7 @@ export const GroupConfigPanel = ({ selectedItem }: GroupConfigPanelProps) => {
   const { t } = useTranslation();
   const { selectedFormLayoutSetName } = useAppContext();
   const { org, app } = useStudioEnvironmentParams();
-  const { mutate: changePageGroup, isPending: mutatingPages } = useChangePageGroupOrder(
+  const { mutate: pageGroupMutation, isPending: mutatingPages } = useChangePageGroupOrder(
     org,
     app,
     selectedFormLayoutSetName,
@@ -55,22 +56,22 @@ export const GroupConfigPanel = ({ selectedItem }: GroupConfigPanelProps) => {
   const onMarkAsCompleted = (event: React.ChangeEvent<HTMLInputElement>) => {
     const updatedPages = { ...pages };
     updatedPages.groups[selectedItem.id].markWhenCompleted = event.target.checked;
-    changePageGroup(updatedPages);
+    pageGroupMutation(updatedPages);
   };
 
   const onChangeGroupType = (typeValue: GroupType) => {
     const updatedPages = { ...pages };
     updatedPages.groups[selectedItem.id].type = typeValue;
 
-    changePageGroup(updatedPages);
+    pageGroupMutation(updatedPages);
   };
 
   const onChangeGroupName = (name: string) => {
     const updatedPages = {
       ...pages,
+      groups: changeGroupName(pages.groups, selectedItem.id, name),
     };
-    updatedPages.groups[selectedItem.id] = { ...selectedGroup, name };
-    changePageGroup(updatedPages);
+    pageGroupMutation(updatedPages);
   };
 
   return (

--- a/frontend/packages/ux-editor/src/utils/pageGroupUtils.test.ts
+++ b/frontend/packages/ux-editor/src/utils/pageGroupUtils.test.ts
@@ -1,9 +1,11 @@
+import type { GroupModel } from 'app-shared/types/api/dto/PageModel';
 import {
   movePageToGroup,
   removePageFromGroups,
   updateGroupNames,
   removeEmptyGroups,
   pageGroupDisplayName,
+  changeGroupName,
 } from './pageGroupUtils';
 
 jest.mock('i18next', () => ({
@@ -102,6 +104,34 @@ describe('pageGroupUtils', () => {
         order: [{ id: 'page1' }],
       });
       expect(groupName).toBe('page1');
+    });
+  });
+
+  describe('changeGroupName', () => {
+    it('should change the name of the specified group with single group', () => {
+      const groups = changeGroupName(
+        [{ name: 'Group 1', order: [{ id: 'page1' }, { id: 'page2' }] }],
+        0,
+        'New Group Name',
+      );
+      expect(groups).toStrictEqual<GroupModel[]>([
+        { name: 'New Group Name', order: [{ id: 'page1' }, { id: 'page2' }] },
+      ]);
+    });
+
+    it('should change the name of the specified group with multiple groups', () => {
+      const groups = changeGroupName(
+        [
+          { name: 'Group 1', order: [{ id: 'page1' }, { id: 'page2' }] },
+          { name: 'Group 2', order: [{ id: 'page3' }, { id: 'page4' }] },
+        ],
+        1,
+        'New Group Name',
+      );
+      expect(groups).toStrictEqual<GroupModel[]>([
+        { name: 'Group 1', order: [{ id: 'page1' }, { id: 'page2' }] },
+        { name: 'New Group Name', order: [{ id: 'page3' }, { id: 'page4' }] },
+      ]);
     });
   });
 });

--- a/frontend/packages/ux-editor/src/utils/pageGroupUtils.ts
+++ b/frontend/packages/ux-editor/src/utils/pageGroupUtils.ts
@@ -34,6 +34,14 @@ export const removeEmptyGroups = (groups: GroupModel[]): GroupModel[] => {
   return groups.filter((group) => group.order.length > 0);
 };
 
+export const changeGroupName = (
+  groups: GroupModel[],
+  index: number,
+  newName: string,
+): GroupModel[] => {
+  return groups.map((group, i) => (i === index ? { ...group, name: newName } : group));
+};
+
 export const getNextValidGroupName = (groups: GroupModel[]): string => {
   const pageGroupPrefix = t('ux_editor.page_layout_group');
   let i = 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds basic functionality to edit group names. Not intended to be the end result.
It does not take text resources into account, which is something i believe we should try to solve together with page id/names as well in a unified way. Extending this component after testing to a more generic studio component, to be used for page names as well, if it works well.

https://github.com/user-attachments/assets/9e526b3e-f9ed-46da-bb0e-a4ec71cdf6a0



## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline editing for group names in the group configuration panel, including localized labels and accessible edit controls.
  * Introduced a new icon for editing actions in the UI.

* **Bug Fixes**
  * Corrected import paths for improved reliability.

* **Style**
  * Updated and added CSS styles to enhance the layout and appearance of group configuration and editing interfaces.

* **Tests**
  * Added comprehensive tests for editing group names and related utility functions to ensure correct behavior and user interactions.

* **Documentation**
  * Added a new Norwegian translation for group name editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->