### PR TITLE
chore: increase pdf tmp memory volume size limit

### DIFF
--- a/src/Runtime/pdf3/infra/kustomize/base/worker.yaml
+++ b/src/Runtime/pdf3/infra/kustomize/base/worker.yaml
@@ -157,7 +157,7 @@ spec:
       volumes:
       - emptyDir:
           medium: Memory
-          sizeLimit: 64Mi
+          sizeLimit: 512Mi
         name: tmpdisk
       securityContext:
         # Run as 'nobody'
@@ -228,7 +228,7 @@ spec:
               # can easily saturate a core (1000m). But it won't do that
               # all the time, so settling on 750m for reserving capacity
               cpu: 750m
-              memory: 512Mi
+              memory: 1Gi
           volumeMounts:
           - mountPath: /tmp
             name: tmpdisk


### PR DESCRIPTION
## Description

After seeing some `net::ERR_INSUFFICIENT_RESOURCES`, errors, I think this is related to the `sizeLimit` on the volumes. That is the only resource that is constrained currently (no process memory limits). Update resource request to match

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased system resource allocation to enhance stability and performance during peak usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->