### PR TITLE
refactor: remove redundant CSS for RequiredIndicator

### DIFF
--- a/frontend/packages/ux-editor/src/components/RequiredIndicator.module.css
+++ b/frontend/packages/ux-editor/src/components/RequiredIndicator.module.css
@@ -1,6 +1,4 @@
 .requiredIndicator {
   display: inline;
-  height: var(--fds-sizing-7);
-  border-radius: var(--fds-radius-sm);
   padding: var(--fds-spacing-2);
 }


### PR DESCRIPTION
## Description

Removed two lines that had no effect in the CSS of RequiredIndicator.
* `height` has no effect when `display: inline` is set. In addition, `padding` takes care of the height.
* the border radius was set to the same as the DS component it is based upon, making it redundant.

There are no visual changes as a result of this PR.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
