### PR TITLE
fix: altinn org model

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Models/AltinnOrgModel.cs
+++ b/src/Designer/backend/src/Designer/Services/Models/AltinnOrgModel.cs
@@ -15,7 +15,7 @@ public class AltinnOrgModel
     public required string OrgNr { get; set; }
 
     [JsonPropertyName("homepage")]
-    public required string Homepage { get; set; }
+    public string Homepage { get; set; }
 
     [JsonPropertyName("environments")]
     public required List<string> Environments { get; set; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added [AltinnOrgModel](https://github.com/Altinn/altinn-studio/pull/16629/files#diff-a55b12aba5afe87f07b04cb96a7fc1671c7e35bb6f4e2d72bf524b552c6e8f67). Deserialization failed due to homepage missing but was set as required. Orgs with missing homepage added in https://github.com/Altinn/altinn-cdn/pull/247.

<img width="467" height="98" alt="bilde" src="https://github.com/user-attachments/assets/d800ddb5-6163-4387-be02-cf43bea203fb" />

According to orgs schema homepage should not be required. https://github.com/Altinn/altinn-cdn/blob/master/orgs/altinn-orgs.schema.v1.json.

Pretty sure orgnr. should be required, I think we had some issues when it was missing: https://github.com/Altinn/altinn-cdn/pull/238


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization homepage field is now optional instead of required, improving flexibility in data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->