### PR TITLE
Dropdown does not rerender when changing value to empty array from other sources

### DIFF
--- a/src/App/frontend/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/App/frontend/src/layout/Dropdown/DropdownComponent.tsx
@@ -38,7 +38,6 @@ export function DropdownComponent({ baseComponentId, overrideDisplay }: PropsFro
     const option = options.find((o) => o.value === value);
     return option ? langAsString(option.label).toLowerCase() : value;
   });
-
   const changeMessageGenerator = (values: string[]) => {
     const label = options
       .filter((o) => values.includes(o.value))
@@ -107,6 +106,8 @@ export function DropdownComponent({ baseComponentId, overrideDisplay }: PropsFro
         <Suggestion
           filter={(args) => optionFilter(args, selectedLabels)}
           data-size='sm'
+          key={selectedValues.toString()}
+          //TODO: Remove this when designsystemet have fixed the update https://github.com/digdir/designsystemet/issues/4109
           selected={formatSelectedValues(selectedValues, options)}
           onSelectedChange={(options) => handleChange(options.map((o) => o.value))}
           onBlur={() => debounce}


### PR DESCRIPTION
Added a temporary workaround for fix while waiting for https://github.com/Altinn/app-frontend-react/issues/3104

**Related issues:**
[Designsystemet - 4109](https://github.com/digdir/designsystemet/issues/4109)
[3104](https://github.com/Altinn/app-frontend-react/issues/3104)

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dropdown suggestions now refresh reliably when your selections change, preventing outdated or stale options from appearing.
  * Improves consistency of the dropdown’s displayed options during rapid selection updates for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->