### PR TITLE
fix(resource-adm): add new feature flag to skip populating Gitea fields in resource list

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -231,7 +231,11 @@ namespace Altinn.Studio.Designer.Controllers
             IEnumerable<ListviewServiceResource> resources;
             if (skipGiteaFields)
             {
-                resources = listviewServiceResources;
+                resources = repositoryResourceList.Select(resource => new ListviewServiceResource
+                {
+                    Identifier = resource.Identifier,
+                    Title = resource.Title,
+                });
             }
             else
             {
@@ -252,7 +256,6 @@ namespace Altinn.Studio.Designer.Controllers
                 IEnumerable<Task<ListviewServiceResource>> tasks = repositoryResourceList.Select(resource => ProcessResourceAsync(resource));
                 resources = await Task.WhenAll(tasks);
             }
-            
 
             foreach (ListviewServiceResource listviewResource in resources)
             {

--- a/src/Designer/frontend/packages/shared/src/api/paths.js
+++ b/src/Designer/frontend/packages/shared/src/api/paths.js
@@ -162,7 +162,7 @@ export const resourceSubjectsPath = (org, repo) => `${apiBasePath}/${org}/${repo
 export const resourceAccessPackagesPath = (org, repo) => `${apiBasePath}/${org}/${repo}/policy/accesspackageoptions`; // Get
 export const resourceAccessPackageServicesPath = (accessPackageUrn, env) => `${apiBasePath}/accesspackageservices/${accessPackageUrn}/${env}`; // Get
 export const resourcePublishStatusPath = (org, repo, id) => `${apiBasePath}/${org}/resources/publishstatus/${repo}/${id}`; // Get
-export const resourceListPath = (org) => `${apiBasePath}/${org}/resources/resourcelist?includeEnvResources=true`; // Get
+export const resourceListPath = (org, skipGiteaFields) => `${apiBasePath}/${org}/resources/resourcelist?includeEnvResources=true&skipGiteaFields=${skipGiteaFields}`; // Get
 export const resourceCreatePath = (org) => `${apiBasePath}/${org}/resources/addresource`; // Post
 export const resourceSinglePath = (org, repo, id) => `${apiBasePath}/${org}/resources/${repo}/${id}`; // Get
 export const resourceEditPath = (org, id) => `${apiBasePath}/${org}/resources/updateresource/${id}`; // Put

--- a/src/Designer/frontend/packages/shared/src/api/queries.ts
+++ b/src/Designer/frontend/packages/shared/src/api/queries.ts
@@ -181,7 +181,7 @@ export const getPolicySubjects = (org: string, repo: string) => get<PolicySubjec
 export const getAccessPackages = (org: string, repo: string) => get<PolicyAccessPackageAreaGroup[]>(resourceAccessPackagesPath(org, repo));
 export const getAccessPackageServices = (accessPackageUrn: string, env: string) => get<AccessPackageResource[]>(resourceAccessPackageServicesPath(accessPackageUrn, env));
 export const getResource = (org: string, repo: string, id: string) => get<Resource>(resourceSinglePath(org, repo, id));
-export const getResourceList = (org: string) => get<ResourceListItem[]>(resourceListPath(org));
+export const getResourceList = (org: string, skipGiteaFields = false) => get<ResourceListItem[]>(resourceListPath(org, skipGiteaFields));
 export const getResourcePublishStatus = (org: string, repo: string, id: string) => get<ResourceVersionStatus>(resourcePublishStatusPath(org, repo, id));
 export const getValidatePolicy = (org: string, repo: string, id: string) => get<Validation>(resourceValidatePolicyPath(org, repo, id));
 export const getValidateResource = (org: string, repo: string, id: string) => get<Validation>(resourceValidateResourcePath(org, repo, id));

--- a/src/Designer/frontend/packages/shared/src/utils/featureToggleUtils.ts
+++ b/src/Designer/frontend/packages/shared/src/utils/featureToggleUtils.ts
@@ -10,6 +10,7 @@ export enum FeatureFlag {
   ShouldOverrideAppLibCheck = 'shouldOverrideAppLibCheck',
   AppMetadata = 'appMetadata',
   ImageUpload = 'imageUpload',
+  HideGiteaFieldsInResourceList = 'hideGiteaFieldsInResourceList',
 }
 
 /*

--- a/src/Designer/frontend/resourceadm/hooks/queries/useGetResourceListQuery.ts
+++ b/src/Designer/frontend/resourceadm/hooks/queries/useGetResourceListQuery.ts
@@ -4,6 +4,7 @@ import { useServicesContext } from 'app-shared/contexts/ServicesContext';
 import { QueryKey } from 'app-shared/types/QueryKey';
 import type { ResourceListItem } from 'app-shared/types/ResourceAdm';
 import { setLastChangedAndSortResourceListByDate } from '../../utils/mapperUtils';
+import { FeatureFlag, shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
 
 /**
  * Query to get the list of resources. It maps the date to correct display format
@@ -22,7 +23,8 @@ export const useGetResourceListQuery = (
 
   return useQuery<ResourceListItem[]>({
     queryKey: [QueryKey.ResourceList, org],
-    queryFn: () => getResourceList(org),
+    queryFn: () =>
+      getResourceList(org, shouldDisplayFeature(FeatureFlag.HideGiteaFieldsInResourceList)),
     select: (resourceListItems: ResourceListItem[]) =>
       resourceListItems && setLastChangedAndSortResourceListByDate(resourceListItems),
     enabled: !disabled,


### PR DESCRIPTION
## Description
- Add feature flag to skip populating last changed and created by for each resource when on GET resource list

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a feature flag to hide certain fields in resource lists for a cleaner view.
  * When enabled, resource lists load with reduced detail for faster, simpler browsing.
  * Backend and frontend now support an option to fetch resource lists with reduced detail.
  * URL generation and queries automatically respect the flag for consistent behavior across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->