### PR TITLE
feat: Add localized fields and extend service configuration model

### DIFF
--- a/backend/src/Designer/Configuration/ServiceConfiguration.cs
+++ b/backend/src/Designer/Configuration/ServiceConfiguration.cs
@@ -1,7 +1,8 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Altinn.Studio.Designer.Models;
 using System.Text.Json.Serialization;
+using Altinn.Studio.Designer.Enums;
+using Altinn.Studio.Designer.Models;
 
 namespace Altinn.Studio.Designer.Configuration
 {
@@ -31,7 +32,8 @@ namespace Altinn.Studio.Designer.Configuration
         /// <summary>
         /// Gets or sets the description of the
         /// </summary>
-        public string ServiceDescription { get; set; }
+        [JsonConverter(typeof(LocalizedStringConverter))]
+        public LocalizedString ServiceDescription { get; set; }
 
         [RegularExpression("^altinnapp$", ErrorMessage = "ResourceType must be 'altinnapp'.")]
         public string ResourceType { get; set; }
@@ -48,27 +50,5 @@ namespace Altinn.Studio.Designer.Configuration
 }
 
 
-public enum ServiceStatus
-{
-    Completed,
-    Deprecated,
-    UnderDevelopment,
-    Withdrawn
-}
-
-public enum AvailableForType
-{
-    PrivatePerson,
-    LegalEntityEnterprise,
-    Company,
-    BankruptcyEstate,
-    SelfRegisteredUser
-}
 
 
-public class LocalizedString
-{
-    public string Nb { get; set; }
-    public string Nn { get; set; }
-    public string En { get; set; }
-}

--- a/backend/src/Designer/Configuration/ServiceConfiguration.cs
+++ b/backend/src/Designer/Configuration/ServiceConfiguration.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using Altinn.Studio.Designer.Models;
+using System.Text.Json.Serialization;
 
 namespace Altinn.Studio.Designer.Configuration
 {
@@ -10,13 +13,15 @@ namespace Altinn.Studio.Designer.Configuration
         /// <summary>
         /// Gets or sets the repository name
         /// </summary>
-        [RegularExpression("^[a-zA-Z]+[a-zA-Z0-9_]*$", ErrorMessage = "Må begynne med en bokstav og ikke inneholde mellomrom eller spesialtegn ('_' er tillatt)")]
+        [RegularExpression("^[a-zA-Z]+[a-zA-Z0-9_]*$",
+            ErrorMessage = "Må begynne med en bokstav og ikke inneholde mellomrom eller spesialtegn ('_' er tillatt)")]
         public string RepositoryName { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the service
         /// </summary>
-        public string ServiceName { get; set; }
+        [JsonConverter(typeof(LocalizedStringConverter))]
+        public LocalizedString ServiceName { get; set; }
 
         /// <summary>
         /// Gets or sets the id of the service
@@ -27,5 +32,43 @@ namespace Altinn.Studio.Designer.Configuration
         /// Gets or sets the description of the
         /// </summary>
         public string ServiceDescription { get; set; }
+
+        [RegularExpression("^altinnapp$", ErrorMessage = "ResourceType must be 'altinnapp'.")]
+        public string ResourceType { get; set; }
+
+        public string Homepage { get; set; }
+        public bool IsDelegable { get; set; }
+        public ServiceStatus Status { get; set; }
+        public bool SelfIdentifiedUserEnabled { get; set; }
+        public bool EnterpriseUserEnabled { get; set; }
+        public AvailableForType AvailableForType { get; set; }
+        public List<ContactPoint> ContactPoints { get; set; } = new List<ContactPoint>();
+        public bool Visible { get; set; }
     }
+}
+
+
+public enum ServiceStatus
+{
+    Completed,
+    Deprecated,
+    UnderDevelopment,
+    Withdrawn
+}
+
+public enum AvailableForType
+{
+    PrivatePerson,
+    LegalEntityEnterprise,
+    Company,
+    BankruptcyEstate,
+    SelfRegisteredUser
+}
+
+
+public class LocalizedString
+{
+    public string Nb { get; set; }
+    public string Nn { get; set; }
+    public string En { get; set; }
 }

--- a/backend/src/Designer/Configuration/ServiceConfiguration.cs
+++ b/backend/src/Designer/Configuration/ServiceConfiguration.cs
@@ -12,43 +12,83 @@ namespace Altinn.Studio.Designer.Configuration
     public class ServiceConfiguration
     {
         /// <summary>
-        /// Gets or sets the repository name
+        /// Indicates whether the service is available for specific user types (e.g., private, enterprise)
+        /// </summary>
+        public AvailableForType AvailableForType { get; set; }
+
+        /// <summary>
+        /// Contact points for the service (e.g., support emails or phone numbers)
+        /// </summary>
+        public List<ContactPoint> ContactPoints { get; set; } = new List<ContactPoint>();
+
+        /// <summary>
+        /// Indicates whether enterprise users can access the service
+        /// </summary>
+        public bool EnterpriseUserEnabled { get; set; }
+
+        /// <summary>
+        /// URL to the homepage
+        /// </summary>
+        public string Homepage { get; set; }
+
+        /// <summary>
+        /// Indicates whether the service can be is delegable
+        /// </summary>
+        public bool IsDelegable { get; set; }
+
+        /// <summary>
+        /// Name of the service in multiple languages
+        /// </summary>
+        [JsonConverter(typeof(LocalizedStringConverter))]
+        public LocalizedString ServiceName { get; set; }
+
+        /// <summary>
+        /// ID of the service
+        /// </summary>
+        public string ServiceId { get; set; }
+
+        /// <summary>
+        /// Description of the service in multiple languages
+        /// </summary>
+        [JsonConverter(typeof(LocalizedStringConverter))]
+        public LocalizedString Description { get; set; }
+
+        /// <summary>
+        /// Indicates whether self-identified users can access the service
+        /// </summary>
+        public bool SelfIdentifiedUserEnabled { get; set; }
+
+        /// <summary>
+        /// Status of the service
+        /// </summary>
+        public ServiceStatus Status { get; set; }
+
+        /// <summary>
+        /// Type of resource; must be 'altinnapp'
+        /// </summary>
+        [RegularExpression("^altinnapp$", ErrorMessage = "ResourceType must be 'altinnapp'.")]
+        public string ResourceType { get; set; }
+
+        /// <summary>
+        /// Repository name; must start with a letter and only contain letters, numbers or underscores
         /// </summary>
         [RegularExpression("^[a-zA-Z]+[a-zA-Z0-9_]*$",
             ErrorMessage = "Må begynne med en bokstav og ikke inneholde mellomrom eller spesialtegn ('_' er tillatt)")]
         public string RepositoryName { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the service
+        /// Description of the rights
         /// </summary>
-        [JsonConverter(typeof(LocalizedStringConverter))]
-        public LocalizedString ServiceName { get; set; }
+        public LocalizedString RightDescription { get; set; }
 
         /// <summary>
-        /// Gets or sets the id of the service
+        /// List of keywords associated with the service
         /// </summary>
-        public string ServiceId { get; set; }
+        public List<Keyword> Keywords { get; set; } = new List<Keyword>();
 
         /// <summary>
-        /// Gets or sets the description of the
+        /// Indicates whether the service should be visible
         /// </summary>
-        [JsonConverter(typeof(LocalizedStringConverter))]
-        public LocalizedString ServiceDescription { get; set; }
-
-        [RegularExpression("^altinnapp$", ErrorMessage = "ResourceType must be 'altinnapp'.")]
-        public string ResourceType { get; set; }
-
-        public string Homepage { get; set; }
-        public bool IsDelegable { get; set; }
-        public ServiceStatus Status { get; set; }
-        public bool SelfIdentifiedUserEnabled { get; set; }
-        public bool EnterpriseUserEnabled { get; set; }
-        public AvailableForType AvailableForType { get; set; }
-        public List<ContactPoint> ContactPoints { get; set; } = new List<ContactPoint>();
         public bool Visible { get; set; }
     }
 }
-
-
-
-

--- a/backend/src/Designer/Controllers/ConfigController.cs
+++ b/backend/src/Designer/Controllers/ConfigController.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Helpers;
+using Altinn.Studio.Designer.Mappers;
+using Altinn.Studio.Designer.Models.Dto;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -61,18 +63,15 @@ namespace Altinn.Studio.Designer.Controllers
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <param name="serviceConfig">the service config</param>
         [HttpPost]
-        public async Task SetServiceConfig(string org, string app, [FromBody] dynamic serviceConfig)
+        public async Task SetServiceConfig(string org, string app, [FromBody] ServiceConfigRequest serviceConfig)
         {
             ServiceConfiguration serviceConfigurationObject = await _applicationMetadataService.GetAppMetadataConfigAsync(org, app);
-            serviceConfigurationObject.ServiceDescription = serviceConfig.serviceDescription.ToString();
-            serviceConfigurationObject.ServiceId = serviceConfig.serviceId.ToString();
-            serviceConfigurationObject.ServiceName = serviceConfig.serviceName.ToString();
+            ServiceConfigurationMapper.UpdateFromRequest(serviceConfigurationObject, serviceConfig);
 
             await _applicationMetadataService.UpdateAppMetadataConfigAsync(org, app, serviceConfigurationObject);
             string developer = AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext);
-            await _textsService.UpdateTextsForKeys(org, app, developer, new Dictionary<string, string> { { "appName", serviceConfig.serviceName.ToString() } }, "nb");
-            await _applicationMetadataService.UpdateAppTitleInAppMetadata(org, app, "nb", serviceConfig.serviceName.ToString());
-
+            await _textsService.UpdateTextsForKeys(org, app, developer, new Dictionary<string, string> { { "appName", serviceConfig.ServiceName.Nb } }, "nb");
+            await _applicationMetadataService.UpdateAppTitleInAppMetadata(org, app, "nb", serviceConfig.ServiceName.Nb);
         }
     }
 }

--- a/backend/src/Designer/Controllers/RepositoryController.cs
+++ b/backend/src/Designer/Controllers/RepositoryController.cs
@@ -185,7 +185,12 @@ namespace Altinn.Studio.Designer.Controllers
                 return BadRequest($"{repository} is an invalid repository name.");
             }
 
-            var config = new ServiceConfiguration { RepositoryName = repository, ServiceName = repository };
+            var config = new ServiceConfiguration { RepositoryName = repository, ServiceName = new LocalizedString()
+            {
+                Nb = repository,
+                Nn = "",
+                En = ""
+            } };
 
             var repositoryResult = await _repository.CreateService(org, config);
             if (repositoryResult.RepositoryCreatedStatus == HttpStatusCode.Created)

--- a/backend/src/Designer/Controllers/RepositoryController.cs
+++ b/backend/src/Designer/Controllers/RepositoryController.cs
@@ -185,12 +185,16 @@ namespace Altinn.Studio.Designer.Controllers
                 return BadRequest($"{repository} is an invalid repository name.");
             }
 
-            var config = new ServiceConfiguration { RepositoryName = repository, ServiceName = new LocalizedString()
+            var config = new ServiceConfiguration
             {
-                Nb = repository,
-                Nn = "",
-                En = ""
-            } };
+                RepositoryName = repository,
+                ServiceName = new LocalizedString()
+                {
+                    Nb = repository,
+                    Nn = "",
+                    En = ""
+                }
+            };
 
             var repositoryResult = await _repository.CreateService(org, config);
             if (repositoryResult.RepositoryCreatedStatus == HttpStatusCode.Created)

--- a/backend/src/Designer/Converters/LocalizedStringConverter.cs
+++ b/backend/src/Designer/Converters/LocalizedStringConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Altinn.Studio.Designer.Models;
 
 public class LocalizedStringConverter : JsonConverter<LocalizedString>
 {

--- a/backend/src/Designer/Converters/LocalizedStringConverter.cs
+++ b/backend/src/Designer/Converters/LocalizedStringConverter.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public class LocalizedStringConverter : JsonConverter<LocalizedString>
+{
+    public override LocalizedString Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var value = reader.GetString() ?? "";
+            return new LocalizedString { Nb = value, Nn = "", En = "" };
+        }
+
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            using var doc = JsonDocument.ParseValue(ref reader);
+            var root = doc.RootElement;
+            return new LocalizedString
+            {
+                Nb = root.TryGetProperty("nb", out var nb) ? nb.GetString() ?? "" : "",
+                Nn = root.TryGetProperty("nn", out var nn) ? nn.GetString() ?? "" : "",
+                En = root.TryGetProperty("en", out var en) ? en.GetString() ?? "" : ""
+            };
+        }
+
+        throw new JsonException("Ugyldig format for LocalizedString.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, LocalizedString value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("nb", value.Nb ?? "");
+        writer.WriteString("nn", value.Nn ?? "");
+        writer.WriteString("en", value.En ?? "");
+        writer.WriteEndObject();
+    }
+}

--- a/backend/src/Designer/Enums/AvailableForType.cs
+++ b/backend/src/Designer/Enums/AvailableForType.cs
@@ -1,0 +1,10 @@
+namespace Altinn.Studio.Designer.Enums;
+
+public enum AvailableForType
+{
+    PrivatePerson,
+    LegalEntityEnterprise,
+    Company,
+    BankruptcyEstate,
+    SelfRegisteredUser
+}

--- a/backend/src/Designer/Enums/ServiceStatus.cs
+++ b/backend/src/Designer/Enums/ServiceStatus.cs
@@ -1,0 +1,9 @@
+namespace Altinn.Studio.Designer.Enums;
+
+public enum ServiceStatus
+{
+    Completed,
+    Deprecated,
+    UnderDevelopment,
+    Withdrawn
+}

--- a/backend/src/Designer/Mappers/ServiceConfigRequestMapper.cs
+++ b/backend/src/Designer/Mappers/ServiceConfigRequestMapper.cs
@@ -1,0 +1,23 @@
+using Altinn.Studio.Designer.Configuration;
+using Altinn.Studio.Designer.Models.Dto;
+
+namespace Altinn.Studio.Designer.Mappers;
+
+public class ServiceConfigurationMapper
+{
+    public static void UpdateFromRequest(ServiceConfiguration target, ServiceConfigRequest source)
+    {
+        target.ServiceDescription = source.ServiceDescription;
+        target.ServiceId = source.ServiceId;
+        target.ServiceName = source.ServiceName;
+        target.Homepage = source.Homepage;
+        target.Status = source.Status;
+        target.Visible = source.Visible;
+        target.ContactPoints = source.ContactPoints;
+        target.IsDelegable = source.IsDelegable;
+        target.ResourceType = source.ResourceType;
+        target.AvailableForType = source.AvailableForType;
+        target.EnterpriseUserEnabled = source.EnterpriseUserEnabled;
+        target.SelfIdentifiedUserEnabled = source.SelfIdentifiedUserEnabled;
+    }
+}

--- a/backend/src/Designer/Mappers/ServiceConfigRequestMapper.cs
+++ b/backend/src/Designer/Mappers/ServiceConfigRequestMapper.cs
@@ -7,15 +7,17 @@ public class ServiceConfigurationMapper
 {
     public static void UpdateFromRequest(ServiceConfiguration target, ServiceConfigRequest source)
     {
-        target.Description = source.ServiceDescription;
+        target.Description = source.Description;
         target.ServiceId = source.ServiceId;
         target.ServiceName = source.ServiceName;
         target.Homepage = source.Homepage;
         target.Status = source.Status;
         target.Visible = source.Visible;
+        target.Keywords = source.Keywords;
         target.ContactPoints = source.ContactPoints;
         target.IsDelegable = source.IsDelegable;
         target.ResourceType = source.ResourceType;
+        target.RightDescription = source.RightDescription;
         target.AvailableForType = source.AvailableForType;
         target.EnterpriseUserEnabled = source.EnterpriseUserEnabled;
         target.SelfIdentifiedUserEnabled = source.SelfIdentifiedUserEnabled;

--- a/backend/src/Designer/Mappers/ServiceConfigRequestMapper.cs
+++ b/backend/src/Designer/Mappers/ServiceConfigRequestMapper.cs
@@ -7,7 +7,7 @@ public class ServiceConfigurationMapper
 {
     public static void UpdateFromRequest(ServiceConfiguration target, ServiceConfigRequest source)
     {
-        target.ServiceDescription = source.ServiceDescription;
+        target.Description = source.ServiceDescription;
         target.ServiceId = source.ServiceId;
         target.ServiceName = source.ServiceName;
         target.Homepage = source.Homepage;

--- a/backend/src/Designer/Models/Dto/ServiceConfigRequest.cs
+++ b/backend/src/Designer/Models/Dto/ServiceConfigRequest.cs
@@ -10,7 +10,7 @@ namespace Altinn.Studio.Designer.Models.Dto;
 public class ServiceConfigRequest
 {
     /// <summary>
-    /// Gets or sets the name of the service.
+    /// Gets or sets the name of the service in multiple languages.
     /// </summary>
     public LocalizedString ServiceName { get; set; }
 
@@ -20,9 +20,14 @@ public class ServiceConfigRequest
     public string ServiceId { get; set; }
 
     /// <summary>
-    /// Gets or sets the description of the service.
+    /// Gets or sets the description of the service in multiple languages.
     /// </summary>
-    public LocalizedString ServiceDescription { get; set; }
+    public LocalizedString Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the description of the rights in multiple languages.
+    /// </summary>
+    public LocalizedString RightDescription { get; set; }
 
     /// <summary>
     /// Gets or sets the resource type.
@@ -64,7 +69,12 @@ public class ServiceConfigRequest
     /// <summary>
     /// Gets or sets the list of contact points associated with the service.
     /// </summary>
-    public List<ContactPoint> ContactPoints { get; set; }
+    public List<ContactPoint> ContactPoints { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the list of keywords associated with the service.
+    /// </summary>
+    public List<Keyword> Keywords { get; set; } = new();
 
     /// <summary>
     /// Gets or sets a value indicating whether the service is visible.

--- a/backend/src/Designer/Models/Dto/ServiceConfigRequest.cs
+++ b/backend/src/Designer/Models/Dto/ServiceConfigRequest.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Altinn.Studio.Designer.Models.Dto;
+
+/// <summary>
+/// DTO representing the service configuration request payload.
+/// </summary>
+public class ServiceConfigRequest
+{
+    /// <summary>
+    /// Gets or sets the name of the service.
+    /// </summary>
+    public LocalizedString ServiceName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the unique identifier of the service.
+    /// </summary>
+    public string ServiceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the description of the service.
+    /// </summary>
+    public string ServiceDescription { get; set; }
+
+    /// <summary>
+    /// Gets or sets the resource type.
+    /// Must be 'altinnapp'.
+    /// </summary>
+    [RegularExpression("^altinnapp$", ErrorMessage = "ResourceType must be 'altinnapp'.")]
+    public string ResourceType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the homepage URL for the service.
+    /// </summary>
+    public string Homepage { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the service is delegable.
+    /// </summary>
+    public bool IsDelegable { get; set; }
+
+    /// <summary>
+    /// Gets or sets the status of the service.
+    /// </summary>
+    public ServiceStatus Status { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether self-identified users are enabled.
+    /// </summary>
+    public bool SelfIdentifiedUserEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether enterprise users are enabled.
+    /// </summary>
+    public bool EnterpriseUserEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of users the service is available for.
+    /// </summary>
+    public AvailableForType AvailableForType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of contact points associated with the service.
+    /// </summary>
+    public List<ContactPoint> ContactPoints { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the service is visible.
+    /// </summary>
+    public bool Visible { get; set; }
+}

--- a/backend/src/Designer/Models/Dto/ServiceConfigRequest.cs
+++ b/backend/src/Designer/Models/Dto/ServiceConfigRequest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using Altinn.Studio.Designer.Enums;
 
 namespace Altinn.Studio.Designer.Models.Dto;
 
@@ -21,7 +22,7 @@ public class ServiceConfigRequest
     /// <summary>
     /// Gets or sets the description of the service.
     /// </summary>
-    public string ServiceDescription { get; set; }
+    public LocalizedString ServiceDescription { get; set; }
 
     /// <summary>
     /// Gets or sets the resource type.

--- a/backend/src/Designer/Models/LocalizedString.cs
+++ b/backend/src/Designer/Models/LocalizedString.cs
@@ -1,0 +1,8 @@
+namespace Altinn.Studio.Designer.Models;
+
+public class LocalizedString
+{
+    public string Nb { get; set; }
+    public string Nn { get; set; }
+    public string En { get; set; }
+}

--- a/backend/src/Designer/Services/Implementation/ApplicationMetadataService.cs
+++ b/backend/src/Designer/Services/Implementation/ApplicationMetadataService.cs
@@ -95,7 +95,12 @@ namespace Altinn.Studio.Designer.Services.Implementation
             }
             catch (FileNotFoundException)
             {
-                ServiceConfiguration serviceConfiguration = new() { RepositoryName = app, ServiceName = app };
+                ServiceConfiguration serviceConfiguration = new() { RepositoryName = app, ServiceName = new LocalizedString()
+                {
+                    Nb = app,
+                    Nn = "",
+                    En = ""
+                } };
                 return serviceConfiguration;
             }
         }

--- a/backend/src/Designer/Services/Implementation/ApplicationMetadataService.cs
+++ b/backend/src/Designer/Services/Implementation/ApplicationMetadataService.cs
@@ -11,6 +11,7 @@ using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Infrastructure.GitRepository;
+using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.App;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Altinn.Studio.Designer.TypedHttpClients.AltinnStorage;
@@ -95,12 +96,16 @@ namespace Altinn.Studio.Designer.Services.Implementation
             }
             catch (FileNotFoundException)
             {
-                ServiceConfiguration serviceConfiguration = new() { RepositoryName = app, ServiceName = new LocalizedString()
+                ServiceConfiguration serviceConfiguration = new()
                 {
-                    Nb = app,
-                    Nn = "",
-                    En = ""
-                } };
+                    RepositoryName = app,
+                    ServiceName = new LocalizedString()
+                    {
+                        Nb = app,
+                        Nn = "",
+                        En = ""
+                    }
+                };
                 return serviceConfiguration;
             }
         }

--- a/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -237,13 +237,13 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 ModelMetadata metadata = new()
                 {
                     Org = org,
-                    ServiceName = serviceConfig.ServiceName,
+                    ServiceName = serviceConfig.ServiceName.Nb,
                     RepositoryName = serviceConfig.RepositoryName,
                 };
 
                 // This creates all files
                 CreateServiceMetadata(metadata);
-                await _applicationMetadataService.CreateApplicationMetadata(org, serviceConfig.RepositoryName, serviceConfig.ServiceName);
+                await _applicationMetadataService.CreateApplicationMetadata(org, serviceConfig.RepositoryName, serviceConfig.ServiceName.Nb);
                 await _textsService.CreateLanguageResources(org, serviceConfig.RepositoryName, developer);
                 await CreateRepositorySettings(org, serviceConfig.RepositoryName, developer);
 

--- a/backend/tests/Designer.Tests/Controllers/ConfigController/GetServiceConfigTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ConfigController/GetServiceConfigTests.cs
@@ -25,7 +25,7 @@ namespace Designer.Tests.Controllers.ConfigController
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             response.EnsureSuccessStatusCode();
             ServiceConfiguration serviceConfigResponse = await response.Content.ReadAsAsync<ServiceConfiguration>();
-            ServiceConfiguration serviceConfiguration = new ServiceConfiguration { RepositoryName = app, ServiceDescription = null, ServiceId = null, ServiceName = null };
+            ServiceConfiguration serviceConfiguration = new ServiceConfiguration { RepositoryName = app, Description = null, ServiceId = null, ServiceName = null };
 
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
             Assert.Equal(serviceConfiguration.RepositoryName, serviceConfigResponse.RepositoryName);
@@ -45,7 +45,7 @@ namespace Designer.Tests.Controllers.ConfigController
 
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
             Assert.Equal(serviceConfiguration.RepositoryName, serviceConfigResponse.RepositoryName);
-            Assert.Equal(serviceConfiguration.ServiceDescription, serviceConfigResponse.ServiceDescription);
+            Assert.Equal(serviceConfiguration.Description, serviceConfigResponse.Description);
             Assert.Equal(serviceConfiguration.ServiceId, serviceConfigResponse.ServiceId);
             Assert.Equal(serviceConfiguration.ServiceName.Nb, serviceConfigResponse.ServiceName.Nb);
         }

--- a/backend/tests/Designer.Tests/Controllers/ConfigController/GetServiceConfigTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ConfigController/GetServiceConfigTests.cs
@@ -47,7 +47,7 @@ namespace Designer.Tests.Controllers.ConfigController
             Assert.Equal(serviceConfiguration.RepositoryName, serviceConfigResponse.RepositoryName);
             Assert.Equal(serviceConfiguration.ServiceDescription, serviceConfigResponse.ServiceDescription);
             Assert.Equal(serviceConfiguration.ServiceId, serviceConfigResponse.ServiceId);
-            Assert.Equal(serviceConfiguration.ServiceName, serviceConfigResponse.ServiceName);
+            Assert.Equal(serviceConfiguration.ServiceName.Nb, serviceConfigResponse.ServiceName.Nb);
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/ConfigController/SetServiceConfigTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ConfigController/SetServiceConfigTests.cs
@@ -2,6 +2,7 @@
 using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Configuration;
+using Altinn.Studio.Designer.Models;
 using Designer.Tests.Controllers.ApiTests;
 using Designer.Tests.Utils;
 using Microsoft.AspNetCore.Http;

--- a/backend/tests/Designer.Tests/Controllers/ConfigController/SetServiceConfigTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ConfigController/SetServiceConfigTests.cs
@@ -27,12 +27,17 @@ namespace Designer.Tests.Controllers.ConfigController
             string dataPathWithData = VersionPrefix(org, targetRepository);
 
             using HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, dataPathWithData);
-            httpRequestMessage.Content = JsonContent.Create(new { serviceName = new LocalizedString()
+            httpRequestMessage.Content = JsonContent.Create(new
             {
-                Nb = "Alternative-form-name",
-                En = "Alternative-form-name-en",
-                Nn = "Alternative-form-name-nn"
-            }, serviceDescription = "", serviceId = "" });
+                serviceName = new LocalizedString()
+                {
+                    Nb = "Alternative-form-name",
+                    En = "Alternative-form-name-en",
+                    Nn = "Alternative-form-name-nn"
+                },
+                serviceDescription = "",
+                serviceId = ""
+            });
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             response.EnsureSuccessStatusCode();

--- a/backend/tests/Designer.Tests/Controllers/ConfigController/SetServiceConfigTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/ConfigController/SetServiceConfigTests.cs
@@ -25,15 +25,21 @@ namespace Designer.Tests.Controllers.ConfigController
             await CopyRepositoryForTest(org, app, developer, targetRepository);
 
             string dataPathWithData = VersionPrefix(org, targetRepository);
+
             using HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, dataPathWithData);
-            httpRequestMessage.Content = JsonContent.Create(new { serviceName = "Alternative-form-name", serviceDescription = "", serviceId = "" });
+            httpRequestMessage.Content = JsonContent.Create(new { serviceName = new LocalizedString()
+            {
+                Nb = "Alternative-form-name",
+                En = "Alternative-form-name-en",
+                Nn = "Alternative-form-name-nn"
+            }, serviceDescription = "", serviceId = "" });
 
             using HttpResponseMessage response = await HttpClient.SendAsync(httpRequestMessage);
             response.EnsureSuccessStatusCode();
             ServiceConfiguration serviceConfiguration = ServiceConfigurationUtils.GetServiceConfiguration(TestRepositoriesLocation, org, targetRepository, "testUser");
 
             Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
-            Assert.Equal("Alternative-form-name", serviceConfiguration.ServiceName);
+            Assert.Equal("Alternative-form-name", serviceConfiguration.ServiceName.Nb);
         }
     }
 }

--- a/backend/tests/Designer.Tests/Converters/LocalizedStringConverterTests.cs
+++ b/backend/tests/Designer.Tests/Converters/LocalizedStringConverterTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using Xunit;
+
+public class LocalizedStringConverterTests
+{
+    private readonly JsonSerializerOptions _options;
+
+    public LocalizedStringConverterTests()
+    {
+        _options = new JsonSerializerOptions
+        {
+            Converters = { new LocalizedStringConverter() },
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = false
+        };
+    }
+
+    [Fact]
+    public void Read_FromString_ShouldReturnLocalizedStringWithNb()
+    {
+        var json = "\"Min tjeneste\"";
+
+        var result = JsonSerializer.Deserialize<LocalizedString>(json, _options);
+
+        Assert.NotNull(result);
+        Assert.Equal("Min tjeneste", result.Nb);
+        Assert.Equal("", result.Nn);
+        Assert.Equal("", result.En);
+    }
+
+    [Fact]
+    public void Read_FromObject_ShouldReturnLocalizedStringCorrectly()
+    {
+        var json = "{\"nb\":\"Hei\",\"nn\":\"Hallo\",\"en\":\"Hello\"}";
+
+        var result = JsonSerializer.Deserialize<LocalizedString>(json, _options);
+
+        Assert.NotNull(result);
+        Assert.Equal("Hei", result.Nb);
+        Assert.Equal("Hallo", result.Nn);
+        Assert.Equal("Hello", result.En);
+    }
+
+    [Fact]
+    public void Write_ShouldSerializeToExpectedJson()
+    {
+        var input = new LocalizedString
+        {
+            Nb = "Tjeneste",
+            Nn = "Teneste",
+            En = "Service"
+        };
+
+        var json = JsonSerializer.Serialize(input, _options);
+
+        const string ExpectedJson = "{\"nb\":\"Tjeneste\",\"nn\":\"Teneste\",\"en\":\"Service\"}";
+        Assert.Equal(ExpectedJson, json);
+    }
+}

--- a/backend/tests/Designer.Tests/Converters/LocalizedStringConverterTests.cs
+++ b/backend/tests/Designer.Tests/Converters/LocalizedStringConverterTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Altinn.Studio.Designer.Models;
 using Xunit;
 
 public class LocalizedStringConverterTests

--- a/backend/tests/Designer.Tests/Services/RepositorySITests.cs
+++ b/backend/tests/Designer.Tests/Services/RepositorySITests.cs
@@ -119,7 +119,12 @@ namespace Designer.Tests.Services
 
             try
             {
-                await repositoryService.CreateService(org, new ServiceConfiguration() { RepositoryName = repositoryName, ServiceName = repositoryName });
+                await repositoryService.CreateService(org, new ServiceConfiguration() { RepositoryName = repositoryName, ServiceName = new LocalizedString()
+                {
+                    Nb = repositoryName,
+                    Nn = repositoryName,
+                    En = repositoryName
+                } });
                 var altinnStudioSettings = await new AltinnGitRepositoryFactory(repositoriesRootDirectory).GetAltinnGitRepository(org, repositoryName, developer).GetAltinnStudioSettings();
                 Assert.Equal(AltinnRepositoryType.App, altinnStudioSettings.RepoType);
             }

--- a/backend/tests/Designer.Tests/Services/RepositorySITests.cs
+++ b/backend/tests/Designer.Tests/Services/RepositorySITests.cs
@@ -119,12 +119,16 @@ namespace Designer.Tests.Services
 
             try
             {
-                await repositoryService.CreateService(org, new ServiceConfiguration() { RepositoryName = repositoryName, ServiceName = new LocalizedString()
+                await repositoryService.CreateService(org, new ServiceConfiguration()
                 {
-                    Nb = repositoryName,
-                    Nn = repositoryName,
-                    En = repositoryName
-                } });
+                    RepositoryName = repositoryName,
+                    ServiceName = new LocalizedString()
+                    {
+                        Nb = repositoryName,
+                        Nn = repositoryName,
+                        En = repositoryName
+                    }
+                });
                 var altinnStudioSettings = await new AltinnGitRepositoryFactory(repositoriesRootDirectory).GetAltinnGitRepository(org, repositoryName, developer).GetAltinnStudioSettings();
                 Assert.Equal(AltinnRepositoryType.App, altinnStudioSettings.RepoType);
             }

--- a/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AboutTab.test.tsx
+++ b/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AboutTab.test.tsx
@@ -82,11 +82,11 @@ describe('AboutTab', () => {
     await resolveAndWaitForSpinnerToDisappear();
 
     const appName = screen.getByLabelText(textMock('app_settings.about_tab_name_label'));
-    expect(appName).toHaveValue(mockAppConfig.serviceName);
+    expect(appName).toHaveValue(mockAppConfig.serviceName.nb);
 
     const mockNewText: string = 'test';
     await user.type(appName, mockNewText);
-    expect(appName).toHaveValue(`${mockAppConfig.serviceName}${mockNewText}`);
+    expect(appName).toHaveValue(`${mockAppConfig.serviceName.nb}${mockNewText}`);
   });
 
   it('displays correct value in "alternative id" input field, and updates the value on change', async () => {

--- a/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AboutTab.tsx
+++ b/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AboutTab.tsx
@@ -115,5 +115,4 @@ const mockAppConfig: AppConfigNew = {
   serviceName: { nb: 'test', nn: '', en: '' },
   serviceId: 'example-service-id',
   description: { nb: 'Test Tjeneste', nn: '', en: '' },
-  homepage: 'TEST123',
 };

--- a/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AboutTab.tsx
+++ b/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AboutTab.tsx
@@ -115,4 +115,5 @@ const mockAppConfig: AppConfigNew = {
   serviceName: { nb: 'test', nn: '', en: '' },
   serviceId: 'example-service-id',
   description: { nb: 'Test Tjeneste', nn: '', en: '' },
+  homepage: 'TEST123',
 };

--- a/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/InputFields/InputFields.test.tsx
+++ b/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/InputFields/InputFields.test.tsx
@@ -31,11 +31,11 @@ describe('InputFields', () => {
     renderInputFields();
 
     const appName = screen.getByLabelText(textMock('app_settings.about_tab_name_label'));
-    expect(appName).toHaveValue(mockAppConfig.serviceName);
+    expect(appName).toHaveValue(mockAppConfig.serviceName.nb);
 
     await user.type(appName, mockNewText);
 
-    expect(appName).toHaveValue(`${mockAppConfig.serviceName}${mockNewText}`);
+    expect(appName).toHaveValue(`${mockAppConfig.serviceName.nb}${mockNewText}`);
   });
 
   it('displays correct value in "alternative id" input field, and updates the value on change', async () => {

--- a/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/InputFields/InputFields.tsx
+++ b/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/InputFields/InputFields.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import type { AppConfig } from 'app-shared/types/AppConfig';
 import { StudioTextfield } from '@studio/components';
 
-type AppConfigForm = Pick<AppConfig, 'serviceName' | 'serviceId'>;
+type AppConfigForm = Pick<AppConfig, 'serviceId'> & { serviceName: string };
 
 export type InputFieldsProps = {
   appConfig: AppConfig;
@@ -24,12 +24,12 @@ export function InputFields({ appConfig, onSave }: InputFieldsProps): ReactEleme
     const form = Object.fromEntries(formData) as AppConfigForm;
     const isFormValid = validateForm(form);
     if (isFormValid) {
-      onSave({ ...appConfig, ...form });
+      onSave({ ...appConfig, ...form, serviceName: { nb: form.serviceName, nn: '', en: '' } });
     }
   };
 
   const validateForm = (form: AppConfigForm): Boolean => {
-    if (form.serviceName.nb.length <= 0) {
+    if (form.serviceName.length <= 0) {
       setAppConfigFormErrors({ serviceName: t('app_settings.about_tab_name_error') });
       return false;
     }
@@ -42,7 +42,7 @@ export function InputFields({ appConfig, onSave }: InputFieldsProps): ReactEleme
       <StudioTextfield
         label={t('app_settings.about_tab_repo_label')}
         description={t('app_settings.about_tab_repo_description')}
-        defaultValue={appConfig.repositoryName.nb}
+        defaultValue={appConfig.repositoryName}
         className={classes.textField}
         readOnly
       />

--- a/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/InputFields/InputFields.tsx
+++ b/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/InputFields/InputFields.tsx
@@ -61,21 +61,6 @@ export function InputFields({ appConfig, onSave }: InputFieldsProps): ReactEleme
         defaultValue={appConfig.serviceId}
         className={classes.textField}
       />
-      <StudioTextfield
-        label='homepage'
-        description={t('app_settings.about_tab_alt_id_description')}
-        name='homepage'
-        defaultValue={appConfig.serviceId}
-        className={classes.textField}
-      />
-
-      <StudioTextfield
-        label='homepage'
-        description={t('app_settings.about_tab_alt_id_description')}
-        name='homepage'
-        defaultValue={appConfig.serviceId}
-        className={classes.textField}
-      />
     </form>
   );
 }

--- a/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/InputFields/InputFields.tsx
+++ b/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/InputFields/InputFields.tsx
@@ -61,6 +61,21 @@ export function InputFields({ appConfig, onSave }: InputFieldsProps): ReactEleme
         defaultValue={appConfig.serviceId}
         className={classes.textField}
       />
+      <StudioTextfield
+        label='homepage'
+        description={t('app_settings.about_tab_alt_id_description')}
+        name='homepage'
+        defaultValue={appConfig.serviceId}
+        className={classes.textField}
+      />
+
+      <StudioTextfield
+        label='homepage'
+        description={t('app_settings.about_tab_alt_id_description')}
+        name='homepage'
+        defaultValue={appConfig.serviceId}
+        className={classes.textField}
+      />
     </form>
   );
 }

--- a/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/InputFields/InputFields.tsx
+++ b/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/InputFields/InputFields.tsx
@@ -15,9 +15,9 @@ export type InputFieldsProps = {
 export function InputFields({ appConfig, onSave }: InputFieldsProps): ReactElement {
   const { t } = useTranslation();
 
-  const [appConfigFormErrors, setAppConfigFormErrors] = useState<
-    Pick<AppConfigForm, 'serviceName'>
-  >({ serviceName: '' });
+  const [appConfigFormErrors, setAppConfigFormErrors] = useState<{ serviceName: string }>({
+    serviceName: '',
+  });
 
   const handleAppConfigFormBlur = (event: FormEvent<HTMLFormElement>) => {
     const formData = new FormData(event.currentTarget);
@@ -29,7 +29,7 @@ export function InputFields({ appConfig, onSave }: InputFieldsProps): ReactEleme
   };
 
   const validateForm = (form: AppConfigForm): Boolean => {
-    if (form.serviceName.length <= 0) {
+    if (form.serviceName.nb.length <= 0) {
       setAppConfigFormErrors({ serviceName: t('app_settings.about_tab_name_error') });
       return false;
     }
@@ -42,7 +42,7 @@ export function InputFields({ appConfig, onSave }: InputFieldsProps): ReactEleme
       <StudioTextfield
         label={t('app_settings.about_tab_repo_label')}
         description={t('app_settings.about_tab_repo_description')}
-        defaultValue={appConfig.repositoryName}
+        defaultValue={appConfig.repositoryName.nb}
         className={classes.textField}
         readOnly
       />
@@ -51,7 +51,7 @@ export function InputFields({ appConfig, onSave }: InputFieldsProps): ReactEleme
         description={t('app_settings.about_tab_name_description')}
         name='serviceName'
         error={appConfigFormErrors.serviceName}
-        defaultValue={appConfig.serviceName}
+        defaultValue={appConfig.serviceName.nb}
         className={classes.textField}
       />
       <StudioTextfield

--- a/frontend/app-development/features/appSettings/mocks/appConfigMock.ts
+++ b/frontend/app-development/features/appSettings/mocks/appConfigMock.ts
@@ -2,7 +2,11 @@ import type { AppConfig } from 'app-shared/types/AppConfig';
 
 export const mockAppConfig: AppConfig = {
   repositoryName: 'test',
-  serviceName: 'test',
+  serviceName: {
+    nb: 'test',
+    nn: '',
+    en: '',
+  },
   serviceId: '',
   serviceDescription: '',
 };

--- a/frontend/app-development/features/overview/components/Header.tsx
+++ b/frontend/app-development/features/overview/components/Header.tsx
@@ -30,7 +30,7 @@ export const Header = () => {
 
   return (
     <Heading level={1} size='xlarge'>
-      {appConfigData?.serviceName || app}
+      {appConfigData?.serviceName.nb || app}
     </Heading>
   );
 };

--- a/frontend/app-development/features/overview/components/Overview.test.tsx
+++ b/frontend/app-development/features/overview/components/Overview.test.tsx
@@ -20,7 +20,11 @@ describe('Overview', () => {
       getOrgList: jest.fn().mockImplementation(() => Promise.resolve({ orgs: [org] })),
       getAppConfig: jest.fn().mockImplementation(() =>
         Promise.resolve({
-          serviceName: title,
+          serviceName: {
+            nb: title,
+            nn: '',
+            en: '',
+          },
         }),
       ),
     });

--- a/frontend/packages/shared/src/types/AppConfig.ts
+++ b/frontend/packages/shared/src/types/AppConfig.ts
@@ -2,7 +2,7 @@ import type { SupportedLanguage, ValidLanguage } from './SupportedLanguages';
 
 export type AppConfig = {
   repositoryName: string;
-  serviceName: string;
+  serviceName: { nb: string; en: string; nn: string };
   serviceId: string;
   serviceDescription?: string;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

PR Description: 

- Replaced `string` with `LocalizedString` (`nb`, `nn`, `en`) for:
  - `ServiceName`
  - `Description`
  - `RightDescription`

- Introduced:
  - `ServiceConfigRequest` DTO
  - `ServiceConfigurationMapper`
  - `LocalizedStringConverter` for backward-compatible deserialization

- Updated `ConfigController` to use strongly typed input.

- Extended `ServiceConfiguration` with:
  - `Status`
  - `ResourceType`
  - `IsDelegable`
  - `Visible`
  - `AvailableForType`
  - `EnterpriseUserEnabled`
  - `SelfIdentifiedUserEnabled`
  - `Keywords`
  - `ContactPoints`

- Frontend updated to use `serviceName.nb` and support `LocalizedString` structure.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
