### PR TITLE
chore: pdf3 - faster shutdown in localtest

### DIFF
--- a/src/Runtime/pdf3/cmd/proxy/main.go
+++ b/src/Runtime/pdf3/cmd/proxy/main.go
@@ -16,6 +16,7 @@ import (
 	"unicode/utf8"
 
 	"altinn.studio/pdf3/internal/assert"
+	"altinn.studio/pdf3/internal/config"
 	ihttp "altinn.studio/pdf3/internal/http"
 	"altinn.studio/pdf3/internal/log"
 	iruntime "altinn.studio/pdf3/internal/runtime"
@@ -36,10 +37,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	cfg := config.ReadConfig()
+	hostParams := config.ResolveHostParametersForEnvironment(cfg.Environment)
+
 	host := iruntime.NewHost(
-		5*time.Second,
-		45*time.Second,
-		3*time.Second,
+		hostParams.ReadinessDrainDelay,
+		hostParams.ShutdownPeriod,
+		hostParams.ShutdownHardPeriod,
 	)
 	defer host.Stop()
 

--- a/src/Runtime/pdf3/cmd/worker/main.go
+++ b/src/Runtime/pdf3/cmd/worker/main.go
@@ -40,10 +40,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	cfg := config.ReadConfig()
+	hostParams := config.ResolveHostParametersForEnvironment(cfg.Environment)
+
 	host := iruntime.NewHost(
-		5*time.Second,
-		45*time.Second,
-		3*time.Second,
+		hostParams.ReadinessDrainDelay,
+		hostParams.ShutdownPeriod,
+		hostParams.ShutdownHardPeriod,
 	)
 	defer host.Stop()
 
@@ -102,7 +105,6 @@ func main() {
 		}
 	})
 
-	cfg := config.ReadConfig()
 	// The localtest harness will run on all dev machines
 	// We can avoid some overhead by just running the single container
 	if cfg.Environment == "localtest" {

--- a/src/Runtime/pdf3/internal/config/config.go
+++ b/src/Runtime/pdf3/internal/config/config.go
@@ -61,3 +61,29 @@ func ReadConfig() *Config {
 		BrowserRestartInterval: browserRestartInterval,
 	}
 }
+
+// HostParameters contains timeout values for runtime.NewHost
+type HostParameters struct {
+	ReadinessDrainDelay time.Duration
+	ShutdownPeriod      time.Duration
+	ShutdownHardPeriod  time.Duration
+}
+
+// ResolveHostParametersForEnvironment returns appropriate host parameters based on environment.
+// Localtest uses zero timeouts for fast restarts, production uses full graceful shutdown periods.
+func ResolveHostParametersForEnvironment(environment string) HostParameters {
+	if environment == "localtest" {
+		// Minimal delays for local development - fast restarts
+		return HostParameters{
+			ReadinessDrainDelay: 0,
+			ShutdownPeriod:      0,
+			ShutdownHardPeriod:  0,
+		}
+	}
+	// Production timeouts - aligned with k8s terminationGracePeriodSeconds
+	return HostParameters{
+		ReadinessDrainDelay: 5 * time.Second,
+		ShutdownPeriod:      45 * time.Second,
+		ShutdownHardPeriod:  3 * time.Second,
+	}
+}


### PR DESCRIPTION
## Description

Restarting localtest is pretty frequent in some cases, we don't need to be graceful about it

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Host lifecycle timing (readiness checks and shutdown periods) is now environment-specific instead of hard-coded, enabling better control over runtime behaviour during deployments and shutdowns across different deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->