### PR TITLE
fix(appMetadata): change about app app name to use `title`, remove added `serviceName`

### DIFF
--- a/src/Designer/backend/src/Designer/Models/App/ApplicationMetadata.cs
+++ b/src/Designer/backend/src/Designer/Models/App/ApplicationMetadata.cs
@@ -21,8 +21,6 @@ public class ApplicationMetadata(string id) : Altinn.App.Core.Models.Application
     public AppMetadataAccess? Access { get; set; }
 
     public List<AppMetadataContactPoint>? ContactPoints { get; set; }
-
-    public AppMetadataTranslatedString? ServiceName { get; set; }
 }
 
 public class AppMetadataContactPoint

--- a/src/Designer/backend/src/Designer/Services/Implementation/Validation/AltinnAppServiceResourceService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/Validation/AltinnAppServiceResourceService.cs
@@ -58,11 +58,11 @@ public static class AltinnAppServiceResourceValidator
 
         if (resource.Title is null)
         {
-            AddError(errors, "serviceName", Required);
+            AddError(errors, "title", Required);
         }
         else
         {
-            ValidateTranslatedString(errors, "serviceName", resource.Title);
+            ValidateTranslatedString(errors, "title", resource.Title);
         }
 
         if (resource.Description is null)
@@ -161,7 +161,7 @@ public static class ApplicationMetadataMapper
         {
             ResourceType = ResourceType.AltinnApp,
             Identifier = applicationmetadata?.Id,
-            Title = applicationmetadata?.ServiceName?.ToDictionary(),
+            Title = applicationmetadata?.Title?.ToDictionary(),
             Description = applicationmetadata?.Description?.ToDictionary(),
             ContactPoints = applicationmetadata?.ContactPoints?.ToServiceContactPoints(),
             RightDescription = applicationmetadata?.Access?.RightDescription?.ToDictionary(),

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/AppConfigForm.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/AppConfigForm.test.tsx
@@ -39,7 +39,7 @@ describe('AppConfigForm', () => {
     expect(repoNameInput).toHaveAttribute('readonly');
   });
 
-  it('displays correct value in "serviceName" input field, and updates the value on change', async () => {
+  it('displays correct value in "title" input field, and updates the value on change', async () => {
     const user = userEvent.setup();
     renderAppConfigForm();
 
@@ -59,12 +59,12 @@ describe('AppConfigForm', () => {
     renderAppConfigForm();
 
     const altId = getServiceNameNbTextbox();
-    expect(altId).toHaveValue(mockAppConfig.serviceName.nb);
+    expect(altId).toHaveValue(mockAppConfig.title.nb);
 
     const newText: string = 'A';
     await user.type(altId, newText);
 
-    expect(altId).toHaveValue(`${mockAppConfig.serviceName.nb}${newText}`);
+    expect(altId).toHaveValue(`${mockAppConfig.title.nb}${newText}`);
   });
 
   it('displays correct value in "description" input field, and updates the value on change', async () => {
@@ -261,10 +261,10 @@ describe('AppConfigForm', () => {
     await user.type(altId, newText);
     await user.tab();
 
-    expect(altId).toHaveValue(`${mockAppConfig.serviceName.nb}${newText}`);
+    expect(altId).toHaveValue(`${mockAppConfig.title.nb}${newText}`);
     const cancelButton = getButton(textMock('app_settings.about_tab_reset_button'));
     await user.click(cancelButton);
-    expect(altId).toHaveValue(`${mockAppConfig.serviceName.nb}${newText}`);
+    expect(altId).toHaveValue(`${mockAppConfig.title.nb}${newText}`);
   });
 
   it('should reset the form to the original values when the cancel button is clicked', async () => {
@@ -281,12 +281,12 @@ describe('AppConfigForm', () => {
     const saveButton = getButton(textMock('app_settings.about_tab_save_button'));
     await user.click(saveButton);
 
-    expect(altId).toHaveValue(`${mockAppConfig.serviceName.nb}${newText}`);
+    expect(altId).toHaveValue(`${mockAppConfig.title.nb}${newText}`);
 
     const cancelButton = getButton(textMock('app_settings.about_tab_reset_button'));
     await user.click(cancelButton);
 
-    expect(altId).toHaveValue(mockAppConfig.serviceName.nb);
+    expect(altId).toHaveValue(mockAppConfig.title.nb);
   });
 });
 
@@ -310,7 +310,7 @@ const mockServiceNameComplete: SupportedLanguage = {
 const mockAppConfig: ApplicationMetadata = {
   id: 'ttd/some-id',
   org: 'ttd',
-  serviceName: mockServiceName,
+  title: mockServiceName,
 };
 const mockContactPoints: ContactPoint = {
   category: 'category',
@@ -321,7 +321,7 @@ const mockContactPoints: ContactPoint = {
 const mockAppConfigComplete: ApplicationMetadata = {
   id: 'ttd/some-id',
   org: 'ttd',
-  serviceName: mockServiceNameComplete,
+  title: mockServiceNameComplete,
   description: mockDescription,
   homepage: mockHomepage,
   access: {

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/AppConfigForm.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/AppConfigForm.tsx
@@ -50,10 +50,10 @@ export function AppConfigForm({ appConfig, saveAppConfig }: AppConfigFormProps):
     }
   };
 
-  const onChangeServiceName = (updatedLanguage: SupportedLanguage): void => {
+  const onChangeTitle = (updatedLanguage: SupportedLanguage): void => {
     setUpdatedAppConfig((oldVal: ApplicationMetadata) => ({
       ...oldVal,
-      serviceName: updatedLanguage,
+      title: updatedLanguage,
     }));
   };
 
@@ -128,9 +128,9 @@ export function AppConfigForm({ appConfig, saveAppConfig }: AppConfigFormProps):
         <InputfieldsWithTranslation
           label={t('app_settings.about_tab_name_label')}
           description={t('app_settings.about_tab_name_description')}
-          id={AppResourceFormFieldIds.ServiceName}
-          value={updatedAppConfig.serviceName}
-          updateLanguage={onChangeServiceName}
+          id={AppResourceFormFieldIds.Title}
+          value={updatedAppConfig.title}
+          updateLanguage={onChangeTitle}
           required
         />
         <InputfieldsWithTranslation
@@ -207,7 +207,7 @@ export function AppConfigForm({ appConfig, saveAppConfig }: AppConfigFormProps):
 }
 
 enum AppResourceFormFieldIds {
-  ServiceName = 'serviceName',
+  Title = 'title',
   Description = 'description',
   RightDescription = 'rightDescription',
   Status = 'status',

--- a/src/Designer/frontend/packages/shared/src/components/AppValidationDialog/AppValidationDialog.tsx
+++ b/src/Designer/frontend/packages/shared/src/components/AppValidationDialog/AppValidationDialog.tsx
@@ -104,20 +104,20 @@ const VALIDATION_FIELD_CONFIG: Record<string, FieldConfig> = {
     anchor: 'identifier',
     translationKey: 'app_validation.app_metadata.identifier.required',
   },
-  serviceName: {
-    anchor: 'serviceName-nb',
+  title: {
+    anchor: 'title-nb',
     translationKey: 'app_validation.app_metadata.title.required',
   },
-  'serviceName.nb': {
-    anchor: 'serviceName-nb',
+  'title.nb': {
+    anchor: 'title-nb',
     translationKey: 'app_validation.app_metadata.title.nb.required',
   },
-  'serviceName.nn': {
-    anchor: 'serviceName-nn',
+  'title.nn': {
+    anchor: 'title-nn',
     translationKey: 'app_validation.app_metadata.title.nn.required',
   },
-  'serviceName.en': {
-    anchor: 'serviceName-en',
+  'title.en': {
+    anchor: 'title-en',
     translationKey: 'app_validation.app_metadata.title.en.required',
   },
   description: {

--- a/src/Designer/frontend/packages/shared/src/types/ApplicationMetadata.ts
+++ b/src/Designer/frontend/packages/shared/src/types/ApplicationMetadata.ts
@@ -22,7 +22,6 @@ export interface ApplicationMetadata {
   validTo?: string;
   versionId?: string;
 
-  serviceName?: SupportedLanguage;
   keywords?: Keyword[];
   description?: SupportedLanguage;
   homepage?: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes `serviceName` added in #17537, use `title` for app name instead.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The application configuration field "Service Name" has been renamed to "Title" across the configuration form, validation/error messages and backend metadata surfaces.

* **Tests**
  * Updated configuration form tests and fixtures to reflect the field rename and corresponding assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->