### PR TITLE
chore: add k8s.pod.uid attr to otel resource attributes

### DIFF
--- a/charts/altinn-designer/templates/deployment.yaml
+++ b/charts/altinn-designer/templates/deployment.yaml
@@ -33,6 +33,13 @@ spec:
           ports:
             - containerPort: {{ .Values.image.containerPort }}
           env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.uid=$(POD_UID)"
             {{- if not (hasKey .Values.environmentVariables .Values.environment) }}
               {{ fail "the chosen environment does not exist" }}
             {{- end }}

--- a/charts/altinn-loadbalancer/templates/deployment.yaml
+++ b/charts/altinn-loadbalancer/templates/deployment.yaml
@@ -22,6 +22,14 @@ spec:
             - containerPort: {{ .Values.image.containerPorts.http }}
             - containerPort: {{ .Values.image.containerPorts.https }}
             - containerPort: {{ .Values.image.containerPorts.lhci }}
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.uid=$(POD_UID)"
           {{- if .Values.volumeMounts }}
           volumeMounts:
           {{- range $mount := .Values.volumeMounts }}

--- a/charts/altinn-repositories/templates/deployment.yaml
+++ b/charts/altinn-repositories/templates/deployment.yaml
@@ -28,6 +28,13 @@ spec:
           ports:
             - containerPort: {{ .Values.image.containerPort }}
           env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.uid=$(POD_UID)"
             {{- if not (hasKey .Values.distinctEnvironmentVariables .Values.environment) }}
               {{ fail "the chosen environment does not exist" }}
             {{- end }}

--- a/src/AI/mcp/infra/kustomize/deployment.yaml
+++ b/src/AI/mcp/infra/kustomize/deployment.yaml
@@ -26,6 +26,13 @@ spec:
               name: http
               protocol: TCP
           env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.uid=$(POD_UID)"
             - name: AZURE_ENDPOINT
               value: "https://hackathons-resource.openai.azure.com/"
             - name: GITEA_URL

--- a/src/Runtime/StudioGateway/infra/kustomize/base/deployment.yaml
+++ b/src/Runtime/StudioGateway/infra/kustomize/base/deployment.yaml
@@ -87,6 +87,13 @@ spec:
               name: http-public
               protocol: TCP
           env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.uid=$(POD_UID)"
             - name: ASPNETCORE_ENVIRONMENT
               valueFrom:
                 # Configmap is created in syncroot

--- a/src/Runtime/StudioGateway/infra/kustomize/fake-oidc/deployment.yaml
+++ b/src/Runtime/StudioGateway/infra/kustomize/fake-oidc/deployment.yaml
@@ -33,6 +33,14 @@ spec:
           image: nginx:alpine
           ports:
             - containerPort: 80
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.uid=$(POD_UID)"
           volumeMounts:
             - name: config
               mountPath: /usr/share/nginx/html/.well-known/oauth-authorization-server

--- a/src/Runtime/operator/config/local-minimal/fakes.yaml
+++ b/src/Runtime/operator/config/local-minimal/fakes.yaml
@@ -42,6 +42,13 @@ spec:
         env:
         - name: OPERATOR_CONFIG_FILE
           value: /config/config.env
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "k8s.pod.uid=$(POD_UID)"
         ports:
         - name: maskinporten
           containerPort: 8050

--- a/src/Runtime/operator/config/manager/manager.yaml
+++ b/src/Runtime/operator/config/manager/manager.yaml
@@ -36,6 +36,13 @@ spec:
         image: controller:latest
         name: manager
         env:
+          - name: POD_UID
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.uid
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: "k8s.pod.uid=$(POD_UID)"
           - name: OPERATOR_UPGRADE_CHANNEL
             valueFrom:
               configMapKeyRef:

--- a/src/Runtime/pdf3/infra/kustomize/base/proxy.yaml
+++ b/src/Runtime/pdf3/infra/kustomize/base/proxy.yaml
@@ -186,6 +186,13 @@ spec:
               containerPort: 5030
               protocol: TCP
           env:
+          - name: POD_UID
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.uid
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: "k8s.pod.uid=$(POD_UID)"
           - name: PDF3_WORKER_HTTP_ADDR
             value: http://pdf3-worker:80
           - name: PDF3_UPGRADE_CHANNEL

--- a/src/Runtime/pdf3/infra/kustomize/base/worker.yaml
+++ b/src/Runtime/pdf3/infra/kustomize/base/worker.yaml
@@ -213,6 +213,13 @@ spec:
             failureThreshold: 5
             timeoutSeconds: 2
           env:
+          - name: POD_UID
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.uid
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: "k8s.pod.uid=$(POD_UID)"
           - name: TZ
             value: Europe/Oslo
           - name: PDF3_UPGRADE_CHANNEL


### PR DESCRIPTION
## Description

Something Vemund did in https://github.com/Altinn/altinn-studio-charts/pull/71
We will soon have otel collectors for all our stuff as well, so adding this to relevant places

references:
  - https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/                                                                                                                                                                                                   
  - https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/        
  - https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
