### PR TITLE
fix: pdf - ignore tracestate cookie with invalid characters

### DIFF
--- a/src/Runtime/pdf3/test/integration/simple/_snapshots/Test_TracestateWithSemicolons_testoutput.json
+++ b/src/Runtime/pdf3/test/integration/simple/_snapshots/Test_TracestateWithSemicolons_testoutput.json
@@ -1,0 +1,32 @@
+{
+  "id": "UUID",
+  "browserStates": [
+    {
+      "state": "Before",
+      "cookies": [],
+      "consoleErrorLogs": 0,
+      "browserErrors": 0
+    },
+    {
+      "state": "BeforeCleanup",
+      "cookies": [
+        {
+          "name": "AltinnStudioRuntime",
+          "domain": "testserver.default.svc.cluster.local"
+        },
+        {
+          "name": "normalCookie",
+          "domain": "testserver.default.svc.cluster.local"
+        }
+      ],
+      "consoleErrorLogs": 0,
+      "browserErrors": 0
+    },
+    {
+      "state": "After",
+      "cookies": [],
+      "consoleErrorLogs": 0,
+      "browserErrors": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Description

See comment

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie handling during PDF generation by filtering out problematic tracestate cookies (those containing semicolons) and centralising cookie data construction, reducing errors and improving reliability when setting cookies for rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->