### PR TITLE
fix: use border radius CSS variables across solution

### DIFF
--- a/frontend/app-development/features/overview/components/Navigation/Navigation.module.css
+++ b/frontend/app-development/features/overview/components/Navigation/Navigation.module.css
@@ -16,7 +16,7 @@
 }
 
 .link {
-  border-radius: 4px;
+  border-radius: var(--ds-border-radius-md);
 
   display: flex;
 

--- a/frontend/app-development/features/overview/components/Navigation/Navigation.module.css
+++ b/frontend/app-development/features/overview/components/Navigation/Navigation.module.css
@@ -1,6 +1,6 @@
 .navigation {
   background-color: #f4f5f6;
-  border-radius: 4px;
+  border-radius: var(--ds-border-radius-md);
 
   display: flex;
   flex-direction: column;

--- a/frontend/app-development/features/overview/components/Overview.module.css
+++ b/frontend/app-development/features/overview/components/Overview.module.css
@@ -22,7 +22,7 @@
 
 .panel {
   background-color: white;
-  border-radius: 4px;
+  border-radius: var(--ds-border-radius-md);
   box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.05);
   padding: var(--fds-spacing-10);
   position: relative;
@@ -43,14 +43,14 @@
 
 .mainSection {
   background-color: #f4f5f6;
-  border-radius: 4px;
+  border-radius: var(--ds-border-radius-md);
   padding: var(--fds-spacing-4);
 }
 
 .asideSection {
   background-color: #fbfbfc;
   border: solid 2px #efefef;
-  border-radius: 4px;
+  border-radius: var(--ds-border-radius-md);
 
   padding: var(--fds-spacing-4);
 }

--- a/frontend/packages/process-editor/src/components/Canvas/BPMNEditor/BPMNEditor.module.css
+++ b/frontend/packages/process-editor/src/components/Canvas/BPMNEditor/BPMNEditor.module.css
@@ -1,6 +1,6 @@
 .editorContainer {
   border: 1px solid var(--fds-semantic-border-neutral-default);
-  border-radius: 5px;
+  border-radius: var(--ds-border-radius-md);
   background-image: var(--canvas-background-image);
   background-size: var(--canvas-background-size);
   background-position: var(--canvas-background-position);

--- a/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/ThreeDotsMenu.module.css
+++ b/frontend/packages/shared/src/components/GiteaHeader/ThreeDotsMenu/ThreeDotsMenu.module.css
@@ -1,5 +1,4 @@
 .popover {
-  border-radius: 5px;
   padding: 0;
 }
 

--- a/frontend/packages/shared/src/components/MergeConflictWarning/MergeConflictWarning.module.css
+++ b/frontend/packages/shared/src/components/MergeConflictWarning/MergeConflictWarning.module.css
@@ -6,7 +6,7 @@
   padding: 50px 100px;
   width: 660px;
   border: 1px solid #c9c9c9;
-  border-radius: 3px;
+  border-radius: var(--ds-border-radius-md);
 }
 
 .buttonContainer {

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/EditLayoutSetForSubform/EditLayoutSet/CreateNewSubformSection/SubformDataModel.module.css
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/EditLayoutSetForSubform/EditLayoutSet/CreateNewSubformSection/SubformDataModel.module.css
@@ -1,4 +1,4 @@
 .displayDataModelButton {
   padding-left: var(--fds-spacing-1);
-  border-radius: var(--fds-sizing-1);
+  border-radius: var(--ds-border-radius-md);
 }

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/EditLayoutSetForSubform/EditLayoutSet/SelectSubformSection/SelectSubformSection.module.css
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/EditLayoutSetForSubform/EditLayoutSet/SelectSubformSection/SelectSubformSection.module.css
@@ -5,7 +5,7 @@
 
 .createSubformLinkButton {
   padding-left: var(--fds-spacing-1);
-  border-radius: var(--fds-sizing-1);
+  border-radius: var(--ds-border-radius-md);
 }
 
 .saveSubformButton,


### PR DESCRIPTION
## Description

Replaces border radiuses stated directly in numbers with border radius variables from Designsystemet.

In som cases, the `--fds-sizing...` variables were used. These were also replaced with border radius variables.

The 5px `border-radius` property was removed from `.popover` in `ThreeDotsMenu.module.css`, so that it uses the default radius of StudioPopover (4px).

There are no visual changes, except where:
* `3px` was changed to `--ds-border-radius-md` - 1px increase.
* `5px` was changed to `--ds-border-radius-md` - 1px decrease.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated multiple components to use a design system variable for border-radius, replacing fixed pixel values or previous variables.
  * Standardized border-radius styling across navigation, overview panels, editor containers, warning containers, and various button elements.
  * Removed border-radius from the popover menu for a more consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->