### PR TITLE
chore: add warning message and fix password reset text for Gitea login page

### DIFF
--- a/src/gitea/files/custom/templates/user/auth/signin.tmpl
+++ b/src/gitea/files/custom/templates/user/auth/signin.tmpl
@@ -1,0 +1,17 @@
+{{template "base/head" .}}
+<div class="page-content user column tw-flex tw-flex-col tw-gap-4 tw-max-w-2xl tw-m-auto">
+    <div class="ui container fluid">
+        <div class="ui top center" style="background: #fae6c6; padding: 12px; border-radius: 5px;">
+            <p>{{ctx.Locale.Tr "auth.github_disabled"}} <a href="https://docs.altinn.studio/nb/altinn-studio/v8/getting-started/create-user/#koble-eksisterende-bruker-til-ansattporten">{{ctx.Locale.Tr "auth.github_disabled_docs"}}</a></p>
+        </div>
+    </div>
+</div>
+<div role="main" aria-label="{{.Title}}" class="page-content user signin{{if .LinkAccountMode}} icon{{end}}">
+	<div class="ui middle very relaxed page grid">
+		{{/* these styles are quite tricky and should also apply to the signup and link_account pages */}}
+		<div class="column tw-flex tw-flex-col tw-gap-4 tw-max-w-2xl tw-m-auto">
+			{{template "user/auth/signin_inner" .}}
+		</div>
+	</div>
+</div>
+{{template "base/footer" .}}

--- a/src/gitea/files/locale/base/locale_nb-NO.ini
+++ b/src/gitea/files/locale/base/locale_nb-NO.ini
@@ -487,6 +487,8 @@ password_pwned_err=Kunne ikke fullføre forespørselen til HaveIBeenPwned
 last_admin=You cannot remove the last admin. There must be at least one admin.
 signin_passkey=Sign in with a passkey
 back_to_sign_in=Back to Sign In
+github_disabled = Login with Github is no longer supported after 29 October 2025. Please use Ansattporten to log in.
+github_disabled_docs = documentation.
 
 [mail]
 view_it_on=Se den på %s
@@ -511,7 +513,7 @@ register_notify.text_3="Hvis denne kontoen er opprettet på dine vegne, vennligs
 
 reset_password=Gjenopprett kontoen din
 reset_password.title=%s, du har bedt om å gjenopprette kontoen din
-reset_password.text=Klikk på følgende lenke for å gjenopprette kontoen din på <b>%s</b>:
+reset_password.text=Klikk på følgende lenke for å gjenopprette kontoen din innen <b>%s</b>:
 
 register_success=Registrering vellykket
 

--- a/src/gitea/files/locale/custom/locale_en-US.ini
+++ b/src/gitea/files/locale/custom/locale_en-US.ini
@@ -10,3 +10,5 @@ oauth_signup_title = Register your email and create a password for Altinn Studio
 authorize_application_description = If you do, this application will be able to read and write to all your account information, including private repos and organizations.
 authorize_title = Do you want to give "%s" access to your Gitea account?
 disable_register_prompt = For security reasons, we are in the process of removing all registration options other than Ansattporten. We therefore recommend that you choose Ansattporten below.
+github_disabled = Login with Github is not supported after 29 October 2025. Please use Ansattporten or username/password to log in. For information on how set up Ansattporten, see our
+github_disabled_docs = documentation.

--- a/src/gitea/files/locale/custom/locale_nb-NO.ini
+++ b/src/gitea/files/locale/custom/locale_nb-NO.ini
@@ -10,3 +10,5 @@ oauth_signup_title = Register din e-post og opprett eget passord for Altinn Stud
 authorize_application_description = Hvis du gjør det, får applikasjonen lese- og skrivetilgang til all din kontoinformasjon, også private kodelagere og organisasjoner.
 authorize_title = Vil du gi "%s" tilgang til Gitea-kontoen din?
 disable_register_prompt = Av sikkerhetsmessige årsaker er vi i gang med å fjerne alle muligheter for registrering utenom Ansattporten. Vi anbefaler derfor at du velger Ansattporten nedenfor.
+github_disabled = Innlogging med Github støttes ikke etter 29. oktober 2025. Hvis du tidligere har brukt Github for å logge inn, kan du nå bruke Ansattporten eller brukernavn/passord for å logge inn. For informasjon om hvordan du kobler din bruker mot Ansattporten, se vår
+github_disabled_docs = dokumentasjon.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a warning message to the login page template, explaining that Github is no longer an option for login after today.
Also updated a Norwegian text related to resetting password to be more correct.

<img width="1503" height="603" alt="Screenshot 2025-10-29 at 12 43 23" src="https://github.com/user-attachments/assets/9ad57e86-c404-4022-b6cf-0a1eb758fca8" />


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added authentication notice banner informing users that GitHub login is no longer supported after 29 October 2025, with guidance on alternative authentication methods.

* **Documentation**
  * Updated user interface text in Norwegian Bokmål and English localisations to reflect authentication changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->