### PR TITLE
fix(resource-adm): catch exception if failing to GET resource list in one environment

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/ResourceAdminController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/ResourceAdminController.cs
@@ -280,8 +280,9 @@ namespace Altinn.Studio.Designer.Controllers
                                 .SetAbsoluteExpiration(new TimeSpan(0, _cacheSettings.DataNorgeApiCacheTimeout, 0));
                             _memoryCache.Set(cacheKey, environmentResources, cacheEntryOptions);
                         }
-                        catch
+                        catch (Exception ex)
                         {
+                            Console.WriteLine($"Error fetching resource list for env {environment}: {ex.Message}");
                             environmentResources = [];
                         }
                     }


### PR DESCRIPTION
## Description
We currently have problems with YT01, and getting the resources list from YT01 returns 503. When getting the resources in GUI, if the GET call to one of the environments fail, the entire list call for all environments fail, and this is not ideal.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during environment resource retrieval to prevent cache-related failures from disrupting requests.
  * Now logs retrieval errors and falls back to a safe empty result instead of propagating exceptions.
  * Ensures the application stays responsive when resource loading encounters issues, preserving a consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->