### PR TITLE
fix: runtime grafana-manifests: grafana namespace to match existing instance

### DIFF
--- a/infra/runtime/grafana-manifests/service-accounts/altinn-studio-gateway-sa.yaml
+++ b/infra/runtime/grafana-manifests/service-accounts/altinn-studio-gateway-sa.yaml
@@ -2,7 +2,6 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaServiceAccount
 metadata:
   name: external-grafana-altinn-studio-gateway-sa
-  namespace: grafana
 spec:
   instanceName: external-grafana
   name: altinn-studio-gateway-sa

--- a/infra/runtime/syncroot/grafana-manifests/grafana-manifests.yaml
+++ b/infra/runtime/syncroot/grafana-manifests/grafana-manifests.yaml
@@ -22,7 +22,7 @@ metadata:
   name: grafana-manifests
   namespace: runtime-grafana
 spec:
-  targetNamespace: runtime-grafana
+  targetNamespace: grafana
   interval: 5m
   retryInterval: 5m
   timeout: 1m


### PR DESCRIPTION
## Description

To make sure GrafanaServiceAccount gets a token. Next step: sync to gateway through operator

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
