### PR TITLE
fix: otel runtime pdf3- prefix instead of exact match for routing connector

### DIFF
--- a/infra/observability/runtime/overlay/patches/gateway-config.yaml
+++ b/infra/observability/runtime/overlay/patches/gateway-config.yaml
@@ -8,17 +8,17 @@ spec:
       routing/traces:
         default_pipelines: [traces/control_plane]
         table:
-          - condition: attributes["service.name"] == "pdf3"
+          - condition: HasPrefix(attributes["service.name"], "pdf3-")
             pipelines: [traces/data_plane]
       routing/metrics:
         default_pipelines: [metrics/control_plane]
         table:
-          - condition: attributes["service.name"] == "pdf3"
+          - condition: HasPrefix(attributes["service.name"], "pdf3-")
             pipelines: [metrics/data_plane]
       routing/logs:
         default_pipelines: [logs/control_plane]
         table:
-          - condition: attributes["service.name"] == "pdf3"
+          - condition: HasPrefix(attributes["service.name"], "pdf3-")
             pipelines: [logs/data_plane]
 
     exporters:


### PR DESCRIPTION
## Description

since service names are pdf3-worker and pdf3-proxy

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced observability service routing configuration to improve flexibility in telemetry data pipeline matching for traces, metrics, and logs collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->