### PR TITLE
fix: fixed translation of "danger " for varsel compoenent

### DIFF
--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -1525,6 +1525,7 @@
   "ux_editor.component_properties.enum_confirm": "Bekreft",
   "ux_editor.component_properties.enum_current": "Nåværende",
   "ux_editor.component_properties.enum_currentAndPrevious": "Nåværende og forrige",
+  "ux_editor.component_properties.enum_danger": "Farlig",
   "ux_editor.component_properties.enum_day": "Dag",
   "ux_editor.component_properties.enum_degree": "Grader",
   "ux_editor.component_properties.enum_desc": "Omvendt alfabetisk",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Translated "danger " into Norwegian = "farlig"
closes: #17057 

<img width="1103" height="227" alt="Screenshot 2025-11-26 at 13 56 34" src="https://github.com/user-attachments/assets/3d1b15d5-0cf5-447e-9243-2ae8fb4de2e3" />


## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
