### PR TITLE
fix: Retrieve designer environment from grafana alert labels

### DIFF
--- a/src/Runtime/StudioGateway/src/StudioGateway.Api/Application/HandleAlerts.cs
+++ b/src/Runtime/StudioGateway/src/StudioGateway.Api/Application/HandleAlerts.cs
@@ -43,13 +43,12 @@ internal static class HandleAlerts
     internal static async Task<IResult> NotifyAlertsUpdatedAsync(
         DesignerClient designerClient,
         AlertPayload alertPayload,
+        StudioEnvironments environments,
         CancellationToken cancellationToken
     )
     {
-        string designerEnvironment = alertPayload.Alerts
-            .Select(a => a.Labels.GetValueOrDefault("DesignerEnvironment"))
-            .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))
-            ?? "prod";
+        string? designerEnvironmentLabel = alertPayload.Alerts.Select(a => a.Labels.GetValueOrDefault("DesignerEnvironment")).FirstOrDefault();
+        string designerEnvironment = !string.IsNullOrWhiteSpace(designerEnvironmentLabel) && environments.ContainsKey(designerEnvironmentLabel) ? designerEnvironmentLabel : "prod";
 
         var alerts = alertPayload
             .Alerts.Where(a =>

--- a/src/Runtime/StudioGateway/src/StudioGateway.Api/Application/HandleAlerts.cs
+++ b/src/Runtime/StudioGateway/src/StudioGateway.Api/Application/HandleAlerts.cs
@@ -43,10 +43,14 @@ internal static class HandleAlerts
     internal static async Task<IResult> NotifyAlertsUpdatedAsync(
         DesignerClient designerClient,
         AlertPayload alertPayload,
-        CancellationToken cancellationToken,
-        string environment = AltinnEnvironments.Prod
+        CancellationToken cancellationToken
     )
     {
+        string designerEnvironment = alertPayload.Alerts
+            .Select(a => a.Labels.GetValueOrDefault("DesignerEnvironment"))
+            .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))
+            ?? "prod";
+
         var alerts = alertPayload
             .Alerts.Where(a =>
             {
@@ -69,7 +73,7 @@ internal static class HandleAlerts
                 };
             });
 
-        await designerClient.NotifyAlertsUpdatedAsync(alerts, environment, cancellationToken);
+        await designerClient.NotifyAlertsUpdatedAsync(alerts, designerEnvironment, cancellationToken);
 
         return Results.Ok();
     }

--- a/src/Runtime/StudioGateway/src/StudioGateway.Api/Program.cs
+++ b/src/Runtime/StudioGateway/src/StudioGateway.Api/Program.cs
@@ -52,6 +52,9 @@ builder
     .Services.AddOptions<MetricsClientSettings>()
     .Bind(builder.Configuration.GetSection("MetricsClientSettings"))
     .ValidateOnStart();
+builder
+    .Services.AddOptions<StudioEnvironments>()
+    .Bind(builder.Configuration.GetSection(nameof(StudioEnvironments)));
 builder.Services.Configure<GatewayContext>(builder.Configuration.GetSection("Gateway"));
 
 // Register class itself as scoped to avoid using IOptions interfaces throughout the codebase
@@ -60,6 +63,7 @@ builder.Services.TryAddScoped(sp => sp.GetRequiredService<IOptionsSnapshot<Grafa
 builder.Services.TryAddScoped(sp => sp.GetRequiredService<IOptionsSnapshot<GatewayContext>>().Value);
 builder.Services.TryAddScoped(sp => sp.GetRequiredService<IOptionsSnapshot<AlertsClientSettings>>().Value);
 builder.Services.TryAddScoped(sp => sp.GetRequiredService<IOptionsSnapshot<MetricsClientSettings>>().Value);
+builder.Services.TryAddScoped(sp => sp.GetRequiredService<IOptionsSnapshot<StudioEnvironments>>().Value);
 
 builder.ConfigureKestrelPorts();
 builder.AddHostingConfiguration();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Alert handling now auto-determines the studio environment from alert metadata (defaults to prod), removing the need to pass an external environment parameter and simplifying downstream notifications.

* **Chores**
  * Added runtime-configurable studio environment settings and registered them for scoped access so environment values can be reloaded without redeploying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->