### PR TITLE
feat: Copy StudioAnimateHeight to studio-components

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioAnimateHeight/StudioAnimateHeight.mdx
+++ b/frontend/libs/studio-components/src/components/StudioAnimateHeight/StudioAnimateHeight.mdx
@@ -1,0 +1,15 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { Heading, Paragraph } from '@digdir/designsystemet-react';
+import * as StudioAnimateHeightStories from './StudioAnimateHeight.stories';
+
+<Meta of={StudioAnimateHeightStories} />
+
+<Heading level={1} size='small'>
+  StudioAnimateHeight
+</Heading>
+<Paragraph>
+  StudioAnimateHeight is a component that animates open and close of a container with a height
+  transition.
+</Paragraph>
+
+<Canvas of={StudioAnimateHeightStories.Preview} />

--- a/frontend/libs/studio-components/src/components/StudioAnimateHeight/StudioAnimateHeight.module.css
+++ b/frontend/libs/studio-components/src/components/StudioAnimateHeight/StudioAnimateHeight.module.css
@@ -1,0 +1,18 @@
+.root {
+  display: grid;
+  grid-template-rows: 0fr;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .root {
+    transition: grid-template-rows 0.25s ease-in-out;
+  }
+}
+
+.root.open {
+  grid-template-rows: 1fr;
+}
+
+.content {
+  overflow: hidden;
+}

--- a/frontend/libs/studio-components/src/components/StudioAnimateHeight/StudioAnimateHeight.stories.tsx
+++ b/frontend/libs/studio-components/src/components/StudioAnimateHeight/StudioAnimateHeight.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react-vite';
+import { StudioAnimateHeight } from './StudioAnimateHeight';
+
+type Story = StoryFn<typeof StudioAnimateHeight>;
+
+const meta: Meta = {
+  title: 'Components/StudioAnimateHeight',
+  component: StudioAnimateHeight,
+};
+export const Preview: Story = (args): React.ReactElement => <StudioAnimateHeight {...args} />;
+
+Preview.args = {
+  children: 'Change the open prop to see the animation in action',
+  open: true,
+};
+export default meta;

--- a/frontend/libs/studio-components/src/components/StudioAnimateHeight/StudioAnimateHeight.test.tsx
+++ b/frontend/libs/studio-components/src/components/StudioAnimateHeight/StudioAnimateHeight.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import type { StudioAnimateHeightProps } from './StudioAnimateHeight';
+import { StudioAnimateHeight } from './StudioAnimateHeight';
+
+/* eslint-disable testing-library/no-node-access */
+describe('StudioAnimateHeight', () => {
+  it('Renders children', () => {
+    const childTestId = 'content';
+    const children = <div data-testid={childTestId} />;
+    renderComponent({ children });
+    expect(screen.getByTestId(childTestId)).toBeInTheDocument();
+  });
+
+  it('Appends given className to root element', () => {
+    const className = 'foo';
+    const { container } = renderComponent({ className });
+    expect(container.firstChild).toHaveClass('root');
+    expect(container.firstChild).toHaveClass(className);
+  });
+
+  it('Appends given style to root element', () => {
+    const style = { color: 'red' };
+    const { container } = renderComponent({ style });
+    expect(container.firstChild).toHaveStyle(style);
+  });
+
+  it('Accepts additional <div> props', () => {
+    const id = 'foo';
+    const { container } = renderComponent({ id });
+    expect(container.firstChild).toHaveAttribute('id', id);
+  });
+
+  it('Sets "open" class when open', () => {
+    const { container } = renderComponent({ open: true });
+    expect(container.firstChild).toHaveClass('open');
+  });
+
+  it('Unsets "open" class when closed', () => {
+    const { container } = renderComponent({ open: false });
+    expect(container.firstChild).not.toHaveClass('open');
+  });
+});
+
+const defaultProps: StudioAnimateHeightProps = { open: false };
+
+const renderComponent = (props?: Partial<StudioAnimateHeightProps>): RenderResult =>
+  render(<StudioAnimateHeight {...defaultProps} {...props} />);

--- a/frontend/libs/studio-components/src/components/StudioAnimateHeight/StudioAnimateHeight.tsx
+++ b/frontend/libs/studio-components/src/components/StudioAnimateHeight/StudioAnimateHeight.tsx
@@ -7,7 +7,7 @@ export type StudioAnimateHeightProps = {
 } & React.HTMLAttributes<HTMLDivElement>;
 
 /**
- * @deprecated Use `StudioAnimateHeight` from `studio-components` instead.
+ * AnimateHeight is a component that animates its height when the `open` prop changes.
  */
 export const StudioAnimateHeight = ({
   children,

--- a/frontend/libs/studio-components/src/components/StudioAnimateHeight/index.ts
+++ b/frontend/libs/studio-components/src/components/StudioAnimateHeight/index.ts
@@ -1,0 +1,2 @@
+export { StudioAnimateHeight } from './StudioAnimateHeight';
+export type { StudioAnimateHeightProps } from './StudioAnimateHeight';

--- a/frontend/libs/studio-components/src/components/index.ts
+++ b/frontend/libs/studio-components/src/components/index.ts
@@ -4,6 +4,7 @@ import '@digdir/designsystemet-theme/altinn.css';
 import './style/studio-variables.css';
 
 export { StudioAlert } from './StudioAlert';
+export { StudioAnimateHeight } from './StudioAnimateHeight';
 export { StudioAvatar } from './StudioAvatar';
 export { StudioDropdown } from './StudioDropdown';
 export { StudioCenter } from './StudioCenter';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Direct copy of the `StudioAnimateHeight` component to `studio-components`
* Marked old component as deprecated.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
