### PR TITLE
chore: prepare renovate for apps-repos

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,15 +51,21 @@
         "/^Microsoft\\.Build/"
       ],
       "enabled": false
+    },
+    {
+      "matchFileNames": ["src/App/codelists/**", "src/App/fileanalyzers/**", "src/App/Designer/**"],
+      "ignoreDeps": ["Altinn.App.Core"]
+    },
+    {
+      "matchFileNames": ["src/App/Designer/**"],
+      "ignoreDeps": [
+        "Moq",
+        "Basic.Reference.Assemblies",
+        "Microsoft.CodeAnalysis.CSharp",
+        "Microsoft.CodeAnalysis.Common"
+      ]
     }
   ],
   "ignorePaths": ["src/Altinn.Platform/**", "src/test/**"],
-  "ignoreDeps": [
-    "Moq",
-    "Altinn.App.Core",
-    "Basic.Reference.Assemblies",
-    "Microsoft.CodeAnalysis.CSharp",
-    "Microsoft.CodeAnalysis.Common"
-  ],
   "schedule": ["before 07:00 on Monday"]
 }


### PR DESCRIPTION
## Description

In preparation for moving in here I thought I'd look into splitting up renovate PRs here.
Added comments inline with the changes that we need to agree on.

Then there are also some global `ignoreDeps` configuration that we should probably scope in some? 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Refined dependency update settings to split minor/patch updates and handle multiple major versions separately.
  - Introduced scoped rules for app dependencies, including grouping and scheduling for design system packages.
  - Applied version constraints for .NET-related packages and disabled updates for certain build/analysis tools.
  - Consolidated ignore lists into targeted rules for specific app areas.
  - Improved branch naming and commit messages for automated update PRs.
- Notes
  - No user-facing changes; this only affects how automated dependency updates are proposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->