### PR TITLE
fix: Remove `index.tsx` from StartPage

### DIFF
--- a/src/Designer/backend/src/Designer/Views/Home/StartPage.cshtml
+++ b/src/Designer/backend/src/Designer/Views/Home/StartPage.cshtml
@@ -23,7 +23,6 @@
         <link href="https://altinncdn.no/fonts/roboto/latin/roboto.css" rel="stylesheet" />
         <link href="https://altinncdn.no/fonts/inter/inter.css" rel="stylesheet" />
 
-        <script type="module" src="index.tsx"></script>
         <link rel="stylesheet" type="text/css" href="/designer/css/startpage.css">
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove `index.tsx` script reference from StartPage as it does not seem to be needed in dev and generates some 404 error logs in production:

<img width="673" height="783" alt="index tsx" src="https://github.com/user-attachments/assets/0c0e5eb5-c101-4a9d-b6cf-3a217b8c0392" />

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated application initialisation configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->