### PR TITLE
chore: Update Slack channel URLs in SlackContactProvider

### DIFF
--- a/src/Designer/frontend/packages/shared/src/getInTouch/providers/SlackContactProvider.ts
+++ b/src/Designer/frontend/packages/shared/src/getInTouch/providers/SlackContactProvider.ts
@@ -3,8 +3,8 @@
 type SlackChannel = 'product-altinn-studio' | 'altinn';
 
 const slackChannelMap: Record<SlackChannel, string> = {
-  'product-altinn-studio': 'https://altinn.slack.com/archives/C02EJ9HKQA3',
-  altinn: 'https://altinn.slack.com',
+  'product-altinn-studio': 'https://digdir-samarbeid.slack.com/archives/C02EJ9HKQA3',
+  altinn: 'https://digdir-samarbeid.slack.com',
 };
 
 export class SlackContactProvider implements GetInTouchProvider<SlackChannel> {


### PR DESCRIPTION
## Description
The Slack workspace details here are outdated: https://altinn.studio/info/contact.

This PR provides the correct workspace, which is now `digdir-samarbeid.slack.com` instead of `altinn.slack.com`.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Slack workspace contact channel URLs to point to the new workspace.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->