### PR TITLE
chore: moved `StudioBlobDownloader` to@studio/componenent

### DIFF
--- a/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioBlobDownloader/StudioBlobDownloader.tsx
+++ b/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioBlobDownloader/StudioBlobDownloader.tsx
@@ -11,6 +11,9 @@ export type StudioBlobDownloaderProps = {
   linkText: string;
 } & StudioButtonProps;
 
+/**
+ * @deprecated use `StudioBlobDownloader` from `@studio/components` instead
+ */
 export const StudioBlobDownloader = ({
   data,
   fileName,

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.mdx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.mdx
@@ -8,8 +8,8 @@ import * as StudioBlobDownloaderStories from './StudioBlobDownloader.stories';
   StudioBlobDownloader
 </Heading>
 <Paragraph>
-  StudioBlowDownloader is a link that triggers the download of the specified data in the specified
-  file format.
+  StudioBlobDownloader renders a button that triggers the download of the specified data in the
+  specified file format.
 </Paragraph>
 
 <Canvas of={StudioBlobDownloaderStories.Preview} />

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.mdx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.mdx
@@ -1,0 +1,15 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { Heading, Paragraph } from '@digdir/designsystemet-react';
+import * as StudioBlobDownloaderStories from './StudioBlobDownloader.stories';
+
+<Meta of={StudioBlobDownloaderStories} />
+
+<Heading level={1} size='small'>
+  StudioBlobDownloader
+</Heading>
+<Paragraph>
+  StudioBlowDownloader is a link that triggers the download of the specified data in the specified
+  file format.
+</Paragraph>
+
+<Canvas of={StudioBlobDownloaderStories.Preview} />

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.stories.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.stories.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { StudioBlobDownloader } from './StudioBlobDownloader';
 
-type Story = StoryFn<typeof StudioBlobDownloader>;
+type Story = StoryObj<typeof StudioBlobDownloader>;
 
 const meta: Meta = {
   title: 'Components/StudioBlobDownloader',
@@ -10,10 +9,11 @@ const meta: Meta = {
 };
 export default meta;
 
-export const Preview: Story = (args): React.ReactElement => <StudioBlobDownloader {...args} />;
-Preview.args = {
-  data: JSON.stringify({ test: 'test' }),
-  fileName: 'testtest.json',
-  fileType: 'application/json',
-  linkText: 'Download JSON',
+export const Preview: Story = {
+  args: {
+    data: JSON.stringify({ test: 'test' }),
+    fileName: 'testtest.json',
+    fileType: 'application/json',
+    linkText: 'Download JSON',
+  },
 };

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.stories.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react-vite';
+import { StudioBlobDownloader } from './StudioBlobDownloader';
+
+type Story = StoryFn<typeof StudioBlobDownloader>;
+
+const meta: Meta = {
+  title: 'Components/StudioBlobDownloader',
+  component: StudioBlobDownloader,
+};
+export default meta;
+
+export const Preview: Story = (args): React.ReactElement => <StudioBlobDownloader {...args} />;
+Preview.args = {
+  data: JSON.stringify({ test: 'test' }),
+  fileName: 'testtest.json',
+  fileType: 'application/json',
+  linkText: 'Download JSON',
+};

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StudioBlobDownloader } from './StudioBlobDownloader';
+import type { StudioBlobDownloaderProps } from './StudioBlobDownloader';
+import { BlobDownloader } from '@studio/pure-functions';
+
+describe('StudioBlobDownloader', () => {
+  type ExampleData = {
+    testField1: string;
+    testField2: number;
+  };
+
+  const mockData: ExampleData = {
+    testField1: 'test',
+    testField2: 1,
+  };
+
+  const handleDownloadClickMock = jest.fn();
+
+  beforeAll(() => {
+    jest
+      .spyOn(BlobDownloader.prototype, 'handleDownloadClick')
+      .mockImplementation(handleDownloadClickMock);
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render', () => {
+    renderStudioBlobDownloader({ data: JSON.stringify(mockData) });
+    expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
+  });
+
+  it('should create a link to Blob with the correct data', async () => {
+    jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+    renderStudioBlobDownloader({ data: JSON.stringify(mockData) });
+    const user = userEvent.setup();
+    const downloadButton = screen.getByRole('button', { name: 'Download' });
+    await user.click(downloadButton);
+    expect(handleDownloadClickMock).toHaveBeenCalled();
+  });
+});
+
+const renderStudioBlobDownloader = (props: Partial<StudioBlobDownloaderProps>): void => {
+  const defaultProps: StudioBlobDownloaderProps = {
+    data: '{}',
+    fileName: 'test.json',
+    linkText: 'Download',
+  };
+  render(<StudioBlobDownloader {...defaultProps} {...props} />);
+};

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.test.tsx
@@ -25,7 +25,7 @@ describe('StudioBlobDownloader', () => {
   });
 
   afterAll(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it('should render', () => {

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/StudioBlobDownloader.tsx
@@ -1,0 +1,32 @@
+import React, { type ReactElement, useMemo } from 'react';
+import { BlobDownloader } from '@studio/pure-functions';
+import { StudioButton } from '../StudioButton';
+import type { StudioButtonProps } from '../StudioButton';
+import { DownloadIcon } from '@studio/icons';
+
+export type StudioBlobDownloaderProps = {
+  data: string;
+  fileName: string;
+  fileType?: string;
+  linkText: string;
+} & StudioButtonProps;
+
+export function StudioBlobDownloader({
+  data,
+  fileName,
+  fileType = 'application/json',
+  linkText,
+  ...rest
+}: StudioBlobDownloaderProps): ReactElement {
+  const blobDownloader = useMemo(
+    () => new BlobDownloader(data, fileType, fileName),
+    [data, fileType, fileName],
+  );
+  const handleExportClick = (): void => blobDownloader.handleDownloadClick();
+
+  return (
+    <StudioButton {...rest} onClick={handleExportClick} variant='tertiary' icon={<DownloadIcon />}>
+      {linkText}
+    </StudioButton>
+  );
+}

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/index.ts
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioBlobDownloader/index.ts
@@ -1,0 +1,2 @@
+export { StudioBlobDownloader } from './StudioBlobDownloader';
+export type { StudioBlobDownloaderProps } from './StudioBlobDownloader';

--- a/src/Designer/frontend/libs/studio-components/src/components/index.ts
+++ b/src/Designer/frontend/libs/studio-components/src/components/index.ts
@@ -9,6 +9,7 @@ export * from './StudioAlert';
 export * from './StudioAnimateHeight';
 export * from './StudioAvatar';
 export * from './StudioBooleanToggleGroup';
+export * from './StudioBlobDownloader';
 export * from './StudioBreadcrumbs';
 export * from './StudioButton';
 export * from './StudioCallToActionBar';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moved `StudioBlobDownloader` to@studio/component with all associated files

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added StudioBlobDownloader: a tertiary download button to export provided data as a file (JSON default) with customizable file name, type, and link text; available in the components library.

- **Documentation**
  - Added Storybook docs with an interactive preview demonstrating usage.

- **Tests**
  - Added tests verifying rendering and the download interaction.

- **Chores**
  - Exported the component from the public components index and marked the legacy export as deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->