### PR TITLE
chore: update issue template with issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,13 +1,14 @@
 name: Bug Report 🐛
 description: File a bug report here
 labels: ["kind/bug", "status/triage"]
+type: Bug
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report 🤗
         Make sure there aren't any open/closed issues for this topic 😃
-        
+
   - type: textarea
     id: bug-description
     attributes:
@@ -15,7 +16,7 @@ body:
       description: Give us a brief description of what happened and what should have happened
     validations:
       required: true
-      
+
   - type: textarea
     id: steps-to-reproduce
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,4 +34,4 @@ body:
     attributes:
       label: Additional Information
       description: |
-        Provide any additional information such as logs, screenshots, likes, scenarios in which the bug occurs so that it facilitates resolving the issue.
+        Provide any additional information such as logs, screenshots, links, scenarios in which the bug occurs so that it facilitates resolving the issue.

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,12 +1,13 @@
 name: Chore ✅
 description: Create a none user-story issue (chore, tech issue, backend issue)
 labels: ["kind/chore", "status/draft"]
+type: Task
 body:
   - type: markdown
     attributes:
       value: |
         Please make sure this chore hasn't been already submitted by someone by looking through other open/closed chore issues.
-          
+
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,12 +1,13 @@
 name: Epic 💎
 description: Create a new epic (very big user story)
 labels: ["Epic", "status/draft"]
-body:          
+type: Epic
+body:
   - type: textarea
     id: description
     attributes:
       label: Description
-      description: A quick introduction to the user need. Make it clear for who, why and what. 
+      description: A quick introduction to the user need. Make it clear for who, why and what.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request ✨
 description: Request a new feature or enhancement
 labels: ["kind/feature-request", "status/triage"]
-type: Feature
+type: Enhancement
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,12 +1,13 @@
 name: Feature Request ✨
 description: Request a new feature or enhancement
 labels: ["kind/feature-request", "status/triage"]
+type: Feature
 body:
   - type: markdown
     attributes:
       value: |
         Please make sure this feature request hasn't been already submitted by someone by looking through other open/closed issues
-  
+
   - type: textarea
     id: description
     attributes:
@@ -14,7 +15,7 @@ body:
       description: Give us a brief description of the feature or enhancement you would like
     validations:
       required: true
-      
+
   - type: textarea
     id: additional-information
     attributes:


### PR DESCRIPTION
## Description
If we're going to use issue types, we should update the issue templates to use them.
Available types:
<img width="315" height="449" alt="image" src="https://github.com/user-attachments/assets/a3ca4f1c-b1cb-4e9a-8d15-da8ba0d976cf" />

Available templates:
<img width="794" height="656" alt="image" src="https://github.com/user-attachments/assets/ae5a5e5e-89a4-41f9-a362-501d7e2fa865" />

There is not a simple 1:1 mapping for all the existing templates here, so not sure what we should do here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Added type classifications to GitHub issue templates: Bug, Task, Epic, and Enhancement (feature) to clarify issue creation; no substantive changes to form fields.
* Style
  * Normalized whitespace and ensured trailing newlines across templates.
* Bug Fixes
  * Minor visible text update in the Additional Information field: “likes” → “links”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->