### PR TITLE
fix(resource-adm): log time it takes to read each resource file when loading resource list

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/RepositorySI.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/RepositorySI.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -26,7 +27,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using System.Diagnostics;
 
 namespace Altinn.Studio.Designer.Services.Implementation
 {
@@ -447,7 +447,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
                     {
                         sw.Stop();
                         _logger.LogError(ex, "Failed to read/deserialize resource file {ResourcePath} (name={ResourceName}) after {ElapsedMs} ms", resourceFile.Path, resourceFile.Name, sw.ElapsedMilliseconds);
-                        return null;
+                        throw;
                     }
                 }
                 finally


### PR DESCRIPTION
## Description
- Loading the resource list takes a long time when deserializing all resource files. Log time it takes to read each file

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for resource deserialisation so failures are logged and exceptions are propagated instead of returning null.

* **Improvements**
  * Added timing and structured logging around resource reads to surface operation durations and contextual metadata for easier diagnosis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->