### PR TITLE
fix: Properly forward the required prop in text fields

### DIFF
--- a/src/Designer/frontend/libs/studio-components/src/components/StudioTextarea/StudioTextarea.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioTextarea/StudioTextarea.test.tsx
@@ -89,6 +89,16 @@ describe('StudioTextarea', () => {
       screen.getByRole('textbox') as HTMLTextAreaElement;
     testCustomAttributes<HTMLTextAreaElement>(renderStudioTextarea, getTextbox);
   });
+
+  it('Does not set the textarea as required by default', () => {
+    renderStudioTextarea();
+    expect(screen.getByRole('textbox')).not.toBeRequired();
+  });
+
+  it('Sets the textarea as required when the required prop is true', () => {
+    renderStudioTextarea({ required: true });
+    expect(screen.getByRole('textbox')).toBeRequired();
+  });
 });
 
 const defaultProps: StudioTextareaProps = {

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioTextarea/StudioTextarea.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioTextarea/StudioTextarea.tsx
@@ -15,16 +15,7 @@ export type StudioTextareaProps = TextareaProps & {
 };
 
 function StudioTextarea(
-  {
-    children,
-    required,
-    tagText,
-    className,
-    label,
-    description,
-    error,
-    ...rest
-  }: StudioTextareaProps,
+  { children, tagText, className, label, description, error, ...rest }: StudioTextareaProps,
   ref: Ref<HTMLTextAreaElement>,
 ): ReactElement {
   const id: string = useId();
@@ -35,7 +26,7 @@ function StudioTextarea(
     <StudioField className={className}>
       {label && (
         <StudioLabel>
-          <StudioLabelWrapper required={required} tagText={tagText}>
+          <StudioLabelWrapper required={rest.required} tagText={tagText}>
             {label}
           </StudioLabelWrapper>
         </StudioLabel>

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioTextfield/StudioTextfield.test.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioTextfield/StudioTextfield.test.tsx
@@ -68,6 +68,16 @@ describe('StudioTextfield', () => {
   it('Appends given classname to internal classname', () => {
     testRootClassNameAppending((className: string) => renderStudioTextfield({ label, className }));
   });
+
+  it('Does not set the field as required by default', () => {
+    renderStudioTextfield({ label });
+    expect(screen.getByRole('textbox')).not.toBeRequired();
+  });
+
+  it('Sets the field as required when the required prop is true', () => {
+    renderStudioTextfield({ label, required: true });
+    expect(screen.getByRole('textbox')).toBeRequired();
+  });
 });
 
 const renderStudioTextfield = (props: StudioTextfieldProps): RenderResult => {

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioTextfield/StudioTextfield.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioTextfield/StudioTextfield.tsx
@@ -10,7 +10,7 @@ export type StudioTextfieldProps = TextfieldProps & {
 };
 
 function StudioTextfield(
-  { children, required, tagText, label, ...rest }: StudioTextfieldProps,
+  { children, tagText, label, ...rest }: StudioTextfieldProps,
   ref: Ref<HTMLInputElement>,
 ): ReactElement {
   // Designsystemet has conditional types, so if we extract label from props, we must
@@ -24,7 +24,7 @@ function StudioTextfield(
       ref={ref}
       {...rest}
       label={
-        <StudioLabelWrapper required={required} tagText={tagText}>
+        <StudioLabelWrapper required={rest.required} tagText={tagText}>
           {label}
         </StudioLabelWrapper>
       }


### PR DESCRIPTION
## Description
There is a bug in the `StudioTextfield` and `StudioTextarea` components: The `required` prop is not forwarded to the native elements they extend. This pull request fixes that. I need this in a form I am working on.

I have added the `skip-second-approval` label since this does not impact current usage. The automated tests I have added should be sufficient for verifying that the code works as intended.

## Verification
- [x] Related issues are connected
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for textarea and textfield components with additional validation scenarios.

* **Refactor**
  * Improved internal prop handling for textarea and textfield components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->