### PR TITLE
fix(resource-adm): only Digdir should be allowed to create resources of type "Systemressurs"

### DIFF
--- a/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
+++ b/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
@@ -18,6 +18,7 @@ import { ServicesContextProvider } from 'app-shared/contexts/ServicesContext';
 import { queriesMock } from 'app-shared/mocks/queriesMock';
 import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
 import { testConsentTemplates } from '../../testing/utils/testUtils';
+import { useParams } from 'react-router-dom';
 
 const mockContactPoint: ResourceContactPoint = {
   category: 'test',
@@ -67,7 +68,7 @@ const mockConsentResource: Resource = {
 const consentTemplates = testConsentTemplates;
 
 const mockResourceType: ResourceTypeOption = textMock(
-  'resourceadm.about_resource_resource_type_system_resource',
+  'resourceadm.about_resource_resource_type_generic_access_resource',
 ) as ResourceTypeOption;
 const mockStatus: ResourceStatusOption = 'Deprecated';
 
@@ -81,12 +82,16 @@ const mockId: string = 'page-content-deploy';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useParams: () => ({
-    resourceId: mockResource1,
-  }),
+  useParams: jest.fn(),
 }));
 
 describe('AboutResourcePage', () => {
+  beforeEach(() => {
+    (useParams as jest.Mock).mockReturnValue({
+      resourceId: mockResource1,
+      org: 'ttd',
+    });
+  });
   afterEach(jest.clearAllMocks);
 
   const mockOnSaveResource = jest.fn();
@@ -114,6 +119,30 @@ describe('AboutResourcePage', () => {
     render(<AboutResourcePage {...defaultProps} />);
 
     const resourceTypeRadio = screen.getByLabelText(mockResourceType);
+    await user.click(resourceTypeRadio);
+
+    expect(resourceTypeRadio).toBeChecked();
+  });
+
+  it('should not show resource type Systemresource for org ttd', () => {
+    render(<AboutResourcePage {...defaultProps} />);
+
+    expect(
+      screen.queryByLabelText(textMock('resourceadm.about_resource_resource_type_system_resource')),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show resource type Systemresource for org digdir', async () => {
+    (useParams as jest.Mock).mockReturnValue({
+      resourceId: mockResource1,
+      org: 'digdir',
+    });
+    const user = userEvent.setup();
+    render(<AboutResourcePage {...defaultProps} />);
+
+    const resourceTypeRadio = screen.getByLabelText(
+      textMock('resourceadm.about_resource_resource_type_system_resource'),
+    );
     await user.click(resourceTypeRadio);
 
     expect(resourceTypeRadio).toBeChecked();

--- a/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
+++ b/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
@@ -35,6 +35,7 @@ import { ResourceReferenceFields } from '../../components/ResourceReferenceField
 import { AccessListEnvLinks } from '../../components/AccessListEnvLinks';
 import { FeatureFlag, shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
 import { ConsentPreview } from '../../components/ConsentPreview';
+import { useUrlParams } from '../../hooks/useUrlParams';
 
 export type AboutResourcePageProps = {
   resourceData: Resource;
@@ -62,6 +63,7 @@ export const AboutResourcePage = ({
   id,
 }: AboutResourcePageProps): React.JSX.Element => {
   const { t } = useTranslation();
+  const { org } = useUrlParams();
   const [consentPreviewText, setConsentPreviewText] = useState<SupportedLanguage>(
     resourceData.consentText,
   );
@@ -71,9 +73,15 @@ export const AboutResourcePage = ({
    * Resource type options
    */
   const resourceTypeOptions = Object.entries(resourceTypeMap)
-    .filter(([key]) =>
-      key === 'Consent' ? shouldDisplayFeature(FeatureFlag.ConsentResource) : true,
-    )
+    .filter(([key]) => {
+      if (key === 'Consent' && !shouldDisplayFeature(FeatureFlag.ConsentResource)) {
+        return false;
+      }
+      if (key === 'Systemresource' && org.toLowerCase() !== 'digdir') {
+        return false;
+      }
+      return true;
+    })
     .map(([key, value]) => ({
       value: key,
       label: t(value),


### PR DESCRIPTION
## Description
Hide radio button for "Systemressurs" resource type for other orgs than digdir in resource admin

## Issue
https://github.com/Altinn/altinn-studio/issues/16251

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
