### PR TITLE
chore: Replace `StudioIconTextfield` from legacyy to the new one.

### DIFF
--- a/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditLayoutSetNameRecommendedAction/RecommendedActionChangeName.tsx
+++ b/src/Designer/frontend/packages/process-editor/src/components/ConfigPanel/ConfigContent/EditLayoutSetNameRecommendedAction/RecommendedActionChangeName.tsx
@@ -1,9 +1,9 @@
 import { useBpmnContext } from '../../../../contexts/BpmnContext';
 import {
-  StudioIconTextfield,
   StudioRecommendedNextAction,
   useStudioRecommendedNextActionContext,
 } from '@studio/components-legacy';
+import { StudioIconTextfield } from '@studio/components';
 import { KeyVerticalIcon } from '@studio/icons';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/AddItem/ItemInfo/ItemInfo.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/DesignView/AddItem/ItemInfo/ItemInfo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { StudioIconTextfield, StudioRecommendedNextAction } from '@studio/components-legacy';
-import { StudioParagraph, StudioHeading } from '@studio/components';
+import { StudioRecommendedNextAction } from '@studio/components-legacy';
+import { StudioParagraph, StudioHeading, StudioIconTextfield } from '@studio/components';
 import {
   getComponentHelperTextByComponentType,
   getTitleByComponentType,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace `StudioIconTextfield` from legacyy to the new one

CLOSES: #16606 


<details><summary> Places to check</summary>  


--- 
<img width="1040" height="445" alt="Screenshot 2025-10-15 at 10 48 45" src="https://github.com/user-attachments/assets/f706a31b-19d9-4859-adf8-a6edaefa1a5e" />

--- 

<img width="440" height="322" alt="Screenshot 2025-10-15 at 10 51 38" src="https://github.com/user-attachments/assets/012b0f55-a3b2-4610-9269-fc68e883db50" />
---  </details>






## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
