### PR TITLE
refactor: change pageconfigwarning to not use useEffect and ref

### DIFF
--- a/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.test.tsx
@@ -5,19 +5,13 @@ import { PageConfigPanel } from './PageConfigPanel';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import { queryClientMock } from 'app-shared/mocks/queryClientMock';
 import type { ITextResources } from 'app-shared/types/global';
-import { DEFAULT_LANGUAGE, DEFAULT_SELECTED_LAYOUT_NAME } from 'app-shared/constants';
+import { DEFAULT_LANGUAGE } from 'app-shared/constants';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import type { IFormLayouts } from '../../../types/global';
-import { layout1NameMock, layoutMock } from '@altinn/ux-editor/testing/layoutMock';
+import { layout1NameMock, layoutMock, pagesModelMock } from '@altinn/ux-editor/testing/layoutMock';
 import { layoutSet1NameMock } from '@altinn/ux-editor/testing/layoutSetsMock';
 import { app, org } from '@studio/testing/testids';
-import { findLayoutsContainingDuplicateComponents } from '../../../utils/formLayoutUtils';
 import { ItemType } from '../ItemType';
-
-jest.mock('../../../utils/formLayoutUtils', () => ({
-  ...jest.requireActual('../../../utils/formLayoutUtils'),
-  findLayoutsContainingDuplicateComponents: jest.fn(),
-}));
 
 // Test data
 const layoutSet = layoutSet1NameMock;
@@ -47,33 +41,20 @@ const layouts: IFormLayouts = {
 
 describe('PageConfigPanel', () => {
   beforeEach(() => {
-    (findLayoutsContainingDuplicateComponents as jest.Mock).mockReturnValue([]);
+    jest.clearAllMocks();
   });
 
-  it('render heading with layout page name when layout is selected', () => {
-    const newSelectedPage = 'newSelectedPage';
+  it('render heading with layout page name when layout is selected', async () => {
+    const newSelectedPage = layout1NameMock;
     renderPageConfigPanel(newSelectedPage);
     screen.getByRole('heading', { name: newSelectedPage });
   });
 
-  it('render all accordion items when layout is selected', () => {
-    const newSelectedPage = 'newSelectedPage';
+  it('render all accordion items when layout is selected', async () => {
+    const newSelectedPage = layout1NameMock;
     renderPageConfigPanel(newSelectedPage);
     screen.getByRole('button', { name: textMock('right_menu.text') });
     screen.getByRole('button', { name: textMock('right_menu.dynamics') });
-  });
-
-  it('render textValue instead of page ID if page ID exists in the text resources', () => {
-    const newSelectedPage = 'newSelectedPage';
-    const newVisualPageName = 'newVisualPageName';
-    renderPageConfigPanel(newSelectedPage, {
-      [DEFAULT_LANGUAGE]: [{ id: newSelectedPage, value: newVisualPageName }],
-    });
-    expect(screen.queryByRole('heading', { name: newSelectedPage })).not.toBeInTheDocument();
-    screen.getByRole('heading', { name: newVisualPageName });
-    screen.getByRole('button', {
-      name: textMock('ux_editor.modal_properties_textResourceBindings_page_id'),
-    });
   });
 
   it('render warning when layout is selected and has duplicated ids', () => {
@@ -92,32 +73,23 @@ describe('PageConfigPanel', () => {
     expect(uniqueIds).not.toBeInTheDocument();
   });
 
-  it('should not show warning modal when there are no duplicated ids across layouts', () => {
-    renderPageConfigPanel();
-
-    const modal = screen.queryByRole('dialog');
-
-    expect(modal).not.toBeInTheDocument();
-  });
-
   it('should show warning modal when there are duplicated ids across layouts', async () => {
-    (findLayoutsContainingDuplicateComponents as jest.Mock).mockReturnValue({
-      duplicateLayouts: [duplicatedLayout],
-    });
     renderPageConfigPanel();
     await waitFor(() => {
       const modal = screen.getByRole('dialog');
       expect(modal).toBeInTheDocument();
     });
+    jest.restoreAllMocks();
   });
 });
 
 const renderPageConfigPanel = (
-  selectedLayoutName: string = DEFAULT_SELECTED_LAYOUT_NAME,
+  selectedLayoutName: string = layout1NameMock,
   textResources = defaultTexts,
 ) => {
   queryClientMock.setQueryData([QueryKey.TextResources, org, app], textResources);
   queryClientMock.setQueryData([QueryKey.FormLayouts, org, app, layoutSet], layouts);
+  queryClientMock.setQueryData([QueryKey.Pages, org, app, layoutSet], pagesModelMock);
   queryClientMock.setQueryData(
     [QueryKey.FormLayoutSettings, org, app, layoutSet],
     formLayoutSettingsMock,

--- a/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigPanel.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useRef } from 'react';
+import React, { Fragment } from 'react';
 import { Accordion } from '@digdir/designsystemet-react';
 import { FileIcon } from '@studio/icons';
 import { StudioSectionHeader } from '@studio/components-legacy';
@@ -6,7 +6,6 @@ import { useText, useTextResourcesSelector, useFormLayouts } from '../../../hook
 import { DEFAULT_LANGUAGE } from 'app-shared/constants';
 import { HiddenExpressionOnLayout } from './HiddenExpressionOnLayout';
 import { TextResource } from '../../TextResource/TextResource';
-import { EditPageId } from './EditPageId';
 import { textResourceByLanguageAndIdSelector } from '../../../selectors/textResourceSelectors';
 import type { ITextResource } from 'app-shared/types/global';
 import {
@@ -20,6 +19,7 @@ import type { IInternalLayout } from '@altinn/ux-editor/types/global';
 import { PdfConfig } from '@altinn/ux-editor/components/Properties/PageConfigPanel/PdfConfig';
 import type { ItemType } from '../ItemType';
 import type { SelectedItem } from '../../../AppContext';
+import { EditPageId } from './EditPageId';
 
 type PageConfigPanelProps = {
   selectedItem: Extract<SelectedItem, { type: ItemType.Page }>;
@@ -27,7 +27,6 @@ type PageConfigPanelProps = {
 
 export const PageConfigPanel = ({ selectedItem }: PageConfigPanelProps) => {
   const t = useText();
-  const modalRef = useRef<HTMLDialogElement>(null);
   const layoutNameTextResourceSelector = textResourceByLanguageAndIdSelector(
     DEFAULT_LANGUAGE,
     selectedItem.id,
@@ -45,12 +44,6 @@ export const PageConfigPanel = ({ selectedItem }: PageConfigPanelProps) => {
   const duplicateLayouts: string[] =
     findLayoutsContainingDuplicateComponents(layouts).duplicateLayouts;
   const hasDuplicatedIdsInAllLayouts = duplicateLayouts?.length > 0;
-
-  useEffect(() => {
-    if (hasDuplicatedIdsInAllLayouts) {
-      modalRef.current?.showModal();
-    }
-  }, [hasDuplicatedIdsInAllLayouts]);
 
   if (hasDuplicatedIds) {
     return <PageConfigWarning selectedFormLayoutName={selectedItem.id} layout={layout} />;
@@ -93,7 +86,7 @@ export const PageConfigPanel = ({ selectedItem }: PageConfigPanelProps) => {
           </Accordion.Item>
         </Accordion>
       </Fragment>
-      <PageConfigWarningModal modalRef={modalRef} />
+      <PageConfigWarningModal open={hasDuplicatedIdsInAllLayouts} />
     </>
   );
 };

--- a/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigWarningModal/PageConfigWarningModal.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PageConfigPanel/PageConfigWarningModal/PageConfigWarningModal.tsx
@@ -1,26 +1,26 @@
 import type { ReactNode } from 'react';
 import React from 'react';
 import classes from './PageConfigWarningModal.module.css';
-import { Modal } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
+import { StudioDialog, StudioHeading } from '@studio/components';
 
 export interface PageConfigWarningModalProps {
-  modalRef: React.MutableRefObject<HTMLDialogElement>;
+  open: boolean;
 }
-export const PageConfigWarningModal = ({ modalRef }: PageConfigWarningModalProps): ReactNode => {
+
+export const PageConfigWarningModal = ({ open }: PageConfigWarningModalProps): ReactNode => {
   const { t } = useTranslation();
   return (
-    <Modal ref={modalRef} role='dialog'>
-      <Modal.Header closeButton={true}>
-        {t('ux_editor.modal_properties_warning_modal_title')}
-      </Modal.Header>
-      <Modal.Content>
+    <StudioDialog open={open}>
+      <StudioDialog.Block>
+        <StudioHeading>{t('ux_editor.modal_properties_warning_modal_title')}</StudioHeading>
+      </StudioDialog.Block>
+      <StudioDialog.Block>
         <div className={classes.subTitle}>
           {t('ux_editor.modal_properties_warning_modal_sub_title')}
         </div>
         {t('ux_editor.modal_properties_warning_modal_instructive_text_body')}
-      </Modal.Content>
-      <Modal.Footer />
-    </Modal>
+      </StudioDialog.Block>
+    </StudioDialog>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

stacked PR
- #15883
- this PR


This change was necessary to avoid issues from tests in #15883 . The previous solution used a useEffect hook to render the dialog, resulting in a state change and rerender on first render. The new solution uses the `open` parameter directly from [Dialog](https://storybook.designsystemet.no/?path=/docs/komponenter-dialog--docs), making the dialog open without re-renders or state changes. 
Updated the old dialog version used to the new studio components package.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the warning modal to use a new dialog component with a simplified, prop-driven approach for visibility.
  * The modal now opens based on a boolean flag rather than using refs and effects.
  * Streamlined and unified test data usage in related tests.

* **Style**
  * Improved the visual structure of the warning modal using updated design system components.

* **Tests**
  * Simplified test setup by reducing unnecessary mocks and removing some tests related to modal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->