### PR TITLE
fix: pdf3 race in browser process close procedure

### DIFF
--- a/src/Runtime/pdf3/internal/browser/browser.go
+++ b/src/Runtime/pdf3/internal/browser/browser.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"syscall"
+	"time"
 
 	"altinn.studio/pdf3/internal/assert"
 	"altinn.studio/pdf3/internal/log"
@@ -63,6 +65,7 @@ func Start(id int) (*Process, error) {
 	}
 
 	cmd := exec.Command(browserPath, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	debugPortStr := fmt.Sprintf("%d", debugPort)
 	debugBaseURL := fmt.Sprintf("http://127.0.0.1:%d", debugPort)
 	cmdLogger := &cmdToLogger{logger: logger}
@@ -91,17 +94,75 @@ func (l *cmdToLogger) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// Close terminates the browser process
+// Close terminates the browser process and removes its data directory
 func (p *Process) Close() error {
+	logger := log.NewComponent("browser").With("dataDir", p.DataDir)
+	logger.Info("Closing browser process")
+
 	if p.Cmd != nil && p.Cmd.Process != nil {
-		err := p.Cmd.Process.Kill()
-		assert.AssertWithMessage(err == nil, "couldn't kill browser process", "error", err)
-		// Wait() error is expected (killed processes return error), so we can ignore it
-		_ = p.Cmd.Wait()
+		pgid, err := syscall.Getpgid(p.Cmd.Process.Pid)
+		if err != nil {
+			logger.Info("Failed to get process group ID", "error", err)
+			pgid = 0
+		} else {
+			logger.Info("Got process group ID", "pgid", pgid)
+		}
+
+		if pgid > 0 {
+			_ = syscall.Kill(-pgid, syscall.SIGTERM)
+		} else {
+			_ = p.Cmd.Process.Signal(syscall.SIGTERM)
+		}
+
+		done := make(chan error, 1)
+		go func() {
+			err := p.Cmd.Wait()
+			done <- err
+			logger.Info("Browser exited", "error", err)
+		}()
+
+		select {
+		case <-done:
+			logger.Info("Browser exited gracefully after SIGTERM")
+		case <-time.After(100 * time.Millisecond):
+			logger.Info("Browser did not exit after SIGTERM, sending SIGKILL")
+			if pgid > 0 {
+				_ = syscall.Kill(-pgid, syscall.SIGKILL)
+			} else {
+				_ = p.Cmd.Process.Kill()
+			}
+			select {
+			case <-done:
+				logger.Info("Browser exited after SIGKILL")
+			case <-time.After(100 * time.Millisecond):
+				logger.Info("Did not observe browser exit after SIGKILL")
+			}
+		}
 	}
-	err := os.RemoveAll(p.DataDir)
+
+	err := removeDataDirWithRetry(p.DataDir, logger)
 	assert.AssertWithMessage(err == nil, "couldn't remove dataDir", "dataDir", p.DataDir, "error", err)
 	return nil
+}
+
+// removeDataDirWithRetry attempts to remove the data directory with retries
+// to handle race conditions where child processes may still hold file handles
+func removeDataDirWithRetry(dataDir string, logger *slog.Logger) error {
+	const maxRetries = 5
+	const retryDelay = 10 * time.Millisecond
+
+	var lastErr error
+	for i := range maxRetries {
+		lastErr = os.RemoveAll(dataDir)
+		if lastErr == nil {
+			return nil
+		}
+		if i < maxRetries-1 {
+			logger.Info("Failed to remove dataDir, retrying", "attempt", i+1, "error", lastErr)
+		}
+		time.Sleep(retryDelay)
+	}
+	return lastErr
 }
 
 // createBrowserArgs returns the Chrome/Chromium arguments for headless PDF generation


### PR DESCRIPTION
## Description

Saw the following assertion failure:
```text
time=2025-11-20T16:17:39.329+01:00 level=ERROR msg="Assertion failed:" component=assert message="couldn't remove dataDir" dataDir=/tmp/browser-78 error="unlinkat /tmp/browser-78/Default/Cache/Cache_Data/index-dir: directory not empty"
```

There is probably some race going on here where the process isn't fully killed. This change:
- Get process group ID for headless-shell
- Shutdown using process group ID (if available)
- Try SIGTERM first with a timeout
- SIGKILL after 100ms
- Remove datadir in a small retry loop (still assert at the end)

Example output from a local run:

```text
time=2025-11-25T09:04:54.017+01:00 level=INFO msg="Starting periodic browser restart" component=generator
time=2025-11-25T09:04:54.017+01:00 level=INFO msg="Creating new browser session for restart" component=generator id=3
time=2025-11-25T09:04:54.017+01:00 level=INFO msg="Starting browser session" component=generator id=3 queueSize=0
time=2025-11-25T09:04:54.017+01:00 level=INFO msg="Starting browser" component=browser id=3 path=/headless-shell/headless-shell port=5053
time=2025-11-25T09:04:54.036+01:00 level=INFO msg="Browser process stdout/stderr" component=browser id=3 message="[1125/090454.036377:ERROR:content/browser/zygote_host/zygote_host_impl_linux.cc:279] Failed to adjust OOM score of renderer with pid 204: Permission denied (13)\n"
time=2025-11-25T09:04:54.043+01:00 level=INFO msg="Browser process stdout/stderr" component=browser id=3 message="[1125/090454.043448:ERROR:content/browser/zygote_host/zygote_host_impl_linux.cc:279] Failed to adjust OOM score of renderer with pid 214: Permission denied (13)\n"
time=2025-11-25T09:04:54.046+01:00 level=INFO msg="Browser process stdout/stderr" component=browser id=3 message="\nDevTools listening on ws://127.0.0.1:5053/devtools/browser/bca75c1e-4808-402d-9feb-6ed5c791a643\n"
time=2025-11-25T09:04:54.071+01:00 level=INFO msg="Attempting to connect to WebSocket" component=cdp id=3 url=ws://127.0.0.1:5053/devtools/page/175D88D0489C1F6C4E6EF2BB2424E318
time=2025-11-25T09:04:54.075+01:00 level=INFO msg="Browser worker initialized successfully" component=generator id=3
time=2025-11-25T09:04:54.075+01:00 level=INFO msg="Swapped to new browser session" component=generator old_id=2 new_id=3
time=2025-11-25T09:04:54.075+01:00 level=INFO msg="Session drained successfully" component=generator id=2
time=2025-11-25T09:04:54.075+01:00 level=INFO msg="Closing worker" component=generator id=2
time=2025-11-25T09:04:54.075+01:00 level=INFO msg="CDP connection watchdog shutting down" component=cdp id=2
time=2025-11-25T09:04:54.075+01:00 level=INFO msg="Request processing loop shutting down (context cancellation)" component=generator id=2
time=2025-11-25T09:04:54.075+01:00 level=INFO msg="Closing browser process" component=browser dataDir=/tmp/browser-2
time=2025-11-25T09:04:54.075+01:00 level=INFO msg="WebSocket message handler shutting down (context cancelled)" component=cdp id=2
time=2025-11-25T09:04:54.075+01:00 level=INFO msg="Got process group ID" component=browser dataDir=/tmp/browser-2 pgid=120
time=2025-11-25T09:04:54.077+01:00 level=INFO msg="Browser process stdout/stderr" component=browser id=2 message="[1125/090454.077660:ERROR:content/common/zygote/zygote_communication_linux.cc:293] Failed to send GetTerminationStatus message to zygote\n[1125/090454.077684:WARNING:content/common/zygote/zygote_communication_linux.cc:305] Socket closed prematurely.\n"
time=2025-11-25T09:04:54.083+01:00 level=INFO msg="Browser process stdout/stderr" component=browser id=2 message="[1125/090454.082960:ERROR:content/common/zygote/zygote_communication_linux.cc:293] Failed to send GetTerminationStatus message to zygote\n[1125/090454.082973:WARNING:content/common/zygote/zygote_communication_linux.cc:305] Socket closed prematurely.\n"
time=2025-11-25T09:04:54.086+01:00 level=INFO msg="Browser exited" component=browser dataDir=/tmp/browser-2 error="exit status 143"
time=2025-11-25T09:04:54.086+01:00 level=INFO msg="Browser exited gracefully after SIGTERM" component=browser dataDir=/tmp/browser-2
time=2025-11-25T09:04:54.086+01:00 level=INFO msg="Worker closed" component=generator id=2
time=2025-11-25T09:04:54.086+01:00 level=INFO msg="Browser restart complete" component=generator old_id=2 new_id=3
time=2025-11-25T09:04:54.086+01:00 level=INFO msg="Periodic browser restart enabled" component=generator interval=2m0s
time=2025-11-25T09:05:54.073+01:00 level=INFO msg="CDP connection watchdog tick" component=cdp id=3

```

chromedp seems to just have a sleep in place before deletion

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser shutdown reliability with enhanced process termination handling.
  * Strengthened data directory cleanup with automatic retry logic to handle edge cases during shutdown.
  * Added comprehensive logging for improved troubleshooting of shutdown operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->