### PR TITLE
fix(resource-adm): fix for button font-sizes in resources dashboard

### DIFF
--- a/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyAccessPackages/PolicyAccordion/PolicyAccordion.module.css
+++ b/src/Designer/frontend/packages/policy-editor/src/components/PolicyCardRules/PolicyRule/PolicyAccessPackages/PolicyAccordion/PolicyAccordion.module.css
@@ -33,4 +33,5 @@
 .accordionSubTitle {
   color: var(--fds-colors-grey-700);
   font-size: var(--fds-sizing-3);
+  font-weight: var(--ds-font-weight-regular);
 }

--- a/src/Designer/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.test.tsx
+++ b/src/Designer/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.test.tsx
@@ -321,6 +321,25 @@ describe('ResourceDashBoardPage', () => {
 
     expect(mockedNavigate).toHaveBeenCalled();
   });
+
+  it('should navigate to access list page', async () => {
+    const user = userEvent.setup();
+    const getResourceList = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve<ResourceListItem[]>(mockResourceList));
+    renderResourceDashboardPage({ getResourceList });
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByLabelText(textMock('resourceadm.dashboard_spinner')),
+    );
+
+    const accessListButton = screen.getByText(
+      textMock('resourceadm.dashboard_change_organization_lists'),
+    );
+    await user.click(accessListButton);
+
+    expect(mockedNavigate).toHaveBeenCalledWith('/ttd/ttd-resources/accesslists');
+  });
 });
 
 const renderResourceDashboardPage = (

--- a/src/Designer/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.tsx
+++ b/src/Designer/frontend/resourceadm/pages/ResourceDashboardPage/ResourceDashboardPage.tsx
@@ -18,7 +18,6 @@ import { ImportAltinn3ResourceModal } from '../../components/ImportAltinn3Resour
 import { useImportResourceFromAltinn3Mutation } from '../../hooks/mutations/useImportResourceFromAltinn3Mutation';
 import type { EnvId } from '../../utils/resourceUtils';
 import type { Resource } from 'app-shared/types/ResourceAdm';
-import { ButtonRouterLink } from 'app-shared/components/ButtonRouterLink';
 
 /**
  * @component
@@ -128,20 +127,20 @@ export const ResourceDashboardPage = (): React.JSX.Element => {
           })}
         </StudioHeading>
         <div className={classes.topRightWrapper}>
-          <ButtonRouterLink
+          <StudioButton
             variant='tertiary'
-            to={`${getResourceDashboardURL(org, app)}/accesslists`}
+            onClick={() => navigate(`${getResourceDashboardURL(org, app)}/accesslists`)}
+            data-size='md'
+            icon={<TasklistIcon />}
           >
             <strong>{t('resourceadm.dashboard_change_organization_lists')}</strong>
-            <TasklistIcon />
-          </ButtonRouterLink>
+          </StudioButton>
           <div className={classes.verticalDivider} data-color='neutral' />
           <StudioButton
             variant='tertiary'
             onClick={() => importAltinn2ServiceModalRef.current.showModal()}
             data-size='md'
             icon={<MigrationIcon />}
-            iconPlacement='right'
           >
             <strong>{t('resourceadm.dashboard_import_resource')}</strong>
           </StudioButton>
@@ -151,7 +150,6 @@ export const ResourceDashboardPage = (): React.JSX.Element => {
             onClick={() => createResourceModalRef.current?.showModal()}
             data-size='md'
             icon={<PlusCircleIcon />}
-            iconPlacement='right'
           >
             <strong>{t('resourceadm.dashboard_create_resource')}</strong>
           </StudioButton>


### PR DESCRIPTION
## Description
- Text size on "Endre tilgangslister" and the other two header buttons was different. Fix text sizes + move icon to left of button text
<img width="961" height="220" alt="image" src="https://github.com/user-attachments/assets/250e4aa8-be84-411b-b147-d4fd904f9892" />


## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified action buttons with consistent StudioButton styling and medium size.
  * Standardized icon alignment by removing right-aligned icon props; icons use default placement.
  * Adjusted subtitle typography in accordions to use regular font weight for improved consistency.
* **Refactor**
  * Replaced link-based top-right action with a StudioButton that navigates on click; removed nested link components.
* **Tests**
  * Added a navigation test to verify the Access lists button routes correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->