### PR TITLE
chore: Moved StudioDisplayTile from legacy

### DIFF
--- a/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioDisplayTile/StudioDisplayTile.tsx
+++ b/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioDisplayTile/StudioDisplayTile.tsx
@@ -11,6 +11,9 @@ export type StudioDisplayTileProps = {
   showPadlock?: boolean;
 } & HTMLAttributes<HTMLDivElement>;
 
+/**
+ * @deprecated Use `StudioDisplayTile` from `studio-components` instead.
+ */
 const StudioDisplayTile = forwardRef<HTMLDivElement, StudioDisplayTileProps>(
   (
     {

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioDisplayTile/StudioDisplayTile.mdx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioDisplayTile/StudioDisplayTile.mdx
@@ -1,0 +1,15 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { StudioParagraph } from '../StudioParagraph';
+import { StudioLabel } from '../StudioLabel';
+import * as StudioDisplayTileStories from './StudioDisplayTile.stories';
+
+<Meta of={StudioDisplayTileStories} />
+
+<StudioLabel level={1} size='small'>
+  StudioDisplayTile
+</StudioLabel>
+<StudioParagraph>
+  StudioDisplayTile is a component that displays a value with icon in non-editable mode.
+</StudioParagraph>
+
+<Canvas of={StudioDisplayTileStories.Preview} />

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioDisplayTile/StudioDisplayTile.module.css
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioDisplayTile/StudioDisplayTile.module.css
@@ -1,0 +1,24 @@
+.container {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: var(--fds-spacing-2);
+}
+
+.container:has(:nth-child(3)) {
+  grid-template-columns: auto 1fr auto;
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: var(--fds-spacing-1);
+  font-weight: 500;
+}
+
+.label,
+.ellipsis {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioDisplayTile/StudioDisplayTile.stories.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioDisplayTile/StudioDisplayTile.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react-vite';
+import { StudioDisplayTile } from './StudioDisplayTile';
+import { PencilIcon } from '@studio/icons';
+
+type Story = StoryFn<typeof StudioDisplayTile>;
+
+const meta: Meta = {
+  title: 'Components/StudioDisplayTile',
+  component: StudioDisplayTile,
+};
+export const Preview: Story = (args): React.ReactElement => <StudioDisplayTile {...args} />;
+
+Preview.args = {
+  label: 'Label',
+  value: 'Value',
+  icon: <PencilIcon />,
+};
+export default meta;

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioDisplayTile/StudioDisplayTile.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioDisplayTile/StudioDisplayTile.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { StudioDisplayTile, type StudioDisplayTileProps } from './StudioDisplayTile';
+
+const padlockIconTestId: string = 'padlockIconTestId';
+
+const label = 'label';
+const value = 'value';
+const defaultProps: StudioDisplayTileProps = {
+  label,
+  value,
+};
+
+describe('StudioDisplayTile', () => {
+  it('should render displayTile', () => {
+    render(<StudioDisplayTile {...defaultProps} />);
+    expect(screen.getByLabelText(label)).toBeInTheDocument();
+  });
+
+  it('should render displayTile with value', () => {
+    render(<StudioDisplayTile {...defaultProps} />);
+    expect(screen.getByText(value)).toBeInTheDocument();
+  });
+
+  it('should show the padlock icon by default', () => {
+    render(<StudioDisplayTile {...defaultProps} />);
+    expect(screen.getByTestId(padlockIconTestId)).toBeInTheDocument();
+  });
+
+  it('should hide the padlock icon when showPadlock is false', () => {
+    render(<StudioDisplayTile {...defaultProps} showPadlock={false} />);
+    expect(screen.queryByTestId(padlockIconTestId)).not.toBeInTheDocument();
+  });
+});

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioDisplayTile/StudioDisplayTile.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioDisplayTile/StudioDisplayTile.tsx
@@ -1,0 +1,47 @@
+import React, { forwardRef, type HTMLAttributes } from 'react';
+import { PadlockLockedFillIcon } from '@studio/icons';
+import { StudioParagraph } from '../StudioParagraph';
+import { StudioLabel } from '../StudioLabel';
+import classes from './StudioDisplayTile.module.css';
+import cn from 'classnames';
+
+export type StudioDisplayTileProps = {
+  icon?: React.ReactNode;
+  label: string;
+  value: string;
+  showPadlock?: boolean;
+} & HTMLAttributes<HTMLDivElement>;
+
+const StudioDisplayTile = forwardRef<HTMLDivElement, StudioDisplayTileProps>(
+  (
+    {
+      icon,
+      label,
+      value,
+      className: givenClassName,
+      showPadlock = true,
+      ...rest
+    }: StudioDisplayTileProps,
+    ref,
+  ): React.ReactElement => {
+    const className = cn(givenClassName, classes.container);
+
+    return (
+      <div {...rest} aria-label={label} className={className} ref={ref}>
+        <div className={classes.ellipsis}>
+          <StudioLabel data-size='sm' className={classes.label}>
+            {icon}
+            {label}
+          </StudioLabel>
+          <StudioParagraph data-size='sm' className={classes.ellipsis}>
+            {value}
+          </StudioParagraph>
+        </div>
+        {showPadlock && <PadlockLockedFillIcon data-testid='padlockIconTestId' />}
+      </div>
+    );
+  },
+);
+
+StudioDisplayTile.displayName = 'StudioDisplayTile';
+export { StudioDisplayTile };

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioDisplayTile/index.ts
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioDisplayTile/index.ts
@@ -1,0 +1,1 @@
+export { StudioDisplayTile, type StudioDisplayTileProps } from './StudioDisplayTile';

--- a/src/Designer/frontend/libs/studio-components/src/components/index.ts
+++ b/src/Designer/frontend/libs/studio-components/src/components/index.ts
@@ -23,6 +23,7 @@ export * from './StudioDecimalInput';
 export * from './StudioDeleteButton';
 export * from './StudioDetails';
 export * from './StudioDialog';
+export * from './StudioDisplayTile';
 export * from './StudioDropdown';
 export * from './StudioErrorSummary';
 export * from './StudioField';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moved StudioDisplayTile from legacy to @studio/component



CLOSE: #16317 

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced StudioDisplayTile: non-editable tile showing label, value, optional icon and optional padlock; accessible labeling and single-line truncation.
- **Style**
  - Added grid-based layout and spacing for consistent alignment and responsive presentation.
- **Documentation**
  - Added Storybook docs and interactive Preview example.
- **Tests**
  - Added unit tests for rendering, value display, accessibility, and conditional padlock visibility.
- **Chores**
  - Public export added; legacy version marked deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->