### PR TITLE
fix: remove info message at top of main page in utforming

### DIFF
--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -1871,7 +1871,6 @@
   "ux_editor.groups.add": "Legg til ny gruppe",
   "ux_editor.image_component.settings": "Innstillinger for bilde",
   "ux_editor.info": "Informasjon",
-  "ux_editor.info.new_overview_page": "På forsiden til Utforming bruker du oppgaver til å utforme appen, noe som gir enklere oversikt over arbeidsflyten. Etter hvert kommer det også innstillinger for å utforme appen på tvers av alle oppgavene i en arbeidsflyt.",
   "ux_editor.input_popover_label": "Gi nytt navn til siden",
   "ux_editor.input_popover_save_button": "Lagre",
   "ux_editor.latitude_label": "Latitude",

--- a/src/Designer/frontend/packages/ux-editor/src/containers/FormDesignNavigation/FormDesignerNavigation.module.css
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/FormDesignNavigation/FormDesignerNavigation.module.css
@@ -9,13 +9,6 @@
   position: relative;
 }
 
-.alert {
-  background-color: var(--fds-semantic-surface-neutral-subtle);
-  width: 80%;
-  max-width: 1050px;
-  margin-left: var(--fds-spacing-5);
-}
-
 .panel {
   background-color: white;
   border-radius: var(--fds-border_radius-medium);

--- a/src/Designer/frontend/packages/ux-editor/src/containers/FormDesignNavigation/FormDesignerNavigation.tsx
+++ b/src/Designer/frontend/packages/ux-editor/src/containers/FormDesignNavigation/FormDesignerNavigation.tsx
@@ -4,7 +4,6 @@ import classes from './FormDesignerNavigation.module.css';
 import { useTranslation } from 'react-i18next';
 import { TaskCardBar } from '../../components/TaskNavigation/TaskCardBar';
 import { SettingsTabs } from '../../components/Settings/SettingsTabs';
-import { StudioAlert } from '@studio/components';
 import { LayoutPageOverviewFeedback } from '../../components/TaskNavigation/LayoutPageOverviewFeedback';
 
 export const FormDesignerNavigation = () => {
@@ -13,9 +12,6 @@ export const FormDesignerNavigation = () => {
   return (
     <div className={classes.wrapper}>
       <main className={classes.container}>
-        <StudioAlert data-size='md' className={classes.alert}>
-          {t('ux_editor.info.new_overview_page')}
-        </StudioAlert>
         <div className={classes.panel}>
           <div className={classes.content}>
             <TaskCardBar />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed the information at the top of the page.

Before:
<img width="2250" height="1052" alt="image" src="https://github.com/user-attachments/assets/10bba57b-f140-4903-bd7d-85cd4a671e32" />

After:
<img width="1731" height="1125" alt="image" src="https://github.com/user-attachments/assets/6039fce5-d4dc-498a-9b7b-c5ed9a7d9076" />




<!--- Describe your changes in detail -->

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed the new overview page alert notification from the form design interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->