### PR TITLE
chore: remove unnecessary push trigger from template build workflow

### DIFF
--- a/.github/workflows/app-template-test.yml
+++ b/.github/workflows/app-template-test.yml
@@ -1,7 +1,5 @@
 name: App Template Build and Test on windows and macos
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
## Description

Noticed it started running after merging unrelated PR

@coderabbitai ignore

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow triggers to run checks on pull requests to the main branch (opened, synchronized, reopened) and via manual dispatch.
  * Removed automatic runs on direct pushes to the main branch to streamline review and merge workflows.
  * No changes to application behavior or user-facing features.
  * This improves pre-merge validation consistency without impacting daily usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->