### PR TITLE
fix: use developer identity for merge commits

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/SourceControlSI.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SourceControlSI.cs
@@ -105,7 +105,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
                     Tree head = repo.Head.Tip.Tree;
                     MergeResult mergeResult = Commands.Pull(
                         repo,
-                        new LibGit2Sharp.Signature("my name", "my email", DateTimeOffset.Now), // I dont want to provide these
+                        GetDeveloperSignature(),
                         pullOptions);
 
                     TreeChanges treeChanges = repo.Diff.Compare<TreeChanges>(head, mergeResult.Commit?.Tree);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Auto-resolving conflicts will now use developer identity instead of `my name` and `my email`.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed developer attribution in remote pull operations to correctly identify the current developer instead of using a generic default signature, ensuring accurate version control history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->