### PR TITLE
test: try to fix flaky dashboard test

### DIFF
--- a/frontend/dashboard/pages/Dashboard/Dashboard.test.tsx
+++ b/frontend/dashboard/pages/Dashboard/Dashboard.test.tsx
@@ -6,10 +6,8 @@ import type { User } from 'app-shared/types/Repository';
 import { SelectedContextType } from '../../enums/SelectedContextType';
 import type { ServicesContextProps } from 'app-shared/contexts/ServicesContext';
 import { repository, searchRepositoryResponse } from 'app-shared/mocks/mocks';
-import type { SearchRepositoryResponse } from 'app-shared/types/api';
 import { DATA_MODEL_REPO_IDENTIFIER } from '../../constants';
 import { renderWithProviders } from 'dashboard/testing/mocks';
-import { type RepoIncludingStarredData } from 'dashboard/utils/repoUtils/repoUtils';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 
 const renderWithMockServices = (services?: Partial<ServicesContextProps>) => {
@@ -33,8 +31,7 @@ describe('Dashboard', () => {
 
   it('should display favorite list with one item', async () => {
     renderWithMockServices({
-      getStarredRepos: () =>
-        Promise.resolve<RepoIncludingStarredData[]>([{ ...repository, hasStarred: true }]),
+      getStarredRepos: jest.fn().mockResolvedValue([{ ...repository, hasStarred: true }]),
     });
 
     await waitForElementToBeRemoved(() => screen.queryAllByText(textMock('general.loading')));
@@ -44,7 +41,7 @@ describe('Dashboard', () => {
     });
     //eslint-disable-next-line testing-library/no-node-access
     const starredContainer = starredHeading.closest('div');
-    const starredRepos = within(starredContainer).getAllByTitle(
+    const starredRepos = await within(starredContainer).findAllByTitle(
       textMock('dashboard.unstar', { appName: repository.name }),
     );
 
@@ -53,11 +50,10 @@ describe('Dashboard', () => {
 
   it('should display application list with one item', async () => {
     renderWithMockServices({
-      searchRepos: () =>
-        Promise.resolve<SearchRepositoryResponse>({
-          ...searchRepositoryResponse,
-          data: [repository],
-        }),
+      searchRepos: jest.fn().mockResolvedValue({
+        ...searchRepositoryResponse,
+        data: [repository],
+      }),
     });
 
     await waitForElementToBeRemoved(() => screen.queryAllByText(textMock('general.loading')));
@@ -81,11 +77,10 @@ describe('Dashboard', () => {
     };
 
     renderWithMockServices({
-      searchRepos: () =>
-        Promise.resolve<SearchRepositoryResponse>({
-          ...searchRepositoryResponse,
-          data: [dataModelsRepository],
-        }),
+      searchRepos: jest.fn().mockResolvedValue({
+        ...searchRepositoryResponse,
+        data: [dataModelsRepository],
+      }),
     });
 
     await waitForElementToBeRemoved(() => screen.queryAllByText(textMock('general.loading')));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I was unable to reproduce the issue locally, i tried:
- running all tests for `dashboard.test.tsx` 100 times sequentially or in parallel, multiple times and had no failing tests.
- running all tests in the dashboard package.
- simulating the github action with [act](https://github.com/nektos/act). This ran fairly slow for me, so not very useful to test flaky behaviour.
#### It might be that the reason for the flakyness is very specific and rare, or somehow environment specific. But i've made two changes that i believe might solve the issue:

* Changes query mock implementation to use `jest.fn()` mocks to get better test isolation (is affected by `jest.clearAllMocks()` call used in afterEach function for these tests). Could solve the issue if it is caused by test contamination in specific orders?
* Add an async `findBy` query to the 'dashboard.unstar' which should stop potential snapshot issues if re-rendering is contributing to the issue. I find this unlikely, as I should probably have been able to reproduce the issue locally if this was the root cause.

<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of dashboard tests by updating mocking of asynchronous service calls and properly awaiting DOM updates.
  * Removed unused type imports to streamline test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->