### PR TITLE
fix: multiple isues with org and app repo

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/Organisation/OrgContentController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/Organisation/OrgContentController.cs
@@ -50,7 +50,8 @@ public class OrgContentController : ControllerBase
         }
 
         var editingContext = CreateAltinnOrgContext(orgName);
-        if (!_orgContentService.OrgContentRepoExists(editingContext))
+        bool repositoryExists = await _orgContentService.OrgContentRepoExists(editingContext);
+        if (!repositoryExists)
         {
             HttpContext.Response.Headers["Reason"] = $"{orgName}-content repo does not exist";
             return NoContent();

--- a/src/Designer/backend/src/Designer/Services/Implementation/GiteaAPIWrapper/GiteaAPIWrapper.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/GiteaAPIWrapper/GiteaAPIWrapper.cs
@@ -463,7 +463,12 @@ namespace Altinn.Studio.Designer.Services.Implementation
         public async Task<List<FileSystemObject>> GetDirectoryAsync(string org, string app, string directoryPath, string shortCommitId)
         {
             HttpResponseMessage response = await _httpClient.GetAsync($"repos/{org}/{app}/contents/{directoryPath}?ref={shortCommitId}");
-            return await response.Content.ReadAsAsync<List<FileSystemObject>>();
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                return await response.Content.ReadAsAsync<List<FileSystemObject>>();
+            }
+
+            return [];
         }
 
         /// <inheritdoc/>

--- a/src/Designer/backend/src/Designer/Services/Implementation/OrgContentService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/OrgContentService.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Enums;
@@ -12,21 +11,17 @@ namespace Altinn.Studio.Designer.Services.Implementation;
 /// <inheritdoc />
 public class OrgContentService : IOrgContentService
 {
-    private readonly IAltinnGitRepositoryFactory _altinnGitRepositoryFactory;
     private readonly IGiteaContentLibraryService _giteaContentLibraryService;
 
-    public OrgContentService(IAltinnGitRepositoryFactory altinnGitRepositoryFactory, IGiteaContentLibraryService giteaContentLibraryService)
+    public OrgContentService(IGiteaContentLibraryService giteaContentLibraryService)
     {
-        _altinnGitRepositoryFactory = altinnGitRepositoryFactory;
         _giteaContentLibraryService = giteaContentLibraryService;
     }
 
     /// <inheritdoc />
-    public bool OrgContentRepoExists(AltinnOrgContext context)
+    public async Task<bool> OrgContentRepoExists(AltinnOrgContext context)
     {
-        string contentRepoName = GetContentRepoName(context.Org);
-        string repoPath = _altinnGitRepositoryFactory.GetRepositoryPath(context.Org, contentRepoName, context.DeveloperName);
-        return Directory.Exists(repoPath);
+        return await _giteaContentLibraryService.OrgContentRepoExists(context.Org);
     }
 
     /// <inheritdoc />

--- a/src/Designer/backend/src/Designer/Services/Interfaces/IGiteaContentLibraryService.cs
+++ b/src/Designer/backend/src/Designer/Services/Interfaces/IGiteaContentLibraryService.cs
@@ -7,6 +7,11 @@ namespace Altinn.Studio.Designer.Services.Interfaces;
 public interface IGiteaContentLibraryService
 {
     /// <summary>
+    /// Checks if the repository exists in gitea.
+    /// </summary>
+    /// <param name="orgName">The name of the organisation.</param>
+    public Task<bool> OrgContentRepoExists(string orgName);
+    /// <summary>
     /// Retrieves a code list from the content repository from Gitea with the specified optionListId.
     /// </summary>
     /// <param name="orgName">The name of the organisation.</param>
@@ -14,11 +19,10 @@ public interface IGiteaContentLibraryService
     /// <returns>The code list</returns>
     public Task<List<Option>> GetCodeList(string orgName, string codeListId);
     /// <summary>
-    ///
+    /// Checks if the code list exists in gitea.
     /// </summary>
     /// <param name="orgName">The name of the organisation.</param>
     /// <param name="codeListId">The name of the code list to check if already exists.</param>
-    /// <returns></returns>
     public Task<bool> CodeListExists(string orgName, string codeListId);
     /// <summary>
     /// Retrieves a list of file names from the CodeLists folder in the content repository in Gitea.

--- a/src/Designer/backend/src/Designer/Services/Interfaces/IOrgContentService.cs
+++ b/src/Designer/backend/src/Designer/Services/Interfaces/IOrgContentService.cs
@@ -24,5 +24,5 @@ public interface IOrgContentService
     /// </summary>
     /// <param name="context">The organisation context containing organisation and developer information.</param>
     /// <returns>True if the content repository exists; otherwise, false.</returns>
-    public bool OrgContentRepoExists(AltinnOrgContext context);
+    public Task<bool> OrgContentRepoExists(AltinnOrgContext context);
 }

--- a/src/Designer/backend/tests/Designer.Tests/Controllers/OrgContentController/GetOrgContentReferencesTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Controllers/OrgContentController/GetOrgContentReferencesTests.cs
@@ -230,6 +230,7 @@ public class GetOrgContentReferencesTests : DesignerEndpointsTestsBase<GetOrgCon
         _orgServiceMock.Setup(service => service.IsOrg(It.IsAny<string>())).ReturnsAsync(true);
         _giteaContentLibraryServiceMock.Setup(service => service.GetCodeListIds(It.IsAny<string>())).ReturnsAsync([]);
         _giteaContentLibraryServiceMock.Setup(service => service.GetTextIds(It.IsAny<string>())).ReturnsAsync([]);
+        _giteaContentLibraryServiceMock.Setup(service => service.OrgContentRepoExists(It.IsAny<string>())).ReturnsAsync(true);
 
         OrgAndRepoName orgAndRepoName = GenerateOrgAndRepoNames();
         const string SourceRepoNameEmpty = "org-content-empty";
@@ -255,6 +256,7 @@ public class GetOrgContentReferencesTests : DesignerEndpointsTestsBase<GetOrgCon
         _orgServiceMock.Verify(service => service.IsOrg(orgAndRepoName.Org.Name), Times.Once);
         _giteaContentLibraryServiceMock.Verify(service => service.GetCodeListIds(orgAndRepoName.Org.Name), Times.Once);
         _giteaContentLibraryServiceMock.Verify(service => service.GetTextIds(orgAndRepoName.Org.Name), Times.Once);
+        _giteaContentLibraryServiceMock.Verify(service => service.OrgContentRepoExists(orgAndRepoName.Org.Name), Times.Once);
     }
 
     [Fact]
@@ -262,6 +264,7 @@ public class GetOrgContentReferencesTests : DesignerEndpointsTestsBase<GetOrgCon
     {
         // Arrange
         _orgServiceMock.Setup(service => service.IsOrg(It.IsAny<string>())).ReturnsAsync(true);
+        _giteaContentLibraryServiceMock.Setup(service => service.OrgContentRepoExists(It.IsAny<string>())).ReturnsAsync(true);
 
         OrgAndRepoName orgAndRepoName = await CreateOrgWithRepository();
         string apiBaseUrl = orgAndRepoName.Org.ApiBaseUrl;
@@ -275,6 +278,7 @@ public class GetOrgContentReferencesTests : DesignerEndpointsTestsBase<GetOrgCon
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         _orgServiceMock.Verify(service => service.IsOrg(orgAndRepoName.Org.Name), Times.Once);
+        _giteaContentLibraryServiceMock.Verify(service => service.OrgContentRepoExists(orgAndRepoName.Org.Name), Times.Once);
     }
 
     private async Task<OrgAndRepoName> CreateOrgWithRepository()
@@ -325,6 +329,9 @@ public class GetOrgContentReferencesTests : DesignerEndpointsTestsBase<GetOrgCon
         _giteaContentLibraryServiceMock
             .Setup(service => service.GetTextIds(It.IsAny<string>()))
             .ReturnsAsync(textIds);
+        _giteaContentLibraryServiceMock
+            .Setup(service => service.OrgContentRepoExists(It.IsAny<string>()))
+            .ReturnsAsync(true);
     }
 
     private class OrgAndRepoName(string orgName, string repoName)

--- a/src/Designer/backend/tests/Designer.Tests/Services/OrgContentServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/OrgContentServiceTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Enums;
 using Altinn.Studio.Designer.Services.Implementation;
@@ -14,13 +13,11 @@ public class OrgContentServiceTests
     private readonly Mock<IGiteaContentLibraryService> _mockGiteaContentLibraryService;
     private readonly OrgContentService _orgContentService;
     private const string OrgName = "ttd";
-    private const string DeveloperName = "testUser";
 
     public OrgContentServiceTests()
     {
-        Mock<IAltinnGitRepositoryFactory> altinnGitRepositoryFactory = new();
         _mockGiteaContentLibraryService = new Mock<IGiteaContentLibraryService>();
-        _orgContentService = new OrgContentService(altinnGitRepositoryFactory.Object, _mockGiteaContentLibraryService.Object);
+        _orgContentService = new OrgContentService(_mockGiteaContentLibraryService.Object);
     }
 
     [Fact]

--- a/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioTextResourceInput/StudioTextResourceInput.tsx
+++ b/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioTextResourceInput/StudioTextResourceInput.tsx
@@ -53,7 +53,9 @@ export const StudioTextResourceInput = forwardRef<HTMLInputElement, StudioTextRe
     ref,
   ): ReactElement => {
     const [currentId, setCurrentId] = usePropState<string | null | undefined>(givenCurrentId);
-    const [textResources, setTextResources] = usePropState<TextResource[]>(givenTextResources);
+    const [textResources, setTextResources] = usePropState<TextResource[]>(
+      givenTextResources ?? [],
+    );
     const [mode, setMode] = useState<Mode>(Mode.EditValue);
 
     const handleChangeCurrentId = (id: string): void => {


### PR DESCRIPTION
## Description
The issues are connected to the gitea api being used as source. We do not currently check the response status before trying to deserialise it's contents. Putting a check on the status code should be enough for dealing with most of our current issues.

I've also changed the initial check to see if the repo exists to point to gitea and not local files.

PR's to split out to:
- Fix repo check
- Add if statement for response status code.
- Fix frontend typing, the text resource can be undefined, and should be set to default value at some point earlier in `CodeListPage` or similar.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
