### PR TITLE
fix: fix size prop in StudioTableLocalPagination

### DIFF
--- a/src/Designer/frontend/libs/studio-components/src/components/StudioTableLocalPagination/StudioTableLocalPagination.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioTableLocalPagination/StudioTableLocalPagination.tsx
@@ -13,7 +13,7 @@ export type LocalPaginationProps = {
 export type StudioTableLocalPaginationProps = {
   columns: Columns;
   rows: Rows;
-  size?: 'small' | 'medium' | 'large';
+  size?: 'sm' | 'md' | 'lg';
   isLoading?: boolean;
   loadingText?: string;
   emptyTableFallback?: React.ReactNode;
@@ -28,7 +28,7 @@ function StudioTableLocalPagination(
     columns,
     rows,
     sortedRows: externalSortedRows,
-    size = 'medium',
+    size = 'md',
     isLoading = false,
     loadingText,
     emptyTableFallback,
@@ -75,7 +75,7 @@ function StudioTableLocalPagination(
     <StudioTableRemotePagination
       columns={columns}
       rows={rowsToRender}
-      data-size={size}
+      size={size}
       isLoading={isLoading}
       loadingText={loadingText}
       emptyTableFallback={emptyTableFallback}


### PR DESCRIPTION
## Description
Fix: `StudioTableRemotePagination` expects prop `size`, not `data-size`

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Breaking Changes**
* Table pagination size property values have been updated and standardised across the application. You will need to replace existing size values: `small`, `medium`, and `large` have been changed to `sm`, `md`, and `lg` respectively.
* Default pagination size has been updated to `md` (previously defaulted to `medium`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->