### PR TITLE
test: Remove skip keyword from data model tests

### DIFF
--- a/src/Designer/frontend/testing/playwright/tests/data-model/data-model.spec.ts
+++ b/src/Designer/frontend/testing/playwright/tests/data-model/data-model.spec.ts
@@ -19,7 +19,7 @@ test.afterAll(async ({ request, testAppName }) => {
   expect(response.ok()).toBeTruthy();
 });
 
-test.skip('Allows to add a data model, include an object with properties and a combination, check for visibility of type selector, generate a C# model from it, and then delete it', async ({
+test('Allows to add a data model, include an object with properties and a combination, check for visibility of type selector, generate a C# model from it, and then delete it', async ({
   page,
   testAppName,
 }): Promise<void> => {
@@ -101,7 +101,7 @@ test.skip('Allows to add a data model, include an object with properties and a c
   await dataModelPage.checkThatDataModelOptionDoesNotExists(dataModelName);
 });
 
-test.skip('Allows to upload and then delete an XSD file', async ({ page, testAppName }) => {
+test('Allows to upload and then delete an XSD file', async ({ page, testAppName }) => {
   // Load the data model page
   const dataModelPage = new DataModelPage(page, { app: testAppName });
   await dataModelPage.loadDataModelPage();
@@ -122,7 +122,7 @@ test.skip('Allows to upload and then delete an XSD file', async ({ page, testApp
   await dataModelPage.checkThatDataModelOptionDoesNotExists(dataModelName);
 });
 
-test.skip('Adding a type and dragging it into an object', async ({ page, testAppName }) => {
+test('Adding a type and dragging it into an object', async ({ page, testAppName }) => {
   // Load the data model page
   const dataModelPage = new DataModelPage(page, { app: testAppName });
   await dataModelPage.loadDataModelPage();


### PR DESCRIPTION
## Description
The end-to-end tests related to tha data model editor run green, so there is no need to skip them. This pull equest removes the skip keyword from these tests.

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reactivated three end-to-end tests for data modeling workflows: creating/deleting models with objects and combinations, uploading/deleting XSD files, and adding/dragging types into objects.
  * These tests now run in CI to validate core data model interactions continuously.
  * No changes to application behavior; only test execution was enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->