### PR TITLE
fix(resource-adm): fix field going from controlled to uncontrolled if language key is missing

### DIFF
--- a/src/Designer/frontend/resourceadm/components/ResourcePageInputs/ResourceLanguageTextField.tsx
+++ b/src/Designer/frontend/resourceadm/components/ResourcePageInputs/ResourceLanguageTextField.tsx
@@ -212,7 +212,7 @@ export const ResourceLanguageTextField = ({
             </div>
           </div>
         }
-        value={translations[selectedLanguage]}
+        value={translations[selectedLanguage] ?? ''}
         onChange={onFieldValueChanged}
         isTextArea={useTextArea}
         error={mainFieldError.length > 0 ? mainFieldError : undefined}

--- a/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
+++ b/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.test.tsx
@@ -9,6 +9,7 @@ import type {
   ResourceContactPoint,
   ResourceStatusOption,
   ResourceTypeOption,
+  SupportedLanguage,
 } from 'app-shared/types/ResourceAdm';
 import {
   mapKeywordsArrayToString,
@@ -700,5 +701,31 @@ describe('AboutResourcePage', () => {
     expect(
       screen.queryByText(textMock('resourceadm.about_resource_limited_by_rrr_label')),
     ).not.toBeInTheDocument();
+  });
+
+  it('should display empty text in description field if language key is not set', async () => {
+    const user = userEvent.setup();
+    render(
+      <AboutResourcePage
+        {...defaultProps}
+        validationErrors={[]}
+        resourceData={{
+          ...mockResource1,
+          description: {
+            nb: mockResource1.description.nb,
+          } as SupportedLanguage,
+        }}
+      />,
+    );
+
+    const descriptionEnTab = screen.getByLabelText(
+      `${textMock('language.en')} ${textMock('resourceadm.about_resource_resource_description_label')}`,
+    );
+    await user.click(descriptionEnTab);
+
+    const descriptionEnInput = screen.getByRole('textbox', {
+      name: textMock('resourceadm.about_resource_resource_description_label'),
+    });
+    expect(descriptionEnInput).toHaveValue('');
   });
 });


### PR DESCRIPTION
## Description
- When importing link service, language key might be missing for some fields. F.ex if `description` is
`{ "nb": "Beskrivelse"}`, when selecting english description the text from "nb" will still be in the field. Language values should not be `undefined`, but rather empty string if not defined.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented undefined values from appearing in the language text input when a translation is missing, defaulting the field to an empty string.
  * Resolves input-control inconsistencies and potential console warnings related to uncontrolled/controlled inputs, ensuring a consistent blank state for untranslated languages.

* **Tests**
  * Added a test verifying the description input shows an empty value when switching to a language with no translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->