### PR TITLE
feat: new image upload component behind feature flag

### DIFF
--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -1746,6 +1746,7 @@
   "ux_editor.component_title.Header": "Tittel",
   "ux_editor.component_title.IFrame": "IFrame",
   "ux_editor.component_title.Image": "Bilde",
+  "ux_editor.component_title.ImageUpload": "Bildeopplaster",
   "ux_editor.component_title.Input": "Lite tekstfelt",
   "ux_editor.component_title.InstanceInformation": "Informasjon om eksemplaret",
   "ux_editor.component_title.InstantiationButton": "Start eksemplar",

--- a/src/Designer/frontend/packages/shared/src/types/ApplicationAttachmentMetadata.ts
+++ b/src/Designer/frontend/packages/shared/src/types/ApplicationAttachmentMetadata.ts
@@ -4,5 +4,5 @@ export interface ApplicationAttachmentMetadata {
   maxCount: number;
   minCount: number;
   maxSize: number;
-  fileType: string;
+  fileType?: string;
 }

--- a/src/Designer/frontend/packages/shared/src/types/ComponentSpecificConfig.ts
+++ b/src/Designer/frontend/packages/shared/src/types/ComponentSpecificConfig.ts
@@ -245,6 +245,13 @@ export type ComponentSpecificConfig<T extends ComponentType = ComponentType> = {
       width?: string;
     };
   };
+  [ComponentType.ImageUpload]: {
+    cropArea?: {
+      type?: 'circle' | 'square';
+      width?: number;
+      height?: number;
+    };
+  };
   [ComponentType.Input]: FormComponentProps &
     SummarizableComponentProps &
     LabeledComponentProps & {

--- a/src/Designer/frontend/packages/shared/src/types/ComponentType.ts
+++ b/src/Designer/frontend/packages/shared/src/types/ComponentType.ts
@@ -19,6 +19,7 @@ export enum ComponentType {
   Header = 'Header',
   IFrame = 'IFrame',
   Image = 'Image',
+  ImageUpload = 'ImageUpload',
   Input = 'Input',
   InstanceInformation = 'InstanceInformation',
   InstantiationButton = 'InstantiationButton',

--- a/src/Designer/frontend/packages/shared/src/utils/featureToggleUtils.ts
+++ b/src/Designer/frontend/packages/shared/src/utils/featureToggleUtils.ts
@@ -10,6 +10,7 @@ export enum FeatureFlag {
   ShouldOverrideAppLibCheck = 'shouldOverrideAppLibCheck',
   ConsentResource = 'consentResource',
   AppMetadata = 'appMetadata',
+  ImageUpload = 'imageUpload',
 }
 
 /*

--- a/src/Designer/frontend/packages/ux-editor/src/data/formItemConfig.test.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/data/formItemConfig.test.ts
@@ -33,4 +33,8 @@ describe('formItemConfig', () => {
   test('that payment component is not available in the visible lists', () => {
     expect(allAvailableComponents.map(({ name }) => name)).not.toContain(ComponentType.Payment);
   });
+
+  it('should not include ImageUpload when feature flag is not enabled', () => {
+    expect(allAvailableComponents.map(({ name }) => name)).not.toContain(ComponentType.ImageUpload);
+  });
 });

--- a/src/Designer/frontend/packages/ux-editor/src/data/formItemConfig.test.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/data/formItemConfig.test.ts
@@ -14,7 +14,12 @@ describe('formItemConfig', () => {
     confOnScreenComponents,
   ];
   const allAvailableComponents = allAvailableLists.flat();
-  const excludedComponents = [ComponentType.Custom, ComponentType.Payment, ComponentType.Summary];
+  const excludedComponents = [
+    ComponentType.Custom,
+    ComponentType.Payment,
+    ComponentType.Summary,
+    ComponentType.ImageUpload,
+  ];
 
   /**  Test that all components, except Custom, Payment, and Summary, are available in one of the visible lists */
   it.each(

--- a/src/Designer/frontend/packages/ux-editor/src/data/formItemConfig.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/data/formItemConfig.ts
@@ -645,7 +645,7 @@ export const allComponents: KeyValuePairs<ComponentType[]> = {
     ComponentType.AttachmentList,
     ComponentType.FileUpload,
     ComponentType.FileUploadWithTag,
-    shouldDisplayFeature(FeatureFlag.ImageUpload) && ComponentType.ImageUpload,
+    ...(shouldDisplayFeature(FeatureFlag.ImageUpload) ? [ComponentType.ImageUpload] : []),
   ],
   container: [
     ComponentType.Group,

--- a/src/Designer/frontend/packages/ux-editor/src/data/formItemConfig.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/data/formItemConfig.ts
@@ -40,6 +40,7 @@ import { LayoutItemType } from '../types/global';
 import type { ComponentSpecificConfig } from 'app-shared/types/ComponentSpecificConfig';
 import type { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
 import { FilterUtils } from './FilterUtils';
+import { FeatureFlag, shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
 
 export type FormItemConfig<T extends ComponentType | CustomComponentType = ComponentType> = {
   name: ComponentType | CustomComponentType;
@@ -291,6 +292,19 @@ export const formItemConfigs: FormItemConfigs = {
       },
     },
     propertyPath: 'definitions/imageComponent',
+    icon: ImageIcon,
+  },
+  [ComponentType.ImageUpload]: {
+    name: ComponentType.ImageUpload,
+    itemType: LayoutItemType.Component,
+    defaultProperties: {
+      cropArea: {
+        type: 'circle',
+        width: 300,
+        height: 300,
+      },
+    },
+    propertyPath: 'definitions/imageUploadComponent',
     icon: ImageIcon,
   },
   [ComponentType.Input]: {
@@ -552,6 +566,7 @@ export const schemaComponents: FormItemConfigs[ComponentType][] = [
   formItemConfigs[ComponentType.InstantiationButton],
   formItemConfigs[ComponentType.ActionButton],
   formItemConfigs[ComponentType.Image],
+  shouldDisplayFeature(FeatureFlag.ImageUpload) && formItemConfigs[ComponentType.ImageUpload],
   formItemConfigs[ComponentType.Link],
   formItemConfigs[ComponentType.IFrame],
   formItemConfigs[ComponentType.InstanceInformation],
@@ -630,6 +645,7 @@ export const allComponents: KeyValuePairs<ComponentType[]> = {
     ComponentType.AttachmentList,
     ComponentType.FileUpload,
     ComponentType.FileUploadWithTag,
+    shouldDisplayFeature(FeatureFlag.ImageUpload) && ComponentType.ImageUpload,
   ],
   container: [
     ComponentType.Group,

--- a/src/Designer/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.test.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.test.ts
@@ -63,6 +63,13 @@ describe('useAddItemToLayoutMutation', () => {
     expect(queriesMock.addAppAttachmentMetadata).toHaveBeenCalledTimes(1);
   });
 
+  it('Adds attachment metadata when component type is imageUpload', async () => {
+    const { result } = renderAddItemToLayoutMutation(selectedLayoutSet);
+    result.current.mutate({ ...defaultArgs, componentType: ComponentType.ImageUpload });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queriesMock.addAppAttachmentMetadata).toHaveBeenCalledTimes(1);
+  });
+
   it('Adds correct taskId to attachment metadata when component type is fileUpload and selectedLayoutSet is test-layout-set-1', async () => {
     const { result } = renderAddItemToLayoutMutation(layoutSet1NameMock);
     result.current.mutate({ ...defaultArgs, componentType: ComponentType.FileUpload });

--- a/src/Designer/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/hooks/mutations/useAddItemToLayoutMutation.ts
@@ -48,6 +48,15 @@ export const useAddItemToLayoutMutation = (org: string, app: string, layoutSetNa
             maxSize: maxFileSizeInMB,
           });
         }
+        if (componentType === ComponentType.ImageUpload) {
+          appAttachmentMetadataMutation.mutate({
+            id: newId,
+            taskId: taskId,
+            maxCount: 1,
+            minCount: 0,
+            maxSize: 10,
+          });
+        }
         return newId; // Returns created id
       });
     },

--- a/src/Designer/frontend/packages/ux-editor/src/testing/componentSchemaMocks.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/testing/componentSchemaMocks.ts
@@ -19,6 +19,7 @@ import GroupSchema from './schemas/json/component/Group.schema.v1.json';
 import HeaderSchema from './schemas/json/component/Header.schema.v1.json';
 import IFrameSchema from './schemas/json/component/IFrame.schema.v1.json';
 import ImageSchema from './schemas/json/component/Image.schema.v1.json';
+import ImageUploadSchema from './schemas/json/component/ImageUpload.schema.v1.json';
 import InputSchema from './schemas/json/component/Input.schema.v1.json';
 import InstanceInformationSchema from './schemas/json/component/InstanceInformation.schema.v1.json';
 import InstantiationButtonSchema from './schemas/json/component/InstantiationButton.schema.v1.json';
@@ -66,6 +67,7 @@ export const componentSchemaMocks: Record<ComponentType, JsonSchema> = {
   [ComponentType.Header]: HeaderSchema,
   [ComponentType.IFrame]: IFrameSchema,
   [ComponentType.Image]: ImageSchema,
+  [ComponentType.ImageUpload]: ImageUploadSchema,
   [ComponentType.Input]: InputSchema,
   [ComponentType.InstanceInformation]: InstanceInformationSchema,
   [ComponentType.InstantiationButton]: InstantiationButtonSchema,

--- a/src/Designer/frontend/packages/ux-editor/src/testing/schemas/json/component/ImageUpload.schema.v1.json
+++ b/src/Designer/frontend/packages/ux-editor/src/testing/schemas/json/component/ImageUpload.schema.v1.json
@@ -145,6 +145,36 @@
         }
       }
     },
+    "cropArea": {
+      "title": "Crop Area",
+      "description": "Configuration of the cropping area",
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "Shape",
+          "description": "The shape of the cropping area",
+          "enum": ["square", "circle"],
+          "default": "circle"
+        },
+        "width": {
+          "title": "Width",
+          "description": "Optional width of the cropping area",
+          "type": "number",
+          "default": 300
+        },
+        "height": {
+          "title": "Height",
+          "description": "Optional height of the cropping area",
+          "type": "number",
+          "default": 300
+        }
+      },
+      "default": {
+        "type": "circle",
+        "width": 300,
+        "height": 300
+      }
+    },
     "dataModelBindings": {
       "title": "Data model binding",
       "description": "Describes the location in the data model where the component should store its value(s). A simple binding is used for components that only store a single value, usually a string.",

--- a/src/Designer/frontend/packages/ux-editor/src/testing/schemas/json/component/ImageUpload.schema.v1.json
+++ b/src/Designer/frontend/packages/ux-editor/src/testing/schemas/json/component/ImageUpload.schema.v1.json
@@ -1,0 +1,159 @@
+{
+  "$id": "https://altinncdn.no/schemas/json/component/ImageUpload.schema.v1.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "id": {
+      "title": "ID",
+      "description": "The component ID. Must be unique within all layouts/pages in a layout-set. Cannot end with <dash><number>.",
+      "type": "string",
+      "pattern": "^[0-9a-zA-Z][0-9a-zA-Z-]*(-?[a-zA-Z]+|[a-zA-Z][0-9]+|-[0-9]{6,})$"
+    },
+    "hidden": {
+      "title": "Hidden",
+      "description": "Boolean value or expression indicating if the component should be hidden. Defaults to false.",
+      "default": false,
+      "$ref": "expression.schema.v1.json#/definitions/boolean"
+    },
+    "grid": {
+      "properties": {
+        "xs": { "$ref": "#/definitions/IGridSize" },
+        "sm": { "$ref": "#/definitions/IGridSize" },
+        "md": { "$ref": "#/definitions/IGridSize" },
+        "lg": { "$ref": "#/definitions/IGridSize" },
+        "xl": { "$ref": "#/definitions/IGridSize" },
+        "labelGrid": { "$ref": "#/definitions/IGridStyling" },
+        "innerGrid": { "$ref": "#/definitions/IGridStyling" }
+      }
+    },
+    "pageBreak": {
+      "title": "Page break",
+      "description": "Optionally insert page-break before/after component when rendered in PDF",
+      "type": "object",
+      "properties": {
+        "breakBefore": {
+          "title": "Page break before",
+          "description": "PDF only: Value or expression indicating whether a page break should be added before the component. Can be either: 'auto' (default), 'always', or 'avoid'.",
+          "examples": ["auto", "always", "avoid"],
+          "default": "auto",
+          "$ref": "expression.schema.v1.json#/definitions/string"
+        },
+        "breakAfter": {
+          "title": "Page break after",
+          "description": "PDF only: Value or expression indicating whether a page break should be added after the component. Can be either: 'auto' (default), 'always', or 'avoid'.",
+          "examples": ["auto", "always", "avoid"],
+          "default": "auto",
+          "$ref": "expression.schema.v1.json#/definitions/string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "readOnly": {
+      "title": "Read only/disabled?",
+      "description": "Boolean value or expression indicating if the component should be read only/disabled. Defaults to false. <br /> <i>Please note that even with read-only fields in components, it may currently be possible to update the field by modifying the request sent to the API or through a direct API call.<i/>",
+      "default": false,
+      "$ref": "expression.schema.v1.json#/definitions/boolean"
+    },
+    "required": {
+      "title": "Required?",
+      "description": "Boolean value or expression indicating if the component should be required. Defaults to false.",
+      "default": false,
+      "$ref": "expression.schema.v1.json#/definitions/boolean"
+    },
+    "showValidations": {
+      "title": "Validation types",
+      "description": "List of validation types to show",
+      "type": "array",
+      "items": {
+        "enum": [
+          "Schema",
+          "Component",
+          "Expression",
+          "CustomBackend",
+          "Required",
+          "AllExceptRequired",
+          "All"
+        ],
+        "type": "string"
+      }
+    },
+    "renderAsSummary": {
+      "title": "Render as summary",
+      "description": "Boolean value indicating if the component should be rendered as a summary. Defaults to false.",
+      "default": false,
+      "type": "boolean"
+    },
+    "forceShowInSummary": {
+      "title": "Force show in summary",
+      "description": "Will force show the component in a summary even if hideEmptyFields is set to true in the summary component.",
+      "default": false,
+      "$ref": "expression.schema.v1.json#/definitions/boolean"
+    },
+    "labelSettings": {
+      "title": "ILabelSettings",
+      "type": "object",
+      "properties": {
+        "optionalIndicator": {
+          "title": "Optional indicator",
+          "description": "Show optional indicator on label",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "type": { "const": "ImageUpload" },
+    "textResourceBindings": {
+      "properties": {
+        "title": {
+          "title": "Title",
+          "description": "Label text/title shown above the component",
+          "$ref": "expression.schema.v1.json#/definitions/string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "Label description shown above the component, below the title",
+          "$ref": "expression.schema.v1.json#/definitions/string"
+        },
+        "help": {
+          "title": "Help text",
+          "description": "Help text shown in a tooltip when clicking the help button",
+          "$ref": "expression.schema.v1.json#/definitions/string"
+        },
+        "tableTitle": {
+          "title": "Table title",
+          "description": "Title used in the table view (overrides the default title)",
+          "$ref": "expression.schema.v1.json#/definitions/string"
+        },
+        "shortName": {
+          "title": "Short name (for validation)",
+          "description": "Alternative name used for required validation messages (overrides the default title)",
+          "$ref": "expression.schema.v1.json#/definitions/string"
+        },
+        "requiredValidation": {
+          "title": "Required validation message",
+          "description": "Full validation message shown when the component is required and no value has been entered (overrides both the default and shortName)",
+          "$ref": "expression.schema.v1.json#/definitions/string"
+        },
+        "summaryTitle": {
+          "title": "Summary title",
+          "description": "Title used in the summary view (overrides the default title)",
+          "$ref": "expression.schema.v1.json#/definitions/string"
+        },
+        "summaryAccessibleTitle": {
+          "title": "Accessible summary title",
+          "description": "Title used for aria-label on the edit button in the summary view (overrides the default and summary title)",
+          "$ref": "expression.schema.v1.json#/definitions/string"
+        }
+      }
+    },
+    "dataModelBindings": {
+      "title": "Data model binding",
+      "description": "Describes the location in the data model where the component should store its value(s). A simple binding is used for components that only store a single value, usually a string.",
+      "type": "object",
+      "properties": { "simpleBinding": { "type": "string" } },
+      "required": ["simpleBinding"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["id", "type"],
+  "title": "ImageUpload component schema"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds support for the new image upload component, and is only available behind the feature flag `imageUpload`. Specific config support to the component comes in a later PR. 


<img width="1445" height="828" alt="image" src="https://github.com/user-attachments/assets/3decb0f3-37c1-4bef-b07f-955abfa89db3" />


<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature-flag gated Image Upload component for the form editor with optional crop area (circle or square; defaults to circle 300×300); appears under Attachments when enabled.

* **Tests & Schemas**
  * Adds component JSON schema, test mappings, and tests to validate feature-flag behavior and that attachment metadata is added for Image Upload.

* **Localization**
  * Adds Norwegian Bokmål title for Image Upload.

* **Chores**
  * Attachment metadata type relaxed: fileType is now optional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->