### PR TITLE
chore: Add automatic PR creation to Makefile sync targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,29 +14,50 @@ DEFAULT_BRANCH = main
 # Extract target names for .PHONY
 SUBTREE_TARGETS := $(foreach subtree,$(SUBTREES),sync-$(word 1,$(subst :, ,$(subtree))))
 
-.PHONY: $(SUBTREE_TARGETS) check-branch help
+.PHONY: $(SUBTREE_TARGETS) help create-pr
 
 help: ## Show this help message
 	@echo "Available targets:"
 	@$(foreach subtree,$(SUBTREES), \
 		echo "  sync-$(word 1,$(subst :, ,$(subtree))) - Sync $(word 1,$(subst :, ,$(subtree))) subtree from $(word 3,$(subst :, ,$(subtree)))";)
-	@echo "  check-branch - Check if current branch follows naming convention"
 	@echo "  help - Show this help message"
 
-check-branch: ## Check if current branch follows chore/subtree-sync-* naming convention
+create-pr: ## Push changes and create pull request for sync job
 	@current_branch=$$(git rev-parse --abbrev-ref HEAD); \
-	case "$$current_branch" in \
-		chore/subtree-sync-*) \
-			echo "OK: Branch name '$$current_branch' follows expected pattern" ;; \
-		*) \
-			echo "ERROR: Current branch '$$current_branch' should follow pattern 'chore/subtree-sync-*' when syncing subtrees"; \
-			exit 1 ;; \
-	esac
+	subtree_name=$$(echo $$current_branch | sed 's/chore\/subtree-sync-//'); \
+	if [ -n "$(SUBTREE_NAME)" ]; then \
+		subtree_name="$(SUBTREE_NAME)"; \
+	fi; \
+	if command -v gh >/dev/null 2>&1; then \
+		echo "Pushing changes to remote..."; \
+		git push -u origin $$current_branch && \
+		echo "Creating pull request..." && \
+		gh pr create --title "chore: syncing $$subtree_name" --body "@coderabbitai ignore" --base $(DEFAULT_BRANCH) --head $$current_branch || \
+		echo "WARNING: Failed to create PR. You may need to create it manually."; \
+	else \
+		echo "WARNING: gh command not found. Skipping automatic PR creation."; \
+		echo "Install GitHub CLI to enable automatic PR creation: https://cli.github.com/"; \
+	fi
 
 # Function to perform sync validation and execution
 # Usage: $(call sync-subtree,name,prefix,repo,remote)
 define sync-subtree
 	@echo "Syncing $(1) subtree..."
+	@current_branch=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ "$$current_branch" != "$(DEFAULT_BRANCH)" ]; then \
+		echo "ERROR: You must be on the $(DEFAULT_BRANCH) branch to start a sync"; \
+		echo "Current branch: $$current_branch"; \
+		echo "Please checkout $(DEFAULT_BRANCH) first: git checkout $(DEFAULT_BRANCH)"; \
+		exit 1; \
+	fi
+	@branch_name="chore/subtree-sync-$(1)"; \
+	if git show-ref --verify --quiet refs/heads/$$branch_name; then \
+		echo "ERROR: Branch $$branch_name already exists"; \
+		echo "Please merge/close that PR and delete your remote and local branch before attempting another sync"; \
+		exit 1; \
+	fi; \
+	echo "Creating branch $$branch_name..."; \
+	git checkout -b $$branch_name
 	@if [ ! -d "$(3)" ]; then \
 		echo "ERROR: Source directory $(3) does not exist"; \
 		exit 1; \
@@ -63,11 +84,27 @@ define sync-subtree
 			exit 1; \
 		fi && \
 		echo "OK: $(3) is up to date with origin/$(DEFAULT_BRANCH)"
-	git subtree pull --prefix=$(2) $(3) $(DEFAULT_BRANCH)
-	@echo "OK: $(1) subtree sync complete"
+	@set -e; \
+	if git subtree pull --prefix=$(2) $(3) $(DEFAULT_BRANCH); then \
+		echo "OK: $(1) subtree sync complete"; \
+		$(MAKE) create-pr SUBTREE_NAME=$(1); \
+	else \
+		echo ""; \
+		echo "==============================================="; \
+		echo "Merge conflicts detected!"; \
+		echo "==============================================="; \
+		echo ""; \
+		echo "Please resolve conflicts in the affected files,"; \
+		echo "then stage and commit your changes:"; \
+		echo "  git add ."; \
+		echo "  git commit --no-edit"; \
+		echo ""; \
+		read -p "Press Enter after resolving conflicts to continue with PR creation..." dummy; \
+		$(MAKE) create-pr SUBTREE_NAME=$(1); \
+	fi
 endef
 
 # Generate sync targets dynamically
 $(foreach subtree,$(SUBTREES), \
-	$(eval sync-$(word 1,$(subst :, ,$(subtree))): check-branch ## Sync $(word 1,$(subst :, ,$(subtree))) subtree) \
+	$(eval sync-$(word 1,$(subst :, ,$(subtree))): ## Sync $(word 1,$(subst :, ,$(subtree))) subtree) \
 	$(eval sync-$(word 1,$(subst :, ,$(subtree))): ; $$(call sync-subtree,$(word 1,$(subst :, ,$(subtree))),$(word 2,$(subst :, ,$(subtree))),$(word 3,$(subst :, ,$(subtree))),$(word 4,$(subst :, ,$(subtree))))))


### PR DESCRIPTION
## Summary

This PR enhances the Makefile subtree sync workflow to automatically create pull requests after syncing, streamlining the sync process.

## Changes

### Automatic Branch Creation
- Creates `chore/subtree-sync-<name>` branch automatically when running `make sync-<name>`
- Validates user is on `main` branch before creating sync branch
- Prevents duplicate sync branches (fails cleanly if branch already exists)

### Automatic PR Creation
- Uses `gh` CLI to automatically push changes and create PR after successful sync
- PR title format: `"chore: syncing <subtree-name>"`
- PR body: `"@coderabbitai ignore"`
- Falls back gracefully if `gh` is not installed

### Interactive Conflict Resolution
- Detects merge conflicts during subtree sync
- Pauses with clear instructions for conflict resolution
- Waits for user input (`Press Enter`) after conflicts are resolved
- Automatically continues with PR creation after confirmation

### New `create-pr` Target
- Standalone target for manual PR creation
- Useful for edge cases or if automatic PR creation fails
- Can be run independently: `make create-pr`

## Workflow Examples

### Normal sync (no conflicts):
```bash
make sync-frontend
# ✅ Creates branch chore/subtree-sync-frontend
# ✅ Syncs frontend subtree
# ✅ Pushes and creates PR automatically
```

### Sync with conflicts:
```bash
make sync-frontend
# ❌ Detects conflicts
# ⏸️  Pauses with instructions
# (resolve conflicts in another terminal)
# ✅ Press Enter to continue
# ✅ Pushes and creates PR
```

## Benefits

- **Streamlined workflow**: Single command to sync and create PR
- **Consistent naming**: Automatic branch and PR title generation
- **Better DX**: Clear error messages and recovery instructions
- **No process termination**: Interactive conflict resolution instead of exiting
- **Safety checks**: Validates branch state before proceeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)