### PR TITLE
chore: runtime app configuration sources

### DIFF
--- a/.github/workflows/deploy-runtime-apps-config.yaml
+++ b/.github/workflows/deploy-runtime-apps-config.yaml
@@ -1,0 +1,106 @@
+name: Runtime - deploy apps config
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - infra/runtime/apps-config/**
+      - .github/workflows/deploy-runtime-apps-config.yaml
+  workflow_dispatch:
+    inputs:
+      rings:
+        description: 'Rings to tag the artifact with. Format of the input object is [{"ring": "at_ring1", "environment": "runtime_at_ring1"}].'
+        required: false
+        default: '[{"ring": "at_ring1", "environment": "runtime_at_ring1"}]'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  get-short-sha:
+    uses: ./.github/workflows/template-short-sha.yaml
+
+  construct-rings-array:
+    runs-on: ubuntu-latest
+    env:
+      default-rings: >-
+        [{"ring": "at_ring1", "environment": "runtime_at_ring1"},{"ring": "at_ring2", "environment": "runtime_at_ring2"},{"ring": "tt_ring1", "environment": "runtime_tt_ring1"},{"ring": "tt_ring2", "environment": "runtime_tt_ring2"},{"ring": "prod_ring1", "environment": "runtime_prod_ring1"},{"ring": "prod_ring2", "environment": "runtime_prod_ring2"}]
+    outputs:
+      ringsjson: ${{ steps.construct-rings.outputs.ringsjson }}
+    steps:
+      - name: Construct rings array
+        id: construct-rings
+        run: |
+          rings='${{ github.event.inputs.rings }}'
+          if [ -z "$rings" ]; then
+            rings='${{ env.default-rings }}'
+          fi
+          echo "Raw rings input: $rings"
+          echo "ringsjson=${rings}" >> $GITHUB_OUTPUT
+
+  push-apps-config-artifact:
+    name: Push apps config as OCI artifact
+    needs: get-short-sha
+    runs-on: ubuntu-latest
+    environment: dev
+    env:
+      REGISTRY_NAME: altinncr
+      CONFIG_REPO: altinncr.azurecr.io/studio-apps/runtime-apps-config-repo:${{ needs.get-short-sha.outputs.short-sha }}
+    outputs:
+      config-repo: altinncr.azurecr.io/studio-apps/runtime-apps-config-repo:${{ needs.get-short-sha.outputs.short-sha }}
+    defaults:
+      run:
+        working-directory: infra/runtime/apps-config
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: az login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID_FC }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID_FC }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_FC }}
+
+      - name: az acr login
+        run: az acr login --name ${{ env.REGISTRY_NAME }}
+
+      - name: flux install
+        uses: fluxcd/flux2/action@8454b02a32e48d775b9f563cb51fdcb1787b5b93 # v2.7.5
+
+      - name: push artifact
+        run: |
+          flux push artifact oci://${{ env.CONFIG_REPO }} \
+            --provider=azure \
+            --reproducible \
+            --path="." \
+            --source="$(git config --get remote.origin.url)" \
+            --revision="$(git branch --show-current)/$(git rev-parse HEAD)"
+
+  tag-apps-config:
+    name: Tag apps config
+    needs: [push-apps-config-artifact, construct-rings-array]
+    runs-on: ubuntu-latest
+    environment: ${{ matrix.environment }}
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.construct-rings-array.outputs.ringsjson) }}
+    steps:
+      - name: az login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID_FC }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID_FC }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_FC }}
+
+      - name: az acr login
+        run: az acr login --name altinncr
+
+      - name: flux install
+        uses: fluxcd/flux2/action@8454b02a32e48d775b9f563cb51fdcb1787b5b93 # v2.7.5
+
+      - name: tag artifact
+        run: |
+          flux tag artifact oci://${{ needs.push-apps-config-artifact.outputs.config-repo }} \
+            --tag ${{ matrix.ring }}

--- a/infra/runtime/apps-config/at22/kustomization.yaml
+++ b/infra/runtime/apps-config/at22/kustomization.yaml
@@ -1,0 +1,53 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: ConfigMap
+      name: apps-runtime-common-config-env
+    patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: apps-runtime-common-config-env
+      data:
+        PlatformSettings__ApiStorageEndpoint: https://platform.at22.altinn.cloud/storage/api/v1/
+        PlatformSettings__ApiRegisterEndpoint: https://platform.at22.altinn.cloud/register/api/v1/
+        PlatformSettings__ApiProfileEndpoint: https://platform.at22.altinn.cloud/profile/api/v1/
+        PlatformSettings__ApiAuthenticationEndpoint: https://platform.at22.altinn.cloud/authentication/api/v1/
+        PlatformSettings__ApiAuthorizationEndpoint: https://platform.at22.altinn.cloud/authorization/api/v1/
+        PlatformSettings__ApiEventsEndpoint: https://platform.at22.altinn.cloud/events/api/v1/
+        PlatformSettings__ApiNotificationEndpoint: https://platform.at22.altinn.cloud/notifications/api/v1/
+        PlatformSettings__ApiAccessManagementEndpoint: https://platform.at22.altinn.cloud/accessmanagement/api/v1/
+        PlatformSettings__ApiCorrespondenceEndpoint: https://platform.at22.altinn.cloud/correspondence/api/v1/
+        GeneralSettings__HostName: at22.altinn.cloud
+        AppSettings__OpenIdWellKnownEndpoint: https://platform.at22.altinn.cloud/authentication/api/v1/openid/
+        ASPNETCORE_ENVIRONMENT: Staging
+  - target:
+      kind: ConfigMap
+      name: apps-runtime-common-config
+    patch: |-
+      - op: add
+        path: /data/runtime-overrides.json
+        value: |-
+          {
+            "PlatformSettings": {
+              "ApiStorageEndpoint": "https://platform.at22.altinn.cloud/storage/api/v1/",
+              "ApiRegisterEndpoint": "https://platform.at22.altinn.cloud/register/api/v1/",
+              "ApiProfileEndpoint": "https://platform.at22.altinn.cloud/profile/api/v1/",
+              "ApiAuthenticationEndpoint": "https://platform.at22.altinn.cloud/authentication/api/v1/",
+              "ApiAuthorizationEndpoint": "https://platform.at22.altinn.cloud/authorization/api/v1/",
+              "ApiEventsEndpoint": "https://platform.at22.altinn.cloud/events/api/v1/",
+              "ApiNotificationEndpoint": "https://platform.at22.altinn.cloud/notifications/api/v1/",
+              "ApiAccessManagementEndpoint": "https://platform.at22.altinn.cloud/accessmanagement/api/v1/",
+              "ApiCorrespondenceEndpoint": "https://platform.at22.altinn.cloud/correspondence/api/v1/"
+            },
+            "GeneralSettings": {
+              "HostName": "at22.altinn.cloud"
+            },
+            "AppSettings": {
+              "OpenIdWellKnownEndpoint": "https://platform.at22.altinn.cloud/authentication/api/v1/openid/"
+            },
+            "ASPNETCORE_ENVIRONMENT": "Staging"
+          }

--- a/infra/runtime/apps-config/at23/kustomization.yaml
+++ b/infra/runtime/apps-config/at23/kustomization.yaml
@@ -1,0 +1,53 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: ConfigMap
+      name: apps-runtime-common-config-env
+    patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: apps-runtime-common-config-env
+      data:
+        PlatformSettings__ApiStorageEndpoint: https://platform.at23.altinn.cloud/storage/api/v1/
+        PlatformSettings__ApiRegisterEndpoint: https://platform.at23.altinn.cloud/register/api/v1/
+        PlatformSettings__ApiProfileEndpoint: https://platform.at23.altinn.cloud/profile/api/v1/
+        PlatformSettings__ApiAuthenticationEndpoint: https://platform.at23.altinn.cloud/authentication/api/v1/
+        PlatformSettings__ApiAuthorizationEndpoint: https://platform.at23.altinn.cloud/authorization/api/v1/
+        PlatformSettings__ApiEventsEndpoint: https://platform.at23.altinn.cloud/events/api/v1/
+        PlatformSettings__ApiNotificationEndpoint: https://platform.at23.altinn.cloud/notifications/api/v1/
+        PlatformSettings__ApiAccessManagementEndpoint: https://platform.at23.altinn.cloud/accessmanagement/api/v1/
+        PlatformSettings__ApiCorrespondenceEndpoint: https://platform.at23.altinn.cloud/correspondence/api/v1/
+        GeneralSettings__HostName: at23.altinn.cloud
+        AppSettings__OpenIdWellKnownEndpoint: https://platform.at23.altinn.cloud/authentication/api/v1/openid/
+        ASPNETCORE_ENVIRONMENT: Staging
+  - target:
+      kind: ConfigMap
+      name: apps-runtime-common-config
+    patch: |-
+      - op: add
+        path: /data/runtime-overrides.json
+        value: |-
+          {
+            "PlatformSettings": {
+              "ApiStorageEndpoint": "https://platform.at23.altinn.cloud/storage/api/v1/",
+              "ApiRegisterEndpoint": "https://platform.at23.altinn.cloud/register/api/v1/",
+              "ApiProfileEndpoint": "https://platform.at23.altinn.cloud/profile/api/v1/",
+              "ApiAuthenticationEndpoint": "https://platform.at23.altinn.cloud/authentication/api/v1/",
+              "ApiAuthorizationEndpoint": "https://platform.at23.altinn.cloud/authorization/api/v1/",
+              "ApiEventsEndpoint": "https://platform.at23.altinn.cloud/events/api/v1/",
+              "ApiNotificationEndpoint": "https://platform.at23.altinn.cloud/notifications/api/v1/",
+              "ApiAccessManagementEndpoint": "https://platform.at23.altinn.cloud/accessmanagement/api/v1/",
+              "ApiCorrespondenceEndpoint": "https://platform.at23.altinn.cloud/correspondence/api/v1/"
+            },
+            "GeneralSettings": {
+              "HostName": "at23.altinn.cloud"
+            },
+            "AppSettings": {
+              "OpenIdWellKnownEndpoint": "https://platform.at23.altinn.cloud/authentication/api/v1/openid/"
+            },
+            "ASPNETCORE_ENVIRONMENT": "Staging"
+          }

--- a/infra/runtime/apps-config/at24/kustomization.yaml
+++ b/infra/runtime/apps-config/at24/kustomization.yaml
@@ -1,0 +1,53 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: ConfigMap
+      name: apps-runtime-common-config-env
+    patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: apps-runtime-common-config-env
+      data:
+        PlatformSettings__ApiStorageEndpoint: https://platform.at24.altinn.cloud/storage/api/v1/
+        PlatformSettings__ApiRegisterEndpoint: https://platform.at24.altinn.cloud/register/api/v1/
+        PlatformSettings__ApiProfileEndpoint: https://platform.at24.altinn.cloud/profile/api/v1/
+        PlatformSettings__ApiAuthenticationEndpoint: https://platform.at24.altinn.cloud/authentication/api/v1/
+        PlatformSettings__ApiAuthorizationEndpoint: https://platform.at24.altinn.cloud/authorization/api/v1/
+        PlatformSettings__ApiEventsEndpoint: https://platform.at24.altinn.cloud/events/api/v1/
+        PlatformSettings__ApiNotificationEndpoint: https://platform.at24.altinn.cloud/notifications/api/v1/
+        PlatformSettings__ApiAccessManagementEndpoint: https://platform.at24.altinn.cloud/accessmanagement/api/v1/
+        PlatformSettings__ApiCorrespondenceEndpoint: https://platform.at24.altinn.cloud/correspondence/api/v1/
+        GeneralSettings__HostName: at24.altinn.cloud
+        AppSettings__OpenIdWellKnownEndpoint: https://platform.at24.altinn.cloud/authentication/api/v1/openid/
+        ASPNETCORE_ENVIRONMENT: Staging
+  - target:
+      kind: ConfigMap
+      name: apps-runtime-common-config
+    patch: |-
+      - op: add
+        path: /data/runtime-overrides.json
+        value: |-
+          {
+            "PlatformSettings": {
+              "ApiStorageEndpoint": "https://platform.at24.altinn.cloud/storage/api/v1/",
+              "ApiRegisterEndpoint": "https://platform.at24.altinn.cloud/register/api/v1/",
+              "ApiProfileEndpoint": "https://platform.at24.altinn.cloud/profile/api/v1/",
+              "ApiAuthenticationEndpoint": "https://platform.at24.altinn.cloud/authentication/api/v1/",
+              "ApiAuthorizationEndpoint": "https://platform.at24.altinn.cloud/authorization/api/v1/",
+              "ApiEventsEndpoint": "https://platform.at24.altinn.cloud/events/api/v1/",
+              "ApiNotificationEndpoint": "https://platform.at24.altinn.cloud/notifications/api/v1/",
+              "ApiAccessManagementEndpoint": "https://platform.at24.altinn.cloud/accessmanagement/api/v1/",
+              "ApiCorrespondenceEndpoint": "https://platform.at24.altinn.cloud/correspondence/api/v1/"
+            },
+            "GeneralSettings": {
+              "HostName": "at24.altinn.cloud"
+            },
+            "AppSettings": {
+              "OpenIdWellKnownEndpoint": "https://platform.at24.altinn.cloud/authentication/api/v1/openid/"
+            },
+            "ASPNETCORE_ENVIRONMENT": "Staging"
+          }

--- a/infra/runtime/apps-config/base/apps-runtime-common-env.yaml
+++ b/infra/runtime/apps-config/base/apps-runtime-common-env.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apps-runtime-common-config-env
+  namespace: default
+data:
+  ServiceRepositorySettings__BaseResourceFolderContainer: /AltinnService/
+  ServiceRepositorySettings__RepositoryLocation: /AltinnService/
+  PdfGeneratorSettings__ServiceEndpointUri: http://pdf-generator.pdf.svc.cluster.local/pdf
+  PlatformSettings__ApiPdf2Endpoint: http://pdf-generator.pdf.svc.cluster.local/pdf
+  GeneralSettings__ExternalAppBaseUrl: https://{org}.apps.{hostName}/{org}/{app}/
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: apps-runtime-common-secrets-env
+  namespace: default
+type: Opaque
+stringData:
+  ApplicationInsights__ConnectionString: ""

--- a/infra/runtime/apps-config/base/apps-runtime-common.yaml
+++ b/infra/runtime/apps-config/base/apps-runtime-common.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apps-runtime-common-config
+  namespace: default
+data:
+  runtime-common.json: |-
+    {
+      "ServiceRepositorySettings": {
+        "BaseResourceFolderContainer": "/AltinnService/",
+        "RepositoryLocation": "/AltinnService/"
+      },
+      "PlatformSettings": {
+        "ApiPdf2Endpoint": "http://pdf-generator.pdf.svc.cluster.local/pdf"
+      },
+      "GeneralSettings": {
+        "ExternalAppBaseUrl": "https://{org}.apps.{hostName}/{org}/{app}/"
+      },
+      "PdfGeneratorSettings": {
+        "ServiceEndpointUri": "http://pdf-generator.pdf.svc.cluster.local/pdf"
+      }
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: apps-runtime-common-secrets
+  namespace: default
+type: Opaque
+stringData:
+  runtime-common-secrets.json: |-
+    {
+      "ApplicationInsights": {
+        "ConnectionString": ""
+      }
+    }

--- a/infra/runtime/apps-config/base/kustomization.yaml
+++ b/infra/runtime/apps-config/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - apps-runtime-common.yaml
+  - apps-runtime-common-env.yaml

--- a/infra/runtime/apps-config/prod/kustomization.yaml
+++ b/infra/runtime/apps-config/prod/kustomization.yaml
@@ -1,0 +1,59 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: ConfigMap
+      name: apps-runtime-common-config-env
+    patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: apps-runtime-common-config-env
+      data:
+        PlatformSettings__ApiStorageEndpoint: https://platform.altinn.no/storage/api/v1/
+        PlatformSettings__ApiRegisterEndpoint: https://platform.altinn.no/register/api/v1/
+        PlatformSettings__ApiProfileEndpoint: https://platform.altinn.no/profile/api/v1/
+        PlatformSettings__ApiAuthenticationEndpoint: https://platform.altinn.no/authentication/api/v1/
+        PlatformSettings__ApiAuthorizationEndpoint: https://platform.altinn.no/authorization/api/v1/
+        PlatformSettings__ApiEventsEndpoint: https://platform.altinn.no/events/api/v1/
+        PlatformSettings__ApiNotificationEndpoint: https://platform.altinn.no/notifications/api/v1/
+        PlatformSettings__ApiAccessManagementEndpoint: https://platform.altinn.no/accessmanagement/api/v1/
+        PlatformSettings__ApiCorrespondenceEndpoint: https://platform.altinn.no/correspondence/api/v1/
+        GeneralSettings__HostName: altinn.no
+        AppSettings__OpenIdWellKnownEndpoint: https://platform.altinn.no/authentication/api/v1/openid/
+        ASPNETCORE_ENVIRONMENT: Production
+        AppSettings__EFormidlingSender: "991825827"
+        EFormidlingClientSettings__BaseUrl: https://platform.altinn.no/eformidling/api/
+  - target:
+      kind: ConfigMap
+      name: apps-runtime-common-config
+    patch: |-
+      - op: add
+        path: /data/runtime-overrides.json
+        value: |-
+          {
+            "PlatformSettings": {
+              "ApiStorageEndpoint": "https://platform.altinn.no/storage/api/v1/",
+              "ApiRegisterEndpoint": "https://platform.altinn.no/register/api/v1/",
+              "ApiProfileEndpoint": "https://platform.altinn.no/profile/api/v1/",
+              "ApiAuthenticationEndpoint": "https://platform.altinn.no/authentication/api/v1/",
+              "ApiAuthorizationEndpoint": "https://platform.altinn.no/authorization/api/v1/",
+              "ApiEventsEndpoint": "https://platform.altinn.no/events/api/v1/",
+              "ApiNotificationEndpoint": "https://platform.altinn.no/notifications/api/v1/",
+              "ApiAccessManagementEndpoint": "https://platform.altinn.no/accessmanagement/api/v1/",
+              "ApiCorrespondenceEndpoint": "https://platform.altinn.no/correspondence/api/v1/"
+            },
+            "GeneralSettings": {
+              "HostName": "altinn.no"
+            },
+            "AppSettings": {
+              "OpenIdWellKnownEndpoint": "https://platform.altinn.no/authentication/api/v1/openid/",
+              "EFormidlingSender": "991825827"
+            },
+            "EFormidlingClientSettings": {
+              "BaseUrl": "https://platform.altinn.no/eformidling/api/"
+            },
+            "ASPNETCORE_ENVIRONMENT": "Production"
+          }

--- a/infra/runtime/apps-config/tt02/kustomization.yaml
+++ b/infra/runtime/apps-config/tt02/kustomization.yaml
@@ -1,0 +1,59 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: ConfigMap
+      name: apps-runtime-common-config-env
+    patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: apps-runtime-common-config-env
+      data:
+        PlatformSettings__ApiStorageEndpoint: https://platform.tt02.altinn.no/storage/api/v1/
+        PlatformSettings__ApiRegisterEndpoint: https://platform.tt02.altinn.no/register/api/v1/
+        PlatformSettings__ApiProfileEndpoint: https://platform.tt02.altinn.no/profile/api/v1/
+        PlatformSettings__ApiAuthenticationEndpoint: https://platform.tt02.altinn.no/authentication/api/v1/
+        PlatformSettings__ApiAuthorizationEndpoint: https://platform.tt02.altinn.no/authorization/api/v1/
+        PlatformSettings__ApiEventsEndpoint: https://platform.tt02.altinn.no/events/api/v1/
+        PlatformSettings__ApiNotificationEndpoint: https://platform.tt02.altinn.no/notifications/api/v1/
+        PlatformSettings__ApiAccessManagementEndpoint: https://platform.tt02.altinn.no/accessmanagement/api/v1/
+        PlatformSettings__ApiCorrespondenceEndpoint: https://platform.tt02.altinn.no/correspondence/api/v1/
+        GeneralSettings__HostName: tt02.altinn.no
+        AppSettings__OpenIdWellKnownEndpoint: https://platform.tt02.altinn.no/authentication/api/v1/openid/
+        ASPNETCORE_ENVIRONMENT: Staging
+        AppSettings__EFormidlingSender: "991825827"
+        EFormidlingClientSettings__BaseUrl: https://platform.tt02.altinn.no/eformidling/api/
+  - target:
+      kind: ConfigMap
+      name: apps-runtime-common-config
+    patch: |-
+      - op: add
+        path: /data/runtime-overrides.json
+        value: |-
+          {
+            "PlatformSettings": {
+              "ApiStorageEndpoint": "https://platform.tt02.altinn.no/storage/api/v1/",
+              "ApiRegisterEndpoint": "https://platform.tt02.altinn.no/register/api/v1/",
+              "ApiProfileEndpoint": "https://platform.tt02.altinn.no/profile/api/v1/",
+              "ApiAuthenticationEndpoint": "https://platform.tt02.altinn.no/authentication/api/v1/",
+              "ApiAuthorizationEndpoint": "https://platform.tt02.altinn.no/authorization/api/v1/",
+              "ApiEventsEndpoint": "https://platform.tt02.altinn.no/events/api/v1/",
+              "ApiNotificationEndpoint": "https://platform.tt02.altinn.no/notifications/api/v1/",
+              "ApiAccessManagementEndpoint": "https://platform.tt02.altinn.no/accessmanagement/api/v1/",
+              "ApiCorrespondenceEndpoint": "https://platform.tt02.altinn.no/correspondence/api/v1/"
+            },
+            "GeneralSettings": {
+              "HostName": "tt02.altinn.no"
+            },
+            "AppSettings": {
+              "OpenIdWellKnownEndpoint": "https://platform.tt02.altinn.no/authentication/api/v1/openid/",
+              "EFormidlingSender": "991825827"
+            },
+            "EFormidlingClientSettings": {
+              "BaseUrl": "https://platform.tt02.altinn.no/eformidling/api/"
+            },
+            "ASPNETCORE_ENVIRONMENT": "Staging"
+          }

--- a/infra/runtime/apps-config/yt01/kustomization.yaml
+++ b/infra/runtime/apps-config/yt01/kustomization.yaml
@@ -1,0 +1,53 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: ConfigMap
+      name: apps-runtime-common-config-env
+    patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: apps-runtime-common-config-env
+      data:
+        PlatformSettings__ApiStorageEndpoint: https://platform.yt01.altinn.cloud/storage/api/v1/
+        PlatformSettings__ApiRegisterEndpoint: https://platform.yt01.altinn.cloud/register/api/v1/
+        PlatformSettings__ApiProfileEndpoint: https://platform.yt01.altinn.cloud/profile/api/v1/
+        PlatformSettings__ApiAuthenticationEndpoint: https://platform.yt01.altinn.cloud/authentication/api/v1/
+        PlatformSettings__ApiAuthorizationEndpoint: https://platform.yt01.altinn.cloud/authorization/api/v1/
+        PlatformSettings__ApiEventsEndpoint: https://platform.yt01.altinn.cloud/events/api/v1/
+        PlatformSettings__ApiNotificationEndpoint: https://platform.yt01.altinn.cloud/notifications/api/v1/
+        PlatformSettings__ApiAccessManagementEndpoint: https://platform.yt01.altinn.cloud/accessmanagement/api/v1/
+        PlatformSettings__ApiCorrespondenceEndpoint: https://platform.yt01.altinn.cloud/correspondence/api/v1/
+        GeneralSettings__HostName: yt01.altinn.cloud
+        AppSettings__OpenIdWellKnownEndpoint: https://platform.yt01.altinn.cloud/authentication/api/v1/openid/
+        ASPNETCORE_ENVIRONMENT: Staging
+  - target:
+      kind: ConfigMap
+      name: apps-runtime-common-config
+    patch: |-
+      - op: add
+        path: /data/runtime-overrides.json
+        value: |-
+          {
+            "PlatformSettings": {
+              "ApiStorageEndpoint": "https://platform.yt01.altinn.cloud/storage/api/v1/",
+              "ApiRegisterEndpoint": "https://platform.yt01.altinn.cloud/register/api/v1/",
+              "ApiProfileEndpoint": "https://platform.yt01.altinn.cloud/profile/api/v1/",
+              "ApiAuthenticationEndpoint": "https://platform.yt01.altinn.cloud/authentication/api/v1/",
+              "ApiAuthorizationEndpoint": "https://platform.yt01.altinn.cloud/authorization/api/v1/",
+              "ApiEventsEndpoint": "https://platform.yt01.altinn.cloud/events/api/v1/",
+              "ApiNotificationEndpoint": "https://platform.yt01.altinn.cloud/notifications/api/v1/",
+              "ApiAccessManagementEndpoint": "https://platform.yt01.altinn.cloud/accessmanagement/api/v1/",
+              "ApiCorrespondenceEndpoint": "https://platform.yt01.altinn.cloud/correspondence/api/v1/"
+            },
+            "GeneralSettings": {
+              "HostName": "yt01.altinn.cloud"
+            },
+            "AppSettings": {
+              "OpenIdWellKnownEndpoint": "https://platform.yt01.altinn.cloud/authentication/api/v1/openid/"
+            },
+            "ASPNETCORE_ENVIRONMENT": "Staging"
+          }

--- a/infra/runtime/syncroot/base/apps-config.yaml
+++ b/infra/runtime/syncroot/base/apps-config.yaml
@@ -1,0 +1,34 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: apps-config-repo
+  namespace: default
+spec:
+  interval: 5m
+  provider: azure
+  ref:
+    tag: ${UPGRADE_CHANNEL}
+  timeout: 5m
+  url: oci://altinncr.azurecr.io/studio-apps/runtime-apps-config-repo
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-config
+  namespace: default
+spec:
+  targetNamespace: default
+  interval: 5m
+  retryInterval: 5m
+  timeout: 1m
+  prune: true
+  force: false
+  wait: true
+  path: ./${ENVIRONMENT}
+  sourceRef:
+    kind: OCIRepository
+    name: apps-config-repo
+    namespace: default
+  postBuild:
+    substitute:
+      ENVIRONMENT: ${ENVIRONMENT}

--- a/infra/runtime/syncroot/base/kustomization.yaml
+++ b/infra/runtime/syncroot/base/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - apps-config.yaml
   - pdf3.yaml
   - operator.yaml
   - pdf.yaml


### PR DESCRIPTION
## Description

Related to: https://github.com/Altinn/app-lib-dotnet/pull/1661

But with -env variants as well so we can use `envFrom` or something in deploy-app pipeline (works also for old apps)

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automated runtime application configuration management with support for multiple deployment environments (production, staging, test rings).

* **Chores**
  * Added infrastructure automation workflows for streamlined deployment of environment-specific configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->