### PR TITLE
fix: make all BPMN task palette titles follow the same pattern

### DIFF
--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
@@ -228,7 +228,7 @@ class SupportedPaletteProvider {
         'create.altinn-user-controlled-signing-task': {
           group: 'activity',
           className: 'bpmn-icon-task-generic bpmn-icon-user-controlled-signing-task',
-          title: translate('Create Altinn User Controlled Signing Task'),
+          title: translate('Create Altinn User-Controlled Signing Task'),
           action: {
             click: createUserControlledSigningTask(),
             dragstart: createUserControlledSigningTask(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR makes all task palette titles in the BPMN editor follow the same general form.

Previously, the signing and user-controlled signing task types were not capitalised, the user-controlled signing type contained a typo, and the payment type did not contain "Create Altinn" within its name.

### Before
<img width="1110" height="581" alt="bilde" src="https://github.com/user-attachments/assets/5094fdfa-432a-442c-85bf-2c48fffd02fd" />

### After
<img width="1207" height="559" alt="bilde" src="https://github.com/user-attachments/assets/c0a40754-c82a-47b2-a01d-9e91c25f21cb" />


## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the titles of Altinn task palette entries in the BPMN editor for improved capitalization, clearer wording, and corrected spelling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->