### PR TITLE
fix: Remove schedule to get more patch PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -95,5 +95,6 @@
       ],
       "versioningTemplate": "semver"
     }
-  ]
+  ],
+  "schedule": []
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Our Renovate config inherits from [renovate-config](https://github.com/Altinn/renovate-config/blob/57b33163bb66838134fec6cf3b546ea5bb7ac802/default.json#L8), which includes this schedule:

```json
"schedule": ["before 07:00 on Thursday"],
```

It looks like we need to set the schedule as an empty list to override it.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
