### PR TITLE
test: Remove skip keyword from app settings tests

### DIFF
--- a/src/Designer/frontend/testing/playwright/tests/app-settings/app-settings.spec.ts
+++ b/src/Designer/frontend/testing/playwright/tests/app-settings/app-settings.spec.ts
@@ -37,7 +37,7 @@ const setUpAndVerifySettingsPage = async (
   return settingsPage;
 };
 
-test.skip('That it is possible to change tab from "About app" tab to "Setup" tab', async ({
+test('That it is possible to change tab from "About app" tab to "Setup" tab', async ({
   page,
   testAppName,
 }) => {
@@ -52,10 +52,7 @@ test.skip('That it is possible to change tab from "About app" tab to "Setup" tab
   await settingsPage.verifyThatTabIsVisible('setup');
 });
 
-test.skip('That it is possible to change tab to "Policy editor" tab', async ({
-  page,
-  testAppName,
-}) => {
+test('That it is possible to change tab to "Policy editor" tab', async ({ page, testAppName }) => {
   const settingsPage: SettingsPage = await setUpAndVerifySettingsPage(page, testAppName, 'setup');
 
   await settingsPage.verifyThatTabIsVisible('setup');
@@ -67,7 +64,7 @@ test.skip('That it is possible to change tab to "Policy editor" tab', async ({
   await settingsPage.verifyThatTabIsVisible('policy');
 });
 
-test.skip('That it is possible to edit security level on "Policy editor" tab, and that changes are saved', async ({
+test('That it is possible to edit security level on "Policy editor" tab, and that changes are saved', async ({
   page,
   testAppName,
 }) => {


### PR DESCRIPTION
## Description
The app settings end-to-end tests run green, so there is no need to skip them. This pull equest removes the `skip` keyword from these tests.

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reactivated automated tests covering navigation between App Settings tabs and interactions in the Policy Editor, increasing test coverage and reliability.
  * No changes to application behavior; tests now run as part of the suite to better detect regressions.

* **Chores**
  * Minor cleanup in test code for readability and consistency, with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->