### PR TITLE
chore: pdf3 - improve assert package naming

### DIFF
--- a/src/Runtime/pdf3/cmd/proxy/main.go
+++ b/src/Runtime/pdf3/cmd/proxy/main.go
@@ -226,7 +226,7 @@ func generatePdf(logger *slog.Logger, client *http.Client, workerAddr string) fu
 
 		attempt := 1
 		for {
-			assert.AssertWithMessage(attempt <= maxRetries, "Overflowed retry attempts")
+			assert.That(attempt <= maxRetries, "Overflowed retry attempts")
 
 			ret := callWorker(
 				reqLogger,
@@ -332,7 +332,7 @@ func callWorker(
 		// In test internals mode, pass back the worker IP to the client
 		// so they can route test output requests to the correct worker pod
 		if iruntime.IsTestInternalsMode && testing.HasTestHeader(r.Header) {
-			assert.AssertWithMessage(workerIP != "", "Worker IP should always be set in test internals mode")
+			assert.That(workerIP != "", "Worker IP should always be set in test internals mode")
 			w.Header().Set("X-Worker-IP", workerIP)
 			w.Header().Set("X-Worker-Id", workerId)
 			logger.Debug("Returning worker info", "worker_ip", workerIP)
@@ -390,7 +390,7 @@ func callWorker(
 	// In test internals mode, pass back the worker IP even on errors
 	// so tests can still fetch test output from the correct worker
 	if iruntime.IsTestInternalsMode && testing.HasTestHeader(r.Header) {
-		assert.Assert(workerIP != "")
+		assert.That(workerIP != "", "Worker IP should always be set in test internals mode")
 		w.Header().Set("X-Worker-IP", workerIP)
 		w.Header().Set("X-Worker-Id", workerId)
 	}
@@ -412,14 +412,14 @@ func callWorker(
 
 func forwardTestOutputRequest(logger *slog.Logger, client *http.Client) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		assert.AssertWithMessage(iruntime.IsTestInternalsMode, "Test output endpoint should only be registered in test internals mode")
+		assert.That(iruntime.IsTestInternalsMode, "Test output endpoint should only be registered in test internals mode")
 
 		// Extract test ID from URL path: /testoutput/{id}
 		testID := strings.TrimPrefix(r.URL.Path, "/testoutput/")
 
 		// Client should provide the worker IP via header to ensure we hit the right pod
 		targetWorkerIP := r.Header.Get("X-Target-Worker-IP")
-		assert.AssertWithMessage(targetWorkerIP != "", "X-Target-Worker-IP header is required in test internals mode")
+		assert.That(targetWorkerIP != "", "X-Target-Worker-IP header is required in test internals mode")
 
 		// Route directly to the specified worker pod IP
 		workerEndpoint := fmt.Sprintf("http://%s:5031%s", targetWorkerIP, r.URL.Path)

--- a/src/Runtime/pdf3/cmd/worker/main.go
+++ b/src/Runtime/pdf3/cmd/worker/main.go
@@ -48,19 +48,19 @@ func main() {
 	defer host.Stop()
 
 	hostname, err := os.Hostname()
-	assert.AssertWithMessage(err == nil, "Could not read hostname", "error", err)
+	assert.That(err == nil, "Could not read hostname", "error", err)
 
 	workerId = hostname
 
 	workerIP, err = discoverLocalIP()
-	assert.AssertWithMessage(err == nil, "Failed to discover local IP", "error", err)
-	assert.AssertWithMessage(workerIP != "", "Worker IP should be available", "worker_id", workerId)
+	assert.That(err == nil, "Failed to discover local IP", "error", err)
+	assert.That(workerIP != "", "Worker IP should be available", "worker_id", workerId)
 
 	// Create logger with worker context
 	logger := baseLogger.With("worker_id", workerId, "worker_ip", workerIP)
 
 	gen, err := generator.New()
-	assert.AssertWithMessage(err == nil, "Failed to create PDF generator", "error", err)
+	assert.That(err == nil, "Failed to create PDF generator", "error", err)
 	defer func() {
 		// Closing PDF generator during shutdown
 		if err := gen.Close(); err != nil {
@@ -156,7 +156,7 @@ func main() {
 }
 
 func generateLocalPdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.HandlerFunc {
-	assert.AssertWithMessage(!iruntime.IsTestInternalsMode, "Localtest env should not run internals test mode")
+	assert.That(!iruntime.IsTestInternalsMode, "Localtest env should not run internals test mode")
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -354,7 +354,7 @@ func discoverLocalIP() (string, error) {
 
 func getTestOutputHandler(logger *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		assert.AssertWithMessage(iruntime.IsTestInternalsMode, "Test output handler should only be registered in test internals mode")
+		assert.That(iruntime.IsTestInternalsMode, "Test output handler should only be registered in test internals mode")
 
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/src/Runtime/pdf3/internal/assert/assert.go
+++ b/src/Runtime/pdf3/internal/assert/assert.go
@@ -11,13 +11,7 @@ import (
 
 var logger *slog.Logger = log.NewComponent("assert")
 
-func Assert(condition bool) {
-	if !condition {
-		panicking("")
-	}
-}
-
-func AssertWithMessage(condition bool, message string, args ...any) {
+func That(condition bool, message string, args ...any) {
 	if !condition {
 		panicking(message, args...)
 	}

--- a/src/Runtime/pdf3/internal/browser/browser.go
+++ b/src/Runtime/pdf3/internal/browser/browser.go
@@ -54,7 +54,7 @@ func Start(id int) (*Process, error) {
 			args[i] = fmt.Sprintf("--remote-debugging-port=%d", debugPort)
 		}
 	}
-	assert.AssertWithMessage(dataDir != "", "Should always initialize dataDir", "id", id)
+	assert.That(dataDir != "", "Should always initialize dataDir", "id", id)
 
 	// Add about:blank argument to create default page target
 	args = append(args, "about:blank")
@@ -141,7 +141,7 @@ func (p *Process) Close() error {
 	}
 
 	err := removeDataDirWithRetry(p.DataDir, logger)
-	assert.AssertWithMessage(err == nil, "couldn't remove dataDir", "dataDir", p.DataDir, "error", err)
+	assert.That(err == nil, "couldn't remove dataDir", "dataDir", p.DataDir, "error", err)
 	return nil
 }
 
@@ -211,6 +211,6 @@ func logArgs(logger *slog.Logger, id int, args []string) {
 	copy(sortedArgs, args)
 	sort.Strings(sortedArgs)
 	argsAsJson, err := json.MarshalIndent(sortedArgs, "", "  ")
-	assert.AssertWithMessage(err == nil, "Failed to marshal browser args to JSON", "id", id, "error", err)
+	assert.That(err == nil, "Failed to marshal browser args to JSON", "id", id, "error", err)
 	logger.Info("Browser args", "args", string(argsAsJson))
 }

--- a/src/Runtime/pdf3/internal/cdp/transport.go
+++ b/src/Runtime/pdf3/internal/cdp/transport.go
@@ -93,7 +93,7 @@ func Connect(ctx context.Context, id int, debugBaseURL string, eventHandler Even
 	}
 
 	// Chrome should always return at least one target (the page we created)
-	assert.AssertWithMessage(len(targets) > 0, "Chrome returned zero targets - browser in invalid state", "id", id)
+	assert.That(len(targets) > 0, "Chrome returned zero targets - browser in invalid state", "id", id)
 
 	// Debug: print available targets
 	logger.Debug("Found targets", "count", len(targets))
@@ -109,7 +109,7 @@ func Connect(ctx context.Context, id int, debugBaseURL string, eventHandler Even
 			break
 		}
 	}
-	assert.AssertWithMessage(target != nil, "no page target found", "id", id)
+	assert.That(target != nil, "no page target found", "id", id)
 	targetID := target.ID
 
 	// Connect to the page's WebSocket
@@ -118,7 +118,7 @@ func Connect(ctx context.Context, id int, debugBaseURL string, eventHandler Even
 		return nil, "", fmt.Errorf("no webSocketDebuggerUrl in response")
 	}
 	// Chrome page targets must have a WebSocket URL - this is a protocol invariant
-	assert.AssertWithMessage(wsURL != "", "Page target missing WebSocketDebuggerURL - protocol violation", "id", id)
+	assert.That(wsURL != "", "Page target missing WebSocketDebuggerURL - protocol violation", "id", id)
 
 	// Add debugging to understand what URL we're trying to connect to
 	logger.Info("Attempting to connect to WebSocket", "url", wsURL)
@@ -140,7 +140,7 @@ func Connect(ctx context.Context, id int, debugBaseURL string, eventHandler Even
 		wsConn, _, err = dialer.Dial(wsURL, nil)
 		if err == nil {
 			wsConn.SetCloseHandler(func(code int, text string) error {
-				assert.AssertWithMessage(
+				assert.That(
 					// We check ctx here as it is tied to host shutdown.
 					// It's OK to close if the host is shutting down, but NOT OK otherwise
 					ctx.Err() != nil,
@@ -165,7 +165,7 @@ func Connect(ctx context.Context, id int, debugBaseURL string, eventHandler Even
 		return nil, "", fmt.Errorf("failed to dial WebSocket: %w", err)
 	}
 	// Successful dial must return a valid connection
-	assert.AssertWithMessage(wsConn != nil, "WebSocket dial succeeded but returned nil connection", "id", id)
+	assert.That(wsConn != nil, "WebSocket dial succeeded but returned nil connection", "id", id)
 
 	// Create connection wrapper
 	conn := &connection{
@@ -192,14 +192,14 @@ func Connect(ctx context.Context, id int, debugBaseURL string, eventHandler Even
 }
 
 func (c *connection) assert(condition bool, message string) {
-	assert.AssertWithMessage(condition, message, "id", c.id)
+	assert.That(condition, message, "id", c.id)
 }
 
 func (c *connection) assertA(condition bool, message string, userArgs ...any) {
 	args := make([]any, 0, 2+len(userArgs))
 	args = append(args, "id", c.id)
 	args = append(args, userArgs...)
-	assert.AssertWithMessage(condition, message, args...)
+	assert.That(condition, message, args...)
 }
 
 func (c *connection) watchdog() {

--- a/src/Runtime/pdf3/internal/concurrent/map.go
+++ b/src/Runtime/pdf3/internal/concurrent/map.go
@@ -66,7 +66,7 @@ func (cm *Map[K, V]) Update(k K, fn func(*V)) bool {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	v, ok := cm.m[k]
-	assert.AssertWithMessage(ok, "Item with key not found")
+	assert.That(ok, "Item with key not found")
 	fn(&v)
 	cm.m[k] = v
 	return true

--- a/src/Runtime/pdf3/internal/config/config.go
+++ b/src/Runtime/pdf3/internal/config/config.go
@@ -20,7 +20,7 @@ type Config struct {
 
 func ReadConfig() *Config {
 	environment := os.Getenv("PDF3_ENVIRONMENT")
-	assert.AssertWithMessage(
+	assert.That(
 		environment != "",
 		"PDF3_ENVIRONMENT environment variable must be set",
 	)

--- a/src/Runtime/pdf3/internal/generator/browser_session.go
+++ b/src/Runtime/pdf3/internal/generator/browser_session.go
@@ -899,9 +899,9 @@ func (w *browserSession) cleanupBrowser(req *workerRequest) {
 
 func (w *browserSession) assert(condition bool, message string) {
 	if req := w.currentRequest.Load(); req != nil {
-		assert.AssertWithMessage(condition, message, "id", w.id, "url", req.request.URL)
+		assert.That(condition, message, "id", w.id, "url", req.request.URL)
 	} else {
-		assert.AssertWithMessage(condition, message, "id", w.id)
+		assert.That(condition, message, "id", w.id)
 	}
 }
 
@@ -911,12 +911,12 @@ func (w *browserSession) assertA(condition bool, message string, userArgs ...any
 		args = append(args, "id", w.id)
 		args = append(args, "url", req.request.URL)
 		args = append(args, userArgs...)
-		assert.AssertWithMessage(condition, message, args...)
+		assert.That(condition, message, args...)
 	} else {
 		args := make([]any, 0, 2+len(userArgs))
 		args = append(args, "id", w.id)
 		args = append(args, userArgs...)
-		assert.AssertWithMessage(condition, message, args...)
+		assert.That(condition, message, args...)
 	}
 }
 

--- a/src/Runtime/pdf3/internal/generator/generator.go
+++ b/src/Runtime/pdf3/internal/generator/generator.go
@@ -69,14 +69,14 @@ func New() (*Custom, error) {
 	go func() {
 		defer func() {
 			r := recover()
-			assert.AssertWithMessage(r == nil, "Generator initialization panicked", "error", r)
+			assert.That(r == nil, "Generator initialization panicked", "error", r)
 		}()
 
 		logger.Info("Initializing Custom CDP")
 
 		// Get and set browser version
 		version, err := getBrowserVersion(logger)
-		assert.AssertWithMessage(err == nil, "Failed to get browser version", "error", err)
+		assert.That(err == nil, "Failed to get browser version", "error", err)
 
 		generator.browserVersion = version
 		logger.Info("Chrome version",
@@ -89,7 +89,7 @@ func New() (*Custom, error) {
 			logger.Info("Starting browser worker", "id", id)
 
 			session, err := newBrowserSession(logger, id)
-			assert.AssertWithMessage(err == nil, "Failed to create worker", "id", id, "error", err)
+			assert.That(err == nil, "Failed to create worker", "id", id, "error", err)
 
 			return session
 		}
@@ -110,8 +110,8 @@ func (g *Custom) IsReady() bool {
 
 func (g *Custom) Generate(ctx context.Context, request types.PdfRequest) (*types.PdfResult, *types.PDFError) {
 	session := g.activeSession.Load()
-	assert.AssertWithMessage(session != nil, "The worker should not call the generator unless it is ready", "url", request.URL)
-	assert.AssertWithMessage(request.Validate() == nil, "Invalid request passed through to worker", "url", request.URL)
+	assert.That(session != nil, "The worker should not call the generator unless it is ready", "url", request.URL)
+	assert.That(request.Validate() == nil, "Invalid request passed through to worker", "url", request.URL)
 
 	responder := make(chan workerResponse, 1)
 	req := workerRequest{
@@ -141,7 +141,7 @@ func (g *Custom) Generate(ctx context.Context, request types.PdfRequest) (*types
 	case <-ctx.Done():
 		return nil, types.NewPDFError(types.ErrClientDropped, "", ctx.Err())
 	case <-time.After(types.RequestTimeout()):
-		assert.AssertWithMessage(false, "generator failed to respond to request, something must be stuck", "url", request.URL)
+		assert.That(false, "generator failed to respond to request, something must be stuck", "url", request.URL)
 		return nil, types.NewPDFError(types.ErrGenerationFail, "internal request timeout", nil)
 	}
 }
@@ -220,7 +220,7 @@ func (r *workerRequest) tryGetTestModeInput() *testing.PdfInternalsTestInput {
 	}
 
 	value, ok := obj.(*testing.PdfInternalsTestInput)
-	assert.AssertWithMessage(ok, "Invalid type for test internals mode input on context")
+	assert.That(ok, "Invalid type for test internals mode input on context")
 	return value
 }
 

--- a/src/Runtime/pdf3/internal/runtime/runtime.go
+++ b/src/Runtime/pdf3/internal/runtime/runtime.go
@@ -90,7 +90,7 @@ func NewHost(
 func (h *Host) run() {
 	defer func() {
 		r := recover()
-		assert.AssertWithMessage(r == nil, "Runtime host shutdown coordinator panicked", "error", r)
+		assert.That(r == nil, "Runtime host shutdown coordinator panicked", "error", r)
 	}()
 
 	// We received SIGINT/SIGTERM

--- a/src/Runtime/pdf3/internal/testing/testing.go
+++ b/src/Runtime/pdf3/internal/testing/testing.go
@@ -24,7 +24,7 @@ type PdfInternalsTestInput struct {
 
 // NewTestInput creates a new test input with a generated UUID
 func NewTestInput(cleanupDelaySeconds int) *PdfInternalsTestInput {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
 	return &PdfInternalsTestInput{
 		ID:                  uuid.New().String(),
 		CleanupDelaySeconds: cleanupDelaySeconds,
@@ -32,7 +32,7 @@ func NewTestInput(cleanupDelaySeconds int) *PdfInternalsTestInput {
 }
 
 func NewTestInputFrom(other *PdfInternalsTestInput) *PdfInternalsTestInput {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
 	return &PdfInternalsTestInput{
 		ID:                  uuid.New().String(),
 		CleanupDelaySeconds: other.CleanupDelaySeconds,
@@ -40,7 +40,7 @@ func NewTestInputFrom(other *PdfInternalsTestInput) *PdfInternalsTestInput {
 }
 
 func NewDefaultTestInput() *PdfInternalsTestInput {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
 	return &PdfInternalsTestInput{
 		ID: uuid.NewString(),
 	}
@@ -54,40 +54,40 @@ func TestInputContextKey() contextKey {
 }
 
 func HasTestHeader(headers http.Header) bool {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
 	return headers.Get(TestInputHeaderName) != ""
 }
 
 func (i *PdfInternalsTestInput) Serialize(headers http.Header) {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
 	json, err := json.Marshal(i)
-	assert.AssertWithMessage(err == nil, "Should be able to serialize input")
+	assert.That(err == nil, "Should be able to serialize input")
 	value := base64.StdEncoding.EncodeToString(json)
 	headers.Add(TestInputHeaderName, value)
 }
 
 func (i *PdfInternalsTestInput) String() string {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
 	json, err := json.MarshalIndent(i, "", "  ")
-	assert.AssertWithMessage(err == nil, "Should be able to JSON serialize")
+	assert.That(err == nil, "Should be able to JSON serialize")
 	return string(json)
 }
 
 func (i *PdfInternalsTestInput) Deserialize(headers http.Header) {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
-	assert.Assert(i != nil)
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(i != nil, "Test input should not be nil")
 	header := headers.Get(TestInputHeaderName)
 	if header != "" {
 		value, err := base64.StdEncoding.DecodeString(string(header))
-		assert.AssertWithMessage(err == nil, "Should be able to decode input")
+		assert.That(err == nil, "Should be able to decode input")
 		err = json.Unmarshal(value, i)
-		assert.AssertWithMessage(err == nil, "Should be able to deserialize input")
-		assert.AssertWithMessage(i.ID != "", "Test input ID is required")
+		assert.That(err == nil, "Should be able to deserialize input")
+		assert.That(i.ID != "", "Test input ID is required")
 	}
 }
 
 func CopyTestInput(dst http.Header, src http.Header) {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
 	header := src.Get(TestInputHeaderName)
 	if header != "" {
 		dst.Set(TestInputHeaderName, header)
@@ -114,9 +114,9 @@ type PdfInternalsTestOutput struct {
 
 // NewTestOutput creates a new test output with the ID from the input
 func NewTestOutput(input *PdfInternalsTestInput) *PdfInternalsTestOutput {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
-	assert.Assert(input != nil)
-	assert.AssertWithMessage(input.ID != "", "Test input ID is required")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(input != nil, "Test input should not be nil")
+	assert.That(input.ID != "", "Test input ID is required")
 	return &PdfInternalsTestOutput{
 		ID:            input.ID,
 		BrowserStates: make([]BrowserState, 0),
@@ -126,7 +126,7 @@ func NewTestOutput(input *PdfInternalsTestInput) *PdfInternalsTestOutput {
 
 // MarkComplete signals that all browser state snapshots have been collected
 func (o *PdfInternalsTestOutput) MarkComplete() {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
 	if o.complete != nil {
 		close(o.complete)
 	}
@@ -134,7 +134,7 @@ func (o *PdfInternalsTestOutput) MarkComplete() {
 
 // WaitForComplete waits for all snapshots to be collected, with a timeout
 func (o *PdfInternalsTestOutput) WaitForComplete(timeout time.Duration) bool {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
 	if o.complete == nil {
 		return true // Already complete or no channel
 	}
@@ -147,7 +147,7 @@ func (o *PdfInternalsTestOutput) WaitForComplete(timeout time.Duration) bool {
 }
 
 func (o *PdfInternalsTestOutput) HadErrors() bool {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
 	for _, state := range o.BrowserStates {
 		if state.ConsoleErrorLogs != 0 || state.BrowserErrors != 0 {
 			return true
@@ -157,18 +157,18 @@ func (o *PdfInternalsTestOutput) HadErrors() bool {
 }
 
 func (o *PdfInternalsTestOutput) String() string {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
 	json, err := json.MarshalIndent(o, "", "  ")
-	assert.AssertWithMessage(err == nil, "Should be able to JSON serialize")
+	assert.That(err == nil, "Should be able to JSON serialize")
 	return string(json)
 }
 
 func (o *PdfInternalsTestOutput) SnapshotString() string {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
 	copy := *o
 	copy.ID = "UUID"
 	json, err := json.MarshalIndent(copy, "", "  ")
-	assert.AssertWithMessage(err == nil, "Should be able to JSON serialize")
+	assert.That(err == nil, "Should be able to JSON serialize")
 	return string(json)
 }
 
@@ -177,23 +177,23 @@ var testOutputStore = concurrent.NewMap[string, *PdfInternalsTestOutput]()
 
 // StoreTestOutput stores a test output by ID (only in test internals mode)
 func StoreTestOutput(output *PdfInternalsTestOutput) {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
-	assert.Assert(output != nil)
-	assert.AssertWithMessage(output.ID != "", "Test output ID is required")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(output != nil, "Test output should not be nil")
+	assert.That(output.ID != "", "Test output ID is required")
 	testOutputStore.Set(output.ID, output)
 }
 
 // GetTestOutput retrieves a test output by ID (only in test internals mode)
 func GetTestOutput(id string) (*PdfInternalsTestOutput, bool) {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
-	assert.AssertWithMessage(id != "", "Test output ID is required")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(id != "", "Test output ID is required")
 	return testOutputStore.Get(id)
 }
 
 // UpdateTestOutput atomically updates a test output by ID (only in test internals mode)
 func UpdateTestOutput(id string, fn func(*PdfInternalsTestOutput)) bool {
-	assert.AssertWithMessage(runtime.IsTestInternalsMode, "Should only run as part of testing")
-	assert.AssertWithMessage(id != "", "Test output ID is required")
+	assert.That(runtime.IsTestInternalsMode, "Should only run as part of testing")
+	assert.That(id != "", "Test output ID is required")
 	return testOutputStore.Update(id, func(ptr **PdfInternalsTestOutput) {
 		fn(*ptr)
 	})

--- a/src/Runtime/pdf3/test/harness/harness.go
+++ b/src/Runtime/pdf3/test/harness/harness.go
@@ -114,8 +114,8 @@ func (r *PdfResponse) LoadOutput(t *testing.T) (*ptesting.PdfInternalsTestOutput
 
 // getTestOutput fetches a test output from the proxy by ID (which forwards to worker)
 func getTestOutput(_ *testing.T, id string, workerIP string) (*ptesting.PdfInternalsTestOutput, error) {
-	assert.Assert(id != "")
-	assert.Assert(workerIP != "")
+	assert.That(id != "", "Test output ID is required")
+	assert.That(workerIP != "", "Worker IP should always be set in test internals mode")
 	url := JumpboxURL + "/testoutput/" + id
 
 	client := &http.Client{


### PR DESCRIPTION
## Description

I think this looks a little nicer. Also removed the message-less overload. I think we should always have a reason in place
Will do the same in operator

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code maintainability by consolidating assertion utilities across the PDF generation runtime, enhancing consistency in error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->