### PR TITLE
chore: Move StudioLabelAsParagraph

### DIFF
--- a/frontend/libs/studio-components-legacy/src/components/StudioLabelAsParagraph/StudioLabelAsParagraph.tsx
+++ b/frontend/libs/studio-components-legacy/src/components/StudioLabelAsParagraph/StudioLabelAsParagraph.tsx
@@ -4,6 +4,9 @@ import type { WithoutAsChild } from '../../types/WithoutAsChild';
 
 type StudioLabelAsParagraphProps = WithoutAsChild<LabelProps>;
 
+/**
+ * @deprecated use `StudioLabelAsParagraph` from `@studio/components` instead.
+ */
 export const StudioLabelAsParagraph = forwardRef<HTMLLabelElement, StudioLabelAsParagraphProps>(
   ({ children, ...rest }, ref) => {
     return (

--- a/frontend/libs/studio-components/src/components/StudioLabelAsParagraph/StudioLabelAsParagraph.mdx
+++ b/frontend/libs/studio-components/src/components/StudioLabelAsParagraph/StudioLabelAsParagraph.mdx
@@ -1,0 +1,17 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { StudioHeading } from '../StudioHeading';
+import { StudioParagraph } from '../StudioParagraph/';
+import * as StudioLabelAsParagraphStories from './StudioLabelAsParagraph.stories';
+
+<Meta of={StudioLabelAsParagraphStories} />
+
+<StudioHeading level={1}>
+  StudioLabelAsParagraph
+</StudioHeading>
+<StudioParagraph>
+  StudioLabelAsParagraph is an extension of the digdir-designsystemet `Label`
+  component with the prop `asChild` added together with a `<p>` element. This
+  gives the component the visual look of a Label, but the behaviour of a paragraph.
+</StudioParagraph>
+
+<Canvas of={StudioLabelAsParagraphStories.Preview} />

--- a/frontend/libs/studio-components/src/components/StudioLabelAsParagraph/StudioLabelAsParagraph.stories.tsx
+++ b/frontend/libs/studio-components/src/components/StudioLabelAsParagraph/StudioLabelAsParagraph.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react-vite';
+import { StudioLabelAsParagraph } from './StudioLabelAsParagraph';
+
+type Story = StoryFn<typeof StudioLabelAsParagraph>;
+
+const meta: Meta = {
+  title: 'Components/StudioLabelAsParagraph',
+  component: StudioLabelAsParagraph,
+};
+export const Preview: Story = (args): React.ReactElement => <StudioLabelAsParagraph {...args} />;
+
+Preview.args = {
+  children: 'Paragraph in bold',
+};
+
+export default meta;

--- a/frontend/libs/studio-components/src/components/StudioLabelAsParagraph/StudioLabelAsParagraph.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioLabelAsParagraph/StudioLabelAsParagraph.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { RenderResult } from '@testing-library/react';
+import { StudioLabelAsParagraph } from './StudioLabelAsParagraph';
+import type { StudioLabelAsParagraphProps } from './StudioLabelAsParagraph';
+import { testRootClassNameAppending } from '../../test-utils/testRootClassNameAppending';
+import { testCustomAttributes } from '../../test-utils/testCustomAttributes';
+
+const mockText: string = 'Test';
+
+describe('StudioLabelAsParagraph', () => {
+  it('renders children correctly', () => {
+    renderStudioLabelAsParagraph();
+    expect(getText(mockText)).toBeInTheDocument();
+  });
+
+  it('applies custom data-size correctly', () => {
+    renderStudioLabelAsParagraph({ 'data-size': 'lg' });
+
+    expect(getText(mockText).getAttribute('data-size')).toBe('lg');
+  });
+
+  it('Appends given classname to internal classname', () => {
+    testRootClassNameAppending((className) => renderStudioLabelAsParagraph({ className }));
+  });
+
+  it('Appends custom attributes to the label element', () => {
+    testCustomAttributes(renderStudioLabelAsParagraph);
+  });
+});
+
+const renderStudioLabelAsParagraph = (
+  props: Partial<StudioLabelAsParagraphProps> = {},
+): RenderResult => {
+  return render(<StudioLabelAsParagraph {...props}>{mockText}</StudioLabelAsParagraph>);
+};
+
+const getText = (text: string): HTMLElement => screen.getByText(text);

--- a/frontend/libs/studio-components/src/components/StudioLabelAsParagraph/StudioLabelAsParagraph.tsx
+++ b/frontend/libs/studio-components/src/components/StudioLabelAsParagraph/StudioLabelAsParagraph.tsx
@@ -1,0 +1,23 @@
+import React, { forwardRef } from 'react';
+import type { ReactElement, Ref } from 'react';
+import { Label, type LabelProps } from '@digdir/designsystemet-react';
+import type { WithoutAsChild } from '../../types/WithoutAsChild';
+
+export type StudioLabelAsParagraphProps = WithoutAsChild<LabelProps>;
+
+function StudioLabelAsParagraph(
+  { children, ...rest }: StudioLabelAsParagraphProps,
+  ref: Ref<HTMLLabelElement>,
+): ReactElement {
+  return (
+    <Label asChild {...rest} ref={ref}>
+      <p>{children}</p>
+    </Label>
+  );
+}
+
+const ForwardedStudioLabelAsParagraph = forwardRef(StudioLabelAsParagraph);
+
+export { ForwardedStudioLabelAsParagraph as StudioLabelAsParagraph };
+
+StudioLabelAsParagraph.displayName = 'StudioLabelAsParagraph';

--- a/frontend/libs/studio-components/src/components/StudioLabelAsParagraph/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioLabelAsParagraph/index.ts
@@ -1,0 +1,1 @@
+export { StudioLabelAsParagraph } from './StudioLabelAsParagraph';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Move `StudioLabelAsParagraph` from legacy to `@studio/components` 

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the new StudioLabelAsParagraph component, combining label styling with paragraph behavior.
  * Added Storybook stories and live previews for StudioLabelAsParagraph.
  * Provided comprehensive documentation for StudioLabelAsParagraph.
* **Tests**
  * Added tests to ensure correct rendering, class name handling, and support for custom attributes in StudioLabelAsParagraph.
* **Chores**
  * Marked the legacy StudioLabelAsParagraph component as deprecated and recommended the new version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->