### PR TITLE
fix: MainConfig property button alignment

### DIFF
--- a/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.module.css
+++ b/frontend/packages/ux-editor/src/components/Properties/PropertiesHeader/ComponentMainConfig.module.css
@@ -1,3 +1,3 @@
 .mainConfigWrapper {
-  padding-inline: var(--fds-spacing-5);
+  padding-inline: var(--ds-size-5);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aligns the property buttons below by changing a css value from `--fds-spacing-5` to `--ds-size-5`. 

| Before | After |
| ----- | ----- |
|<img width="776" height="399" alt="bilde" src="https://github.com/user-attachments/assets/060ec94a-dc8b-4eb1-832b-c9aaa6fba11c" /> | <img width="776" height="400" alt="bilde" src="https://github.com/user-attachments/assets/2fb8f0c1-630f-48cf-8ef0-e103ca684449" /> |

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated padding in the Component Properties header’s main configuration section to align with current design system spacing tokens.
  - Results in slightly refined horizontal spacing for improved alignment and visual consistency.
  - No functional changes; purely visual polish to enhance readability and coherence across the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->