### PR TITLE
feat: add missing datamodel warning to expression editor

### DIFF
--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -441,6 +441,7 @@
   "expression.error.invalidDataModelPath": "Det finnes ikke noe datamodellfelt med denne pekeren. Velg en peker fra listen.",
   "expression.error.invalidFirstOperand": "Den første verdien er ikke gyldig.",
   "expression.error.invalidSecondOperand": "Den andre verdien er ikke gyldig.",
+  "expression.error.missingDataModel": "Det er ikke knyttet en datamodell til dette utfyllingssteget.",
   "expression.error.numericRelationOperatorWithWrongType": "Den operatoren du har valgt kan ikke brukes sammen med de valgte verdiene. Den kan kun brukes med tall.",
   "expression.errorListFooter": "Rett opp feilene og prøv igjen.",
   "expression.errorListHeader": "Kan ikke lagre uttrykket på grunn av disse feilene:",

--- a/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/SubExpression/SubExpressionValueSelector/SubExpressionValueContentInput/DataModelPointerSelector.tsx
+++ b/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioExpression/SimplifiedEditor/LogicalExpressionEditor/SubExpression/SubExpressionValueSelector/SubExpressionValueContentInput/DataModelPointerSelector.tsx
@@ -27,9 +27,10 @@ export const DataModelPointerSelector = ({
     }
   };
 
+  const error = errorKey === null ? undefined : texts.errorMessages[errorKey];
   return (
     <Combobox
-      error={errorKey === null ? undefined : texts.errorMessages[errorKey]}
+      error={options.length === 0 ? texts.missingDataModelLabel : error}
       label={texts.dataModelPath}
       onValueChange={handleChange}
       size='small'

--- a/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioExpression/test-data/texts.ts
+++ b/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioExpression/test-data/texts.ts
@@ -86,6 +86,7 @@ export const texts: ExpressionTexts = {
   logicalOperator: 'Logical operator',
   logicalTupleOperators,
   manual: 'Manual',
+  missingDataModelLabel: 'Det er ikke knyttet en datamodell til dette utfyllingssteget.',
   numberValidationError: 'The value must be a number.',
   or: 'or',
   predefinedGatewayActions,

--- a/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioExpression/types/ExpressionTexts.ts
+++ b/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioExpression/types/ExpressionTexts.ts
@@ -32,6 +32,7 @@ export type ExpressionTexts = {
   logicalOperator: string;
   logicalTupleOperators: Record<LogicalTupleOperator, string>;
   manual: string;
+  missingDataModelLabel: string;
   numberValidationError: string;
   or: string;
   predefinedGatewayActions: Record<PredefinedGatewayAction, string>;

--- a/src/Designer/frontend/packages/shared/src/hooks/useExpressionTexts.ts
+++ b/src/Designer/frontend/packages/shared/src/hooks/useExpressionTexts.ts
@@ -80,6 +80,7 @@ export const useExpressionTexts = (): ExpressionTexts => {
     logicalOperator: t('expression.logicalOperator'),
     logicalTupleOperators,
     manual: t('expression.manual'),
+    missingDataModelLabel: t('expression.error.missingDataModel'),
     numberValidationError: t('validation_errors.numbers_only'),
     or: t('expression.or'),
     predefinedGatewayActions,


### PR DESCRIPTION

## Description

Added a warning message when trying to configure an expression with datamodels, when there is no datamodel connected to the process step.

<img width="720" height="311" alt="Screenshot 2025-09-17 at 08 05 52" src="https://github.com/user-attachments/assets/5b30b5c4-8cfc-409d-992b-fa9b949ef061" />

before: 
<img width="720" height="311" alt="Screenshot 2025-09-17 at 08 07 57" src="https://github.com/user-attachments/assets/48449773-01fb-4580-af62-2bcf288ea371" />

<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
