### PR TITLE
fix: appConfigLanguageUtils test type error

### DIFF
--- a/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/utils/appConfigLanguageUtils.test.ts
+++ b/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/utils/appConfigLanguageUtils.test.ts
@@ -8,7 +8,7 @@ import { textMock } from '@studio/testing/mocks/i18nMock';
 
 describe('appConfigLanguageUtils', () => {
   describe('mapLanguageKeyToLanguageText', () => {
-    it.each<ValidLanguage>(['nb', 'nn', 'en'])('returns translation key for %s', (lang) => {
+    it.each(['nb', 'nn', 'en'])('returns translation key for %s', (lang: ValidLanguage) => {
       const result = mapLanguageKeyToLanguageText(lang, textMock);
       expect(result).toBe(textMock(`language.${lang}`));
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the type error:
```
frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/utils/appConfigLanguageUtils.test.ts:11:5 - error TS2347: Untyped function calls may not accept type arguments.
11     it.each<ValidLanguage>(['nb', 'nn', 'en'])('returns translation key for %s', (lang) => {
```

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
