### PR TITLE
chore: Move OverridableComponent types

### DIFF
--- a/frontend/libs/studio-components-legacy/src/types/OverridableComponent.ts
+++ b/frontend/libs/studio-components-legacy/src/types/OverridableComponent.ts
@@ -1,6 +1,9 @@
 import type { RefAttributes, FC, ElementType } from 'react';
 import type { OverridableComponentProps } from './OverridableComponentProps';
 
+/**
+ * @deprecated Use `OverridableComponent` from `@studio/components` instead.
+ */
 export type OverridableComponent<ComponentProps, Element extends HTMLElement> = {
   (props: ComponentProps & RefAttributes<Element>): ReturnType<FC>;
   <As extends ElementType>(props: OverridableComponentProps<ComponentProps, As>): ReturnType<FC>;

--- a/frontend/libs/studio-components-legacy/src/types/OverridableComponentProps.ts
+++ b/frontend/libs/studio-components-legacy/src/types/OverridableComponentProps.ts
@@ -1,5 +1,8 @@
 import type { ComponentPropsWithRef, ElementType } from 'react';
 
+/**
+ * @deprecated Use `OverridableComponentProps` from `@studio/components` instead.
+ */
 export type OverridableComponentProps<ComponentProps, As extends ElementType> = {
   as?: As;
 } & ComponentPropsWithRef<As> &

--- a/frontend/libs/studio-components-legacy/src/types/OverridableComponentRef.ts
+++ b/frontend/libs/studio-components-legacy/src/types/OverridableComponentRef.ts
@@ -1,3 +1,6 @@
 import type { ComponentPropsWithRef, ElementType } from 'react';
 
+/**
+ * @deprecated Use `OverridableComponentRef` from `@studio/components` instead.
+ */
 export type OverridableComponentRef<As extends ElementType> = ComponentPropsWithRef<As>['ref'];

--- a/frontend/libs/studio-components-legacy/src/types/Override.ts
+++ b/frontend/libs/studio-components-legacy/src/types/Override.ts
@@ -1,1 +1,4 @@
+/**
+ * @deprecated Use `Override` from `@studio/components` instead.
+ */
 export type Override<Primary, Secondary> = Primary & Omit<Secondary, keyof Primary>;

--- a/frontend/libs/studio-components/src/types/OverridableComponent.ts
+++ b/frontend/libs/studio-components/src/types/OverridableComponent.ts
@@ -1,0 +1,7 @@
+import type { RefAttributes, FC, ElementType } from 'react';
+import type { OverridableComponentProps } from './OverridableComponentProps';
+
+export type OverridableComponent<ComponentProps, Element extends HTMLElement> = {
+  (props: ComponentProps & RefAttributes<Element>): ReturnType<FC>;
+  <As extends ElementType>(props: OverridableComponentProps<ComponentProps, As>): ReturnType<FC>;
+} & Pick<FC, 'displayName'>;

--- a/frontend/libs/studio-components/src/types/OverridableComponentProps.ts
+++ b/frontend/libs/studio-components/src/types/OverridableComponentProps.ts
@@ -1,0 +1,6 @@
+import type { ComponentPropsWithRef, ElementType } from 'react';
+
+export type OverridableComponentProps<ComponentProps, As extends ElementType> = {
+  as?: As;
+} & ComponentPropsWithRef<As> &
+  Omit<ComponentProps, keyof ComponentPropsWithRef<As>>;

--- a/frontend/libs/studio-components/src/types/OverridableComponentRef.ts
+++ b/frontend/libs/studio-components/src/types/OverridableComponentRef.ts
@@ -1,0 +1,3 @@
+import type { ComponentPropsWithRef, ElementType } from 'react';
+
+export type OverridableComponentRef<As extends ElementType> = ComponentPropsWithRef<As>['ref'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Moving the following types from legacy to `@studio/components` to be used in components being moved
  - `OverridableComponent`
  - `OverridableComponentProps`
  - `OverridableComponentRef`


## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Introduced improved typing utilities for polymorphic/overridable components, including prop and ref support and display name preservation. No runtime changes.
* Documentation
  * Marked legacy typings as deprecated with guidance to migrate to the updated package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->