### PR TITLE
Avoids deserializing+serializing ApplicationMetadata when updating Storage

### DIFF
--- a/backend/src/Designer/Helpers/ApplicationMetadataJsonHelper.cs
+++ b/backend/src/Designer/Helpers/ApplicationMetadataJsonHelper.cs
@@ -1,0 +1,75 @@
+#nullable enable
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Altinn.Studio.Designer.Models.App;
+
+namespace Altinn.Studio.Designer.Helpers;
+
+public static class ApplicationMetadataJsonHelper
+{
+    public static string SetCopyInstanceEnabled(string json, bool enabled, JsonSerializerOptions? serializationOptions = null)
+    {
+        var jsonObj = ParseAndEnsureJsonObject(json);
+        bool usesPascalCase = UsesPascalCaseProps(jsonObj);
+        var keys = new
+        {
+            CopyInstance = usesPascalCase ? "CopyInstanceSettings" : "copyInstanceSettings",
+            Enabled = usesPascalCase ? "Enabled" : "enabled"
+        };
+
+        if (jsonObj[keys.CopyInstance] is not JsonObject config)
+        {
+            config = new JsonObject();
+            jsonObj[keys.CopyInstance] = config;
+        }
+
+        config[keys.Enabled] = enabled;
+
+        return jsonObj.ToJsonString(serializationOptions);
+    }
+
+    public static string SetId(string json, string id, JsonSerializerOptions? serializationOptions = null)
+    {
+        var jsonObj = ParseAndEnsureJsonObject(json);
+        string key = UsesPascalCaseProps(jsonObj) ? "Id" : "id";
+
+        jsonObj[key] = id;
+
+        return jsonObj.ToJsonString(serializationOptions);
+    }
+
+    public static string SetVersionId(string json, string versionId, JsonSerializerOptions? serializationOptions = null)
+    {
+        var jsonObj = ParseAndEnsureJsonObject(json);
+        string key = UsesPascalCaseProps(jsonObj) ? "VersionId" : "versionId";
+
+        jsonObj[key] = versionId;
+
+        return jsonObj.ToJsonString(serializationOptions);
+    }
+
+    private static JsonObject ParseAndEnsureJsonObject(string json)
+    {
+        JsonNode? rootNode = JsonNode.Parse(json);
+        if (rootNode is not JsonObject jsonObj)
+        {
+            throw new InvalidOperationException($"Invalid JSON input: Expected a JSON object, got {rootNode?.GetType().Name}");
+        }
+
+        return jsonObj;
+    }
+
+    private static bool UsesPascalCaseProps(JsonObject obj)
+    {
+        foreach (var property in obj)
+        {
+            if (string.IsNullOrEmpty(property.Key))
+                continue;
+
+            return char.IsUpper(property.Key[0]);
+        }
+
+        return false;
+    }
+}

--- a/backend/src/Designer/Scheduling/DeploymentPipelinePollingJob.cs
+++ b/backend/src/Designer/Scheduling/DeploymentPipelinePollingJob.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Altinn.Authorization.ABAC.Utils;
-using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Studio.Designer.Events;
 using Altinn.Studio.Designer.Hubs.EntityUpdate;
 using Altinn.Studio.Designer.Models;
@@ -99,14 +98,11 @@ public class DeploymentPipelinePollingJob : IJob
 
     }
 
-
     private async Task UpdateMetadataInStorage(AltinnRepoEditingContext editingContext, string environment)
     {
-        var appMetadata = await _altinnStorageAppMetadataClient.GetApplicationMetadataAsync(editingContext, environment);
-        var copyInstanceSettings = appMetadata.CopyInstanceSettings ?? new CopyInstanceSettings();
-        copyInstanceSettings.Enabled = false;
-        appMetadata.CopyInstanceSettings = copyInstanceSettings;
-        await _altinnStorageAppMetadataClient.UpsertApplicationMetadata(editingContext.Org, editingContext.Repo, appMetadata, environment);
+        string appMetadataJson = await _altinnStorageAppMetadataClient.GetApplicationMetadataJsonAsync(editingContext, environment);
+        appMetadataJson = Helpers.ApplicationMetadataJsonHelper.SetCopyInstanceEnabled(appMetadataJson, enabled: false);
+        await _altinnStorageAppMetadataClient.UpsertApplicationMetadata(editingContext.Org, editingContext.Repo, appMetadataJson, environment);
     }
 
     private static void CancelJob(IJobExecutionContext context)

--- a/backend/src/Designer/Services/Implementation/ApplicationMetadataService.cs
+++ b/backend/src/Designer/Services/Implementation/ApplicationMetadataService.cs
@@ -227,8 +227,8 @@ namespace Altinn.Studio.Designer.Services.Implementation
         public async Task UpdateApplicationMetadataInStorageAsync(string org, string app, string shortCommitId, string envName, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            ApplicationMetadata applicationFromRepository = await GetApplicationMetadataFromSpecificReference(org, app, shortCommitId);
-            await UpdateApplicationMetadataInStorage(org, app, applicationFromRepository, envName, shortCommitId);
+            string appMetadataJson = await GetApplicationMetadataJsonFromSpecificReference(org, app, shortCommitId);
+            await UpdateApplicationMetadataInStorage(org, app, appMetadataJson, envName, shortCommitId);
         }
 
         public async Task<ApplicationMetadata> GetApplicationMetadataFromRepository(string org, string app)
@@ -246,7 +246,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
         /// <param name="app">Application identifier which is unique within an organisation.</param>
         /// <param name="referenceId">The name of the commit/branch/tag. Default the repository’s default branch</param>
         /// <returns>The application metadata for an application.</returns>
-        private async Task<ApplicationMetadata> GetApplicationMetadataFromSpecificReference(string org, string app, string referenceId)
+        private async Task<string> GetApplicationMetadataJsonFromSpecificReference(string org, string app, string referenceId)
         {
             var file = await _giteaApiWrapper.GetFileAsync(org, app, "App/config/applicationmetadata.json", referenceId);
             if (string.IsNullOrEmpty(file.Content))
@@ -254,16 +254,10 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 throw new NotFoundHttpRequestException("There is no ApplicationMetadata file in repo.");
             }
 
-            // It's used to avoid sensibility to BOM
+            // Passing the file content through a MemoryStream to deal with potential BOM issues
             using var fileStream = new MemoryStream(Convert.FromBase64String(file.Content));
             using StreamReader utf8Reader = new(fileStream, Encoding.UTF8);
-            return JsonSerializer.Deserialize<ApplicationMetadata>(await utf8Reader.ReadToEndAsync(),
-                new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true,
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-                });
+            return await utf8Reader.ReadToEndAsync();
         }
 
         public bool ApplicationMetadataExistsInRepository(string org, string app)
@@ -273,12 +267,12 @@ namespace Altinn.Studio.Designer.Services.Implementation
             return altinnAppGitRepository.ApplicationMetadataExists();
         }
 
-        private async Task UpdateApplicationMetadataInStorage(string org, string app, ApplicationMetadata applicationFromRepository, string envName, string shortCommitId)
+        private async Task UpdateApplicationMetadataInStorage(string org, string app, string applicationMetadataJson, string envName, string shortCommitId)
         {
-            applicationFromRepository.Id = $"{org}/{app}";
-            applicationFromRepository.VersionId = shortCommitId;
+            applicationMetadataJson = ApplicationMetadataJsonHelper.SetId(applicationMetadataJson, id: $"{org}/{app}");
+            applicationMetadataJson = ApplicationMetadataJsonHelper.SetVersionId(applicationMetadataJson, versionId: shortCommitId);
 
-            await _storageAppMetadataClient.UpsertApplicationMetadata(org, app, applicationFromRepository, envName);
+            await _storageAppMetadataClient.UpsertApplicationMetadata(org, app, applicationMetadataJson, envName);
         }
     }
 }

--- a/backend/src/Designer/TypedHttpClients/AltinnStorage/AltinnStorageAppMetadataClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnStorage/AltinnStorageAppMetadataClient.cs
@@ -61,9 +61,20 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
             ApplicationMetadata applicationMetadata,
             string envName)
         {
+            // TODO: It's unclear to me how this serializer retains camelCase without options, when the JsonProperties used in ApplicationMetadata are from Newtonsoft
+            string stringContent = JsonSerializer.Serialize(applicationMetadata);
+            await UpsertApplicationMetadata(org, app, stringContent, envName);
+        }
+
+        /// <inheritdoc />
+        public async Task UpsertApplicationMetadata(
+            string org,
+            string app,
+            string applicationMetadataJson,
+            string envName)
+        {
             var storageUri = await CreateStorageUri(envName);
             Uri uri = new($"{storageUri}?appId={org}/{app}");
-            string stringContent = JsonSerializer.Serialize(applicationMetadata);
             /*
              * Have to create a HttpRequestMessage instead of using helper extension methods like _httpClient.PostAsync(...)
              * because the base address can change on each request and after HttpClient gets initial base address,
@@ -71,12 +82,24 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
              */
             using HttpRequestMessage request = new(HttpMethod.Post, uri)
             {
-                Content = new StringContent(stringContent, Encoding.UTF8, "application/json"),
+                Content = new StringContent(applicationMetadataJson, Encoding.UTF8, "application/json"),
             };
             await _httpClient.SendAsync(request);
         }
 
-        public async Task<ApplicationMetadata> GetApplicationMetadataAsync(AltinnRepoContext altinnRepoContext,
+        /// <inheritdoc />
+        public async Task<ApplicationMetadata> GetApplicationMetadataAsync(
+            AltinnRepoContext altinnRepoContext,
+            string envName,
+            CancellationToken cancellationToken = default)
+        {
+            string rawContent = await GetApplicationMetadataJsonAsync(altinnRepoContext, envName, cancellationToken);
+            return JsonSerializer.Deserialize<ApplicationMetadata>(rawContent, s_jsonOptions);
+        }
+
+        /// <inheritdoc />
+        public async Task<string> GetApplicationMetadataJsonAsync(
+            AltinnRepoContext altinnRepoContext,
             string envName,
             CancellationToken cancellationToken = default)
         {
@@ -85,9 +108,9 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
             var storageUri = await CreateStorageUri(envName);
             Uri uri = new($"{storageUri}{altinnRepoContext.Org}/{altinnRepoContext.Repo}");
             using HttpRequestMessage request = new(HttpMethod.Get, uri);
-            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-            return await response.Content.ReadFromJsonAsync<ApplicationMetadata>(s_jsonOptions, cancellationToken);
+            using HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
 
+            return await response.Content.ReadAsStringAsync(cancellationToken);
         }
 
         private async Task<Uri> CreateStorageUri(string envName)

--- a/backend/src/Designer/TypedHttpClients/AltinnStorage/IAltinnStorageAppMetadataClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnStorage/IAltinnStorageAppMetadataClient.cs
@@ -20,6 +20,9 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
         /// <returns></returns>
         Task UpsertApplicationMetadata(string org, string app, ApplicationMetadata applicationMetadata, string envName);
 
+        /// <inheritdoc cref="UpsertApplicationMetadata(string,string,Altinn.Studio.Designer.Models.App.ApplicationMetadata,string)"/>
+        Task UpsertApplicationMetadata(string org, string app, string applicationMetadataJson, string envName);
+
         /// <summary>
         /// Returns the application metadata that is stored in Platform.Storage
         /// </summary>
@@ -29,5 +32,8 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
         /// <returns>An <see cref="ApplicationMetadata"/> that's currently stored in the storage</returns>
         Task<ApplicationMetadata> GetApplicationMetadataAsync(AltinnRepoContext altinnRepoContext, string envName, CancellationToken cancellationToken = default);
 
+        /// <inheritdoc cref="GetApplicationMetadataAsync"/>
+        /// <returns>A raw (<see cref="string"/>) representation of the <see cref="ApplicationMetadata"/> for an app, as currently stored in the Storage service</returns>
+        Task<string> GetApplicationMetadataJsonAsync(AltinnRepoContext altinnRepoContext, string envName, CancellationToken cancellationToken = default);
     }
 }

--- a/backend/tests/Designer.Tests/Scheduling/DeploymentPipelinePollingJobTest.cs
+++ b/backend/tests/Designer.Tests/Scheduling/DeploymentPipelinePollingJobTest.cs
@@ -1,0 +1,158 @@
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Events;
+using Altinn.Studio.Designer.Hubs.EntityUpdate;
+using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Models.App;
+using Altinn.Studio.Designer.Repository;
+using Altinn.Studio.Designer.Repository.Models;
+using Altinn.Studio.Designer.Scheduling;
+using Altinn.Studio.Designer.TypedHttpClients.AltinnStorage;
+using Altinn.Studio.Designer.TypedHttpClients.AzureDevOps;
+using Altinn.Studio.Designer.TypedHttpClients.AzureDevOps.Enums;
+using MediatR;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Newtonsoft.Json;
+using Quartz;
+using Xunit;
+using SchedulerConstants = Altinn.Studio.Designer.Scheduling.DeploymentPipelinePollingJobConstants.Arguments;
+
+namespace Designer.Tests.Scheduling;
+
+public class DeploymentPipelinePollingJobTest
+{
+    [Fact]
+    public async Task Execute_Undeploy_UpdatesJsonData_PassesPayloadToStorageClient()
+    {
+        // Arrange
+        var fixture = Fixture.Create();
+        var jobExecutionContext = JobExecutionContextFactory(PipelineType.Undeploy);
+        var appMetadata = new ApplicationMetadata("org/app");
+        var capturedAppMetadataJson = string.Empty;
+
+        fixture
+            .MockStorageAppMetadataClient.Setup(x =>
+                x.GetApplicationMetadataJsonAsync(
+                    It.IsAny<AltinnRepoEditingContext>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(JsonConvert.SerializeObject(appMetadata));
+
+        fixture
+            .MockStorageAppMetadataClient.Setup(x =>
+                x.UpsertApplicationMetadata(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                )
+            )
+            .Callback(
+                (string org, string app, string applicationMetadataJson, string envName) =>
+                {
+                    capturedAppMetadataJson = applicationMetadataJson;
+                }
+            );
+
+        fixture
+            .MockAzureDevOpsBuildClient.Setup(x => x.Get(It.IsAny<string>()))
+            .ReturnsAsync(
+                new BuildEntity { Status = BuildStatus.Completed, Result = BuildResult.Succeeded }
+            );
+
+        fixture
+            .MockDeploymentRepository.Setup(x => x.Get(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(
+                new DeploymentEntity { Build = new BuildEntity { Status = BuildStatus.None } }
+            );
+
+        // Act
+        await fixture.Service.Execute(jobExecutionContext);
+
+        // Assert
+        var capturedAppMetadata = JsonConvert.DeserializeObject<ApplicationMetadata>(
+            capturedAppMetadataJson
+        );
+        Assert.NotNull(capturedAppMetadata);
+        Assert.False(capturedAppMetadata.CopyInstanceSettings.Enabled);
+    }
+
+    private sealed record Fixture(
+        DeploymentPipelinePollingJob DeploymentPipelinePollingJob,
+        Mock<IAltinnStorageAppMetadataClient> MockStorageAppMetadataClient,
+        Mock<IDeploymentRepository> MockDeploymentRepository,
+        Mock<IAzureDevOpsBuildClient> MockAzureDevOpsBuildClient
+    )
+    {
+        public DeploymentPipelinePollingJob Service => DeploymentPipelinePollingJob;
+
+        public static Fixture Create()
+        {
+            var mockStorageAppMetadataClient = new Mock<IAltinnStorageAppMetadataClient>();
+            var mockDeploymentRepository = new Mock<IDeploymentRepository>();
+            var mockAzureDevOpsBuildClient = new Mock<IAzureDevOpsBuildClient>();
+            var mockHubContext = MockHubContextFactory<EntityUpdatedHub, IEntityUpdateClient>();
+
+            var service = new DeploymentPipelinePollingJob(
+                mockAzureDevOpsBuildClient.Object,
+                mockDeploymentRepository.Object,
+                mockStorageAppMetadataClient.Object,
+                mockHubContext.Object,
+                Mock.Of<IPublisher>(),
+                NullLogger<DeploymentPipelinePollingJob>.Instance
+            );
+
+            return new Fixture(
+                service,
+                mockStorageAppMetadataClient,
+                mockDeploymentRepository,
+                mockAzureDevOpsBuildClient
+            );
+        }
+    }
+
+    private static IJobExecutionContext JobExecutionContextFactory(PipelineType pipelineType)
+    {
+        var mockJobExecutionContext = new Mock<IJobExecutionContext>();
+        var mockJobDetail = new Mock<IJobDetail>();
+
+        mockJobDetail.Setup(x => x.Key).Returns(JobKey.Create("testjob"));
+        mockJobDetail
+            .Setup(x => x.JobDataMap)
+            .Returns(
+                new JobDataMap
+                {
+                    [SchedulerConstants.Org] = "testorg",
+                    [SchedulerConstants.App] = "testapp",
+                    [SchedulerConstants.Developer] = "testdeveloper",
+                    [SchedulerConstants.BuildId] = "12345",
+                    [SchedulerConstants.PipelineType] = pipelineType.ToString(),
+                    [SchedulerConstants.Environment] = "tt02"
+                }
+            );
+
+        mockJobExecutionContext.Setup(x => x.JobDetail).Returns(mockJobDetail.Object);
+        mockJobExecutionContext.Setup(x => x.Scheduler).Returns(Mock.Of<IScheduler>());
+
+        return mockJobExecutionContext.Object;
+    }
+
+    private static Mock<IHubContext<THub, T>> MockHubContextFactory<THub, T>()
+        where THub : Hub<T>
+        where T : class
+    {
+        var mockEntityUpdateClient = new Mock<T>();
+        var mockClients = new Mock<IHubClients<T>>();
+        mockClients.Setup(c => c.Group(It.IsAny<string>())).Returns(mockEntityUpdateClient.Object);
+
+        var mockHubContext = new Mock<IHubContext<THub, T>>();
+        mockHubContext.Setup(h => h.Clients).Returns(mockClients.Object);
+
+        return mockHubContext;
+    }
+}

--- a/backend/tests/Designer.Tests/Services/Implementation/ApplicationMetadataServiceTest.cs
+++ b/backend/tests/Designer.Tests/Services/Implementation/ApplicationMetadataServiceTest.cs
@@ -1,0 +1,130 @@
+#nullable enable
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Models.App;
+using Altinn.Studio.Designer.Services.Implementation;
+using Altinn.Studio.Designer.Services.Interfaces;
+using Altinn.Studio.Designer.TypedHttpClients.AltinnStorage;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Designer.Tests.Services.Implementation;
+
+public class ApplicationMetadataServiceTest
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task UpdateApplicationMetadataInStorageAsync_UpdatesJsonData_PassesPayloadToStorageClient(
+        bool usePascalCasePropertyNames
+    )
+    {
+        // Arrange
+        var fixture = Fixture.Create();
+        var appMetadata = new ApplicationMetadata("old-org/old-app");
+        string? capturedAppMetadataJson = null;
+        var jsonSerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = usePascalCasePropertyNames ? JsonNamingPolicy.CamelCase : null
+        };
+
+        fixture
+            .MockGiteaApiWrapper.Setup(x =>
+                x.GetFileAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                )
+            )
+            .ReturnsAsync(Base64FileSystemObjectFactory(appMetadata, jsonSerializerOptions));
+
+        fixture
+            .MockStorageAppMetadataClient.Setup(x =>
+                x.UpsertApplicationMetadata(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                )
+            )
+            .Callback(
+                (string org, string app, string applicationMetadataJson, string envName) =>
+                {
+                    capturedAppMetadataJson = applicationMetadataJson;
+                }
+            );
+
+        // Act
+        await fixture.Service.UpdateApplicationMetadataInStorageAsync(
+            "new-org",
+            "new-app",
+            "abcd1234",
+            "tt02",
+            CancellationToken.None
+        );
+
+        // Assert
+        var capturedAppMetadata = JsonSerializer.Deserialize<ApplicationMetadata>(
+            capturedAppMetadataJson!,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true } // Simulate usage in AltinnStorageAppMetadataClient.GetApplicationMetadataAsync
+        );
+        Assert.NotNull(capturedAppMetadata);
+        Assert.Equal("new-org/new-app", capturedAppMetadata.Id);
+        Assert.Equal("abcd1234", capturedAppMetadata.VersionId);
+    }
+
+    private sealed record Fixture(
+        ApplicationMetadataService ApplicationMetadataService,
+        Mock<IAltinnStorageAppMetadataClient> MockStorageAppMetadataClient,
+        Mock<IAltinnGitRepositoryFactory> MockAltinnGitRepositoryFactory,
+        Mock<IGitea> MockGiteaApiWrapper
+    )
+    {
+        public ApplicationMetadataService Service => ApplicationMetadataService;
+
+        public static Fixture Create()
+        {
+            var mockStorageAppMetadataClient = new Mock<IAltinnStorageAppMetadataClient>();
+            var mockAltinnGitRepositoryFactory = new Mock<IAltinnGitRepositoryFactory>();
+            var mockGiteaApiWrapper = new Mock<IGitea>();
+
+            var service = new ApplicationMetadataService(
+                NullLogger<ApplicationMetadataService>.Instance,
+                mockStorageAppMetadataClient.Object,
+                mockAltinnGitRepositoryFactory.Object,
+                Mock.Of<IHttpContextAccessor>(),
+                mockGiteaApiWrapper.Object
+            );
+
+            return new Fixture(
+                service,
+                mockStorageAppMetadataClient,
+                mockAltinnGitRepositoryFactory,
+                mockGiteaApiWrapper
+            );
+        }
+    }
+
+    private FileSystemObject Base64FileSystemObjectFactory<T>(
+        T content,
+        JsonSerializerOptions? jsonSerializerOptions = null
+    )
+    {
+        string serializedString = JsonSerializer.Serialize(content, jsonSerializerOptions);
+        byte[] plainBytes = System.Text.Encoding.UTF8.GetBytes(serializedString);
+        string base64String = Convert.ToBase64String(plainBytes);
+
+        return new FileSystemObject
+        {
+            Content = base64String,
+            Encoding = "base64",
+            Type = "file"
+        };
+    }
+}


### PR DESCRIPTION
## Description
As described in the linked issue, this modification to behaviour addresses how `applicationmetadata.json` content is sent to the Storage service for... err, storage.

The motivation for wanting to avoid deserializing + serializing the ApplicationMetadata content in transit to Storage, is because the `Altinn.Platform.Storage.Interface` package referenced in this project is currently at `v3.34.0`, while the newest version available is `v4.13.0`.

The newer version(s) contain updates to `ApplicationMetadata` which has now become necessary to read directly from the Storage database (because the Storage service makes use of it). The serialization process strips off all unknown properties, which at this point in time is frankly a whole lot.

To avoid this problem repeating itself in the future, treating the data as raw text in transit to Storage seems to make sense.

Note: There are plenty of other uses of deserialized `ApplicationMetadata` objects spread throughout the `backend` project. These should absolutely base themselves on an updated version of the `Storage.Interface` package. But that is beyond the scope of this PR. 

## Related issues
- closes #15969

## Verification
- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
