### PR TITLE
chore: Replaced `StudioIconCard` from legacy to the new one

### DIFF
--- a/src/Designer/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/components/TaskNavigation/TaskCard.tsx
@@ -1,6 +1,5 @@
 import React, { useState, type MouseEvent } from 'react';
 import type { LayoutSetModel } from 'app-shared/types/api/dto/LayoutSetModel';
-import { StudioIconCard } from '@studio/components-legacy/src/components/StudioIconCard/StudioIconCard';
 import { PencilIcon } from '@studio/icons';
 import { getLayoutSetTypeTranslationKey } from 'app-shared/utils/layoutSetsUtils';
 import { useTranslation } from 'react-i18next';
@@ -9,6 +8,7 @@ import {
   StudioParagraph,
   StudioDeleteButton,
   StudioHeading,
+  StudioIconCard,
 } from '@studio/components';
 import { getLayoutSetIcon } from '../../utils/getLayoutSetIcon';
 import { useDeleteLayoutSetMutation } from 'app-development/hooks/mutations/useDeleteLayoutSetMutation';

--- a/src/Designer/frontend/packages/ux-editor/src/utils/getLayoutSetIcon.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/utils/getLayoutSetIcon.tsx
@@ -10,7 +10,7 @@ import {
 } from '@studio/icons';
 import type { LayoutSetModel } from 'app-shared/types/api/dto/LayoutSetModel';
 import type { BpmnTaskType } from 'app-shared/types/BpmnTaskType';
-import type { StudioIconCardIconColors } from '@studio/components-legacy';
+import type { StudioIconCardIconColors } from '@studio/components';
 
 type IconMetaData = {
   icon: ReactElement;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replaced StudioIconCard from legacy to the new one 

CLOSES: #16604

Place to cheeck:

<img width="996" height="288" alt="Screenshot 2025-10-15 at 10 31 35" src="https://github.com/user-attachments/assets/942575b1-d9b8-483a-b54e-a44de6b5a018" />



## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated icon card components and related types to the modern component library for consistency.
  * Standardized imports across task navigation and layout icon utilities.
  * No functional or visual changes expected for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->