### PR TITLE
refactor: Add return types to functions in content library

### DIFF
--- a/src/Designer/frontend/libs/studio-content-library/.eslintrc.js
+++ b/src/Designer/frontend/libs/studio-content-library/.eslintrc.js
@@ -14,6 +14,8 @@ module.exports = {
             ],
           },
         ],
+        '@typescript-eslint/explicit-function-return-type': 'error',
+        '@typescript-eslint/no-explicit-any': 'error',
       },
     },
   ],

--- a/src/Designer/frontend/libs/studio-content-library/package.json
+++ b/src/Designer/frontend/libs/studio-content-library/package.json
@@ -19,7 +19,7 @@
     "typescript": "5.9.3"
   },
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts?(x)\"",
     "lint:fix": "yarn run lint --fix",
     "test": "jest",
     "typecheck": "tsc --noEmit"

--- a/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/LibraryBody.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/LibraryBody.tsx
@@ -10,7 +10,10 @@ type LibraryBodyProps<T extends PageName> = {
   page: Page<T>;
 };
 
-export function LibraryBody<T extends PageName>({ config, page }: LibraryBodyProps<T>) {
+export function LibraryBody<T extends PageName>({
+  config,
+  page,
+}: LibraryBodyProps<T>): React.ReactElement {
   return (
     <div className={classes.libraryContent}>
       <PagesRouter config={config} />
@@ -24,6 +27,6 @@ type PageViewProps<T extends PageName> = {
   page: Page<T>;
 };
 
-function PageView<T extends PageName>({ config, page }: PageViewProps<T>) {
+function PageView<T extends PageName>({ config, page }: PageViewProps<T>): React.ReactElement {
   return <div className={classes.component}>{page.renderPage(config)}</div>;
 }

--- a/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/PagesRouter/PagesRouter.test.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/PagesRouter/PagesRouter.test.tsx
@@ -41,7 +41,7 @@ const renderPagesRouter = (
     heading: 'Test library',
     pages: mockPagesConfig,
   },
-) => {
+): void => {
   renderWithProviders(
     <RouterContext.Provider
       value={{ currentPage: PageName.CodeListsWithTextResources, navigate: navigateMock }}

--- a/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/PagesRouter/PagesRouter.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/ContentLibrary/LibraryBody/PagesRouter/PagesRouter.tsx
@@ -13,7 +13,7 @@ type PagesRouterProps = {
 export function PagesRouter({ config }: PagesRouterProps): React.ReactElement {
   const { navigate, currentPage } = useRouterContext();
 
-  const handleNavigation = (pageToNavigateTo: PageName) => {
+  const handleNavigation = (pageToNavigateTo: PageName): void => {
     navigate(pageToNavigateTo);
   };
 

--- a/src/Designer/frontend/libs/studio-content-library/src/components/InfoBox/InfoBox.test.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/components/InfoBox/InfoBox.test.tsx
@@ -31,6 +31,6 @@ describe('InfoBox', () => {
   });
 });
 
-const renderInfoBox = (pageName: PageName = pageNameMock) => {
+const renderInfoBox = (pageName: PageName = pageNameMock): void => {
   render(<InfoBox pageName={pageName} />);
 };

--- a/src/Designer/frontend/libs/studio-content-library/src/contexts/RouterContext.test.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/contexts/RouterContext.test.tsx
@@ -7,7 +7,7 @@ import { PageName } from '../types/PageName';
 
 jest.mock('../hooks/useNavigation');
 
-const MockComponent = () => {
+const MockComponent = (): React.ReactElement => {
   const { currentPage, navigate } = useRouterContext();
 
   return (
@@ -58,7 +58,7 @@ describe('RouterContext', () => {
 
   it('should throw an error when useRouterContext is used outside of a RouterContextProvider', () => {
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const TestComponent = () => {
+    const TestComponent = (): React.ReactElement => {
       useRouterContext();
       return <div>Test</div>;
     };

--- a/src/Designer/frontend/libs/studio-content-library/src/contexts/RouterContext.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/contexts/RouterContext.tsx
@@ -13,7 +13,9 @@ export type RouterContextProviderProps = {
   children: React.ReactNode;
 };
 
-export const RouterContextProvider = ({ children }: RouterContextProviderProps) => {
+export const RouterContextProvider = ({
+  children,
+}: RouterContextProviderProps): React.ReactElement => {
   const { navigate, currentPage } = useNavigation();
 
   return (

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/AddCodeListDropdown/AddCodeListDropdown.test.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/AddCodeListDropdown/AddCodeListDropdown.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
+import type { RenderResult } from '@testing-library/react';
 import { renderWithProviders } from '../../../../../../test-utils/renderWithProviders';
 import type { AddCodeListDropdownProps } from './AddCodeListDropdown';
 import { AddCodeListDropdown } from './AddCodeListDropdown';
@@ -110,7 +111,10 @@ describe('AddCodeListDropdown', () => {
   });
 });
 
-const uploadFileWithFileName = async (user: UserEvent, fileNameWithExtension: string) => {
+const uploadFileWithFileName = async (
+  user: UserEvent,
+  fileNameWithExtension: string,
+): Promise<void> => {
   const fileUploaderButton = screen.getByLabelText(
     textMock('app_content_library.code_lists_with_text_resources.upload_code_list'),
   );
@@ -127,6 +131,6 @@ const defaultCodeListActionBarProps: AddCodeListDropdownProps = {
   codeListNames: [codeListName1, codeListName2],
 };
 
-const renderAddCodeListDropdown = (props: Partial<AddCodeListDropdownProps> = {}) => {
+const renderAddCodeListDropdown = (props: Partial<AddCodeListDropdownProps> = {}): RenderResult => {
   return renderWithProviders(<AddCodeListDropdown {...defaultCodeListActionBarProps} {...props} />);
 };

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/AddCodeListDropdown/AddCodeListDropdown.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/AddCodeListDropdown/AddCodeListDropdown.tsx
@@ -43,22 +43,23 @@ export function AddCodeListDropdown({
 
   const getInvalidUploadFileNameErrorMessage = useUploadCodeListNameErrorMessage();
 
-  const onSubmit = (file: File) => {
+  const onSubmit = (file: File): void => {
     const fileNameError = FileNameUtils.findFileNameError(
       FileNameUtils.removeExtension(file.name),
       codeListNames,
     );
     if (fileNameError) {
-      return toast.error(getInvalidUploadFileNameErrorMessage(fileNameError));
+      toast.error(getInvalidUploadFileNameErrorMessage(fileNameError));
+    } else {
+      onUploadCodeList(file);
     }
-    onUploadCodeList(file);
   };
 
-  const handleOpenAddCodeListDialog = () => {
+  const handleOpenAddCodeListDialog = (): void => {
     addCodeListRef.current?.showModal();
   };
 
-  const handleOpenImportCodeListDialog = () => {
+  const handleOpenImportCodeListDialog = (): void => {
     importCodeListRef.current?.showModal();
   };
 

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/AddCodeListDropdown/CreateNewCodeListDialog/CreateNewCodeListDialog.test.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/AddCodeListDropdown/CreateNewCodeListDialog/CreateNewCodeListDialog.test.tsx
@@ -121,21 +121,21 @@ describe('CreateNewCodeListDialog', () => {
 const inputCodeListTitle = async (
   user: UserEvent,
   codeListTitle: string = newCodeListTitleMock,
-) => {
+): Promise<void> => {
   const codeListNameInput = screen.getByRole('textbox', {
     name: textMock('app_content_library.code_lists_with_text_resources.create_new_code_list_name'),
   });
   await user.type(codeListNameInput, codeListTitle);
 };
 
-const addCodeListItem = async (user: UserEvent) => {
+const addCodeListItem = async (user: UserEvent): Promise<void> => {
   const addCodeListItemButton = screen.getByRole('button', {
     name: textMock('code_list_editor.add_option'),
   });
   await user.click(addCodeListItemButton);
 };
 
-const addDuplicatedCodeListValues = async (user: UserEvent) => {
+const addDuplicatedCodeListValues = async (user: UserEvent): Promise<void> => {
   await addCodeListItem(user);
   await addCodeListItem(user);
 };
@@ -178,7 +178,7 @@ const renderCreateNewCodeListDialog = (
   return render(<Component />);
 };
 
-const useShowModal = (ref: React.RefObject<HTMLDialogElement>) => {
+const useShowModal = (ref: React.RefObject<HTMLDialogElement>): void => {
   useEffect(() => {
     ref.current?.showModal();
   }, [ref]);

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/AddCodeListDropdown/CreateNewCodeListDialog/CreateNewCodeListDialog.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/AddCodeListDropdown/CreateNewCodeListDialog/CreateNewCodeListDialog.tsx
@@ -36,7 +36,7 @@ function CreateNewCodeListDialog(
   const { t } = useTranslation();
   const newCodeList: CodeListWithTextResources = [];
 
-  const handleCloseDialog = () => {
+  const handleCloseDialog = (): void => {
     ref.current?.close();
   };
 
@@ -89,7 +89,7 @@ function CreateNewCodeList({
   onUpdateTextResource,
   onCloseModal,
   textResources,
-}: CreateNewCodeListProps) {
+}: CreateNewCodeListProps): React.ReactElement {
   const { t } = useTranslation();
   const editorTexts: CodeListEditorTexts = useCodeListEditorTexts();
   const getInvalidInputFileNameErrorMessage = useInputCodeListNameErrorMessage();
@@ -102,13 +102,13 @@ function CreateNewCodeList({
   const [currentCodeListWithMetadata, setCurrentCodeListWithMetadata] =
     useState<CodeListWithMetadata>(initialCodeListWithMetadata);
 
-  const handleSaveCodeList = () => {
+  const handleSaveCodeList = (): void => {
     onCreateCodeList(currentCodeListWithMetadata);
     onCloseModal();
     setCurrentCodeListWithMetadata(initialCodeListWithMetadata);
   };
 
-  const handleCodeListTitleChange = (updatedTitle: string) => {
+  const handleCodeListTitleChange = (updatedTitle: string): void => {
     const fileNameError = FileNameUtils.findFileNameError(updatedTitle, codeListNames);
     const errorMessage = getInvalidInputFileNameErrorMessage(fileNameError);
     setCodeListTitleError(errorMessage ?? '');
@@ -121,7 +121,7 @@ function CreateNewCodeList({
     }
   };
 
-  const handleUpdateCodeList = (updatedCodeList: CodeListWithTextResources) => {
+  const handleUpdateCodeList = (updatedCodeList: CodeListWithTextResources): void => {
     setIsCodeListValid(true);
     const updatedCodeListWithMetadata = updateCodeListInCodeListWithMetadata(
       currentCodeListWithMetadata,
@@ -130,7 +130,7 @@ function CreateNewCodeList({
     setCurrentCodeListWithMetadata(updatedCodeListWithMetadata);
   };
 
-  const handleInvalidCodeList = () => {
+  const handleInvalidCodeList = (): void => {
     setIsCodeListValid(false);
   };
 

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/AddCodeListDropdown/ImportFromOrgLibraryDialog/ImportFromOrgLibraryDialog.test.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/AddCodeListDropdown/ImportFromOrgLibraryDialog/ImportFromOrgLibraryDialog.test.tsx
@@ -103,7 +103,7 @@ const renderImportFromOrgLibraryDialog = (
   return render(<Component />);
 };
 
-const useShowModal = (ref: React.RefObject<HTMLDialogElement>) => {
+const useShowModal = (ref: React.RefObject<HTMLDialogElement>): void => {
   useEffect(() => {
     ref.current?.showModal();
   }, [ref]);

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/AddCodeListDropdown/ImportFromOrgLibraryDialog/ImportFromOrgLibraryDialog.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/AddCodeListDropdown/ImportFromOrgLibraryDialog/ImportFromOrgLibraryDialog.tsx
@@ -16,11 +16,11 @@ function ImportFromOrgLibraryDialog(
 ): ReactElement {
   const { t } = useTranslation();
 
-  const handleCloseDialog = () => {
+  const handleCloseDialog = (): void => {
     ref.current?.close();
   };
 
-  const handleImportCodeListFromOrg = (codeListId: string) => {
+  const handleImportCodeListFromOrg = (codeListId: string): void => {
     onImportCodeListFromOrg(codeListId);
     handleCloseDialog();
   };
@@ -60,12 +60,12 @@ function ImportCodeList({
 
   const [selectedCodeListId, setSelectedCodeListId] = useState<string>('');
 
-  const handleSelectCodeListId = (event: ChangeEvent<HTMLSelectElement>) => {
+  const handleSelectCodeListId = (event: ChangeEvent<HTMLSelectElement>): void => {
     const codeListId: string = event.target.value;
     setSelectedCodeListId(codeListId);
   };
 
-  const handleImportCodeList = () => {
+  const handleImportCodeList = (): void => {
     setSelectedCodeListId('');
     onImportCodeListFromOrg(selectedCodeListId);
   };

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/CodeListsActionsBar.test.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/CodeListsActionsBar.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
+import type { RenderResult } from '@testing-library/react';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import type { CodeListsActionsBarProps } from './CodeListsActionsBar';
 import { CodeListsActionsBar } from './CodeListsActionsBar';
@@ -56,6 +57,6 @@ const defaultCodeListActionBarProps: CodeListsActionsBarProps = {
   onSetSearchString: onSetSearchStringMock,
 };
 
-const renderCodeListsActionsBar = () => {
+const renderCodeListsActionsBar = (): RenderResult => {
   return renderWithProviders(<CodeListsActionsBar {...defaultCodeListActionBarProps} />);
 };

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/CodeListsActionsBar.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsActionsBar/CodeListsActionsBar.tsx
@@ -30,10 +30,10 @@ export function CodeListsActionsBar({
   textResources,
   externalResources,
   onImportCodeListFromOrg,
-}: CodeListsActionsBarProps) {
+}: CodeListsActionsBarProps): React.ReactElement {
   const { t } = useTranslation();
 
-  const handleChangeSearch = (event: ChangeEvent<HTMLInputElement>) =>
+  const handleChangeSearch = (event: ChangeEvent<HTMLInputElement>): void =>
     onSetSearchString(event.target.value);
 
   return (

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsCounterMessage/CodeListsCounterMessage.test.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsCounterMessage/CodeListsCounterMessage.test.tsx
@@ -29,6 +29,6 @@ describe('CodeListsCounterMessage', () => {
   });
 });
 
-const renderCodeListsCounterMessage = (codeListsCount: number) => {
+const renderCodeListsCounterMessage = (codeListsCount: number): void => {
   render(<CodeListsCounterMessage codeListsCount={codeListsCount} />);
 };

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsWithTextResources/CodeListsWithTextResources.test.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsWithTextResources/CodeListsWithTextResources.test.tsx
@@ -299,7 +299,11 @@ describe('CodeListsWithTextResources', () => {
   });
 });
 
-const changeCodeListId = async (user: UserEvent, oldCodeListId: string, newCodeListId: string) => {
+const changeCodeListId = async (
+  user: UserEvent,
+  oldCodeListId: string,
+  newCodeListId: string,
+): Promise<void> => {
   const codeListIdToggleTextfield = screen.getByTitle(
     textMock('app_content_library.code_lists_with_text_resources.code_list_view_id_title', {
       codeListName: oldCodeListId,
@@ -362,7 +366,7 @@ describe('updateCodeListWithMetadata', () => {
   });
 });
 
-const getButton = (name: string, expanded?: boolean) =>
+const getButton = (name: string, expanded?: boolean): HTMLElement =>
   screen.getByRole('button', { name, expanded });
 
-const queryButton = (name: string) => screen.queryByRole('button', { name });
+const queryButton = (name: string): HTMLElement | null => screen.queryByRole('button', { name });

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsWithTextResources/EditCodeList/CodeListUsages/CodeListUsages.test.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsWithTextResources/EditCodeList/CodeListUsages/CodeListUsages.test.tsx
@@ -101,7 +101,7 @@ const defaultCodeListUsagesProps: CodeListUsagesProps = {
   codeListSources: [{ taskType, taskId, layoutName, componentIds }],
 };
 
-const renderCodeListUsages = (props: Partial<CodeListUsagesProps> = {}) => {
+const renderCodeListUsages = (props: Partial<CodeListUsagesProps> = {}): void => {
   render(<CodeListUsages {...defaultCodeListUsagesProps} {...props} />);
 };
 

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsWithTextResources/EditCodeList/EditCodeList.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsWithTextResources/EditCodeList/EditCodeList.tsx
@@ -111,11 +111,11 @@ function EditCodeListTitle({
   const { t } = useTranslation();
   const getInvalidInputFileNameErrorMessage = useInputCodeListNameErrorMessage();
 
-  const handleUpdateCodeListId = (newCodeListId: string) => {
+  const handleUpdateCodeListId = (newCodeListId: string): void => {
     if (newCodeListId !== codeListTitle) onUpdateCodeListId(codeListTitle, newCodeListId);
   };
 
-  const handleValidateCodeListId = (newCodeListId: string) => {
+  const handleValidateCodeListId = (newCodeListId: string): string | undefined => {
     const invalidCodeListNames = ArrayUtils.removeItemByValue(codeListNames, codeListTitle);
     const fileNameError = FileNameUtils.findFileNameError(newCodeListId, invalidCodeListNames);
     return getInvalidInputFileNameErrorMessage(fileNameError);

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsWithTextResourcesPage.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/CodeListsWithTextResources/CodeListsWithTextResourcesPage/CodeListsWithTextResourcesPage.tsx
@@ -87,12 +87,12 @@ export function CodeListsWithTextResourcesPage({
     'title',
   );
 
-  const handleUploadCodeList = (uploadedCodeList: File) => {
+  const handleUploadCodeList = (uploadedCodeList: File): void => {
     setCodeListInEditMode(FileNameUtils.removeExtension(uploadedCodeList.name));
     onUploadCodeList(uploadedCodeList);
   };
 
-  const handleUpdateCodeListId = (codeListId: string, newCodeListId: string) => {
+  const handleUpdateCodeListId = (codeListId: string, newCodeListId: string): void => {
     setCodeListInEditMode(newCodeListId);
     onUpdateCodeListId(codeListId, newCodeListId);
   };

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/Images/ImagesPage/ImagesPage.test.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/Images/ImagesPage/ImagesPage.test.tsx
@@ -53,6 +53,6 @@ const defaultImagesProps: ImagesPageProps = {
   onUpdateImage: onUpdateImageMock,
 };
 
-const renderImages = (props: Partial<ImagesPageProps> = {}) => {
+const renderImages = (props: Partial<ImagesPageProps> = {}): void => {
   render(<ImagesPage {...defaultImagesProps} {...props} />);
 };

--- a/src/Designer/frontend/libs/studio-content-library/src/pages/Landing/LandingPage/LandingPage.test.tsx
+++ b/src/Designer/frontend/libs/studio-content-library/src/pages/Landing/LandingPage/LandingPage.test.tsx
@@ -21,6 +21,6 @@ describe('LandingPage', () => {
   });
 });
 
-const renderLandingPage = () => {
+const renderLandingPage = (): void => {
   render(<LandingPage />);
 };


### PR DESCRIPTION
## Description
This pull request adds return types to all functions that are missing return types in the `@studio/content-library` package. It also adds the `@typescript-eslint/explicit-function-return-type` rule to ensure that all functions added in the future have return types.

I have also added the `@typescript-eslint/no-explicit-any` rule. There are no violations of this rule in the content library code, but the rule will ensure that we keep it this way.

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- Automated test not relevant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Uploads for code lists now stop when filename validation errors exist, preventing unintended submissions.

* **Chores**
  * Strengthened TypeScript linting and expanded linting to include additional file types.
  * Improved codebase type annotations and signatures for more consistent type safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->