### PR TITLE
chore: Remove unnecessary TODO

### DIFF
--- a/backend/src/Designer/TypedHttpClients/AltinnStorage/AltinnStorageAppMetadataClient.cs
+++ b/backend/src/Designer/TypedHttpClients/AltinnStorage/AltinnStorageAppMetadataClient.cs
@@ -60,7 +60,6 @@ namespace Altinn.Studio.Designer.TypedHttpClients.AltinnStorage
             ApplicationMetadata applicationMetadata,
             string envName)
         {
-            // TODO: It's unclear to me how this serializer retains camelCase without options, when the JsonProperties used in ApplicationMetadata are from Newtonsoft
             string stringContent = JsonSerializer.Serialize(applicationMetadata);
             await UpsertApplicationMetadata(org, app, stringContent, envName);
         }


### PR DESCRIPTION
## Description
[A previous pull request](https://github.com/Altinn/altinn-studio/pull/15989) accidentally left behind a `TODO` note. This note is no longer required, as the question it raised has been dealt with.

**TL;DR **
The (de)serialization of the `AppMetadata` object across both Studio and Storage is quite confusing, since both `System.Text.Json` and `Newtonsoft.Json` are used  interchangeably. The situation as it stands right now, is that the file contents in `applicationmetadata.json` is _camelCase_, but is serialized by studio on the way to Storage as _PascalCase_, which is how it is currently stored in the postgres database.

If it ain't broke, don't fix it, etc.