### PR TITLE
fix: Increase Renovate hourly PR limit from 2 to 4

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>Altinn/renovate-config"],
+  "extends": ["local>Altinn/renovate-config", ":prHourlyLimit4"],
   "separateMinorPatch": true,
   "separateMultipleMajor": true,
   "packageRules": [
@@ -51,10 +51,7 @@
     },
     {
       "matchFileNames": ["src/App/**"],
-      "matchPackageNames": [
-        "/^Microsoft\\.CodeAnalysis/",
-        "/^Microsoft\\.Build/"
-      ],
+      "matchPackageNames": ["/^Microsoft\\.CodeAnalysis/", "/^Microsoft\\.Build/"],
       "enabled": false
     },
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Renovate only creates about 4 PRs every Monday, partly due to the `prHourlyLimit` being set to 2 per hour by default:
https://docs.renovatebot.com/configuration-options/#prhourlylimit

This update increases the Renovate configuration limit to 4 pull requests per hour (instead of 2), allowing more PR to be created within the same schedule window:
https://docs.renovatebot.com/presets-default/#prhourlylimit4

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management settings to allow unlimited hourly pull requests, improving the cadence of automated updates and reducing waiting time for dependency refreshes.
- **Style**
  - Standardized formatting in dependency update rules for consistency and readability; no functional impact on the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->