### PR TITLE
fix: outdated link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The development environment consist of several services defined in [compose.yaml
 
 - `studio-loadbalancer` which is a simple nginx-container using `nginx:alpine` directly, just used for development.
 - `studio-designer` which is the actual build artifact with the .NET backend and the react-apps.
-- `studio-repos` which is [gitea][14] with some custom config. More [here](gitea/README.md).
+- `studio-repos` which is [gitea][14] with some custom config. More [here](src/gitea/README.md).
 - `studio-db` which is a postgres database used by both `studio-designer` and `studio-repos`.
 - `database_migrations` which is a one-time task container designed to perform and complete database migrations before exiting.
 - `pgadmin` which is a administration and development platform for PostgreSQL.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Invalid link, the gitea folder is under src.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Corrected the Docker Compose reference link for studio repositories in the README to point to the current Gitea documentation location.
  - Improves navigation by fixing an outdated hyperlink, making it easier to find setup instructions.
  - No changes to application behavior, configuration, or runtime; this update is purely informational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->