### PR TITLE
chore: Adding `sync all` to Makefile + refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,36 +88,36 @@ endef
 
 # Pull a single subtree (usage: $(call pull-subtree,name,prefix,repo-url,branch))
 define pull-subtree
-	@echo ""; \
+	echo ""; \
 	echo "Syncing $(1) subtree from $(3) ($(4))..."; \
 	git fetch $(3) $(4) && \
 	if GIT_MERGE_AUTOEDIT=no git subtree pull --prefix=$(2) $(3) $(4); then \
 		echo "OK: $(1) subtree synced successfully"; \
 	else \
 		$(handle-conflicts); \
-	fi
+	fi;
 endef
 
 # Pull a single test app (usage: $(call pull-test-app,name,repo-url,branch))
 define pull-test-app
-	@echo "Syncing test app $(1) from $(2) ($(3))..."; \
+	echo "Syncing test app $(1) from $(2) ($(3))..."; \
 	git fetch $(2) $(3) && \
 	if GIT_MERGE_AUTOEDIT=no git subtree pull --prefix=src/test/apps/$(1) $(2) $(3); then \
 		echo "OK: $(1) synced successfully"; \
 	else \
 		$(handle-conflicts); \
-	fi
+	fi;
 endef
 
 # Pull all test apps (uses | delimiter)
 define pull-all-test-apps
-	$(foreach app,$(TEST_APPS), \
+	@$(foreach app,$(TEST_APPS), \
 		$(call pull-test-app,$(word 1,$(subst |, ,$(app))),$(word 2,$(subst |, ,$(app))),$(word 3,$(subst |, ,$(app)))))
 endef
 
 # Pull all main subtrees
 define pull-all-subtrees
-	$(foreach subtree,$(SUBTREES), \
+	@$(foreach subtree,$(SUBTREES), \
 		$(call pull-subtree,$(word 1,$(subst |, ,$(subtree))),$(word 2,$(subst |, ,$(subtree))),$(word 3,$(subst |, ,$(subtree))),$(word 4,$(subst |, ,$(subtree)))))
 endef
 


### PR DESCRIPTION
## Description

This adds a `sync all` command to the `Makefile`, which makes it possible to sync all subtrees into the same branch and create PRs like I did in #17492. I believe this is needed because there inter-dependencies between these repos that sometimes requires them all to be synced to the latest state for tests to go through, so syncing one repo at a time in different PRs creates periods where tests are broken on main. Also, we won't really know if tests _will_ pass until the last sync PR runs its tests.

The prime example here is: app-frontend and the test-apps rely on each other. We often change the test-apps slightly to add components or other functionality that have test-changes in app-frontend. These are not always backwards compatible, so they are sometimes completely dependent on each other.

This change also refactors the Makefile a bit to make this possible, and also:
- Pulls directly from github origin URLs rather than relying on up-to-date checkouts in local directories (we already did this for test-apps, but now it's done for all synced repos)
- Automatically commits changes after resolving merge conflicts (instead of telling you how to do it manually). This makes for a faster and easier workflow where you can resolve conflicts, press enter, resolve the next conflicts, rinse and repeat.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `sync-all` target to consolidate synchronisation of all subtrees and test apps in a single workflow.
  * Enhanced synchronisation process with improved conflict resolution and branch management.
  * Streamlined test app synchronisation capabilities with more robust pull workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->