### PR TITLE
chore: pdf3 config tweaks

### DIFF
--- a/src/Runtime/pdf3/infra/kustomize/base/proxy.yaml
+++ b/src/Runtime/pdf3/infra/kustomize/base/proxy.yaml
@@ -39,7 +39,7 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 75
 ---
 apiVersion: v1
 kind: Service
@@ -55,8 +55,10 @@ metadata:
     # The idea is that application pods (which also have linkerd sidecars)
     # will route PDF requests to pods residing in the same AZ.
     # The linkerd sidecar uses the below annotation to make routing decisions.
-    # See doc: https://linkerd.io/2-edge/tasks/enabling-topology-aware-routing/
-    service.kubernetes.io/topology-aware-hints: auto
+    # See docs:
+    # - https://linkerd.io/2-edge/tasks/enabling-topology-aware-routing/
+    # - https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/
+    service.kubernetes.io/topology-mode: Auto
 spec:
   # ClusterIP is the default and recommended type for internal services
   # Explicit declaration improves clarity and prevents accidental exposure
@@ -249,5 +251,5 @@ spec:
             # For a 1 CPU core + 1 GB RAM VM, current configuration
             # would fit 3 replicas on one 1 node
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi


### PR DESCRIPTION
## Description

- less resource usage on proxy side, even now in brg prod in relatively busy time of day, CPU is taking 2mcpu
- use the newer topology-mode annotation

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated service topology routing configuration to use current standards.
  * Adjusted resource allocation settings for improved efficiency.
  * Modified autoscaling parameters for better performance optimisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->