### PR TITLE
chore: limit label-and-approve workflow concurrency

### DIFF
--- a/.github/workflows/label-and-auto-approve-pr.yaml
+++ b/.github/workflows/label-and-auto-approve-pr.yaml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   label-and-approve:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - name: Label PR based on changed files
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5


### PR DESCRIPTION
## Description

Noticed that https://github.com/Altinn/altinn-studio/pull/16979 was approved twice, I assume the workflow ran multiple times due to different triggers/pushes (synchronized) 🤔 
Also renaming the workflow file to reflect what it is doing

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimised GitHub Actions workflow configuration to improve efficiency of pull request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->