### PR TITLE
feat: (Admin) add process task filter to instances list and use infinite query

### DIFF
--- a/frontend/admin/features/instances/Instances.module.css
+++ b/frontend/admin/features/instances/Instances.module.css
@@ -1,0 +1,4 @@
+.filterWrapper {
+  display: flex;
+  margin-bottom: 1rem;
+}

--- a/frontend/admin/features/instances/Instances.tsx
+++ b/frontend/admin/features/instances/Instances.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classes from './Instances.module.css';
 import { Link, useParams } from 'react-router-dom';
 import { InstancesTable } from './components/InstancesTable';
 import { StudioBreadcrumbs } from '@studio/components';
@@ -28,7 +29,9 @@ export const Instances = () => {
       <h1>
         {env} / {app}
       </h1>
-      <ProcessTaskPicker org={org} env={env} app={app} state={processTaskPickerState} />
+      <div className={classes.filterWrapper}>
+        <ProcessTaskPicker org={org} env={env} app={app} state={processTaskPickerState} />
+      </div>
       <InstancesTable
         org={org}
         env={env}

--- a/frontend/admin/features/instances/Instances.tsx
+++ b/frontend/admin/features/instances/Instances.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { InstancesTable } from './components/InstancesTable';
 import { StudioBreadcrumbs } from '@studio/components';
-import { ProcessTaskPicker } from './components/ProcessTaskPicker';
+import { ProcessTaskPicker, useProcessTaskPicker } from './components/ProcessTaskPicker';
 
 export const Instances = () => {
   const { org, env, app } = useParams();
-  const [currentTaskFilter, setCurrentTaskFilter] = useState<string | null>(null);
+  const processTaskPickerState = useProcessTaskPicker();
 
   return (
     <div>
@@ -28,14 +28,14 @@ export const Instances = () => {
       <h1>
         {env} / {app}
       </h1>
-      <ProcessTaskPicker
+      <ProcessTaskPicker org={org} env={env} app={app} state={processTaskPickerState} />
+      <InstancesTable
         org={org}
         env={env}
         app={app}
-        value={currentTaskFilter}
-        onChange={setCurrentTaskFilter}
+        currentTask={processTaskPickerState.currentTask}
+        processIsComplete={processTaskPickerState.isComplete}
       />
-      <InstancesTable org={org} env={env} app={app} currentTask={currentTaskFilter} />
     </div>
   );
 };

--- a/frontend/admin/features/instances/Instances.tsx
+++ b/frontend/admin/features/instances/Instances.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { InstancesTable } from './components/InstancesTable';
 import { StudioBreadcrumbs } from '@studio/components';
+import { ProcessTaskPicker } from './components/ProcessTaskPicker';
 
 export const Instances = () => {
   const { org, env, app } = useParams();
+  const [currentTaskFilter, setCurrentTaskFilter] = useState<string | null>(null);
+
   return (
     <div>
       <StudioBreadcrumbs>
@@ -25,7 +28,14 @@ export const Instances = () => {
       <h1>
         {env} / {app}
       </h1>
-      <InstancesTable org={org} env={env} app={app} />
+      <ProcessTaskPicker
+        org={org}
+        env={env}
+        app={app}
+        value={currentTaskFilter}
+        onChange={setCurrentTaskFilter}
+      />
+      <InstancesTable org={org} env={env} app={app} currentTask={currentTaskFilter} />
     </div>
   );
 };

--- a/frontend/admin/features/instances/components/InstancesTable.module.css
+++ b/frontend/admin/features/instances/components/InstancesTable.module.css
@@ -1,0 +1,4 @@
+.footerCell {
+  padding: 1rem;
+  text-align: center;
+}

--- a/frontend/admin/features/instances/components/InstancesTable.tsx
+++ b/frontend/admin/features/instances/components/InstancesTable.tsx
@@ -14,14 +14,22 @@ type InstancesTableProps = {
   env: string;
   app: string;
   currentTask?: string;
+  processIsComplete?: boolean;
 };
 
-export const InstancesTable = ({ org, env, app, currentTask }: InstancesTableProps) => {
+export const InstancesTable = ({
+  org,
+  env,
+  app,
+  currentTask,
+  processIsComplete,
+}: InstancesTableProps) => {
   const { data, status, fetchNextPage, hasNextPage } = useAppInstancesQuery(
     org,
     env,
     app,
     currentTask,
+    processIsComplete,
   );
   const { t } = useTranslation();
 

--- a/frontend/admin/features/instances/components/InstancesTable.tsx
+++ b/frontend/admin/features/instances/components/InstancesTable.tsx
@@ -13,10 +13,16 @@ type InstancesTableProps = {
   org: string;
   env: string;
   app: string;
+  currentTask?: string;
 };
 
-export const InstancesTable = ({ org, env, app }: InstancesTableProps) => {
-  const { data, status, fetchNextPage, hasNextPage } = useAppInstancesQuery(org, env, app);
+export const InstancesTable = ({ org, env, app, currentTask }: InstancesTableProps) => {
+  const { data, status, fetchNextPage, hasNextPage } = useAppInstancesQuery(
+    org,
+    env,
+    app,
+    currentTask,
+  );
   const { t } = useTranslation();
 
   switch (status) {
@@ -80,7 +86,9 @@ const InstancesTableWithData = ({
                 <Link to={`${instance.id}`}>{instance.id}</Link>
               </StudioTable.Cell>
               <StudioTable.Cell>{formatDateAndTime(instance.createdAt)}</StudioTable.Cell>
-              <StudioTable.Cell>{instance.currentTask ?? 'Avsluttet'}</StudioTable.Cell>
+              <StudioTable.Cell>
+                {instance.currentTaskName ?? instance.currentTaskId ?? 'Avsluttet'}
+              </StudioTable.Cell>
               <StudioTable.Cell>{getStatus(instance)}</StudioTable.Cell>
             </StudioTable.Row>
           ))}

--- a/frontend/admin/features/instances/components/InstancesTable.tsx
+++ b/frontend/admin/features/instances/components/InstancesTable.tsx
@@ -1,11 +1,13 @@
-import { StudioSpinner, StudioTable } from '@studio/components';
+import { StudioButton, StudioSpinner, StudioTable } from '@studio/components';
+import classes from './InstancesTable.module.css';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StudioError, StudioSearch } from '@studio/components-legacy';
 import { Link } from 'react-router-dom';
 import { useAppInstancesQuery } from 'admin/hooks/queries/useAppInstancesQuery';
-import type { SimpleInstance } from 'admin/types/SimpleInstance';
+import type { SimpleInstance } from 'admin/types/InstancesResponse';
 import { formatDateAndTime } from 'admin/utils/formatDateAndTime';
+import { useMutation } from '@tanstack/react-query';
 
 type InstancesTableProps = {
   org: string;
@@ -14,7 +16,7 @@ type InstancesTableProps = {
 };
 
 export const InstancesTable = ({ org, env, app }: InstancesTableProps) => {
-  const { data, status } = useAppInstancesQuery(org, env, app);
+  const { data, status, fetchNextPage, hasNextPage } = useAppInstancesQuery(org, env, app);
   const { t } = useTranslation();
 
   switch (status) {
@@ -23,17 +25,32 @@ export const InstancesTable = ({ org, env, app }: InstancesTableProps) => {
     case 'error':
       return <StudioError>{t('general.page_error_title')}</StudioError>;
     case 'success':
-      return <InstancesTableWithData instances={data} />;
+      return (
+        <InstancesTableWithData
+          instances={data}
+          hasMoreResults={hasNextPage}
+          fetchMoreResults={fetchNextPage}
+        />
+      );
   }
 };
 
 type InstancesTableWithDataProps = {
   instances: SimpleInstance[];
+  hasMoreResults: boolean;
+  fetchMoreResults: () => Promise<unknown>;
 };
 
-const InstancesTableWithData = ({ instances }: InstancesTableWithDataProps) => {
+const InstancesTableWithData = ({
+  instances,
+  hasMoreResults,
+  fetchMoreResults,
+}: InstancesTableWithDataProps) => {
   const { t } = useTranslation();
   const [search, setSearch] = useState('');
+  const { isPending: isFetchingMoreResults, mutate: doFetchMoreResults } = useMutation({
+    mutationFn: fetchMoreResults,
+  });
 
   const instancesFiltered = instances.filter(
     (instance) => !search || instance.id.toLowerCase().includes(search.toLowerCase()),
@@ -68,6 +85,18 @@ const InstancesTableWithData = ({ instances }: InstancesTableWithDataProps) => {
             </StudioTable.Row>
           ))}
         </StudioTable.Body>
+        {hasMoreResults && (
+          <StudioTable.Foot>
+            <StudioTable.Row>
+              <StudioTable.Cell className={classes.footerCell} colSpan={4}>
+                <StudioButton disabled={isFetchingMoreResults} onClick={() => doFetchMoreResults()}>
+                  {isFetchingMoreResults && <StudioSpinner aria-label={t('general.loading')} />}
+                  {t('Last inn 10 flere rader')}
+                </StudioButton>
+              </StudioTable.Cell>
+            </StudioTable.Row>
+          </StudioTable.Foot>
+        )}
       </StudioTable>
     </>
   );

--- a/frontend/admin/features/instances/components/InstancesTable.tsx
+++ b/frontend/admin/features/instances/components/InstancesTable.tsx
@@ -2,7 +2,7 @@ import { StudioButton, StudioSpinner, StudioTable } from '@studio/components';
 import classes from './InstancesTable.module.css';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StudioError, StudioSearch } from '@studio/components-legacy';
+import { StudioError } from '@studio/components-legacy';
 import { Link } from 'react-router-dom';
 import { useAppInstancesQuery } from 'admin/hooks/queries/useAppInstancesQuery';
 import type { SimpleInstance } from 'admin/types/InstancesResponse';
@@ -61,60 +61,47 @@ const InstancesTableWithData = ({
   fetchMoreResults,
 }: InstancesTableWithDataProps) => {
   const { t } = useTranslation();
-  const [search, setSearch] = useState('');
   const { isPending: isFetchingMoreResults, mutate: doFetchMoreResults } = useMutation({
     mutationFn: fetchMoreResults,
   });
 
-  const instancesFiltered = instances.filter(
-    (instance) => !search || instance.id.toLowerCase().includes(search.toLowerCase()),
-  );
-
   return (
-    <>
-      <StudioSearch
-        value={search}
-        autoComplete='off'
-        onChange={(e) => setSearch(e.target.value)}
-        label={t('Søk på instans-ID')}
-      />
-      <StudioTable zebra>
-        <StudioTable.Head>
-          <StudioTable.Row>
-            <StudioTable.Cell>{t('Id')}</StudioTable.Cell>
-            <StudioTable.Cell>{t('Opprettet')}</StudioTable.Cell>
-            <StudioTable.Cell>{t('Prosessteg')}</StudioTable.Cell>
-            <StudioTable.Cell>{t('Status')}</StudioTable.Cell>
+    <StudioTable zebra>
+      <StudioTable.Head>
+        <StudioTable.Row>
+          <StudioTable.Cell>{t('Id')}</StudioTable.Cell>
+          <StudioTable.Cell>{t('Opprettet')}</StudioTable.Cell>
+          <StudioTable.Cell>{t('Prosessteg')}</StudioTable.Cell>
+          <StudioTable.Cell>{t('Status')}</StudioTable.Cell>
+        </StudioTable.Row>
+      </StudioTable.Head>
+      <StudioTable.Body>
+        {instances.map((instance) => (
+          <StudioTable.Row key={instance.id}>
+            <StudioTable.Cell>
+              <Link to={`${instance.id}`}>{instance.id}</Link>
+            </StudioTable.Cell>
+            <StudioTable.Cell>{formatDateAndTime(instance.createdAt)}</StudioTable.Cell>
+            <StudioTable.Cell>
+              {instance.currentTaskName ?? instance.currentTaskId ?? 'Avsluttet'}
+            </StudioTable.Cell>
+            <StudioTable.Cell>{getStatus(instance)}</StudioTable.Cell>
           </StudioTable.Row>
-        </StudioTable.Head>
-        <StudioTable.Body>
-          {instancesFiltered.map((instance) => (
-            <StudioTable.Row key={instance.id}>
-              <StudioTable.Cell>
-                <Link to={`${instance.id}`}>{instance.id}</Link>
-              </StudioTable.Cell>
-              <StudioTable.Cell>{formatDateAndTime(instance.createdAt)}</StudioTable.Cell>
-              <StudioTable.Cell>
-                {instance.currentTaskName ?? instance.currentTaskId ?? 'Avsluttet'}
-              </StudioTable.Cell>
-              <StudioTable.Cell>{getStatus(instance)}</StudioTable.Cell>
-            </StudioTable.Row>
-          ))}
-        </StudioTable.Body>
-        {hasMoreResults && (
-          <StudioTable.Foot>
-            <StudioTable.Row>
-              <StudioTable.Cell className={classes.footerCell} colSpan={4}>
-                <StudioButton disabled={isFetchingMoreResults} onClick={() => doFetchMoreResults()}>
-                  {isFetchingMoreResults && <StudioSpinner aria-label={t('general.loading')} />}
-                  {t('Last inn 10 flere rader')}
-                </StudioButton>
-              </StudioTable.Cell>
-            </StudioTable.Row>
-          </StudioTable.Foot>
-        )}
-      </StudioTable>
-    </>
+        ))}
+      </StudioTable.Body>
+      {hasMoreResults && (
+        <StudioTable.Foot>
+          <StudioTable.Row>
+            <StudioTable.Cell className={classes.footerCell} colSpan={4}>
+              <StudioButton disabled={isFetchingMoreResults} onClick={() => doFetchMoreResults()}>
+                {isFetchingMoreResults && <StudioSpinner aria-label={t('general.loading')} />}
+                {t('Last inn 10 flere rader')}
+              </StudioButton>
+            </StudioTable.Cell>
+          </StudioTable.Row>
+        </StudioTable.Foot>
+      )}
+    </StudioTable>
   );
 };
 

--- a/frontend/admin/features/instances/components/ProcessTaskPicker.tsx
+++ b/frontend/admin/features/instances/components/ProcessTaskPicker.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { StudioSpinner, StudioSelect } from '@studio/components';
+import { StudioError } from '@studio/components-legacy';
+import { useAppProcessTasks } from 'admin/hooks/queries/useAppProcessTasks';
+import { useTranslation } from 'react-i18next';
+import type { ProcessTask } from 'admin/types/ProcessTask';
+
+type ProcessTaskPickerProps = {
+  org: string;
+  env: string;
+  app: string;
+  value: string | null;
+  onChange: (value: string) => void;
+};
+
+export const ProcessTaskPicker = ({ org, env, app, value, onChange }: ProcessTaskPickerProps) => {
+  const { data, status } = useAppProcessTasks(org, env, app);
+  const { t } = useTranslation();
+
+  switch (status) {
+    case 'pending':
+      return <StudioSpinner aria-label={t('general.loading')} />;
+    case 'error':
+      return <StudioError>{t('general.page_error_title')}</StudioError>;
+    case 'success':
+      return <ProcessTaskPickerWithData processTasks={data} value={value} onChange={onChange} />;
+  }
+};
+
+type ProcessTaskPickerWithDataProps = {
+  processTasks: ProcessTask[];
+  value: string | null;
+  onChange: (value: string) => void;
+};
+
+const ProcessTaskPickerWithData = ({
+  processTasks,
+  value,
+  onChange,
+}: ProcessTaskPickerWithDataProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <StudioSelect
+      label={t('Prosessteg')}
+      value={value}
+      onChange={(e) => onChange(e.target.value || null)}
+    >
+      <StudioSelect.Option value={''}>{t('Alle')}</StudioSelect.Option>
+      {processTasks.map((task) => (
+        <StudioSelect.Option key={task.id} value={task.id}>
+          {task.name}
+        </StudioSelect.Option>
+      ))}
+    </StudioSelect>
+  );
+};

--- a/frontend/admin/hooks/queries/useAppInstancesQuery.ts
+++ b/frontend/admin/hooks/queries/useAppInstancesQuery.ts
@@ -9,13 +9,18 @@ export const useAppInstancesQuery = (
   org: string,
   env: string,
   app: string,
+  currentTask?: string,
 ): UseInfiniteQueryResult<SimpleInstance[]> => {
   return useInfiniteQuery({
     initialPageParam: undefined,
-    queryKey: [QueryKey.AppInstances, org, env, app],
+    queryKey: [QueryKey.AppInstances, org, env, app, currentTask],
     queryFn: async ({ signal, pageParam = null }) =>
-      (await axios.get<InstancesResponse>(instancesListPath(org, env, app, pageParam), { signal }))
-        .data,
+      (
+        await axios.get<InstancesResponse>(
+          instancesListPath(org, env, app, pageParam, currentTask),
+          { signal },
+        )
+      ).data,
     getNextPageParam: (lastPage) => lastPage.continuationToken,
     select: (data) => data.pages.flatMap((page) => page.instances),
   });

--- a/frontend/admin/hooks/queries/useAppInstancesQuery.ts
+++ b/frontend/admin/hooks/queries/useAppInstancesQuery.ts
@@ -10,14 +10,15 @@ export const useAppInstancesQuery = (
   env: string,
   app: string,
   currentTask?: string,
+  processIsComplete?: boolean,
 ): UseInfiniteQueryResult<SimpleInstance[]> => {
   return useInfiniteQuery({
     initialPageParam: undefined,
-    queryKey: [QueryKey.AppInstances, org, env, app, currentTask],
+    queryKey: [QueryKey.AppInstances, org, env, app, currentTask, processIsComplete],
     queryFn: async ({ signal, pageParam = null }) =>
       (
         await axios.get<InstancesResponse>(
-          instancesListPath(org, env, app, pageParam, currentTask),
+          instancesListPath(org, env, app, pageParam, currentTask, processIsComplete),
           { signal },
         )
       ).data,

--- a/frontend/admin/hooks/queries/useAppInstancesQuery.ts
+++ b/frontend/admin/hooks/queries/useAppInstancesQuery.ts
@@ -1,18 +1,22 @@
-import type { UseQueryResult } from '@tanstack/react-query';
-import { useQuery } from '@tanstack/react-query';
+import type { UseInfiniteQueryResult } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import axios from 'axios';
-import type { SimpleInstance } from 'admin/types/SimpleInstance';
+import type { InstancesResponse, SimpleInstance } from 'admin/types/InstancesResponse';
 import { instancesListPath } from 'admin/utils/apiPaths';
 
 export const useAppInstancesQuery = (
   org: string,
   env: string,
   app: string,
-): UseQueryResult<SimpleInstance[]> => {
-  return useQuery<SimpleInstance[]>({
+): UseInfiniteQueryResult<SimpleInstance[]> => {
+  return useInfiniteQuery({
+    initialPageParam: undefined,
     queryKey: [QueryKey.AppInstances, org, env, app],
-    queryFn: async ({ signal }) =>
-      (await axios.get<SimpleInstance[]>(instancesListPath(org, env, app), { signal })).data,
+    queryFn: async ({ signal, pageParam = null }) =>
+      (await axios.get<InstancesResponse>(instancesListPath(org, env, app, pageParam), { signal }))
+        .data,
+    getNextPageParam: (lastPage) => lastPage.continuationToken,
+    select: (data) => data.pages.flatMap((page) => page.instances),
   });
 };

--- a/frontend/admin/hooks/queries/useAppProcessTasks.ts
+++ b/frontend/admin/hooks/queries/useAppProcessTasks.ts
@@ -1,0 +1,22 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import axios from 'axios';
+import { appProcessTasksPath } from 'admin/utils/apiPaths';
+import type { ProcessTask } from 'admin/types/ProcessTask';
+
+export const useAppProcessTasks = (
+  org: string,
+  env: string,
+  app: string,
+): UseQueryResult<ProcessTask[]> => {
+  return useQuery<ProcessTask[]>({
+    queryKey: [QueryKey.AppProcessTasks, org, env, app],
+    queryFn: async ({ signal }) =>
+      (
+        await axios.get<ProcessTask[]>(appProcessTasksPath(org, env, app), {
+          signal,
+        })
+      ).data,
+  });
+};

--- a/frontend/admin/layout/PageLayout.module.css
+++ b/frontend/admin/layout/PageLayout.module.css
@@ -1,0 +1,3 @@
+.pageWrapper {
+  padding: 2rem 4rem;
+}

--- a/frontend/admin/layout/PageLayout.tsx
+++ b/frontend/admin/layout/PageLayout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classes from './PageLayout.module.css';
 import { Outlet, matchPath, useLocation, Navigate } from 'react-router-dom';
 import { PageHeader } from './PageHeader';
 import { useUserQuery } from 'app-shared/hooks/queries';
@@ -6,9 +7,6 @@ import { StudioCenter, StudioPageSpinner } from '@studio/components-legacy';
 import { useTranslation } from 'react-i18next';
 import { useOrgListQuery } from 'app-shared/hooks/queries/useOrgListQuery';
 
-/**
- * Displays the layout for the app development pages
- */
 export const PageLayout = (): React.ReactNode => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
@@ -33,7 +31,9 @@ export const PageLayout = (): React.ReactNode => {
   return (
     <>
       <PageHeader user={user} org={orgs?.[org]} />
-      <Outlet />
+      <div className={classes.pageWrapper}>
+        <Outlet />
+      </div>
     </>
   );
 };

--- a/frontend/admin/types/InstancesResponse.ts
+++ b/frontend/admin/types/InstancesResponse.ts
@@ -1,3 +1,8 @@
+export type InstancesResponse = {
+  instances: SimpleInstance[];
+  continuationToken?: string;
+};
+
 export type SimpleInstance = {
   id: string;
   org: string;

--- a/frontend/admin/types/InstancesResponse.ts
+++ b/frontend/admin/types/InstancesResponse.ts
@@ -7,7 +7,8 @@ export type SimpleInstance = {
   id: string;
   org: string;
   app: string;
-  currentTask?: string;
+  currentTaskName?: string;
+  currentTaskId?: string;
   dueBefore?: string;
   isComplete: boolean;
   completedAt?: string;

--- a/frontend/admin/types/ProcessTask.ts
+++ b/frontend/admin/types/ProcessTask.ts
@@ -1,0 +1,4 @@
+export type ProcessTask = {
+  id: string;
+  name?: string;
+};

--- a/frontend/admin/utils/apiPaths.ts
+++ b/frontend/admin/utils/apiPaths.ts
@@ -1,8 +1,15 @@
 const adminApiBasePath = `/admin/api/v1`;
 
 export const runningAppsPath = (org: string) => `${adminApiBasePath}/applications/${org}`; // Get
-export const instancesListPath = (org: string, env: string, app: string) =>
-  `${adminApiBasePath}/instances/${org}/${env}/${app}`; // Get
+export const instancesListPath = (
+  org: string,
+  env: string,
+  app: string,
+  continuationToken?: string,
+) => {
+  const queryString = getQueryStringFromObject({ continuationToken });
+  return `${adminApiBasePath}/instances/${org}/${env}/${app}${queryString}`; // Get
+};
 export const instancePath = (org: string, env: string, app: string, instanceId: string) =>
   `${adminApiBasePath}/instances/${org}/${env}/${app}/${instanceId}`; // Get
 export const instanceProcessHistoryPath = (
@@ -20,3 +27,17 @@ export const instanceDataElementPath = (
   instanceId: string,
   dataElementId: string,
 ) => `${adminApiBasePath}/instances/${org}/${env}/${app}/${instanceId}/data/${dataElementId}`; // Get
+
+/**
+ * Returns an encoded query string from a key-value object, or an empty string if the object is empty.
+ * Also removes parameters that are empty, null, or undefined.
+ * Example: { a: 'b', c: 'd' } => '?a=b&c=d'
+ * Example: {} => ''
+ * Example: { a: 'b', c: null } => '?a=b'
+ */
+function getQueryStringFromObject(obj: Record<string, string | null | undefined>): string {
+  const cleanObj = Object.fromEntries(Object.entries(obj).filter(([_, value]) => !!value));
+  const queryParams = new URLSearchParams(cleanObj);
+  const queryString = queryParams.toString();
+  return queryString ? `?${queryString}` : '';
+}

--- a/frontend/admin/utils/apiPaths.ts
+++ b/frontend/admin/utils/apiPaths.ts
@@ -6,10 +6,13 @@ export const instancesListPath = (
   env: string,
   app: string,
   continuationToken?: string,
+  currentTask?: string,
 ) => {
-  const queryString = getQueryStringFromObject({ continuationToken });
+  const queryString = getQueryStringFromObject({ continuationToken, currentTask });
   return `${adminApiBasePath}/instances/${org}/${env}/${app}${queryString}`; // Get
 };
+export const appProcessTasksPath = (org: string, env: string, app: string) =>
+  `${adminApiBasePath}/app-resources/${org}/${env}/${app}/process-tasks`; // Get
 export const instancePath = (org: string, env: string, app: string, instanceId: string) =>
   `${adminApiBasePath}/instances/${org}/${env}/${app}/${instanceId}`; // Get
 export const instanceProcessHistoryPath = (

--- a/frontend/admin/utils/apiPaths.ts
+++ b/frontend/admin/utils/apiPaths.ts
@@ -7,8 +7,13 @@ export const instancesListPath = (
   app: string,
   continuationToken?: string,
   currentTask?: string,
+  processIsComplete?: boolean,
 ) => {
-  const queryString = getQueryStringFromObject({ continuationToken, currentTask });
+  const queryString = getQueryStringFromObject({
+    continuationToken,
+    currentTask,
+    processIsComplete: typeof processIsComplete === 'boolean' ? String(processIsComplete) : null,
+  });
   return `${adminApiBasePath}/instances/${org}/${env}/${app}${queryString}`; // Get
 };
 export const appProcessTasksPath = (org: string, env: string, app: string) =>

--- a/frontend/packages/shared/src/types/QueryKey.ts
+++ b/frontend/packages/shared/src/types/QueryKey.ts
@@ -61,6 +61,7 @@ export enum QueryKey {
   // Admin
   AppInstances = 'AppInstances',
   AppInstanceDetails = 'AppInstanceDetails',
+  AppProcessTasks = 'AppProcessTasks',
   ProcessHistory = 'ProcessHistory',
   InstanceEvents = 'InstanceEvents',
   RunningApps = 'RunningApps',

--- a/src/StudioAdmin/Controllers/AppResourcesController.cs
+++ b/src/StudioAdmin/Controllers/AppResourcesController.cs
@@ -1,0 +1,48 @@
+using Altinn.Studio.Admin.Models;
+using Altinn.Studio.Admin.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.Studio.Admin.Controllers;
+
+[ApiController]
+[Route("admin/api/v1/app-resources")]
+public class AppResourcesController : ControllerBase
+{
+    private readonly IAppResourcesService _appResourcesService;
+    private readonly ILogger<InstancesController> _logger;
+
+    public AppResourcesController(
+        IAppResourcesService appResourcesService,
+        ILogger<InstancesController> logger
+    )
+    {
+        _appResourcesService = appResourcesService;
+        _logger = logger;
+    }
+
+    [HttpGet("{org}/{env}/{app}/process-tasks")]
+    public async Task<ActionResult<IEnumerable<ProcessTask>>> GetProcessTasks(
+        string org,
+        string env,
+        string app,
+        CancellationToken ct
+    )
+    {
+        try
+        {
+            return Ok(await _appResourcesService.GetProcessTasks(org, env, app, ct));
+        }
+        catch (HttpRequestException ex)
+        {
+            return StatusCode((int?)ex.StatusCode ?? 500);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (OperationCanceledException)
+        {
+            return StatusCode(499);
+        }
+    }
+}

--- a/src/StudioAdmin/Controllers/InstancesController.cs
+++ b/src/StudioAdmin/Controllers/InstancesController.cs
@@ -23,12 +23,13 @@ public class InstancesController : ControllerBase
         string org,
         string env,
         string app,
+        [FromQuery] string? continuationToken,
         CancellationToken ct
     )
     {
         try
         {
-            return Ok(await _storageService.GetInstances(org, env, app, ct));
+            return Ok(await _storageService.GetInstances(org, env, app, continuationToken, ct));
         }
         catch (HttpRequestException ex)
         {

--- a/src/StudioAdmin/Controllers/InstancesController.cs
+++ b/src/StudioAdmin/Controllers/InstancesController.cs
@@ -25,6 +25,7 @@ public class InstancesController : ControllerBase
         string app,
         [FromQuery] string? continuationToken,
         [FromQuery] string? currentTask,
+        [FromQuery] bool? processIsComplete,
         CancellationToken ct
     )
     {
@@ -37,6 +38,7 @@ public class InstancesController : ControllerBase
                     app,
                     continuationToken,
                     currentTask,
+                    processIsComplete,
                     ct
                 )
             );

--- a/src/StudioAdmin/Controllers/InstancesController.cs
+++ b/src/StudioAdmin/Controllers/InstancesController.cs
@@ -24,12 +24,22 @@ public class InstancesController : ControllerBase
         string env,
         string app,
         [FromQuery] string? continuationToken,
+        [FromQuery] string? currentTask,
         CancellationToken ct
     )
     {
         try
         {
-            return Ok(await _storageService.GetInstances(org, env, app, continuationToken, ct));
+            return Ok(
+                await _storageService.GetInstances(
+                    org,
+                    env,
+                    app,
+                    continuationToken,
+                    currentTask,
+                    ct
+                )
+            );
         }
         catch (HttpRequestException ex)
         {

--- a/src/StudioAdmin/Models/InstancesResponse.cs
+++ b/src/StudioAdmin/Models/InstancesResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Studio.Admin.Models;
+
+public class InstancesResponse
+{
+    [JsonPropertyName("instances")]
+    public required List<SimpleInstance> Instances { get; set; }
+
+    [JsonPropertyName("continuationToken")]
+    public string? ContinuationToken { get; set; }
+}

--- a/src/StudioAdmin/Models/ProcessTask.cs
+++ b/src/StudioAdmin/Models/ProcessTask.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Studio.Admin.Models;
+
+public class ProcessTask
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+}

--- a/src/StudioAdmin/Models/SimpleInstance.cs
+++ b/src/StudioAdmin/Models/SimpleInstance.cs
@@ -14,8 +14,11 @@ public class SimpleInstance
     [JsonPropertyName("app")]
     public required string App { get; set; }
 
-    [JsonPropertyName("currentTask")]
-    public string? CurrentTask { get; set; }
+    [JsonPropertyName("currentTaskName")]
+    public string? CurrentTaskName { get; set; }
+
+    [JsonPropertyName("currentTaskId")]
+    public string? CurrentTaskId { get; set; }
 
     [JsonPropertyName("dueBefore")]
     public DateTimeOffset? DueBefore { get; set; }
@@ -80,7 +83,8 @@ public class SimpleInstance
             Id = instance.Id.Substring(partyIdPrefix.Length),
             Org = instance.Org,
             App = instance.AppId.Substring(orgPrefix.Length),
-            CurrentTask = instance.Process.CurrentTask?.Name,
+            CurrentTaskName = instance.Process.CurrentTask?.Name,
+            CurrentTaskId = instance.Process.CurrentTask?.ElementId,
             DueBefore = instance.DueBefore,
             IsComplete = instance.Process.Ended != null,
             CompletedAt = instance.Process.Ended,

--- a/src/StudioAdmin/Program.cs
+++ b/src/StudioAdmin/Program.cs
@@ -23,6 +23,7 @@ builder.Services.AddHttpClient<ICdnConfigService, CdnConfigService>();
 builder.Services.AddHttpClient<TestToolsTokenGeneratorService>();
 builder.Services.AddHttpClient<IStorageService, TestStorageService>();
 builder.Services.AddHttpClient<IApplicationsService, ApplicationsService>();
+builder.Services.AddHttpClient<IAppResourcesService, AppResourcesService>();
 builder.Services.AddControllers();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi

--- a/src/StudioAdmin/Services/AppResourcesService.cs
+++ b/src/StudioAdmin/Services/AppResourcesService.cs
@@ -1,0 +1,49 @@
+using System.Xml.Linq;
+using Altinn.Studio.Admin.Models;
+using Altinn.Studio.Admin.Services.Interfaces;
+
+namespace Altinn.Studio.Admin.Services;
+
+class AppResourcesService : IAppResourcesService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ICdnConfigService _cdnConfigService;
+
+    private readonly XNamespace BPMN = "http://www.omg.org/spec/BPMN/20100524/MODEL";
+
+    public AppResourcesService(HttpClient httpClient, ICdnConfigService cdnConfigService)
+    {
+        _httpClient = httpClient;
+        _cdnConfigService = cdnConfigService;
+    }
+
+    public async Task<IEnumerable<ProcessTask>> GetProcessTasks(
+        string org,
+        string env,
+        string app,
+        CancellationToken ct
+    )
+    {
+        var appsBaseUrl = await _cdnConfigService.GetAppsBaseUrl(org, env);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"{appsBaseUrl}/{org}/{app}/api/v1/meta/process"
+        );
+        var response = await _httpClient.SendAsync(request);
+
+        response.EnsureSuccessStatusCode();
+        string responseString = await response.Content.ReadAsStringAsync();
+        XDocument processXml = XDocument.Parse(responseString);
+
+        ct.ThrowIfCancellationRequested();
+
+        return processXml
+            .Descendants(BPMN + "task")
+            .Select(e => new ProcessTask()
+            {
+                Id = (string?)e.Attribute("id") ?? throw new NullReferenceException($"A process task id in the app {org}/{env}/{app} was null."),
+                Name = (string?)e.Attribute("name"),
+            });
+    }
+}

--- a/src/StudioAdmin/Services/ApplicationsService.cs
+++ b/src/StudioAdmin/Services/ApplicationsService.cs
@@ -36,8 +36,6 @@ public class ApplicationsService : IApplicationsService
 
         var tasks = orgEnvironments.Select(async env =>
         {
-            ct.ThrowIfCancellationRequested();
-
             var appsBaseUrl = await _cdnConfigService.GetAppsBaseUrl(org, env);
             var response = await _httpClient.GetAsync(
                 $"{appsBaseUrl}/kuberneteswrapper/api/v1/deployments"
@@ -45,6 +43,7 @@ public class ApplicationsService : IApplicationsService
             response.EnsureSuccessStatusCode();
 
             var deployments = await response.Content.ReadFromJsonAsync<List<Deployment>>();
+            ct.ThrowIfCancellationRequested();
             if (deployments == null)
             {
                 return;

--- a/src/StudioAdmin/Services/Interfaces/IAppResourcesService.cs
+++ b/src/StudioAdmin/Services/Interfaces/IAppResourcesService.cs
@@ -1,0 +1,14 @@
+using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Studio.Admin.Models;
+
+namespace Altinn.Studio.Admin.Services.Interfaces;
+
+public interface IAppResourcesService
+{
+    public Task<IEnumerable<ProcessTask>> GetProcessTasks(
+        string org,
+        string env,
+        string app,
+        CancellationToken ct
+    );
+}

--- a/src/StudioAdmin/Services/Interfaces/IStorageService.cs
+++ b/src/StudioAdmin/Services/Interfaces/IStorageService.cs
@@ -25,6 +25,7 @@ public interface IStorageService
         string env,
         string app,
         string? continuationToken,
+        string? currentTaskFilter,
         CancellationToken ct
     );
 

--- a/src/StudioAdmin/Services/Interfaces/IStorageService.cs
+++ b/src/StudioAdmin/Services/Interfaces/IStorageService.cs
@@ -20,10 +20,11 @@ public interface IStorageService
     /// <param name="app">The application identifier.</param>
     /// <returns>The task result contains a list of <see cref="SimpleInstance"/> objects representing the instances.
     /// </returns>
-    public Task<List<SimpleInstance>> GetInstances(
+    public Task<InstancesResponse> GetInstances(
         string org,
         string env,
         string app,
+        string? continuationToken,
         CancellationToken ct
     );
 

--- a/src/StudioAdmin/Services/Interfaces/IStorageService.cs
+++ b/src/StudioAdmin/Services/Interfaces/IStorageService.cs
@@ -26,6 +26,7 @@ public interface IStorageService
         string app,
         string? continuationToken,
         string? currentTaskFilter,
+        bool? processIsCompleteFilter,
         CancellationToken ct
     );
 

--- a/src/StudioAdmin/Services/TestStorageService.cs
+++ b/src/StudioAdmin/Services/TestStorageService.cs
@@ -42,6 +42,7 @@ class TestStorageService : IStorageService
         string app,
         string? continuationToken,
         string? currentTaskFilter,
+        bool? processIsCompleteFilter,
         CancellationToken ct
     )
     {
@@ -63,6 +64,7 @@ class TestStorageService : IStorageService
                 ["size"] = $"{SIZE}",
                 ["continuationToken"] = continuationToken,
                 ["process.currentTask"] = currentTaskFilter,
+                ["process.isComplete"] = processIsCompleteFilter != null ? processIsCompleteFilter.ToString() : null,
             }
         );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Part of #15638
- Instead of an arbitrary cutoff for fetching instances, I now return the continuationToken to the client and allow the client to request more instances for a given query.
- Add support for filtering instances on `currentTask` and `isComplete` with a dropdown.
  - Maybe the `isComplete` filter should be moved to some form of status filter in the future when that gets added? That would simplify the logic here a bit, but on the other hand it makes intuitive sense to have it here, since you cannot both be in a specific task and have the isComplete status 🤔 

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
