### PR TITLE
fix: Set default return on utils function for text resources in content library (2)

### DIFF
--- a/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/CodeLists.tsx
@@ -20,7 +20,7 @@ export type CodeListsProps = {
   codeListInEditMode: string | undefined;
   codeListNames: string[];
   codeListsUsages: CodeListReference[];
-  textResources?: TextResource[];
+  textResources: TextResource[];
 };
 
 export function CodeLists({

--- a/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/EditCodeList/EditCodeList.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/CodeLists/EditCodeList/EditCodeList.tsx
@@ -27,7 +27,7 @@ export type EditCodeListProps = {
   onUpdateTextResource?: (textResource: TextResource) => void;
   codeListNames: string[];
   codeListSources: CodeListIdSource[];
-  textResources?: TextResource[];
+  textResources: TextResource[];
 };
 
 export function EditCodeList({

--- a/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/utils/utils.test.ts
+++ b/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/utils/utils.test.ts
@@ -182,11 +182,11 @@ describe('utils', () => {
     });
 
     it('Returns undefined when the language does not exist', () => {
-      expect(getTextResourcesForLanguage('eo', textResources)).toBeUndefined();
+      expect(getTextResourcesForLanguage('eo', textResources)).toEqual([]);
     });
 
     it('Returns undefined when the textResources parameter is undefined', () => {
-      expect(getTextResourcesForLanguage('nb', undefined)).toBeUndefined();
+      expect(getTextResourcesForLanguage('nb', undefined)).toEqual([]);
     });
   });
 

--- a/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/utils/utils.ts
+++ b/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/pages/CodeListPage/utils/utils.ts
@@ -52,7 +52,7 @@ function caseInsensitiveMatch(target: string, searchString: string): boolean {
 export const getTextResourcesForLanguage = (
   language: string,
   textResources?: TextResources,
-): TextResource[] | undefined => textResources?.[language];
+): TextResource[] => textResources?.[language] ?? [];
 
 export const createTextResourceWithLanguage = (
   language: string,


### PR DESCRIPTION
## Description
Sometimes we end up not getting text resources from the backend which results in issues with setting some variables in the frontend. This PR aims to fix it by setting a default value to a empty list if it's not found.

## Verification
- PR itself, Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
