### PR TITLE
fix: handle case-only rename for layout

### DIFF
--- a/backend/src/Designer/Infrastructure/GitRepository/GitRepository.cs
+++ b/backend/src/Designer/Infrastructure/GitRepository/GitRepository.cs
@@ -272,7 +272,7 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
                 throw new FileNotFoundException($"File {sourceRelativeFilePath} does not exist.");
             }
 
-            if (FileExistsByRelativePath(destRelativeFilePath))
+            if (!IsCasingOnlyRenameFile(sourceRelativeFilePath, destRelativeFilePath) && FileExistsByRelativePath(destRelativeFilePath))
             {
                 throw new IOException($"Suggested file name {destinationFileName} already exists.");
             }
@@ -284,6 +284,10 @@ namespace Altinn.Studio.Designer.Infrastructure.GitRepository
             Guard.AssertFilePathWithinParentDirectory(RepositoryDirectory, destAbsoluteFilePath);
 
             File.Move(sourceAbsoluteFilePath, destAbsoluteFilePath);
+        }
+        private static bool IsCasingOnlyRenameFile(string sourceRelativeFilePath, string destRelativeFilePath)
+        {
+            return string.Equals(sourceRelativeFilePath, destRelativeFilePath, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateFormLayoutNameTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateFormLayoutNameTests.cs
@@ -117,10 +117,8 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
 
 
             string url = $"{VersionPrefix("ttd", app)}/form-layout-name/{layoutName}?layoutSetName={layoutSetName}";
-            string relativeOldLayoutPath = Path.Combine("App", "ui", layoutSetName, "layouts", $"{layoutName}.json");
-            string relativeNewLayoutPath = Path.Combine("App", "ui", layoutSetName, "layouts", $"{newLayoutName}.json");
-            string oldLayoutPath = Path.Combine(TestRepoPath, relativeOldLayoutPath);
-            string newLayoutPath = Path.Combine(TestRepoPath, relativeNewLayoutPath);
+            string oldLayoutPath = Path.Join(TestRepoPath, "App", "ui", layoutSetName, "layouts", $"{layoutName}.json");
+            string newLayoutPath = Path.Join(TestRepoPath, "App", "ui", layoutSetName, "layouts", $"{newLayoutName}.json");
 
             Directory.CreateDirectory(Path.GetDirectoryName(oldLayoutPath));
             await File.WriteAllTextAsync(oldLayoutPath, "{}");

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateFormLayoutNameTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateFormLayoutNameTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -129,11 +130,12 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
                 Content = new StringContent($"\"{newLayoutName}\"", Encoding.UTF8, MediaTypeNames.Application.Json)
             };
 
-            using var response = await HttpClient.SendAsync(request);
+            using HttpResponseMessage response = await HttpClient.SendAsync(request);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.False(File.Exists(oldLayoutPath));
-            Assert.True(File.Exists(newLayoutPath));
+            List<string> list = [.. Directory.GetFiles(Path.GetDirectoryName(oldLayoutPath))];
+            Assert.DoesNotContain(oldLayoutPath, list);
+            Assert.Contains(newLayoutPath, list);
         }
     }
 }

--- a/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateFormLayoutNameTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/AppDevelopmentController/UpdateFormLayoutNameTests.cs
@@ -103,5 +103,37 @@ namespace Designer.Tests.Controllers.AppDevelopmentController
                 Assert.True(JsonUtils.DeepEquals(actual, expected));
             });
         }
+
+        [Fact]
+        public async Task UpdateFormLayoutName_CaseOnlyRenameWithSetName_ShouldReturnOkAndRenameFile()
+        {
+            string layoutSetName = "layoutSet1";
+            string layoutName = "page1";
+            string newLayoutName = "PAGE1";
+            string actualApp = "app-with-summary2-components";
+            string app = TestDataHelper.GenerateTestRepoName();
+            await CopyRepositoryForTest("ttd", actualApp, "testUser", app);
+
+
+            string url = $"{VersionPrefix("ttd", app)}/form-layout-name/{layoutName}?layoutSetName={layoutSetName}";
+            string relativeOldLayoutPath = Path.Combine("App", "ui", layoutSetName, "layouts", $"{layoutName}.json");
+            string relativeNewLayoutPath = Path.Combine("App", "ui", layoutSetName, "layouts", $"{newLayoutName}.json");
+            string oldLayoutPath = Path.Combine(TestRepoPath, relativeOldLayoutPath);
+            string newLayoutPath = Path.Combine(TestRepoPath, relativeNewLayoutPath);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(oldLayoutPath));
+            await File.WriteAllTextAsync(oldLayoutPath, "{}");
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = new StringContent($"\"{newLayoutName}\"", Encoding.UTF8, MediaTypeNames.Application.Json)
+            };
+
+            using var response = await HttpClient.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.False(File.Exists(oldLayoutPath));
+            Assert.True(File.Exists(newLayoutPath));
+        }
     }
 }

--- a/backend/tests/Designer.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
+++ b/backend/tests/Designer.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
@@ -110,7 +110,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
         [Fact]
         public async Task MoveFileByRelativePath_ValidPaths_MovesFileSuccessfully()
         {
-            // Arrange
+
             var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
             var repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", TestDataHelper.GenerateTestRepoName(), "testUser");
             var gitRepository = new Altinn.Studio.Designer.Infrastructure.GitRepository.GitRepository(repositoriesRootDirectory, repositoryDirectory);
@@ -120,17 +120,13 @@ namespace Designer.Tests.Infrastructure.GitRepository
             var destinationFileName = "newfile.txt";
             var testContent = "test content";
 
-            // Create source file
             await gitRepository.WriteTextByRelativePathAsync(sourceRelativePath, testContent, true);
             Assert.True(gitRepository.FileExistsByRelativePath(sourceRelativePath));
             Assert.False(gitRepository.FileExistsByRelativePath(destRelativePath));
 
             try
             {
-                // Act
                 gitRepository.MoveFileByRelativePath(sourceRelativePath, destRelativePath, destinationFileName);
-
-                // Assert
                 Assert.False(gitRepository.FileExistsByRelativePath(sourceRelativePath));
                 Assert.True(gitRepository.FileExistsByRelativePath(destRelativePath));
                 string content = await gitRepository.ReadTextByRelativePathAsync(destRelativePath);
@@ -145,7 +141,6 @@ namespace Designer.Tests.Infrastructure.GitRepository
         [Fact]
         public void MoveFileByRelativePath_SourceFileDoesNotExist_ThrowsFileNotFoundException()
         {
-            // Arrange
             var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
             var repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", TestDataHelper.GenerateTestRepoName(), "testUser");
             var gitRepository = new Altinn.Studio.Designer.Infrastructure.GitRepository.GitRepository(repositoriesRootDirectory, repositoryDirectory);
@@ -159,7 +154,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
             try
             {
                 gitRepository.MoveFileByRelativePath(sourceRelativePath, destRelativePath, destinationFileName);
-                Assert.False(true, "Expected FileNotFoundException was not thrown.");
+                Assert.False("Expected FileNotFoundException was not thrown.");
             }
             catch (FileNotFoundException ex)
             {
@@ -191,7 +186,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
             try
             {
                 gitRepository.MoveFileByRelativePath(sourceRelativePath, destRelativePath, destinationFileName);
-                Assert.False(true, "Expected IOException was not thrown.");
+                Assert.False("Expected IOException was not thrown.");
             }
             catch (IOException ex)
             {

--- a/backend/tests/Designer.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
+++ b/backend/tests/Designer.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
@@ -113,7 +113,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
             // Arrange
             var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
             var repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", TestDataHelper.GenerateTestRepoName(), "testUser");
-            var gitRepository = new GitRepository(repositoriesRootDirectory, repositoryDirectory);
+            var gitRepository = new Altinn.Studio.Designer.Infrastructure.GitRepository.GitRepository(repositoriesRootDirectory, repositoryDirectory);
 
             var sourceRelativePath = "source/file.txt";
             var destRelativePath = "dest/newfile.txt";
@@ -148,7 +148,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
             // Arrange
             var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
             var repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", TestDataHelper.GenerateTestRepoName(), "testUser");
-            var gitRepository = new GitRepository(repositoriesRootDirectory, repositoryDirectory);
+            var gitRepository = new Altinn.Studio.Designer.Infrastructure.GitRepository.GitRepository(repositoriesRootDirectory, repositoryDirectory);
 
             var sourceRelativePath = "source/nonexistent.txt";
             var destRelativePath = "dest/newfile.txt";
@@ -177,7 +177,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
         {
             var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
             var repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", TestDataHelper.GenerateTestRepoName(), "testUser");
-            var gitRepository = new GitRepository(repositoriesRootDirectory, repositoryDirectory);
+            var gitRepository = new Altinn.Studio.Designer.Infrastructure.GitRepository.GitRepository(repositoriesRootDirectory, repositoryDirectory);
 
             var sourceRelativePath = "source/file.txt";
             var destRelativePath = "dest/existing.txt";
@@ -209,7 +209,7 @@ namespace Designer.Tests.Infrastructure.GitRepository
         {
             var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
             var repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", TestDataHelper.GenerateTestRepoName(), "testUser");
-            var gitRepository = new GitRepository(repositoriesRootDirectory, repositoryDirectory);
+            var gitRepository = new Altinn.Studio.Designer.Infrastructure.GitRepository.GitRepository(repositoriesRootDirectory, repositoryDirectory);
 
             var sourceRelativePath = "source/file.txt";
             var destRelativePath = "source/File.txt";

--- a/backend/tests/Designer.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
+++ b/backend/tests/Designer.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
@@ -130,33 +130,6 @@ namespace Designer.Tests.Infrastructure.GitRepository
         }
 
         [Fact]
-        public void IsCasingOnlyRenameFile_SamePathDifferentCasing_ShouldReturnTrue()
-        {
-            string sourcePath = "App/models/file.txt";
-            string destPath = "App/models/File.txt";
-            bool result = InvokeIsCasingOnlyRenameFile(sourcePath, destPath);
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void IsCasingOnlyRenameFile_SamePathExactMatch_ShouldReturnTrue()
-        {
-            string sourcePath = "App/models/file.txt";
-            string destPath = "App/models/file.txt";
-            bool result = InvokeIsCasingOnlyRenameFile(sourcePath, destPath);
-            Assert.True(result);
-        }
-
-        [Fact]
-        public void IsCasingOnlyRenameFile_DifferentPaths_ShouldReturnFalse()
-        {
-            string sourcePath = "App/models/file.txt";
-            string destPath = "App/models/anotherfile.txt";
-            bool result = InvokeIsCasingOnlyRenameFile(sourcePath, destPath);
-            Assert.False(result);
-        }
-
-        [Fact]
         public void DirectoryExistsByRelativePath_Directory_ShouldReturnFalse()
         {
             var gitRepository = GetTestRepository("ttd", "hvem-er-hvem", "testUser");

--- a/backend/tests/Designer.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
+++ b/backend/tests/Designer.Tests/Infrastructure/GitRepository/GitRepositoryTests.cs
@@ -107,127 +107,6 @@ namespace Designer.Tests.Infrastructure.GitRepository
             }
         }
 
-        [Fact]
-        public async Task MoveFileByRelativePath_ValidPaths_MovesFileSuccessfully()
-        {
-
-            var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
-            var repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", TestDataHelper.GenerateTestRepoName(), "testUser");
-            var gitRepository = new Altinn.Studio.Designer.Infrastructure.GitRepository.GitRepository(repositoriesRootDirectory, repositoryDirectory);
-
-            var sourceRelativePath = "source/file.txt";
-            var destRelativePath = "dest/newfile.txt";
-            var destinationFileName = "newfile.txt";
-            var testContent = "test content";
-
-            await gitRepository.WriteTextByRelativePathAsync(sourceRelativePath, testContent, true);
-            Assert.True(gitRepository.FileExistsByRelativePath(sourceRelativePath));
-            Assert.False(gitRepository.FileExistsByRelativePath(destRelativePath));
-
-            try
-            {
-                gitRepository.MoveFileByRelativePath(sourceRelativePath, destRelativePath, destinationFileName);
-                Assert.False(gitRepository.FileExistsByRelativePath(sourceRelativePath));
-                Assert.True(gitRepository.FileExistsByRelativePath(destRelativePath));
-                string content = await gitRepository.ReadTextByRelativePathAsync(destRelativePath);
-                Assert.Equal(testContent, content);
-            }
-            finally
-            {
-                TestDataHelper.DeleteDirectory(repositoryDirectory);
-            }
-        }
-
-        [Fact]
-        public void MoveFileByRelativePath_SourceFileDoesNotExist_ThrowsFileNotFoundException()
-        {
-            var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
-            var repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", TestDataHelper.GenerateTestRepoName(), "testUser");
-            var gitRepository = new Altinn.Studio.Designer.Infrastructure.GitRepository.GitRepository(repositoriesRootDirectory, repositoryDirectory);
-
-            var sourceRelativePath = "source/nonexistent.txt";
-            var destRelativePath = "dest/newfile.txt";
-            var destinationFileName = "newfile.txt";
-
-            Assert.False(gitRepository.FileExistsByRelativePath(sourceRelativePath));
-
-            try
-            {
-                gitRepository.MoveFileByRelativePath(sourceRelativePath, destRelativePath, destinationFileName);
-                Assert.False("Expected FileNotFoundException was not thrown.");
-            }
-            catch (FileNotFoundException ex)
-            {
-                Assert.Contains(sourceRelativePath, ex.Message);
-            }
-            finally
-            {
-                TestDataHelper.DeleteDirectory(repositoryDirectory);
-            }
-        }
-
-
-        [Fact]
-        public async Task MoveFileByRelativePath_DestinationFileExists_ThrowsIOException()
-        {
-            var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
-            var repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", TestDataHelper.GenerateTestRepoName(), "testUser");
-            var gitRepository = new Altinn.Studio.Designer.Infrastructure.GitRepository.GitRepository(repositoriesRootDirectory, repositoryDirectory);
-
-            var sourceRelativePath = "source/file.txt";
-            var destRelativePath = "dest/existing.txt";
-            var destinationFileName = "existing.txt";
-
-            await gitRepository.WriteTextByRelativePathAsync(sourceRelativePath, "source content", true);
-            await gitRepository.WriteTextByRelativePathAsync(destRelativePath, "dest content", true);
-            Assert.True(gitRepository.FileExistsByRelativePath(sourceRelativePath));
-            Assert.True(gitRepository.FileExistsByRelativePath(destRelativePath));
-
-            try
-            {
-                gitRepository.MoveFileByRelativePath(sourceRelativePath, destRelativePath, destinationFileName);
-                Assert.False("Expected IOException was not thrown.");
-            }
-            catch (IOException ex)
-            {
-                Assert.Contains(destinationFileName, ex.Message);
-            }
-            finally
-            {
-                TestDataHelper.DeleteDirectory(repositoryDirectory);
-            }
-        }
-
-
-        [Fact]
-        public async Task MoveFileByRelativePath_CasingOnlyRename_MovesFileSuccessfully()
-        {
-            var repositoriesRootDirectory = TestDataHelper.GetTestDataRepositoriesRootDirectory();
-            var repositoryDirectory = TestDataHelper.CreateEmptyRepositoryForTest("ttd", TestDataHelper.GenerateTestRepoName(), "testUser");
-            var gitRepository = new Altinn.Studio.Designer.Infrastructure.GitRepository.GitRepository(repositoriesRootDirectory, repositoryDirectory);
-
-            var sourceRelativePath = "source/file.txt";
-            var destRelativePath = "source/File.txt";
-            var destinationFileName = "File.txt";
-            var testContent = "test content";
-
-            await gitRepository.WriteTextByRelativePathAsync(sourceRelativePath, testContent, true);
-            Assert.True(gitRepository.FileExistsByRelativePath(sourceRelativePath));
-
-            try
-            {
-                gitRepository.MoveFileByRelativePath(sourceRelativePath, destRelativePath, destinationFileName);
-                Assert.False(gitRepository.FileExistsByRelativePath(sourceRelativePath));
-                Assert.True(gitRepository.FileExistsByRelativePath(destRelativePath));
-                string content = await gitRepository.ReadTextByRelativePathAsync(destRelativePath);
-                Assert.Equal(testContent, content);
-            }
-            finally
-            {
-                TestDataHelper.DeleteDirectory(repositoryDirectory);
-            }
-        }
-
         [Theory]
         [InlineData(@"this.dont.exists.schema.json")]
         [InlineData(@"c:/this/should/not/exist/HvemErHvem.json")]
@@ -248,6 +127,33 @@ namespace Designer.Tests.Infrastructure.GitRepository
             var gitRepository = GetTestRepository("ttd", "hvem-er-hvem", "testUser");
 
             Assert.True(gitRepository.FileExistsByRelativePath(relativePath));
+        }
+
+        [Fact]
+        public void IsCasingOnlyRenameFile_SamePathDifferentCasing_ShouldReturnTrue()
+        {
+            string sourcePath = "App/models/file.txt";
+            string destPath = "App/models/File.txt";
+            bool result = InvokeIsCasingOnlyRenameFile(sourcePath, destPath);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsCasingOnlyRenameFile_SamePathExactMatch_ShouldReturnTrue()
+        {
+            string sourcePath = "App/models/file.txt";
+            string destPath = "App/models/file.txt";
+            bool result = InvokeIsCasingOnlyRenameFile(sourcePath, destPath);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsCasingOnlyRenameFile_DifferentPaths_ShouldReturnFalse()
+        {
+            string sourcePath = "App/models/file.txt";
+            string destPath = "App/models/anotherfile.txt";
+            bool result = InvokeIsCasingOnlyRenameFile(sourcePath, destPath);
+            Assert.False(result);
         }
 
         [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated the `MoveFileByRelativePath` method in `AltinnAppGitRepository` to handle case-only renames (e.g., `page1.json` to `PAGE1.json`) correctly on case-sensitive file systems. Modified the `if`-condition to use `IsCasingOnlyRenameFile` to skip the destination file exist check for case-only renames.

https://github.com/user-attachments/assets/9668c110-1067-41ec-9009-877a2a4c800e


<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File renaming now accepts case-only name changes (e.g., "file.txt" → "File.txt") without error, preventing spurious failures during rename operations and preserving files in existing layout sets.

* **Tests**
  * Added an end-to-end test that verifies case-only renames succeed and result in the expected on-disk filename change and successful response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->