### PR TITLE
fix: add component modal buttons turn white when selected

### DIFF
--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/AddItem/ComponentButton.module.css
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/AddItem/ComponentButton.module.css
@@ -5,7 +5,6 @@
   padding: 2px;
   overflow: wrap;
   text-align: center;
-  background-color: var(--ds-color-neutral-background-default);
 }
 
 .componentButtonInline {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

closes #16527

- Removed `background-color` styling override causing buttons to always have the same color regardless of variant.

<img width="1247" height="742" alt="Screenshot 2025-10-08 at 12 55 23" src="https://github.com/user-attachments/assets/463ababa-f442-4246-8690-8d0cad64c696" />

<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Refined button styling in the design view: standard component buttons no longer display a solid background, creating a cleaner, more modern look aligned with the current theme.
  - Inline component buttons retain their existing background styling for visual distinction.
  - Improves visual consistency and reduces clutter without affecting functionality or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->