### PR TITLE
chore: pdf3 - improve/simplify topology spread

### DIFF
--- a/src/Runtime/pdf3/infra/kustomize/base/proxy.yaml
+++ b/src/Runtime/pdf3/infra/kustomize/base/proxy.yaml
@@ -134,24 +134,20 @@ spec:
         # such as topology aware routing
         linkerd.io/inject: enabled
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          # Spread pods across different hosts/nodes during scheduling
-          # This prevents multiple replicas from running on the same node
-          # improving fault tolerance if a node fails
-          - weight: 100
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  app: pdf3-proxy
       topologySpreadConstraints:
-        # Ensure that pods are evenly spread across availability zones
-        # a skew of 1 _can_ result in 1 AZ being unused when AZs = 3 and replicas = 3
+        # Try to spread across availability zones first (highest priority)
+        # A skew of 1 can result in 1 AZ being unused when AZs = 3 and replicas = 3
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
           # ScheduleAnyway ensures progress even if distribution is imperfect
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: pdf3-proxy
+        # Try to spread across nodes within zones
+        # Prevents multiple replicas from running on the same node, improving fault tolerance
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:

--- a/src/Runtime/pdf3/infra/kustomize/base/worker.yaml
+++ b/src/Runtime/pdf3/infra/kustomize/base/worker.yaml
@@ -128,24 +128,20 @@ spec:
         component: pdf3
       # We don't use linkerd annotation here as only the proxy contacts it
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          # Spread pods across different hosts/nodes during scheduling
-          # This prevents multiple replicas from running on the same node
-          # improving fault tolerance if a node fails
-          - weight: 100
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  app: pdf3-worker
       topologySpreadConstraints:
-        # Ensure that pods are evenly spread across availability zones
-        # a skew of 1 _can_ result in 1 AZ being unused when AZs = 3 and replicas = 3
+        # Try to spread across availability zones first (highest priority)
+        # A skew of 1 can result in 1 AZ being unused when AZs = 3 and replicas = 3
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
           # ScheduleAnyway ensures progress even if distribution is imperfect
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: pdf3-worker
+        # Try to spread across nodes within zones
+        # Prevents multiple replicas from running on the same node, improving fault tolerance
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:


### PR DESCRIPTION
## Description

Got some comments on this from plattform (though they recommended the other way around, sticking to podAntiAffinity), but that did prompt me to dig into this a little and it seems like documentation reccommends the opposite. I don't think it makes a notable difference for us, but it does simplify the config which is a benefit I guess. Resources:

- https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/895-pod-topology-spread#impact-to-other-features
- https://github.com/kubernetes/kubernetes/issues/72479

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Refined pod scheduling configuration to prioritise distribution across availability zones, with secondary spreading across individual nodes.
- Enhanced system resilience and failover capability through improved pod placement strategies.
- Optimised resource utilisation and cluster-wide load balancing to ensure better service availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->