### PR TITLE
fix: Fix data model bindings of file upload components

### DIFF
--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/DataModelBindings.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/DataModelBindings.test.tsx
@@ -243,10 +243,7 @@ describe('DataModelBindings', () => {
     expect(handleUpdate).toHaveBeenCalledTimes(1);
     expect(handleUpdate).toHaveBeenCalledWith({
       ...componentMocks[ComponentType.FileUpload],
-      dataModelBindings: {
-        list: { field: '', dataType: '' },
-        simpleBinding: { field: undefined, dataType: '' },
-      },
+      dataModelBindings: undefined,
     });
   });
 
@@ -257,7 +254,6 @@ describe('DataModelBindings', () => {
       props: {
         formItem: {
           ...componentMocks[ComponentType.FileUpload],
-          dataModelBindings: { list: { field: 'someListDataModelField', dataType: '' } },
         },
         formItemId: componentMocks[ComponentType.FileUpload].id,
         handleUpdate,
@@ -270,7 +266,7 @@ describe('DataModelBindings', () => {
     expect(handleUpdate).toHaveBeenCalledTimes(1);
     expect(handleUpdate).toHaveBeenCalledWith({
       ...componentMocks[ComponentType.FileUpload],
-      dataModelBindings: { list: undefined, simpleBinding: { field: '', dataType: '' } },
+      dataModelBindings: undefined,
     });
   });
 

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/DataModelBindings.test.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/DataModelBindings.test.tsx
@@ -243,7 +243,10 @@ describe('DataModelBindings', () => {
     expect(handleUpdate).toHaveBeenCalledTimes(1);
     expect(handleUpdate).toHaveBeenCalledWith({
       ...componentMocks[ComponentType.FileUpload],
-      dataModelBindings: undefined,
+      dataModelBindings: {
+        list: { field: '', dataType: '' },
+        simpleBinding: undefined,
+      },
     });
   });
 
@@ -254,6 +257,7 @@ describe('DataModelBindings', () => {
       props: {
         formItem: {
           ...componentMocks[ComponentType.FileUpload],
+          dataModelBindings: { list: { field: 'someListDataModelField', dataType: '' } },
         },
         formItemId: componentMocks[ComponentType.FileUpload].id,
         handleUpdate,
@@ -266,7 +270,7 @@ describe('DataModelBindings', () => {
     expect(handleUpdate).toHaveBeenCalledTimes(1);
     expect(handleUpdate).toHaveBeenCalledWith({
       ...componentMocks[ComponentType.FileUpload],
-      dataModelBindings: undefined,
+      dataModelBindings: { list: undefined, simpleBinding: { field: '', dataType: '' } },
     });
   });
 

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/DataModelBindings.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/DataModelBindings.tsx
@@ -40,10 +40,7 @@ export const DataModelBindings = (): React.JSX.Element => {
     const updatedComponent = {
       ...formItem,
       itemType: 'COMPONENT',
-      dataModelBindings: {
-        simpleBinding: { field: !updatedValue ? '' : undefined, dataType: '' },
-        list: updatedValue ? { field: '', dataType: '' } : undefined,
-      },
+      dataModelBindings: undefined,
     } as FormComponent;
     handleUpdate(updatedComponent);
     debounceSave(formItemId, updatedComponent);

--- a/src/Designer/frontend/packages/ux-editor/src/components/Properties/DataModelBindings.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Properties/DataModelBindings.tsx
@@ -40,7 +40,10 @@ export const DataModelBindings = (): React.JSX.Element => {
     const updatedComponent = {
       ...formItem,
       itemType: 'COMPONENT',
-      dataModelBindings: undefined,
+      dataModelBindings: {
+        simpleBinding: updatedValue ? undefined : { field: '', dataType: '' },
+        list: updatedValue ? { field: '', dataType: '' } : undefined,
+      },
     } as FormComponent;
     handleUpdate(updatedComponent);
     debounceSave(formItemId, updatedComponent);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixed data model bindings of file upload components

<table>
<tr>
<th>BEFORE</th>
<th>AFTER</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/ceefa284-aa6a-4653-9220-8aa230722b93

</td>
<td>

https://github.com/user-attachments/assets/66804304-fec3-464e-a3ab-e0cda602c8c7

</td>
</tr>

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changing the “Allow multiple attachments” setting for File Upload now clears data model bindings instead of auto-populating placeholder values. This prevents stale or conflicting bindings when toggling the option on or off.
  * The Properties panel reflects the cleared state immediately, ensuring a clean configuration before setting new bindings and reducing confusion caused by previously pre-filled fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->