### PR TITLE
fix(resource-adm): allow links in consent text to start with a metadata variable

### DIFF
--- a/src/Designer/frontend/resourceadm/utils/resourceUtils/resourceUtils.test.tsx
+++ b/src/Designer/frontend/resourceadm/utils/resourceUtils/resourceUtils.test.tsx
@@ -281,7 +281,7 @@ describe('deepCompare', () => {
       });
 
       it('should allow links in nb consentText field which starts with a metadata value', () => {
-        const invalidLink = '[Link]({metadata})';
+        const validLink = '[Link]({metadata})';
         const resource: Resource = {
           identifier: 'res',
           resourceType: 'Consent',
@@ -290,7 +290,7 @@ describe('deepCompare', () => {
             metadata: { optional: false },
           },
           consentText: {
-            nb: `test ${invalidLink}`,
+            nb: `test ${validLink}`,
             nn: 'test',
             en: 'test',
           },
@@ -302,7 +302,7 @@ describe('deepCompare', () => {
             validationErrors,
             'nb',
             textMock('resourceadm.about_resource_error_consent_text_link_invalid', {
-              link: invalidLink,
+              link: validLink,
               interpolation: { escapeValue: false },
             }),
           ),

--- a/src/Designer/frontend/resourceadm/utils/resourceUtils/resourceUtils.ts
+++ b/src/Designer/frontend/resourceadm/utils/resourceUtils/resourceUtils.ts
@@ -369,7 +369,7 @@ export const validateResource = (
         const urlMatch = link.match(/\[[^\]]+\]\(([^)]+)\)/);
         const linkUrl = urlMatch?.[1];
         const isLinkUrlValid =
-          !!linkUrl && (/^https?:\/\//.test(linkUrl) || /^{[a-z]*}/.test(linkUrl));
+          !!linkUrl && (/^https?:\/\//.test(linkUrl) || /^{[a-z]+}/.test(linkUrl));
         if (!isLinkUrlValid) {
           errors.push({
             field: 'consentText',


### PR DESCRIPTION
## Description
 - We currently validate if links used in consent text starts with http or https. This PR also allows these links to start with a metadata value (so links can be set in consent request). The following link is now allowed: `[test link]({link})`

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consent links now accept placeholder patterns formatted as {value} as well as standard http(s):// URLs, allowing metadata-based link references in consent resources.

* **Tests**
  * Added test coverage to confirm that consent text links beginning with metadata-based placeholders are treated as valid.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->