### PR TITLE
fix: Make new StudioButton support ref forwarding

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioButton/StudioButton.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioButton/StudioButton.test.tsx
@@ -1,3 +1,4 @@
+import type { ForwardedRef } from 'react';
 import React from 'react';
 import type { StudioButtonProps } from './StudioButton';
 import { StudioButton } from './StudioButton';
@@ -6,6 +7,7 @@ import type { RenderResult } from '@testing-library/react';
 import type { IconPlacement } from '../../types/IconPlacement';
 import { testRootClassNameAppending } from '../../test-utils/testRootClassNameAppending';
 import { testCustomAttributes } from '../../test-utils/testCustomAttributes';
+import { testRefForwarding } from '../../test-utils/testRefForwarding';
 
 const iconPlacementCases: IconPlacement[] = ['left', 'right'];
 const iconTestId: string = 'icon';
@@ -46,9 +48,15 @@ describe('StudioButton', () => {
   it('Appends given classname to internal classname', () => {
     testRootClassNameAppending((className) => renderButton({ className }));
   });
+
+  it('Forwards the ref to the button element if given', () => {
+    testRefForwarding<HTMLButtonElement>((ref) => renderButton({}, ref));
+  });
 });
 
-const renderButton = (props: StudioButtonProps): RenderResult =>
-  render(<StudioButton {...props} />);
+const renderButton = (
+  props: StudioButtonProps,
+  ref?: ForwardedRef<HTMLButtonElement>,
+): RenderResult => render(<StudioButton {...props} ref={ref} />);
 
 const getButtonByName = (name: string): HTMLButtonElement => screen.getByRole('button', { name });

--- a/frontend/libs/studio-components/src/components/StudioButton/StudioButton.tsx
+++ b/frontend/libs/studio-components/src/components/StudioButton/StudioButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import classes from './StudioButton.module.css';
 import cn from 'classnames';
@@ -11,27 +11,34 @@ export type StudioButtonProps = {
   iconPlacement?: IconPlacement;
 } & Omit<ButtonProps, 'asChild' | 'icon'>;
 
-export const StudioButton = ({
-  icon,
-  iconPlacement = 'left',
-  'data-size': dataSize,
-  className: givenClassName,
-  children,
-  ...rest
-}: StudioButtonProps): ReactElement => {
-  const classNames = cn(givenClassName, classes.studioButton, {
-    [classes.smallWithIconOnly]: dataSize === 'sm' && !children,
-  });
+export const StudioButton = forwardRef<HTMLButtonElement, StudioButtonProps>(
+  (
+    {
+      icon,
+      iconPlacement = 'left',
+      'data-size': dataSize,
+      className: givenClassName,
+      children,
+      ...rest
+    },
+    ref,
+  ): ReactElement => {
+    const classNames = cn(givenClassName, classes.studioButton, {
+      [classes.smallWithIconOnly]: dataSize === 'sm' && !children,
+    });
 
-  return (
-    <Button className={classNames} icon={!children} data-size={dataSize} {...rest}>
-      {icon ? (
-        <TextWithIcon icon={icon} iconPlacement={iconPlacement}>
-          {children}
-        </TextWithIcon>
-      ) : (
-        children
-      )}
-    </Button>
-  );
-};
+    return (
+      <Button className={classNames} icon={!children} data-size={dataSize} {...rest} ref={ref}>
+        {icon ? (
+          <TextWithIcon icon={icon} iconPlacement={iconPlacement}>
+            {children}
+          </TextWithIcon>
+        ) : (
+          children
+        )}
+      </Button>
+    );
+  },
+);
+
+StudioButton.displayName = 'StudioButton';


### PR DESCRIPTION
## Description
The new `StudioButton` component is missing `ref` forwarding. Many other components rely on referencing the component's `<button>` element, including `StudioProperty.Button`, which I am currently moving into the new library. Therefore I have created this pull request, which adds support for `ref` forwarding to `StudioButton`. `forwardRef` is depracated in React 19, but as long as we use React 18 in Studio, we still need to use it.

The diff may look large, but that's just because of a change in indentation, which is caused by the component being wrapped in the `forwardRef` function.

I have added the `skip-manual-testing` label since the ref is not in use yet (it will be in a future pull request, when moving `StudioProperty.Button`).

## References
- [Official documentation of `forwardRef`](https://react.dev/reference/react/forwardRef)

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required) _Tested by using the ref in some code._
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The StudioButton component now supports ref forwarding, allowing you to attach refs directly to the button element.

* **Tests**
  * Added a test case to verify that refs are correctly forwarded by the StudioButton component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->