### PR TITLE
fix: operator to not delete dest in secretsync

### DIFF
--- a/src/Runtime/operator/internal/controller/secretsync/controller.go
+++ b/src/Runtime/operator/internal/controller/secretsync/controller.go
@@ -96,7 +96,7 @@ func (r *SecretSyncReconciler) reconcileFromSource(
 	err := r.k8sClient.Get(ctx, sourceKey, source)
 	if apierrors.IsNotFound(err) {
 		if !mapping.CanDeleteDest {
-			return ctrl.Result{}, nil
+			return r.clearDestination(ctx, span, destKey, mapping)
 		}
 		return r.deleteDestination(ctx, span, destKey)
 	}
@@ -121,7 +121,7 @@ func (r *SecretSyncReconciler) reconcileFromDest(
 	err := r.k8sClient.Get(ctx, sourceKey, source)
 	if apierrors.IsNotFound(err) {
 		if !mapping.CanDeleteDest {
-			return ctrl.Result{}, nil
+			return r.clearDestination(ctx, span, destKey, mapping)
 		}
 		return r.deleteDestination(ctx, span, destKey)
 	}
@@ -234,6 +234,39 @@ func (r *SecretSyncReconciler) deleteDestination(
 		return ctrl.Result{}, fmt.Errorf("failed to delete destination secret: %w", err)
 	}
 	r.logger.Info("deleted destination secret (source was deleted)",
+		"name", destKey.Name,
+		"namespace", destKey.Namespace,
+	)
+	return ctrl.Result{}, nil
+}
+
+func (r *SecretSyncReconciler) clearDestination(
+	ctx context.Context,
+	span trace.Span,
+	destKey client.ObjectKey,
+	mapping SecretSyncMapping,
+) (ctrl.Result, error) {
+	dest := &corev1.Secret{}
+	err := r.k8sClient.Get(ctx, destKey, dest)
+	if apierrors.IsNotFound(err) {
+		return ctrl.Result{}, nil
+	}
+	if err != nil {
+		span.RecordError(err)
+		return ctrl.Result{}, fmt.Errorf("failed to get destination secret for clearing: %w", err)
+	}
+
+	if mapping.ClearOutput != nil {
+		dest.Data = map[string][]byte{mapping.DestKey: mapping.ClearOutput()}
+	} else {
+		dest.Data = nil
+	}
+
+	if err := r.k8sClient.Update(ctx, dest); err != nil {
+		span.RecordError(err)
+		return ctrl.Result{}, fmt.Errorf("failed to clear destination secret: %w", err)
+	}
+	r.logger.Info("cleared destination secret (source was deleted)",
 		"name", destKey.Name,
 		"namespace", destKey.Namespace,
 	)

--- a/src/Runtime/operator/internal/controller/secretsync/types.go
+++ b/src/Runtime/operator/internal/controller/secretsync/types.go
@@ -24,6 +24,9 @@ type SecretSyncMapping struct {
 	// CanDeleteDest allows deletion of destination when source is deleted.
 	// Set to false when destination may be mounted to pods.
 	CanDeleteDest bool
+	// ClearOutput returns the data to use when source is deleted and CanDeleteDest is false.
+	// If nil, Data is set to nil. Only used with DestKey (single-key destination).
+	ClearOutput func() []byte
 }
 
 // DefaultMappings returns the default secret sync mappings.
@@ -35,7 +38,8 @@ func DefaultMappings() []SecretSyncMapping {
 			DestNamespace:   "runtime-gateway",
 			DestName:        "external-grafana-altinn-studio-gateway-token",
 			DestKey:         "secrets.json",
-			CanDeleteDest:   false, // Relied upon to exist by gateway
+			CanDeleteDest:   false,
+			ClearOutput:     func() []byte { return []byte("{}") },
 			BuildOutput: func(ctx context.Context, k8sClient client.Client, data map[string][]byte) ([]byte, error) {
 				grafana := &grafanav1beta1.Grafana{}
 				// Grafana operator is used in tt02 and prod


### PR DESCRIPTION
## Description

Some destination secrets shouldn't be deleted, e.g. the one for gateway, as it is mounted as a volume

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New mapping options let you preserve destination secrets when a source is deleted and provide a configurable cleared output for preserved secrets.

* **Bug Fixes / Behaviour Changes**
  * Deletion is now conditional: destinations are deleted only when allowed; otherwise destination data is cleared (optionally using the configured clear output).

* **Tests**
  * Added coverage for the new deletion/clearing behaviours.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->