### PR TITLE
fix: Export props type from StudioCard

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioCard/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioCard/index.ts
@@ -1,1 +1,1 @@
-export { StudioCard } from './StudioCard';
+export * from './StudioCard';


### PR DESCRIPTION
## Description
The index file in the `StudioCard` folder currently only exports the component. This pull request makes it export the props type as well, using wildcard export, to adhere to our standards.

I will add the `skip-manual-testing` label since the props type is not used anywhere yet. I have tested it locally by importing it into some typescript file.

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated export structure for StudioCard components to improve accessibility of all available exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->