### PR TITLE
fix(resource-adm): move consent metadata field below consent text field

### DIFF
--- a/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
+++ b/src/Designer/frontend/resourceadm/pages/AboutResourcePage/AboutResourcePage.tsx
@@ -201,19 +201,6 @@ export const AboutResourcePage = ({
                 {t('resourceadm.about_resource_consent_templates_error')}
               </StudioAlert>
             )}
-            <ResourceTextField
-              id='consentMetadata'
-              label={t('resourceadm.about_resource_consent_metadata')}
-              description={t('resourceadm.about_resource_consent_metadata_description')}
-              value={Object.keys(resourceData.consentMetadata ?? {}).join(', ')}
-              regexp={/[^a-z, ]/g}
-              onBlur={(val: string) =>
-                handleSave({
-                  ...resourceData,
-                  consentMetadata: convertMetadataStringToConsentMetadata(val),
-                })
-              }
-            />
             <ResourceLanguageTextField
               id='consentText'
               label={t('resourceadm.about_resource_consent_text_label')}
@@ -228,6 +215,19 @@ export const AboutResourcePage = ({
               hasMarkdownToolbar
               onSetLanguage={(setLanguage: ValidLanguage) => setPreviewLanguage(setLanguage)}
               errors={validationErrors.filter((error) => error.field === 'consentText')}
+            />
+            <ResourceTextField
+              id='consentMetadata'
+              label={t('resourceadm.about_resource_consent_metadata')}
+              description={t('resourceadm.about_resource_consent_metadata_description')}
+              value={Object.keys(resourceData.consentMetadata ?? {}).join(', ')}
+              regexp={/[^a-z, ]/g}
+              onBlur={(val: string) =>
+                handleSave({
+                  ...resourceData,
+                  consentMetadata: convertMetadataStringToConsentMetadata(val),
+                })
+              }
             />
             <ResourceSwitchInput
               id='isOneTimeConsent'


### PR DESCRIPTION
## Description

- Move consent metadata field below consent text field

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated layout of the Consent flow: the consent metadata field is now displayed after the consent text.
  * Only the visual order has changed; field behavior, validation, and data handling remain the same.
  * This affects the About Resource page in the resource administration area. Users will see the field appear below the consent text when reviewing or editing resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->