### PR TITLE
fix(resource-adm): include resource.identifier as search field in resource dashboard search

### DIFF
--- a/frontend/resourceadm/utils/resourceListUtils/resourceListUtils.test.ts
+++ b/frontend/resourceadm/utils/resourceListUtils/resourceListUtils.test.ts
@@ -1,42 +1,42 @@
 import { filterTableData } from './resourceListUtils';
 import type { ResourceListItem } from 'app-shared/types/ResourceAdm';
 
+const dataToFilter: ResourceListItem[] = [
+  {
+    title: { nb: 'Test', nn: 'Test', en: 'Test' },
+    createdBy: 'William',
+    lastChanged: new Date('2023-08-24'),
+    identifier: 'resource-id',
+    environments: ['gitea'],
+  },
+  {
+    title: { nb: 'Test 2', nn: 'Test 2', en: 'Test 2' },
+    createdBy: 'William',
+    lastChanged: new Date('2023-08-24'),
+    identifier: 'res2',
+    environments: ['gitea'],
+  },
+  {
+    title: null,
+    createdBy: 'William',
+    lastChanged: new Date('2023-08-24'),
+    identifier: 'res3',
+    environments: ['gitea'],
+  },
+];
+
+const expectedResult: ResourceListItem[] = [
+  {
+    title: { nb: 'Test 2', nn: 'Test 2', en: 'Test 2' },
+    createdBy: 'William',
+    lastChanged: new Date('2023-08-24'),
+    identifier: 'res2',
+    environments: ['gitea'],
+  },
+];
+
 describe('filterTableData', () => {
   it('Filter out the data searched for', () => {
-    const dataToFilter: ResourceListItem[] = [
-      {
-        title: { nb: 'Test', nn: 'Test', en: 'Test' },
-        createdBy: 'William',
-        lastChanged: new Date('2023-08-24'),
-        identifier: 'resource-id',
-        environments: ['gitea'],
-      },
-      {
-        title: { nb: 'Test 2', nn: 'Test 2', en: 'Test 2' },
-        createdBy: 'William',
-        lastChanged: new Date('2023-08-24'),
-        identifier: 'res2',
-        environments: ['gitea'],
-      },
-      {
-        title: { nb: '123', nn: '123', en: '123' },
-        createdBy: 'William',
-        lastChanged: new Date('2023-08-24'),
-        identifier: 'res3',
-        environments: ['gitea'],
-      },
-    ];
-
-    const expectedResult: ResourceListItem[] = [
-      {
-        title: { nb: 'Test 2', nn: 'Test 2', en: 'Test 2' },
-        createdBy: 'William',
-        lastChanged: new Date('2023-08-24'),
-        identifier: 'resource-id',
-        environments: ['gitea'],
-      },
-    ];
-
     let result = filterTableData('sT 2', dataToFilter);
     expect(result).toEqual(expectedResult);
 
@@ -53,6 +53,11 @@ describe('filterTableData', () => {
     expect(result).toEqual(expectedResult);
 
     result = filterTableData('resource-id', dataToFilter);
-    expect(result).toEqual(expectedResult);
+    expect(result).toEqual([dataToFilter[0]]);
+  });
+
+  it('Retuns all resources when search string is empty', () => {
+    const result = filterTableData('', dataToFilter);
+    expect(result).toEqual(dataToFilter);
   });
 });

--- a/frontend/resourceadm/utils/resourceListUtils/resourceListUtils.ts
+++ b/frontend/resourceadm/utils/resourceListUtils/resourceListUtils.ts
@@ -12,7 +12,10 @@ export const filterTableData = (
   const searchValueLower = searchValue.toLocaleLowerCase();
 
   return list.filter((resource: ResourceListItem) => {
-    const titles = Object.values(resource.title).map((title) => title.toLocaleLowerCase());
+    if (!searchValueLower) {
+      return true; // If no search value, return all resources
+    }
+    const titles = Object.values(resource.title ?? {}).map((title) => title.toLocaleLowerCase());
     const isTitleMatch = titles.some((titleLower) => titleLower.includes(searchValueLower));
     const isIdMatch = resource.identifier.toLocaleLowerCase().includes(searchValueLower);
     return isTitleMatch || isIdMatch;


### PR DESCRIPTION
## Description

- Search field on resource dashboard should also search by resource.identifier (not just resource name)

Issue https://github.com/Altinn/altinn-resource-registry/issues/595

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced resource list filtering: matches on both title and identifier (case-insensitive), handles missing titles, and returns all items when the search is empty.

* **Tests**
  * Standardized test data with distinct identifiers.
  * Added assertions for exact-identifier matches and for empty-search returning all resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->