### PR TITLE
fix: deprecate StudioButton component

### DIFF
--- a/frontend/libs/studio-components-legacy/src/components/StudioButton/StudioButton.tsx
+++ b/frontend/libs/studio-components-legacy/src/components/StudioButton/StudioButton.tsx
@@ -19,6 +19,10 @@ export type StudioButtonProps = Override<
   Omit<ButtonProps, 'asChild'>
 >;
 
+/**
+ * @deprecated use `StudioButton` from `@studio/components` instead
+ */
+
 const StudioButton: OverridableComponent<StudioButtonProps, HTMLButtonElement> = forwardRef(
   <As extends ElementType = 'button'>(
     {


### PR DESCRIPTION
## Description
The old `StudioButton` component in `studio-components-legacy` library is now marked as deprecated.

## Verification
- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
