### PR TITLE
chore: replace StudioSearch from legacy

### DIFF
--- a/src/Designer/frontend/admin/features/apps/components/AppsTable.tsx
+++ b/src/Designer/frontend/admin/features/apps/components/AppsTable.tsx
@@ -1,10 +1,10 @@
 import { useRunningAppsQuery } from 'admin/hooks/queries/useRunningAppsQuery';
 import classes from './AppsTable.module.css';
 import type { RunningApplication } from 'admin/types/RunningApplication';
-import { StudioSpinner, StudioTable } from '@studio/components';
+import { StudioSpinner, StudioTable, StudioSearch } from '@studio/components';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StudioError, StudioSearch, StudioTabs } from '@studio/components-legacy';
+import { StudioError, StudioTabs } from '@studio/components-legacy';
 import { Link } from 'react-router-dom';
 import type { TFunction } from 'i18next';
 
@@ -57,9 +57,7 @@ const AppsTableWithData = ({ runningApps }: AppsTableWithDataProps) => {
           <StudioSearch
             className={classes.appSearch}
             value={search}
-            autoComplete='off'
-            onChange={(e) => setSearch(e.target.value)}
-            onClear={() => setSearch('')}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)}
             label={t('Søk i apper')}
           />
           <StudioTable>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Just replaced StudioSerach from legacy, 

CLOSES: #16380 

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Apps table search to use the latest Studio search component for consistency across the admin UI.
* **Bug Fixes**
  * Improved typing responsiveness and reliability in the search field.
  * Enabled browser autocomplete support in the search input.
  * Removed the custom clear action; clearing now follows the component’s default behavior.
* **Style**
  * Minor visual adjustments may be observed due to the updated search component, while overall layout and filtering behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->