### PR TITLE
fix: make renovate keep the v prefix in the .tool-versions file in the go fixture

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -93,6 +93,7 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n[^\\s]+\\s+(?<currentValue>\\S+)"
       ],
+      "extractVersionTemplate": "^(?<version>v.*)$",
       "versioningTemplate": "semver"
     }
   ],

--- a/src/Runtime/test/fixture/pkg/tools/.tool-versions
+++ b/src/Runtime/test/fixture/pkg/tools/.tool-versions
@@ -2,9 +2,9 @@
 # Format: <tool-name> <version> <checksum-url-template>
 # URL templates support {os}, {arch}, {version}, {version_no_v} placeholders
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-golangci-lint 2.6.2 https://github.com/golangci/golangci-lint/releases/download/{version}/golangci-lint-{version_no_v}-checksums.txt
+golangci-lint v2.6.2 https://github.com/golangci/golangci-lint/releases/download/{version}/golangci-lint-{version_no_v}-checksums.txt
 # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-kind 0.30.0 https://github.com/kubernetes-sigs/kind/releases/download/{version}/kind-{os}-{arch}.sha256sum
+kind v0.30.0 https://github.com/kubernetes-sigs/kind/releases/download/{version}/kind-{os}-{arch}.sha256sum
 # renovate: datasource=github-releases depName=helm/helm
 helm v3.19.2 https://get.helm.sh/helm-{version}-{os}-{arch}.tar.gz.sha256sum
 # renovate: datasource=github-releases depName=kubernetes/kubernetes


### PR DESCRIPTION
## Description

I had a bug in the renovate config, the default regex parses out the semver version (i.e. drops the `v` prefix)

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated dependency management configuration to improve version parsing for prefixed version strings.
  * Updated development tool versions and added new tools to the project's tool configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->