### PR TITLE
fix: Avoid overriding CSS on the hidden code list tab in the layout editor

### DIFF
--- a/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/OptionTabs.module.css
+++ b/src/Designer/frontend/packages/ux-editor/src/components/config/editModal/EditOptions/OptionTabs/OptionTabs.module.css
@@ -1,4 +1,4 @@
-.tabContent {
+.tabContent:not([hidden]) {
   padding: var(--fds-spacing-5) 0;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Description
A recent breaking change in The Design System caused both the tabs in the code list tool in the layout editor to be visible at once. This happens because we are overriding the `display` setting on the tab in the CSS. This pull request fixes this by setting `:not([hidden])` on the selector, so that our CSS is only applied to the visible tab.

The images in the table below show the implication of this fix.

| | Code list editor tab | Reference ID tab |
|--------|--------|--------|
| **Current** | <img width="346" height="490" alt="studio localhost_editor_localgiteaadmin_dfsdfs_ui-editor_layoutSet_form_layout=Side1" src="https://github.com/user-attachments/assets/e3a0c1a1-a778-4b25-9570-d3013b53bf85" /> | <img width="346" height="490" alt="studio localhost_editor_localgiteaadmin_dfsdfs_ui-editor_layoutSet_form_layout=Side1 (1)" src="https://github.com/user-attachments/assets/02f9aa8d-bdf7-4def-86ff-9021462bb98a" /> |
| **This pull request** | <img width="346" height="241" alt="studio localhost_editor_localgiteaadmin_dfsdfs_ui-editor_layoutSet_form_layout=Side1 (2)" src="https://github.com/user-attachments/assets/1d527d46-a49c-42f1-942b-3416f1dccc20" /> | <img width="346" height="286" alt="studio localhost_editor_localgiteaadmin_dfsdfs_ui-editor_layoutSet_form_layout=Side1 (3)" src="https://github.com/user-attachments/assets/89e9873f-97ab-49dd-9fcb-b7dcee194363" /> | 

## Verification
- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- Automated test not necessary as this change is CSS-only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined tab content styling so styles now apply only to visible tab panels, preserving layout (padding, display, direction, gap) while avoiding hidden elements receiving styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->