### PR TITLE
fix: pathing for designer scan workflow.

### DIFF
--- a/.github/workflows/designer-scan.yml
+++ b/.github/workflows/designer-scan.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Build the Docker image
-      run: docker build ./src/Designer/ --tag altinn-designer:${{github.sha}}
+      run: docker build --file ./src/Designer/Dockerfile --tag altinn-designer:${{github.sha}} .
 
     - uses: Azure/container-scan@f9af925b897d8af5f7e0026b8bca9346261abc93 # v0
       env:


### PR DESCRIPTION
## Description
Update docker build command for the workflow `designer-scan.yml`, the workflow cannot find the docker file since it has been moved when we moved to monorepo.

workflow run: https://github.com/Altinn/altinn-studio/actions/runs/20717855413/job/59473424630

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required) 
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container image build configuration to explicitly specify the build file and preserve the repository root as the build context, improving reliability and consistency of image builds and the deployment pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->