### PR TITLE
fix: remove border radius properties from EditGrid container and OptionListSelector modal

### DIFF
--- a/frontend/packages/ux-editor/src/components/config/editModal/EditGrid/EditGrid.module.css
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditGrid/EditGrid.module.css
@@ -1,6 +1,5 @@
 .gridContainer {
   background-color: white;
-  border-radius: var(--fds-border_radius-large);
   display: grid;
 }
 

--- a/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListSelector/OptionListSelector.module.css
+++ b/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/EditTab/OptionListSelector/OptionListSelector.module.css
@@ -4,7 +4,6 @@
 
   min-width: var(--code-list-modal-min-width);
   height: var(--code-list-modal-height);
-  border-radius: var(--fds-border_radius-xxlarge);
 }
 
 .content {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes redundant border radius settings.
* EditGrid's container has no border to apply border radius to (white content on white background).
* OptionListSelector's modal does not need a custom border-radius, we can instead use the default from Designsystemet, so that it matches the other modals in Studio.

| Before | After |
| --- | --- |
| <img width="209" height="185" alt="image" src="https://github.com/user-attachments/assets/f5ae7afb-31fe-4710-8740-47da2cb699e2" /> | <img width="191" height="188" alt="image" src="https://github.com/user-attachments/assets/555dcd9d-ee21-4f19-a41c-8c96b1358c48" /> |

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed large border radius from grid container and modal elements for a more streamlined appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->