### PR TITLE
chore: update kindest/node versions for kind clusters

### DIFF
--- a/src/Runtime/test/fixture/pkg/runtimes/kind/config/kind.config.minimal.yaml
+++ b/src/Runtime/test/fixture/pkg/runtimes/kind/config/kind.config.minimal.yaml
@@ -7,7 +7,7 @@ containerdConfigPatches:
     config_path = "/etc/containerd/certs.d"
 nodes:
 - role: control-plane
-  image: kindest/node:v1.30.0@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+  image: kindest/node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration
@@ -22,6 +22,6 @@ nodes:
   - containerPort: 30002
     hostPort: 8020
 - role: worker
-  image: kindest/node:v1.30.0@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+  image: kindest/node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
   labels:
     topology.kubernetes.io/zone: 'zone-1'

--- a/src/Runtime/test/fixture/pkg/runtimes/kind/config/kind.config.standard.yaml
+++ b/src/Runtime/test/fixture/pkg/runtimes/kind/config/kind.config.standard.yaml
@@ -7,7 +7,7 @@ containerdConfigPatches:
     config_path = "/etc/containerd/certs.d"
 nodes:
 - role: control-plane
-  image: kindest/node:v1.30.0@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+  image: kindest/node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration
@@ -22,14 +22,14 @@ nodes:
   - containerPort: 30002
     hostPort: 8020
 - role: worker
-  image: kindest/node:v1.30.0@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+  image: kindest/node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
   labels:
     topology.kubernetes.io/zone: 'zone-1'
 - role: worker
-  image: kindest/node:v1.30.0@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+  image: kindest/node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
   labels:
     topology.kubernetes.io/zone: 'zone-2'
 - role: worker
-  image: kindest/node:v1.30.0@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+  image: kindest/node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
   labels:
     topology.kubernetes.io/zone: 'zone-3'


### PR DESCRIPTION
## Description

App clusters use 1.33 currently, so this matches that

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Kubernetes node image versions in test configurations from v1.30.0 to v1.33.4 across control-plane and worker node sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->