### PR TITLE
fix: set sortable to false for createdBy property

### DIFF
--- a/frontend/dashboard/components/RepoList/RepoList.tsx
+++ b/frontend/dashboard/components/RepoList/RepoList.tsx
@@ -63,7 +63,7 @@ export const RepoList = ({
     {
       accessor: 'createdBy',
       heading: t('dashboard.created_by'),
-      sortable: true,
+      sortable: false,
       headerCellClass: classes.createdByHeaderCell,
     },
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`createdBy` does not seem to be a keyword thats available to sort by in Gitea any more. Setting `sortable=false` on the column to make it clear to the user that they cannot sort by this column.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Disabled sorting for the "createdBy" column in the repository list table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->