### PR TITLE
feat: change policy_summarization_tool to accept XML content instead of file path

### DIFF
--- a/src/AI/mcp/pyproject.toml
+++ b/src/AI/mcp/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "langchain-community",
     "scikit-learn>=1.3.0",
     "beautifulsoup4>=4.12.0",
+    "defusedxml>=0.7.1",
 ]
 
 [build-system]

--- a/src/AI/mcp/requirements.txt
+++ b/src/AI/mcp/requirements.txt
@@ -32,3 +32,4 @@ langfuse>=2.0.0
 langchain-community
 scikit-learn>=1.3.0
 beautifulsoup4>=4.12.0
+defusedxml>=0.7.1

--- a/src/AI/mcp/server/tools/policy_summarization_tool/policy_summarization_tool.py
+++ b/src/AI/mcp/server/tools/policy_summarization_tool/policy_summarization_tool.py
@@ -1,5 +1,6 @@
 import json
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
+from xml.etree.ElementTree import Element  # For type hints only
 from typing import Dict, Any, List, Optional
 from mcp.types import ToolAnnotations
 
@@ -58,8 +59,11 @@ def summarize_policy_content(xml_content: str) -> List[Dict[str, Any]]:
     """
     Summarizes a policy XML content by iterating through its elements and checking for policy rules.
     
+    Security Note: This function uses defusedxml to safely parse potentially untrusted XML input,
+    protecting against XXE (XML External Entity) and billion laughs attacks.
+    
     Args:
-        xml_content: The XML content of the policy file as a string.
+        xml_content: The XML content of the policy file as a string (potentially untrusted).
         
     Returns:
         Dictionary containing policy metadata and rule summaries.
@@ -106,7 +110,7 @@ def summarize_policy_content(xml_content: str) -> List[Dict[str, Any]]:
     except ET.ParseError as e:
         return {"status": "error", "message": f"XML parsing error: {str(e)}"}
 
-def summarize_rule(rule: ET.Element, rule_index: int) -> List[Dict[str, Any]]:
+def summarize_rule(rule: Element, rule_index: int) -> List[Dict[str, Any]]:
     """
     Summarizes a single rule element in the policy file.
     Decomposes rule into role (subject-category:access-subject), 


### PR DESCRIPTION
Update policy_summarization_tool to accept XML content as a string parameter instead of a file path. This aligns with the pattern used in other tools and removes file system dependencies.

Changes:
- Replace file_path parameter with xml_content parameter
- Remove os module import (no longer needed)
- Remove file existence and extension validation
- Update summarize_policy_file to summarize_policy_content
- Parse XML content directly using

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Policy summarisation tool now accepts XML content as a string rather than requiring a file path, simplifying integration and in-memory processing.

* **Chores**
  * Added a secure XML parsing dependency to improve safety when handling XML content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->