### PR TITLE
chore: remove featureflag imageUpload

### DIFF
--- a/src/Designer/frontend/libs/studio-feature-flags/src/FeatureFlag.ts
+++ b/src/Designer/frontend/libs/studio-feature-flags/src/FeatureFlag.ts
@@ -4,6 +4,5 @@ export enum FeatureFlag {
   Maskinporten = 'maskinporten',
   ShouldOverrideAppLibCheck = 'shouldOverrideAppLibCheck',
   AppMetadata = 'appMetadata',
-  ImageUpload = 'imageUpload',
   NewCodeLists = 'newCodeLists',
 }

--- a/src/Designer/frontend/libs/studio-feature-flags/src/useFeatureFlag.test.tsx
+++ b/src/Designer/frontend/libs/studio-feature-flags/src/useFeatureFlag.test.tsx
@@ -8,7 +8,7 @@ import { useFeatureFlag } from './useFeatureFlag';
 
 // Test data:
 const enabledFlag = FeatureFlag.Maskinporten;
-const disabledFlag = FeatureFlag.ImageUpload;
+const disabledFlag = FeatureFlag.NewCodeLists;
 const flags = [enabledFlag];
 const contextValue: FeatureFlagsContextValue = { flags };
 

--- a/src/Designer/frontend/libs/studio-feature-flags/src/useFeatureToggle.test.tsx
+++ b/src/Designer/frontend/libs/studio-feature-flags/src/useFeatureToggle.test.tsx
@@ -9,7 +9,7 @@ import { FeatureFlagMutationContextProvider } from './FeatureFlagMutationContext
 
 // Test data:
 const enabledFlag = FeatureFlag.Maskinporten;
-const disabledFlag = FeatureFlag.ImageUpload;
+const disabledFlag = FeatureFlag.NewCodeLists;
 const flags = [enabledFlag];
 const addFlag = jest.fn();
 const removeFlag = jest.fn();

--- a/src/Designer/frontend/packages/ux-editor/src/data/formItemConfig.test.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/data/formItemConfig.test.ts
@@ -14,12 +14,7 @@ describe('formItemConfig', () => {
     confOnScreenComponents,
   ];
   const allAvailableComponents = allAvailableLists.flat();
-  const excludedComponents = [
-    ComponentType.Custom,
-    ComponentType.Payment,
-    ComponentType.Summary,
-    ComponentType.ImageUpload,
-  ];
+  const excludedComponents = [ComponentType.Custom, ComponentType.Payment, ComponentType.Summary];
 
   /**  Test that all components, except Custom, Payment, and Summary, are available in one of the visible lists */
   it.each(
@@ -32,9 +27,5 @@ describe('formItemConfig', () => {
 
   test('that payment component is not available in the visible lists', () => {
     expect(allAvailableComponents.map(({ name }) => name)).not.toContain(ComponentType.Payment);
-  });
-
-  it('should not include ImageUpload when feature flag is not enabled', () => {
-    expect(allAvailableComponents.map(({ name }) => name)).not.toContain(ComponentType.ImageUpload);
   });
 });

--- a/src/Designer/frontend/packages/ux-editor/src/data/formItemConfig.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/data/formItemConfig.ts
@@ -40,7 +40,6 @@ import { LayoutItemType } from '../types/global';
 import type { ComponentSpecificConfig } from 'app-shared/types/ComponentSpecificConfig';
 import type { KeyValuePairs } from 'app-shared/types/KeyValuePairs';
 import { FilterUtils } from './FilterUtils';
-import { FeatureFlag, shouldDisplayFeature } from 'app-shared/utils/featureToggleUtils';
 
 export type FormItemConfig<T extends ComponentType | CustomComponentType = ComponentType> = {
   name: ComponentType | CustomComponentType;
@@ -572,7 +571,7 @@ export const schemaComponents: FormItemConfigs[ComponentType][] = [
   formItemConfigs[ComponentType.InstantiationButton],
   formItemConfigs[ComponentType.ActionButton],
   formItemConfigs[ComponentType.Image],
-  shouldDisplayFeature(FeatureFlag.ImageUpload) && formItemConfigs[ComponentType.ImageUpload],
+  formItemConfigs[ComponentType.ImageUpload],
   formItemConfigs[ComponentType.Link],
   formItemConfigs[ComponentType.IFrame],
   formItemConfigs[ComponentType.InstanceInformation],
@@ -653,7 +652,7 @@ export const allComponents: KeyValuePairs<ComponentType[]> = {
     ComponentType.AttachmentList,
     ComponentType.FileUpload,
     ComponentType.FileUploadWithTag,
-    ...(shouldDisplayFeature(FeatureFlag.ImageUpload) ? [ComponentType.ImageUpload] : []),
+    ComponentType.ImageUpload,
   ],
   container: [
     ComponentType.Group,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As image upload is now released in app frontend, we can remove the feature flag in studio designer.

<img width="996" height="444" alt="image" src="https://github.com/user-attachments/assets/c5510d4c-38fb-402d-bc79-322a4b6ff2e6" />


<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed feature flag restrictions for the ImageUpload component; it is now permanently available to all users.
  * Updated internal feature flag references and test data accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->