### PR TITLE
fix: revert rename of gateway serviceaccount

### DIFF
--- a/src/Runtime/gateway/infra/kustomize/base/deployment.yaml
+++ b/src/Runtime/gateway/infra/kustomize/base/deployment.yaml
@@ -57,7 +57,7 @@ spec:
           labelSelector:
             matchLabels:
               app: gateway
-      serviceAccountName: gateway
+      serviceAccountName: studio-gateway
       terminationGracePeriodSeconds: 30
       # explicitly set security context to embedded .net non-root user (1654)
       securityContext:

--- a/src/Runtime/gateway/infra/kustomize/base/rolebinding.yaml
+++ b/src/Runtime/gateway/infra/kustomize/base/rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gateway-role-binding
 subjects:
   - kind: ServiceAccount
-    name: gateway
+    name: studio-gateway
     namespace: runtime-gateway
 roleRef:
   kind: ClusterRole

--- a/src/Runtime/gateway/infra/kustomize/base/serviceaccount.yaml
+++ b/src/Runtime/gateway/infra/kustomize/base/serviceaccount.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: gateway
+  # Keep this stable: Azure Entra federated credential subject binds to SA name + namespace.
+  name: studio-gateway
   annotations:
     azure.workload.identity/client-id: "${GATEWAY_ENTRA_CLIENT_ID}"


### PR DESCRIPTION
## Description

Missed this, it is of course used in federated credential config on the Azure side... Added a comment 
Bug in #17693 

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure service account configuration to ensure proper access control and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->