### PR TITLE
fix(policy-editor): use property IsResourcePolicyAvailable for roles

### DIFF
--- a/src/Designer/backend/PolicyAdmin/Models/SubjectOption.cs
+++ b/src/Designer/backend/PolicyAdmin/Models/SubjectOption.cs
@@ -16,6 +16,8 @@
 
         public string? LegacyUrn { get; set; }
 
+        public bool IsResourcePolicyAvailable { get; set; }
+
         public required SubjectOptionProvider Provider { get; set; }
     }
 


### PR DESCRIPTION
## Description
- Use property IsResourcePolicyAvailable to determine which roles should be shown in policy editor
- Use only metadata API for roles, stop using the old roles list hosted on altinn-studio-docs

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resource policy availability status for subject options.

* **Improvements**
  * Enhanced subject options retrieval with streamlined filtering and alphabetical sorting by name for improved usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->