### PR TITLE
fix: Add [Required] annotations to string properties

### DIFF
--- a/src/Designer/backend/src/DataModeling/Converter/Csharp/Compiler.cs
+++ b/src/Designer/backend/src/DataModeling/Converter/Csharp/Compiler.cs
@@ -48,7 +48,16 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
                     List<string> customErrorMessages = new();
                     foreach (Diagnostic diagnostic in diagnostics)
                     {
-                        customErrorMessages.Add(diagnostic.Id + "" + diagnostic.GetMessage() + csharpCode[(diagnostic.Location.SourceSpan.Start - 10)..(diagnostic.Location.SourceSpan.End + 10)]);
+                        int contextStart = Math.Max(0, diagnostic.Location.SourceSpan.Start - 10);
+                        int contextEnd = Math.Min(
+                            csharpCode.Length,
+                            diagnostic.Location.SourceSpan.End + 10
+                        );
+                        string codeContext = csharpCode[contextStart..contextEnd];
+
+                        customErrorMessages.Add(
+                            diagnostic.Id + "" + diagnostic.GetMessage() + codeContext
+                        );
                     }
 
                     throw new CsharpCompilationException("Csharp compilation failed.", customErrorMessages);

--- a/src/Designer/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
+++ b/src/Designer/backend/src/DataModeling/Converter/Csharp/JsonMetadataToCsharpConverter.cs
@@ -172,7 +172,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
             else if (element.IsTagContent)
             {
                 classBuilder.AppendLine(Indent(2) + "[XmlText()]");
-                if (required && isValueType) // Why [Required] only on value types?
+                if (required)
                 {
                     classBuilder.AppendLine(Indent(2) + "[Required]");
                 }
@@ -195,7 +195,7 @@ namespace Altinn.Studio.DataModeling.Converter.Csharp
                 }
                 else
                 {
-                    if (required && isValueType)
+                    if (required)
                     {
                         classBuilder.AppendLine(Indent(2) + "[Required]");
                     }

--- a/src/Designer/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
+++ b/src/Designer/backend/tests/DataModeling.Tests/CsharpEnd2EndGenerationTests.cs
@@ -39,6 +39,10 @@ namespace DataModeling.Tests
         [ClassData(typeof(CSharpE2ERestrictionsTestData))]
         public void Convert_CSharpClass_ShouldContainRestriction(string xsdSchemaPath, string propertyName, string expectedPropertyType, string restrictionString)
         {
+            _testOutput.WriteLine("xsdSchemaPath: " + xsdSchemaPath);
+            _testOutput.WriteLine("propertyName: " + propertyName);
+            _testOutput.WriteLine("expectedPropertyType: " + expectedPropertyType);
+            _testOutput.WriteLine("restrictionString: " + restrictionString);
             Given.That.XsdSchemaLoaded(xsdSchemaPath)
                 .When.LoadedXsdSchemaConvertedToJsonSchema()
                 .And.ConvertedJsonSchemaConvertedToModelMetadata()
@@ -46,6 +50,7 @@ namespace DataModeling.Tests
                 .And.CSharpClassesCompiledToAssembly();
 
             Assert.NotNull(CompiledAssembly);
+            _testOutput.WriteLine(CSharpClasses);
 
             And.PropertyShouldHaveDefinedTypeAndContainAnnotation("Root", propertyName, expectedPropertyType, restrictionString);
         }

--- a/src/Designer/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
+++ b/src/Designer/backend/tests/DataModeling.Tests/TestDataClasses/CSharpE2ERestrictionsTestData.cs
@@ -13,6 +13,7 @@ public class CSharpE2ERestrictionsTestData : IEnumerable<object[]>
         yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t1", "string", "[MaxLength(20)]"];
         yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t2", "string", "[MinLength(10)]"];
         yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t2", "string", "[MaxLength(10)]"];
+        yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t2", "string", "[Required]"];
         yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "t4", "string", @"[RegularExpression(@""^\d\.\d\.\d$"")]"];
         yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "n1", "decimal?", @"[RegularExpression(@""^-?(([0-9]){1}(\.)?){0,10}$"")]"];
         yield return ["Model/XmlSchema/General/SimpleTypeRestrictionsExtended.xsd", "n1", "decimal?", "[Range(-100d, 100d)]"];

--- a/src/Designer/testdata/Model/CSharp/Gitea/3422-39646.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/3422-39646.cs
@@ -73,6 +73,7 @@ namespace Altinn.App.Models
   public class ArsregnskapType25942
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -84,6 +85,7 @@ namespace Altinn.App.Models
   public class ArsregnskapValutakode34984
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -95,6 +97,7 @@ namespace Altinn.App.Models
   public class ArsregnskapValor28974
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -255,6 +258,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -349,6 +353,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -441,6 +446,7 @@ namespace Altinn.App.Models
   public class NoteTilskuddAndre33421
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -534,6 +540,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -628,6 +635,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -722,6 +730,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -816,6 +825,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -910,6 +920,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -1004,6 +1015,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -1098,6 +1110,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -1192,6 +1205,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -1286,6 +1300,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -1429,6 +1444,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -1523,6 +1539,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -1617,6 +1634,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -1711,6 +1729,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -1805,6 +1824,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -1899,6 +1919,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -1993,6 +2014,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -2087,6 +2109,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -2181,6 +2204,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -2329,6 +2353,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -2423,6 +2448,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -2517,6 +2543,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -2611,6 +2638,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -2705,6 +2733,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -2799,6 +2828,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -2893,6 +2923,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -2987,6 +3018,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -3079,6 +3111,7 @@ namespace Altinn.App.Models
   public class NoteResultatkomponenterAndreIFRS35536
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -3173,6 +3206,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -3296,6 +3330,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -3390,6 +3425,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -3484,6 +3520,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -3578,6 +3615,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -3672,6 +3710,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -3812,6 +3851,7 @@ namespace Altinn.App.Models
   public class NotePatenterRettigheter18560
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -3906,6 +3946,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -4000,6 +4041,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -4094,6 +4136,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -4207,6 +4250,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -4301,6 +4345,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -4395,6 +4440,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -4503,6 +4549,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -4597,6 +4644,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -4725,6 +4773,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -4819,6 +4868,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -4913,6 +4963,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -5007,6 +5058,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -5101,6 +5153,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -5195,6 +5248,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -5327,6 +5381,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -5421,6 +5476,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -5534,6 +5590,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -5628,6 +5685,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -5722,6 +5780,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -5840,6 +5899,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -5934,6 +5994,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -6028,6 +6089,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -6122,6 +6184,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -6240,6 +6303,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -6334,6 +6398,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -6428,6 +6493,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -6522,6 +6588,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -6659,6 +6726,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -6753,6 +6821,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -6847,6 +6916,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -6927,6 +6997,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -7021,6 +7092,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -7129,6 +7201,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -7223,6 +7296,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -7346,6 +7420,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -7440,6 +7515,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -7534,6 +7610,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -7628,6 +7705,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -7722,6 +7800,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -7859,6 +7938,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -7953,6 +8033,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -8047,6 +8128,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -8141,6 +8223,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -8259,6 +8342,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -8353,6 +8437,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -8447,6 +8532,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -8541,6 +8627,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -8679,6 +8766,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -8773,6 +8861,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -8867,6 +8956,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -8961,6 +9051,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -9055,6 +9146,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -9149,6 +9241,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -9243,6 +9336,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -9337,6 +9431,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -9445,6 +9540,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -9539,6 +9635,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]

--- a/src/Designer/testdata/Model/CSharp/Gitea/3430-39615.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/3430-39615.cs
@@ -85,6 +85,7 @@ namespace Altinn.App.Models
     [MinLength(9)]
     [MaxLength(9)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -98,6 +99,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -111,6 +113,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(175)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -143,6 +146,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(70)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -172,6 +176,7 @@ namespace Altinn.App.Models
   public class ArsregnskapSysteminnsending35139
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -259,6 +264,7 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -271,6 +277,7 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -283,6 +290,7 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^[0-9]{4}$")]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -319,6 +327,7 @@ namespace Altinn.App.Models
   public class Morselskap4168
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -330,6 +339,7 @@ namespace Altinn.App.Models
   public class KonsernregnskapVedlegg25943
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -341,6 +351,7 @@ namespace Altinn.App.Models
   public class UtenlandskKonsern36640
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -412,6 +423,7 @@ namespace Altinn.App.Models
   public class RegnskapsreglerSmaForetak8079
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -423,6 +435,7 @@ namespace Altinn.App.Models
   public class RegnskapsoppsettIFRS25021
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -434,6 +447,7 @@ namespace Altinn.App.Models
   public class ForenkletIFRS36639
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -445,6 +459,7 @@ namespace Altinn.App.Models
   public class RegnskapsoppsettKonsernIFRS25944
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -456,6 +471,7 @@ namespace Altinn.App.Models
   public class ForenkletIFRSKonsern36641
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -467,6 +483,7 @@ namespace Altinn.App.Models
   public class ArsregnskapIkkeRevisjonBesluttet34669
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -478,6 +495,7 @@ namespace Altinn.App.Models
   public class ArsregnskapUtarbeidelseAvAutorisertRegnskapsforer34670
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -489,6 +507,7 @@ namespace Altinn.App.Models
   public class TjenestebistandEksternAutorisertRegnskapsforer34671
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -519,6 +538,7 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]
@@ -532,6 +552,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(70)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("orid")]

--- a/src/Designer/testdata/Model/CSharp/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/Brønnøysundregistrene_ReelleRettighetshavere_M.cs
@@ -51,11 +51,13 @@ namespace Altinn.App.Models
     [XmlElement("tjeneste", Order = 1)]
     [JsonProperty("tjeneste")]
     [JsonPropertyName("tjeneste")]
+    [Required]
     public string tjeneste { get; set; }
 
     [XmlElement("tjenestehandling", Order = 2)]
     [JsonProperty("tjenestehandling")]
     [JsonPropertyName("tjenestehandling")]
+    [Required]
     public string tjenestehandling { get; set; }
 
   }
@@ -165,6 +167,7 @@ namespace Altinn.App.Models
     [XmlElement("organisasjonsnummer", Order = 1)]
     [JsonProperty("organisasjonsnummer")]
     [JsonPropertyName("organisasjonsnummer")]
+    [Required]
     public string organisasjonsnummer { get; set; }
 
     [XmlElement("hfSoekOrganisasjonsnummerFeilkode", Order = 2)]
@@ -386,11 +389,13 @@ namespace Altinn.App.Models
     [XmlElement("stoerrelsesintervall", Order = 1)]
     [JsonProperty("stoerrelsesintervall")]
     [JsonPropertyName("stoerrelsesintervall")]
+    [Required]
     public string stoerrelsesintervall { get; set; }
 
     [XmlElement("grunnlag", Order = 2)]
     [JsonProperty("grunnlag")]
     [JsonPropertyName("grunnlag")]
+    [Required]
     public string grunnlag { get; set; }
 
     [XmlElement("mellomliggendeVirksomhet", Order = 3)]
@@ -453,6 +458,7 @@ namespace Altinn.App.Models
     [XmlElement("navn", Order = 2)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
+    [Required]
     public string navn { get; set; }
 
     [XmlElement("adresse", Order = 3)]
@@ -467,6 +473,7 @@ namespace Altinn.App.Models
     [XmlElement("friAdressetekst1", Order = 1)]
     [JsonProperty("friAdressetekst1")]
     [JsonPropertyName("friAdressetekst1")]
+    [Required]
     public string friAdressetekst1 { get; set; }
 
     [XmlElement("friAdressetekst2", Order = 2)]
@@ -482,6 +489,7 @@ namespace Altinn.App.Models
     [XmlElement("landkode", Order = 4)]
     [JsonProperty("landkode")]
     [JsonPropertyName("landkode")]
+    [Required]
     public string landkode { get; set; }
 
   }
@@ -491,6 +499,7 @@ namespace Altinn.App.Models
     [XmlElement("grunnlag", Order = 1)]
     [JsonProperty("grunnlag")]
     [JsonPropertyName("grunnlag")]
+    [Required]
     public string grunnlag { get; set; }
 
     [XmlElement("mellomliggendeVirksomhet", Order = 2)]
@@ -505,6 +514,7 @@ namespace Altinn.App.Models
     [XmlElement("markedstype", Order = 1)]
     [JsonProperty("markedstype")]
     [JsonPropertyName("markedstype")]
+    [Required]
     public string markedstype { get; set; }
 
     [XmlElement("hfLandnavn", Order = 2)]
@@ -529,11 +539,13 @@ namespace Altinn.App.Models
     [XmlElement("navn", Order = 1)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
+    [Required]
     public string navn { get; set; }
 
     [XmlElement("landkode", Order = 2)]
     [JsonProperty("landkode")]
     [JsonPropertyName("landkode")]
+    [Required]
     public string landkode { get; set; }
 
   }
@@ -543,6 +555,7 @@ namespace Altinn.App.Models
     [XmlElement("registertype", Order = 1)]
     [JsonProperty("registertype")]
     [JsonPropertyName("registertype")]
+    [Required]
     public string registertype { get; set; }
 
     [XmlElement("hfLandnavn", Order = 2)]
@@ -571,16 +584,19 @@ namespace Altinn.App.Models
     [XmlElement("foedselsdato", Order = 1)]
     [JsonProperty("foedselsdato")]
     [JsonPropertyName("foedselsdato")]
+    [Required]
     public string foedselsdato { get; set; }
 
     [XmlElement("fulltNavn", Order = 2)]
     [JsonProperty("fulltNavn")]
     [JsonPropertyName("fulltNavn")]
+    [Required]
     public string fulltNavn { get; set; }
 
     [XmlElement("rolle", Order = 3)]
     [JsonProperty("rolle")]
     [JsonPropertyName("rolle")]
+    [Required]
     public string rolle { get; set; }
 
   }

--- a/src/Designer/testdata/Model/CSharp/Gitea/Kursdomene_APINøkkel_M_2020-05-26_5702_34556_SERES.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/Kursdomene_APINøkkel_M_2020-05-26_5702_34556_SERES.cs
@@ -46,21 +46,25 @@ namespace Altinn.App.Models
     [XmlElement("applikasjonNavn", Order = 2)]
     [JsonProperty("applikasjonNavn")]
     [JsonPropertyName("applikasjonNavn")]
+    [Required]
     public string applikasjonNavn { get; set; }
 
     [XmlElement("applikasjonType", Order = 3)]
     [JsonProperty("applikasjonType")]
     [JsonPropertyName("applikasjonType")]
+    [Required]
     public string applikasjonType { get; set; }
 
     [XmlElement("begrunnelse", Order = 4)]
     [JsonProperty("begrunnelse")]
     [JsonPropertyName("begrunnelse")]
+    [Required]
     public string begrunnelse { get; set; }
 
     [XmlElement("beskrivelse", Order = 5)]
     [JsonProperty("beskrivelse")]
     [JsonPropertyName("beskrivelse")]
+    [Required]
     public string beskrivelse { get; set; }
 
     [XmlElement("miljoe", Order = 6, IsNullable = true)]
@@ -114,16 +118,19 @@ namespace Altinn.App.Models
     [XmlElement("kontaktpersonEpost", Order = 1)]
     [JsonProperty("kontaktpersonEpost")]
     [JsonPropertyName("kontaktpersonEpost")]
+    [Required]
     public string kontaktpersonEpost { get; set; }
 
     [XmlElement("kontaktpersonNavn", Order = 2)]
     [JsonProperty("kontaktpersonNavn")]
     [JsonPropertyName("kontaktpersonNavn")]
+    [Required]
     public string kontaktpersonNavn { get; set; }
 
     [XmlElement("kontaktpersonTelefon", Order = 3)]
     [JsonProperty("kontaktpersonTelefon")]
     [JsonPropertyName("kontaktpersonTelefon")]
+    [Required]
     public string kontaktpersonTelefon { get; set; }
 
     [Range(Double.MinValue,Double.MaxValue)]
@@ -136,6 +143,7 @@ namespace Altinn.App.Models
     [XmlElement("produsentNavn", Order = 5)]
     [JsonProperty("produsentNavn")]
     [JsonPropertyName("produsentNavn")]
+    [Required]
     public string produsentNavn { get; set; }
 
   }

--- a/src/Designer/testdata/Model/CSharp/Gitea/Kursdomene_BekrefteBruksvilkår_M_2020-05-25_5704_34554_SERES.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/Kursdomene_BekrefteBruksvilkår_M_2020-05-25_5704_34554_SERES.cs
@@ -41,17 +41,20 @@ namespace Altinn.App.Models
     [XmlElement("navn", Order = 1)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
+    [Required]
     public string navn { get; set; }
 
     [RegularExpression(@"[0-9]{9}")]
     [XmlElement("organisasjonsnummer", Order = 2)]
     [JsonProperty("organisasjonsnummer")]
     [JsonPropertyName("organisasjonsnummer")]
+    [Required]
     public string organisasjonsnummer { get; set; }
 
     [XmlElement("navnPaaGodkjenner", Order = 3)]
     [JsonProperty("navnPaaGodkjenner")]
     [JsonPropertyName("navnPaaGodkjenner")]
+    [Required]
     public string navnPaaGodkjenner { get; set; }
 
   }

--- a/src/Designer/testdata/Model/CSharp/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/Kursdomene_BliTjenesteeier_M_2020-05-25_5703_34553_SERES.cs
@@ -46,17 +46,20 @@ namespace Altinn.App.Models
     [XmlElement("navnBokmaal", Order = 1)]
     [JsonProperty("navnBokmaal")]
     [JsonPropertyName("navnBokmaal")]
+    [Required]
     public string navnBokmaal { get; set; }
 
     [RegularExpression(@"[0-9]{9}")]
     [XmlElement("organisasjonsnummer", Order = 2)]
     [JsonProperty("organisasjonsnummer")]
     [JsonPropertyName("organisasjonsnummer")]
+    [Required]
     public string organisasjonsnummer { get; set; }
 
     [XmlElement("sektor", Order = 3)]
     [JsonProperty("sektor")]
     [JsonPropertyName("sektor")]
+    [Required]
     public string sektor { get; set; }
 
     [XmlElement("navnNynorsk", Order = 4, IsNullable = true)]
@@ -72,27 +75,32 @@ namespace Altinn.App.Models
     [XmlElement("akronym", Order = 6)]
     [JsonProperty("akronym")]
     [JsonPropertyName("akronym")]
+    [Required]
     public string akronym { get; set; }
 
     [XmlElement("ipAdresse", Order = 7)]
     [JsonProperty("ipAdresse")]
     [JsonPropertyName("ipAdresse")]
+    [Required]
     public string ipAdresse { get; set; }
 
     [RegularExpression(@"[0-9]{11}")]
     [XmlElement("adminTEServicearkivFoedselsnr", Order = 8)]
     [JsonProperty("adminTEServicearkivFoedselsnr")]
     [JsonPropertyName("adminTEServicearkivFoedselsnr")]
+    [Required]
     public string adminTEServicearkivFoedselsnr { get; set; }
 
     [XmlElement("adminTEServicearkivNavn", Order = 9)]
     [JsonProperty("adminTEServicearkivNavn")]
     [JsonPropertyName("adminTEServicearkivNavn")]
+    [Required]
     public string adminTEServicearkivNavn { get; set; }
 
     [XmlElement("adminTEServicearkivTelefon", Order = 10)]
     [JsonProperty("adminTEServicearkivTelefon")]
     [JsonPropertyName("adminTEServicearkivTelefon")]
+    [Required]
     public string adminTEServicearkivTelefon { get; set; }
 
   }
@@ -102,16 +110,19 @@ namespace Altinn.App.Models
     [XmlElement("navn", Order = 1)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
+    [Required]
     public string navn { get; set; }
 
     [XmlElement("epost", Order = 2)]
     [JsonProperty("epost")]
     [JsonPropertyName("epost")]
+    [Required]
     public string epost { get; set; }
 
     [XmlElement("telefonnummer", Order = 3)]
     [JsonProperty("telefonnummer")]
     [JsonPropertyName("telefonnummer")]
+    [Required]
     public string telefonnummer { get; set; }
 
   }
@@ -121,6 +132,7 @@ namespace Altinn.App.Models
     [XmlElement("hvaKanViBrukeAltinnTil", Order = 1)]
     [JsonProperty("hvaKanViBrukeAltinnTil")]
     [JsonPropertyName("hvaKanViBrukeAltinnTil")]
+    [Required]
     public string hvaKanViBrukeAltinnTil { get; set; }
 
   }

--- a/src/Designer/testdata/Model/CSharp/Gitea/aal-vedlegg.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/aal-vedlegg.cs
@@ -15,11 +15,13 @@ namespace Altinn.App.Models
     [XmlElement("personid", Order = 1)]
     [JsonProperty("personid")]
     [JsonPropertyName("personid")]
+    [Required]
     public string personid { get; set; }
 
     [XmlElement("personidtype", Order = 2)]
     [JsonProperty("personidtype")]
     [JsonPropertyName("personidtype")]
+    [Required]
     public string personidtype { get; set; }
 
     [XmlElement("navn", Order = 3)]
@@ -30,16 +32,19 @@ namespace Altinn.App.Models
     [XmlElement("soeknadsreferense", Order = 4)]
     [JsonProperty("soeknadsreferense")]
     [JsonPropertyName("soeknadsreferense")]
+    [Required]
     public string soeknadsreferense { get; set; }
 
     [XmlElement("vedleggsbeskrivelse", Order = 5)]
     [JsonProperty("vedleggsbeskrivelse")]
     [JsonPropertyName("vedleggsbeskrivelse")]
+    [Required]
     public string vedleggsbeskrivelse { get; set; }
 
     [XmlElement("innsendingsbekreftelse", Order = 6)]
     [JsonProperty("innsendingsbekreftelse")]
     [JsonPropertyName("innsendingsbekreftelse")]
+    [Required]
     public string innsendingsbekreftelse { get; set; }
 
   }
@@ -49,6 +54,7 @@ namespace Altinn.App.Models
     [XmlElement("fornavn", Order = 1)]
     [JsonProperty("fornavn")]
     [JsonPropertyName("fornavn")]
+    [Required]
     public string fornavn { get; set; }
 
     [XmlElement("mellomnavn", Order = 2)]
@@ -59,6 +65,7 @@ namespace Altinn.App.Models
     [XmlElement("etternavn", Order = 3)]
     [JsonProperty("etternavn")]
     [JsonPropertyName("etternavn")]
+    [Required]
     public string etternavn { get; set; }
 
   }

--- a/src/Designer/testdata/Model/CSharp/Gitea/bokskjema.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/bokskjema.cs
@@ -15,26 +15,31 @@ namespace Altinn.App.Models
     [XmlElement("userLanguage", Order = 1)]
     [JsonProperty("userLanguage")]
     [JsonPropertyName("userLanguage")]
+    [Required]
     public string userLanguage { get; set; }
 
     [XmlElement("materialType", Order = 2)]
     [JsonProperty("materialType")]
     [JsonPropertyName("materialType")]
+    [Required]
     public string materialType { get; set; }
 
     [XmlElement("theaterType", Order = 3)]
     [JsonProperty("theaterType")]
     [JsonPropertyName("theaterType")]
+    [Required]
     public string theaterType { get; set; }
 
     [XmlElement("title", Order = 4)]
     [JsonProperty("title")]
     [JsonPropertyName("title")]
+    [Required]
     public string title { get; set; }
 
     [XmlElement("subtitle", Order = 5)]
     [JsonProperty("subtitle")]
     [JsonPropertyName("subtitle")]
+    [Required]
     public string subtitle { get; set; }
 
     [XmlElement("persons", Order = 6)]
@@ -50,12 +55,14 @@ namespace Altinn.App.Models
     [XmlElement("submitter", Order = 8)]
     [JsonProperty("submitter")]
     [JsonPropertyName("submitter")]
+    [Required]
     public string submitter { get; set; }
 
     [RegularExpression(@"^(19|20)[0-9]{2}$")]
     [XmlElement("publishYear", Order = 9)]
     [JsonProperty("publishYear")]
     [JsonPropertyName("publishYear")]
+    [Required]
     public string publishYear { get; set; }
 
     [XmlElement("meantForPress", Order = 10)]
@@ -68,26 +75,31 @@ namespace Altinn.App.Models
     [XmlElement("language", Order = 11)]
     [JsonProperty("language")]
     [JsonPropertyName("language")]
+    [Required]
     public string language { get; set; }
 
     [XmlElement("edition", Order = 12)]
     [JsonProperty("edition")]
     [JsonPropertyName("edition")]
+    [Required]
     public string edition { get; set; }
 
     [XmlElement("publishPlace", Order = 13)]
     [JsonProperty("publishPlace")]
     [JsonPropertyName("publishPlace")]
+    [Required]
     public string publishPlace { get; set; }
 
     [XmlElement("numberOfPages", Order = 14)]
     [JsonProperty("numberOfPages")]
     [JsonPropertyName("numberOfPages")]
+    [Required]
     public string numberOfPages { get; set; }
 
     [XmlElement("premiereDateAndPlace", Order = 15)]
     [JsonProperty("premiereDateAndPlace")]
     [JsonPropertyName("premiereDateAndPlace")]
+    [Required]
     public string premiereDateAndPlace { get; set; }
 
     [XmlElement("hasISBN", Order = 16)]
@@ -101,11 +113,13 @@ namespace Altinn.App.Models
     [XmlElement("isbn", Order = 17)]
     [JsonProperty("isbn")]
     [JsonPropertyName("isbn")]
+    [Required]
     public string isbn { get; set; }
 
     [XmlElement("originalTitle", Order = 18)]
     [JsonProperty("originalTitle")]
     [JsonPropertyName("originalTitle")]
+    [Required]
     public string originalTitle { get; set; }
 
     [XmlElement("isSeries", Order = 19)]
@@ -119,41 +133,49 @@ namespace Altinn.App.Models
     [XmlElement("issn", Order = 20)]
     [JsonProperty("issn")]
     [JsonPropertyName("issn")]
+    [Required]
     public string issn { get; set; }
 
     [XmlElement("seriesTitle", Order = 21)]
     [JsonProperty("seriesTitle")]
     [JsonPropertyName("seriesTitle")]
+    [Required]
     public string seriesTitle { get; set; }
 
     [XmlElement("numberInSeries", Order = 22)]
     [JsonProperty("numberInSeries")]
     [JsonPropertyName("numberInSeries")]
+    [Required]
     public string numberInSeries { get; set; }
 
     [XmlElement("summary", Order = 23)]
     [JsonProperty("summary")]
     [JsonPropertyName("summary")]
+    [Required]
     public string summary { get; set; }
 
     [XmlElement("missionClient", Order = 24)]
     [JsonProperty("missionClient")]
     [JsonPropertyName("missionClient")]
+    [Required]
     public string missionClient { get; set; }
 
     [XmlElement("missionExecutor", Order = 25)]
     [JsonProperty("missionExecutor")]
     [JsonPropertyName("missionExecutor")]
+    [Required]
     public string missionExecutor { get; set; }
 
     [XmlElement("documentType", Order = 26)]
     [JsonProperty("documentType")]
     [JsonPropertyName("documentType")]
+    [Required]
     public string documentType { get; set; }
 
     [XmlElement("scale", Order = 27)]
     [JsonProperty("scale")]
     [JsonPropertyName("scale")]
+    [Required]
     public string scale { get; set; }
 
     [XmlElement("hasISMN", Order = 28)]
@@ -167,6 +189,7 @@ namespace Altinn.App.Models
     [XmlElement("ismn", Order = 29)]
     [JsonProperty("ismn")]
     [JsonPropertyName("ismn")]
+    [Required]
     public string ismn { get; set; }
 
     [Range(Double.MinValue,Double.MaxValue)]
@@ -187,6 +210,7 @@ namespace Altinn.App.Models
     [XmlElement("comment", Order = 32)]
     [JsonProperty("comment")]
     [JsonPropertyName("comment")]
+    [Required]
     public string comment { get; set; }
 
     [XmlElement("publishers", Order = 33)]
@@ -209,16 +233,19 @@ namespace Altinn.App.Models
     [XmlElement("role", Order = 1)]
     [JsonProperty("role")]
     [JsonPropertyName("role")]
+    [Required]
     public string role { get; set; }
 
     [XmlElement("firstname", Order = 2)]
     [JsonProperty("firstname")]
     [JsonPropertyName("firstname")]
+    [Required]
     public string firstname { get; set; }
 
     [XmlElement("lastname", Order = 3)]
     [JsonProperty("lastname")]
     [JsonPropertyName("lastname")]
+    [Required]
     public string lastname { get; set; }
 
   }
@@ -236,11 +263,13 @@ namespace Altinn.App.Models
     [XmlElement("orgName", Order = 1)]
     [JsonProperty("orgName")]
     [JsonPropertyName("orgName")]
+    [Required]
     public string orgName { get; set; }
 
     [XmlElement("orgRole", Order = 2)]
     [JsonProperty("orgRole")]
     [JsonPropertyName("orgRole")]
+    [Required]
     public string orgRole { get; set; }
 
   }
@@ -258,6 +287,7 @@ namespace Altinn.App.Models
     [XmlElement("publisherName", Order = 1)]
     [JsonProperty("publisherName")]
     [JsonPropertyName("publisherName")]
+    [Required]
     public string publisherName { get; set; }
 
   }

--- a/src/Designer/testdata/Model/CSharp/Gitea/dat-aarligmelding-bemanning.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/dat-aarligmelding-bemanning.cs
@@ -122,6 +122,7 @@ namespace Altinn.App.Models
     [XmlElement("MeldingTilArbeidstilsynet", Order = 1)]
     [JsonProperty("MeldingTilArbeidstilsynet")]
     [JsonPropertyName("MeldingTilArbeidstilsynet")]
+    [Required]
     public string MeldingTilArbeidstilsynet { get; set; }
 
   }

--- a/src/Designer/testdata/Model/CSharp/Gitea/dihe-redusert-foreldrebetaling-bhg.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/dihe-redusert-foreldrebetaling-bhg.cs
@@ -15,6 +15,7 @@ namespace Altinn.App.Models
     [XmlElement("FORMID", Order = 1)]
     [JsonProperty("FORMID")]
     [JsonPropertyName("FORMID")]
+    [Required]
     public string FORMID { get; set; }
 
     [XmlElement("AVSMOT", Order = 2)]
@@ -54,81 +55,97 @@ namespace Altinn.App.Models
     [XmlElement("AM_ID", Order = 1)]
     [JsonProperty("AM_ID")]
     [JsonPropertyName("AM_ID")]
+    [Required]
     public string AM_ID { get; set; }
 
     [XmlElement("AM_JPID", Order = 2)]
     [JsonProperty("AM_JPID")]
     [JsonPropertyName("AM_JPID")]
+    [Required]
     public string AM_JPID { get; set; }
 
     [XmlElement("AM_IHTYPE", Order = 3)]
     [JsonProperty("AM_IHTYPE")]
     [JsonPropertyName("AM_IHTYPE")]
+    [Required]
     public string AM_IHTYPE { get; set; }
 
     [XmlElement("AM_KOPIMOT", Order = 4)]
     [JsonProperty("AM_KOPIMOT")]
     [JsonPropertyName("AM_KOPIMOT")]
+    [Required]
     public string AM_KOPIMOT { get; set; }
 
     [XmlElement("AM_BEHANSV", Order = 5)]
     [JsonProperty("AM_BEHANSV")]
     [JsonPropertyName("AM_BEHANSV")]
+    [Required]
     public string AM_BEHANSV { get; set; }
 
     [XmlElement("AM_NAVN", Order = 6)]
     [JsonProperty("AM_NAVN")]
     [JsonPropertyName("AM_NAVN")]
+    [Required]
     public string AM_NAVN { get; set; }
 
     [XmlElement("AM_GRUPPEMOT", Order = 7)]
     [JsonProperty("AM_GRUPPEMOT")]
     [JsonPropertyName("AM_GRUPPEMOT")]
+    [Required]
     public string AM_GRUPPEMOT { get; set; }
 
     [XmlElement("AM_ADRESSE", Order = 8)]
     [JsonProperty("AM_ADRESSE")]
     [JsonPropertyName("AM_ADRESSE")]
+    [Required]
     public string AM_ADRESSE { get; set; }
 
     [XmlElement("AM_POSTNR_PO", Order = 9)]
     [JsonProperty("AM_POSTNR_PO")]
     [JsonPropertyName("AM_POSTNR_PO")]
+    [Required]
     public string AM_POSTNR_PO { get; set; }
 
     [XmlElement("AM_POSTSTED", Order = 10)]
     [JsonProperty("AM_POSTSTED")]
     [JsonPropertyName("AM_POSTSTED")]
+    [Required]
     public string AM_POSTSTED { get; set; }
 
     [XmlElement("AM_EPOSTADR", Order = 11)]
     [JsonProperty("AM_EPOSTADR")]
     [JsonPropertyName("AM_EPOSTADR")]
+    [Required]
     public string AM_EPOSTADR { get; set; }
 
     [XmlElement("AM_ADMID_AI", Order = 12)]
     [JsonProperty("AM_ADMID_AI")]
     [JsonPropertyName("AM_ADMID_AI")]
+    [Required]
     public string AM_ADMID_AI { get; set; }
 
     [XmlElement("AM_NASJONALIDENTIFIKATOR_G", Order = 13)]
     [JsonProperty("AM_NASJONALIDENTIFIKATOR_G")]
     [JsonPropertyName("AM_NASJONALIDENTIFIKATOR_G")]
+    [Required]
     public string AM_NASJONALIDENTIFIKATOR_G { get; set; }
 
     [XmlElement("AM_TLF_G", Order = 14)]
     [JsonProperty("AM_TLF_G")]
     [JsonPropertyName("AM_TLF_G")]
+    [Required]
     public string AM_TLF_G { get; set; }
 
     [XmlElement("AM_IFKODE_IF", Order = 15)]
     [JsonProperty("AM_IFKODE_IF")]
     [JsonPropertyName("AM_IFKODE_IF")]
+    [Required]
     public string AM_IFKODE_IF { get; set; }
 
     [XmlElement("AM_PERSON_G", Order = 16)]
     [JsonProperty("AM_PERSON_G")]
     [JsonPropertyName("AM_PERSON_G")]
+    [Required]
     public string AM_PERSON_G { get; set; }
 
   }
@@ -146,11 +163,13 @@ namespace Altinn.App.Models
     [XmlElement("DL_DOKID_DB", Order = 1)]
     [JsonProperty("DL_DOKID_DB")]
     [JsonPropertyName("DL_DOKID_DB")]
+    [Required]
     public string DL_DOKID_DB { get; set; }
 
     [XmlElement("DL_TYPE_DT", Order = 2)]
     [JsonProperty("DL_TYPE_DT")]
     [JsonPropertyName("DL_TYPE_DT")]
+    [Required]
     public string DL_TYPE_DT { get; set; }
 
   }
@@ -168,11 +187,13 @@ namespace Altinn.App.Models
     [XmlElement("DB_DOKID", Order = 1)]
     [JsonProperty("DB_DOKID")]
     [JsonPropertyName("DB_DOKID")]
+    [Required]
     public string DB_DOKID { get; set; }
 
     [XmlElement("DB_TITTEL", Order = 2)]
     [JsonProperty("DB_TITTEL")]
     [JsonPropertyName("DB_TITTEL")]
+    [Required]
     public string DB_TITTEL { get; set; }
 
   }
@@ -190,16 +211,19 @@ namespace Altinn.App.Models
     [XmlElement("VE_DOKID_DB", Order = 1)]
     [JsonProperty("VE_DOKID_DB")]
     [JsonPropertyName("VE_DOKID_DB")]
+    [Required]
     public string VE_DOKID_DB { get; set; }
 
     [XmlElement("VE_DOKFORMAT_LF", Order = 2)]
     [JsonProperty("VE_DOKFORMAT_LF")]
     [JsonPropertyName("VE_DOKFORMAT_LF")]
+    [Required]
     public string VE_DOKFORMAT_LF { get; set; }
 
     [XmlElement("VE_FILREF", Order = 3)]
     [JsonProperty("VE_FILREF")]
     [JsonPropertyName("VE_FILREF")]
+    [Required]
     public string VE_FILREF { get; set; }
 
   }
@@ -209,6 +233,7 @@ namespace Altinn.App.Models
     [XmlElement("kommune", Order = 1)]
     [JsonProperty("kommune")]
     [JsonPropertyName("kommune")]
+    [Required]
     public string kommune { get; set; }
 
     [XmlElement("soker", Order = 2)]
@@ -224,6 +249,7 @@ namespace Altinn.App.Models
     [XmlElement("girSamtykke", Order = 4)]
     [JsonProperty("girSamtykke")]
     [JsonPropertyName("girSamtykke")]
+    [Required]
     public string girSamtykke { get; set; }
 
     [XmlElement("sokerSkattegrunnlag", Order = 5)]
@@ -246,16 +272,19 @@ namespace Altinn.App.Models
     [XmlElement("nedgangInntekt", Order = 8)]
     [JsonProperty("nedgangInntekt")]
     [JsonPropertyName("nedgangInntekt")]
+    [Required]
     public string nedgangInntekt { get; set; }
 
     [XmlElement("upload_vedlegg", Order = 9)]
     [JsonProperty("upload_vedlegg")]
     [JsonPropertyName("upload_vedlegg")]
+    [Required]
     public string upload_vedlegg { get; set; }
 
     [XmlElement("riktigInntekt", Order = 10)]
     [JsonProperty("riktigInntekt")]
     [JsonPropertyName("riktigInntekt")]
+    [Required]
     public string riktigInntekt { get; set; }
 
   }
@@ -265,41 +294,49 @@ namespace Altinn.App.Models
     [XmlElement("navn", Order = 1)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
+    [Required]
     public string navn { get; set; }
 
     [XmlElement("fodselsnummer", Order = 2)]
     [JsonProperty("fodselsnummer")]
     [JsonPropertyName("fodselsnummer")]
+    [Required]
     public string fodselsnummer { get; set; }
 
     [XmlElement("adresse", Order = 3)]
     [JsonProperty("adresse")]
     [JsonPropertyName("adresse")]
+    [Required]
     public string adresse { get; set; }
 
     [XmlElement("postnummer", Order = 4)]
     [JsonProperty("postnummer")]
     [JsonPropertyName("postnummer")]
+    [Required]
     public string postnummer { get; set; }
 
     [XmlElement("poststed", Order = 5)]
     [JsonProperty("poststed")]
     [JsonPropertyName("poststed")]
+    [Required]
     public string poststed { get; set; }
 
     [XmlElement("medSokerNavn", Order = 6)]
     [JsonProperty("medSokerNavn")]
     [JsonPropertyName("medSokerNavn")]
+    [Required]
     public string medSokerNavn { get; set; }
 
     [XmlElement("medSokerFodselsnummer", Order = 7)]
     [JsonProperty("medSokerFodselsnummer")]
     [JsonPropertyName("medSokerFodselsnummer")]
+    [Required]
     public string medSokerFodselsnummer { get; set; }
 
     [XmlElement("medSokerSammeAdresseSomSoker", Order = 8)]
     [JsonProperty("medSokerSammeAdresseSomSoker")]
     [JsonPropertyName("medSokerSammeAdresseSomSoker")]
+    [Required]
     public string medSokerSammeAdresseSomSoker { get; set; }
 
   }
@@ -317,26 +354,31 @@ namespace Altinn.App.Models
     [XmlElement("navn", Order = 1)]
     [JsonProperty("navn")]
     [JsonPropertyName("navn")]
+    [Required]
     public string navn { get; set; }
 
     [XmlElement("fodselsnummer", Order = 2)]
     [JsonProperty("fodselsnummer")]
     [JsonPropertyName("fodselsnummer")]
+    [Required]
     public string fodselsnummer { get; set; }
 
     [XmlElement("navnBhgSfo", Order = 3)]
     [JsonProperty("navnBhgSfo")]
     [JsonPropertyName("navnBhgSfo")]
+    [Required]
     public string navnBhgSfo { get; set; }
 
     [XmlElement("sokerOm", Order = 4)]
     [JsonProperty("sokerOm")]
     [JsonPropertyName("sokerOm")]
+    [Required]
     public string sokerOm { get; set; }
 
     [XmlElement("bhgEllerSfo", Order = 5)]
     [JsonProperty("bhgEllerSfo")]
     [JsonPropertyName("bhgEllerSfo")]
+    [Required]
     public string bhgEllerSfo { get; set; }
 
   }
@@ -354,6 +396,7 @@ namespace Altinn.App.Models
     [XmlElement("grunnlagNavn", Order = 1)]
     [JsonProperty("grunnlagNavn")]
     [JsonPropertyName("grunnlagNavn")]
+    [Required]
     public string grunnlagNavn { get; set; }
 
     [Range(Double.MinValue,Double.MaxValue)]
@@ -370,11 +413,13 @@ namespace Altinn.App.Models
     [XmlElement("testFelt", Order = 1)]
     [JsonProperty("testFelt")]
     [JsonPropertyName("testFelt")]
+    [Required]
     public string testFelt { get; set; }
 
     [XmlElement("sokerForBarn", Order = 2)]
     [JsonProperty("sokerForBarn")]
     [JsonPropertyName("sokerForBarn")]
+    [Required]
     public string sokerForBarn { get; set; }
 
     [XmlElement("prefillBarn", Order = 3)]
@@ -385,16 +430,19 @@ namespace Altinn.App.Models
     [XmlElement("prefillBarnNavn", Order = 4)]
     [JsonProperty("prefillBarnNavn")]
     [JsonPropertyName("prefillBarnNavn")]
+    [Required]
     public string prefillBarnNavn { get; set; }
 
     [XmlElement("skjulSkatteinfo", Order = 5)]
     [JsonProperty("skjulSkatteinfo")]
     [JsonPropertyName("skjulSkatteinfo")]
+    [Required]
     public string skjulSkatteinfo { get; set; }
 
     [XmlElement("folkeregPartner", Order = 6)]
     [JsonProperty("folkeregPartner")]
     [JsonPropertyName("folkeregPartner")]
+    [Required]
     public string folkeregPartner { get; set; }
 
   }

--- a/src/Designer/testdata/Model/CSharp/Gitea/hi-algeskjema.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/hi-algeskjema.cs
@@ -25,11 +25,13 @@ namespace Altinn.App.Models
     [XmlElement("stationtype", Order = 3)]
     [JsonProperty("stationtype")]
     [JsonPropertyName("stationtype")]
+    [Required]
     public string stationtype { get; set; }
 
     [XmlElement("stationid", Order = 4)]
     [JsonProperty("stationid")]
     [JsonPropertyName("stationid")]
+    [Required]
     public string stationid { get; set; }
 
     [XmlElement("longitude", Order = 5)]
@@ -58,6 +60,7 @@ namespace Altinn.App.Models
     [XmlElement("sampledate", Order = 8)]
     [JsonProperty("sampledate")]
     [JsonPropertyName("sampledate")]
+    [Required]
     public string sampledate { get; set; }
 
     [Range(Double.MinValue,Double.MaxValue)]

--- a/src/Designer/testdata/Model/CSharp/Gitea/krt-1188a-1.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/krt-1188a-1.cs
@@ -95,6 +95,7 @@ namespace Altinn.App.Models
   {
     [MaxLength(4)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -107,6 +108,7 @@ namespace Altinn.App.Models
   {
     [MaxLength(175)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -119,6 +121,7 @@ namespace Altinn.App.Models
   {
     [MaxLength(35)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -150,6 +153,7 @@ namespace Altinn.App.Models
     [MinLength(9)]
     [MaxLength(9)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -162,6 +166,7 @@ namespace Altinn.App.Models
   {
     [MaxLength(255)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -275,6 +280,7 @@ namespace Altinn.App.Models
   public class Arkivkode
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -318,6 +324,7 @@ namespace Altinn.App.Models
   public class Epost_S01
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -330,6 +337,7 @@ namespace Altinn.App.Models
   {
     [MaxLength(255)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -342,6 +350,7 @@ namespace Altinn.App.Models
   {
     [MaxLength(20)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -354,6 +363,7 @@ namespace Altinn.App.Models
   {
     [MaxLength(4)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -397,6 +407,7 @@ namespace Altinn.App.Models
   public class Epost_S02
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -409,6 +420,7 @@ namespace Altinn.App.Models
   {
     [MaxLength(255)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -421,6 +433,7 @@ namespace Altinn.App.Models
   {
     [MaxLength(20)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -433,6 +446,7 @@ namespace Altinn.App.Models
   {
     [MaxLength(4)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -463,6 +477,7 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^[0-9]{4}$")]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -474,6 +489,7 @@ namespace Altinn.App.Models
   public class Periodetype
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -497,6 +513,7 @@ namespace Altinn.App.Models
   {
     [MaxLength(50)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -510,6 +527,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(60)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -522,6 +540,7 @@ namespace Altinn.App.Models
   {
     [MaxLength(120)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -533,6 +552,7 @@ namespace Altinn.App.Models
   public class Avdeling
   {
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -546,6 +566,7 @@ namespace Altinn.App.Models
     [MinLength(1)]
     [MaxLength(255)]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]
@@ -558,6 +579,7 @@ namespace Altinn.App.Models
   {
     [RegularExpression(@"^[0-9]{4}$")]
     [XmlText()]
+    [Required]
     public string value { get; set; }
 
     [XmlAttribute("guid")]

--- a/src/Designer/testdata/Model/CSharp/Gitea/skd-formueinntekt-skattemelding-v2.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/skd-formueinntekt-skattemelding-v2.cs
@@ -16,6 +16,7 @@ namespace Altinn.App.Models
     [XmlElement("inntektsaar", Order = 1)]
     [JsonProperty("inntektsaar")]
     [JsonPropertyName("inntektsaar")]
+    [Required]
     public string inntektsaar { get; set; }
 
   }

--- a/src/Designer/testdata/Model/CSharp/Gitea/skjema.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/skjema.cs
@@ -36,6 +36,7 @@ namespace Altinn.App.Models
     [XmlElement("Organisasjonsnummer", Order = 1)]
     [JsonProperty("Organisasjonsnummer")]
     [JsonPropertyName("Organisasjonsnummer")]
+    [Required]
     public string Organisasjonsnummer { get; set; }
 
     [MinLength(0)]
@@ -43,6 +44,7 @@ namespace Altinn.App.Models
     [XmlElement("Navn", Order = 2)]
     [JsonProperty("Navn")]
     [JsonPropertyName("Navn")]
+    [Required]
     public string Navn { get; set; }
 
     [XmlElement("Oppdragsfullmakt", Order = 3)]
@@ -61,6 +63,7 @@ namespace Altinn.App.Models
     [XmlElement("InnloggetBruker", Order = 5)]
     [JsonProperty("InnloggetBruker")]
     [JsonPropertyName("InnloggetBruker")]
+    [Required]
     public string InnloggetBruker { get; set; }
 
   }
@@ -72,6 +75,7 @@ namespace Altinn.App.Models
     [XmlElement("Gateadresse", Order = 1)]
     [JsonProperty("Gateadresse")]
     [JsonPropertyName("Gateadresse")]
+    [Required]
     public string Gateadresse { get; set; }
 
     [MinLength(0)]
@@ -79,6 +83,7 @@ namespace Altinn.App.Models
     [XmlElement("Postnr", Order = 2)]
     [JsonProperty("Postnr")]
     [JsonPropertyName("Postnr")]
+    [Required]
     public string Postnr { get; set; }
 
     [MinLength(0)]
@@ -86,6 +91,7 @@ namespace Altinn.App.Models
     [XmlElement("Poststed", Order = 3)]
     [JsonProperty("Poststed")]
     [JsonPropertyName("Poststed")]
+    [Required]
     public string Poststed { get; set; }
 
     [MinLength(0)]

--- a/src/Designer/testdata/Model/CSharp/Gitea/stami-atid-databehandler-2022.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/stami-atid-databehandler-2022.cs
@@ -22,26 +22,31 @@ namespace Altinn.App.Models
     [XmlElement("signatorNavn", Order = 2)]
     [JsonProperty("signatorNavn")]
     [JsonPropertyName("signatorNavn")]
+    [Required]
     public string signatorNavn { get; set; }
 
     [XmlElement("organisasjonsnummer", Order = 3)]
     [JsonProperty("organisasjonsnummer")]
     [JsonPropertyName("organisasjonsnummer")]
+    [Required]
     public string organisasjonsnummer { get; set; }
 
     [XmlElement("organisasjonsnavn", Order = 4)]
     [JsonProperty("organisasjonsnavn")]
     [JsonPropertyName("organisasjonsnavn")]
+    [Required]
     public string organisasjonsnavn { get; set; }
 
     [XmlElement("agreementCheckbox", Order = 5)]
     [JsonProperty("agreementCheckbox")]
     [JsonPropertyName("agreementCheckbox")]
+    [Required]
     public string agreementCheckbox { get; set; }
 
     [XmlElement("authorizedCheckbox", Order = 6)]
     [JsonProperty("authorizedCheckbox")]
     [JsonPropertyName("authorizedCheckbox")]
+    [Required]
     public string authorizedCheckbox { get; set; }
 
     [XmlElement("contactEmail", Order = 7)]

--- a/src/Designer/testdata/Model/CSharp/Gitea/stami-mu-bestilling-2021.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/stami-mu-bestilling-2021.cs
@@ -15,27 +15,32 @@ namespace Altinn.App.Models
     [XmlElement("organisasjonsnummer", Order = 1)]
     [JsonProperty("organisasjonsnummer")]
     [JsonPropertyName("organisasjonsnummer")]
+    [Required]
     public string organisasjonsnummer { get; set; }
 
     [XmlElement("organisasjonsnavn", Order = 2)]
     [JsonProperty("organisasjonsnavn")]
     [JsonPropertyName("organisasjonsnavn")]
+    [Required]
     public string organisasjonsnavn { get; set; }
 
     [RegularExpression(@"[^@]+@[^\.]+\..+")]
     [XmlElement("epost", Order = 3)]
     [JsonProperty("epost")]
     [JsonPropertyName("epost")]
+    [Required]
     public string epost { get; set; }
 
     [XmlElement("modulvalg", Order = 4)]
     [JsonProperty("modulvalg")]
     [JsonPropertyName("modulvalg")]
+    [Required]
     public string modulvalg { get; set; }
 
     [XmlElement("moduldef", Order = 5)]
     [JsonProperty("moduldef")]
     [JsonPropertyName("moduldef")]
+    [Required]
     public string moduldef { get; set; }
 
   }

--- a/src/Designer/testdata/Model/CSharp/Gitea/stami-mu-databehandler-2021.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/stami-mu-databehandler-2021.cs
@@ -22,26 +22,31 @@ namespace Altinn.App.Models
     [XmlElement("signatorNavn", Order = 2)]
     [JsonProperty("signatorNavn")]
     [JsonPropertyName("signatorNavn")]
+    [Required]
     public string signatorNavn { get; set; }
 
     [XmlElement("organisasjonsnummer", Order = 3)]
     [JsonProperty("organisasjonsnummer")]
     [JsonPropertyName("organisasjonsnummer")]
+    [Required]
     public string organisasjonsnummer { get; set; }
 
     [XmlElement("organisasjonsnavn", Order = 4)]
     [JsonProperty("organisasjonsnavn")]
     [JsonPropertyName("organisasjonsnavn")]
+    [Required]
     public string organisasjonsnavn { get; set; }
 
     [XmlElement("agreementCheckbox", Order = 5)]
     [JsonProperty("agreementCheckbox")]
     [JsonPropertyName("agreementCheckbox")]
+    [Required]
     public string agreementCheckbox { get; set; }
 
     [XmlElement("authorizedCheckbox", Order = 6)]
     [JsonProperty("authorizedCheckbox")]
     [JsonPropertyName("authorizedCheckbox")]
+    [Required]
     public string authorizedCheckbox { get; set; }
 
     [XmlElement("contactEmail", Order = 7)]

--- a/src/Designer/testdata/Model/CSharp/Gitea/udi-unntak-karantenehotell-velferd.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/udi-unntak-karantenehotell-velferd.cs
@@ -49,6 +49,7 @@ namespace Altinn.App.Models
     [XmlElement("hvemSokesDetFor", Order = 1)]
     [JsonProperty("hvemSokesDetFor")]
     [JsonPropertyName("hvemSokesDetFor")]
+    [Required]
     public string hvemSokesDetFor { get; set; }
 
   }
@@ -60,6 +61,7 @@ namespace Altinn.App.Models
     [XmlElement("fornavn", Order = 1)]
     [JsonProperty("fornavn")]
     [JsonPropertyName("fornavn")]
+    [Required]
     public string fornavn { get; set; }
 
     [MinLength(1)]
@@ -74,12 +76,14 @@ namespace Altinn.App.Models
     [XmlElement("etternavn", Order = 3)]
     [JsonProperty("etternavn")]
     [JsonPropertyName("etternavn")]
+    [Required]
     public string etternavn { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
     [XmlElement("fodselsdato", Order = 4)]
     [JsonProperty("fodselsdato")]
     [JsonPropertyName("fodselsdato")]
+    [Required]
     public string fodselsdato { get; set; }
 
     [RegularExpression(@"[0-9]{11}")]
@@ -93,26 +97,31 @@ namespace Altinn.App.Models
     [XmlElement("nummerPaaReisedokument", Order = 6)]
     [JsonProperty("nummerPaaReisedokument")]
     [JsonPropertyName("nummerPaaReisedokument")]
+    [Required]
     public string nummerPaaReisedokument { get; set; }
 
     [XmlElement("Adresse", Order = 7)]
     [JsonProperty("Adresse")]
     [JsonPropertyName("Adresse")]
+    [Required]
     public string Adresse { get; set; }
 
     [XmlElement("Postnummer", Order = 8)]
     [JsonProperty("Postnummer")]
     [JsonPropertyName("Postnummer")]
+    [Required]
     public string Postnummer { get; set; }
 
     [XmlElement("Poststed", Order = 9)]
     [JsonProperty("Poststed")]
     [JsonPropertyName("Poststed")]
+    [Required]
     public string Poststed { get; set; }
 
     [XmlElement("Land", Order = 10)]
     [JsonProperty("Land")]
     [JsonPropertyName("Land")]
+    [Required]
     public string Land { get; set; }
 
     [MinLength(1)]
@@ -121,6 +130,7 @@ namespace Altinn.App.Models
     [XmlElement("telefonnummer", Order = 11)]
     [JsonProperty("telefonnummer")]
     [JsonPropertyName("telefonnummer")]
+    [Required]
     public string telefonnummer { get; set; }
 
     [MinLength(1)]
@@ -129,6 +139,7 @@ namespace Altinn.App.Models
     [XmlElement("epost", Order = 12)]
     [JsonProperty("epost")]
     [JsonPropertyName("epost")]
+    [Required]
     public string epost { get; set; }
 
   }
@@ -140,6 +151,7 @@ namespace Altinn.App.Models
     [XmlElement("fornavn", Order = 1)]
     [JsonProperty("fornavn")]
     [JsonPropertyName("fornavn")]
+    [Required]
     public string fornavn { get; set; }
 
     [MinLength(1)]
@@ -154,6 +166,7 @@ namespace Altinn.App.Models
     [XmlElement("etternavn", Order = 3)]
     [JsonProperty("etternavn")]
     [JsonPropertyName("etternavn")]
+    [Required]
     public string etternavn { get; set; }
 
     [RegularExpression(@"[0-9]{11}")]
@@ -165,21 +178,25 @@ namespace Altinn.App.Models
     [XmlElement("Adresse", Order = 5)]
     [JsonProperty("Adresse")]
     [JsonPropertyName("Adresse")]
+    [Required]
     public string Adresse { get; set; }
 
     [XmlElement("Postnummer", Order = 6)]
     [JsonProperty("Postnummer")]
     [JsonPropertyName("Postnummer")]
+    [Required]
     public string Postnummer { get; set; }
 
     [XmlElement("Poststed", Order = 7)]
     [JsonProperty("Poststed")]
     [JsonPropertyName("Poststed")]
+    [Required]
     public string Poststed { get; set; }
 
     [XmlElement("Land", Order = 8)]
     [JsonProperty("Land")]
     [JsonPropertyName("Land")]
+    [Required]
     public string Land { get; set; }
 
     [MinLength(1)]
@@ -206,6 +223,7 @@ namespace Altinn.App.Models
     [XmlElement("ankomstdato", Order = 1)]
     [JsonProperty("ankomstdato")]
     [JsonPropertyName("ankomstdato")]
+    [Required]
     public string ankomstdato { get; set; }
 
     [XmlElement("landOppholdtI", Order = 2)]
@@ -225,6 +243,7 @@ namespace Altinn.App.Models
     [XmlElement("sammenstilling", Order = 1)]
     [JsonProperty("sammenstilling")]
     [JsonPropertyName("sammenstilling")]
+    [Required]
     public string sammenstilling { get; set; }
 
     [XmlElement("helseproblemer", Order = 2)]
@@ -305,11 +324,13 @@ namespace Altinn.App.Models
     [XmlElement("avsender", Order = 2)]
     [JsonProperty("avsender")]
     [JsonPropertyName("avsender")]
+    [Required]
     public string avsender { get; set; }
 
     [XmlElement("altinnRef", Order = 3)]
     [JsonProperty("altinnRef")]
     [JsonPropertyName("altinnRef")]
+    [Required]
     public string altinnRef { get; set; }
 
   }

--- a/src/Designer/testdata/Model/CSharp/Gitea/udir-invitasjon-vfkl.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/udir-invitasjon-vfkl.cs
@@ -15,87 +15,104 @@ namespace Altinn.App.Models
     [XmlElement("VurderingsType", Order = 1)]
     [JsonProperty("VurderingsType")]
     [JsonPropertyName("VurderingsType")]
+    [Required]
     public string VurderingsType { get; set; }
 
     [XmlElement("BrukerID", Order = 2)]
     [JsonProperty("BrukerID")]
     [JsonPropertyName("BrukerID")]
+    [Required]
     public string BrukerID { get; set; }
 
     [XmlElement("BrukerEpost", Order = 3)]
     [JsonProperty("BrukerEpost")]
     [JsonPropertyName("BrukerEpost")]
+    [Required]
     public string BrukerEpost { get; set; }
 
     [XmlElement("Læremiddel", Order = 4)]
     [JsonProperty("Læremiddel")]
     [JsonPropertyName("Læremiddel")]
+    [Required]
     public string Læremiddel { get; set; }
 
     [XmlElement("LæremiddelLeverandør", Order = 5)]
     [JsonProperty("LæremiddelLeverandør")]
     [JsonPropertyName("LæremiddelLeverandør")]
+    [Required]
     public string LæremiddelLeverandør { get; set; }
 
     [XmlElement("Læreplan", Order = 6)]
     [JsonProperty("Læreplan")]
     [JsonPropertyName("Læreplan")]
+    [Required]
     public string Læreplan { get; set; }
 
     [XmlElement("Skolenivå", Order = 7)]
     [JsonProperty("Skolenivå")]
     [JsonPropertyName("Skolenivå")]
+    [Required]
     public string Skolenivå { get; set; }
 
     [XmlElement("Utdanningsprogram", Order = 8)]
     [JsonProperty("Utdanningsprogram")]
     [JsonPropertyName("Utdanningsprogram")]
+    [Required]
     public string Utdanningsprogram { get; set; }
 
     [XmlElement("Programområde", Order = 9)]
     [JsonProperty("Programområde")]
     [JsonPropertyName("Programområde")]
+    [Required]
     public string Programområde { get; set; }
 
     [XmlElement("gruppeVurderingsID", Order = 10)]
     [JsonProperty("gruppeVurderingsID")]
     [JsonPropertyName("gruppeVurderingsID")]
+    [Required]
     public string gruppeVurderingsID { get; set; }
 
     [RegularExpression(@"^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$")]
     [XmlElement("VurderingsFrist", Order = 11)]
     [JsonProperty("VurderingsFrist")]
     [JsonPropertyName("VurderingsFrist")]
+    [Required]
     public string VurderingsFrist { get; set; }
 
     [XmlElement("MottakerEposter", Order = 12)]
     [JsonProperty("MottakerEposter")]
     [JsonPropertyName("MottakerEposter")]
+    [Required]
     public string MottakerEposter { get; set; }
 
     [XmlElement("Navn", Order = 13)]
     [JsonProperty("Navn")]
     [JsonPropertyName("Navn")]
+    [Required]
     public string Navn { get; set; }
 
     [XmlElement("BortvalgteSpørsmål", Order = 14)]
     [JsonProperty("BortvalgteSpørsmål")]
     [JsonPropertyName("BortvalgteSpørsmål")]
+    [Required]
     public string BortvalgteSpørsmål { get; set; }
 
     [XmlElement("BortvalgteSpørsmålDel1", Order = 15)]
     [JsonProperty("BortvalgteSpørsmålDel1")]
     [JsonPropertyName("BortvalgteSpørsmålDel1")]
+    [Required]
     public string BortvalgteSpørsmålDel1 { get; set; }
 
     [XmlElement("BortvalgteSpørsmålDel2", Order = 16)]
     [JsonProperty("BortvalgteSpørsmålDel2")]
     [JsonPropertyName("BortvalgteSpørsmålDel2")]
+    [Required]
     public string BortvalgteSpørsmålDel2 { get; set; }
 
     [XmlElement("BortvalgteSpørsmålDel3", Order = 17)]
     [JsonProperty("BortvalgteSpørsmålDel3")]
     [JsonPropertyName("BortvalgteSpørsmålDel3")]
+    [Required]
     public string BortvalgteSpørsmålDel3 { get; set; }
 
     [XmlElement("AppLogikk", Order = 18)]
@@ -110,21 +127,25 @@ namespace Altinn.App.Models
     [XmlElement("samledeEposter", Order = 1)]
     [JsonProperty("samledeEposter")]
     [JsonPropertyName("samledeEposter")]
+    [Required]
     public string samledeEposter { get; set; }
 
     [XmlElement("feilendeEposter", Order = 2)]
     [JsonProperty("feilendeEposter")]
     [JsonPropertyName("feilendeEposter")]
+    [Required]
     public string feilendeEposter { get; set; }
 
     [XmlElement("velgBortSpørsmål", Order = 3)]
     [JsonProperty("velgBortSpørsmål")]
     [JsonPropertyName("velgBortSpørsmål")]
+    [Required]
     public string velgBortSpørsmål { get; set; }
 
     [XmlElement("godtarVilkaar", Order = 4)]
     [JsonProperty("godtarVilkaar")]
     [JsonPropertyName("godtarVilkaar")]
+    [Required]
     public string godtarVilkaar { get; set; }
 
   }

--- a/src/Designer/testdata/Model/CSharp/Gitea/udir-vfkl.cs
+++ b/src/Designer/testdata/Model/CSharp/Gitea/udir-vfkl.cs
@@ -15,66 +15,79 @@ namespace Altinn.App.Models
     [XmlElement("VurderingsType", Order = 1)]
     [JsonProperty("VurderingsType")]
     [JsonPropertyName("VurderingsType")]
+    [Required]
     public string VurderingsType { get; set; }
 
     [XmlElement("brukerID", Order = 2)]
     [JsonProperty("brukerID")]
     [JsonPropertyName("brukerID")]
+    [Required]
     public string brukerID { get; set; }
 
     [XmlElement("Læremiddel", Order = 3)]
     [JsonProperty("Læremiddel")]
     [JsonPropertyName("Læremiddel")]
+    [Required]
     public string Læremiddel { get; set; }
 
     [XmlElement("LæremiddelLeverandør", Order = 4)]
     [JsonProperty("LæremiddelLeverandør")]
     [JsonPropertyName("LæremiddelLeverandør")]
+    [Required]
     public string LæremiddelLeverandør { get; set; }
 
     [XmlElement("Læreplan", Order = 5)]
     [JsonProperty("Læreplan")]
     [JsonPropertyName("Læreplan")]
+    [Required]
     public string Læreplan { get; set; }
 
     [XmlElement("LæreplanKode", Order = 6)]
     [JsonProperty("LæreplanKode")]
     [JsonPropertyName("LæreplanKode")]
+    [Required]
     public string LæreplanKode { get; set; }
 
     [XmlElement("Skolenivå", Order = 7)]
     [JsonProperty("Skolenivå")]
     [JsonPropertyName("Skolenivå")]
+    [Required]
     public string Skolenivå { get; set; }
 
     [XmlElement("Utdanningsprogram", Order = 8)]
     [JsonProperty("Utdanningsprogram")]
     [JsonPropertyName("Utdanningsprogram")]
+    [Required]
     public string Utdanningsprogram { get; set; }
 
     [XmlElement("Programområde", Order = 9)]
     [JsonProperty("Programområde")]
     [JsonPropertyName("Programområde")]
+    [Required]
     public string Programområde { get; set; }
 
     [XmlElement("VurderingsID", Order = 10)]
     [JsonProperty("VurderingsID")]
     [JsonPropertyName("VurderingsID")]
+    [Required]
     public string VurderingsID { get; set; }
 
     [XmlElement("VurderingsFrist", Order = 11)]
     [JsonProperty("VurderingsFrist")]
     [JsonPropertyName("VurderingsFrist")]
+    [Required]
     public string VurderingsFrist { get; set; }
 
     [XmlElement("GruppeVurderingsID", Order = 12)]
     [JsonProperty("GruppeVurderingsID")]
     [JsonPropertyName("GruppeVurderingsID")]
+    [Required]
     public string GruppeVurderingsID { get; set; }
 
     [XmlElement("Navn", Order = 13)]
     [JsonProperty("Navn")]
     [JsonPropertyName("Navn")]
+    [Required]
     public string Navn { get; set; }
 
     [XmlElement("AlleFag", Order = 14)]
@@ -100,6 +113,7 @@ namespace Altinn.App.Models
     [XmlElement("OppsummeringsKommentar", Order = 18)]
     [JsonProperty("OppsummeringsKommentar")]
     [JsonPropertyName("OppsummeringsKommentar")]
+    [Required]
     public string OppsummeringsKommentar { get; set; }
 
     [XmlElement("AppLogikk", Order = 19)]
@@ -133,6 +147,7 @@ namespace Altinn.App.Models
     [XmlElement("onskerIkkeSvare", Order = 1)]
     [JsonProperty("onskerIkkeSvare")]
     [JsonPropertyName("onskerIkkeSvare")]
+    [Required]
     public string onskerIkkeSvare { get; set; }
 
     [XmlElement("paastand1", Order = 2)]
@@ -169,11 +184,13 @@ namespace Altinn.App.Models
     [XmlElement("kommentar", Order = 2)]
     [JsonProperty("kommentar")]
     [JsonPropertyName("kommentar")]
+    [Required]
     public string kommentar { get; set; }
 
     [XmlElement("valgtBortForGruppe", Order = 3)]
     [JsonProperty("valgtBortForGruppe")]
     [JsonPropertyName("valgtBortForGruppe")]
+    [Required]
     public string valgtBortForGruppe { get; set; }
 
   }
@@ -183,6 +200,7 @@ namespace Altinn.App.Models
     [XmlElement("onskerIkkeSvare", Order = 1)]
     [JsonProperty("onskerIkkeSvare")]
     [JsonPropertyName("onskerIkkeSvare")]
+    [Required]
     public string onskerIkkeSvare { get; set; }
 
     [XmlElement("paastand1", Order = 2)]
@@ -222,6 +240,7 @@ namespace Altinn.App.Models
     [XmlElement("onskerIkkeSvare", Order = 1)]
     [JsonProperty("onskerIkkeSvare")]
     [JsonPropertyName("onskerIkkeSvare")]
+    [Required]
     public string onskerIkkeSvare { get; set; }
 
     [XmlElement("paastand1", Order = 2)]
@@ -749,11 +768,13 @@ namespace Altinn.App.Models
     [XmlElement("godtarVilkaar", Order = 1)]
     [JsonProperty("godtarVilkaar")]
     [JsonPropertyName("godtarVilkaar")]
+    [Required]
     public string godtarVilkaar { get; set; }
 
     [XmlElement("valgtBortPaastandFlagg", Order = 2)]
     [JsonProperty("valgtBortPaastandFlagg")]
     [JsonPropertyName("valgtBortPaastandFlagg")]
+    [Required]
     public string valgtBortPaastandFlagg { get; set; }
 
   }


### PR DESCRIPTION
For some reason we don't add [Required] annotations on properties that are not valueTypes (ie string). The reason might be a missunderstanding the isValueType indicated that this is a nested class, but it actually notes if it must be nullable value type or not.


- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Generated C# models now consistently apply Required to all required fields, enabling stricter validation across numerous schemas and properties.

- Bug Fixes
  - Improved compile error reporting with safer code snippet extraction, preventing edge-case failures and providing clearer diagnostics.

- Tests
  - Expanded end-to-end coverage for required-field validation and added new test cases.
  - Added targeted diagnostic logging to aid troubleshooting during C# generation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->