### PR TITLE
fix: Correct error message for data model name validation

### DIFF
--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -130,7 +130,7 @@
   "app_data_modelling.landing_dialog_paragraph": "Velkommen til datamodellering! Her kan du laste opp en datamodell du har fra før, eller lage en ny modell du kan bruke i appen din.",
   "app_data_modelling.landing_dialog_upload": "Last opp datamodell",
   "app_data_modelling.upload_xsd": "Last opp",
-  "app_data_modelling.upload_xsd_invalid_name_error": "Filnavnet er ugyldig. Du kan bruke tall og store og små bokstaver fra det norske alfabetet, understrek og punktum. Navnet må alltid starte med en bokstav.",
+  "app_data_modelling.upload_xsd_invalid_name_error": "Filnavnet er ugyldig. Du kan bruke sifre, store og små bokstaver fra det norske alfabetet, understrek og punktum. Navnet må alltid starte med en bokstav.",
   "app_data_modelling.uploading_xsd": "Laster opp XSD...",
   "app_deployment.btn_deploy_new_version": "Publiser ny versjon",
   "app_deployment.choose_version": "Velg den versjonen du vil publisere.",


### PR DESCRIPTION
## Description
This pull request fixes an error message that says dashes are valid file names for data models, while they are not.

Updated message (in Norwegian):
<img width="459" height="196" alt="image" src="https://github.com/user-attachments/assets/7146afb3-fbe2-4bc1-b856-0472d84b1322" />

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- Automated test not necessary (this is text only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated XSD file upload validation messaging: file names must now start with a letter and may contain only letters, underscores and dots. Hyphens are no longer permitted in file names. The error text has been clarified to reflect the allowed characters and naming requirement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->