### PR TITLE
feat: add feedback component to admin

### DIFF
--- a/src/Designer/frontend/admin/components/FeedbackForm/FeedbackForm.ts
+++ b/src/Designer/frontend/admin/components/FeedbackForm/FeedbackForm.ts
@@ -1,0 +1,49 @@
+import type { ReactElement } from 'react';
+import { submitFeedbackOrgPath, submitFeedbackPublishedAppPath } from 'app-shared/api/paths';
+import { FeedbackFormImpl } from '@studio/feedback-form';
+import { useParams } from 'react-router-dom';
+
+/**
+ * This is a feedback form to gather feedback on the new admin page.
+ * It uses the FeedbackForm component from the @studio/feedback-form package.
+ * The form is temporary, and will be removed once the new design is fully tested, or we decide to go in a different direction.
+ * As such, all texts are hardcoded in Norwegian, to avoid adding unnecessary translations.
+ * @returns The FeedbackForm component.
+ */
+export function FeedbackForm(): ReactElement {
+  const { org, environment, app } = useParams() as {
+    org: string;
+    environment?: string;
+    app?: string;
+  };
+
+  const submitPath =
+    environment && app
+      ? submitFeedbackPublishedAppPath(org, environment, app)
+      : submitFeedbackOrgPath(org);
+
+  const feedbackForm = new FeedbackFormImpl({
+    id: 'admin-feedback',
+    submitPath,
+    buttonTexts: {
+      submit: 'Send',
+      trigger: 'Gi tilbakemelding',
+      close: 'Lukk',
+    },
+    heading: 'Gi tilbakemelding',
+    description:
+      'Hei! Så bra at du har testet det nye admin-verktøyet! Vi vil gjerne høre hva du synes.',
+    disclaimer:
+      'Merk at KI-verktøy kan bli brukt til å analysere svarene. Påse at du ikke inkluderer personopplysninger i dine svar.',
+    position: 'fixed',
+    questions: [
+      {
+        id: 'kommentar',
+        type: 'text',
+        questionText: 'Har du kommentarer eller forslag til forbedringer?',
+      },
+    ],
+  });
+
+  return feedbackForm.getFeedbackForm();
+}

--- a/src/Designer/frontend/admin/layout/App.tsx
+++ b/src/Designer/frontend/admin/layout/App.tsx
@@ -9,6 +9,7 @@ import en from '../../language/src/en.json';
 import { DEFAULT_LANGUAGE } from 'app-shared/constants';
 import { appContentWrapperId } from '@studio/testing/testids';
 import { WebSocketSyncWrapper } from './WebSocketSyncWrapper';
+import { FeedbackForm } from 'admin/components/FeedbackForm/FeedbackForm';
 
 i18next.use(initReactI18next).init({
   ns: 'translation',
@@ -40,6 +41,7 @@ export function App() {
           <Outlet />
         </WebSocketSyncWrapper>
       </div>
+      <FeedbackForm />
       <ScrollRestoration />
     </div>
   );

--- a/src/Designer/frontend/packages/shared/src/api/paths.js
+++ b/src/Designer/frontend/packages/shared/src/api/paths.js
@@ -42,6 +42,8 @@ export const dataModelAddXsdFromRepoPath = (org, app, filePath) => `${apiBasePat
 
 // Feedback form
 export const submitFeedbackPath = (org, app) => `${apiBasePath}/${org}/${app}/feedbackform/submit`; // Post
+export const submitFeedbackOrgPath = (org) => `${apiBasePath}/${org}/feedbackform/submit`; // Post
+export const submitFeedbackPublishedAppPath = (org, environment, app) => `${apiBasePath}/${org}/${environment}/${app}/feedbackform/submit`; // Post
 
 // FormEditor
 export const ruleHandlerPath = (org, app, layoutSetName) => `${apiBasePath}/${org}/${app}/app-development/rule-handler?${s({ layoutSetName })}`; // Get, Post


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds one single feedback component visible everywhere in admin. Questions are yet to be determined (hence, draft PR). The FeedbackController's path is a bit awkward for this, it uses `org/app`, but in the case of admin, the relevant concepts are `org` and `org/env/app`, I extended the controller to include this. Do let me know if this is unecessary.

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
