### PR TITLE
chore: handle 204 response

### DIFF
--- a/development/utils/gitea-api.js
+++ b/development/utils/gitea-api.js
@@ -17,10 +17,15 @@ module.exports = async (options) => {
       body: options.body ? JSON.stringify(options.body) : undefined,
     });
 
+    console.log(options.method, options.path, response.status, response.statusText);
+
+    if (response.status === 204) {
+      return null; // No content response
+    }
+
     const data = await response.json().catch((err) => {
       console.error('Error:', err);
     });
-    console.log(options.method, options.path, response.status, response.statusText);
     return data;
   } catch (error) {
     console.error('Error:', error);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add explicit handling of 204 No Content response, so we don't try to parse it to json and get error messages in the console.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Handles 204 No Content responses without JSON parsing, returning null for empty bodies.
  * Maintains normal JSON parsing for other responses, improving reliability of API interactions and reducing errors on empty responses.
* **Chores**
  * Streamlined network logging to a single pre-parse entry for clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->