### PR TITLE
fix: revert css link color change

### DIFF
--- a/src/Designer/frontend/app-development/layout/App.css
+++ b/src/Designer/frontend/app-development/layout/App.css
@@ -18,6 +18,10 @@ a {
   text-decoration: none;
 }
 
+a:visited {
+  color: inherit;
+}
+
 a.fds-link--inverted {
   color: var(--fds-link--inverted);
   text-decoration: underline;


### PR DESCRIPTION
The removal of this rule made error messages colored depending on 'visited'

Partial revert of 19fff0a8344dec9644f5301d17dbb0b5ee16a5af
<!--- Provide a general summary of your changes in the Title above -->

<img width="428" height="140" alt="Screenshot 2026-02-10 at 13 22 35" src="https://github.com/user-attachments/assets/09bfb3c9-4afc-40f6-91e1-8246f32e8898" />

## Description

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visited link styling to ensure consistent colour appearance across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->