### PR TITLE
feat: display style config for Link component in main config

### DIFF
--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
@@ -58,7 +58,7 @@ describe('ComponentMainConfig', () => {
     expect(imageHeader).toBeInTheDocument();
   });
 
-  it('should render link config when the component type matches', async () => {
+  it('should render link config when the component type matches', () => {
     renderComponentMainConfig(mainConfigComponentMock(ComponentType.Link), true);
     const linkConfigStyle = screen.getByText(textMock('ux_editor.component_properties.style'));
     expect(linkConfigStyle).toBeInTheDocument();

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
@@ -78,8 +78,8 @@ const renderComponentMainConfig = (component: FormItem, setSchemaData: boolean =
 
   if (setSchemaData) {
     queryClient.setQueryData(
-      [QueryKey.FormComponent, componentMocks[component.type].type],
-      componentSchemaMocks[componentMocks[component.type].type],
+      [QueryKey.FormComponent, component.type],
+      componentSchemaMocks[component.type],
     );
   }
 

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
@@ -10,7 +10,6 @@ import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { app, org } from '@studio/testing/testids';
 import { layoutSetsExtendedMock } from '@altinn/ux-editor/testing/layoutSetsMock';
-import { componentMocks } from '@altinn/ux-editor/testing/componentMocks';
 import { componentSchemaMocks } from '@altinn/ux-editor/testing/componentSchemaMocks';
 
 const mainConfigComponentMock = (type: ComponentType) =>

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
@@ -10,6 +10,8 @@ import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { app, org } from '@studio/testing/testids';
 import { layoutSetsExtendedMock } from '@altinn/ux-editor/testing/layoutSetsMock';
+import { componentMocks } from '@altinn/ux-editor/testing/componentMocks';
+import { componentSchemaMocks } from '@altinn/ux-editor/testing/componentSchemaMocks';
 
 const mainConfigComponentMock = (type: ComponentType) =>
   ({
@@ -56,6 +58,12 @@ describe('ComponentMainConfig', () => {
     expect(imageHeader).toBeInTheDocument();
   });
 
+  it('should render link config when the component type matches', async () => {
+    renderComponentMainConfig(mainConfigComponentMock(ComponentType.Link), true);
+    const linkConfigStyle = screen.getByText(textMock('ux_editor.component_properties.style'));
+    expect(linkConfigStyle).toBeInTheDocument();
+  });
+
   it('should not render any config when the component type does not match', async () => {
     renderComponentMainConfig(component1Mock);
     const wrapper = screen.getByTestId('component-wrapper');
@@ -63,10 +71,18 @@ describe('ComponentMainConfig', () => {
   });
 });
 
-const renderComponentMainConfig = (component: FormItem) => {
+const renderComponentMainConfig = (component: FormItem, setSchemaData: boolean = false) => {
   const handleComponentChange = jest.fn();
   const queryClient = createQueryClientMock();
   queryClient.setQueryData([QueryKey.LayoutSetsExtended, org, app], layoutSetsExtendedMock);
+
+  if (setSchemaData) {
+    queryClient.setQueryData(
+      [QueryKey.FormComponent, componentMocks[component.type].type],
+      componentSchemaMocks[componentMocks[component.type].type],
+    );
+  }
+
   return renderWithProviders(
     <div data-testid='component-wrapper'>
       <ComponentMainConfig component={component} handleComponentChange={handleComponentChange} />

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.tsx
@@ -6,6 +6,7 @@ import { SubformMainConfig } from './SpecificMainConfig/SubformMainConfig';
 import { OptionsMainConfig } from './SpecificMainConfig/OptionsMainConfig';
 import { ImageMainConfig } from './SpecificMainConfig/ImageMainConfig';
 import classes from './ComponentMainConfig.module.css';
+import { LinkMainConfig } from './SpecificMainConfig/LinkMainConfig';
 
 export type ComponentMainConfigProps = {
   component: FormItem;
@@ -44,6 +45,14 @@ export const ComponentMainConfig = ({
     case ComponentType.Image:
       return (
         <ImageMainConfig component={component} handleComponentChange={handleComponentChange} />
+      );
+    case ComponentType.Link:
+      return (
+        <LinkMainConfig
+          component={component}
+          handleComponentChange={handleComponentChange}
+          className={classes.mainConfigWrapper}
+        />
       );
     default:
       return null;

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/SpecificMainConfig/LinkMainConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/SpecificMainConfig/LinkMainConfig.tsx
@@ -6,7 +6,7 @@ import { useComponentSchemaQuery } from '@altinn/ux-editor/hooks/queries/useComp
 import type { properties } from '../../../../testing/schemas/json/component/Link.schema.v1.json';
 
 type LinkMainProperties = (keyof typeof properties)[];
-export const LinkMainProperties: LinkMainProperties = ['style'];
+const linkMainProperties: LinkMainProperties = ['style'];
 
 type LinkMainConfigProps = {
   component: FormItem<ComponentType.Link>;
@@ -26,7 +26,7 @@ export const LinkMainConfig = ({
       component={component}
       handleComponentUpdate={handleComponentChange}
       schema={schema}
-      stringPropertyKeys={LinkMainProperties}
+      stringPropertyKeys={linkMainProperties}
       className={className}
     />
   );

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/SpecificMainConfig/LinkMainConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/SpecificMainConfig/LinkMainConfig.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import type { FormItem } from '@altinn/ux-editor/types/FormItem';
-import type { ComponentType } from 'app-shared/types/ComponentType';
-import { ConfigStringProperties } from '@altinn/ux-editor/components/config/ConfigProperties';
-import { useComponentSchemaQuery } from '@altinn/ux-editor/hooks/queries/useComponentSchemaQuery';
+import type { FormItem } from '../../../../types/FormItem';
+import type { ComponentType } from '../../../../../../shared/src/types/ComponentType';
+import { ConfigStringProperties } from '../../../config/ConfigProperties/ConfigStringProperties';
+import { useComponentSchemaQuery } from '../../../../hooks/queries/useComponentSchemaQuery';
 import type { properties } from '../../../../testing/schemas/json/component/Link.schema.v1.json';
 
 type LinkMainProperties = (keyof typeof properties)[];

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/SpecificMainConfig/LinkMainConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/SpecificMainConfig/LinkMainConfig.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import type { FormItem } from '@altinn/ux-editor/types/FormItem';
+import type { ComponentType } from 'app-shared/types/ComponentType';
+import { ConfigStringProperties } from '@altinn/ux-editor/components/config/ConfigProperties';
+import { useComponentSchemaQuery } from '@altinn/ux-editor/hooks/queries/useComponentSchemaQuery';
+import type { properties } from '../../../../testing/schemas/json/component/Link.schema.v1.json';
+
+type LinkMainProperties = (keyof typeof properties)[];
+export const LinkMainProperties: LinkMainProperties = ['style'];
+
+type LinkMainConfigProps = {
+  component: FormItem<ComponentType.Link>;
+  handleComponentChange: (component: FormItem) => void;
+  className?: string;
+};
+
+export const LinkMainConfig = ({
+  component,
+  handleComponentChange,
+  className,
+}: LinkMainConfigProps): React.ReactElement => {
+  const { data: schema } = useComponentSchemaQuery(component.type);
+
+  return (
+    <ConfigStringProperties
+      component={component}
+      handleComponentUpdate={handleComponentChange}
+      schema={schema}
+      stringPropertyKeys={LinkMainProperties}
+      className={className}
+    />
+  );
+};

--- a/frontend/packages/ux-editor/src/testing/componentMocks.ts
+++ b/frontend/packages/ux-editor/src/testing/componentMocks.ts
@@ -197,6 +197,11 @@ const summary2Component: FormComponent<ComponentType.Summary2> = {
   },
 };
 
+const linkComponent: FormComponent<ComponentType.Link> = {
+  ...commonProps(ComponentType.Link),
+  style: 'link',
+};
+
 export const componentMocks = {
   [ComponentType.AccordionGroup]: accordionGroupContainer,
   [ComponentType.Accordion]: accordionContainer,
@@ -216,6 +221,7 @@ export const componentMocks = {
   [ComponentType.Header]: headerComponent,
   [ComponentType.Image]: imageComponent,
   [ComponentType.Input]: inputComponent,
+  [ComponentType.Link]: linkComponent,
   [ComponentType.Map]: mapComponent,
   [ComponentType.NavigationBar]: navigationBarComponent,
   [ComponentType.Panel]: panelComponent,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<img width="1695" height="461" alt="image" src="https://github.com/user-attachments/assets/ec235bd2-b08e-47f1-85e5-b8a94499b255" />


<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration support for Link components in the UX editor, allowing users to edit the style property for Link elements.

* **Tests**
  * Introduced new tests to verify Link component configuration rendering.

* **Chores**
  * Added mock data for Link components to support testing and development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->