### PR TITLE
fix: Allow `azure-devops-mock` to deploy several applications

### DIFF
--- a/src/Designer/development/azure-devops-mock/src/routes/builds.js
+++ b/src/Designer/development/azure-devops-mock/src/routes/builds.js
@@ -19,7 +19,15 @@ export const buildsRoute = async (req, res) => {
 
   if (isDeploy) {
     deploys = [
-      ...deploys.filter((item) => item.envName !== params.APP_ENVIRONMENT),
+      ...deploys.filter(
+        (d) =>
+          !(
+            d.app === params.APP_REPO &&
+            d.org === params.APP_OWNER &&
+            d.envName === params.APP_ENVIRONMENT &&
+            d.tagName === params.TAGNAME
+          ),
+      ),
       {
         app: params.APP_REPO,
         org: params.APP_OWNER,
@@ -66,7 +74,7 @@ export const buildsRoute = async (req, res) => {
 // http://localhost:6161/_apis/build/builds/80891942?api-version=5.1
 export const buildRoute = async (req, res) => {
   const { BuildNumber } = req.params;
-  const build = builds.find((b) => b.Id === parseInt(BuildNumber));
+  const build = builds.find((b) => b.Id === parseInt(BuildNumber)) || {};
   if (build.Status === 'notStarted') {
     build.Status = 'inProgress';
     build.Result = 'none';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make it possible to deploy multiple apps with `azure-devops-mock`

<table>
<tr>
<th>BEFORE</th>
<th>AFTER</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/9f1d9af8-9c95-4e79-a6e4-d5d30512392c

</td>
<td>

https://github.com/user-attachments/assets/8620d5b7-1828-4eff-95a5-c91e382be381

</td>
</tr>
</table>

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deploy entry management to ensure accurate tracking when multiple deployments exist.
  * Enhanced error resilience in build retrieval to prevent application failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->