### PR TITLE
fix: grafana-manifests restore config

### DIFF
--- a/infra/runtime/syncroot/prod/kustomization.yaml
+++ b/infra/runtime/syncroot/prod/kustomization.yaml
@@ -2,3 +2,26 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../grafana-manifests
+patches:
+  - target:
+      kind: OCIRepository
+      name: apps-syncroot-repo
+    patch: |-
+      - op: replace
+        path: /spec/ref/tag
+        value: production
+  - target:
+      kind: Kustomization
+      name: syncroot-apps-kustomization
+    patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./production
+  - target:
+      kind: Kustomization
+      name: grafana-manifests
+    patch: |-
+      - op: replace
+        path: /spec/postBuild/substitute/GATEWAY_URL
+        value: "https://${SERVICEOWNER_ID}.apps.altinn.no/runtime/gateway/api/v1"

--- a/infra/runtime/syncroot/tt02/kustomization.yaml
+++ b/infra/runtime/syncroot/tt02/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../grafana-manifests


### PR DESCRIPTION
## Description

I incorrectly removed these in https://github.com/Altinn/altinn-studio/pull/17372/changes/c5877b685a2b928c63031ab30ab261f100c0a2ff#diff-a7c77de72b5e2b7e629f05bb05e91d87390f5d97f08f05738b0f3cd857120d45


## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grafana monitoring resources now deployed to production and test environments
  * Production configuration updated to route through production gateway endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->