### PR TITLE
chore: operator config switch to test.maskinporten.no env for our at envs

### DIFF
--- a/src/Runtime/operator/config/at22/operator-config-patch.yaml
+++ b/src/Runtime/operator/config/at22/operator-config-patch.yaml
@@ -4,8 +4,8 @@ metadata:
   name: operator-config
 data:
   config.env: |
-    maskinporten_api.authority_url=https://maskinporten.dev
-    maskinporten_api.self_service_url=https://api.samarbeid.digdir.dev
+    maskinporten_api.authority_url=https://test.maskinporten.no
+    maskinporten_api.self_service_url=https://api.test.samarbeid.digdir.no
     maskinporten_api.scope=idporten:dcr.altinn
     org_registry.url=https://altinncdn.no/orgs/altinn-orgs.json
     maskinporten_controller.requeue_after=24h

--- a/src/Runtime/operator/config/at23/operator-config-patch.yaml
+++ b/src/Runtime/operator/config/at23/operator-config-patch.yaml
@@ -4,8 +4,8 @@ metadata:
   name: operator-config
 data:
   config.env: |
-    maskinporten_api.authority_url=https://maskinporten.dev
-    maskinporten_api.self_service_url=https://api.samarbeid.digdir.dev
+    maskinporten_api.authority_url=https://test.maskinporten.no
+    maskinporten_api.self_service_url=https://api.test.samarbeid.digdir.no
     maskinporten_api.scope=idporten:dcr.altinn
     org_registry.url=https://altinncdn.no/orgs/altinn-orgs.json
     maskinporten_controller.requeue_after=24h

--- a/src/Runtime/operator/config/at24/operator-config-patch.yaml
+++ b/src/Runtime/operator/config/at24/operator-config-patch.yaml
@@ -4,8 +4,8 @@ metadata:
   name: operator-config
 data:
   config.env: |
-    maskinporten_api.authority_url=https://maskinporten.dev
-    maskinporten_api.self_service_url=https://api.samarbeid.digdir.dev
+    maskinporten_api.authority_url=https://test.maskinporten.no
+    maskinporten_api.self_service_url=https://api.test.samarbeid.digdir.no
     maskinporten_api.scope=idporten:dcr.altinn
     org_registry.url=https://altinncdn.no/orgs/altinn-orgs.json
     maskinporten_controller.requeue_after=24h


### PR DESCRIPTION
## Description

Then we use Maskinporten test env for all but prod environment

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated Maskin Porten API integration endpoints across multiple environment configurations, redirecting authority and self-service URLs from development to test environment domains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->