### PR TITLE
fix: use `production` as tag for apps syncroot in prod

### DIFF
--- a/infra/runtime/syncroot/prod/kustomization.yaml
+++ b/infra/runtime/syncroot/prod/kustomization.yaml
@@ -13,6 +13,13 @@ patches:
         value: production
   - target:
       kind: Kustomization
+      name: syncroot-apps-kustomization
+    patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./production
+  - target:
+      kind: Kustomization
       name: grafana-manifests
     patch: |-
       - op: replace


### PR DESCRIPTION
## Description

The deploy pipeline pushes to prod using `production` as a tag. Since people have already done that, it is easier to switch just patch the ocirepo here

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration: repository reference now uses the "production" tag and the sync path has been switched to the production directory for deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->