### PR TITLE
fix: Export StudioProperty from the new component library

### DIFF
--- a/frontend/libs/studio-components/src/components/index.ts
+++ b/frontend/libs/studio-components/src/components/index.ts
@@ -34,6 +34,7 @@ export * from './StudioLinkButton';
 export * from './StudioNotFoundPage';
 export * from './StudioParagraph';
 export * from './StudioPopover';
+export * from './StudioProperty';
 export * from './StudioRadio';
 export * from './StudioRadioGroup';
 export * from './StudioRedirectBox';


### PR DESCRIPTION
## Description
The barrel file export was missed out when copying `StudioProperty` from the legacy component library to the new one. This pull request adds it.

I have added the `skip-manual-testing` label since the component is obviously not yet in use.

## Verification
- Related issue: #15761 (not possible to connect).
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done: Tested by importing the component in another package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * StudioProperty is now exposed through the public components API, enabling direct import alongside other Studio components. This improves discoverability and standardizes import patterns, making it easier to integrate into your UI without relying on internal paths. No behavioral changes to existing components; this is an availability enhancement for broader use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->