### PR TITLE
fix: Type errors when using `it.each` and Node v22

### DIFF
--- a/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/utils/appConfigLanguageUtils.test.ts
+++ b/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/utils/appConfigLanguageUtils.test.ts
@@ -8,7 +8,7 @@ import { textMock } from '@studio/testing/mocks/i18nMock';
 
 describe('appConfigLanguageUtils', () => {
   describe('mapLanguageKeyToLanguageText', () => {
-    it.each<ValidLanguage>(['nb', 'nn', 'en'])('returns translation key for %s', (lang) => {
+    it.each(['nb', 'nn', 'en'])('returns translation key for %s', (lang: ValidLanguage) => {
       const result = mapLanguageKeyToLanguageText(lang, textMock);
       expect(result).toBe(textMock(`language.${lang}`));
     });

--- a/frontend/libs/studio-hooks/src/hooks/useOrgAppScopedStorage.test.tsx
+++ b/frontend/libs/studio-hooks/src/hooks/useOrgAppScopedStorage.test.tsx
@@ -1,5 +1,9 @@
 import { renderHook } from '@testing-library/react';
-import { type UseOrgAppScopedStorage, useOrgAppScopedStorage } from './useOrgAppScopedStorage';
+import {
+  type SupportedStorage,
+  type UseOrgAppScopedStorage,
+  useOrgAppScopedStorage,
+} from './useOrgAppScopedStorage';
 import { useParams } from 'react-router-dom';
 
 jest.mock('react-router-dom', () => ({
@@ -9,7 +13,7 @@ jest.mock('react-router-dom', () => ({
 const mockedOrg: string = 'testOrg';
 const mockedApp: string = 'testApp';
 const scopedStorageKey: string = 'testOrg-testApp';
-const storagesToTest: Array<UseOrgAppScopedStorage['storage']> = ['localStorage', 'sessionStorage'];
+const storagesToTest: SupportedStorage[] = ['localStorage', 'sessionStorage'];
 
 describe('useOrgAppScopedStorage', () => {
   afterEach(() => {
@@ -19,7 +23,7 @@ describe('useOrgAppScopedStorage', () => {
 
   it.each(storagesToTest)(
     'initializes ScopedStorageImpl with correct storage scope, %s',
-    (storage) => {
+    (storage: SupportedStorage) => {
       const { result } = renderUseOrgAppScopedStorage({ storage });
 
       result.current.setItem('key', 'value');

--- a/frontend/libs/studio-hooks/src/hooks/useOrgAppScopedStorage.ts
+++ b/frontend/libs/studio-hooks/src/hooks/useOrgAppScopedStorage.ts
@@ -10,13 +10,15 @@ type OrgAppParams = {
   app: string;
 };
 
-const supportedStorageMap: Record<UseOrgAppScopedStorage['storage'], ScopedStorage> = {
+export type SupportedStorage = 'localStorage' | 'sessionStorage';
+
+const supportedStorageMap: Record<SupportedStorage, ScopedStorage> = {
   localStorage: window.localStorage,
   sessionStorage: window.sessionStorage,
 };
 
 export type UseOrgAppScopedStorage = {
-  storage?: 'localStorage' | 'sessionStorage';
+  storage?: SupportedStorage;
 };
 
 type UseOrgAppScopedStorageResult = ScopedStorageResult;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the following type errors for developers with Node v22 LTS:
```
frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/utils/appConfigLanguageUtils.test.ts:11:5 - error TS2347: Untyped function calls may not accept type arguments.
11     it.each<ValidLanguage>(['nb', 'nn', 'en'])('returns translation key for %s', (lang) => {
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
frontend/libs/studio-hooks/src/hooks/useOrgAppScopedStorage.test.tsx:30:30 - error TS2339: Property 'getItem' does not exist on type 'Window'.
30       expect(window[storage].getItem(scopedStorageKey)).toBe('{"key":"value"}');
                                ~~~~~~~
Found 2 errors in 2 files.
```
While these errors don't occur in Node v18 LTS (our current Docker version) or v20 LTS, we should address them to ensure compatibility with Node v22 LTS, which is the latest LTS release.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced a standardized type for supported storage options to improve consistency and maintainability.
  * Aligned related types to use the new storage type across the codebase.

* **Tests**
  * Strengthened type annotations in parameterized tests for clearer intent and better type safety.
  * Updated storage-related tests to use the standardized storage type.

* **Chores**
  * Internal type cleanup only; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->