### PR TITLE
feat: copy useMediaQuery to studio-hooks

### DIFF
--- a/frontend/libs/studio-hooks/src/hooks/index.ts
+++ b/frontend/libs/studio-hooks/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './useDebounce';
 export * from './useForwardedRef';
 export * from './usePropState';
 export * from './useUniqueKeys';
+export * from './useMediaQuery';

--- a/frontend/libs/studio-hooks/src/hooks/useMediaQuery.test.ts
+++ b/frontend/libs/studio-hooks/src/hooks/useMediaQuery.test.ts
@@ -1,0 +1,69 @@
+import { renderHook } from '@testing-library/react';
+import { useMediaQuery } from './useMediaQuery';
+import MockedFunction = jest.MockedFunction;
+
+// Test data:
+const query = '(min-width: 600px)';
+
+describe('useMediaQuery', () => {
+  afterEach(() => jest.resetAllMocks());
+
+  it.each([true, false])('Returns value from window.matchMedia.matches when it is %s', (value) => {
+    const matchMedia = mockMatchMediaApi({ matches: value });
+    const { result } = renderHook(() => useMediaQuery(query));
+    expect(matchMedia).toHaveBeenCalledWith(query);
+    expect(result.current).toBe(value);
+  });
+
+  it('Returns false when window.matchMedia.matches is undefined', () => {
+    const matchMedia = mockMatchMediaApi({ matches: undefined });
+    const { result } = renderHook(() => useMediaQuery(query));
+    expect(matchMedia).toHaveBeenCalledWith(query);
+    expect(result.current).toBe(false);
+  });
+
+  it('Adds event listener', () => {
+    const addEventListener = jest.fn();
+    mockMatchMediaApi({ matches: false, addEventListener });
+    renderHook(() => useMediaQuery(query));
+    expect(addEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('Removes the event listener on unmount', () => {
+    const removeEventListener = jest.fn();
+    mockMatchMediaApi({ matches: false, removeEventListener });
+    const { unmount } = renderHook(() => useMediaQuery(query));
+    expect(removeEventListener).not.toHaveBeenCalled();
+    unmount();
+    expect(removeEventListener).toHaveBeenCalledTimes(1);
+  });
+});
+
+type MatchMediaMockOptions = {
+  matches: boolean | undefined;
+  addEventListener?: jest.Mock;
+  removeEventListener?: jest.Mock;
+};
+
+function mockMatchMediaApi(
+  options: MatchMediaMockOptions,
+): MockedFunction<typeof window.matchMedia> {
+  const matchMediaMock = createMatchMediaMock(options);
+  Object.defineProperty(window, 'matchMedia', { writable: true, value: matchMediaMock });
+  return matchMediaMock;
+}
+
+function createMatchMediaMock({
+  matches,
+  addEventListener = jest.fn(),
+  removeEventListener = jest.fn(),
+}): MockedFunction<typeof window.matchMedia> {
+  return jest.fn().mockImplementation((query) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener,
+    removeEventListener,
+    dispatchEvent: jest.fn(),
+  }));
+}

--- a/frontend/libs/studio-hooks/src/hooks/useMediaQuery.ts
+++ b/frontend/libs/studio-hooks/src/hooks/useMediaQuery.ts
@@ -4,9 +4,6 @@ function getMatches(query: string): boolean {
   return window.matchMedia(query).matches ?? false;
 }
 
-/**
- * @deprecated Use `useMediaQuery` from `studio-hooks` instead.
- */
 export function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = useState<boolean>(() => getMatches(query));
 


### PR DESCRIPTION
## Description
Pure copy of the `useMediaQuery` hook and its test from `studio-component-legacy` to `studio-hooks`.

PR #15949 depends on this PR.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new media query hook for responsive design support.
  * The new media query hook is now available for import from the updated hooks library.

* **Bug Fixes**
  * Added comprehensive tests to ensure the reliability and correct behavior of the new media query hook.

* **Documentation**
  * Marked the legacy media query hook as deprecated and recommended switching to the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->