### PR TITLE
fix: disable minimum release age checks for digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,11 @@
   "separateMultipleMajor": true,
   "packageRules": [
     {
+      "description": "Disable minimum release age checks for digest updates",
+      "matchUpdateTypes": ["digest"],
+      "minimumReleaseAge": null
+    },
+    {
       "groupName": "LibGit2Sharp dependency",
       "groupSlug": "LibGit2Sharp",
       "matchPackageNames": ["LibGit2Sharp"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Disable minimum release age checks for digest updates, as suggested here: https://github.com/renovatebot/renovate/discussions/39781

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled minimum release-age checks for digest-type dependency updates, allowing digest updates to be processed without the usual delay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->