### PR TITLE
fix: remove previous error message on Data Models page

### DIFF
--- a/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/GenerateModelsButton/GenerateModelsButton.tsx
+++ b/frontend/app-development/features/dataModelling/SchemaEditorWithToolbar/TopToolbar/GenerateModelsButton/GenerateModelsButton.tsx
@@ -29,12 +29,8 @@ export const GenerateModelsButton = ({
         onSetSchemaGenerationErrorMessages([]);
       },
       onError: (error) => {
-        const customErrorMessages = error?.response?.data?.customErrorMessages;
-        if (customErrorMessages) {
-          onSetSchemaGenerationErrorMessages(customErrorMessages);
-        } else {
-          onSetSchemaGenerationErrorMessages([]);
-        }
+        const customErrorMessages = error?.response?.data?.customErrorMessages || [];
+        onSetSchemaGenerationErrorMessages(customErrorMessages);
       },
     });
   };


### PR DESCRIPTION
## Description
On the data models page we have a component which renders custom error messages. If an error which does not contain a custom error message is sent after one that does have a custom message, then the previous error with a custom message is still displayed.

With resetting the state to an empty list, the previous error is no longer rendered.

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling for model generation by ensuring error messages are cleared when no custom errors are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->