### PR TITLE
fix: Remove period from valid characters in data model name validation message

### DIFF
--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -130,7 +130,7 @@
   "app_data_modelling.landing_dialog_paragraph": "Velkommen til datamodellering! Her kan du laste opp en datamodell du har fra før, eller lage en ny modell du kan bruke i appen din.",
   "app_data_modelling.landing_dialog_upload": "Last opp datamodell",
   "app_data_modelling.upload_xsd": "Last opp",
-  "app_data_modelling.upload_xsd_invalid_name_error": "Filnavnet er ugyldig. Du kan bruke sifre, store og små bokstaver fra det norske alfabetet, understrek og punktum. Navnet må alltid starte med en bokstav.",
+  "app_data_modelling.upload_xsd_invalid_name_error": "Filnavnet er ugyldig. Du kan bruke sifre, store og små bokstaver fra A til Z og understrek. Navnet må alltid starte med en bokstav.",
   "app_data_modelling.uploading_xsd": "Laster opp XSD...",
   "app_deployment.btn_deploy_new_version": "Publiser ny versjon",
   "app_deployment.choose_version": "Velg den versjonen du vil publisere.",


### PR DESCRIPTION
## Description
While resolving #16345, it was discovered that [period should also be an invalid character in data model names](https://github.com/Altinn/altinn-studio/pull/17265#pullrequestreview-3583378477). I have verified that the validation already takes care of that, so all we need to do is to correct the message.

This is the validation regex: `^[a-zA-Z][a-zA-Z0-9_]*$`

Here is the updated message (in Norwegian). Currently it also says that all Norwegian letters are valid, but that's also incorrect, as the characters Æ. Ø and Å are not covered by the regex. I corrected that to "letters from A to Z".
<img width="690" height="298" alt="image" src="https://github.com/user-attachments/assets/46c9a4f5-2c91-49ae-9072-b99a4533a73d" />

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- Automated test not necessary, as the content of texts is not tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated validation messaging for file naming rules to specify allowed characters as English letters (A-Z), digits and underscore; files must start with a letter.

<sub> Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->