### PR TITLE
fix: error message placement for input field in image component

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Image/ImageComponent.module.css
+++ b/frontend/packages/ux-editor/src/components/config/componentSpecificContent/Image/ImageComponent.module.css
@@ -1,7 +1,7 @@
 .root > div {
   display: flex;
   flex-direction: column;
-  gap: var(--fieldset-gap);
+  margin-bottom: var(--ds-size-5);
 }
 
 .widthAndPlacement {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This turned out to be a local styling issue for the Image component.
Added skip-manual-testing, as the images below displays all cases after the adjustment.



After:

![image](https://github.com/user-attachments/assets/ac4e3e1b-8ccf-45e7-ab7f-7a7b865190c5)

![image](https://github.com/user-attachments/assets/8b4c9a6b-cb9b-40c5-8e2c-da4db6a2b57e)





Closes #15751

<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
