### PR TITLE
fix: Add hideLegend prop to new fieldset component

### DIFF
--- a/src/Designer/frontend/libs/studio-components/src/components/StudioFieldset/StudioFieldset.module.css
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioFieldset/StudioFieldset.module.css
@@ -3,5 +3,15 @@
 }
 
 .fieldset.withHiddenLegend > legend {
-  display: none;
+  block-size: 1px;
+  border: 0;
+  clip-path: inset(50%);
+  clip: rect(0 0 0 0);
+  display: block;
+  inline-size: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
 }

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioFieldset/StudioFieldset.module.css
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioFieldset/StudioFieldset.module.css
@@ -1,3 +1,7 @@
 .fieldset > legend {
   display: contents;
 }
+
+.fieldset.withHiddenLegend > legend {
+  display: none;
+}

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioFieldset/StudioFieldset.stories.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioFieldset/StudioFieldset.stories.tsx
@@ -1,32 +1,34 @@
 import React from 'react';
-import type { ReactElement } from 'react';
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { StudioFieldset } from './';
 import { StudioTextfield } from '../StudioTextfield';
 
-const ComposedComponent = (args): ReactElement => (
-  <StudioFieldset {...args}>
-    <StudioTextfield label='Tekstfelt' />
-  </StudioFieldset>
-);
-
-type Story = StoryFn<typeof ComposedComponent>;
-
 const meta: Meta = {
   title: 'Components/StudioFieldset',
-  component: ComposedComponent,
-  argTypes: {
-    'data-size': {
-      control: 'select',
-      options: ['sm', 'md', 'lg'],
-    },
+  component: StudioFieldset,
+};
+
+type Story = StoryObj<typeof meta>;
+
+const defaultArgs: Story['args'] = {
+  children: (
+    <>
+      <StudioTextfield label='Tekstfelt 1' />
+      <StudioTextfield label='Tekstfelt 2' />
+    </>
+  ),
+  legend: 'Legend',
+};
+
+export const Preview: Story = {
+  args: defaultArgs,
+};
+
+export const WithHiddenLegend = {
+  args: {
+    ...defaultArgs,
+    hideLegend: true,
   },
 };
-export const Preview: Story = (args): ReactElement => <ComposedComponent {...args} />;
 
-Preview.args = {
-  'data-size': 'sm',
-  legend: 'My legend',
-  description: 'My description',
-};
 export default meta;

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioFieldset/StudioFieldset.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioFieldset/StudioFieldset.test.tsx
@@ -21,9 +21,9 @@ describe('StudioFieldset', () => {
     testCustomAttributes(renderFieldset);
   });
 
-  it('Renders the legend ', () => {
+  it('Renders a group element connected to the given legend', () => {
     renderFieldset();
-    expect(screen.getByText(legend)).toBeInTheDocument();
+    expect(screen.getByRole('group')).toHaveAccessibleName(legend);
   });
 
   it('Renders the description ', () => {
@@ -31,6 +31,19 @@ describe('StudioFieldset', () => {
     renderFieldset({ description });
     expect(screen.getByText(description)).toBeInTheDocument();
   });
+
+  it('Renders with the withHiddenLegend class when hideLegend is true', () => {
+    renderFieldset({ hideLegend: true });
+    expect(screen.getByRole('group')).toHaveClass('withHiddenLegend');
+  });
+
+  it.each([false, undefined])(
+    'Does not render with the withHiddenLegend class when hideLegend is %s',
+    (hideLegend) => {
+      renderFieldset({ hideLegend });
+      expect(screen.getByRole('group')).not.toHaveClass('withHiddenLegend');
+    },
+  );
 });
 
 const legend: string = 'Legend';

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioFieldset/StudioFieldset.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioFieldset/StudioFieldset.tsx
@@ -8,13 +8,21 @@ import cn from 'classnames';
 export type StudioFieldsetProps = FieldsetProps & {
   legend?: ReactNode;
   description?: ReactNode;
+  hideLegend?: boolean;
 };
 
 function StudioFieldset(
-  { children, legend, description, className: givenClass, ...rest }: StudioFieldsetProps,
+  {
+    children,
+    className: givenClass,
+    description,
+    hideLegend = false,
+    legend,
+    ...rest
+  }: StudioFieldsetProps,
   ref: Ref<HTMLFieldSetElement>,
 ): ReactElement {
-  const className = cn(classes.fieldset, givenClass);
+  const className = cn(classes.fieldset, givenClass, hideLegend && classes.withHiddenLegend);
   return (
     <Fieldset className={className} {...rest} ref={ref}>
       {legend && (
@@ -27,6 +35,7 @@ function StudioFieldset(
     </Fieldset>
   );
 }
+
 const ForwardedStudioFieldset = forwardRef(StudioFieldset);
 
 export { ForwardedStudioFieldset as StudioFieldset };


### PR DESCRIPTION
## Description
The lagecy `StudioFieldset` component has a `hideLegend` prop that hides the legend visually while keeping it accessible in the DOM. We use this extensively in Studio. It is based on the built-in prop from the corresponding component in version 0 of The Design System. In version 1, such prop does not exist, so we need to implement it ourselves in the new component library. I have fixed that in this pull request. I have also simplified the `stories` file to use the `StoryObj` format and added a story where the legend is hidden.

I have added the `skip-manual-testing` label since the new component is not yet in use with `hideLegend`.

Here is what the component looks like in Storybook with `legend='Legend'` and `hideLabel={true}`:
<img width="619" height="311" alt="image" src="https://github.com/user-attachments/assets/0fcfeff4-8bed-48fc-81f5-22a0d740d8af" />

And this is the accessibility tree of the same component:
<img width="265" height="214" alt="image" src="https://github.com/user-attachments/assets/ee67e8c9-aa01-429a-8787-137dd95db89a" />

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to hide a fieldset legend for cleaner UIs.

* **Tests**
  * Updated accessibility checks to assert group accessible name.
  * Added tests verifying hidden-legend behavior and class application.

* **Chores**
  * Migrated Storybook stories to the newer format and added an example demonstrating the hidden-legend option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->