### PR TITLE
feat: support text component in studio

### DIFF
--- a/frontend/language/src/nb.json
+++ b/frontend/language/src/nb.json
@@ -1759,6 +1759,7 @@
   "ux_editor.component_title.Subform": "Tabell for underskjema",
   "ux_editor.component_title.Summary": "Oppsummering",
   "ux_editor.component_title.Summary2": "Oppsummering",
+  "ux_editor.component_title.Text": "Tekst",
   "ux_editor.component_title.TextArea": "Stort tekstfelt",
   "ux_editor.component_unknown": "Ukjent komponent",
   "ux_editor.config.warning_duplicates.heading": "Du har den samme ID-en på flere komponenter",

--- a/frontend/packages/shared/src/types/ComponentType.ts
+++ b/frontend/packages/shared/src/types/ComponentType.ts
@@ -41,6 +41,7 @@ export enum ComponentType {
   Subform = 'Subform',
   Summary = 'Summary',
   Summary2 = 'Summary2',
+  Text = 'Text',
   TextArea = 'TextArea',
   Divider = 'Divider',
 }

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.test.tsx
@@ -108,6 +108,12 @@ describe('ComponentMainConfig', () => {
     expect(actionButtonConfigText).toBeInTheDocument();
   });
 
+  it('should render text config when the component type matches', () => {
+    renderComponentMainConfig(mainConfigComponentMock(ComponentType.Text), true);
+    const textConfigValue = screen.getByText(textMock('ux_editor.component_properties.value'));
+    expect(textConfigValue).toBeInTheDocument();
+  });
+
   it('should not render any config when the component type does not match', () => {
     renderComponentMainConfig(component1Mock);
     const wrapper = screen.getByTestId('component-wrapper');

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.tsx
@@ -13,6 +13,7 @@ import { LinkMainConfig } from './SpecificMainConfig/LinkMainConfig';
 import { PanelMainConfig } from './SpecificMainConfig/PanelMainConfig';
 import { TitleMainConfig } from './SpecificMainConfig/TitleMainConfig';
 import { CustomButtonMainConfig } from './SpecificMainConfig/CustomButtonMainConfig';
+import { TextMainConfig } from './SpecificMainConfig/TextMainConfig';
 
 export type ComponentMainConfigProps = {
   component: FormItem;
@@ -96,6 +97,14 @@ export const ComponentMainConfig = ({
     case ComponentType.Header:
       return (
         <TitleMainConfig
+          component={component}
+          handleComponentChange={handleComponentChange}
+          className={classes.mainConfigWrapper}
+        />
+      );
+    case ComponentType.Text:
+      return (
+        <TextMainConfig
           component={component}
           handleComponentChange={handleComponentChange}
           className={classes.mainConfigWrapper}

--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/SpecificMainConfig/TextMainConfig.tsx
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/SpecificMainConfig/TextMainConfig.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useComponentSchemaQuery } from '@altinn/ux-editor/hooks/queries/useComponentSchemaQuery';
+import { ConfigStringProperties } from '../../../config/ConfigProperties/ConfigStringProperties';
+import type { FormItem } from '@altinn/ux-editor/types/FormItem';
+import type { ComponentType } from 'app-shared/types/ComponentType';
+import type { properties } from '../../../../testing/schemas/json/component/Text.schema.v1.json';
+
+type TextMainProperties = (keyof typeof properties)[];
+const textMainProperties: TextMainProperties = ['value'];
+
+export type TextMainConfigProps = {
+  component: FormItem<ComponentType.Text>;
+  handleComponentChange: (component: FormItem<ComponentType.Text>) => void;
+  className?: string;
+};
+export const TextMainConfig = ({
+  component,
+  handleComponentChange,
+  className,
+}: TextMainConfigProps): JSX.Element => {
+  const { data: schema } = useComponentSchemaQuery(component.type);
+
+  return (
+    <ConfigStringProperties
+      component={component}
+      handleComponentUpdate={handleComponentChange}
+      schema={schema}
+      stringPropertyKeys={textMainProperties}
+      className={className}
+    />
+  );
+};

--- a/frontend/packages/ux-editor/src/data/formItemConfig.ts
+++ b/frontend/packages/ux-editor/src/data/formItemConfig.ts
@@ -492,6 +492,13 @@ export const formItemConfigs: FormItemConfigs = {
     propertyPath: 'definitions/summary2Component',
     icon: FileTextIcon,
   },
+  [ComponentType.Text]: {
+    name: ComponentType.Text,
+    itemType: LayoutItemType.Component,
+    defaultProperties: {},
+    propertyPath: 'definitions/textComponent',
+    icon: TextIcon,
+  },
   [ComponentType.TextArea]: {
     name: ComponentType.TextArea,
     itemType: LayoutItemType.Component,
@@ -563,6 +570,7 @@ export const textComponents: FormItemConfigs[ComponentType][] = [
   formItemConfigs[ComponentType.Paragraph],
   formItemConfigs[ComponentType.Panel],
   formItemConfigs[ComponentType.Alert],
+  formItemConfigs[ComponentType.Text],
 ];
 
 export const confOnScreenComponents: FormItemConfigs[ComponentType][] = [
@@ -603,6 +611,7 @@ export const allComponents: KeyValuePairs<ComponentType[]> = {
     ComponentType.Panel,
     ComponentType.Alert,
     ComponentType.Divider,
+    ComponentType.Text,
   ],
   select: [
     ComponentType.Checkboxes,

--- a/frontend/packages/ux-editor/src/testing/componentSchemaMocks.ts
+++ b/frontend/packages/ux-editor/src/testing/componentSchemaMocks.ts
@@ -41,6 +41,7 @@ import RepeatingGroupSchema from './schemas/json/component/RepeatingGroup.schema
 import SubformSchema from './schemas/json/component/Subform.schema.v1.json';
 import SummarySchema from './schemas/json/component/Summary.schema.v1.json';
 import Summary2Schema from './schemas/json/component/Summary2.schema.v1.json';
+import TextSchema from './schemas/json/component/Text.schema.v1.json';
 import TextAreaSchema from './schemas/json/component/TextArea.schema.v1.json';
 import { ComponentType } from 'app-shared/types/ComponentType';
 import type { JsonSchema } from 'app-shared/types/JsonSchema';
@@ -88,6 +89,7 @@ export const componentSchemaMocks: Record<ComponentType, JsonSchema> = {
   [ComponentType.Subform]: SubformSchema,
   [ComponentType.Summary]: SummarySchema,
   [ComponentType.Summary2]: Summary2Schema,
+  [ComponentType.Text]: TextSchema,
   [ComponentType.TextArea]: TextAreaSchema,
   [ComponentType.Divider]: Divider,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR enables support for Text component in studio, and also moving up its required property `value` to main config.
Closes #15656

<img width="1533" height="552" alt="image" src="https://github.com/user-attachments/assets/42072f47-3992-42d5-a07f-fcf1bbdd4e42" />



<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
