### PR TITLE
chore(renovate): prevent Renovate from creating PRs before minimum release age is met

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["local>Altinn/renovate-config", ":prHourlyLimit4"],
   "separateMinorPatch": true,
   "separateMultipleMajor": true,
+  "prCreation": "not-pending",
   "packageRules": [
     {
       "groupName": "LibGit2Sharp dependency",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This prevents Renovate from creating PRs before minimum release age is met.

This is a recommended setting: https://docs.renovatebot.com/key-concepts/minimum-release-age/#recommended-settings

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
