### PR TITLE
chore: make localtest compose file work for default docker driver

### DIFF
--- a/.github/actions/app-build-localtest/action.yaml
+++ b/.github/actions/app-build-localtest/action.yaml
@@ -28,7 +28,7 @@ runs:
         DOCKER_BUILDKIT: 1
         COMPOSE_DOCKER_CLI_BUILD: 1
         BUILDKIT_PROGRESS: plain
-        USE_REGISTRY_CACHE: true
+        COMPOSE_FILE: 'docker-compose.yml:docker-compose.ci.yml'
       run: |
         args=""
         if [[ "${{ inputs.docker-profile }}" != "" ]]; then

--- a/.github/actions/app-run-local-env/action.yaml
+++ b/.github/actions/app-run-local-env/action.yaml
@@ -61,7 +61,7 @@ runs:
       if: ${{ inputs.run-localtest == 'true' }}
       working-directory: src/Runtime/localtest
       env:
-        USE_REGISTRY_CACHE: true
+        COMPOSE_FILE: 'docker-compose.yml:docker-compose.ci.yml'
       run: |
         args="${{ steps.set-profile.outputs.profile-args }}"
 
@@ -88,7 +88,7 @@ runs:
       env:
         TEST_DOMAIN: local.altinn.cloud
         ALTINN3LOCAL_PORT: 80
-        USE_REGISTRY_CACHE: true
+        COMPOSE_FILE: 'docker-compose.yml:docker-compose.ci.yml'
 
     - name: Start frontend server
       if: ${{ inputs.run-frontend == 'true' }}

--- a/src/Runtime/localtest/docker-compose.ci.yml
+++ b/src/Runtime/localtest/docker-compose.ci.yml
@@ -1,0 +1,28 @@
+services:
+  localtest_loadbalancer:
+    build:
+      cache_from:
+        - type=registry,ref=ghcr.io/altinn/altinn-studio/localtest-loadbalancer-cache:latest
+      cache_to:
+        - type=registry,ref=ghcr.io/altinn/altinn-studio/localtest-loadbalancer-cache:latest,mode=max
+
+  altinn_pdf3:
+    build:
+      cache_from:
+        - type=registry,ref=ghcr.io/altinn/altinn-studio/localtest-pdf3-cache:latest
+      cache_to:
+        - type=registry,ref=ghcr.io/altinn/altinn-studio/localtest-pdf3-cache:latest,mode=max
+
+  altinn_localtest:
+    build:
+      cache_from:
+        - type=registry,ref=ghcr.io/altinn/altinn-studio/localtest-main-cache:latest
+      cache_to:
+        - type=registry,ref=ghcr.io/altinn/altinn-studio/localtest-main-cache:latest,mode=max
+
+  altinn_test_apps:
+    build:
+      cache_from:
+        - type=registry,ref=ghcr.io/altinn/altinn-studio/localtest-test-apps-cache:latest
+      cache_to:
+        - type=registry,ref=ghcr.io/altinn/altinn-studio/localtest-test-apps-cache:latest,mode=max

--- a/src/Runtime/localtest/docker-compose.yml
+++ b/src/Runtime/localtest/docker-compose.yml
@@ -10,10 +10,6 @@ services:
       context: ./loadbalancer
       args:
         NGINX_VERSION: 1.25.3
-      cache_from:
-        - ${USE_REGISTRY_CACHE:-type=inline}${USE_REGISTRY_CACHE:+type:registry,ref=ghcr.io/altinn/altinn-studio/localtest-loadbalancer-cache:latest}
-      cache_to:
-        - ${USE_REGISTRY_CACHE:-type=inline}${USE_REGISTRY_CACHE:+type:registry,ref=ghcr.io/altinn/altinn-studio/localtest-loadbalancer-cache:latest}
     restart: always
     networks:
       - altinntestlocal_network
@@ -40,10 +36,6 @@ services:
     build:
       context: ../pdf3
       dockerfile: Dockerfile.worker
-      cache_from:
-        - ${USE_REGISTRY_CACHE:-type=inline}${USE_REGISTRY_CACHE:+type:registry,ref=ghcr.io/altinn/altinn-studio/localtest-pdf3-cache:latest}
-      cache_to:
-        - ${USE_REGISTRY_CACHE:-type=inline}${USE_REGISTRY_CACHE:+type:registry,ref=ghcr.io/altinn/altinn-studio/localtest-pdf3-cache:latest}
     restart: always
     networks:
       - altinntestlocal_network
@@ -67,10 +59,6 @@ services:
       - '5101:5101'
     build:
       context: .
-      cache_from:
-        - ${USE_REGISTRY_CACHE:-type=inline}${USE_REGISTRY_CACHE:+type:registry,ref=ghcr.io/altinn/altinn-studio/localtest-main-cache:latest}
-      cache_to:
-        - ${USE_REGISTRY_CACHE:-type=inline}${USE_REGISTRY_CACHE:+type:registry,ref=ghcr.io/altinn/altinn-studio/localtest-main-cache:latest}
     environment:
       - DOTNET_ENVIRONMENT=Docker
       - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-80}
@@ -174,10 +162,6 @@ services:
     build:
       context: ../../..
       dockerfile: src/test/apps/Dockerfile
-      cache_from:
-        - ${USE_REGISTRY_CACHE:-type=inline}${USE_REGISTRY_CACHE:+type:registry,ref=ghcr.io/altinn/altinn-studio/localtest-test-apps-cache:latest}
-      cache_to:
-        - ${USE_REGISTRY_CACHE:-type=inline}${USE_REGISTRY_CACHE:+type:registry,ref=ghcr.io/altinn/altinn-studio/localtest-test-apps-cache:latest}
     restart: always
     networks:
       - altinntestlocal_network


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Only use ghcr.io cache registry in ci using multiple compose files and merging them using an env var in the relevant github actions.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Local test environment now loads multiple Docker Compose files for more flexible configuration.
  * Added CI-local compose configuration to enable container cache sharing for local testing.
  * Optimised caching strategy for local test services to improve build performance.
  * Standardised compose file formatting for consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->