### PR TITLE
fix(resource-adm): look up resource last modified and changed by in parallel to speed up resource list

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -228,9 +228,11 @@ namespace Altinn.Studio.Designer.Controllers
             List<ServiceResource> repositoryResourceList = _repository.GetServiceResources(org, repository);
             List<ListviewServiceResource> listviewServiceResources = new List<ListviewServiceResource>();
 
-            foreach (ServiceResource resource in repositoryResourceList)
+            IEnumerable<Task<ListviewServiceResource>> tasks = repositoryResourceList.Select(resource => _giteaApi.MapServiceResourceToListViewResource(org, repository, resource));
+            IEnumerable<ListviewServiceResource> resources = await Task.WhenAll(tasks);
+
+            foreach (ListviewServiceResource listviewResource in resources)
             {
-                ListviewServiceResource listviewResource = await _giteaApi.MapServiceResourceToListViewResource(org, repository, resource);
                 listviewResource.HasPolicy = true;
                 listviewResource.Environments = ["gitea"];
                 listviewServiceResources.Add(listviewResource);

--- a/src/Designer/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -228,7 +228,7 @@ namespace Altinn.Studio.Designer.Controllers
             List<ServiceResource> repositoryResourceList = _repository.GetServiceResources(org, repository);
             List<ListviewServiceResource> listviewServiceResources = new List<ListviewServiceResource>();
 
-            SemaphoreSlim semaphore = new(25); // Limit to 25 concurrent requests
+            using SemaphoreSlim semaphore = new(25); // Limit to 25 concurrent requests
             List<Task<ListviewServiceResource>> tasks = [];
 
             foreach (ServiceResource resource in repositoryResourceList)

--- a/src/Designer/backend/src/Designer/Services/Implementation/GiteaAPIWrapper/GiteaAPIWrapper.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/GiteaAPIWrapper/GiteaAPIWrapper.cs
@@ -213,7 +213,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
         }
 
         /// <inheritdoc/>
-        public async Task<ListviewServiceResource> MapServiceResourceToListViewResource(string org, string repo, ServiceResource serviceResource)
+        public async Task<ListviewServiceResource> MapServiceResourceToListViewResource(string org, string repo, ServiceResource serviceResource, CancellationToken cancellationToken)
         {
             ListviewServiceResource listviewResource = new ListviewServiceResource
             {
@@ -223,7 +223,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
             string resourceFolder = serviceResource.Identifier;
 
-            HttpResponseMessage fileResponse = await _httpClient.GetAsync($"repos/{org}/{repo}/commits?path={resourceFolder}&stat=false&verification=false&files=false");
+            HttpResponseMessage fileResponse = await _httpClient.GetAsync($"repos/{org}/{repo}/commits?path={resourceFolder}&stat=false&verification=false&files=false", cancellationToken);
 
             if (fileResponse.StatusCode == HttpStatusCode.OK)
             {
@@ -231,7 +231,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
 
                 try
                 {
-                    commitResponse = await fileResponse.Content.ReadAsAsync<List<GiteaCommit>>();
+                    commitResponse = await fileResponse.Content.ReadAsAsync<List<GiteaCommit>>(cancellationToken);
                 }
                 catch (JsonException)
                 {

--- a/src/Designer/backend/src/Designer/Services/Interfaces/IGitea.cs
+++ b/src/Designer/backend/src/Designer/Services/Interfaces/IGitea.cs
@@ -125,8 +125,9 @@ namespace Altinn.Studio.Designer.Services.Interfaces
         /// <param name="org">The org</param>
         /// <param name="repo">The repository</param>
         /// <param name="serviceResource">The ServiceResource that is to be converted into a ListviewServiceResource</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Returns the ListviewServiceResource based on the information from input and additional fields</returns>
-        Task<ListviewServiceResource> MapServiceResourceToListViewResource(string org, string repo, ServiceResource serviceResource);
+        Task<ListviewServiceResource> MapServiceResourceToListViewResource(string org, string repo, ServiceResource serviceResource, CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets a list of files in a folder from a folder path. Note that the file content is not returned, only metadata.

--- a/src/Designer/backend/tests/Designer.Tests/Mocks/IGiteaMock.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Mocks/IGiteaMock.cs
@@ -214,7 +214,7 @@ namespace Designer.Tests.Mocks
             throw new NotImplementedException();
         }
 
-        public Task<ListviewServiceResource> MapServiceResourceToListViewResource(string org, string repo, ServiceResource serviceResource)
+        public Task<ListviewServiceResource> MapServiceResourceToListViewResource(string org, string repo, ServiceResource serviceResource, CancellationToken cancellation)
         {
             return Task.FromResult(new ListviewServiceResource { CreatedBy = "testUser", Identifier = serviceResource.Identifier, Title = new Dictionary<string, string> { { "test", "test" } }, LastChanged = DateTime.Now, HasPolicy = true });
         }


### PR DESCRIPTION
## Description
- Set last modified and changed by fields in resource list in parallel to attempt to reduce loading time of resource list

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster loading of repository resource lists via parallel processing for noticeably quicker view population.
  * Improved responsiveness when navigating away or cancelling operations — long fetches can be interrupted.
  * Reduced wait time when displaying many resources.
  * Preserves existing behavior (policies and environments still displayed correctly).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->