### PR TITLE
fix(resource-adm): Show last changed date for resources if they exist in Gitea in resource list

### DIFF
--- a/frontend/resourceadm/components/ResourceTable/ResourceTable.test.tsx
+++ b/frontend/resourceadm/components/ResourceTable/ResourceTable.test.tsx
@@ -115,6 +115,18 @@ describe('ResourceTable', () => {
     expect(lastChangedCell).not.toBeInTheDocument();
   });
 
+  it('displays last changed date blank if resource has last changed date min date', () => {
+    render(
+      <ResourceTable
+        {...defaultProps}
+        list={[{ ...mockResourceListItem3, lastChanged: new Date(null) }]}
+      />,
+    );
+
+    const lastChangedCell = screen.queryByText('01.01.1970');
+    expect(lastChangedCell).not.toBeInTheDocument();
+  });
+
   it('displays environments for resource', () => {
     render(<ResourceTable {...defaultProps} />);
 

--- a/frontend/resourceadm/components/ResourceTable/ResourceTable.tsx
+++ b/frontend/resourceadm/components/ResourceTable/ResourceTable.tsx
@@ -20,6 +20,10 @@ const isDateEqualToLocalResourceChangedTime = (date: Date): boolean => {
   );
 };
 
+const isDateEqualToMinDate = (date: Date): boolean => {
+  return new Date(date).getTime() === 0;
+};
+
 export type ResourceTableProps = {
   /**
    * The list to display in the table
@@ -163,7 +167,7 @@ export const ResourceTable = ({
           return '';
         }
         const date = new Date(value);
-        if (isDateEqualToLocalResourceChangedTime(date)) {
+        if (isDateEqualToLocalResourceChangedTime(date) || isDateEqualToMinDate(date)) {
           return '';
         }
         return date.toLocaleDateString('no-NB', {

--- a/frontend/resourceadm/utils/mapperUtils/mapperUtils.test.ts
+++ b/frontend/resourceadm/utils/mapperUtils/mapperUtils.test.ts
@@ -75,7 +75,6 @@ describe('mapperUtils', () => {
       expect(resultResourceList[2].identifier).toBe(resource3Id);
       // Verify that resources with null dates appear last
       expect(resultResourceList[3].identifier).toBe(resource1Id);
-      expect(resultResourceList[3].lastChanged).toBeNull();
     });
 
     it('should set lastChanged to static value if lastChanged is null and environments includes gitea', () => {

--- a/frontend/resourceadm/utils/mapperUtils/mapperUtils.test.ts
+++ b/frontend/resourceadm/utils/mapperUtils/mapperUtils.test.ts
@@ -75,6 +75,7 @@ describe('mapperUtils', () => {
       expect(resultResourceList[2].identifier).toBe(resource3Id);
       // Verify that resources with null dates appear last
       expect(resultResourceList[3].identifier).toBe(resource1Id);
+      expect(resultResourceList[3].lastChanged).toBeNull();
     });
 
     it('should set lastChanged to static value if lastChanged is null and environments includes gitea', () => {

--- a/frontend/resourceadm/utils/mapperUtils/mapperUtils.ts
+++ b/frontend/resourceadm/utils/mapperUtils/mapperUtils.ts
@@ -5,9 +5,12 @@ import { LOCAL_RESOURCE_CHANGED_TIME } from '../../utils/resourceListUtils';
 const EnvOrder = ['prod', 'tt02', 'at22', 'at23', 'at24', 'gitea'];
 
 const setLastChangedDate = (resource: ResourceListItem): Date => {
-  return resource.lastChanged === null && resource.environments.includes('gitea')
-    ? LOCAL_RESOURCE_CHANGED_TIME
-    : new Date(resource.lastChanged);
+  if (resource.lastChanged === null && resource.environments.includes('gitea')) {
+    return LOCAL_RESOURCE_CHANGED_TIME;
+  } else if (!!resource.lastChanged) {
+    return new Date(resource.lastChanged);
+  }
+  return null;
 };
 
 /**

--- a/frontend/resourceadm/utils/mapperUtils/mapperUtils.ts
+++ b/frontend/resourceadm/utils/mapperUtils/mapperUtils.ts
@@ -4,13 +4,10 @@ import { LOCAL_RESOURCE_CHANGED_TIME } from '../../utils/resourceListUtils';
 
 const EnvOrder = ['prod', 'tt02', 'at22', 'at23', 'at24', 'gitea'];
 
-const setLastChangedDate = (resource: ResourceListItem): Date => {
-  if (resource.lastChanged === null && resource.environments.includes('gitea')) {
-    return LOCAL_RESOURCE_CHANGED_TIME;
-  } else if (!!resource.lastChanged) {
-    return new Date(resource.lastChanged);
-  }
-  return null;
+const setLastChangedDate = (resource: ResourceListItem): Date | null => {
+  return resource.lastChanged === null && resource.environments.includes('gitea')
+    ? LOCAL_RESOURCE_CHANGED_TIME
+    : new Date(resource.lastChanged);
 };
 
 /**


### PR DESCRIPTION
## Description
- Due to a bug, resources not in Gitea had their last changed display date set to 1.1.1970. These should not display a last changed date, but the underlying value should be `null` so they would appear last if user sort resources by date

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Resource Table no longer displays the date "01.01.1970" when a resource's last changed date is set to the minimum possible value.
* **Tests**
  * Added a test to ensure that resources with the minimum date value do not display "01.01.1970" in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->