### PR TITLE
Fix(resource-adm): move message for no access list member search results

### DIFF
--- a/frontend/resourceadm/components/AccessListMembers/AccessListMembers.module.css
+++ b/frontend/resourceadm/components/AccessListMembers/AccessListMembers.module.css
@@ -6,11 +6,6 @@
   margin-top: var(--fds-spacing-8);
 }
 
-.noSearchResults {
-  position: absolute;
-  margin-top: 0.5rem;
-}
-
 .spinnerContainer {
   height: 500px; /* height of 10 grid rows (must be equal to height of grid to avoid scroll jumping when changing pagination page) */
 }

--- a/frontend/resourceadm/components/AccessListMembers/AccessListMembers.tsx
+++ b/frontend/resourceadm/components/AccessListMembers/AccessListMembers.tsx
@@ -204,15 +204,6 @@ export const AccessListMembers = ({
                 setSearchText(event.target.value);
               }}
             />
-            <div className={classes.noSearchResults} aria-live='polite'>
-              {resultData?.parties?.length === 0 && (
-                <div>
-                  {isSubPartySearch
-                    ? t('resourceadm.listadmin_search_no_sub_parties')
-                    : t('resourceadm.listadmin_search_no_parties')}
-                </div>
-              )}
-            </div>
             <StudioRadio.Group
               hideLegend
               onChange={() => setIsSubPartySearch((old) => !old)}
@@ -227,6 +218,15 @@ export const AccessListMembers = ({
                 {t('resourceadm.listadmin_sub_parties')}
               </StudioRadio>
             </StudioRadio.Group>
+          </div>
+          <div aria-live='polite'>
+            {resultData?.parties?.length === 0 && (
+              <div>
+                {isSubPartySearch
+                  ? t('resourceadm.listadmin_search_no_sub_parties')
+                  : t('resourceadm.listadmin_search_no_parties')}
+              </div>
+            )}
           </div>
           <AccessListMembersTable
             isHeaderHidden


### PR DESCRIPTION
## Description

Move message shown when no organizations are found for the current search for access list members

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
