### PR TITLE
chore: runtime add safe-to-evict annotation to allow better scaling behavior

### DIFF
--- a/infra/observability/runtime/overlay/patches/linkerd-injection.yaml
+++ b/infra/observability/runtime/overlay/patches/linkerd-injection.yaml
@@ -6,6 +6,7 @@ spec:
   podAnnotations:
     linkerd.io/inject: "enabled"
     config.linkerd.io/skip-outbound-ports: "443"
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 ---
 apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
@@ -15,3 +16,4 @@ spec:
   podAnnotations:
     linkerd.io/inject: "enabled"
     config.linkerd.io/skip-outbound-ports: "443"
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/src/Runtime/StudioGateway/infra/kustomize/base/deployment.yaml
+++ b/src/Runtime/StudioGateway/infra/kustomize/base/deployment.yaml
@@ -37,6 +37,7 @@ spec:
       annotations:
         # for mTLS mainly
         linkerd.io/inject: enabled
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       topologySpreadConstraints:
         # Try to spread across availability zones first (highest priority)

--- a/src/Runtime/StudioGateway/infra/kustomize/fake-oidc/deployment.yaml
+++ b/src/Runtime/StudioGateway/infra/kustomize/fake-oidc/deployment.yaml
@@ -27,6 +27,8 @@ spec:
     metadata:
       labels:
         app: fake-oidc
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       containers:
         - name: nginx

--- a/src/Runtime/kubernetes-wrapper/integrationtests/kubewrapper.yaml
+++ b/src/Runtime/kubernetes-wrapper/integrationtests/kubewrapper.yaml
@@ -54,6 +54,8 @@ spec:
       labels:
         app: kuberneteswrapper
         release: kuberneteswrapper
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       serviceAccountName: kuberneteswrapper
       containers:
@@ -97,6 +99,8 @@ spec:
       creationTimestamp: null
       labels:
         app: dummy-deployment
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       containers:
         - image: nginx:alpine
@@ -122,6 +126,8 @@ spec:
       creationTimestamp: null
       labels:
         app: dummy-daemonset
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       containers:
         - image: nginx:alpine

--- a/src/Runtime/operator/config/local-minimal/fakes.yaml
+++ b/src/Runtime/operator/config/local-minimal/fakes.yaml
@@ -32,6 +32,8 @@ spec:
     metadata:
       labels:
         app: fakes
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/src/Runtime/operator/config/manager/manager.yaml
+++ b/src/Runtime/operator/config/manager/manager.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         control-plane: controller-manager
         azure.workload.identity/use: 'true'

--- a/src/Runtime/pdf3/infra/kustomize/base/proxy.yaml
+++ b/src/Runtime/pdf3/infra/kustomize/base/proxy.yaml
@@ -133,6 +133,7 @@ spec:
         # linkerd provides automatic mTLS and some nice features
         # such as topology aware routing
         linkerd.io/inject: enabled
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       topologySpreadConstraints:
         # Try to spread across availability zones first (highest priority)

--- a/src/Runtime/pdf3/infra/kustomize/base/worker.yaml
+++ b/src/Runtime/pdf3/infra/kustomize/base/worker.yaml
@@ -126,7 +126,9 @@ spec:
       labels:
         app: pdf3-worker
         component: pdf3
-      # We don't use linkerd annotation here as only the proxy contacts it
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        # We don't use linkerd annotation here as only the proxy contacts it
     spec:
       topologySpreadConstraints:
         # Try to spread across availability zones first (highest priority)


### PR DESCRIPTION
## Description

After having undeployed a ton of apps, noticed that the cluster (e.g. ttd-at22) wasn't scaling down much (only lost 1 node initially). 
There are a couple of things that are known to block eviction and thus scaledowns due to freed capacity: 

- Aggressive PDBs
- emptyDir and similar volumes (pods may rely on node fs), see FAQ: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#basics
- Overprovisioning on resource requests

Have not found issues due to PDB (we are perhaps lacking in the other direction here), but we do suffer from both the other issues. Vibed up a tool to look into pod volume blockers (there were more rows, but I extracted some relevant ones): 

```
Pods blocking eviction due to local storage volumes:
NAMESPACE/POD                                                          NODE                               WORKLOAD                                                         VOLUMES
------------------------------                                         -------------------------          -----------------------------------                              ------------------------------------------------------------
default/ttd-frontend-test-deployment-v2-6b6b66c946-ndmdl               aks-workpool-16962601-vmss00003g   default/Deployment/ttd-frontend-test-deployment-v2               emptyDir:linkerd-proxy-init-xtables-lock
external-secrets/external-secrets-6b7d48d95f-29l4j                     aks-workpool-16962601-vmss00002l   external-secrets/Deployment/external-secrets                     emptyDir:linkerd-proxy-init-xtables-lock
external-secrets/external-secrets-cert-controller-5bfc846cd7-mmtzf     aks-workpool-16962601-vmss00003g   external-secrets/Deployment/external-secrets-cert-controller     emptyDir:linkerd-proxy-init-xtables-lock
external-secrets/external-secrets-webhook-7cbdc8bd89-rhrvh             aks-workpool-16962601-vmss00003s   external-secrets/Deployment/external-secrets-webhook             emptyDir:linkerd-proxy-init-xtables-lock
monitoring/dis-otel-operator-opentelemetry-operator-67b5df7448-7mrc5   aks-workpool-16962601-vmss00002l   monitoring/Deployment/dis-otel-operator-opentelemetry-operator   emptyDir:linkerd-proxy-init-xtables-lock
monitoring/lakmus-67fc97b5d8-g67bq                                     aks-workpool-16962601-vmss00003g   monitoring/Deployment/lakmus                                     emptyDir:linkerd-proxy-init-xtables-lock
monitoring/monitoring-prometheus-blackbox-exporter-774675c9f-slrdt     aks-workpool-16962601-vmss00002l   monitoring/Deployment/monitoring-prometheus-blackbox-exporter    emptyDir:linkerd-proxy-init-xtables-lock
monitoring/otel-collector-ccc4b9875-7dzbx                              aks-workpool-16962601-vmss00003g   monitoring/Deployment/otel-collector                             emptyDir:linkerd-proxy-init-xtables-lock
runtime-gateway/studio-gateway-6bb6cc64f6-4nbq8                        aks-workpool-16962601-vmss000049   runtime-gateway/Deployment/studio-gateway                        emptyDir:linkerd-proxy-init-xtables-lock
```

So this PR ensures we use the `safe-to-evict` annotation to all our services in runtime clusters. It seems we should talk to platform about adding this to the various `monitoring/` stuff as well. There is an app there as well which I just undeployed (had originally whitelisted fronted-test because it is used in cypress-tests, but not from at22 which this report is from). Apps deployed a very long time ago does not have the safe-to-evict annotation (it was [introduced in 2023 it seems](https://github.com/Altinn/altinn-studio-charts/pull/9))

For now I will just merge this and release to ttd environments

Overprovisioning due to resource requests is also something we should look into...

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated deployment configurations across multiple services to mark pods as safe for eviction during cluster autoscaling operations. This optimises infrastructure resource efficiency and improves system reliability and stability during cluster scaling events, reducing operational overhead and infrastructure costs whilst ensuring continued service availability, performance, and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->