### PR TITLE
chore: cleanup and standardize GH actions workflows

### DIFF
--- a/.github/workflows/app-backend-codeql.yml
+++ b/.github/workflows/app-backend-codeql.yml
@@ -1,18 +1,11 @@
-name: "App Backend - CodeQL"
+name: App Backend - CodeQL
 
 on:
-  push:
-    branches:
-      - "main"
-    paths:
-      - 'src/App/backend/**'
-      - '.github/workflows/app-backend*.yml'
   pull_request:
-    branches:
-      - "main"
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/App/backend/**'
-      - '.github/workflows/app-backend*.yml'
+      - '.github/workflows/app-backend-codeql.yml'
   workflow_dispatch:
   schedule:
     - cron: '37 20 * * 3'

--- a/.github/workflows/app-backend-formatting.yml
+++ b/.github/workflows/app-backend-formatting.yml
@@ -1,10 +1,11 @@
-name: App Backend - Verify dotnet format
+name: App Backend - Verify formatting
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/App/backend/**'
-      - '.github/workflows/app-backend*.yml'
+      - '.github/workflows/app-backend-formatting.yml'
 
 jobs:
   verify-no-changes:

--- a/.github/workflows/app-backend-tests.yml
+++ b/.github/workflows/app-backend-tests.yml
@@ -1,18 +1,11 @@
-name: App Backend - Build and Test
+name: App Backend - Build and test
 
 on:
-  push:
-    branches:
-      - "main"
-    paths:
-      - 'src/App/backend/**'
-      - '.github/workflows/app-backend*.yml'
   pull_request:
-    branches:
-      - "main"
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/App/backend/**'
-      - '.github/workflows/app-backend*.yml'
+      - '.github/workflows/app-backend-tests.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/app-frontend-codeql.yml
+++ b/.github/workflows/app-frontend-codeql.yml
@@ -1,15 +1,12 @@
-name: "App Frontend - CodeQL"
+name: App Frontend - CodeQL
 
 on:
-  push:
-    branches: [ "main" ]
-    paths:
-      - 'src/App/frontend/**'
-      - '.github/workflows/app-frontend*.yml'
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/App/frontend/**'
-      - '.github/workflows/app-frontend*.yml'
+      - '.github/workflows/app-frontend-codeql.yml'
+  workflow_dispatch:
   schedule:
     - cron: "5 12 * * 0"
 

--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -1,25 +1,13 @@
 name: App Frontend - Cypress
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'src/App/frontend/src/**'
-      - 'src/App/frontend/test/**'
-      - 'src/App/frontend/yarn.lock'
-      - '.github/workflows/app-frontend*.yml'
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/App/frontend/src/**'
       - 'src/App/frontend/test/**'
       - 'src/App/frontend/yarn.lock'
-      - '.github/workflows/app-frontend*.yml'
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-
+      - '.github/workflows/app-frontend-cypress.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/app-frontend-unit-tests.yml
+++ b/.github/workflows/app-frontend-unit-tests.yml
@@ -1,18 +1,12 @@
-name: App Frontend - Tests
+name: App Frontend - Unit tests
+
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/App/frontend/src/**'
-      - 'src/App/frontend/yarn.lock'
-      - '.github/workflows/app-frontend*.yml'
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/App/frontend/src/**'
       - 'src/App/frontend/yarn.lock'
-      - '.github/workflows/app-frontend*.yml'
+      - '.github/workflows/app-frontend-unit-tests.yml'
 
 jobs:
   unit-tests:

--- a/.github/workflows/app-template-build-on-pr.yaml
+++ b/.github/workflows/app-template-build-on-pr.yaml
@@ -1,12 +1,13 @@
-name: App Template docker build on PR
+name: App Template - docker build on PR
+
 on:
   pull_request:
-    branches: [ main ]
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/App/template/**'
       - '.github/workflows/app-template-build-on-pr.yaml'
   workflow_dispatch:
+
 jobs:
   analyze:
     strategy:

--- a/.github/workflows/app-template-test.yml
+++ b/.github/workflows/app-template-test.yml
@@ -1,12 +1,13 @@
-name: App Template Build and Test on windows and macos
+name: App Template - Build and test
+
 on:
   pull_request:
-    branches: [ main ]
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/App/template/**'
       - '.github/workflows/app-template-test.yml'
   workflow_dispatch:
+
 jobs:
   analyze:
     strategy:

--- a/.github/workflows/cli-build-test.yaml
+++ b/.github/workflows/cli-build-test.yaml
@@ -1,12 +1,13 @@
-name: CLI - build and test on windows, macos and ubuntu
+name: CLI - Build and test
+
 on:
   pull_request:
-    branches: [ main ]
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - "src/cli/**"
       - .github/workflows/cli-build-test.yaml
   workflow_dispatch:
+
 jobs:
   analyze:
     strategy:

--- a/.github/workflows/designer-backend-check-quartz-update.yml
+++ b/.github/workflows/designer-backend-check-quartz-update.yml
@@ -1,14 +1,11 @@
-name: Designer Verify Quartz migrations
+name: Designer Backend - Verify Quartz migrations
+
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'src/Designer/backend/Directory.Packages.props'
   pull_request:
-    branches: [ main ]
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/Designer/backend/**'
+      - '.github/workflows/designer-backend-check-quartz-update.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/designer-backend-codeql.yml
+++ b/.github/workflows/designer-backend-codeql.yml
@@ -1,20 +1,15 @@
-name: "CodeQL"
+name: Designer Backend - CodeQL
 
 on:
-  push:
-    branches: [ "main" ]
-    paths:
-      - 'src/Designer/testdata/**'
-      - 'src/Designer/backend/**'
-      - 'src/StudioAdmin/**'
-      - 'src/KubernetesWrapper/**'
   pull_request:
-    branches: [ "main" ]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/Designer/testdata/**'
       - 'src/Designer/backend/**'
       - 'src/StudioAdmin/**'
       - 'src/KubernetesWrapper/**'
+      - '.github/workflows/designer-backend-codeql.yml'
+  workflow_dispatch:
   schedule:
     - cron: "55 4 * * 6"
 

--- a/.github/workflows/designer-backend-dotnet-format.yaml
+++ b/.github/workflows/designer-backend-dotnet-format.yaml
@@ -1,13 +1,11 @@
-name: Designer Dotnet format check
+name: Designer Backend - dotnet format check
+
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'src/Designer/backend/**'
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/Designer/backend/**'
+      - '.github/workflows/designer-backend-dotnet-format.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml
+++ b/.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml
@@ -1,11 +1,11 @@
-name: Designer Ensure Migrations Compatibility
+name: Designer Backend - Ensure Migrations Compatibility
+
 on:
   pull_request:
-    branches: [ main ]
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/Designer/backend/**'
-      - '.github/workflows/designer-dotnet-migrations-ensure-compatibility.yaml'
+      - '.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/designer-backend-dotnet-test.yaml
+++ b/.github/workflows/designer-backend-dotnet-test.yaml
@@ -1,18 +1,12 @@
-name: Designer Build and Test on windows, linux and macos
-on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'src/Designer/testdata/**'
-      - 'src/Designer/backend/**'
-      - '.github/workflows/designer-dotnet-test.yaml'
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - 'src/Designer/backend/**'
-      - 'src/Designer/testdata/**'
-      - '.github/workflows/designer-dotnet-test.yaml'
+name: Designer Backend - Build and test
 
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - 'src/Designer/backend/**'
+      - 'src/Designer/testdata/**'
+      - '.github/workflows/designer-backend-dotnet-test.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/designer-backend-gitea-and-db-integration-tests.yaml
+++ b/.github/workflows/designer-backend-gitea-and-db-integration-tests.yaml
@@ -1,17 +1,13 @@
-name: Designer run gitea and db integration tests
+name: Designer Backend - Gitea and Db integration tests
+
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'src/Designer/testdata/**'
-      - 'src/Designer/backend/**'
   pull_request:
-    branches: [ main ]
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/Designer/backend/**'
       - 'src/Designer/testdata/**'
       - 'src/gitea/**'
+      - '.github/workflows/designer-backend-gitea-and-db-integration-tests.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/designer-frontend-config-coverage.yml
+++ b/.github/workflows/designer-frontend-config-coverage.yml
@@ -1,7 +1,8 @@
-name: Designer frontend Configuration coverage stats
+name: Designer Frontend - Configuration coverage stats
 
 on:
-  push:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
     - 'src/Designer/frontend/app-development/**'
     - 'src/Designer/frontend/packages/ux-editor/**'

--- a/.github/workflows/designer-frontend-playwright-staging.yml
+++ b/.github/workflows/designer-frontend-playwright-staging.yml
@@ -1,4 +1,4 @@
-name: Designer Playwright Tests in Staging
+name: Designer Frontend - Playwright tests in Staging
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - 'src/Designer/frontend/**'
-      - '.github/workflows/designer-playwright-staging.yml'
+      - '.github/workflows/designer-frontend-playwright-staging.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
+++ b/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
@@ -1,4 +1,5 @@
-name: Designer Playwright tests on pr
+name: Designer Frontend - Playwright tests on PR
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -7,7 +8,7 @@ on:
       - '!src/Designer/frontend/admin/**'
       - '!src/Designer/frontend/stats/**'
       - 'src/Designer/backend/**'
-      - '.github/workflows/designer-run-playwright-on-pr.yaml'
+      - '.github/workflows/designer-frontend-run-playwright-on-pr.yaml'
       - 'src/Designer/compose.yaml'
       - 'src/Designer/Dockerfile'
       - 'src/gitea/**'

--- a/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
+++ b/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
@@ -2,7 +2,7 @@ name: Designer Frontend - Playwright tests on PR
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/Designer/frontend/**'
       - '!src/Designer/frontend/admin/**'

--- a/.github/workflows/designer-frontend-unit-tests.yml
+++ b/.github/workflows/designer-frontend-unit-tests.yml
@@ -1,7 +1,8 @@
-name: Designer Frontend Tests
+name: Designer Frontend - Unit tests
 
 on:
-  push:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/Designer/frontend/**'
       - 'src/Designer/frontend/testing/cypress/**'

--- a/.github/workflows/gitea-check-texts-file.yml
+++ b/.github/workflows/gitea-check-texts-file.yml
@@ -1,8 +1,8 @@
 name: Gitea check local gitea locale files
+
 on:
   pull_request:
-    branches: [ main ]
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/gitea/Dockerfile'
       - 'src/gitea/files/locale/**'

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,8 +1,7 @@
 name: "Lint PR"
 on:
   pull_request:
-    branches: [ main ]
-    types: [ opened, synchronize, reopened, edited ]
+    types: [opened, reopened, synchronize, ready_for_review, edited]
 
 permissions:
   pull-requests: read

--- a/.github/workflows/runtime-kubernetes-wrapper-dotnet-format.yaml
+++ b/.github/workflows/runtime-kubernetes-wrapper-dotnet-format.yaml
@@ -1,13 +1,11 @@
-name: K8s wrapper Dotnet format check
+name: K8s wrapper - Dotnet format check
+
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'src/Runtime/KubernetesWrapper/src/**'
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/Runtime/KubernetesWrapper/src/**'
+      - '.github/workflows/runtime-kubernetes-wrapper-dotnet-format.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/runtime-kubernetes-wrapper-integrationtests-kind.yaml
+++ b/.github/workflows/runtime-kubernetes-wrapper-integrationtests-kind.yaml
@@ -1,15 +1,12 @@
-name: K8s wrapper Integrationtests
+name: K8s wrapper - Integrationtests
 
 on:
-  push:
-    branches: [ "main" ]
-    paths:
-      - 'src/Runtime/KubernetesWrapper/**'
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/Runtime/KubernetesWrapper/**'
+      - '.github/workflows/runtime-kubernetes-wrapper-integrationtests-kind.yaml'
+  workflow_dispatch:
 
 jobs:
   integrationtests:

--- a/.github/workflows/runtime-localtest-build.yml
+++ b/.github/workflows/runtime-localtest-build.yml
@@ -1,7 +1,8 @@
-name: Localtest build
+name: Localtest - Build
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/Runtime/localtest/**'
 

--- a/.github/workflows/studio-admin-dotnet-format.yml
+++ b/.github/workflows/studio-admin-dotnet-format.yml
@@ -1,11 +1,7 @@
-name: Dotnet format check
+name: StudioAdmin - Dotnet format check
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'src/StudioAdmin/**'
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'src/StudioAdmin/**'
   workflow_dispatch:


### PR DESCRIPTION
## Description

* Consistent file and workflow naming for the Studio-owned workflows (there are some that I wasn't sure about)
* Use mostly `pull_request` triggers for anything that isn't related to deploys or integration tests that are expected to run from `main`
* Consistent `pull_request.types`

Hoping that this will solve some of the weirdness of unrelated pipelines running during subtree pull/add PRs (monorepo migrations)

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized GitHub Actions across projects: removed push triggers, now run on pull_request events (opened, reopened, synchronize, ready_for_review).
  - Refined path filters to target relevant sources and include workflow files; added workflow_dispatch where applicable.
- Style
  - Harmonized workflow display names and capitalization for clearer UI presentation.
- Tests
  - CI behavior aligned to PR-driven runs for unit, integration, security, formatting, and e2e suites; no test logic changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->