### PR TITLE
fix: New text button text wrap

### DIFF
--- a/frontend/packages/text-editor/src/TextEditor.module.css
+++ b/frontend/packages/text-editor/src/TextEditor.module.css
@@ -33,13 +33,14 @@
   align-items: flex-end;
   gap: var(--fds-spacing-4);
   justify-content: flex-end;
-  width: 100%;
+  /*width: 100%;*/
 }
 
 .sortAlphabetically {
   gap: var(--fds-spacing-4);
   display: flex;
   align-items: center;
+  text-wrap: nowrap;
 }
 
 .textEditorBody {

--- a/frontend/packages/text-editor/src/TextEditor.tsx
+++ b/frontend/packages/text-editor/src/TextEditor.tsx
@@ -97,6 +97,7 @@ export const TextEditor = ({
           </StudioButton>
           <div className={classes.filterAndSearch}>
             <Chip.Toggle
+              size='small'
               onClick={() => setSortTextsAlphabetically(!sortTextsAlphabetically)}
               selected={sortTextsAlphabetically}
             >


### PR DESCRIPTION
## Description

On the language page, the "new text" button had gotten a line break, which this PR fixes.

I also noticed that the "sort alphabetically" chip had the default medium size, so it has been changed to small, to align with the other component sizes in Studio.

### Before
<img width="1986" height="319" alt="bilde" src="https://github.com/user-attachments/assets/7fc8c015-eb3e-48d9-9afc-6b81a34124bd" />

### After
<img width="1984" height="317" alt="bilde" src="https://github.com/user-attachments/assets/e9744b63-3158-4dee-87f8-56058f90cbe0" />

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
