### PR TITLE
feat: display text content and severity in main config for Alert component

### DIFF
--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
@@ -10,7 +10,6 @@ import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { app, org } from '@studio/testing/testids';
 import { layoutSetsExtendedMock } from '@altinn/ux-editor/testing/layoutSetsMock';
-import { componentMocks } from '@altinn/ux-editor/testing/componentMocks';
 import { componentSchemaMocks } from '@altinn/ux-editor/testing/componentSchemaMocks';
 
 const mainConfigComponentMock = (type: ComponentType) =>

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
@@ -10,6 +10,8 @@ import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { app, org } from '@studio/testing/testids';
 import { layoutSetsExtendedMock } from '@altinn/ux-editor/testing/layoutSetsMock';
+import { componentMocks } from '@altinn/ux-editor/testing/componentMocks';
+import { componentSchemaMocks } from '@altinn/ux-editor/testing/componentSchemaMocks';
 
 const mainConfigComponentMock = (type: ComponentType) =>
   ({
@@ -56,6 +58,12 @@ describe('ComponentMainConfig', () => {
     expect(imageHeader).toBeInTheDocument();
   });
 
+  it('should render alert config when the component type matches', async () => {
+    renderComponentMainConfig(mainConfigComponentMock(ComponentType.Alert), true);
+    const alertTextSeverity = screen.getByText(textMock('ux_editor.component_properties.severity'));
+    expect(alertTextSeverity).toBeInTheDocument();
+  });
+
   it('should not render any config when the component type does not match', async () => {
     renderComponentMainConfig(component1Mock);
     const wrapper = screen.getByTestId('component-wrapper');
@@ -63,10 +71,18 @@ describe('ComponentMainConfig', () => {
   });
 });
 
-const renderComponentMainConfig = (component: FormItem) => {
+const renderComponentMainConfig = (component: FormItem, setSchemaData: boolean = false) => {
   const handleComponentChange = jest.fn();
   const queryClient = createQueryClientMock();
   queryClient.setQueryData([QueryKey.LayoutSetsExtended, org, app], layoutSetsExtendedMock);
+
+  if (setSchemaData) {
+    queryClient.setQueryData(
+      [QueryKey.FormComponent, component.type],
+      componentSchemaMocks[component.type],
+    );
+  }
+
   return renderWithProviders(
     <div data-testid='component-wrapper'>
       <ComponentMainConfig component={component} handleComponentChange={handleComponentChange} />

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.tsx
@@ -6,6 +6,7 @@ import { SubformMainConfig } from './SpecificMainConfig/SubformMainConfig';
 import { OptionsMainConfig } from './SpecificMainConfig/OptionsMainConfig';
 import { ImageMainConfig } from './SpecificMainConfig/ImageMainConfig';
 import classes from './ComponentMainConfig.module.css';
+import { AlertMainConfig } from './SpecificMainConfig/AlertMainConfig';
 
 export type ComponentMainConfigProps = {
   component: FormItem;
@@ -44,6 +45,14 @@ export const ComponentMainConfig = ({
     case ComponentType.Image:
       return (
         <ImageMainConfig component={component} handleComponentChange={handleComponentChange} />
+      );
+    case ComponentType.Alert:
+      return (
+        <AlertMainConfig
+          component={component}
+          handleComponentChange={handleComponentChange}
+          className={classes.mainConfigWrapper}
+        />
       );
     default:
       return null;

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/SpecificMainConfig/AlertMainConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/SpecificMainConfig/AlertMainConfig.tsx
@@ -3,8 +3,8 @@ import type { FormItem } from '../../../../types/FormItem';
 import type { ComponentType } from '../../../../../../shared/src/types/ComponentType';
 import { useComponentSchemaQuery } from '../../../../hooks/queries/useComponentSchemaQuery';
 import type { properties } from '../../../../testing/schemas/json/component/Alert.schema.v1.json';
-import { ConfigStringProperties } from '@altinn/ux-editor/components/config/ConfigProperties';
-import { EditTextResourceBindings } from '@altinn/ux-editor/components/config/editModal/EditTextResourceBindings/EditTextResourceBindings';
+import { ConfigStringProperties } from '../../../config/ConfigProperties/ConfigStringProperties';
+import { EditTextResourceBindings } from '../../../config/editModal/EditTextResourceBindings/EditTextResourceBindings';
 
 type AlertMainContentProperties = (keyof typeof properties)[];
 const alertMainContentProperties: AlertMainContentProperties = ['severity'];

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/SpecificMainConfig/AlertMainConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/SpecificMainConfig/AlertMainConfig.tsx
@@ -1,0 +1,44 @@
+import React, { type ReactElement } from 'react';
+import type { FormItem } from '../../../../types/FormItem';
+import type { ComponentType } from '../../../../../../shared/src/types/ComponentType';
+import { useComponentSchemaQuery } from '../../../../hooks/queries/useComponentSchemaQuery';
+import type { properties } from '../../../../testing/schemas/json/component/Alert.schema.v1.json';
+import { ConfigStringProperties } from '@altinn/ux-editor/components/config/ConfigProperties';
+import { EditTextResourceBindings } from '@altinn/ux-editor/components/config/editModal/EditTextResourceBindings/EditTextResourceBindings';
+
+type AlertMainContentProperties = (keyof typeof properties)[];
+const alertMainContentProperties: AlertMainContentProperties = ['severity'];
+
+type AlertMainTextProperties = (keyof typeof properties.textResourceBindings.properties)[];
+const alertMainTextProperties: AlertMainTextProperties = ['body'];
+
+type AlertMainConfigProps = {
+  component: FormItem<ComponentType.Alert>;
+  handleComponentChange: (component: FormItem) => void;
+  className?: string;
+};
+
+export const AlertMainConfig = ({
+  component,
+  handleComponentChange,
+  className,
+}: AlertMainConfigProps): ReactElement => {
+  const { data: schema } = useComponentSchemaQuery(component.type);
+
+  return (
+    <div>
+      <EditTextResourceBindings
+        component={component}
+        handleComponentChange={handleComponentChange}
+        textResourceBindingKeys={alertMainTextProperties}
+      />
+      <ConfigStringProperties
+        component={component}
+        handleComponentUpdate={handleComponentChange}
+        schema={schema}
+        stringPropertyKeys={alertMainContentProperties}
+        className={className}
+      />
+    </div>
+  );
+};

--- a/frontend/packages/ux-editor/src/testing/componentMocks.ts
+++ b/frontend/packages/ux-editor/src/testing/componentMocks.ts
@@ -197,10 +197,16 @@ const summary2Component: FormComponent<ComponentType.Summary2> = {
   },
 };
 
+const alertComponent: FormComponent<ComponentType.Alert> = {
+  ...commonProps(ComponentType.Alert),
+  severity: 'info',
+};
+
 export const componentMocks = {
   [ComponentType.AccordionGroup]: accordionGroupContainer,
   [ComponentType.Accordion]: accordionContainer,
   [ComponentType.Address]: addressComponent,
+  [ComponentType.Alert]: alertComponent,
   [ComponentType.AttachmentList]: attachmentListComponent,
   [ComponentType.ButtonGroup]: buttonGroupContainer,
   [ComponentType.Button]: buttonComponent,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<img width="1557" height="688" alt="image" src="https://github.com/user-attachments/assets/bd1eb568-b5d8-41c8-b2d3-206219e8a0ce" />



<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration UI for Alert components in the form editor, allowing users to edit alert text and severity.
* **Tests**
  * Introduced tests to verify that Alert component configuration renders correctly.
* **Chores**
  * Added mock data for Alert components to support testing and development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->