### PR TITLE
chore: pdf3 improve otel tracing

### DIFF
--- a/src/Runtime/pdf3/cmd/proxy/main.go
+++ b/src/Runtime/pdf3/cmd/proxy/main.go
@@ -141,7 +141,7 @@ func generatePdf(logger *slog.Logger, client *http.Client, workerAddr string) fu
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		if r.Method != http.MethodPost {
-			ihttp.WriteProblemDetails(logger, w, http.StatusMethodNotAllowed, ihttp.ProblemDetails{
+			ihttp.WriteProblemDetails(logger, w, r, http.StatusMethodNotAllowed, ihttp.ProblemDetails{
 				Type:   "https://tools.ietf.org/html/rfc7231#section-6.5.5",
 				Title:  "Method Not Allowed",
 				Status: http.StatusMethodNotAllowed,
@@ -151,7 +151,7 @@ func generatePdf(logger *slog.Logger, client *http.Client, workerAddr string) fu
 		}
 		ct := strings.ToLower(r.Header.Get("Content-Type"))
 		if !strings.HasPrefix(ct, "application/json") {
-			ihttp.WriteProblemDetails(logger, w, http.StatusUnsupportedMediaType, ihttp.ProblemDetails{
+			ihttp.WriteProblemDetails(logger, w, r, http.StatusUnsupportedMediaType, ihttp.ProblemDetails{
 				Type:   "https://tools.ietf.org/html/rfc7231#section-6.5.13",
 				Title:  "Unsupported Media Type",
 				Status: http.StatusUnsupportedMediaType,
@@ -161,7 +161,7 @@ func generatePdf(logger *slog.Logger, client *http.Client, workerAddr string) fu
 		}
 		const maxBodySize = 1024 * 64 // 64K should be plenty for the JSON request
 		if r.ContentLength > maxBodySize {
-			ihttp.WriteProblemDetails(logger, w, http.StatusRequestEntityTooLarge, ihttp.ProblemDetails{
+			ihttp.WriteProblemDetails(logger, w, r, http.StatusRequestEntityTooLarge, ihttp.ProblemDetails{
 				Type:   "https://tools.ietf.org/html/rfc7231#section-6.5.11",
 				Title:  "Request Entity Too Large",
 				Status: http.StatusRequestEntityTooLarge,
@@ -170,7 +170,7 @@ func generatePdf(logger *slog.Logger, client *http.Client, workerAddr string) fu
 			return
 		}
 		if !iruntime.IsTestInternalsMode && r.Header.Get(testing.TestInputHeaderName) != "" {
-			ihttp.WriteProblemDetails(logger, w, http.StatusBadRequest, ihttp.ProblemDetails{
+			ihttp.WriteProblemDetails(logger, w, r, http.StatusBadRequest, ihttp.ProblemDetails{
 				Type:   "https://tools.ietf.org/html/rfc7231#section-6.5.1",
 				Title:  "Bad Request",
 				Status: http.StatusBadRequest,
@@ -184,7 +184,7 @@ func generatePdf(logger *slog.Logger, client *http.Client, workerAddr string) fu
 
 		var req types.PdfRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			ihttp.WriteProblemDetails(logger, w, http.StatusBadRequest, ihttp.ProblemDetails{
+			ihttp.WriteProblemDetails(logger, w, r, http.StatusBadRequest, ihttp.ProblemDetails{
 				Type:   "https://tools.ietf.org/html/rfc7231#section-6.5.1",
 				Title:  "Bad Request",
 				Status: http.StatusBadRequest,
@@ -195,7 +195,7 @@ func generatePdf(logger *slog.Logger, client *http.Client, workerAddr string) fu
 
 		// Validate request
 		if err := req.Validate(); err != nil {
-			ihttp.WriteProblemDetails(logger, w, http.StatusBadRequest, ihttp.ProblemDetails{
+			ihttp.WriteProblemDetails(logger, w, r, http.StatusBadRequest, ihttp.ProblemDetails{
 				Type:   "https://tools.ietf.org/html/rfc7231#section-6.5.1",
 				Title:  "Bad Request",
 				Status: http.StatusBadRequest,
@@ -217,7 +217,7 @@ func generatePdf(logger *slog.Logger, client *http.Client, workerAddr string) fu
 		// Prepare request body
 		reqBody, err := json.Marshal(req)
 		if err != nil {
-			ihttp.WriteProblemDetails(reqLogger, w, http.StatusInternalServerError, ihttp.ProblemDetails{
+			ihttp.WriteProblemDetails(reqLogger, w, r, http.StatusInternalServerError, ihttp.ProblemDetails{
 				Type:   "https://tools.ietf.org/html/rfc7231#section-6.6.1",
 				Title:  "Internal Server Error",
 				Status: http.StatusInternalServerError,
@@ -273,7 +273,7 @@ func callWorker(
 	// Call worker via HTTP
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, workerEndpoint, bytes.NewReader(reqBody))
 	if err != nil {
-		ihttp.WriteProblemDetails(logger, w, http.StatusInternalServerError, ihttp.ProblemDetails{
+		ihttp.WriteProblemDetails(logger, w, r, http.StatusInternalServerError, ihttp.ProblemDetails{
 			Type:   "https://tools.ietf.org/html/rfc7231#section-6.6.1",
 			Title:  "Internal Server Error",
 			Status: http.StatusInternalServerError,
@@ -316,7 +316,7 @@ func callWorker(
 			}
 			return false
 		}
-		ihttp.WriteProblemDetails(logger, w, http.StatusInternalServerError, ihttp.ProblemDetails{
+		ihttp.WriteProblemDetails(logger, w, r, http.StatusInternalServerError, ihttp.ProblemDetails{
 			Type:   "https://tools.ietf.org/html/rfc7231#section-6.6.1",
 			Title:  "Internal Server Error",
 			Status: http.StatusInternalServerError,
@@ -399,7 +399,7 @@ func callWorker(
 		w.Header().Set("X-Worker-Id", workerId)
 	}
 
-	ihttp.WriteProblemDetails(logger, w, statusCode, ihttp.ProblemDetails{
+	ihttp.WriteProblemDetails(logger, w, r, statusCode, ihttp.ProblemDetails{
 		Type:   problemType,
 		Title:  problemTitle,
 		Status: statusCode,

--- a/src/Runtime/pdf3/cmd/worker/main.go
+++ b/src/Runtime/pdf3/cmd/worker/main.go
@@ -21,6 +21,8 @@ import (
 	"altinn.studio/pdf3/internal/telemetry"
 	"altinn.studio/pdf3/internal/testing"
 	"altinn.studio/pdf3/internal/types"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var (
@@ -157,33 +159,42 @@ func generateLocalPdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.H
 	assert.That(!iruntime.IsTestInternalsMode, "Localtest env should not run internals test mode")
 
 	return func(w http.ResponseWriter, r *http.Request) {
+		data := telemetry.NewRequestEventData()
+		r = r.WithContext(telemetry.WithRequestEventData(r.Context(), data))
+		span := trace.SpanFromContext(r.Context())
+		setWorkerSpanAttrs(span)
+		defer telemetry.EmitRequestSummary(span, data)
+
 		if r.Method != http.MethodPost {
-			ihttp.WriteProblemDetails(logger, w, http.StatusMethodNotAllowed, ihttp.ProblemDetails{
-				Type:   "https://tools.ietf.org/html/rfc7231#section-6.5.5",
-				Title:  "Method Not Allowed",
-				Status: http.StatusMethodNotAllowed,
-				Detail: "Only POST method is allowed",
+			ihttp.WriteProblemDetails(logger, w, r, http.StatusMethodNotAllowed, ihttp.ProblemDetails{
+				Type:                 "https://tools.ietf.org/html/rfc7231#section-6.5.5",
+				Title:                "Method Not Allowed",
+				Status:               http.StatusMethodNotAllowed,
+				Detail:               "Only POST method is allowed",
+				TraceRejectionReason: "method_not_allowed",
 			})
 			return
 		}
 
 		ct := strings.ToLower(r.Header.Get("Content-Type"))
 		if !strings.HasPrefix(ct, "application/json") {
-			ihttp.WriteProblemDetails(logger, w, http.StatusUnsupportedMediaType, ihttp.ProblemDetails{
-				Type:   "https://tools.ietf.org/html/rfc7231#section-6.5.13",
-				Title:  "Unsupported Media Type",
-				Status: http.StatusUnsupportedMediaType,
-				Detail: "Content-Type must be application/json",
+			ihttp.WriteProblemDetails(logger, w, r, http.StatusUnsupportedMediaType, ihttp.ProblemDetails{
+				Type:                 "https://tools.ietf.org/html/rfc7231#section-6.5.13",
+				Title:                "Unsupported Media Type",
+				Status:               http.StatusUnsupportedMediaType,
+				Detail:               "Content-Type must be application/json",
+				TraceRejectionReason: "unsupported_media_type",
 			})
 			return
 		}
 		const maxBodySize = 1024 * 64 // 64K should be plenty for the JSON request
 		if r.ContentLength > maxBodySize {
-			ihttp.WriteProblemDetails(logger, w, http.StatusRequestEntityTooLarge, ihttp.ProblemDetails{
-				Type:   "https://tools.ietf.org/html/rfc7231#section-6.5.11",
-				Title:  "Request Entity Too Large",
-				Status: http.StatusRequestEntityTooLarge,
-				Detail: fmt.Sprintf("Request body too large (max %d bytes)", maxBodySize),
+			ihttp.WriteProblemDetails(logger, w, r, http.StatusRequestEntityTooLarge, ihttp.ProblemDetails{
+				Type:                 "https://tools.ietf.org/html/rfc7231#section-6.5.11",
+				Title:                "Request Entity Too Large",
+				Status:               http.StatusRequestEntityTooLarge,
+				Detail:               fmt.Sprintf("Request body too large (max %d bytes)", maxBodySize),
+				TraceRejectionReason: "request_entity_too_large",
 			})
 			return
 		}
@@ -193,23 +204,28 @@ func generateLocalPdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.H
 
 		var req types.PdfRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			ihttp.WriteProblemDetails(logger, w, http.StatusBadRequest, ihttp.ProblemDetails{
-				Type:   "https://tools.ietf.org/html/rfc7231#section-6.5.1",
-				Title:  "Bad Request",
-				Status: http.StatusBadRequest,
-				Detail: fmt.Sprintf("Invalid JSON payload: %v", err),
+			ihttp.WriteProblemDetails(logger, w, r, http.StatusBadRequest, ihttp.ProblemDetails{
+				Type:                 "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+				Title:                "Bad Request",
+				Status:               http.StatusBadRequest,
+				Detail:               fmt.Sprintf("Invalid JSON payload: %v", err),
+				TraceRejectionReason: "invalid_json",
+				TraceRejectionError:  err,
 			})
 			return
 		}
 
 		logger = logger.With("url", req.URL)
+		data.SetPdfRequest(req)
 
 		if err := req.Validate(); err != nil {
-			ihttp.WriteProblemDetails(logger, w, http.StatusBadRequest, ihttp.ProblemDetails{
-				Type:   "https://tools.ietf.org/html/rfc7231#section-6.5.1",
-				Title:  "Bad Request",
-				Status: http.StatusBadRequest,
-				Detail: fmt.Sprintf("Validation error: %v", err),
+			ihttp.WriteProblemDetails(logger, w, r, http.StatusBadRequest, ihttp.ProblemDetails{
+				Type:                 "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+				Title:                "Bad Request",
+				Status:               http.StatusBadRequest,
+				Detail:               fmt.Sprintf("Validation error: %v", err),
+				TraceRejectionReason: "validation_error",
+				TraceRejectionError:  err,
 			})
 			return
 		}
@@ -218,6 +234,7 @@ func generateLocalPdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.H
 		result, pdfErr := gen.Generate(requestContext, req)
 
 		if pdfErr != nil {
+			recordPDFError(span, pdfErr)
 			errStr := pdfErr.Error()
 			errorCode := http.StatusInternalServerError
 
@@ -229,7 +246,9 @@ func generateLocalPdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.H
 				errorCode = http.StatusTooManyRequests
 			}
 
-			ihttp.WriteProblemDetails(logger, w, errorCode, ihttp.ProblemDetails{
+			data.SetPDFError(pdfErr)
+			data.SetResponseStatus(errorCode)
+			ihttp.WriteProblemDetails(logger, w, r, errorCode, ihttp.ProblemDetails{
 				Type:   problemType,
 				Title:  problemTitle,
 				Status: errorCode,
@@ -244,6 +263,8 @@ func generateLocalPdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.H
 		}
 
 		// Success - return PDF bytes
+		data.SetResponseStatus(http.StatusOK)
+		data.SetResponseSize(len(result.Data))
 		w.Header().Set("Content-Type", "application/pdf")
 
 		w.WriteHeader(http.StatusOK)
@@ -258,7 +279,16 @@ func generatePdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.Handle
 		w.Header().Set("X-Worker-Id", workerId)
 		w.Header().Set("X-Worker-IP", workerIP)
 
+		data := telemetry.NewRequestEventData()
+		r = r.WithContext(telemetry.WithRequestEventData(r.Context(), data))
+		span := trace.SpanFromContext(r.Context())
+		setWorkerSpanAttrs(span)
+		defer telemetry.EmitRequestSummary(span, data)
+
 		if r.Method != http.MethodPost {
+			data.SetRejection("method_not_allowed", nil)
+			data.SetErrorMessageIfEmpty("Only POST method is allowed")
+			data.SetResponseStatus(http.StatusMethodNotAllowed)
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			if _, err := w.Write([]byte("Only POST method is allowed")); err != nil {
 				logger.Error("Failed to write error response", "error", err)
@@ -268,6 +298,9 @@ func generatePdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.Handle
 
 		ct := strings.ToLower(r.Header.Get("Content-Type"))
 		if !strings.HasPrefix(ct, "application/json") {
+			data.SetRejection("unsupported_media_type", nil)
+			data.SetErrorMessageIfEmpty("Content-Type must be application/json")
+			data.SetResponseStatus(http.StatusUnsupportedMediaType)
 			w.WriteHeader(http.StatusUnsupportedMediaType)
 			if _, err := w.Write([]byte("Content-Type must be application/json")); err != nil {
 				logger.Error("Failed to write error response", "error", err)
@@ -275,6 +308,9 @@ func generatePdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.Handle
 			return
 		}
 		if !iruntime.IsTestInternalsMode && r.Header.Get(testing.TestInputHeaderName) != "" {
+			data.SetRejection("illegal_test_header", nil)
+			data.SetErrorMessageIfEmpty("Illegal internals test mode header")
+			data.SetResponseStatus(http.StatusBadRequest)
 			w.WriteHeader(http.StatusBadRequest)
 			if _, err := w.Write([]byte("Illegal internals test mode header")); err != nil {
 				logger.Error("Failed to write error response", "error", err)
@@ -286,6 +322,9 @@ func generatePdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.Handle
 
 		var req types.PdfRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			data.SetRejection("invalid_json", err)
+			data.SetErrorMessageIfEmpty(fmt.Sprintf("Invalid JSON payload: %v", err))
+			data.SetResponseStatus(http.StatusBadRequest)
 			w.WriteHeader(http.StatusBadRequest)
 			if _, err := fmt.Fprintf(w, "Invalid JSON payload: %v", err); err != nil {
 				logger.Error("Failed to write error response", "error", err)
@@ -294,6 +333,7 @@ func generatePdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.Handle
 		}
 
 		logger = logger.With("url", req.URL)
+		data.SetPdfRequest(req)
 
 		requestContext := r.Context()
 		if iruntime.IsTestInternalsMode && testing.HasTestHeader(r.Header) {
@@ -306,6 +346,7 @@ func generatePdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.Handle
 		result, pdfErr := gen.Generate(requestContext, req)
 
 		if pdfErr != nil {
+			recordPDFError(span, pdfErr)
 			errStr := pdfErr.Error()
 			errorCode := http.StatusInternalServerError
 
@@ -314,6 +355,8 @@ func generatePdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.Handle
 				errorCode = http.StatusTooManyRequests
 			}
 
+			data.SetPDFError(pdfErr)
+			data.SetResponseStatus(errorCode)
 			w.WriteHeader(errorCode)
 			if _, err := w.Write([]byte(errStr)); err != nil {
 				logger.Error("Failed to write error response", "error", err)
@@ -322,6 +365,8 @@ func generatePdfHandler(logger *slog.Logger, gen types.PdfGenerator) http.Handle
 		}
 
 		// Success - return PDF bytes
+		data.SetResponseStatus(http.StatusOK)
+		data.SetResponseSize(len(result.Data))
 		w.Header().Set("Content-Type", "application/pdf")
 
 		w.WriteHeader(http.StatusOK)
@@ -409,4 +454,21 @@ func getTestOutputHandler(logger *slog.Logger) http.HandlerFunc {
 			logger.Error("Failed to write test output response", "error", err)
 		}
 	}
+}
+
+func setWorkerSpanAttrs(span trace.Span) {
+	if !span.IsRecording() {
+		return
+	}
+	span.SetAttributes(
+		attribute.String("worker.id", workerId),
+		attribute.String("worker.ip", workerIP),
+	)
+}
+
+func recordPDFError(span trace.Span, pdfErr *types.PDFError) {
+	if pdfErr == nil || !span.IsRecording() {
+		return
+	}
+	span.RecordError(pdfErr)
 }

--- a/src/Runtime/pdf3/internal/generator/browser_session.go
+++ b/src/Runtime/pdf3/internal/generator/browser_session.go
@@ -20,8 +20,12 @@ import (
 	"altinn.studio/pdf3/internal/cdp"
 	"altinn.studio/pdf3/internal/config"
 	"altinn.studio/pdf3/internal/runtime"
+	"altinn.studio/pdf3/internal/telemetry"
 	"altinn.studio/pdf3/internal/testing"
 	"altinn.studio/pdf3/internal/types"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type browserSession struct {
@@ -30,6 +34,7 @@ type browserSession struct {
 	browser  *browser.Process
 	conn     cdp.Connection
 	targetID string
+	tracer   trace.Tracer
 
 	queue          chan workerRequest
 	state          atomic.Uint32
@@ -62,6 +67,7 @@ func newBrowserSession(logger *slog.Logger, id int) (*browserSession, error) {
 		state:  atomic.Uint32{},
 		ctx:    ctx,
 		cancel: cancel,
+		tracer: telemetry.Tracer(),
 	}
 
 	// Start browser process
@@ -150,6 +156,8 @@ func (w *browserSession) handleRequests() {
 				return
 			}
 
+			w.recordQueueWait(&req)
+
 			// Reset error counters for this request
 			w.consoleErrors.Store(0)
 			w.browserErrors.Store(0)
@@ -172,17 +180,60 @@ func (w *browserSession) handleRequests() {
 	}
 }
 
+func (w *browserSession) recordQueueWait(req *workerRequest) {
+	if req == nil {
+		return
+	}
+	ctx := req.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	start := req.enqueuedAt
+	now := time.Now()
+	if start.IsZero() || start.After(now) {
+		start = now
+	}
+	_, span := w.tracer.Start(ctx, "pdf.queue.wait", trace.WithTimestamp(start))
+	if data := telemetry.RequestEventDataFromContext(ctx); data != nil {
+		data.SetSessionID(w.id)
+		data.SetQueueStats(len(w.queue), cap(w.queue))
+	}
+	span.End()
+}
+
 func (w *browserSession) handleRequest(req *workerRequest) {
+	ctx := req.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, span := w.tracer.Start(ctx, "pdf.session.process", trace.WithSpanKind(trace.SpanKindInternal))
+	req.ctx = ctx
+
+	if span.IsRecording() {
+		span.SetAttributes(attribute.Int("pdf.session.id", w.id))
+	}
+
 	w.logger.Info("Processing PDF request")
 	start := time.Now()
 
 	defer func() {
 		if r := recover(); r != nil {
 			w.logger.Error("Recovered from panic", "error", r)
+			if span.IsRecording() {
+				err := fmt.Errorf("%v", r)
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "panic")
+			}
 			req.tryRespondError(types.NewPDFError(types.ErrGenerationFail, req.request.URL, fmt.Errorf("%v", r)))
 		}
 
+		if data := telemetry.RequestEventDataFromContext(ctx); data != nil {
+			data.SetSessionID(w.id)
+			data.SetConsoleErrors(int(w.consoleErrors.Load()))
+			data.SetBrowserErrors(int(w.browserErrors.Load()))
+		}
 		duration := time.Since(start)
+		span.End()
 		w.logger.Info("Completed PDF request", "duration", duration)
 	}()
 
@@ -199,6 +250,10 @@ func (w *browserSession) handleRequest(req *workerRequest) {
 
 	err := w.generatePdf(req)
 	if err != nil {
+		if span.IsRecording() {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "generate_failed")
+		}
 		req.tryRespondError(mapCustomError(err))
 	}
 }
@@ -210,6 +265,14 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 
 	// Ensure cleanup always runs
 	defer func() {
+		cleanupCtx := req.ctx
+		if cleanupCtx == nil {
+			cleanupCtx = context.Background()
+		}
+		_, cleanupSpan := w.tracer.Start(cleanupCtx, "pdf.session.cleanup", trace.WithSpanKind(trace.SpanKindInternal))
+		cleanupStart := time.Now()
+		defer cleanupSpan.End()
+
 		// When we get here we can already accept a request into the queue
 		// Cleanup should run fairly fast (low ms range)
 
@@ -219,11 +282,14 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 		if !startedProcessing {
 			w.logger.Info("Never started processing, skipping cleanup")
 			req.cleanedUp = true
+			if data := telemetry.RequestEventDataFromContext(cleanupCtx); data != nil {
+				data.SetSessionID(w.id)
+				data.SetCleanup(0, true, true)
+			}
 			return
 		}
 
 		// Navigate back to default
-		start := time.Now()
 		var err error
 		for range 3 {
 			// Not using request context here, the client might have dropped out already and we should always complete cleanup
@@ -234,6 +300,10 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 				break
 			}
 			w.logger.Warn("Failed to navigate back to about:blank, retrying")
+		}
+		if err != nil && cleanupSpan.IsRecording() {
+			cleanupSpan.RecordError(err)
+			cleanupSpan.SetStatus(codes.Error, "cleanup_navigate_failed")
 		}
 		w.assertA(
 			err == nil,
@@ -246,14 +316,17 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 			time.Sleep(time.Duration(testInput.CleanupDelaySeconds) * time.Second)
 		}
 
+		cleanupAttempts := 0
 		// Cleanup browser storage
 		w.cleanupBrowser(req)
+		cleanupAttempts++
 
 		// Retry cleanup if it failed
 		if !req.cleanedUp {
 			w.logger.Warn("Failed to cleanup storage, retrying")
 			for range 3 {
 				w.cleanupBrowser(req)
+				cleanupAttempts++
 				if req.cleanedUp {
 					break
 				}
@@ -265,7 +338,15 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 			)
 		}
 
-		duration := time.Since(start)
+		if data := telemetry.RequestEventDataFromContext(cleanupCtx); data != nil {
+			data.SetSessionID(w.id)
+			data.SetCleanup(cleanupAttempts, req.cleanedUp, false)
+		}
+		if !req.cleanedUp {
+			cleanupSpan.SetStatus(codes.Error, "cleanup_failed")
+		}
+
+		duration := time.Since(cleanupStart)
 		w.logger.Info("Cleanup completed", "duration", duration)
 	}()
 
@@ -275,6 +356,8 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 
 	// Set cookies
 	if len(request.Cookies) > 0 {
+		_, cookiesSpan := w.tracer.Start(req.ctx, "pdf.session.set_cookies", trace.WithSpanKind(trace.SpanKindInternal))
+
 		// Build cookies array for Network.setCookies
 		cookies := make([]map[string]any, 0, len(request.Cookies))
 		for _, cookie := range request.Cookies {
@@ -327,9 +410,15 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 			"cookies": cookies,
 		})
 		if err != nil {
+			if cookiesSpan.IsRecording() {
+				cookiesSpan.RecordError(err)
+				cookiesSpan.SetStatus(codes.Error, "set_cookies_failed")
+			}
+			cookiesSpan.End()
 			req.tryRespondError(contextErrorToPDFError(err, types.ErrSetCookieFail, ""))
 			return nil
 		}
+		cookiesSpan.End()
 	}
 
 	// Navigate to URL
@@ -342,13 +431,20 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 	}
 
 	startedProcessing = true
+	_, navigateSpan := w.tracer.Start(req.ctx, "pdf.session.navigate", trace.WithSpanKind(trace.SpanKindInternal))
 	_, err := w.conn.SendCommand(req.ctx, "Page.navigate", map[string]any{
 		"url": request.URL,
 	})
 	if err != nil {
+		if navigateSpan.IsRecording() {
+			navigateSpan.RecordError(err)
+			navigateSpan.SetStatus(codes.Error, "navigate_failed")
+		}
+		navigateSpan.End()
 		req.tryRespondError(contextErrorToPDFError(err, types.ErrGenerationFail, ""))
 		return nil
 	}
+	navigateSpan.End()
 
 	if req.hasResponded() {
 		return nil
@@ -362,18 +458,32 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 		const maxWaitMs int32 = types.MaxTimeoutMs
 		if selector, ok := request.WaitFor.AsString(); ok {
 			// Simple string selector - wait for element existence only
+			_, waitSpan := w.tracer.Start(req.ctx, "pdf.session.wait", trace.WithSpanKind(trace.SpanKindInternal))
 			err := w.waitForElement(req, selector, maxWaitMs, false, false)
 			if err != nil {
+				if waitSpan.IsRecording() {
+					waitSpan.RecordError(err)
+					waitSpan.SetStatus(codes.Error, "wait_failed")
+				}
+				waitSpan.End()
 				return nil
 			}
+			waitSpan.End()
 		} else if timeout, ok := request.WaitFor.AsTimeout(); ok {
 			// Simple timeout delay
+			_, waitSpan := w.tracer.Start(req.ctx, "pdf.session.wait", trace.WithSpanKind(trace.SpanKindInternal))
 			select {
 			case <-time.After(time.Duration(timeout) * time.Millisecond):
 			case <-req.ctx.Done():
+				if waitSpan.IsRecording() {
+					waitSpan.RecordError(req.ctx.Err())
+					waitSpan.SetStatus(codes.Error, "client_dropped")
+				}
+				waitSpan.End()
 				req.tryRespondError(types.NewPDFError(types.ErrClientDropped, "", req.ctx.Err()))
 				return nil
 			}
+			waitSpan.End()
 		} else if opts, ok := request.WaitFor.AsOptions(); ok {
 			// Full options with selector, visible, hidden, timeout
 			timeoutMs := maxWaitMs // default timeout
@@ -383,14 +493,22 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 			checkVisible := opts.Visible != nil && *opts.Visible
 			checkHidden := opts.Hidden != nil && *opts.Hidden
 
+			_, waitSpan := w.tracer.Start(req.ctx, "pdf.session.wait", trace.WithSpanKind(trace.SpanKindInternal))
 			err := w.waitForElement(req, opts.Selector, timeoutMs, checkVisible, checkHidden)
 			if err != nil {
+				if waitSpan.IsRecording() {
+					waitSpan.RecordError(err)
+					waitSpan.SetStatus(codes.Error, "wait_failed")
+				}
+				waitSpan.End()
 				return nil
 			}
+			waitSpan.End()
 		}
 	} else {
 		// No waitFor specified - just wait for page load event
 		const maxWaitMs int32 = types.MaxTimeoutMs
+		_, waitSpan := w.tracer.Start(req.ctx, "pdf.session.wait", trace.WithSpanKind(trace.SpanKindInternal))
 		expression := fmt.Sprintf("(function(timeoutMs){ return %s; })(%d)", loadWaitSnippet(), maxWaitMs)
 		resp, err := w.conn.SendCommand(req.ctx, "Runtime.evaluate", map[string]any{
 			"expression":    expression,
@@ -399,14 +517,25 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 		})
 		if err != nil {
 			w.logger.Warn("Failed to wait for page load event", "error", err)
+			if waitSpan.IsRecording() {
+				waitSpan.RecordError(err)
+				waitSpan.SetStatus(codes.Error, "wait_failed")
+			}
+			waitSpan.End()
 			req.tryRespondError(contextErrorToPDFError(err, types.ErrGenerationFail, "page load"))
 			return nil
 		}
 
 		err = w.processWaitResult(req, resp)
 		if err != nil {
+			if waitSpan.IsRecording() {
+				waitSpan.RecordError(err)
+				waitSpan.SetStatus(codes.Error, "wait_failed")
+			}
+			waitSpan.End()
 			return err
 		}
+		waitSpan.End()
 		w.logger.Info("Page load event completed")
 	}
 
@@ -417,6 +546,9 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 		req.tryRespondError(types.NewPDFError(types.ErrClientDropped, "", req.ctx.Err()))
 		return nil
 	}
+
+	_, printSpan := w.tracer.Start(req.ctx, "pdf.session.print_to_pdf", trace.WithSpanKind(trace.SpanKindInternal))
+	defer printSpan.End()
 
 	// Generate PDF with Puppeteer-compatible defaults
 	pdfParams := map[string]any{
@@ -477,6 +609,10 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 
 	resp, err := w.conn.SendCommand(req.ctx, "Page.printToPDF", pdfParams)
 	if err != nil {
+		if printSpan.IsRecording() {
+			printSpan.RecordError(err)
+			printSpan.SetStatus(codes.Error, "print_failed")
+		}
 		req.tryRespondError(contextErrorToPDFError(err, types.ErrGenerationFail, ""))
 		return nil
 	}
@@ -484,18 +620,32 @@ func (w *browserSession) generatePdf(req *workerRequest) error {
 	// Extract PDF data
 	result, ok := resp.Result.(map[string]any)
 	if !ok {
-		req.tryRespondError(types.NewPDFError(types.ErrGenerationFail, "", fmt.Errorf("invalid PDF response format")))
+		err := fmt.Errorf("invalid PDF response format")
+		if printSpan.IsRecording() {
+			printSpan.RecordError(err)
+			printSpan.SetStatus(codes.Error, "print_failed")
+		}
+		req.tryRespondError(types.NewPDFError(types.ErrGenerationFail, "", err))
 		return nil
 	}
 
 	dataStr, ok := result["data"].(string)
 	if !ok {
-		req.tryRespondError(types.NewPDFError(types.ErrGenerationFail, "", fmt.Errorf("no PDF data in response")))
+		err := fmt.Errorf("no PDF data in response")
+		if printSpan.IsRecording() {
+			printSpan.RecordError(err)
+			printSpan.SetStatus(codes.Error, "print_failed")
+		}
+		req.tryRespondError(types.NewPDFError(types.ErrGenerationFail, "", err))
 		return nil
 	}
 
 	pdfBytes, err := base64.StdEncoding.DecodeString(dataStr)
 	if err != nil {
+		if printSpan.IsRecording() {
+			printSpan.RecordError(err)
+			printSpan.SetStatus(codes.Error, "print_failed")
+		}
 		req.tryRespondError(types.NewPDFError(types.ErrGenerationFail, "", err))
 		return nil
 	}
@@ -968,17 +1118,18 @@ func (w *browserSession) isProcessing() bool {
 }
 
 // waitForDrain waits for active request to complete, up to timeout
-func (w *browserSession) waitForDrain(timeout time.Duration) {
+func (w *browserSession) waitForDrain(timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if !w.isProcessing() {
 			w.logger.Info("Session drained successfully")
-			return // Drained successfully
+			return true
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 	// Timeout - log warning but don't crash
 	w.logger.Warn("Session drain timeout, forcing close", "timeout", timeout)
+	return false
 }
 
 // paperFormats defines standard paper sizes in inches (compatible with Puppeteer)

--- a/src/Runtime/pdf3/internal/http/http.go
+++ b/src/Runtime/pdf3/internal/http/http.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+
+	"altinn.studio/pdf3/internal/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type ProblemDetails struct {
@@ -13,9 +17,34 @@ type ProblemDetails struct {
 	Detail     string         `json:"detail,omitempty"`
 	Instance   string         `json:"instance,omitempty"`
 	Extensions map[string]any `json:"extensions,omitempty"`
+	// Internal tracing details; not serialized to JSON.
+	TraceRejectionReason string `json:"-"`
+	TraceRejectionError  error  `json:"-"`
 }
 
-func WriteProblemDetails(logger *slog.Logger, w http.ResponseWriter, statusCode int, problem ProblemDetails) {
+func WriteProblemDetails(logger *slog.Logger, w http.ResponseWriter, r *http.Request, statusCode int, problem ProblemDetails) {
+	if r != nil {
+		span := trace.SpanFromContext(r.Context())
+		if span.IsRecording() && problem.TraceRejectionReason != "" {
+			attrs := []attribute.KeyValue{attribute.String("pdf.request.rejected.reason", problem.TraceRejectionReason)}
+			span.SetAttributes(attribute.Bool("pdf.request.rejected", true))
+			if problem.TraceRejectionError != nil {
+				span.RecordError(problem.TraceRejectionError, trace.WithAttributes(attrs...))
+			} else {
+				span.AddEvent("pdf.request.rejected", trace.WithAttributes(attrs...))
+			}
+		}
+		if data := telemetry.RequestEventDataFromContext(r.Context()); data != nil {
+			data.SetResponseStatus(statusCode)
+			if problem.Detail != "" {
+				data.SetErrorMessageIfEmpty(problem.Detail)
+			}
+			if problem.TraceRejectionReason != "" {
+				data.SetRejection(problem.TraceRejectionReason, problem.TraceRejectionError)
+			}
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	encoder := json.NewEncoder(w)

--- a/src/Runtime/pdf3/internal/telemetry/request_event.go
+++ b/src/Runtime/pdf3/internal/telemetry/request_event.go
@@ -1,0 +1,285 @@
+package telemetry
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"sync"
+
+	"altinn.studio/pdf3/internal/types"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type requestEventKey struct{}
+
+type RequestEventData struct {
+	mu    sync.Mutex
+	attrs []attribute.KeyValue
+	index map[attribute.Key]int
+}
+
+func NewRequestEventData() *RequestEventData {
+	return &RequestEventData{
+		attrs: make([]attribute.KeyValue, 0, 64),
+		index: make(map[attribute.Key]int, 64),
+	}
+}
+
+func WithRequestEventData(ctx context.Context, data *RequestEventData) context.Context {
+	if data == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, requestEventKey{}, data)
+}
+
+func RequestEventDataFromContext(ctx context.Context) *RequestEventData {
+	if ctx == nil {
+		return nil
+	}
+	if data, ok := ctx.Value(requestEventKey{}).(*RequestEventData); ok {
+		return data
+	}
+	return nil
+}
+
+func (d *RequestEventData) SetPdfRequest(req types.PdfRequest) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.setURLLocked(req.URL)
+	d.setWaitForLocked(req.WaitFor)
+
+	d.setKVLocked(attribute.Int("pdf.request.cookies.count", len(req.Cookies)))
+	if len(req.Cookies) > 0 {
+		names := make([]string, 0, len(req.Cookies))
+		lengths := make([]int64, 0, len(req.Cookies))
+		for _, cookie := range req.Cookies {
+			names = append(names, cookie.Name)
+			lengths = append(lengths, int64(len(cookie.Value)))
+		}
+		d.setKVLocked(attribute.StringSlice("pdf.request.cookies.names", names))
+		d.setKVLocked(attribute.Int64Slice("pdf.request.cookies.value_lengths", lengths))
+	}
+
+	d.setKVLocked(attribute.Bool("pdf.request.set_javascript_enabled", req.SetJavaScriptEnabled))
+
+	if req.Options.Format != "" {
+		d.setKVLocked(attribute.String("pdf.request.options.format", req.Options.Format))
+	}
+	if req.Options.PrintBackground {
+		d.setKVLocked(attribute.Bool("pdf.request.options.print_background", true))
+	}
+	if req.Options.DisplayHeaderFooter {
+		d.setKVLocked(attribute.Bool("pdf.request.options.display_header_footer", true))
+	}
+	if req.Options.HeaderTemplate != "" {
+		d.setKVLocked(attribute.Int("pdf.request.options.header_template_len", len(req.Options.HeaderTemplate)))
+	}
+	if req.Options.FooterTemplate != "" {
+		d.setKVLocked(attribute.Int("pdf.request.options.footer_template_len", len(req.Options.FooterTemplate)))
+	}
+	if req.Options.Margin.Top != "" {
+		d.setKVLocked(attribute.String("pdf.request.options.margin_top", req.Options.Margin.Top))
+	}
+	if req.Options.Margin.Right != "" {
+		d.setKVLocked(attribute.String("pdf.request.options.margin_right", req.Options.Margin.Right))
+	}
+	if req.Options.Margin.Bottom != "" {
+		d.setKVLocked(attribute.String("pdf.request.options.margin_bottom", req.Options.Margin.Bottom))
+	}
+	if req.Options.Margin.Left != "" {
+		d.setKVLocked(attribute.String("pdf.request.options.margin_left", req.Options.Margin.Left))
+	}
+}
+
+func (d *RequestEventData) SetQueueStats(depth, capacity int) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.setKVLocked(attribute.Int("pdf.process.queue_depth", depth))
+	d.setKVLocked(attribute.Int("pdf.process.queue_capacity", capacity))
+}
+
+func (d *RequestEventData) SetSessionID(id int) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.setKVLocked(attribute.Int("pdf.session.id", id))
+}
+
+func (d *RequestEventData) SetConsoleErrors(count int) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.setKVLocked(attribute.Int("pdf.process.console_errors", count))
+}
+
+func (d *RequestEventData) SetBrowserErrors(count int) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.setKVLocked(attribute.Int("pdf.process.browser_errors", count))
+}
+
+func (d *RequestEventData) SetCleanup(attempts int, succeeded bool, skipped bool) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.setKVLocked(attribute.Int("pdf.process.cleanup_attempts", attempts))
+	d.setKVLocked(attribute.Bool("pdf.process.cleanup_succeeded", succeeded))
+	d.setKVLocked(attribute.Bool("pdf.process.cleanup_skipped", skipped))
+}
+
+func (d *RequestEventData) SetResponseStatus(code int) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.setKVLocked(attribute.Int("pdf.response.status_code", code))
+}
+
+func (d *RequestEventData) SetResponseSize(size int) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.setKVLocked(attribute.Int("pdf.response.size_bytes", size))
+}
+
+func (d *RequestEventData) SetPDFError(pdfErr *types.PDFError) {
+	if d == nil || pdfErr == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.setKVLocked(attribute.String("pdf.response.error_type", pdfErr.Type.Error()))
+	d.setKVIfAbsentLocked(attribute.String("pdf.response.error_message", pdfErr.Error()))
+}
+
+func (d *RequestEventData) SetRejection(reason string, _ error) {
+	if d == nil || reason == "" {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.setKVIfAbsentLocked(attribute.String("pdf.response.rejection_reason", reason))
+}
+
+func (d *RequestEventData) SetErrorMessageIfEmpty(message string) {
+	if d == nil || message == "" {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.setKVIfAbsentLocked(attribute.String("pdf.response.error_message", message))
+}
+
+func EmitRequestSummary(span trace.Span, data *RequestEventData) {
+	if data == nil || !span.IsRecording() {
+		return
+	}
+
+	data.mu.Lock()
+	attrs := make([]attribute.KeyValue, len(data.attrs))
+	copy(attrs, data.attrs)
+	data.mu.Unlock()
+
+	span.AddEvent("pdf.request.summary", trace.WithAttributes(attrs...))
+}
+
+func (d *RequestEventData) setKVLocked(kv attribute.KeyValue) {
+	if idx, ok := d.index[kv.Key]; ok {
+		d.attrs[idx] = kv
+		return
+	}
+	d.index[kv.Key] = len(d.attrs)
+	d.attrs = append(d.attrs, kv)
+}
+
+func (d *RequestEventData) setKVIfAbsentLocked(kv attribute.KeyValue) {
+	if _, ok := d.index[kv.Key]; ok {
+		return
+	}
+	d.index[kv.Key] = len(d.attrs)
+	d.attrs = append(d.attrs, kv)
+}
+
+func (d *RequestEventData) setURLLocked(raw string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		d.setKVLocked(attribute.Bool("pdf.request.url.invalid", true))
+		return
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		d.setKVLocked(attribute.Bool("pdf.request.url.invalid", true))
+		return
+	}
+
+	path := u.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	d.setKVLocked(attribute.String("pdf.request.url.scheme", u.Scheme))
+	d.setKVLocked(attribute.String("pdf.request.url.host", u.Host))
+	d.setKVLocked(attribute.String("pdf.request.url.path", path))
+}
+
+func (d *RequestEventData) setWaitForLocked(waitFor *types.WaitFor) {
+	if waitFor == nil {
+		d.setKVLocked(attribute.String("pdf.request.wait_for.type", "load_event"))
+		return
+	}
+	if _, ok := waitFor.AsString(); ok {
+		d.setKVLocked(attribute.String("pdf.request.wait_for.type", "selector"))
+		d.setKVLocked(attribute.Bool("pdf.request.wait_for.selector_present", true))
+		return
+	}
+	if timeout, ok := waitFor.AsTimeout(); ok {
+		d.setKVLocked(attribute.String("pdf.request.wait_for.type", "timeout"))
+		d.setKVLocked(attribute.Int64("pdf.request.wait_for.timeout_ms", int64(timeout)))
+		return
+	}
+	if opts, ok := waitFor.AsOptions(); ok {
+		d.setKVLocked(attribute.String("pdf.request.wait_for.type", "options"))
+		d.setKVLocked(attribute.Bool("pdf.request.wait_for.selector_present", opts.Selector != ""))
+		if opts.Timeout != nil {
+			d.setKVLocked(attribute.Int64("pdf.request.wait_for.timeout_ms", int64(*opts.Timeout)))
+		}
+		if opts.Visible != nil {
+			d.setKVLocked(attribute.Bool("pdf.request.wait_for.visible", *opts.Visible))
+		}
+		if opts.Hidden != nil {
+			d.setKVLocked(attribute.Bool("pdf.request.wait_for.hidden", *opts.Hidden))
+		}
+		return
+	}
+
+	d.setKVLocked(attribute.String("pdf.request.wait_for.type", "unknown"))
+}


### PR DESCRIPTION
## Description

To build on the OTel setup here
- add lots of context to worker request span (wide event with centralized info)
- span per phase in session/generator (print, cleanup, etc)

The thinking was that the wide request span event gives us 1 single place to find most relevant info.
Granular spans per phase gives us the timing and specific error conditions

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Enhanced request tracing and monitoring throughout the PDF generation pipeline with improved error context propagation.
  * Implemented comprehensive telemetry data collection for PDF requests, capturing queue statistics, session details, and response metrics.

* **Bug Fixes**
  * Improved error handling and recovery with better context preservation during failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->