### PR TITLE
chore(resource-adm): update consent preview styling after design changes

### DIFF
--- a/src/Designer/frontend/resourceadm/components/ConsentPreview/ConsentPreview.module.css
+++ b/src/Designer/frontend/resourceadm/components/ConsentPreview/ConsentPreview.module.css
@@ -1,42 +1,3 @@
-.consentBlock {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ds-size-8);
-  background-color: var(--ds-color-accent-background-default);
-  padding: var(--ds-size-12);
-  margin-bottom: 3px;
-}
-
-.expiration {
-  margin-top: var(--ds-size-4);
-}
-
-.boldText {
-  font-weight: var(--ds-font-weight-medium);
-}
-
-.buttonRow {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: var(--ds-size-4);
-  margin-top: var(--ds-size-15);
-  pointer-events: none;
-}
-
-.consentRight {
-  display: flex;
-  flex-direction: row;
-  gap: var(--ds-size-4);
-}
-.consentRightIcon {
-  font-size: var(--ds-font-size-6);
-}
-
-.consentRightContent {
-  flex: 1;
-}
-
 .previewControls {
   display: flex;
   flex-direction: column;
@@ -50,6 +11,7 @@
   display: flex;
   flex-direction: column;
   background-color: var(--ds-color-neutral-background-tinted);
+  font-family: 'Inter', sans-serif;
   position: sticky;
   height: 100vh;
   top: 0;
@@ -66,16 +28,84 @@
   width: 45%;
 }
 
+/* styling from ConsentRequestPage */
+
+.consentBlock {
+  background-color: var(--ds-color-accent-background-default);
+  padding: var(--ds-size-9) var(--ds-size-15);
+  margin-bottom: var(--ds-size-12);
+}
+.headerBlock {
+  padding-top: var(--ds-size-14);
+  margin-bottom: 3px;
+}
+
+.consentContent {
+  display: flex;
+  flex-direction: column;
+  max-width: 55rem;
+}
+
+.heading {
+  font-weight: var(--ds-font-weight-semibold);
+  font-size: var(--ds-body-md-font-size);
+  margin-bottom: var(--ds-size-8);
+}
+
+.consentMessage {
+  margin-bottom: var(--ds-size-13);
+}
+
+.serviceIntro {
+  font-weight: var(--ds-font-weight-medium);
+  font-size: var(--ds-body-md-font-size);
+  margin-bottom: var(--ds-size-8);
+}
+
+.handledBy {
+  margin-top: var(--ds-size-5);
+}
+
+.expiration {
+  font-weight: var(--ds-font-weight-semibold);
+}
+
+.consentRights {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-4);
+  margin-bottom: var(--ds-size-8);
+}
+
+.consentRight {
+  display: flex;
+  flex-direction: row;
+  gap: var(--ds-size-3);
+}
+.consentRightTitle {
+  font-weight: var(--ds-font-weight-semibold);
+}
+.consentRightContent {
+  flex: 1;
+}
+.consentRightIcon {
+  font-size: var(--ds-size-7);
+}
+
+.buttonRow {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: var(--ds-size-4);
+  margin-top: var(--ds-size-13);
+  margin-bottom: var(--ds-size-6);
+}
+
 .mobileView {
   max-width: 25rem;
 }
-.mobileView h1 {
-  font-size: var(--ds-heading-2xs-font-size);
-}
 .mobileView .consentBlock {
-  padding: var(--ds-size-5);
-}
-.mobileView .expiration,
-.mobileView .buttonRow {
-  margin-top: 0;
+  padding-left: var(--ds-size-6);
+  padding-right: var(--ds-size-6);
+  margin-bottom: 6px;
 }

--- a/src/Designer/frontend/resourceadm/components/ConsentPreview/ConsentPreview.tsx
+++ b/src/Designer/frontend/resourceadm/components/ConsentPreview/ConsentPreview.tsx
@@ -182,7 +182,7 @@ export const ConsentPreview = ({
 
 const replaceMetadata = (consentText: string, metadata: { [key: string]: string }): string => {
   return Object.keys(metadata).reduce((acc, metadataKey) => {
-    return acc.replace(`{${metadataKey}}`, metadata[metadataKey]);
+    return acc.replaceAll(`{${metadataKey}}`, metadata[metadataKey]);
   }, consentText);
 };
 
@@ -201,7 +201,7 @@ const getDummyResourceMetadata = (consentMetadata: ConsentMetadata) => {
 };
 
 const getDummyDateString = (): string => {
-  return new Date().toLocaleDateString('no-NB', {
+  return new Date().toLocaleDateString('nb-NO', {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',

--- a/src/Designer/frontend/resourceadm/components/ConsentPreview/ConsentPreview.tsx
+++ b/src/Designer/frontend/resourceadm/components/ConsentPreview/ConsentPreview.tsx
@@ -135,32 +135,36 @@ export const ConsentPreview = ({
           data-testid='consentPreviewContainer'
           className={isMobileViewEnabled ? classes.mobileView : undefined}
         >
-          <div className={classes.consentBlock}>
+          <div className={cn(classes.consentBlock, classes.headerBlock)}>
             <StudioHeading level={1} data-size='md'>
               {texts.title}
             </StudioHeading>
           </div>
           <div className={classes.consentBlock}>
-            <StudioParagraph className={classes.boldText}>{texts.heading}</StudioParagraph>
-            <StudioParagraph>{texts.consentMessage}</StudioParagraph>
-            <StudioHeading level={2} data-size='2xs'>
-              {texts.serviceIntro}
-            </StudioHeading>
-            <div className={classes.consentRight}>
-              <CheckmarkIcon className={classes.consentRightIcon} />
-              <div className={classes.consentRightContent}>
-                <StudioHeading level={3} data-size='2xs'>
-                  {resourceName[language]}
-                </StudioHeading>
-                <div data-testid={resourceAdmConsentPreview}>
-                  {transformText(texts.resourceText)}
+            <div className={classes.consentContent}>
+              <StudioParagraph className={classes.heading}>{texts.heading}</StudioParagraph>
+              <StudioParagraph className={classes.consentMessage}>
+                {texts.consentMessage}
+              </StudioParagraph>
+              <StudioParagraph className={classes.serviceIntro}>
+                {texts.serviceIntro}
+              </StudioParagraph>
+              <div className={classes.consentRights}>
+                <div className={classes.consentRight}>
+                  <CheckmarkIcon className={classes.consentRightIcon} />
+                  <div className={classes.consentRightContent}>
+                    <StudioParagraph className={classes.consentRightTitle}>
+                      {resourceName[language]}
+                    </StudioParagraph>
+                    <div data-testid={resourceAdmConsentPreview}>
+                      {transformText(texts.resourceText)}
+                    </div>
+                  </div>
                 </div>
+                <StudioParagraph className={classes.expiration}>{texts.expiration}</StudioParagraph>
+                <StudioParagraph className={classes.handledBy}>{texts.handledBy}</StudioParagraph>
               </div>
             </div>
-            <StudioParagraph className={cn(classes.expiration, classes.boldText)}>
-              {texts.expiration}
-            </StudioParagraph>
-            <StudioParagraph>{texts.handledBy}</StudioParagraph>
             <div className={classes.buttonRow}>
               <StudioButton variant='primary' tabIndex={-1}>
                 {texts.approve}


### PR DESCRIPTION
## Description
- Update consent preview styling after minor design changes.
- Use "Inter" font for preview

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Revamped Consent Preview with a clearer, sectioned layout aligned with the Consent Request page.

- Style
  - Standardized typography to Inter and updated spacing for improved readability.
  - Refreshed visual blocks (header, content, rights) with consistent backgrounds, padding, and improved mobile spacing.

- Refactor
  - Reorganized content into semantic sections (heading, message, service info, rights, expiration, handled by) for a more coherent presentation without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->