### PR TITLE
fix: pdf3 deploy relax security scan requirements

### DIFF
--- a/.github/workflows/deploy-runtime-pdf3.yaml
+++ b/.github/workflows/deploy-runtime-pdf3.yaml
@@ -121,7 +121,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
+          severity: 'CRITICAL'
 
       - name: scan image - worker
         if: success() || failure()
@@ -132,7 +132,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
+          severity: 'CRITICAL'
 
       - name: push images
         run: |


### PR DESCRIPTION
## Description

This is kind of kicking the can down the road, but I personally don't think this is a big deal. I don't see what the security risk is for these services

<img width="976" height="355" alt="image" src="https://github.com/user-attachments/assets/ebd3b2ee-a504-4b00-a04c-f4dddbed8249" />


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted security scanning threshold for deployment processes to flag only critical-level issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->