### PR TITLE
fix: Adjust font weight on new property button

### DIFF
--- a/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyButton/StudioPropertyButton.module.css
+++ b/frontend/libs/studio-components/src/components/StudioProperty/StudioPropertyButton/StudioPropertyButton.module.css
@@ -2,6 +2,7 @@
   border-radius: 0;
   border: none;
   display: grid;
+  font-weight: normal;
   grid-template-columns: 1fr auto;
   justify-content: flex-start;
   margin: calc(-1 * var(--studio-property-button-vertical-spacing)) 0;
@@ -11,7 +12,6 @@
 
 .propertyButton.withValue .content {
   color: var(--ds-color-neutral-text-default);
-  font-weight: normal;
   text-align: left;
 }
 


### PR DESCRIPTION
## Description
Version 1 of The Design System makes the text in buttons bold by default. However, the text on the `StudioProperty.Button` component should remain normal. This pull request fixes that.

Current:
<img width="310" height="49" alt="image" src="https://github.com/user-attachments/assets/4894973e-652b-4054-92f1-3f348b0a4196" />

This pull request:
<img width="306" height="46" alt="image" src="https://github.com/user-attachments/assets/9f57f14d-9169-4231-9346-cb2b2c39813c" />

I have added the `skip-manual-testing` label since the component is not yet in use.

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardizes Studio Property button text to normal for a consistent appearance across states.
  * When a button has a value, its inner content now inherits font weight, resolving inconsistent bold/normal text and aligning with surrounding typography.
  * Improves visual consistency without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->