### PR TITLE
test: Fix end-to-end test for dashboard navigation

### DIFF
--- a/src/Designer/frontend/testing/playwright/pages/OrgLibraryPage/OrgLibraryPage.ts
+++ b/src/Designer/frontend/testing/playwright/pages/OrgLibraryPage/OrgLibraryPage.ts
@@ -21,7 +21,7 @@ export class OrgLibraryPage extends BasePage {
   }
 
   public async waitForPageHeaderToBeVisible(): Promise<void> {
-    const headingText = `${this.textMock('app_content_library.library_heading')} Beta`;
+    const headingText = `${this.textMock('org_content_library.library_heading')} Beta`;
 
     const heading = this.page.getByRole('heading', {
       name: headingText,

--- a/src/Designer/frontend/testing/playwright/tests/dashboard/dashboard-navigation.spec.ts
+++ b/src/Designer/frontend/testing/playwright/tests/dashboard/dashboard-navigation.spec.ts
@@ -26,7 +26,7 @@ test.afterAll(async ({ request, testAppName }) => {
   expect(response.ok()).toBeTruthy();
 });
 
-test.skip('that it is possible to navigate from dashboard page to library page and back again', async ({
+test('that it is possible to navigate from dashboard page to library page and back again', async ({
   page,
   testAppName,
 }) => {


### PR DESCRIPTION
## Description
This pull request makes the dashboard navigation test work again by correcting an outdated text key reference.

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated page header validation to align with the Organization Content Library title (including the “Beta” label), improving accuracy and stability of UI assertions.
  * Re-enabled a previously skipped dashboard navigation test, restoring its execution to enhance test coverage and catch regressions earlier.

* **Note**
  * No user-facing functionality changes; updates are focused on test reliability and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->