### PR TITLE
ci: Add .eslintcache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,6 +270,9 @@ Session.vim
 # TSLint report
 tslint_report.json
 
+# Eslint cache
+.eslintcache
+
 
 
 ## -- Repositories --


### PR DESCRIPTION
## Description
This pull request adds `.eslintcache` to `.gitignore`. Eslint generates files with this name to handle local caching for linting scripts. They contain information about the local file structure, so they should not be published to the global repository.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required) - _Tested by creating an `.eslintcache` file locally and observing that it is ignored by Git._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Excludes ESLint cache files from version control to keep the repository clean and prevent accidental commits of transient artifacts.
  * Reduces noisy diffs in pull requests, cuts review overhead, and minimizes CI churn from irrelevant file changes.
  * Streamlines developer workflows by preserving local lint caches without polluting the repo.
  * No user-facing changes; functionality and UI remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->