### PR TITLE
chore: push pdf3 images to public registry

### DIFF
--- a/.github/workflows/deploy-runtime-pdf3.yaml
+++ b/.github/workflows/deploy-runtime-pdf3.yaml
@@ -63,10 +63,16 @@ jobs:
       - name: set vars
         id: vars
         run: |
+          SHA=$(git rev-parse --short HEAD)
+          GHCR_BASE="ghcr.io/altinn/altinn-studio"
+          ACR_PREFIX="altinncr.azurecr.io"
+
           echo "registry-name=altinncr" >> $GITHUB_OUTPUT
-          echo "image-proxy-repo=ghcr.io/altinn/altinn-studio/runtime-pdf3-proxy:$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "image-worker-repo=ghcr.io/altinn/altinn-studio/runtime-pdf3-worker:$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "config-repo=altinncr.azurecr.io/studio-apps/runtime-pdf3-repo:$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "ghcr-image-proxy-repo=${GHCR_BASE}/runtime-pdf3-proxy:${SHA}" >> $GITHUB_OUTPUT
+          echo "ghcr-image-worker-repo=${GHCR_BASE}/runtime-pdf3-worker:${SHA}" >> $GITHUB_OUTPUT
+          echo "image-proxy-repo=${ACR_PREFIX}/${GHCR_BASE}/runtime-pdf3-proxy:${SHA}" >> $GITHUB_OUTPUT
+          echo "image-worker-repo=${ACR_PREFIX}/${GHCR_BASE}/runtime-pdf3-worker:${SHA}" >> $GITHUB_OUTPUT
+          echo "config-repo=${ACR_PREFIX}/studio-apps/runtime-pdf3-repo:${SHA}" >> $GITHUB_OUTPUT
 
       - name: login to ghcr
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -87,9 +93,9 @@ jobs:
       - name: docker build
         run: |
           set -e
-          docker build -t ${{ steps.vars.outputs.image-proxy-repo }} -f Dockerfile.proxy . &
+          docker build -t ${{ steps.vars.outputs.ghcr-image-proxy-repo }} -f Dockerfile.proxy . &
           PROXY_PID=$!
-          docker build -t ${{ steps.vars.outputs.image-worker-repo }} -f Dockerfile.worker . &
+          docker build -t ${{ steps.vars.outputs.ghcr-image-worker-repo }} -f Dockerfile.worker . &
           WORKER_PID=$!
           wait $PROXY_PID
           wait $WORKER_PID
@@ -97,7 +103,7 @@ jobs:
       - name: scan image - proxy
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
-          image-ref: '${{ steps.vars.outputs.image-proxy-repo }}'
+          image-ref: '${{ steps.vars.outputs.ghcr-image-proxy-repo }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
@@ -108,7 +114,7 @@ jobs:
         if: success() || failure()
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
-          image-ref: '${{ steps.vars.outputs.image-worker-repo }}'
+          image-ref: '${{ steps.vars.outputs.ghcr-image-worker-repo }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
@@ -118,9 +124,9 @@ jobs:
       - name: push images
         run: |
           set -e
-          docker push ${{ steps.vars.outputs.image-proxy-repo }} &
+          docker push ${{ steps.vars.outputs.ghcr-image-proxy-repo }} &
           PROXY_PID=$!
-          docker push ${{ steps.vars.outputs.image-worker-repo }} &
+          docker push ${{ steps.vars.outputs.ghcr-image-worker-repo }} &
           WORKER_PID=$!
           wait $PROXY_PID
           wait $WORKER_PID


### PR DESCRIPTION
## Description

So that we can use it in localtest

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to publish container images to GitHub Container Registry, added registry write permission and an automated GHCR login, introduced GHCR and ACR image reference outputs, and adjusted build, scan and push image references accordingly.

**Note:** This release contains no user-facing changes; infrastructure-only updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->