### PR TITLE
chore: changed-breadcumb-Forside-to-Oversikt in-nb.json

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1330,7 +1330,7 @@
   "ux_editor.address_component.settings": "Innstillinger for adressekomponent",
   "ux_editor.adjust_zoom": "Standard zoom",
   "ux_editor.attribution_label": "Opphav",
-  "ux_editor.breadcrumbs.front_page": "Forside",
+  "ux_editor.breadcrumbs.front_page": "Oversikt",
   "ux_editor.button_component.settings": "Innstillinger for knapp",
   "ux_editor.center_location": "Sentrum av kartet",
   "ux_editor.checkboxes_error_DuplicateValues": "Alle verdier må være unike.",


### PR DESCRIPTION
Changed breadcrumb Forside to Oversikt

<!--- Provide a general summary of your changes in the Title above -->

## Description

As agreed in issue and Slack discussion

## Verification

- [ ] [[Related issue](https://github.com/orgs/Altinn/projects/36/views/45?filterQuery=sprint%3A%40current+&pane=issue&itemId=121109682&issue=Altinn%7Caltinn-studio%7C15905#:~:text=breadcrumbs%20to%20Oversikt-,%2315905,-Parent%3A)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Norwegian Bokmål translation for the front page breadcrumb from "Forside" to "Oversikt".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->