### PR TITLE
chore: fixing flaky pdf test when `returnToForm: true`

### DIFF
--- a/src/App/frontend/test/e2e/support/custom.ts
+++ b/src/App/frontend/test/e2e/support/custom.ts
@@ -718,15 +718,15 @@ Cypress.Commands.add(
         cy.viewport(width, height);
       });
       cy.get('body').invoke('css', 'margin', '');
+      cy.get('#readyForPrint').should('exist');
 
       // Exit pdf by removing pdf queryparam
-      cy.location('search').then((search) => {
-        const params = new URLSearchParams(search);
-        params.delete('pdf');
-        const newSearch = params.toString();
-        cy.location('pathname').then((pathname) => {
-          cy.visit(pathname + (newSearch ? `?${newSearch}` : ''));
-        });
+      cy.location().then((location) => {
+        const params = new URLSearchParams(location.search);
+        if (params.has('pdf')) {
+          params.delete('pdf');
+          cy.visit(location.pathname + (params.size ? `?${params}` : ''));
+        }
       });
 
       cy.get('#readyForPrint').should('not.exist');


### PR DESCRIPTION
## Description

This optimizes the code path tied to `returnToForm: true` by avoiding double location lookup and adding a wait before the `cy.location()` to make sure we don't end up in a double-visit situation. This caused the test to fail sometimes, because the app was loading already when the `cy.visit()` was called, and thus requests got cancelled from the page we were navigating away from.

Examples of failed test runs:
- https://cloud.cypress.io/projects/o7mikf/runs/845
- https://cloud.cypress.io/projects/o7mikf/runs/846
- https://cloud.cypress.io/projects/o7mikf/runs/842
- https://cloud.cypress.io/projects/o7mikf/runs/840

Tested and verified to not be flaky anymore by running this ~80 times in a loop locally.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved robustness and clarity of PDF workflow end-to-end tests through enhanced assertion placement and streamlined location-handling logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->