### PR TITLE
fix: designer app deploy: check whole app name instead of prefix

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/GitOps/GitRepoGitOpsConfigurationManager.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/GitOps/GitRepoGitOpsConfigurationManager.cs
@@ -139,10 +139,8 @@ public class GitRepoGitOpsConfigurationManager(
         string repoName,
         AltinnEnvironment environment)
     {
-        string envKusomizationContent = await repository.ReadTextByRelativePathAsync(ManifestsPathHelper.EnvironmentManifests.KustomizationPath(environment.Name));
-
-        string expectedResourcePath = ManifestsPathHelper.EnvironmentManifests.KustomizationAppResource(repoName);
-        return envKusomizationContent.Contains(expectedResourcePath, StringComparison.InvariantCulture);
+        var existingApps = await GetExistingAppsFromEnvironmentKustomization(repository, environment);
+        return existingApps.Contains(AltinnRepoName.FromName(repoName));
     }
 
     public async Task AddAppToGitOpsConfigurationAsync(AltinnRepoEditingContext context, AltinnEnvironment environment)

--- a/src/Designer/backend/tests/Designer.Tests/Services/GitOps/GitRepoGitOpsConfigurationManagerTests/AppExistsInGitOpsConfigurationTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/GitOps/GitRepoGitOpsConfigurationManagerTests/AppExistsInGitOpsConfigurationTests.cs
@@ -11,6 +11,7 @@ public class AppExistsInGitOpsConfigurationTests : GitRepoGitOpsConfigurationMan
     [Theory]
     [InlineData("test-app", "tt02", false, "dummy-app1", "dummy-app2")]
     [InlineData("test-app", "tt02", true, "test-app", "dummy-app2")]
+    [InlineData("test", "tt02", false, "test-app", "test-app-2")]
     public async Task WhenAppDirectory_DoesExists_ShouldReturn_BasedOnEnvironmentManifest(string app, string environment, bool expectedShouldExist, params string[] appsInEnvironment)
     {
         await Given.That


### PR DESCRIPTION
## Description

Reuses the existing `GetExistingAppsFromEnvironmentKustomization` to check if an app is deployed instead. Testcase added failed before changing impl

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved the mechanism for identifying existing applications within environment configurations using a more efficient approach.

* **Tests**
  * Extended test coverage for application existence validation to include additional scenarios for Git operations configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->