### PR TITLE
chore: Add spacing to StudioHeading

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioHeading/StudioHeading.module.css
+++ b/frontend/libs/studio-components/src/components/StudioHeading/StudioHeading.module.css
@@ -1,0 +1,3 @@
+.spacing {
+  margin-bottom: var(--ds-size-4);
+}

--- a/frontend/libs/studio-components/src/components/StudioHeading/StudioHeading.tsx
+++ b/frontend/libs/studio-components/src/components/StudioHeading/StudioHeading.tsx
@@ -2,9 +2,23 @@ import React from 'react';
 import type { ReactElement } from 'react';
 import { Heading, type HeadingProps } from '@digdir/designsystemet-react';
 import type { WithoutAsChild } from '../../types/WithoutAsChild';
+import classes from './StudioHeading.module.css';
+import cn from 'classnames';
 
-export type StudioHeadingProps = WithoutAsChild<HeadingProps>;
+export type StudioHeadingProps = WithoutAsChild<HeadingProps> & {
+  spacing?: boolean;
+};
 
-export function StudioHeading({ children, ...rest }: StudioHeadingProps): ReactElement {
-  return <Heading {...rest}>{children}</Heading>;
+export function StudioHeading({
+  children,
+  spacing = false,
+  ...rest
+}: StudioHeadingProps): ReactElement {
+  const className = cn(rest.className, { [classes.spacing]: spacing });
+
+  return (
+    <Heading {...rest} className={className}>
+      {children}
+    </Heading>
+  );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adding the `spacing` prop to the `StudioHeading` component

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional spacing property to the StudioHeading component, allowing users to add extra bottom margin when desired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->