### PR TITLE
fix(resource-adm): Design og andre forbedringer for samtykkeressurs i ressursregisteret

### DIFF
--- a/frontend/packages/policy-editor/src/components/ConsentResourcePolicyRulesEditor/ConsentResourcePolicyRulesEditor.module.css
+++ b/frontend/packages/policy-editor/src/components/ConsentResourcePolicyRulesEditor/ConsentResourcePolicyRulesEditor.module.css
@@ -18,7 +18,7 @@
   border-bottom: 0;
   min-height: var(--ds-size-12);
   align-items: center;
-  margin-top: var(--ds-size-8);
+  margin-bottom: var(--ds-size-8);
   font-weight: 500;
 }
 .allOrganizationsItemLabel {

--- a/frontend/packages/policy-editor/src/components/ConsentResourcePolicyRulesEditor/ConsentResourcePolicyRulesEditor.tsx
+++ b/frontend/packages/policy-editor/src/components/ConsentResourcePolicyRulesEditor/ConsentResourcePolicyRulesEditor.tsx
@@ -133,6 +133,16 @@ const RequestConsentPolicyRule = ({ policyRule }: RequestConsentPolicyRuleProps)
         description={t('policy_editor.consent_resource_request_consent_description')}
       >
         <div>
+          <StudioCheckbox
+            value={organizationSubject.subjectId}
+            label={
+              <span className={classes.allOrganizationsItemLabel}>
+                {t('policy_editor.consent_resource_all_organizations')}
+              </span>
+            }
+            className={cn(classes.accessListItem, classes.allOrganizationsItem)}
+            {...getCheckboxProps(organizationSubject.subjectId)}
+          />
           {accessListSubjects.length === 0 && (
             <StudioAlert>{t('policy_editor.consent_resource_no_access_lists')}</StudioAlert>
           )}
@@ -146,16 +156,6 @@ const RequestConsentPolicyRule = ({ policyRule }: RequestConsentPolicyRuleProps)
               {...getCheckboxProps(subject.subjectId)}
             />
           ))}
-          <StudioCheckbox
-            value={organizationSubject.subjectId}
-            label={
-              <span className={classes.allOrganizationsItemLabel}>
-                {t('policy_editor.consent_resource_all_organizations')}
-              </span>
-            }
-            className={cn(classes.accessListItem, classes.allOrganizationsItem)}
-            {...getCheckboxProps(organizationSubject.subjectId)}
-          />
           {hasSubjectError && (
             <StudioValidationMessage>
               {t('policy_editor.consent_resource_request_consent_error')}

--- a/frontend/resourceadm/components/ResourcePageInputs/ResourceLanguageTextField.tsx
+++ b/frontend/resourceadm/components/ResourcePageInputs/ResourceLanguageTextField.tsx
@@ -132,7 +132,7 @@ export const ResourceLanguageTextField = ({
   };
 
   const onAddMarkdownLink = (): void => {
-    onAddMarkdown('[Link](https://altinn.no)', 'Link');
+    onAddMarkdown('[Lenketekst](https://altinn.no)', 'Link');
   };
 
   const onAddMarkdownList = (): void => {

--- a/frontend/resourceadm/language/src/nb.json
+++ b/frontend/resourceadm/language/src/nb.json
@@ -42,6 +42,7 @@
   "resourceadm.about_resource_error_translation_missing_consent_text_en": "Det mangler oversettelse for samtykketekst på engelsk",
   "resourceadm.about_resource_error_translation_missing_consent_text_nn": "Det mangler oversettelse for samtykketekst på nynorsk",
   "resourceadm.about_resource_error_unknown_metadata_language": "Metadata-verdi {{unknownMetadataValues}} er ikke definert i feltet samtykkemetadata for {{lang1}}",
+  "resourceadm.about_resource_error_consent_text_link_invalid": "Lenken {{link}} er ugyldig",
   "resourceadm.about_resource_homepage_label": "Hjemmeside",
   "resourceadm.about_resource_homepage_text": "Lenke til informasjon om hvor sluttbrukerne kan finne tjenesten og informasjon om den.",
   "resourceadm.about_resource_identifier_description": "Dette er en unik ID for ressursen både i URL-er og i API-er.",

--- a/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
+++ b/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
@@ -235,13 +235,13 @@ export const AboutResourcePage = ({
               }
               toggleTextTranslationKey='resourceadm.about_resource_one_time_consent_show_text'
             />
-            {consentTemplates && resourceData.consentTemplate && consentPreviewText && (
+            {consentTemplates && resourceData.consentTemplate && (
               <ConsentPreview
                 template={consentTemplates.find(
                   (template) => template.id === resourceData.consentTemplate,
                 )}
                 resourceName={resourceData.title}
-                consentText={consentPreviewText}
+                consentText={consentPreviewText ?? { nb: '', nn: '', en: '' }}
                 consentMetadata={resourceData.consentMetadata ?? {}}
                 isOneTimeConsent={resourceData.isOneTimeConsent}
                 language={previewLanguage}

--- a/frontend/resourceadm/utils/resourceUtils/resourceUtils.test.tsx
+++ b/frontend/resourceadm/utils/resourceUtils/resourceUtils.test.tsx
@@ -252,6 +252,33 @@ describe('deepCompare', () => {
           ),
         ).toBeTruthy();
       });
+
+      it('should return error for invalid links in nb consentText field', () => {
+        const invalidLink = '[Link](htttps://altinn.no)';
+        const resource: Resource = {
+          identifier: 'res',
+          resourceType: 'Consent',
+          title: null,
+          consentMetadata: {},
+          consentText: {
+            nb: `test ${invalidLink}`,
+            nn: 'test',
+            en: 'test',
+          },
+        };
+        const validationErrors = validateResource(resource, textMock);
+
+        expect(
+          hasConsentFieldError(
+            validationErrors,
+            'nb',
+            textMock('resourceadm.about_resource_error_consent_text_link_invalid', {
+              link: invalidLink,
+              interpolation: { escapeValue: false },
+            }),
+          ),
+        ).toBeTruthy();
+      });
     });
 
     it('should show empty errors for contactPoints and resourceReferences', () => {


### PR DESCRIPTION
## Description
- add simple validation for consent metadata links
- show consent preview even if consentText is empty
- change default text for consent markdown link
- show "Samtykketjenesten skal ikke begrenses av tilgangslister" checkbox above access list list

Issue https://github.com/Altinn/altinn-access-management-frontend/issues/1545

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
