### PR TITLE
chore: bump Go versions

### DIFF
--- a/src/Runtime/StudioGateway/go.mod
+++ b/src/Runtime/StudioGateway/go.mod
@@ -1,6 +1,6 @@
 module altinn.studio/gateway
 
-go 1.25.5
+go 1.25.6
 
 require altinn.studio/runtime-fixture v0.0.0
 

--- a/src/Runtime/operator/Dockerfile
+++ b/src/Runtime/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25.5-trixie@sha256:1763926ff08117bdf4c76182c02fecbcfc3086771169b2a03574273dde17fcee AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.6-trixie@sha256:fb4b74a39c7318d53539ebda43ccd3ecba6e447a78591889c0efc0a7235ea8b3 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/src/Runtime/operator/Dockerfile.fakes
+++ b/src/Runtime/operator/Dockerfile.fakes
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25.5-trixie@sha256:1763926ff08117bdf4c76182c02fecbcfc3086771169b2a03574273dde17fcee AS builder
+FROM golang:1.25.6-trixie@sha256:fb4b74a39c7318d53539ebda43ccd3ecba6e447a78591889c0efc0a7235ea8b3 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/src/Runtime/operator/go.mod
+++ b/src/Runtime/operator/go.mod
@@ -1,6 +1,6 @@
 module altinn.studio/operator
 
-go 1.25.5
+go 1.25.6
 
 require (
 	altinn.studio/runtime-fixture v0.0.0

--- a/src/Runtime/pdf3/Dockerfile.proxy
+++ b/src/Runtime/pdf3/Dockerfile.proxy
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25.5-trixie@sha256:5d35fb8d28b9095d123b7d96095bbf3750ff18be0a87e5a21c9cffc4351fbf96 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.6-trixie@sha256:fb4b74a39c7318d53539ebda43ccd3ecba6e447a78591889c0efc0a7235ea8b3 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/src/Runtime/pdf3/Dockerfile.worker
+++ b/src/Runtime/pdf3/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25.5-trixie@sha256:5d35fb8d28b9095d123b7d96095bbf3750ff18be0a87e5a21c9cffc4351fbf96 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.6-trixie@sha256:fb4b74a39c7318d53539ebda43ccd3ecba6e447a78591889c0efc0a7235ea8b3 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/src/Runtime/pdf3/go.mod
+++ b/src/Runtime/pdf3/go.mod
@@ -1,6 +1,6 @@
 module altinn.studio/pdf3
 
-go 1.25.5
+go 1.25.6
 
 require github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 

--- a/src/Runtime/test/fixture/go.mod
+++ b/src/Runtime/test/fixture/go.mod
@@ -1,6 +1,6 @@
 module altinn.studio/runtime-fixture
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/fluxcd/flux2/v2 v2.7.5

--- a/src/Runtime/test/health/go.mod
+++ b/src/Runtime/test/health/go.mod
@@ -1,6 +1,6 @@
 module altinn.studio/runtime-health
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/fluxcd/helm-controller/api v1.4.5


### PR DESCRIPTION
## Description

Bump Go versions

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Go toolchain version from 1.25.5 to 1.25.6 across all runtime modules and Docker images to maintain consistency and ensure alignment with the latest toolchain release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->