### PR TITLE
refactor: Remove overrides in SavableSchemaModel

### DIFF
--- a/src/Designer/frontend/packages/schema-editor/src/classes/SavableSchemaModel.test.ts
+++ b/src/Designer/frontend/packages/schema-editor/src/classes/SavableSchemaModel.test.ts
@@ -5,7 +5,6 @@ import {
   uiSchemaNodesMock,
   definitionNodeMock,
   fieldNode1Mock,
-  combinationNodeMock,
 } from '../../test/mocks/uiSchemaMock';
 
 describe('SavableSchemaModel', () => {
@@ -18,57 +17,45 @@ describe('SavableSchemaModel', () => {
 
   afterEach(jest.clearAllMocks);
 
-  describe('addField', () => {
+  describe('addFieldAndSave', () => {
     it('Adds a field, saves the model once and returns the new node', () => {
       const savableSchema = setupSchema();
       const name = 'field';
-      const field = savableSchema.addField(name);
+      const field = savableSchema.addFieldAndSave(name);
       expect(savableSchema.hasNode(field.schemaPointer)).toBe(true);
       expect(save).toHaveBeenCalledTimes(1);
       expect(save).toHaveBeenCalledWith(savableSchema);
     });
   });
 
-  describe('addCombination', () => {
+  describe('addCombinationAndSave', () => {
     it('Adds a combination, saves the model once and returns the new node', () => {
       const savableSchema = setupSchema();
       const name = 'combination';
-      const combination = savableSchema.addCombination(name);
+      const combination = savableSchema.addCombinationAndSave(name);
       expect(savableSchema.hasNode(combination.schemaPointer)).toBe(true);
       expect(save).toHaveBeenCalledTimes(1);
       expect(save).toHaveBeenCalledWith(savableSchema);
     });
   });
 
-  describe('addReference', () => {
+  describe('addReferenceAndSave', () => {
     it('Adds a reference, saves the model once and returns the new node', () => {
       const savableSchema = setupSchema();
       const name = 'reference';
       const referenceName = extractNameFromPointer(definitionNodeMock.schemaPointer);
-      const reference = savableSchema.addReference(name, referenceName);
+      const reference = savableSchema.addReferenceAndSave(name, referenceName);
       expect(savableSchema.hasNode(reference.schemaPointer)).toBe(true);
       expect(save).toHaveBeenCalledTimes(1);
       expect(save).toHaveBeenCalledWith(savableSchema);
     });
   });
 
-  describe('addFieldType', () => {
-    it('Adds a field definition, saves the model once and returns the new node', () => {
-      const savableSchema = setupSchema();
-      const name = 'testdef';
-      const definitionNode = savableSchema.addFieldType(name);
-      expect(savableSchema.hasDefinition(name)).toBe(true);
-      expect(savableSchema.getDefinition(name)).toBe(definitionNode);
-      expect(save).toHaveBeenCalledTimes(1);
-      expect(save).toHaveBeenCalledWith(savableSchema);
-    });
-  });
-
-  describe('deleteNode', () => {
+  describe('deleteNodeAndSave', () => {
     it('Deletes a node, saves the model once and returns the object', () => {
       const savableSchema = setupSchema();
       const { schemaPointer } = fieldNode1Mock;
-      const result = savableSchema.deleteNode(schemaPointer);
+      const result = savableSchema.deleteNodeAndSave(schemaPointer);
       expect(savableSchema.hasNode(schemaPointer)).toBe(false);
       expect(save).toHaveBeenCalledTimes(1);
       expect(save).toHaveBeenCalledWith(savableSchema);
@@ -76,12 +63,12 @@ describe('SavableSchemaModel', () => {
     });
   });
 
-  describe('convertToDefinition', () => {
+  describe('convertToDefinitionAndSave', () => {
     it('Converts a node to a definition, saves the model once and returns the object', () => {
       const savableSchema = setupSchema();
       const { schemaPointer } = fieldNode1Mock;
       const name = extractNameFromPointer(schemaPointer);
-      const result = savableSchema.convertToDefinition(schemaPointer);
+      const result = savableSchema.convertToDefinitionAndSave(schemaPointer);
       expect(savableSchema.hasDefinition(name)).toBe(true);
       expect(save).toHaveBeenCalledTimes(1);
       expect(save).toHaveBeenCalledWith(savableSchema);
@@ -89,7 +76,7 @@ describe('SavableSchemaModel', () => {
     });
   });
 
-  describe('moveNode', () => {
+  describe('moveNodeAndSave', () => {
     it('Moves a node, saves the model once and returns the moved node', () => {
       const savableSchema = setupSchema();
       const { schemaPointer } = fieldNode1Mock;
@@ -98,25 +85,11 @@ describe('SavableSchemaModel', () => {
         parentPointer: ROOT_POINTER,
         index: -1,
       };
-      const movedNode = savableSchema.moveNode(schemaPointer, target);
+      const movedNode = savableSchema.moveNodeAndSave(schemaPointer, target);
       expect(savableSchema.doesNodeHaveChildWithName(ROOT_POINTER, name)).toBe(true);
       expect(save).toHaveBeenCalledTimes(1);
       expect(save).toHaveBeenCalledWith(savableSchema);
       expect(movedNode).toBe(savableSchema.getNodeBySchemaPointer(movedNode.schemaPointer));
-    });
-  });
-
-  describe('updateNode', () => {
-    it('Updates a node, saves the model once and returns the object', () => {
-      const savableSchema = setupSchema();
-      const { schemaPointer } = combinationNodeMock;
-      const newNode = savableSchema.getNodeBySchemaPointer(schemaPointer);
-      newNode.isRequired = true;
-      const result = savableSchema.updateNode(schemaPointer, newNode);
-      expect(savableSchema.getNodeBySchemaPointer(schemaPointer).isRequired).toBe(true);
-      expect(save).toHaveBeenCalledTimes(1);
-      expect(save).toHaveBeenCalledWith(savableSchema);
-      expect(result).toBe(savableSchema);
     });
   });
 });

--- a/src/Designer/frontend/packages/schema-editor/src/classes/SavableSchemaModel.ts
+++ b/src/Designer/frontend/packages/schema-editor/src/classes/SavableSchemaModel.ts
@@ -1,4 +1,12 @@
-import type { CombinationNode, FieldNode, NodePosition, UiSchemaNode } from '@altinn/schema-model';
+import type {
+  CombinationKind,
+  CombinationNode,
+  FieldNode,
+  FieldType,
+  NodePosition,
+  ReferenceNode,
+  UiSchemaNode,
+} from '@altinn/schema-model';
 import { SchemaModel } from '@altinn/schema-model';
 
 type SaveSchemaModel = (schema: SchemaModel) => void;
@@ -16,36 +24,45 @@ export class SavableSchemaModel extends SchemaModel {
     return this;
   }
 
-  protected addNode<T extends UiSchemaNode>(name: string, node: T, target: NodePosition): T {
-    const newNode: T = super.addNode<T>(name, node, target);
+  public addFieldAndSave(name?: string, fieldType?: FieldType, target?: NodePosition): FieldNode {
+    const newField = this.addField(name, fieldType, target);
     this.save();
-    return newNode;
+    return newField;
   }
 
-  protected addType<T extends FieldNode | CombinationNode>(name: string, node: T): T {
-    const newNode: T = super.addType(name, node);
+  public addCombinationAndSave(
+    name?: string,
+    target?: NodePosition,
+    combinationType?: CombinationKind,
+  ): CombinationNode {
+    const newCombination = this.addCombination(name, target, combinationType);
     this.save();
-    return newNode;
+    return newCombination;
   }
 
-  public deleteNode(schemaPointer: string): SavableSchemaModel {
-    super.deleteNode(schemaPointer);
+  public addReferenceAndSave(
+    name: string | undefined,
+    referenceName: string,
+    target?: NodePosition,
+  ): ReferenceNode {
+    const newReference = this.addReference(name, referenceName, target);
+    this.save();
+    return newReference;
+  }
+
+  public deleteNodeAndSave(schemaPointer: string): SavableSchemaModel {
+    this.deleteNode(schemaPointer);
     return this.save();
   }
 
-  public convertToDefinition(schemaPointer: string): SavableSchemaModel {
-    super.convertToDefinition(schemaPointer);
+  public convertToDefinitionAndSave(schemaPointer: string): SavableSchemaModel {
+    this.convertToDefinition(schemaPointer);
     return this.save();
   }
 
-  public moveNode(schemaPointer: string, target: NodePosition): UiSchemaNode {
-    const movedNode = super.moveNode(schemaPointer, target);
+  public moveNodeAndSave(schemaPointer: string, target: NodePosition): UiSchemaNode {
+    const movedNode = this.moveNode(schemaPointer, target);
     this.save();
     return movedNode;
-  }
-
-  public updateNode(schemaPointer: string, newNode: UiSchemaNode): SavableSchemaModel {
-    super.updateNode(schemaPointer, newNode);
-    return this.save();
   }
 }

--- a/src/Designer/frontend/packages/schema-editor/src/components/NodePanel/HeadingRow/HeadingRow.tsx
+++ b/src/Designer/frontend/packages/schema-editor/src/components/NodePanel/HeadingRow/HeadingRow.tsx
@@ -158,7 +158,7 @@ const DeleteButton = ({ schemaPointer }: DeleteButtonProps) => {
   const handleDelete = () => {
     setSelectedUniquePointer(null);
     setSelectedTypePointer(null);
-    savableModel.deleteNode(schemaPointer);
+    savableModel.deleteNodeAndSave(schemaPointer);
   };
 
   return (

--- a/src/Designer/frontend/packages/schema-editor/src/components/SchemaEditor/hooks/useAddReference.ts
+++ b/src/Designer/frontend/packages/schema-editor/src/components/SchemaEditor/hooks/useAddReference.ts
@@ -24,7 +24,7 @@ export const useAddReference = (): HandleAdd<string> => {
       const target: NodePosition = { parentPointer, index };
       const { schemaPointer } = savableModel.getFinalNode(target.parentPointer);
       const refName = savableModel.generateUniqueChildName(schemaPointer, 'ref');
-      const ref = savableModel.addReference(refName, reference, target);
+      const ref = savableModel.addReferenceAndSave(refName, reference, target);
       const uniquePointer = SchemaModel.getUniquePointer(ref.schemaPointer);
       setSelectedUniquePointer(uniquePointer);
     },

--- a/src/Designer/frontend/packages/schema-editor/src/components/SchemaEditor/hooks/useMoveProperty.ts
+++ b/src/Designer/frontend/packages/schema-editor/src/components/SchemaEditor/hooks/useMoveProperty.ts
@@ -28,7 +28,7 @@ export const useMoveProperty = (): HandleMove => {
         movementErrorAlert(error, { name, parent });
         return;
       }
-      const movedNode = savableModel.moveNode(schemaPointer, target);
+      const movedNode = savableModel.moveNodeAndSave(schemaPointer, target);
       if (selectedUniquePointer === uniquePointer) {
         const movedUniquePointer = SchemaModel.getUniquePointer(
           movedNode.schemaPointer,

--- a/src/Designer/frontend/packages/schema-editor/src/components/SchemaTree/SchemaNode/ActionButtons/ActionButtons.tsx
+++ b/src/Designer/frontend/packages/schema-editor/src/components/SchemaTree/SchemaNode/ActionButtons/ActionButtons.tsx
@@ -21,7 +21,7 @@ export const ActionButtons = ({ schemaPointer, className, uniquePointer }: Actio
   const deleteNode = useDeleteNode(schemaPointer, savableModel);
   const node = savableModel.getNodeBySchemaPointer(schemaPointer);
 
-  const convertToReference = () => savableModel.convertToDefinition(schemaPointer);
+  const convertToReference = () => savableModel.convertToDefinitionAndSave(schemaPointer);
   const hasReferringNodes = savableModel.hasReferringNodes(schemaPointer);
   const actionButtonTitleKey = hasReferringNodes
     ? 'schema_editor.disable_deletion_info_for_used_definition'
@@ -60,7 +60,7 @@ const useDeleteNode = (schemaPointer: string, savableModel: SavableSchemaModel) 
       : t('schema_editor.data_model_field_deletion_text');
     if (confirm(confirmMessage)) {
       setSelectedUniquePointer(null);
-      savableModel.deleteNode(schemaPointer);
+      savableModel.deleteNodeAndSave(schemaPointer);
     }
   }, [savableModel, schemaPointer, t, setSelectedUniquePointer]);
 };

--- a/src/Designer/frontend/packages/schema-editor/src/hooks/useAddProperty.ts
+++ b/src/Designer/frontend/packages/schema-editor/src/hooks/useAddProperty.ts
@@ -34,7 +34,7 @@ export const useAddProperty = (): AddProperty => {
     const reference = prompt(t('schema_editor.add_reference.prompt'));
     if (!reference) return undefined;
     if (savableModel.hasDefinition(reference)) {
-      const { schemaPointer } = savableModel.addReference(name, reference, target);
+      const { schemaPointer } = savableModel.addReferenceAndSave(name, reference, target);
       return schemaPointer;
     } else {
       alert(t('schema_editor.add_reference.type_does_not_exist', { reference }));
@@ -43,12 +43,12 @@ export const useAddProperty = (): AddProperty => {
   };
 
   const addField = (name: string, target: NodePosition, fieldType?: FieldType): string => {
-    const { schemaPointer } = savableModel.addField(name, fieldType, target);
+    const { schemaPointer } = savableModel.addFieldAndSave(name, fieldType, target);
     return schemaPointer;
   };
 
   const addCombination = (name: string, target: NodePosition): string => {
-    const { schemaPointer } = savableModel.addCombination(name, target);
+    const { schemaPointer } = savableModel.addCombinationAndSave(name, target);
     return schemaPointer;
   };
 


### PR DESCRIPTION
## Description
The `SavableSchemaModel` class, which is used in the data model editor, violates the Liskov substitution principle by overriding the methods of its superclass. This is blocking #11841 (and consequently #17471), since the new `convertToDefinition` method will depend on the overridden methods.

This pull request resolves this by renaming the additional methods with an `AndSave` suffix, so that the original methods of the superclass are still available. It also removes a couple of methods that are not in use.

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- New automated tests not necessary; refactoring only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Schema editor now automatically saves changes after adding, deleting, moving or converting schema elements, making edits persistent immediately and removing the need for manual saves.
  * Related UI flows remain unchanged; behaviour is more consistent across property, reference and node operations.

<sub>✏️ Tip: You can customise this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->