### PR TITLE
fix: notes merge conflict

### DIFF
--- a/src/Designer/backend/src/Designer/Controllers/RepositoryController.cs
+++ b/src/Designer/backend/src/Designer/Controllers/RepositoryController.cs
@@ -325,6 +325,7 @@ namespace Altinn.Studio.Designer.Controllers
         [Route("repo/{org}/{repository:regex(^(?!datamodels$)[[a-z]][[a-z0-9-]]{{1,28}}[[a-z0-9]]$)}/commit")]
         public async Task<ActionResult> Commit(string org, string repository, [FromBody] CommitInfo commitInfo)
         {
+            // TODO: This method is never used, should it be removed?
             await Task.CompletedTask;
             try
             {
@@ -346,6 +347,7 @@ namespace Altinn.Studio.Designer.Controllers
         [Route("repo/{org}/{repository:regex(^(?!datamodels$)[[a-z]][[a-z0-9-]]{{1,28}}[[a-z0-9]]$)}/push")]
         public async Task<ActionResult> Push(string org, string repository)
         {
+            // TODO: This method is never used, should it be removed?
             bool pushSuccess = await _sourceControl.Push(org, repository);
             return pushSuccess ? Ok() : StatusCode(StatusCodes.Status500InternalServerError);
         }

--- a/src/Designer/backend/src/Designer/Middleware/UserRequestSynchronization/RepoUserWide/RequestSyncEvaluators/EndpointNameSyncEligibilityEvaluator.cs
+++ b/src/Designer/backend/src/Designer/Middleware/UserRequestSynchronization/RepoUserWide/RequestSyncEvaluators/EndpointNameSyncEligibilityEvaluator.cs
@@ -25,8 +25,8 @@ public class EndpointNameSyncEligibilityEvaluator : IRepoUserSyncEligibilityEval
                 nameof(RepositoryController.Pull),
                 nameof(RepositoryController.ResetLocalRepository),
                 nameof(RepositoryController.CommitAndPushRepo),
-                nameof(RepositoryController.Commit),
-                nameof(RepositoryController.Push)
+                nameof(RepositoryController.Commit), // TODO: This method is never used, should it be removed?
+                nameof(RepositoryController.Push) // TODO: This method is never used, should it be removed?
             )
         },
         {

--- a/src/Designer/backend/src/Designer/Services/Implementation/SourceControlSI.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/SourceControlSI.cs
@@ -224,11 +224,13 @@ namespace Altinn.Studio.Designer.Services.Implementation
         /// <param name="commitInfo">Information about the commit</param>
         public void Commit(CommitInfo commitInfo)
         {
+            // TODO: This method is never used, should it be removed?
             CommitAndAddStudioNote(commitInfo.Org, commitInfo.Repository, commitInfo.Message);
         }
 
         private void CommitAndAddStudioNote(string org, string repository, string message)
         {
+            // TODO: This method is never used, should it be removed?
             string localServiceRepoFolder = _settings.GetServicePath(org, repository, AuthenticationHelper.GetDeveloperUserName(_httpContextAccessor.HttpContext));
             using LibGit2Sharp.Repository repo = new LibGit2Sharp.Repository(localServiceRepoFolder);
             string remoteUrl = FindRemoteRepoLocation(org, repository);


### PR DESCRIPTION
## Description
Fetch git notes on pull and before push operations to Gitea. This has resulted in users getting merge conflicts when not having any real conflicts in code changes. The commits have been pushed successfully, but notes have been missing because of it.

## Verification
- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
