### PR TITLE
feat: add hover effect

### DIFF
--- a/frontend/packages/ux-editor/src/components/toolbar/ToolbarItemComponent.module.css
+++ b/frontend/packages/ux-editor/src/components/toolbar/ToolbarItemComponent.module.css
@@ -9,7 +9,7 @@
 }
 
 .toolbarItem:hover {
-  background-color: var(--fds-semantic-surface-action-no_fill-hover);
+  background-color: var(--ds-color-surface-hover);
 }
 
 .componentIcon {

--- a/frontend/packages/ux-editor/src/components/toolbar/ToolbarItemComponent.module.css
+++ b/frontend/packages/ux-editor/src/components/toolbar/ToolbarItemComponent.module.css
@@ -8,6 +8,10 @@
   gap: var(--fds-spacing-2);
 }
 
+.toolbarItem:hover {
+  background-color: var(--fds-semantic-surface-action-no_fill-hover);
+}
+
 .componentIcon {
   min-width: var(--fds-spacing-10);
   display: flex;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a background effect when hovering over toolbar items.
Went with the v1 token, that gives better contrast. When we migrate other elements in Utforming, they’ll get the same hover background.
 
Closes #15745 

https://github.com/user-attachments/assets/76273a4a-b9cd-41e8-a011-932dc6100b48


<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
