### PR TITLE
fix: BPMN palette titles

### DIFF
--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
@@ -201,7 +201,7 @@ class SupportedPaletteProvider {
         'create.altinn-data-task': {
           group: 'activity',
           className: 'bpmn-icon-task-generic bpmn-icon-data-task',
-          title: translate('Create Altinn Data Task'),
+          title: translate('Create Altinn data task'),
           action: {
             click: createCustomTask('data'),
             dragstart: createCustomTask('data'),
@@ -209,7 +209,7 @@ class SupportedPaletteProvider {
         },
         'create.altinn-feedback-task': {
           group: 'activity',
-          title: translate('Create Altinn Feedback Task'),
+          title: translate('Create Altinn feedback task'),
           className: 'bpmn-icon-task-generic bpmn-icon-feedback-task',
           action: {
             click: createCustomTask('feedback'),
@@ -219,7 +219,7 @@ class SupportedPaletteProvider {
         'create.altinn-signing-task': {
           group: 'activity',
           className: 'bpmn-icon-task-generic bpmn-icon-signing-task',
-          title: translate('Create Altinn Signing Task'),
+          title: translate('Create Altinn signing task'),
           action: {
             click: createCustomSigningTask(),
             dragstart: createCustomSigningTask(),
@@ -228,7 +228,7 @@ class SupportedPaletteProvider {
         'create.altinn-user-controlled-signing-task': {
           group: 'activity',
           className: 'bpmn-icon-task-generic bpmn-icon-user-controlled-signing-task',
-          title: translate('Create Altinn User-Controlled Signing Task'),
+          title: translate('Create Altinn user-controlled signing task'),
           action: {
             click: createUserControlledSigningTask(),
             dragstart: createUserControlledSigningTask(),
@@ -237,7 +237,7 @@ class SupportedPaletteProvider {
         'create.altinn-confirmation-task': {
           group: 'activity',
           className: 'bpmn-icon-task-generic bpmn-icon-confirmation-task',
-          title: translate('Create Altinn Confirm Task'),
+          title: translate('Create Altinn confirm task'),
           action: {
             click: createCustomConfirmationTask(),
             dragstart: createCustomConfirmationTask(),
@@ -246,7 +246,7 @@ class SupportedPaletteProvider {
         'create.altinn-payment-task': {
           group: 'activity',
           className: `bpmn-icon-task-generic bpmn-icon-payment-task`,
-          title: translate('Create Altinn Payment Task'),
+          title: translate('Create Altinn payment task'),
           action: {
             click: createCustomPaymentTask(),
             dragstart: createCustomPaymentTask(),

--- a/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
+++ b/frontend/packages/process-editor/src/bpmnProviders/SupportedPaletteProvider.js
@@ -201,7 +201,7 @@ class SupportedPaletteProvider {
         'create.altinn-data-task': {
           group: 'activity',
           className: 'bpmn-icon-task-generic bpmn-icon-data-task',
-          title: translate('Create Altinn data task'),
+          title: translate('Create data task'),
           action: {
             click: createCustomTask('data'),
             dragstart: createCustomTask('data'),
@@ -209,7 +209,7 @@ class SupportedPaletteProvider {
         },
         'create.altinn-feedback-task': {
           group: 'activity',
-          title: translate('Create Altinn feedback task'),
+          title: translate('Create feedback task'),
           className: 'bpmn-icon-task-generic bpmn-icon-feedback-task',
           action: {
             click: createCustomTask('feedback'),
@@ -219,7 +219,7 @@ class SupportedPaletteProvider {
         'create.altinn-signing-task': {
           group: 'activity',
           className: 'bpmn-icon-task-generic bpmn-icon-signing-task',
-          title: translate('Create Altinn signing task'),
+          title: translate('Create signing task'),
           action: {
             click: createCustomSigningTask(),
             dragstart: createCustomSigningTask(),
@@ -228,7 +228,7 @@ class SupportedPaletteProvider {
         'create.altinn-user-controlled-signing-task': {
           group: 'activity',
           className: 'bpmn-icon-task-generic bpmn-icon-user-controlled-signing-task',
-          title: translate('Create Altinn user-controlled signing task'),
+          title: translate('Create user-controlled signing task'),
           action: {
             click: createUserControlledSigningTask(),
             dragstart: createUserControlledSigningTask(),
@@ -237,7 +237,7 @@ class SupportedPaletteProvider {
         'create.altinn-confirmation-task': {
           group: 'activity',
           className: 'bpmn-icon-task-generic bpmn-icon-confirmation-task',
-          title: translate('Create Altinn confirm task'),
+          title: translate('Create confirm task'),
           action: {
             click: createCustomConfirmationTask(),
             dragstart: createCustomConfirmationTask(),
@@ -246,7 +246,7 @@ class SupportedPaletteProvider {
         'create.altinn-payment-task': {
           group: 'activity',
           className: `bpmn-icon-task-generic bpmn-icon-payment-task`,
-          title: translate('Create Altinn payment task'),
+          title: translate('Create payment task'),
           action: {
             click: createCustomPaymentTask(),
             dragstart: createCustomPaymentTask(),

--- a/frontend/testing/playwright/pages/ProcessEditorPage/ProcessEditorPage.ts
+++ b/frontend/testing/playwright/pages/ProcessEditorPage/ProcessEditorPage.ts
@@ -57,7 +57,7 @@ export class ProcessEditorPage extends BasePage {
     const targetX = boundingBox.width / 2 + (extraDistanceX ?? 0);
     const targetY = boundingBox.y + boundingBox.height / 2 + (extraDistanceY ?? 0);
 
-    const title = `Create Altinn ${task} task`;
+    const title = `Create ${task} task`;
     await this.startDragElement(title);
     await this.stopDragElement(targetX, targetY);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes tooltip format from "Create Altinn Data Task" to "Create data task" for all tasks.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the display titles of BPMN palette entries by removing the "Altinn" prefix and adjusting capitalization for a more generic appearance. No functionality changes.
  * Modified drag-and-drop task titles to remove the "Altinn" prefix for consistency with palette entry updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->