### PR TITLE
fix: StudioIconCard menu icon border radius

### DIFF
--- a/frontend/libs/studio-components-legacy/src/components/StudioIconCard/StudioIconCard.module.css
+++ b/frontend/libs/studio-components-legacy/src/components/StudioIconCard/StudioIconCard.module.css
@@ -56,7 +56,7 @@
 .editIcon {
   padding: var(--fds-sizing-0);
   position: absolute;
-  border-radius: var(--fds-border_radius-full);
+  border-radius: var(--ds-border-radius-md);
   right: var(--fds-spacing-1);
   top: var(--fds-spacing-1);
   height: var(--fds-sizing-10);

--- a/frontend/libs/studio-components-legacy/src/components/StudioIconCard/StudioIconCard.module.css
+++ b/frontend/libs/studio-components-legacy/src/components/StudioIconCard/StudioIconCard.module.css
@@ -56,7 +56,7 @@
 .editIcon {
   padding: var(--fds-sizing-0);
   position: absolute;
-  border-radius: var(--ds-border-radius-md);
+  border-radius: var(--fds-border_radius-medium);
   right: var(--fds-spacing-1);
   top: var(--fds-spacing-1);
   height: var(--fds-sizing-10);


### PR DESCRIPTION
## Description

Currently, when hovering the menu button in StudioIconCard, it has a round/full border radius. This is inconsistent with the other menu buttons in Studio, which have 4 px border radiuses. This PR changes it to `--fds-border_radius-medium` (4px) to match the others.

| Before | After |
| ------- | ----- |
| <img width="382" height="406" alt="bilde" src="https://github.com/user-attachments/assets/8c2a94ec-6aad-40d2-8d90-e9681044cee5" /> | <img width="378" height="406" alt="bilde" src="https://github.com/user-attachments/assets/14484749-90ea-4054-b91b-da7fc5ef334b" />



## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
