### PR TITLE
fix: revert pdf scaledown

### DIFF
--- a/infra/runtime/syncroot/base/pdf.yaml
+++ b/infra/runtime/syncroot/base/pdf.yaml
@@ -82,6 +82,6 @@ spec:
         namespace: default
   values:
     environment: ${ENVIRONMENT}
-    replicaCount: 0
-    autoscaling:
-      enabled: false
+    # replicaCount: 0
+    # autoscaling:
+    #   enabled: false


### PR DESCRIPTION
## Description

had some issues in one tt02 environment

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings by disabling explicit replica count and autoscaling overrides, allowing the system to revert to default or inherited values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->