### PR TITLE
fix: operator use digdir as orgnumber for ttd in non-localtest environments

### DIFF
--- a/src/Runtime/operator/internal/operatorcontext/operatorcontext.go
+++ b/src/Runtime/operator/internal/operatorcontext/operatorcontext.go
@@ -84,9 +84,16 @@ func Discover(ctx context.Context, environment string, orgRegistry *orgs.OrgRegi
 			if serviceOwnerOrgName == "" {
 				serviceOwnerOrgName = org.Name.En
 			}
-		} else if serviceOwnerId == "ttd" && environment != EnvironmentLocal {
-			// The fake org registry has the env number set, but the altinn-orgs.json in CDN does not have org nr for ttd (it's not real)
-			serviceOwnerOrgNo = "405003309" // NOTE: this matches the org nr in the registry testdata in localtest, keep in sync
+			if serviceOwnerId == "ttd" && environment != EnvironmentLocal {
+				// NOTE: we use digdir org number here. ttd is a bit chaotic:
+				// - ttd has no org number in altinn-orgs.json
+				// - ttd has no org number in Register service for tt02 and other non-prod environments
+				// - ttd has an org number in production (405003309)
+				// - ttd has an org number in localtest (405003309)
+				// - app backend interprets ttd as digdir (991825827). Apps for ttd typically includes authorization rules for digdir (in addition to [org])
+				// Since this is going to be used a lot for generating service owner tokens, we prefer to match the app backend behavior using digdir org number.
+				serviceOwnerOrgNo = "991825827"
+			}
 		} else {
 			return nil, fmt.Errorf("could not find org for service owner id %s", serviceOwnerId)
 		}


### PR DESCRIPTION
## Description

See comment for reasoning

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected organisation number assignment for a specific service configuration in non-local environments to ensure proper system alignment with backend operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->