### PR TITLE
chore: Moved StudioPageImageBackgroundContainer to @studio/component

### DIFF
--- a/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.tsx
+++ b/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.tsx
@@ -5,6 +5,9 @@ export type StudioPageImageBackgroundContainerProps = {
   image: string;
 } & HTMLAttributes<HTMLDivElement>;
 
+/**
+ * @deprecated Use `StudioPageImageBackgroundContainer` from `@studio/components` instead.
+ */
 export const StudioPageImageBackgroundContainer = ({
   children,
   image,

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.module.css
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.module.css
@@ -1,0 +1,10 @@
+.wrapper {
+  background-color: #e6eff8;
+}
+
+.pageContainer {
+  position: relative;
+  background-size: 100% auto;
+  background-repeat: no-repeat;
+  overflow: hidden;
+}

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.stories.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.stories.tsx
@@ -1,0 +1,36 @@
+import React, { type ReactElement } from 'react';
+import type { Meta, StoryFn } from '@storybook/react-vite';
+import { StudioPageImageBackgroundContainer } from './StudioPageImageBackgroundContainer';
+
+const ChildrenComponent = (): ReactElement => {
+  return (
+    <div
+      style={{
+        minWidth: '400px',
+        height: '150px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      Children content
+    </div>
+  );
+};
+
+type Story = StoryFn<typeof StudioPageImageBackgroundContainer>;
+
+const meta: Meta = {
+  title: 'Components/StudioPageImageBackgroundContainer',
+  component: StudioPageImageBackgroundContainer,
+};
+export const Preview: Story = (args): React.ReactElement => (
+  <StudioPageImageBackgroundContainer {...args} />
+);
+
+Preview.args = {
+  image: 'https://info.altinn.no/Static/img/illustration/illustrasjon_logginn_alt.svg',
+  children: <ChildrenComponent />,
+};
+
+export default meta;

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.test.tsx
@@ -6,8 +6,7 @@ import {
 } from './index';
 import type { RenderResult } from '@testing-library/react';
 
-const customImage1 = 'https://example.com/custom-image1.jpg';
-const customImage2 = 'https://example.com/custom-image2.jpg';
+const customImage = 'https://example.com/custom-image.jpg';
 const testChildren = <div>Test Child</div>;
 
 describe('StudioPageImageBackgroundContainer', () => {
@@ -20,7 +19,7 @@ describe('StudioPageImageBackgroundContainer', () => {
     renderStudioPageImageBackgroundContainer();
     const childElement = screen.getByText('Test Child');
     const backgroundDiv = getBackgroundElement(childElement);
-    expect(backgroundDiv).toHaveStyle(`background-image: url(${customImage1})`);
+    expect(backgroundDiv).toHaveStyle(`background-image: url(${customImage})`);
   });
 
   it('should apply custom className', () => {
@@ -29,14 +28,6 @@ describe('StudioPageImageBackgroundContainer', () => {
     const wrapperDiv = getWrapperElement(container);
     expect(wrapperDiv).toHaveClass('wrapper');
     expect(wrapperDiv).toHaveClass(customClass);
-  });
-
-  it('should handle different image URLs', () => {
-    renderStudioPageImageBackgroundContainer({ image: customImage2 });
-
-    const childElement = screen.getByText('Test Child');
-    const backgroundDiv = getBackgroundElement(childElement);
-    expect(backgroundDiv).toHaveStyle(`background-image: url(${customImage2})`);
   });
 });
 
@@ -51,7 +42,7 @@ const getBackgroundElement = (childElement: HTMLElement): HTMLElement => {
 };
 
 const defaultProps: StudioPageImageBackgroundContainerProps = {
-  image: customImage1,
+  image: customImage,
   children: testChildren,
 };
 

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import {
+  StudioPageImageBackgroundContainer,
+  type StudioPageImageBackgroundContainerProps,
+} from './StudioPageImageBackgroundContainer';
+import type { RenderResult } from '@testing-library/react';
+
+const testImage = 'test-image-url';
+const testChildren = <div>Test Child</div>;
+
+describe('StudioPageImageBackgroundContainer', () => {
+  it('should render children', () => {
+    renderStudioPageImageBackgroundContainer();
+    expect(screen.getByText('Test Child')).toBeInTheDocument();
+  });
+});
+
+const defaultProps: StudioPageImageBackgroundContainerProps = {
+  image: testImage,
+  children: testChildren,
+};
+
+const renderStudioPageImageBackgroundContainer = (
+  props?: Partial<StudioPageImageBackgroundContainerProps>,
+): RenderResult => render(<StudioPageImageBackgroundContainer {...defaultProps} {...props} />);

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.test.tsx
@@ -3,10 +3,11 @@ import { screen, render } from '@testing-library/react';
 import {
   StudioPageImageBackgroundContainer,
   type StudioPageImageBackgroundContainerProps,
-} from './StudioPageImageBackgroundContainer';
+} from './index';
 import type { RenderResult } from '@testing-library/react';
 
-const testImage = 'test-image-url';
+const customImage1 = 'https://example.com/custom-image1.jpg';
+const customImage2 = 'https://example.com/custom-image2.jpg';
 const testChildren = <div>Test Child</div>;
 
 describe('StudioPageImageBackgroundContainer', () => {
@@ -18,14 +19,39 @@ describe('StudioPageImageBackgroundContainer', () => {
   it('should apply the background image correctly', () => {
     renderStudioPageImageBackgroundContainer();
     const childElement = screen.getByText('Test Child');
-    // eslint-disable-next-line testing-library/no-node-access
-    const backgroundDiv = childElement.closest('[style*="background-image"]');
-    expect(backgroundDiv).toHaveStyle(`background-image: url(${testImage})`);
+    const backgroundDiv = getBackgroundElement(childElement);
+    expect(backgroundDiv).toHaveStyle(`background-image: url(${customImage1})`);
+  });
+
+  it('should apply custom className', () => {
+    const customClass = 'my-custom-class';
+    const { container } = renderStudioPageImageBackgroundContainer({ className: customClass });
+    const wrapperDiv = getWrapperElement(container);
+    expect(wrapperDiv).toHaveClass('wrapper');
+    expect(wrapperDiv).toHaveClass(customClass);
+  });
+
+  it('should handle different image URLs', () => {
+    renderStudioPageImageBackgroundContainer({ image: customImage2 });
+
+    const childElement = screen.getByText('Test Child');
+    const backgroundDiv = getBackgroundElement(childElement);
+    expect(backgroundDiv).toHaveStyle(`background-image: url(${customImage2})`);
   });
 });
 
+const getWrapperElement = (container: HTMLElement): HTMLElement => {
+  // eslint-disable-next-line testing-library/no-node-access
+  return container.querySelector('.wrapper') as HTMLElement;
+};
+
+const getBackgroundElement = (childElement: HTMLElement): HTMLElement => {
+  // eslint-disable-next-line testing-library/no-node-access
+  return childElement.closest('[style*="background-image"]') as HTMLElement;
+};
+
 const defaultProps: StudioPageImageBackgroundContainerProps = {
-  image: testImage,
+  image: customImage1,
   children: testChildren,
 };
 

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.test.tsx
@@ -14,6 +14,14 @@ describe('StudioPageImageBackgroundContainer', () => {
     renderStudioPageImageBackgroundContainer();
     expect(screen.getByText('Test Child')).toBeInTheDocument();
   });
+
+  it('should apply the background image correctly', () => {
+    renderStudioPageImageBackgroundContainer();
+    const childElement = screen.getByText('Test Child');
+    // eslint-disable-next-line testing-library/no-node-access
+    const backgroundDiv = childElement.closest('[style*="background-image"]');
+    expect(backgroundDiv).toHaveStyle(`background-image: url(${testImage})`);
+  });
 });
 
 const defaultProps: StudioPageImageBackgroundContainerProps = {
@@ -23,4 +31,6 @@ const defaultProps: StudioPageImageBackgroundContainerProps = {
 
 const renderStudioPageImageBackgroundContainer = (
   props?: Partial<StudioPageImageBackgroundContainerProps>,
-): RenderResult => render(<StudioPageImageBackgroundContainer {...defaultProps} {...props} />);
+): RenderResult => {
+  return render(<StudioPageImageBackgroundContainer {...defaultProps} {...props} />);
+};

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.tsx
@@ -1,0 +1,19 @@
+import React, { type HTMLAttributes, type ReactElement } from 'react';
+import classes from './StudioPageImageBackgroundContainer.module.css';
+
+export type StudioPageImageBackgroundContainerProps = {
+  image: string;
+} & HTMLAttributes<HTMLDivElement>;
+
+export const StudioPageImageBackgroundContainer = ({
+  children,
+  image,
+}: StudioPageImageBackgroundContainerProps): ReactElement => {
+  return (
+    <div className={classes.wrapper}>
+      <div style={{ backgroundImage: `url(${image})` }} className={classes.pageContainer}>
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/StudioPageImageBackgroundContainer.tsx
@@ -8,9 +8,11 @@ export type StudioPageImageBackgroundContainerProps = {
 export const StudioPageImageBackgroundContainer = ({
   children,
   image,
+  className,
+  ...rest
 }: StudioPageImageBackgroundContainerProps): ReactElement => {
   return (
-    <div className={classes.wrapper}>
+    <div className={`${classes.wrapper} ${className ?? ''}`} {...rest}>
       <div style={{ backgroundImage: `url(${image})` }} className={classes.pageContainer}>
         {children}
       </div>

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/index.ts
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioPageImageBackgroundContainer/index.ts
@@ -1,0 +1,4 @@
+export {
+  StudioPageImageBackgroundContainer,
+  type StudioPageImageBackgroundContainerProps,
+} from './StudioPageImageBackgroundContainer';

--- a/src/Designer/frontend/libs/studio-components/src/components/index.ts
+++ b/src/Designer/frontend/libs/studio-components/src/components/index.ts
@@ -35,6 +35,7 @@ export * from './StudioLabel';
 export * from './StudioLink';
 export * from './StudioLinkButton';
 export * from './StudioNotFoundPage';
+export * from './StudioPageImageBackgroundContainer';
 export * from './StudioParagraph';
 export * from './StudioPopover';
 export * from './StudioProperty';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moved StudioPageImageBackgroundContainer to @studio/component


CLOSE: #16319 

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a reusable page container that supports a configurable background image, sizing, no-repeat behavior, and content wrapping with complementary styling.

- **Documentation**
  - Added a Storybook preview demonstrating usage with an image and nested content.

- **Tests**
  - Added unit tests verifying children rendering, background-image application, and custom class support.

- **Chores**
  - Exported the new component from the component library and marked the legacy export as deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->