### PR TITLE
refactor: useMediaQuery

### DIFF
--- a/frontend/libs/studio-components-legacy/src/hooks/useMediaQuery.test.ts
+++ b/frontend/libs/studio-components-legacy/src/hooks/useMediaQuery.test.ts
@@ -1,6 +1,6 @@
-import { renderHook } from '@testing-library/react';
-
+import { renderHook, act } from '@testing-library/react';
 import { useMediaQuery } from './useMediaQuery';
+import MockedFunction = jest.MockedFunction;
 
 // Test data:
 const query = '(min-width: 600px)';
@@ -8,26 +8,30 @@ const query = '(min-width: 600px)';
 describe('useMediaQuery', () => {
   afterEach(() => jest.resetAllMocks());
 
-  it.each([true, false])(
-    'Returns value from window.matchMedia.matches when it is %s',
-    (matches) => {
-      const matchMediaValue = matchMediaValueMock({ matches });
-      const { result } = renderHook(() => useMediaQuery(query));
-      expect(matchMediaValue).toHaveBeenCalledWith(query);
-      expect(result.current).toBe(matches);
-    },
-  );
+  it.each([true, false])('Returns value from window.matchMedia.matches when it is %s', (value) => {
+    const matchMedia = mockMatchMediaApi({ matches: value });
+    const { result } = renderHook(() => useMediaQuery(query));
+    expect(matchMedia).toHaveBeenCalledWith(query);
+    expect(result.current).toBe(value);
+  });
+
+  it('Returns false when window.matchMedia.matches is undefined', () => {
+    const matchMedia = mockMatchMediaApi({ matches: undefined });
+    const { result } = renderHook(() => useMediaQuery(query));
+    expect(matchMedia).toHaveBeenCalledWith(query);
+    expect(result.current).toBe(false);
+  });
 
   it('Adds event listener', () => {
     const addEventListener = jest.fn();
-    matchMediaValueMock({ addEventListener });
+    mockMatchMediaApi({ matches: false, addEventListener });
     renderHook(() => useMediaQuery(query));
     expect(addEventListener).toHaveBeenCalledTimes(1);
   });
 
   it('Removes the event listener on unmount', () => {
     const removeEventListener = jest.fn();
-    matchMediaValueMock({ removeEventListener });
+    mockMatchMediaApi({ matches: false, removeEventListener });
     const { unmount } = renderHook(() => useMediaQuery(query));
     expect(removeEventListener).not.toHaveBeenCalled();
     unmount();
@@ -35,23 +39,31 @@ describe('useMediaQuery', () => {
   });
 });
 
-const matchMediaValueMock = ({
+type MatchMediaMockOptions = {
+  matches: boolean | undefined;
+  addEventListener?: jest.Mock;
+  removeEventListener?: jest.Mock;
+};
+
+function mockMatchMediaApi(
+  options: MatchMediaMockOptions,
+): MockedFunction<typeof window.matchMedia> {
+  const matchMediaMock = createMatchMediaMock(options);
+  Object.defineProperty(window, 'matchMedia', { writable: true, value: matchMediaMock });
+  return matchMediaMock;
+}
+
+function createMatchMediaMock({
   matches,
-  addEventListener,
-  removeEventListener,
-}: Partial<{
-  matches: boolean;
-  addEventListener: jest.Mock;
-  removeEventListener: jest.Mock;
-}>) => {
-  const value = jest.fn().mockImplementation((query) => ({
-    matches: matches ?? false,
+  addEventListener = jest.fn(),
+  removeEventListener = jest.fn(),
+}): MockedFunction<typeof window.matchMedia> {
+  return jest.fn().mockImplementation((query) => ({
+    matches,
     media: query,
     onchange: null,
-    addEventListener: addEventListener ?? jest.fn(),
-    removeEventListener: removeEventListener ?? jest.fn(),
+    addEventListener,
+    removeEventListener,
     dispatchEvent: jest.fn(),
   }));
-  Object.defineProperty(window, 'matchMedia', { writable: true, value });
-  return value;
-};
+}

--- a/frontend/libs/studio-components-legacy/src/hooks/useMediaQuery.ts
+++ b/frontend/libs/studio-components-legacy/src/hooks/useMediaQuery.ts
@@ -1,20 +1,23 @@
 import { useEffect, useState } from 'react';
 
+function getMatches(query: string): boolean {
+  return window.matchMedia(query).matches ?? false;
+}
+
 export function useMediaQuery(query: string): boolean {
-  const getMatches = (query: string): boolean => window?.matchMedia(query).matches ?? false;
-
-  const [matches, setMatches] = useState<boolean>(getMatches(query));
-
-  const eventListener = () => {
-    setMatches(getMatches(query));
-  };
+  const [matches, setMatches] = useState<boolean>(() => getMatches(query));
 
   useEffect(() => {
-    const matchMedia = window.matchMedia(query);
-    eventListener();
-    matchMedia.addEventListener('change', eventListener);
-    return () => matchMedia.removeEventListener('change', eventListener);
-  }, [query]); // eslint-disable-line react-hooks/exhaustive-deps
+    const updateMatches = (): void => {
+      setMatches(getMatches(query));
+    };
+
+    updateMatches();
+
+    const mediaQueryList = window.matchMedia(query);
+    mediaQueryList.addEventListener('change', updateMatches);
+    return (): void => mediaQueryList.removeEventListener('change', updateMatches);
+  }, [query]);
 
   return matches;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Preparing hook before transfer to `studio-hooks`. The files in this PR are in accordance with the "strict null checks" rule.

#15949 depends on this PR.

**useMediaQuery.ts**
Refactored due to concerns about stale state from CodeRabbit.
* Moved the event handler definition into the useEffect, to ensure that it does not check for matches against a stale `query`
* Moved the `getMatches` utility outside the hook
* Renamed the event handler from `eventListener` to `updateMatches`

**useMediaQuery.test.ts**
* The `matchMediaValueMock` function has been refactored into two separate functions - one that creates the mock implementation, and another that handles applying the mock to the environment
* Variables have been renamed for improved clarity

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
