### PR TITLE
fix: add limit for max width of grid selector

### DIFF
--- a/frontend/libs/studio-components-legacy/src/components/StudioGridSelector/StudioGridSelector.module.css
+++ b/frontend/libs/studio-components-legacy/src/components/StudioGridSelector/StudioGridSelector.module.css
@@ -6,7 +6,8 @@
   --selected-square-colour: var(--fds-semantic-surface-action-second-default);
   --unselected-square-colour: var(--fds-semantic-surface-action-second-no_fill-active);
   --hover-square-color: var(--fds-semantic-surface-action-hover);
-  --thumb-width: calc(100% / 12);
+  --slider-width: min(100%, 500px);
+  --thumb-width: calc(var(--slider-width) / 12);
 }
 
 .sliderContainer.disabled {
@@ -24,7 +25,7 @@
   outline-offset: var(--outline-offset);
   outline: var(--outline);
   padding: 0;
-  width: 100%;
+  width: var(--slider-width);
 }
 
 .range:disabled {
@@ -64,7 +65,7 @@ datalist {
   pointer-events: none;
   position: absolute;
   top: 0;
-  width: 100%;
+  width: var(--slider-width);
 }
 
 .option {

--- a/frontend/libs/studio-components-legacy/src/components/StudioGridSelector/StudioGridSelector.module.css
+++ b/frontend/libs/studio-components-legacy/src/components/StudioGridSelector/StudioGridSelector.module.css
@@ -8,6 +8,7 @@
   --hover-square-color: var(--fds-semantic-surface-action-hover);
   --slider-width: min(100%, 500px);
   --thumb-width: calc(var(--slider-width) / 12);
+  max-width: var(--slider-width);
 }
 
 .sliderContainer.disabled {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Tiny CSS fix to avoid tabs disappearing when expanding config column a lot.
Set max width to 500px. Why 500px? Why not 😄 Any bigger and the selector looks kind of silly with how big it gets.

https://github.com/user-attachments/assets/e0267b30-ac68-4a08-a48f-8f185c382a76

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated slider styling to centralize width control, ensuring consistent sizing and improved maintainability. The slider and related elements now adapt more responsively to available space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->