### PR TITLE
Renovate: ignore subtrees

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -71,6 +71,14 @@
       ]
     }
   ],
-  "ignorePaths": ["src/Altinn.Platform/**", "src/test/**"],
+  "ignorePaths": [
+    "src/Altinn.Platform/**",
+    "src/test/**",
+    "src/Runtime/localtest/**",
+    "src/App/frontend/**",
+    "src/App/backend/**",
+    "src/App/fileanalyzers/**",
+    "src/App/codelists/**"
+  ],
   "schedule": ["before 07:00 on Monday"]
 }


### PR DESCRIPTION
Ignore paths that are pulled from subtree repos in renovate. Dependency updates should happen in the external repositories and get synced here.