### PR TITLE
feat: Update source for ContentController

### DIFF
--- a/backend/src/Designer/Controllers/Organisation/OrgContentController.cs
+++ b/backend/src/Designer/Controllers/Organisation/OrgContentController.cs
@@ -61,7 +61,7 @@ public class OrgContentController : ControllerBase
 
         if (string.IsNullOrEmpty(contentType))
         {
-            return await _orgContentService.GetOrgContentReferences(null, editingContext, cancellationToken);
+            return await _orgContentService.GetOrgContentReferences(null, orgName, cancellationToken);
         }
 
         bool didParse = Enum.TryParse<LibraryContentType>(contentType, ignoreCase: true, out var parsedContentType);
@@ -70,7 +70,7 @@ public class OrgContentController : ControllerBase
             return BadRequest($"Invalid content type '{contentType}'.");
         }
 
-        return await _orgContentService.GetOrgContentReferences(parsedContentType, editingContext, cancellationToken);
+        return await _orgContentService.GetOrgContentReferences(parsedContentType, orgName, cancellationToken);
     }
 
     private AltinnOrgContext CreateAltinnOrgContext(string orgName)

--- a/backend/src/Designer/Infrastructure/ServiceRegistration.cs
+++ b/backend/src/Designer/Infrastructure/ServiceRegistration.cs
@@ -93,6 +93,7 @@ namespace Altinn.Studio.Designer.Infrastructure
             services.RegisterDatamodeling(configuration);
             services.RegisterSettingsSingleton<KafkaSettings>(configuration);
             services.AddTransient<IKafkaProducer, KafkaProducer>();
+            services.AddTransient<IGiteaContentLibraryService, GiteaContentLibraryService>();
 
             return services;
         }

--- a/backend/src/Designer/Services/Implementation/GiteaContentLibraryService.cs
+++ b/backend/src/Designer/Services/Implementation/GiteaContentLibraryService.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Services.Interfaces;
+
+namespace Altinn.Studio.Designer.Services.Implementation;
+
+public class GiteaContentLibraryService : IGiteaContentLibraryService
+{
+    private readonly IGitea _giteaApiWrapper;
+    private const string CodeListFolderPath = "CodeLists/";
+    private const string TextResourceFolderPath = "Texts/";
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public GiteaContentLibraryService(IGitea giteaApiWrapper)
+    {
+        _giteaApiWrapper = giteaApiWrapper;
+    }
+
+    /// <inheritdoc />
+    public async Task<List<string>> GetCodeListIds(string orgName)
+    {
+        List<FileSystemObject> files = await _giteaApiWrapper.GetDirectoryAsync(orgName, GetContentRepoName(orgName), CodeListFolderPath, "");
+        IEnumerable<string> fileNames = files.Select(file => file.Name);
+        return fileNames.Select(Path.GetFileNameWithoutExtension).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<List<Option>> GetCodeList(string orgName, string optionListId)
+    {
+        string filePath = StaticContentCodeListFilePath(optionListId);
+        string decodedString = await GetFileFromGitea(orgName, filePath);
+        return JsonSerializer.Deserialize<List<Option>>(decodedString);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<string>> GetTextIds(string orgName)
+    {
+        List<string> textIds = [];
+        List<string> languageCodes = await GetLanguages(orgName);
+
+        foreach (string languageCode in languageCodes)
+        {
+            string textResourceString = await GetFileFromGitea(orgName, StaticContentTextResourceFilePath(languageCode));
+            TextResource textResource = JsonSerializer.Deserialize<TextResource>(textResourceString, s_jsonOptions);
+
+            if (textResource.Resources.Count == 0) { continue; }
+            IEnumerable<string> textResourceElementIds = textResource.Resources.Select(textResourceElement => textResourceElement.Id);
+            textIds.AddRange(textResourceElementIds);
+        }
+
+        return textIds.Distinct().ToList();
+    }
+
+    public async Task<TextResource> GetTextResource(string orgName, string languageCode)
+    {
+        string filePath = StaticContentTextResourceFilePath(languageCode);
+        string decodedString = await GetFileFromGitea(orgName, filePath);
+        return JsonSerializer.Deserialize<TextResource>(decodedString, s_jsonOptions);
+    }
+
+    public async Task<List<string>> GetLanguages(string orgName)
+    {
+        List<FileSystemObject> files = await _giteaApiWrapper.GetDirectoryAsync(orgName, GetContentRepoName(orgName), TextResourceFolderPath, "");
+        IEnumerable<string> languageFilePaths = files.Select(file => file.Name);
+        IEnumerable<string> fileNames = languageFilePaths
+            .Select(Path.GetFileName)
+            .Select(Path.GetFileNameWithoutExtension);
+
+        List<string> languages = [];
+        foreach (string fileName in fileNames)
+        {
+            var match = Regex.Match(fileName, @"^resource\.(?<lang>[A-Za-z]{2,3})$");
+            if (match.Success)
+            {
+                languages.Add(fileName.Split('.')[^1]);
+            }
+        }
+
+        languages.Sort(StringComparer.Ordinal);
+        return languages;
+    }
+
+    private async Task<string> GetFileFromGitea(string orgName, string filePath)
+    {
+        string repoName = GetContentRepoName(orgName);
+        FileSystemObject file = await _giteaApiWrapper.GetFileAsync(orgName, repoName, filePath, "");
+        byte[] binaryData = Convert.FromBase64String(file.Content);
+        return Encoding.UTF8.GetString(binaryData);
+    }
+
+    private static string StaticContentTextResourceFilePath(string languageCode)
+    {
+        return Path.Combine(TextResourceFolderPath, $"resource.{languageCode}.json");
+    }
+
+    private static string StaticContentCodeListFilePath(string optionListId)
+    {
+        return Path.Combine(CodeListFolderPath, $"{optionListId}.json");
+    }
+
+    private static string GetContentRepoName(string orgName)
+    {
+        return $"{orgName}-content";
+    }
+}

--- a/backend/src/Designer/Services/Implementation/GiteaContentLibraryService.cs
+++ b/backend/src/Designer/Services/Implementation/GiteaContentLibraryService.cs
@@ -102,12 +102,12 @@ public class GiteaContentLibraryService : IGiteaContentLibraryService
 
     private static string StaticContentTextResourceFilePath(string languageCode)
     {
-        return Path.Combine(TextResourceFolderPath, $"resource.{languageCode}.json");
+        return Path.Join(TextResourceFolderPath, $"resource.{languageCode}.json");
     }
 
     private static string StaticContentCodeListFilePath(string optionListId)
     {
-        return Path.Combine(CodeListFolderPath, $"{optionListId}.json");
+        return Path.Join(CodeListFolderPath, $"{optionListId}.json");
     }
 
     private static string GetContentRepoName(string orgName)

--- a/backend/src/Designer/Services/Implementation/OrgContentService.cs
+++ b/backend/src/Designer/Services/Implementation/OrgContentService.cs
@@ -7,7 +7,6 @@ using Altinn.Studio.Designer.Enums;
 using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.Dto;
 using Altinn.Studio.Designer.Services.Interfaces;
-using Altinn.Studio.Designer.Services.Interfaces.Organisation;
 
 namespace Altinn.Studio.Designer.Services.Implementation;
 
@@ -15,14 +14,15 @@ namespace Altinn.Studio.Designer.Services.Implementation;
 public class OrgContentService : IOrgContentService
 {
     private readonly IAltinnGitRepositoryFactory _altinnGitRepositoryFactory;
-    private readonly IOrgCodeListService _orgCodeListService;
-    private readonly IOrgTextsService _orgTextsService;
+    private readonly IGiteaContentLibraryService _giteaContentLibraryService;
 
-    public OrgContentService(IAltinnGitRepositoryFactory altinnGitRepositoryFactory, IOrgCodeListService orgCodeListService, IOrgTextsService orgTextsService)
+    public OrgContentService(
+        IAltinnGitRepositoryFactory altinnGitRepositoryFactory,
+        IGiteaContentLibraryService giteaContentLibraryService
+    )
     {
         _altinnGitRepositoryFactory = altinnGitRepositoryFactory;
-        _orgCodeListService = orgCodeListService;
-        _orgTextsService = orgTextsService;
+        _giteaContentLibraryService = giteaContentLibraryService;
     }
 
     /// <inheritdoc />
@@ -34,45 +34,46 @@ public class OrgContentService : IOrgContentService
     }
 
     /// <inheritdoc />
-    public async Task<List<LibraryContentReference>> GetOrgContentReferences(LibraryContentType? contentType, AltinnOrgContext context, CancellationToken cancellationToken = default)
+    public async Task<List<LibraryContentReference>> GetOrgContentReferences(LibraryContentType? contentType, string orgName, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         switch (contentType)
         {
             case LibraryContentType.CodeList:
-                return GetCodeListReferences(context, cancellationToken);
+                return await GetCodeListReferences(orgName);
 
             case LibraryContentType.TextResource:
-                return await GetTextResourceReferences(context, cancellationToken);
+                return await GetTextResourceReferences(orgName);
 
             case null:
-                return await GetAllReferences(context, cancellationToken);
+                return await GetAllReferences(orgName);
 
             default:
                 return [];
         }
     }
 
-    private async Task<List<LibraryContentReference>> GetAllReferences(AltinnOrgContext context, CancellationToken cancellationToken = default)
+    private async Task<List<LibraryContentReference>> GetAllReferences(string orgName)
     {
-        var codeListContent = GetCodeListReferences(context, cancellationToken);
-        var textContent = await GetTextResourceReferences(context, cancellationToken);
+        var codeListContent = GetCodeListReferences(orgName);
+        var textContent = GetTextResourceReferences(orgName);
 
         var result = new List<LibraryContentReference>();
-        result.AddRange(codeListContent);
-        result.AddRange(textContent);
+        result.AddRange(await codeListContent);
+        result.AddRange(await textContent);
         return result;
     }
 
-    private List<LibraryContentReference> GetCodeListReferences(AltinnOrgContext context, CancellationToken cancellationToken = default)
+    private async Task<List<LibraryContentReference>> GetCodeListReferences(string orgName)
     {
-        List<string> codeListIds = _orgCodeListService.GetCodeListIds(context.Org, context.DeveloperName, cancellationToken);
-        return CreateContentReferences(LibraryContentType.CodeList, codeListIds, context.Org);
+        List<string> codeListIds = await _giteaContentLibraryService.GetCodeListIds(orgName);
+        return CreateContentReferences(LibraryContentType.CodeList, codeListIds, orgName);
     }
 
-    private async Task<List<LibraryContentReference>> GetTextResourceReferences(AltinnOrgContext context, CancellationToken cancellationToken = default)
+    private async Task<List<LibraryContentReference>> GetTextResourceReferences(string orgName)
     {
-        List<string> textIds = await _orgTextsService.GetTextIds(context.Org, context.DeveloperName, cancellationToken);
-        return CreateContentReferences(LibraryContentType.TextResource, textIds, context.Org);
+        List<string> textIds = await _giteaContentLibraryService.GetTextIds(orgName);
+        return CreateContentReferences(LibraryContentType.TextResource, textIds, orgName);
     }
 
     private static List<LibraryContentReference> CreateContentReferences(LibraryContentType contentType, List<string> contentIds, string orgName)

--- a/backend/src/Designer/Services/Interfaces/IGiteaContentLibraryService.cs
+++ b/backend/src/Designer/Services/Interfaces/IGiteaContentLibraryService.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Models;
+
+namespace Altinn.Studio.Designer.Services.Interfaces;
+
+public interface IGiteaContentLibraryService
+{
+    /// <summary>
+    /// Retrieves a code list from the content repository from Gitea with the specified optionListId.
+    /// </summary>
+    /// <param name="orgName">The name of the organisation.</param>
+    /// <param name="optionListId">The name of the options list to fetch.</param>
+    /// <returns>The code list</returns>
+    public Task<List<Option>> GetCodeList(string orgName, string optionListId);
+    /// <summary>
+    /// Retrieves a list of file names from the CodeLists folder in the content repository in Gitea.
+    /// </summary>
+    /// <param name="orgName">The name of the organisation.</param>
+    /// <returns>A list of code list ids.</returns>
+    public Task<List<string>> GetCodeListIds(string orgName);
+    /// <summary>
+    /// Retrieves the language codes from the content repository from Gitea.
+    /// </summary>
+    /// <param name="orgName">The name of the organisation.</param>
+    /// <returns>Language codes</returns>
+    public Task<List<string>> GetLanguages(string orgName);
+    /// <summary>
+    /// Retrieves the text file in the content repository from Gitea
+    /// </summary>
+    /// <param name="orgName">The name of the organisation.</param>
+    /// <param name="languageCode"></param>
+    /// <returns>The text file</returns>
+    public Task<TextResource> GetTextResource(string orgName, string languageCode);
+    /// <summary>
+    /// Retrieves ids for all text resource elements in the content repository from Gitea.
+    /// </summary>
+    /// <param name="orgName">The name of the organisation.</param>
+    /// <returns>A list of text IDs.</returns>
+    public Task<List<string>> GetTextIds(string orgName);
+}

--- a/backend/src/Designer/Services/Interfaces/IOrgContentService.cs
+++ b/backend/src/Designer/Services/Interfaces/IOrgContentService.cs
@@ -16,10 +16,10 @@ public interface IOrgContentService
     /// Retrieves a list of available library content based on the specified type.
     /// </summary>
     /// <param name="contentType">The type of content to retrieve.</param>
-    /// <param name="context">The organisation context.</param>
+    /// <param name="orgName">The name of the organisation.</param>
     /// <param name="cancellationToken">A token to observe cancellation requests.</param>
     /// <returns>A list of external content library resources.</returns>
-    public Task<List<LibraryContentReference>> GetOrgContentReferences(LibraryContentType? contentType, AltinnOrgContext context, CancellationToken cancellationToken = default);
+    public Task<List<LibraryContentReference>> GetOrgContentReferences(LibraryContentType? contentType, string orgName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Checks if the organisation's content repository exists in the specified context.

--- a/backend/tests/Designer.Tests/Controllers/OrgCodeListController/GetCodeListsTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OrgCodeListController/GetCodeListsTests.cs
@@ -33,7 +33,7 @@ public class GetCodeListsTests : DesignerEndpointsTestsBase<GetCodeListsTests>, 
         string codeListLabelWithObject = @"[{ ""value"": ""someValue"", ""label"": {}}]";
         string codeListLabelWithNumber = @"[{ ""value"": ""someValue"", ""label"": 12345}]";
         string codeListLabelWithBool = @"[{ ""value"": ""someValue"", ""label"": true}]";
-        string repoPath = TestDataHelper.GetOrgRepositoryDirectory(Developer, targetOrg, targetRepository);
+        string repoPath = TestDataHelper.GetRepositoryDirectory(Developer, targetOrg, targetRepository);
         string filePath = Path.Join(repoPath, "CodeLists/");
         await File.WriteAllTextAsync(Path.Join(filePath, "codeListLabelWithObject.json"), codeListLabelWithObject);
         await File.WriteAllTextAsync(Path.Join(filePath, "codeListLabelWithNumber.json"), codeListLabelWithNumber);

--- a/backend/tests/Designer.Tests/Controllers/OrgContentController/GetOrgContentReferencesTests.cs
+++ b/backend/tests/Designer.Tests/Controllers/OrgContentController/GetOrgContentReferencesTests.cs
@@ -1,8 +1,12 @@
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Enums;
+using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Models.Dto;
 using Altinn.Studio.Designer.Services.Interfaces;
 using Designer.Tests.Controllers.ApiTests;
@@ -19,17 +23,28 @@ public class GetOrgContentReferencesTests
         IClassFixture<WebApplicationFactory<Program>>
 {
     private readonly Mock<IOrgService> _orgServiceMock;
+    private readonly Mock<IGiteaContentLibraryService> _giteaContentLibraryServiceMock;
+    private const string Username = "testUser";
+    private const string SourceOrgName = "ttd";
+    private const string SourceRepoName = "org-content";
 
-    public GetOrgContentReferencesTests(WebApplicationFactory<Program> factory)
-        : base(factory)
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public GetOrgContentReferencesTests(WebApplicationFactory<Program> factory) : base(factory)
     {
         _orgServiceMock = new Mock<IOrgService>();
+        _giteaContentLibraryServiceMock = new Mock<IGiteaContentLibraryService>();
     }
 
     protected override void ConfigureTestServices(IServiceCollection services)
     {
         base.ConfigureTestServices(services);
         services.AddSingleton(_orgServiceMock.Object);
+        services.AddSingleton(_giteaContentLibraryServiceMock.Object);
     }
 
     [Fact]
@@ -37,6 +52,7 @@ public class GetOrgContentReferencesTests
     {
         // Arrange
         _orgServiceMock.Setup(service => service.IsOrg(It.IsAny<string>())).ReturnsAsync(true);
+        MockGiteaResponses();
 
         OrgAndRepoName orgAndRepoName = await CreateOrgWithRepository();
         string apiBaseUrl = orgAndRepoName.Org.ApiBaseUrl;
@@ -59,6 +75,8 @@ public class GetOrgContentReferencesTests
         );
 
         _orgServiceMock.Verify(service => service.IsOrg(orgAndRepoName.Org.Name), Times.Once);
+        _giteaContentLibraryServiceMock.Verify(service => service.GetCodeListIds(orgAndRepoName.Org.Name), Times.Once);
+        _giteaContentLibraryServiceMock.Verify(service => service.GetTextIds(orgAndRepoName.Org.Name), Times.Once);
     }
 
     [Fact]
@@ -66,6 +84,7 @@ public class GetOrgContentReferencesTests
     {
         // Arrange
         _orgServiceMock.Setup(service => service.IsOrg(It.IsAny<string>())).ReturnsAsync(true);
+        MockGiteaResponses();
 
         OrgAndRepoName orgAndRepoName = await CreateOrgWithRepository();
         string apiBaseUrl = orgAndRepoName.Org.ApiBaseUrl;
@@ -92,6 +111,7 @@ public class GetOrgContentReferencesTests
         );
 
         _orgServiceMock.Verify(service => service.IsOrg(orgAndRepoName.Org.Name), Times.Once);
+        _giteaContentLibraryServiceMock.Verify(service => service.GetCodeListIds(orgAndRepoName.Org.Name), Times.Once);
     }
 
     [Fact]
@@ -99,6 +119,7 @@ public class GetOrgContentReferencesTests
     {
         // Arrange
         _orgServiceMock.Setup(service => service.IsOrg(It.IsAny<string>())).ReturnsAsync(true);
+        MockGiteaResponses();
 
         OrgAndRepoName orgAndRepoName = await CreateOrgWithRepository();
         string apiBaseUrl = orgAndRepoName.Org.ApiBaseUrl;
@@ -125,6 +146,7 @@ public class GetOrgContentReferencesTests
         );
 
         _orgServiceMock.Verify(service => service.IsOrg(orgAndRepoName.Org.Name), Times.Once);
+        _giteaContentLibraryServiceMock.Verify(service => service.GetTextIds(orgAndRepoName.Org.Name), Times.Once);
     }
 
     [Fact]
@@ -132,6 +154,7 @@ public class GetOrgContentReferencesTests
     {
         // Arrange
         _orgServiceMock.Setup(service => service.IsOrg(It.IsAny<string>())).ReturnsAsync(true);
+        MockGiteaResponses();
 
         OrgAndRepoName orgAndRepoName = await CreateOrgWithRepository();
         string apiBaseUrl = orgAndRepoName.Org.ApiBaseUrl;
@@ -158,6 +181,7 @@ public class GetOrgContentReferencesTests
         );
 
         _orgServiceMock.Verify(service => service.IsOrg(orgAndRepoName.Org.Name), Times.Once);
+        _giteaContentLibraryServiceMock.Verify(service => service.GetTextIds(orgAndRepoName.Org.Name), Times.Once);
     }
 
     [Fact]
@@ -166,8 +190,8 @@ public class GetOrgContentReferencesTests
         // Arrange
         _orgServiceMock.Setup(service => service.IsOrg(It.IsAny<string>())).ReturnsAsync(false);
 
-        const string OrgName = "invalidOrgName";
-        string apiBaseUrl = new Organisation(OrgName).ApiBaseUrl;
+        const string TargetOrgName = "invalidOrgName";
+        string apiBaseUrl = new Organisation(TargetOrgName).ApiBaseUrl;
         using var request = new HttpRequestMessage(HttpMethod.Get, apiBaseUrl);
 
         // Act
@@ -176,9 +200,9 @@ public class GetOrgContentReferencesTests
         // Assert
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         string reasonHeader = Assert.Single(response.Headers.GetValues("Reason"));
-        Assert.Equal($"{OrgName} is not a valid organisation", reasonHeader);
+        Assert.Equal($"{TargetOrgName} is not a valid organisation", reasonHeader);
 
-        _orgServiceMock.Verify(service => service.IsOrg(OrgName), Times.Once);
+        _orgServiceMock.Verify(service => service.IsOrg(TargetOrgName), Times.Once);
     }
 
     [Fact]
@@ -187,8 +211,8 @@ public class GetOrgContentReferencesTests
         // Arrange
         _orgServiceMock.Setup(service => service.IsOrg(It.IsAny<string>())).ReturnsAsync(true);
 
-        const string OrgName = "orgWithoutRepositories";
-        string apiBaseUrl = new Organisation(OrgName).ApiBaseUrl;
+        const string TargetOrgName = "orgWithoutRepositories";
+        string apiBaseUrl = new Organisation(TargetOrgName).ApiBaseUrl;
         using var request = new HttpRequestMessage(HttpMethod.Get, apiBaseUrl);
 
         // Act
@@ -197,9 +221,9 @@ public class GetOrgContentReferencesTests
         // Assert
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         string reasonHeader = Assert.Single(response.Headers.GetValues("Reason"));
-        Assert.Equal($"{OrgName}-content repo does not exist", reasonHeader);
+        Assert.Equal($"{TargetOrgName}-content repo does not exist", reasonHeader);
 
-        _orgServiceMock.Verify(service => service.IsOrg(OrgName), Times.Once);
+        _orgServiceMock.Verify(service => service.IsOrg(TargetOrgName), Times.Once);
     }
 
     [Fact]
@@ -207,15 +231,15 @@ public class GetOrgContentReferencesTests
     {
         // Arrange
         _orgServiceMock.Setup(service => service.IsOrg(It.IsAny<string>())).ReturnsAsync(true);
+        _giteaContentLibraryServiceMock.Setup(service => service.GetCodeListIds(It.IsAny<string>())).ReturnsAsync([]);
+        _giteaContentLibraryServiceMock.Setup(service => service.GetTextIds(It.IsAny<string>())).ReturnsAsync([]);
 
+        const string SourceRepoNameEmpty = "org-content-empty";
         OrgAndRepoName orgAndRepoName = GenerateOrgAndRepoNames();
-        const string Username = "testUser";
-        const string SourceOrgName = "ttd";
-        const string SourceRepoName = "org-content-empty";
         await CopyOrgRepositoryForTest(
             Username,
             SourceOrgName,
-            SourceRepoName,
+            SourceRepoNameEmpty,
             orgAndRepoName.Org.Name,
             orgAndRepoName.RepoName
         );
@@ -232,6 +256,8 @@ public class GetOrgContentReferencesTests
         Assert.Empty(contentList);
 
         _orgServiceMock.Verify(service => service.IsOrg(orgAndRepoName.Org.Name), Times.Once);
+        _giteaContentLibraryServiceMock.Verify(service => service.GetCodeListIds(orgAndRepoName.Org.Name), Times.Once);
+        _giteaContentLibraryServiceMock.Verify(service => service.GetTextIds(orgAndRepoName.Org.Name), Times.Once);
     }
 
     [Fact]
@@ -271,16 +297,37 @@ public class GetOrgContentReferencesTests
 
     private async Task CreateTestRepository(OrgAndRepoName orgAndRepoName)
     {
-        const string Username = "testUser";
-        const string OrgName = "ttd";
-        const string RepoName = "org-content";
         await CopyOrgRepositoryForTest(
             Username,
-            OrgName,
-            RepoName,
+            SourceOrgName,
+            SourceRepoName,
             orgAndRepoName.Org.Name,
             orgAndRepoName.RepoName
         );
+    }
+
+    private void MockGiteaResponses()
+    {
+        string[] codeListFileNames = TestDataHelper.GetRepositoryFileNames(Username, SourceOrgName, SourceRepoName, "CodeLists/");
+        string[] textResourceFileNames = TestDataHelper.GetRepositoryFileNames(Username, SourceOrgName, SourceRepoName, "Texts/");
+
+        List<string> codeListIds = codeListFileNames.Select(Path.GetFileNameWithoutExtension).ToList();
+        List<string> textResourceElementIds = [];
+
+        foreach (string fileName in textResourceFileNames)
+        {
+            string file = TestDataHelper.GetFileFromRepo(SourceOrgName, SourceRepoName, Username, fileName);
+            TextResource textResource = JsonSerializer.Deserialize<TextResource>(file, s_jsonOptions);
+            textResourceElementIds.AddRange(textResource.Resources.Select(elem => elem.Id));
+        }
+        List<string> textIds = textResourceElementIds.Distinct().ToList();
+
+        _giteaContentLibraryServiceMock
+            .Setup(s => s.GetCodeListIds(It.IsAny<string>()))
+            .ReturnsAsync(codeListIds);
+        _giteaContentLibraryServiceMock
+            .Setup(s => s.GetTextIds(It.IsAny<string>()))
+            .ReturnsAsync(textIds);
     }
 
     private class OrgAndRepoName(string orgName, string repoName)

--- a/backend/tests/Designer.Tests/Services/OrgContentServiceTests.cs
+++ b/backend/tests/Designer.Tests/Services/OrgContentServiceTests.cs
@@ -2,10 +2,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Enums;
-using Altinn.Studio.Designer.Models;
 using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
-using Altinn.Studio.Designer.Services.Interfaces.Organisation;
 using Moq;
 using Xunit;
 
@@ -13,20 +11,16 @@ namespace Designer.Tests.Services;
 
 public class OrgContentServiceTests
 {
-    private readonly Mock<IOrgCodeListService> _mockOrgCodeListService;
-    private readonly Mock<IOrgTextsService> _mockOrgTextsService;
+
+    private readonly Mock<IGiteaContentLibraryService> _mockGiteaContentLibraryService;
     private readonly OrgContentService _orgContentService;
-    private readonly AltinnOrgContext _context;
     private const string OrgName = "ttd";
-    private const string DeveloperName = "testUser";
 
     public OrgContentServiceTests()
     {
         Mock<IAltinnGitRepositoryFactory> altinnGitRepositoryFactory = new();
-        _mockOrgCodeListService = new Mock<IOrgCodeListService>();
-        _mockOrgTextsService = new Mock<IOrgTextsService>();
-        _orgContentService = new OrgContentService(altinnGitRepositoryFactory.Object, _mockOrgCodeListService.Object, _mockOrgTextsService.Object);
-        _context = AltinnOrgContext.FromOrg(OrgName, DeveloperName);
+        _mockGiteaContentLibraryService = new Mock<IGiteaContentLibraryService>();
+        _orgContentService = new OrgContentService(altinnGitRepositoryFactory.Object, _mockGiteaContentLibraryService.Object);
     }
 
     [Fact]
@@ -36,15 +30,11 @@ public class OrgContentServiceTests
         var codeListIds = new List<string> { "codelist1", "codelist2" };
         var textIds = new List<string> { "text1", "text2" };
 
-        _mockOrgCodeListService
-            .Setup(s => s.GetCodeListIds(OrgName, DeveloperName, CancellationToken.None))
-            .Returns(codeListIds);
-        _mockOrgTextsService
-            .Setup(s => s.GetTextIds(OrgName, DeveloperName, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(textIds);
+        _mockGiteaContentLibraryService.Setup(service => service.GetCodeListIds(OrgName)).ReturnsAsync(codeListIds);
+        _mockGiteaContentLibraryService.Setup(service => service.GetTextIds(OrgName)).ReturnsAsync(textIds);
 
         // Act
-        var result = await _orgContentService.GetOrgContentReferences(null, _context);
+        var result = await _orgContentService.GetOrgContentReferences(null, OrgName);
 
         // Assert
         Assert.Equal(4, result.Count);
@@ -60,12 +50,10 @@ public class OrgContentServiceTests
     {
         // Arrange
         var codeListIds = new List<string> { "codelist1", "codelist2" };
-        _mockOrgCodeListService
-            .Setup(s => s.GetCodeListIds(OrgName, DeveloperName, CancellationToken.None))
-            .Returns(codeListIds);
+        _mockGiteaContentLibraryService.Setup(service => service.GetCodeListIds(OrgName)).ReturnsAsync(codeListIds);
 
         // Act
-        var contentList = await _orgContentService.GetOrgContentReferences(LibraryContentType.CodeList, _context);
+        var contentList = await _orgContentService.GetOrgContentReferences(LibraryContentType.CodeList, OrgName);
 
         // Assert
         Assert.Equal(2, contentList.Count);
@@ -74,8 +62,7 @@ public class OrgContentServiceTests
         Assert.Contains(contentList, contentItem => contentItem.Id == "codelist1");
         Assert.Contains(contentList, contentItem => contentItem.Id == "codelist2");
 
-        _mockOrgCodeListService.Verify(s =>
-            s.GetCodeListIds(OrgName, DeveloperName, CancellationToken.None), Times.Once);
+        _mockGiteaContentLibraryService.Verify(service => service.GetCodeListIds(OrgName), Times.Once);
     }
 
     [Fact]
@@ -83,12 +70,10 @@ public class OrgContentServiceTests
     {
         // Arrange
         var textIds = new List<string> { "text1", "text2", "text3" };
-        _mockOrgTextsService
-            .Setup(s => s.GetTextIds(OrgName, DeveloperName, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(textIds);
+        _mockGiteaContentLibraryService.Setup(service => service.GetTextIds(OrgName)).ReturnsAsync(textIds);
 
         // Act
-        var contentList = await _orgContentService.GetOrgContentReferences(LibraryContentType.TextResource, _context);
+        var contentList = await _orgContentService.GetOrgContentReferences(LibraryContentType.TextResource, OrgName);
 
         // Assert
         Assert.Equal(3, contentList.Count);
@@ -98,22 +83,19 @@ public class OrgContentServiceTests
         Assert.Contains(contentList, contentItem => contentItem.Id == "text2");
         Assert.Contains(contentList, contentItem => contentItem.Id == "text3");
 
-        _mockOrgTextsService.Verify(s =>
-            s.GetTextIds(OrgName, DeveloperName, It.IsAny<CancellationToken>()), Times.Once);
+        _mockGiteaContentLibraryService.Verify(service => service.GetTextIds(OrgName), Times.Once);
     }
 
     [Fact]
     public async Task GetOrgContentReferences_WithUnsupportedType_ReturnsEmptyList()
     {
         // Act
-        var result = await _orgContentService.GetOrgContentReferences((LibraryContentType)999, _context);
+        var result = await _orgContentService.GetOrgContentReferences((LibraryContentType)999, OrgName);
 
         // Assert
         Assert.Empty(result);
-        _mockOrgCodeListService.Verify(s =>
-            s.GetCodeListIds(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        _mockOrgTextsService.Verify(s =>
-            s.GetTextIds(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockGiteaContentLibraryService.Verify(service => service.GetCodeListIds(It.IsAny<string>()), Times.Never);
+        _mockGiteaContentLibraryService.Verify(service => service.GetTextIds(It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
@@ -124,27 +106,23 @@ public class OrgContentServiceTests
         var token = cts.Token;
         var textIds = new List<string> { "text1" };
 
-        _mockOrgTextsService
-            .Setup(s => s.GetTextIds(OrgName, DeveloperName, token))
-            .ReturnsAsync(textIds);
+        _mockGiteaContentLibraryService.Setup(service => service.GetTextIds(OrgName)).ReturnsAsync(textIds);
 
         // Act
-        await _orgContentService.GetOrgContentReferences(LibraryContentType.TextResource, _context, token);
+        await _orgContentService.GetOrgContentReferences(LibraryContentType.TextResource, OrgName, token);
 
         // Assert
-        _mockOrgTextsService.Verify(s => s.GetTextIds(OrgName, DeveloperName, token), Times.Once);
+        _mockGiteaContentLibraryService.Verify(service => service.GetTextIds(OrgName), Times.Once);
     }
 
     [Fact]
     public async Task GetCodeListReferences_WithNoIdsFound_ReturnsEmptyList()
     {
         // Arrange
-        _mockOrgCodeListService
-            .Setup(s => s.GetCodeListIds(OrgName, DeveloperName, CancellationToken.None))
-            .Returns([]);
+        _mockGiteaContentLibraryService.Setup(service => service.GetCodeListIds(OrgName)).ReturnsAsync([]);
 
         // Act
-        var result = await _orgContentService.GetOrgContentReferences(LibraryContentType.CodeList, _context);
+        var result = await _orgContentService.GetOrgContentReferences(LibraryContentType.CodeList, OrgName);
 
         // Assert
         Assert.Empty(result);
@@ -154,12 +132,10 @@ public class OrgContentServiceTests
     public async Task GetTextResourceReferences_WithNoIdsFound_ReturnsEmptyList()
     {
         // Arrange
-        _mockOrgTextsService
-            .Setup(s => s.GetTextIds(OrgName, DeveloperName, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+        _mockGiteaContentLibraryService.Setup(service => service.GetTextIds(OrgName)).ReturnsAsync([]);
 
         // Act
-        var result = await _orgContentService.GetOrgContentReferences(LibraryContentType.TextResource, _context);
+        var result = await _orgContentService.GetOrgContentReferences(LibraryContentType.TextResource, OrgName);
 
         // Assert
         Assert.Empty(result);

--- a/backend/tests/Designer.Tests/Utils/TestDataHelper.cs
+++ b/backend/tests/Designer.Tests/Utils/TestDataHelper.cs
@@ -434,9 +434,9 @@ namespace Designer.Tests.Utils
 
         public static async Task<string> CopyOrgForTest(string developer, string org, string repository, string targetOrg, string targetRepository)
         {
-            string sourceDirectory = GetOrgRepositoryDirectory(developer, org, repository);
+            string sourceDirectory = GetRepositoryDirectory(developer, org, repository);
             string targetOrgDirectory = GetOrgDirectory(targetOrg, developer);
-            string targetRepoDirectory = GetOrgRepositoryDirectory(developer, targetOrg, targetRepository);
+            string targetRepoDirectory = GetRepositoryDirectory(developer, targetOrg, targetRepository);
 
             CreateEmptyDirectory(targetOrgDirectory);
             await CopyDirectory(sourceDirectory, targetRepoDirectory);
@@ -446,8 +446,8 @@ namespace Designer.Tests.Utils
 
         public static async Task AddRepositoryToTestOrg(string developer, string org, string repository, string targetOrg, string targetRepository)
         {
-            string sourceDirectory = GetOrgRepositoryDirectory(developer, org, repository);
-            string targetRepoDirectory = GetOrgRepositoryDirectory(developer, targetOrg, targetRepository);
+            string sourceDirectory = GetRepositoryDirectory(developer, org, repository);
+            string targetRepoDirectory = GetRepositoryDirectory(developer, targetOrg, targetRepository);
 
             await CopyDirectory(sourceDirectory, targetRepoDirectory);
         }
@@ -457,9 +457,14 @@ namespace Designer.Tests.Utils
             return Path.Combine(GetTestDataRepositoriesRootDirectory(), developer, org);
         }
 
-        public static string GetOrgRepositoryDirectory(string developer, string org, string repository)
+        public static string GetRepositoryDirectory(string developer, string org, string repository)
         {
             return Path.Combine(GetTestDataRepositoriesRootDirectory(), developer, org, repository);
+        }
+
+        public static string[] GetRepositoryFileNames(string developer, string org, string repository, string searchPattern)
+        {
+            return Directory.GetFiles(GetRepositoryDirectory(developer, org, repository), searchPattern);
         }
 
         public static void DeleteOrgDirectory(string developer, string org)


### PR DESCRIPTION
## Description
Changed source for where resource ids. are collected from.

Created a new service named `GiteaContentLibraryService` which is a service which knows where to get certain types from Gitea. Currently only text resources and code lists. It retrieves files only from any specified `{org}-content` repository.



## Verification
- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
