### PR TITLE
fix: allow nested paths with navigateBack navigation state

### DIFF
--- a/src/Designer/frontend/app-development/layout/PageHeader/SubHeader/SettingsPageButton/SettingsPageButton.tsx
+++ b/src/Designer/frontend/app-development/layout/PageHeader/SubHeader/SettingsPageButton/SettingsPageButton.tsx
@@ -61,7 +61,7 @@ function getButtonTextKey(isSettingsPage: boolean, from?: string): string {
   return 'sync_header.settings';
 }
 function splitKeyFromFullPath(fullPath: string): string {
-  const parts: string[] = fullPath.split('?');
+  const parts: string[] = fullPath.split('?')[0].split('/');
   return parts[0];
 }
 

--- a/src/Designer/frontend/app-development/layout/PageHeader/SubHeader/SettingsPageButton/useNavigateFrom.ts
+++ b/src/Designer/frontend/app-development/layout/PageHeader/SubHeader/SettingsPageButton/useNavigateFrom.ts
@@ -12,7 +12,7 @@ export const useNavigateFrom = () => {
   const state = location.state as LocationState;
 
   const navigateFrom: RoutePaths | undefined = getNavigateFrom(state);
-  const currentRoutePath: string = UrlUtils.extractThirdRouterParam(location.pathname);
+  const currentRoutePath: string = UrlUtils.extractAllParamsFromThird(location.pathname);
   const search: string = location?.search ?? '';
 
   return {

--- a/src/Designer/frontend/libs/studio-pure-functions/src/UrlUtils/UrlUtils.ts
+++ b/src/Designer/frontend/libs/studio-pure-functions/src/UrlUtils/UrlUtils.ts
@@ -25,6 +25,20 @@ export class UrlUtils {
   static extractThirdRouterParam = (pathname: string): string => {
     return extractParamFromStart(pathname, 3);
   };
+
+  /**
+   * Returns all parameters from the url pathname starting from the third parameter.
+   * @param pathname The url pathname to extract the parameters from.
+   * @returns All parameters from the url pathname starting from the third parameter, joined by '/'.
+   */
+  static extractAllParamsFromThird = (pathname: string): string => {
+    return extractParamsFromStart(pathname, 3).join('/');
+  };
+}
+
+function extractParamsFromStart(pathname: string, positionFromStart: number): string[] {
+  const params = extractParams(pathname);
+  return params.slice(positionFromStart);
 }
 
 function extractParamFromStart(pathname: string, positionFromStart: number): string {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently navigating from an app layout to settings and clicking the back to button does not bring you to the layout.
This change alters the logic to not _just_ use the third slash part of the path, but all parts from third and after. Allowing nested paths to be used.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Settings button now correctly recognises deeper nested routes and handles query strings so navigation and button labelling reflect the intended page context.
  * Resolved inconsistencies when navigating to Settings from deeply nested pages, preserving the expected context.

* **Refactor**
  * URL parsing streamlined to derive the current route more reliably across complex paths, improving navigation robustness and label accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->