### PR TITLE
fix: return app text resources after import if org has no text resources (2)

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/OptionsService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/OptionsService.cs
@@ -244,7 +244,7 @@ public class OptionsService : IOptionsService
     {
         if (appTextResources.TryGetValue(languageCode, out TextResource textResource))
         {
-            return [.. textResource.Resources];
+            return textResource.Resources;
         }
 
         return [];

--- a/src/Designer/backend/src/Designer/Services/Implementation/OptionsService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/OptionsService.cs
@@ -244,7 +244,7 @@ public class OptionsService : IOptionsService
     {
         if (appTextResources.TryGetValue(languageCode, out TextResource textResource))
         {
-            return [..textResource.Resources];
+            return [.. textResource.Resources];
         }
 
         return [];


### PR DESCRIPTION
> [!IMPORTANT]
> This pull request is stacked upon #16211, which should be merged first.

## Description
Fixes an issue where importing a code list caused Designer to return `null` for text resources if the `{org}-content` repository had none, even when some text resources existed in the app. This change ensures that Designer always returns the app’s existing text resources, regardless of whether any were imported.

## Verification
- PR itself, Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Consolidated loading of text resources for all languages into a single preloaded store, replacing per-language on-demand retrieval.
  - Centralized access to language-specific resources from the in-memory cache to simplify logic and reduce repeated reads.
  - Improves responsiveness and consistency of localization across the app, particularly when switching languages or rendering multi-language content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->