### PR TITLE
feat(process-editor): add eFormidling config to BPMN task extensions

### DIFF
--- a/src/Designer/frontend/packages/process-editor/src/extensions/__snapshots__/altinnCustomTasks.test.ts.snap
+++ b/src/Designer/frontend/packages/process-editor/src/extensions/__snapshots__/altinnCustomTasks.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`altinnCustomTasks preserves the eFormidlingConfig section when the BPMN is parsed and serialized again 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:altinn="http://altinn.no/process" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Altinn_SingleDataTask_Process_Definition" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="SingleDataTask" isExecutable="false">
+    <bpmn:serviceTask id="Task_eFormidling" name="eFormidling">
+      <bpmn:extensionElements>
+        <altinn:taskExtension>
+          <altinn:taskType>eFormidling</altinn:taskType>
+          <altinn:eFormidlingConfig>
+            <altinn:disabled env="local">true</altinn:disabled>
+            <altinn:disabled env="tt02">false</altinn:disabled>
+            <altinn:receiver>991825827</altinn:receiver>
+            <altinn:receiver env="production">123456789</altinn:receiver>
+            <altinn:process>urn:no:difi:profile:arkivmelding:administrasjon:ver1.0</altinn:process>
+            <altinn:standard>urn:no:difi:arkivmelding:xsd::arkivmelding</altinn:standard>
+            <altinn:typeVersion>2.0</altinn:typeVersion>
+            <altinn:type>arkivmelding</altinn:type>
+            <altinn:securityLevel>3</altinn:securityLevel>
+            <altinn:dpfShipmentType env="production">digital</altinn:dpfShipmentType>
+            <altinn:dataTypes>
+              <altinn:dataType>ref-data-as-pdf</altinn:dataType>
+              <altinn:dataType>model</altinn:dataType>
+            </altinn:dataTypes>
+            <altinn:dataTypes env="production">
+              <altinn:dataType>ref-data-as-pdf</altinn:dataType>
+            </altinn:dataTypes>
+          </altinn:eFormidlingConfig>
+        </altinn:taskExtension>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+</bpmn:definitions>
+"
+`;

--- a/src/Designer/frontend/packages/process-editor/src/extensions/altinnCustomTasks.test.ts
+++ b/src/Designer/frontend/packages/process-editor/src/extensions/altinnCustomTasks.test.ts
@@ -1,0 +1,44 @@
+import BpmnModdle from 'bpmn-moddle';
+import { altinnCustomTasks } from './altinnCustomTasks';
+
+const bpmnXmlWithEFormidlingConfig = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:altinn="http://altinn.no/process" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Altinn_SingleDataTask_Process_Definition" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="SingleDataTask" isExecutable="false">
+    <bpmn:serviceTask id="Task_eFormidling" name="eFormidling">
+      <bpmn:extensionElements>
+        <altinn:taskExtension>
+          <altinn:taskType>eFormidling</altinn:taskType>
+          <altinn:eFormidlingConfig>
+            <altinn:disabled env="local">true</altinn:disabled>
+            <altinn:disabled env="tt02">false</altinn:disabled>
+            <altinn:receiver>991825827</altinn:receiver>
+            <altinn:receiver env="production">123456789</altinn:receiver>
+            <altinn:process>urn:no:difi:profile:arkivmelding:administrasjon:ver1.0</altinn:process>
+            <altinn:standard>urn:no:difi:arkivmelding:xsd::arkivmelding</altinn:standard>
+            <altinn:typeVersion>2.0</altinn:typeVersion>
+            <altinn:type>arkivmelding</altinn:type>
+            <altinn:securityLevel>3</altinn:securityLevel>
+            <altinn:dpfShipmentType env="production">digital</altinn:dpfShipmentType>
+            <altinn:dataTypes>
+              <altinn:dataType>ref-data-as-pdf</altinn:dataType>
+              <altinn:dataType>model</altinn:dataType>
+            </altinn:dataTypes>
+            <altinn:dataTypes env="production">
+              <altinn:dataType>ref-data-as-pdf</altinn:dataType>
+            </altinn:dataTypes>
+          </altinn:eFormidlingConfig>
+        </altinn:taskExtension>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+</bpmn:definitions>`;
+
+describe('altinnCustomTasks', () => {
+  it('preserves the eFormidlingConfig section when the BPMN is parsed and serialized again', async () => {
+    const moddle = new BpmnModdle({ altinn: altinnCustomTasks });
+    const { rootElement } = await moddle.fromXML(bpmnXmlWithEFormidlingConfig);
+    const { xml: savedXml } = await moddle.toXML(rootElement, { format: true });
+
+    expect(savedXml).toMatchSnapshot();
+  });
+});

--- a/src/Designer/frontend/packages/process-editor/src/extensions/altinnCustomTasks.ts
+++ b/src/Designer/frontend/packages/process-editor/src/extensions/altinnCustomTasks.ts
@@ -36,6 +36,11 @@ export const altinnCustomTasks = {
           isMany: false,
           type: 'PdfConfig',
         },
+        {
+          name: 'eFormidlingConfig',
+          isMany: false,
+          type: 'EFormidlingConfig',
+        },
       ],
     },
     {
@@ -215,6 +220,113 @@ export const altinnCustomTasks = {
           name: 'value',
           isMany: false,
           isBody: true,
+          type: 'String',
+        },
+      ],
+    },
+    {
+      name: 'EFormidlingConfig',
+      properties: [
+        {
+          name: 'disabled',
+          isMany: true,
+          type: 'EnvironmentConfig',
+          xml: {
+            serialize: 'property',
+          },
+        },
+        {
+          name: 'receiver',
+          isMany: true,
+          type: 'EnvironmentConfig',
+          xml: {
+            serialize: 'property',
+          },
+        },
+        {
+          name: 'process',
+          isMany: true,
+          type: 'EnvironmentConfig',
+          xml: {
+            serialize: 'property',
+          },
+        },
+        {
+          name: 'standard',
+          isMany: true,
+          type: 'EnvironmentConfig',
+          xml: {
+            serialize: 'property',
+          },
+        },
+        {
+          name: 'typeVersion',
+          isMany: true,
+          type: 'EnvironmentConfig',
+          xml: {
+            serialize: 'property',
+          },
+        },
+        {
+          name: 'type',
+          isMany: true,
+          type: 'EnvironmentConfig',
+          xml: {
+            serialize: 'property',
+          },
+        },
+        {
+          name: 'securityLevel',
+          isMany: true,
+          type: 'EnvironmentConfig',
+          xml: {
+            serialize: 'property',
+          },
+        },
+        {
+          name: 'dpfShipmentType',
+          isMany: true,
+          type: 'EnvironmentConfig',
+          xml: {
+            serialize: 'property',
+          },
+        },
+        {
+          name: 'dataTypes',
+          isMany: true,
+          type: 'EFormidlingDataTypes',
+          xml: {
+            serialize: 'property',
+          },
+        },
+      ],
+    },
+    {
+      name: 'EnvironmentConfig',
+      properties: [
+        {
+          name: 'value',
+          isBody: true,
+          type: 'String',
+        },
+        {
+          name: 'env',
+          isAttr: true,
+          type: 'String',
+        },
+      ],
+    },
+    {
+      name: 'EFormidlingDataTypes',
+      properties: [
+        {
+          name: 'values',
+          isMany: true,
+          type: 'DataType',
+        },
+        {
+          name: 'env',
+          isAttr: true,
           type: 'String',
         },
       ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Process editor now supports eFormidling configuration: define environment-specific settings (receiver, process, standard, type/version, security level, shipment type) and configure data-type definitions per environment for multi-environment deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->