### PR TITLE
fix: renovate config to get more patch PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,11 @@
       "commitMessageSuffix": " (localtest)"
     },
     {
+      "matchFileNames": ["src/Runtime/pdf3/**"],
+      "additionalBranchPrefix": "pdf3/",
+      "commitMessageSuffix": " (pdf3)"
+    },
+    {
       "matchFileNames": ["src/App/**"],
       "matchPackageNames": [
         "@digdir/designsystemet-react",
@@ -90,6 +95,5 @@
       ],
       "versioningTemplate": "semver"
     }
-  ],
-  "schedule": ["before 07:00 on Monday"]
+  ]
 }

--- a/src/Runtime/localtest/renovate.json
+++ b/src/Runtime/localtest/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>Altinn/renovate-config"
-  ]
-}


### PR DESCRIPTION
## Description

- remove renovate config from localtest, forgot that during migration probably
- add pdf3 to its' own PRs
- remove schedule

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated Renovate dependency management configuration with a new rule for path-specific updates, including custom branch prefixes and commit message formatting options.
- Removed a global scheduling entry that previously restricted when dependency updates could occur.
- Deleted a localtest-specific Renovate configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->