### PR TITLE
fix: Update string restrictions correctly

### DIFF
--- a/src/Designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemRestrictions/ItemRestrictions.tsx
+++ b/src/Designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemRestrictions/ItemRestrictions.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from 'react';
-import React from 'react';
+import React, { useCallback } from 'react';
 import type { UiSchemaNode } from '@altinn/schema-model';
 import {
   isField,
@@ -52,6 +52,13 @@ export const ItemRestrictions = ({ schemaNode }: ItemRestrictionsProps) => {
   const onChangeRestrictions = (path: string, changedRestrictions: KeyValuePairs) =>
     save(setRestrictions(schemaModel, { path, restrictions: changedRestrictions }));
 
+  const handleChangeStringRestrictions = useCallback(
+    (path: string, newRestrictions: KeyValuePairs): void => {
+      save(schemaModel.setRestrictions(path, newRestrictions));
+    },
+    [schemaModel, save],
+  );
+
   const restrictionProps: RestrictionItemProps = {
     restrictions: restrictions ?? {},
     readonly: isReference(schemaNode),
@@ -76,7 +83,12 @@ export const ItemRestrictions = ({ schemaNode }: ItemRestrictionsProps) => {
           [FieldType.Integer]: <NumberRestrictions {...restrictionProps} isInteger />,
           [FieldType.Number]: <NumberRestrictions {...restrictionProps} isInteger={false} />,
           [FieldType.Object]: <ObjectRestrictions {...restrictionProps} />,
-          [FieldType.String]: <StringRestrictions {...restrictionProps} />,
+          [FieldType.String]: (
+            <StringRestrictions
+              {...restrictionProps}
+              onChangeRestrictions={handleChangeStringRestrictions}
+            />
+          ),
         }[schemaNode.fieldType]}
       {isArray && <ArrayRestrictions {...restrictionProps} />}
       {isField(schemaNode) &&

--- a/src/Designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemRestrictions/StringRestrictions/StringRestrictions.test.tsx
+++ b/src/Designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemRestrictions/StringRestrictions/StringRestrictions.test.tsx
@@ -94,7 +94,7 @@ describe('StringRestrictions', () => {
     expect(onChangeRestrictions).toHaveBeenCalledTimes(1);
     expect(onChangeRestrictions).toHaveBeenCalledWith(
       path,
-      expect.objectContaining({ [StrRestrictionKey.format]: '' }),
+      expect.not.objectContaining({ [StrRestrictionKey.format]: expect.anything() }),
     );
   });
 
@@ -266,14 +266,22 @@ describe('StringRestrictions', () => {
   });
 
   test('onChangeRestrictions is called with correct input when minimum length is changed', async () => {
-    renderStringRestrictions({ restrictions: { minLength: '1' } });
-    const minLengthField = screen.getByLabelText(textMock('schema_editor.minLength'));
-    await user.type(minLengthField, '2');
-    await user.tab();
+    renderStringRestrictions({ restrictions: { minLength: 1 } });
+    await user.type(screen.getByLabelText(textMock('schema_editor.minLength')), '2');
     expect(onChangeRestrictions).toHaveBeenCalledTimes(1);
     expect(onChangeRestrictions).toHaveBeenCalledWith(
       path,
-      expect.objectContaining({ [StrRestrictionKey.minLength]: '12' }),
+      expect.objectContaining({ [StrRestrictionKey.minLength]: 12 }),
+    );
+  });
+
+  test('onChangeRestrictions is called with correct input when minimum length is removed', async () => {
+    renderStringRestrictions({ restrictions: { minLength: 1 } });
+    await user.clear(screen.getByLabelText(textMock('schema_editor.minLength')));
+    expect(onChangeRestrictions).toHaveBeenCalledTimes(1);
+    expect(onChangeRestrictions).toHaveBeenCalledWith(
+      path,
+      expect.not.objectContaining({ [StrRestrictionKey.minLength]: expect.anything() }),
     );
   });
 
@@ -285,14 +293,22 @@ describe('StringRestrictions', () => {
   });
 
   test('onChangeRestrictions is called with correct input when maximum length is changed', async () => {
-    renderStringRestrictions({ restrictions: { maxLength: '14' } });
-    const maxLengthField = screen.getByLabelText(textMock('schema_editor.maxLength'));
-    await user.type(maxLengthField, '4');
-    await user.tab();
+    renderStringRestrictions({ restrictions: { maxLength: 14 } });
+    await user.type(screen.getByLabelText(textMock('schema_editor.maxLength')), '4');
     expect(onChangeRestrictions).toHaveBeenCalledTimes(1);
     expect(onChangeRestrictions).toHaveBeenCalledWith(
       path,
-      expect.objectContaining({ [StrRestrictionKey.maxLength]: '144' }),
+      expect.objectContaining({ [StrRestrictionKey.maxLength]: 144 }),
+    );
+  });
+
+  test('onChangeRestrictions is called with correct input when maximum length is removed', async () => {
+    renderStringRestrictions({ restrictions: { maxLength: 14 } });
+    await user.clear(screen.getByLabelText(textMock('schema_editor.maxLength')));
+    expect(onChangeRestrictions).toHaveBeenCalledTimes(1);
+    expect(onChangeRestrictions).toHaveBeenCalledWith(
+      path,
+      expect.not.objectContaining({ [StrRestrictionKey.maxLength]: expect.anything() }),
     );
   });
 

--- a/src/Designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemRestrictions/StringRestrictions/utils.test.ts
+++ b/src/Designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemRestrictions/StringRestrictions/utils.test.ts
@@ -1,9 +1,70 @@
-import { retrieveDateTimeFormatState, updateDateTimeRestrictions } from './utils';
+import { retrieveDateTimeFormatState, updateDateTimeRestrictions, updateFormat } from './utils';
 import type { DateTimeFormatState } from './utils';
-import { StrRestrictionKey } from '@altinn/schema-model/types';
+import { StringFormat, StrRestrictionKey } from '@altinn/schema-model/types';
 import type { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
 
 describe('StringRestrictions utils', () => {
+  describe('updateFormat', () => {
+    it('Removes formatMaximum and formatMinimum restrictions when changing to a different format', () => {
+      const initialRestrictions: KeyValuePairs = {
+        [StrRestrictionKey.format]: StringFormat.DateTime,
+        [StrRestrictionKey.formatMinimum]: '2020-01-01T00:00:00Z',
+        [StrRestrictionKey.formatMaximum]: '2022-01-01T00:00:00Z',
+        [StrRestrictionKey.pattern]: '^.+$',
+      };
+      const newFormat = StringFormat.Email;
+      const expectedResult: KeyValuePairs = {
+        [StrRestrictionKey.format]: newFormat,
+        [StrRestrictionKey.pattern]: '^.+$',
+      };
+      const result = updateFormat(initialRestrictions, newFormat);
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('Removes formatExclusiveMaximum and formatExclusiveMinimum restrictions when changing to a different format', () => {
+      const initialRestrictions: KeyValuePairs = {
+        [StrRestrictionKey.format]: StringFormat.DateTime,
+        [StrRestrictionKey.formatExclusiveMinimum]: '2020-01-01T00:00:00Z',
+        [StrRestrictionKey.formatExclusiveMaximum]: '2022-01-01T00:00:00Z',
+        [StrRestrictionKey.pattern]: '^.+$',
+      };
+      const newFormat = StringFormat.Email;
+      const expectedResult: KeyValuePairs = {
+        [StrRestrictionKey.format]: newFormat,
+        [StrRestrictionKey.pattern]: '^.+$',
+      };
+      const result = updateFormat(initialRestrictions, newFormat);
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('Does not change anything when format is not changed', () => {
+      const format = StringFormat.DateTime;
+      const initialRestrictions: KeyValuePairs = {
+        [StrRestrictionKey.format]: format,
+        [StrRestrictionKey.formatMinimum]: '2020-01-01T00:00:00Z',
+        [StrRestrictionKey.formatMaximum]: '2022-01-01T00:00:00Z',
+        [StrRestrictionKey.pattern]: '^.+$',
+      };
+      const initialRestrictionsCopy = { ...initialRestrictions };
+      const result = updateFormat(initialRestrictions, format);
+      expect(result).toEqual(initialRestrictionsCopy);
+    });
+
+    it('Removes all format-specific restrictions including "format" when format is set to null', () => {
+      const initialRestrictions: KeyValuePairs = {
+        [StrRestrictionKey.format]: StringFormat.DateTime,
+        [StrRestrictionKey.formatMinimum]: '2020-01-01T00:00:00Z',
+        [StrRestrictionKey.formatMaximum]: '2022-01-01T00:00:00Z',
+        [StrRestrictionKey.pattern]: '^.+$',
+      };
+      const expectedResult: KeyValuePairs = {
+        [StrRestrictionKey.pattern]: '^.+$',
+      };
+      const result = updateFormat(initialRestrictions, null);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
   describe('retrieveDateTimeFormatState', () => {
     it('Returns correct state when minimum and maximum are set and they are inclusive', () => {
       const restrictions: KeyValuePairs = {

--- a/src/Designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemRestrictions/StringRestrictions/utils.ts
+++ b/src/Designer/frontend/packages/schema-editor/src/components/SchemaInspector/ItemRestrictions/StringRestrictions/utils.ts
@@ -8,13 +8,51 @@ export function isDateOrTimeFormat(stringRestrictions: KeyValuePairs): boolean {
   );
 }
 
+export function updateFormat(
+  stringRestrictions: KeyValuePairs,
+  format: StringFormat | null,
+): KeyValuePairs {
+  if (stringRestrictions.format === format) return stringRestrictions;
+  const cleanRestrictions = removeFormatSpecificRestrictions(stringRestrictions);
+  return format ? { ...cleanRestrictions, format } : cleanRestrictions;
+}
+
+function removeFormatSpecificRestrictions(stringRestrictions: KeyValuePairs): KeyValuePairs {
+  const formatSpecificRestrictions = [
+    StrRestrictionKey.format,
+    StrRestrictionKey.formatExclusiveMinimum,
+    StrRestrictionKey.formatMinimum,
+    StrRestrictionKey.formatExclusiveMaximum,
+    StrRestrictionKey.formatMaximum,
+  ];
+  return removeRestrictions(stringRestrictions, formatSpecificRestrictions);
+}
+
+function removeRestrictions(
+  stringRestrictions: KeyValuePairs,
+  keys: StrRestrictionKey[],
+): KeyValuePairs {
+  const entries = Object.entries(stringRestrictions);
+  const filteredEntries = entries.filter(([key]) => !keys.includes(key as StrRestrictionKey));
+  return Object.fromEntries(filteredEntries);
+}
+
 export function updateRestriction(
   stringRestrictions: KeyValuePairs,
   key: StrRestrictionKey,
-  value: string,
+  value: string | number,
 ): KeyValuePairs {
   const newRestrictions = ObjectUtils.deepCopy(stringRestrictions);
   newRestrictions[key] = value;
+  return newRestrictions;
+}
+
+export function removeRestriction(
+  stringRestrictions: KeyValuePairs,
+  key: StrRestrictionKey,
+): KeyValuePairs {
+  const newRestrictions = ObjectUtils.deepCopy(stringRestrictions);
+  delete newRestrictions[key];
   return newRestrictions;
 }
 

--- a/src/Designer/frontend/packages/schema-model/src/lib/SchemaModel/SchemaModel.ts
+++ b/src/Designer/frontend/packages/schema-model/src/lib/SchemaModel/SchemaModel.ts
@@ -35,6 +35,7 @@ import {
 import { convertPropToType } from '../mutations/convert-node';
 import { SchemaModelBase } from './SchemaModelBase';
 import { CircularReferenceDetector } from './CircularReferenceDetector';
+import type { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
 
 export class SchemaModel extends SchemaModelBase {
   constructor(nodes: NodeMap) {
@@ -498,6 +499,12 @@ export class SchemaModel extends SchemaModelBase {
   ): boolean {
     const detector = new CircularReferenceDetector(this.nodeMap);
     return detector.willResultInCircularReferences(childSchemaPointer, parentSchemaPointer);
+  }
+
+  public setRestrictions(path: string, restrictions: KeyValuePairs): SchemaModel {
+    const node = this.getNodeBySchemaPointer(path);
+    const newNode: UiSchemaNode = { ...node, restrictions };
+    return this.updateNode(path, newNode);
   }
 }
 


### PR DESCRIPTION
## Description
This pull request addresses the issue where the data model restrictions `formatMinimum`, `formatMaximum`, `formatExclusiveMinimum` and `formatExclusiveMaximum` are not reset when the user changes the `format` setting. There are actually two things that both make this happen:
- Within the `StringRestrictions` component, the format is updated with the internal `setRestriction` functions, which does not care about other restrictions than the one specified.
- The `setRestrictions` function in the `schemaModel` package is more complex than its name suggests. It does not simply replace the restrictions object, but it also handles type casting (converting strings to numbers where necessary), and it keeps all restrictions that are not specified in the input object untouched.

In order to solve the first problem, I have created a new function called `updateFormat`, which ensures that format specific restrictions are deleted from the restrictions object. However, since `setRestrictions` ignores the deleted restrictions (the second problem), that does not make any difference by itself. Therefore I found it best to create a new and cleaner function for updating restrictions, and make `StringRestrictions` use that function instead. I placed that function within the new `SchemaModel` class.

This implied that I also had to change the way the `minLength` and `maxLength` restrictions were updated. These have integer values, but within the `StringRestrictions` component, they were handled as strings. It was the `setRestrictions` function that converted them to numbers. I solved this by using our own `StudioDecimalInput` component, making sure the values are handled as numbers all the way.

## Demo
The easiest way to test this is to verify that the format specific restrictions are removed when the user changes the format.

The following video shows what happens now. Notice that the "earliest" value remains when switching format back and forth.

https://github.com/user-attachments/assets/166ef7a7-d404-4fda-9f65-4b85d6bde197

This video shows what happens with this pull request. Notice that the "earliest" value is removed when the format is changed:

https://github.com/user-attachments/assets/e3aff5d5-793a-4a3c-bb3a-26716504f23f

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Numeric inputs for minLength and maxLength on string fields.
  - Improved format handling: changing or clearing format automatically cleans up related format-specific restrictions.
- Bug Fixes
  - Removing minLength, maxLength, or format now properly deletes those restrictions instead of leaving empty values.
  - More reliable saving of string-field restrictions.
- Tests
  - Updated and added tests for numeric length handling and format cleanup to validate removal behavior and ensure accurate restriction updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->