### PR TITLE
fix: org nr validation

### DIFF
--- a/src/App/frontend/src/layout/OrganisationLookup/validation.test.ts
+++ b/src/App/frontend/src/layout/OrganisationLookup/validation.test.ts
@@ -4,6 +4,39 @@ describe('CheckValidOrgNr', () => {
   it('should return true when the orgNr is valid', () => {
     expect(checkValidOrgnNr('043871668')).toBe(true);
   });
+  it('should return true when the orgNr is valid', () => {
+    expect(checkValidOrgnNr('974683520')).toBe(true);
+  });
+  it('should return true when the orgNr is valid', () => {
+    expect(checkValidOrgnNr('900010605')).toBe(true);
+  });
+  it('should return true when the orgNr is valid', () => {
+    expect(checkValidOrgnNr('123778847')).toBe(true);
+  });
+  it('should return true when the orgNr is valid', () => {
+    expect(checkValidOrgnNr('344547211')).toBe(true);
+  });
+  it('should return true when the orgNr is valid', () => {
+    expect(checkValidOrgnNr('542683430')).toBe(true);
+  });
+  it('should return true when the orgNr is valid', () => {
+    expect(checkValidOrgnNr('473324261')).toBe(true);
+  });
+  it('should return true when the orgNr is valid', () => {
+    expect(checkValidOrgnNr('883863631')).toBe(true);
+  });
+  it('should return true when the orgNr is valid', () => {
+    expect(checkValidOrgnNr('594027922')).toBe(true);
+  });
+  it('should return true when the orgNr is valid', () => {
+    expect(checkValidOrgnNr('688701473')).toBe(true);
+  });
+  it('should return true when the orgNr is valid', () => {
+    expect(checkValidOrgnNr('696902453')).toBe(true);
+  });
+  it('should return true when the orgNr is valid', () => {
+    expect(checkValidOrgnNr('899350766')).toBe(true);
+  });
   it('should return false when the orgNr is invalid', () => {
     expect(checkValidOrgnNr('143871668')).toBe(false);
   });

--- a/src/App/frontend/src/layout/OrganisationLookup/validation.ts
+++ b/src/App/frontend/src/layout/OrganisationLookup/validation.ts
@@ -42,12 +42,19 @@ export function checkValidOrgnNr(orgNr: string): boolean {
 
   const [w1, w2, w3, w4, w5, w6, w7, w8] = [3, 2, 7, 6, 5, 4, 3, 2];
   const sum = a1 * w1 + a2 * w2 + a3 * w3 + a4 * w4 + a5 * w5 + a6 * w6 + a7 * w7 + a8 * w8;
-  const calculatedCheckDigit = 11 - (sum % 11);
+
+  let calculatedCheckDigit = mod11(sum);
+
+  if (calculatedCheckDigit === 11) {
+    calculatedCheckDigit = 0;
+  }
 
   return calculatedCheckDigit === allegedCheckDigit;
 }
 
 export const validateOrgnr = ajv.compile(orgNrSchema);
+
+const mod11 = (value: number): number => 11 - (value % 11);
 
 const organisationLookupResponseSchema: JSONSchemaType<OrganisationLookupResponse> = {
   type: 'object',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Repoted issue with the validation of org number on external slack: 
https://digdir-samarbeid.slack.com/archives/CCQEQKGJD/p1762502941835949

This was due to a special case handling of the controll number for the case where the calculated check number is 11.

PR created for app-frontend-react instead: https://github.com/Altinn/app-frontend-react/pull/3838

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded organisation number validation test coverage with 12 additional positive test cases, ensuring robustness across various 9-digit organisation numbers.

* **Refactor**
  * Optimised organisation number validation calculation by introducing a modular helper approach for check digit computation, improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->