### PR TITLE
chore: Using project references more places

### DIFF
--- a/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/App/App.csproj
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_testapps/basic/App/App.csproj
@@ -9,8 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../../../../src/Altinn.App.Api/Altinn.App.Api.csproj" />
-    <ProjectReference Include="../../../../../src/Altinn.App.Core/Altinn.App.Core.csproj" />
+    <!--
+      We reference wildcard versions because the integration test harness
+      is building and packing the libaries and providing them as a local NuGet feed.
+      So we dont care about the exact version, it just has to be compiled from the code in the current commit
+    -->
+    <PackageReference Include="Altinn.App.Api" Version="*-*">
+        <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
+    </PackageReference>
+    <PackageReference Include="Altinn.App.Core" Version="*-*" />
 
     <!-- Required for the fixture - compilation of injected services -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />

--- a/src/App/template/src/App/App.csproj
+++ b/src/App/template/src/App/App.csproj
@@ -5,8 +5,10 @@
     <RootNamespace>Altinn.App</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="../../../backend/src/Altinn.App.Api/Altinn.App.Api.csproj" />
-    <ProjectReference Include="../../../backend/src/Altinn.App.Core/Altinn.App.Core.csproj" />
+    <PackageReference Include="Altinn.App.Api" Version="8.8.3">
+      <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
+    </PackageReference>
+    <PackageReference Include="Altinn.App.Core" Version="8.8.3" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\css\" />

--- a/src/Runtime/operator/test/app/App/App.csproj
+++ b/src/Runtime/operator/test/app/App/App.csproj
@@ -8,6 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="8.0.8" />
-    <ProjectReference Include="../../../../../App/backend/src/Altinn.App.Core/Altinn.App.Core.csproj" />
+    <PackageReference Include="Altinn.App.Core" Version="8.9.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

Some projects were not using project references, even though it's been a while since the monorepo migration. This should hopefully fix some things that breaks in #17492

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated build configuration to use local project references for core and API libraries instead of NuGet package dependencies across multiple test and template projects.
* Removed centralised package version pinning declarations to streamline the build dependency management system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->