### PR TITLE
fix(resource-adm): lowercase consent metadata values

### DIFF
--- a/frontend/resourceadm/components/ResourcePageInputs/ResourceTextField.tsx
+++ b/frontend/resourceadm/components/ResourcePageInputs/ResourceTextField.tsx
@@ -35,6 +35,10 @@ type ResourceTextFieldProps = {
    * Whether this field is read only or not
    */
   readOnly?: boolean;
+  /**
+   * Whether the value in this field can only be lowercase
+   */
+  isLowerCase?: boolean;
 };
 
 /**
@@ -48,6 +52,7 @@ type ResourceTextFieldProps = {
  * @property {function}[onBlur] - Function to be executed on blur
  * @property {boolean}[required] - Whether this field is required or not
  * @property {boolean}[readOnly] - Whether this field is read only or not
+ * @property {boolean}[isLowerCase] - Whether the value in this field can only be lowercase
  *
  * @returns {ReactElement} - The rendered component
  */
@@ -59,6 +64,7 @@ export const ResourceTextField = ({
   onBlur,
   required,
   readOnly,
+  isLowerCase,
 }: ResourceTextFieldProps): ReactElement => {
   const [val, setVal] = useState(value);
 
@@ -70,7 +76,7 @@ export const ResourceTextField = ({
         description={description}
         value={val}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-          setVal(e.target.value);
+          setVal(isLowerCase ? e.target.value.toLowerCase() : e.target.value);
         }}
         onBlur={() => onBlur(val)}
         required={required}

--- a/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
+++ b/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
@@ -393,7 +393,7 @@ describe('AboutResourcePage', () => {
     ).toBeInTheDocument();
   });
 
-  it('handles consentMetadata changes', async () => {
+  it('handles consentMetadata changes and lowercase value', async () => {
     const user = userEvent.setup();
     render(
       <AboutResourcePage
@@ -405,7 +405,7 @@ describe('AboutResourcePage', () => {
     const consentMetadataField = screen.getByLabelText(
       textMock('resourceadm.about_resource_consent_metadata'),
     );
-    await user.type(consentMetadataField, ', year');
+    await user.type(consentMetadataField, ', YEAR');
     await waitFor(() => consentMetadataField.blur());
 
     expect(mockOnSaveResource).toHaveBeenCalledWith({

--- a/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
+++ b/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
@@ -201,6 +201,7 @@ export const AboutResourcePage = ({
               label={t('resourceadm.about_resource_consent_metadata')}
               description={t('resourceadm.about_resource_consent_metadata_description')}
               value={Object.keys(resourceData.consentMetadata ?? {}).join(', ')}
+              isLowerCase
               onBlur={(val: string) =>
                 handleSave({
                   ...resourceData,


### PR DESCRIPTION
## Description
- All consent metadata values should be lowercase

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
