### PR TITLE
fix: Add missing parameter to mutation call - ProcessEditor

### DIFF
--- a/frontend/app-development/features/processEditor/handlers/OnProcessTaskAddHandler.test.ts
+++ b/frontend/app-development/features/processEditor/handlers/OnProcessTaskAddHandler.test.ts
@@ -113,6 +113,7 @@ describe('OnProcessTaskAddHandler', () => {
       taskId: 'testElementId',
     });
     expect(addDataTypeToAppMetadataMock).toHaveBeenNthCalledWith(2, {
+      allowedContributers: ['app:owned'],
       dataTypeId: 'paymentReceiptPdf-1234',
       taskId: 'testElementId',
     });

--- a/frontend/app-development/features/processEditor/handlers/OnProcessTaskAddHandler.test.ts
+++ b/frontend/app-development/features/processEditor/handlers/OnProcessTaskAddHandler.test.ts
@@ -1,6 +1,6 @@
 import type { Policy } from 'app-shared/types/Policy';
 import type { OnProcessTaskEvent } from '@altinn/process-editor/types/OnProcessTask';
-import { OnProcessTaskAddHandler } from './OnProcessTaskAddHandler';
+import { OnProcessTaskAddHandler, AllowedContributor } from './OnProcessTaskAddHandler';
 import type { TaskEvent } from '@altinn/process-editor/types/TaskEvent';
 import type { BpmnTaskType } from '@altinn/process-editor/types/BpmnTaskType';
 import { app, org } from '@studio/testing/testids';
@@ -108,12 +108,12 @@ describe('OnProcessTaskAddHandler', () => {
     });
     expect(addDataTypeToAppMetadataMock).toHaveBeenCalledTimes(2);
     expect(addDataTypeToAppMetadataMock).toHaveBeenNthCalledWith(1, {
-      allowedContributers: ['app:owned'],
+      allowedContributers: [AllowedContributor.AppOwned],
       dataTypeId: 'paymentInformation-1234',
       taskId: 'testElementId',
     });
     expect(addDataTypeToAppMetadataMock).toHaveBeenNthCalledWith(2, {
-      allowedContributers: ['app:owned'],
+      allowedContributers: [AllowedContributor.AppOwned],
       dataTypeId: 'paymentReceiptPdf-1234',
       taskId: 'testElementId',
     });
@@ -140,7 +140,7 @@ describe('OnProcessTaskAddHandler', () => {
     });
 
     expect(addDataTypeToAppMetadataMock).toHaveBeenCalledWith({
-      allowedContributers: ['app:owned'],
+      allowedContributers: [AllowedContributor.AppOwned],
       dataTypeId: 'signatureInformation-1234',
       taskId: 'testElementId',
     });
@@ -167,7 +167,7 @@ describe('OnProcessTaskAddHandler', () => {
     });
 
     expect(addDataTypeToAppMetadataMock).toHaveBeenCalledWith({
-      allowedContributers: ['app:owned'],
+      allowedContributers: [AllowedContributor.AppOwned],
       dataTypeId: 'userControlledSigningInformation-1234',
       taskId: 'testElementId',
     });

--- a/frontend/app-development/features/processEditor/handlers/OnProcessTaskAddHandler.ts
+++ b/frontend/app-development/features/processEditor/handlers/OnProcessTaskAddHandler.ts
@@ -82,6 +82,7 @@ export class OnProcessTaskAddHandler {
     this.addDataTypeToAppMetadata({
       dataTypeId: receiptPdfDataTypeId,
       taskId: taskMetadata.taskEvent.element.id,
+      allowedContributers: [AllowedContributor.AppOwned],
     });
 
     const paymentPolicyBuilder = new PaymentPolicyBuilder(this.org, this.app);

--- a/frontend/app-development/features/processEditor/handlers/OnProcessTaskAddHandler.ts
+++ b/frontend/app-development/features/processEditor/handlers/OnProcessTaskAddHandler.ts
@@ -7,7 +7,7 @@ import type {
 } from '../../../hooks/mutations/useAddLayoutSetMutation';
 import { StudioModeler } from '@altinn/process-editor/utils/bpmnModeler/StudioModeler';
 
-enum AllowedContributor {
+export enum AllowedContributor {
   AppOwned = 'app:owned',
 }
 


### PR DESCRIPTION
## Description
A missing parameter, `allowedContributers`, was causing a mutation call to not go through.
Now the parameter has been added, and creating a payment task works as expected again.

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated metadata for receipt PDF data types to include contributor information, ensuring consistency with other data types.

* **Refactor**
  * Improved code maintainability by standardizing the use of contributor enums across the application and related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->