### PR TITLE
chore: show message that instances are unavailable

### DIFF
--- a/src/Designer/frontend/admin/features/instances/Instances.tsx
+++ b/src/Designer/frontend/admin/features/instances/Instances.tsx
@@ -94,7 +94,7 @@ export const Instances = () => {
       </div>
       <InstancesTable
         org={org}
-        env={environment}
+        environment={environment}
         app={app}
         currentTask={currentTask}
         isArchived={isArchived}

--- a/src/Designer/frontend/admin/features/instances/components/InstancesTable.tsx
+++ b/src/Designer/frontend/admin/features/instances/components/InstancesTable.tsx
@@ -21,7 +21,7 @@ import { Link } from 'react-router-dom';
 
 type InstancesTableProps = {
   org: string;
-  env: string;
+  environment: string;
   app: string;
   currentTask?: string;
   isArchived?: boolean;
@@ -34,7 +34,7 @@ type InstancesTableProps = {
 
 export const InstancesTable = ({
   org,
-  env,
+  environment,
   app,
   currentTask,
   isArchived,
@@ -46,7 +46,7 @@ export const InstancesTable = ({
 }: InstancesTableProps) => {
   const { data, status, error, fetchNextPage, hasNextPage } = useAppInstancesQuery(
     org,
-    env,
+    environment,
     app,
     currentTask,
     isArchived,
@@ -58,7 +58,7 @@ export const InstancesTable = ({
   );
   const { t, i18n } = useTranslation();
   const orgName = useCurrentOrg().name[i18n.language];
-  const envTitle = useEnvironmentTitle(env);
+  const envTitle = useEnvironmentTitle(environment);
 
   switch (status) {
     case 'pending':
@@ -68,6 +68,13 @@ export const InstancesTable = ({
         return (
           <StudioAlert data-color='info'>
             {t('admin.instances.missing_rights', { envTitle, orgName })}
+          </StudioAlert>
+        );
+      }
+      if (isAxiosError(error) && error.response?.status === 404) {
+        return (
+          <StudioAlert data-color='info'>
+            {t('admin.instances.unavailable', { envTitle, orgName })}
           </StudioAlert>
         );
       }

--- a/src/Designer/frontend/admin/hooks/queries/useAppInstancesQuery.ts
+++ b/src/Designer/frontend/admin/hooks/queries/useAppInstancesQuery.ts
@@ -54,7 +54,9 @@ export const useAppInstancesQuery = (
     getNextPageParam: (lastPage) => lastPage.continuationToken,
     select: (data) => data.pages.flatMap((page) => page.instances),
     meta: {
-      hideDefaultError: (error: any) => isAxiosError(error) && error.response?.status === 403,
+      hideDefaultError: (error: any) =>
+        isAxiosError(error) &&
+        ([403, 404] as (number | undefined)[]).includes(error.response?.status),
     },
   });
 };

--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -51,6 +51,7 @@
   "admin.instances.status.deleted": "Slettet",
   "admin.instances.status.unread": "Ulest",
   "admin.instances.title": "Instanser",
+  "admin.instances.unavailable": "Instansoversikt er ikke tilgjengelig for {{orgName}} i {{envTitle}}.",
   "admin.metrics.altinn_app_lib_processes_ended": "fullførte instanser",
   "admin.metrics.altinn_app_lib_processes_started": "påbegynte instanser",
   "admin.metrics.app.error": "Kunne ikke laste inn applikasjonsmetrikker for denne appen. Prøv igjen senere.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently, If you are a member of e.g. `Admin-AT22`, you can see metrics etc. but fetching instances fails due to the hardcoded restriction in storage, which returns 404 unless you are in `ttd-tt02`. In case we want to release admin before we lift this restriction, its annoying to get this error toast every time, so I added a separate info alert when instances returns 404.

<img width="673" height="261" alt="bilde" src="https://github.com/user-attachments/assets/f86a73ee-8e3d-4d36-9a2d-9bdd95f50f53" />


<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and messaging for the instances overview, now providing clearer feedback when instance information is unavailable or inaccessible
  * Improved error detection to handle additional failure scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->