### PR TITLE
fix: typo in process editor alert

### DIFF
--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -914,7 +914,7 @@
   "process_editor.configuration_panel.correspondence_resource_description": "For å benytte brukerstyrt signering må du bruke Meldingstjenesten i Altinn. Da får de som skal signere beskjed om å gjøre det, og de får en kvittering i innboksen når det er gjort.",
   "process_editor.configuration_panel.edit_default_user_controlled_interface": "Bruk et eget grensesnitt for brukerstyrt signering",
   "process_editor.configuration_panel.edit_default_user_controlled_interface_description": "Hvis du vil bruke et eget grensesnitt i stedet for standarden, oppgir du navnet på det her.",
-  "process_editor.configuration_panel.edit_policy_alert_message": "Du må ha tilgangsregler som dekker alle oppgaver. Gå til Tilganger for å sjekke om du har en regel som dekker denne oppgaven. Hvis du ikke har en regel for oppgaven, kan du enten lage en ny regel eller inkluderedenne oppgaven i en regel som allerede finnes.",
+  "process_editor.configuration_panel.edit_policy_alert_message": "Du må ha tilgangsregler som dekker alle oppgaver. Gå til Tilganger for å sjekke om du har en regel som dekker denne oppgaven. Hvis du ikke har en regel for oppgaven, kan du enten lage en ny regel eller inkludere denne oppgaven i en regel som allerede finnes.",
   "process_editor.configuration_panel.edit_policy_open_policy_editor_button": "Gå til Tilganger",
   "process_editor.configuration_panel.edit_policy_open_policy_editor_heading": "Åpne Tilganger for å redigere tilgangsregler",
   "process_editor.configuration_panel_actions_action_card_custom": "Lag egendefinert handling",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes this typo:
<img width="400" height="890" alt="bilde" src="https://github.com/user-attachments/assets/acd2b22f-4b92-4cd5-9f77-115c7856af43" />

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typographical error in the Norwegian (nb) translation for the policy edit alert message in the configuration panel, improving clarity and readability for end-users.
  * This is a text-only update with no impact on functionality, logic, or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->