### PR TITLE
chore: apps syncroot disable wait

### DIFF
--- a/infra/runtime/syncroot/base/apps-syncroot.yaml
+++ b/infra/runtime/syncroot/base/apps-syncroot.yaml
@@ -23,7 +23,7 @@ spec:
   timeout: 1m
   prune: true
   force: false
-  wait: true
+  wait: false
   path: ./${ENVIRONMENT}
   postBuild:
     substitute:


### PR DESCRIPTION
## Description

We have seen syncroots essentially seeming stuck on "Reconciliation in progress". Seeing if this improves anything..

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified deployment orchestration behaviour during post-build processing to streamline the build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->