### PR TITLE
fix(policy-editor): allow access package eksplisitt tjenestedelegering to be selected

### DIFF
--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyAccessPackages/policyAccessPackageUtils.test.ts
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyAccessPackages/policyAccessPackageUtils.test.ts
@@ -38,6 +38,15 @@ const area1: PolicyAccessPackageArea = {
   ],
 };
 
+const eksplisittPackage = {
+  id: 'c0eb20c1-2268-48f5-88c5-f26cb47a6b1f',
+  name: 'Eksplisitt tjenestedelegering',
+  urn: 'urn:altinn:accesspackage:eksplisitt',
+  description:
+    'Denne fullmakten er ikke delegerbar, og er ikke knyttet til noen roller i ENhetsregisteret. Tilgang til tjenester knyttet til denne pakken kan gis av Hovedadministrator gjennom enkeltrettighetsdelegering.',
+  isDelegable: false,
+};
+
 const area2: PolicyAccessPackageArea = {
   id: 'area2',
   name: 'Area 2',
@@ -120,6 +129,16 @@ describe('policyAccessPackageUtils', () => {
     it('filters away non-delegable access packages', () => {
       const result = filterAccessPackagesByIsDelegable([area1]);
       expect(result).toEqual([{ ...area1, packages: [area1.packages[0], area1.packages[1]] }]);
+    });
+
+    it('should not filter urn:altinn:accesspackage:eksplisitt', () => {
+      const result = filterAccessPackagesByIsDelegable([
+        {
+          ...area1,
+          packages: [eksplisittPackage],
+        },
+      ]);
+      expect(result).toEqual([{ ...area1, packages: [eksplisittPackage] }]);
     });
   });
 

--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyAccessPackages/policyAccessPackageUtils.ts
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyAccessPackages/policyAccessPackageUtils.ts
@@ -48,7 +48,10 @@ export const filterAccessPackagesByIsDelegable = (
   return areas.map((area) => {
     return {
       ...area,
-      packages: area.packages.filter((accessPackage) => accessPackage.isDelegable),
+      packages: area.packages.filter(
+        (accessPackage) =>
+          accessPackage.isDelegable || accessPackage.urn === 'urn:altinn:accesspackage:eksplisitt',
+      ),
     };
   });
 };


### PR DESCRIPTION
## Description
Temp fix: access package "Eksplisitt tjenestedelegering" should be selectable for apps and resources. In a later PR, the `HasResources` flag will determine if an access package should be selectable or not

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Ensures the “Explicit” access package is always shown in the policy editor and not filtered out, even when it’s non-delegable.

- Tests
  - Added test coverage to verify the “Explicit” access package remains visible when filtering access packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->