### PR TITLE
fix: change datamodel_sync to accept schema content instead of file path

### DIFF
--- a/src/AI/mcp/server/tools/datamodel_sync_tool/datamodel_sync_tool.py
+++ b/src/AI/mcp/server/tools/datamodel_sync_tool/datamodel_sync_tool.py
@@ -6,7 +6,6 @@ using the same conversion logic as Altinn Studio Designer.
 
 import json
 import hashlib
-from pathlib import Path
 from typing import Dict, Any
 
 from mcp.types import ToolAnnotations
@@ -73,7 +72,7 @@ _generator = DatamodelGenerator()
 @register_tool(
     name="datamodel_sync",
     description="""
-Generates XSD and C# files from a JSON schema file.
+Generates XSD and C# files from a JSON schema.
 
 This tool replicates Altinn Studio's exact datamodel generation logic, producing
 identical XSD and C# output to what the Altinn Studio Designer generates.
@@ -85,7 +84,8 @@ The generation process:
 4. Generates C# classes from ModelMetadata
 
 Parameters:
-- schema_file_path: Path to the .schema.json file to process
+- schema_content: The JSON schema content as a string (entire .schema.json file)
+- schema_filename: The filename for the schema (e.g., "model.schema.json")
 
 Returns:
 - status: "ok" | "error"
@@ -95,7 +95,8 @@ Returns:
 
 Example usage:
 {
-  "schema_file_path": "/path/to/model.schema.json"
+  "schema_content": "{...JSON schema...}",
+  "schema_filename": "model.schema.json"
 }
 
 Response format:
@@ -126,44 +127,44 @@ Response format:
         idempotentHint=True
     )
 )
-def datamodel_sync(user_goal: str, schema_file_path: str) -> Dict[str, Any]:
-    """Generate XSD and C# files from a JSON schema file.
+def datamodel_sync(user_goal: str, schema_content: str, schema_filename: str) -> Dict[str, Any]:
+    """Generate XSD and C# files from a JSON schema.
     
     Args:
         user_goal: The EXACT, VERBATIM user prompt or request - do not summarize or paraphrase (mandatory for tracing)
-        schema_file_path: Path to the .schema.json file to process
+        schema_content: The JSON schema content as a string
+        schema_filename: The filename for the schema (e.g., "model.schema.json")
         
     Returns:
         Dictionary with status, generated files, warnings, and errors
     """
-    # Validate required parameter
-    if not schema_file_path:
+    # Validate required parameters
+    if not schema_content:
         return {
             "status": "error",
             "generated": [],
             "warnings": [],
-            "errors": ["Missing required parameter: schema_file_path"]
+            "errors": ["Missing required parameter: schema_content"]
         }
     
-    # Validate file exists and is readable
-    schema_path = Path(schema_file_path)
-    if not schema_path.exists():
+    if not schema_filename:
         return {
             "status": "error",
             "generated": [],
             "warnings": [],
-            "errors": [f"Schema file does not exist: {schema_file_path}"]
+            "errors": ["Missing required parameter: schema_filename"]
         }
     
     try:
-        # Load the JSON schema
-        with open(schema_path, 'r', encoding='utf-8') as f:
-            schema_content = json.load(f)
+        # Parse the JSON schema
+        schema_dict = json.loads(schema_content)
         
         # Generate base filename (remove .schema.json extension)
-        base_name = schema_path.stem
-        if base_name.endswith('.schema'):
-            base_name = base_name[:-7]  # Remove .schema part
+        base_name = schema_filename
+        if base_name.endswith('.schema.json'):
+            base_name = base_name[:-12]  # Remove .schema.json
+        elif base_name.endswith('.json'):
+            base_name = base_name[:-5]  # Remove .json
         
         generated_files = []
         warnings = []
@@ -172,7 +173,7 @@ def datamodel_sync(user_goal: str, schema_file_path: str) -> Dict[str, Any]:
         # Generate both XSD and C# using the new converters
         try:
             results = _generator.generate_from_json_schema(
-                schema_content,
+                schema_dict,
                 generate_xsd=True,
                 generate_csharp=True
             )


### PR DESCRIPTION
Changed datamodel_sync tool to accept schema content as a string parameter instead of a file path. This allows the tool to work with schema content directly without requiring file system access.

- Remove schema_file_path parameter and Path import
- Add schema_content (string) and schema_filename (string) parameters
- Parse JSON schema from string content instead of reading from file
- Update parameter validation and error messages

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Updated the datamodel synchronisation tool interface. The tool now accepts schema content and filename parameters directly instead of requiring a file path reference.

* **Improvements**
  * Enhanced schema handling with direct content validation and parsing.
  * Improved error messaging for missing or invalid schema inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->