### PR TITLE
chore: otel reduce metric usage

### DIFF
--- a/infra/observability/base/gateway.yaml
+++ b/infra/observability/base/gateway.yaml
@@ -54,6 +54,68 @@ spec:
               - set(attributes["http.host"], resource.attributes["service.name"]) where resource.attributes["linkerd.io/proxy-deployment"] != nil
               - set(attributes["http.target"], resource.attributes["service.name"]) where resource.attributes["linkerd.io/proxy-deployment"] != nil
               - set(attributes["server.address"], resource.attributes["service.name"]) where resource.attributes["linkerd.io/proxy-deployment"] != nil
+      filter/metrics_allowlist:
+        error_mode: ignore
+        metrics:
+          include:
+            match_type: regexp
+            metric_names:
+              - '^(altinn|http|dotnet|go)([._].*)?$'
+      cumulativetodelta/metrics:
+        include:
+          metric_types: [sum, histogram, exponentialhistogram]
+        initial_value: auto
+        # Bound in-memory state for inactive series while still covering typical scrape/export jitter.
+        max_staleness: 1h
+      transform/metrics_cost_control:
+        error_mode: ignore
+        metric_statements:
+          - context: datapoint
+            statements:
+              - delete_key(attributes, "client.address")
+              - delete_key(resource.attributes, "client.address")
+              - delete_key(attributes, "cloud.platform")
+              - delete_key(resource.attributes, "cloud.platform")
+              - delete_key(attributes, "cloud.provider")
+              - delete_key(resource.attributes, "cloud.provider")
+              - delete_key(attributes, "host.id")
+              - delete_key(resource.attributes, "host.id")
+              - delete_key(attributes, "host.name")
+              - delete_key(resource.attributes, "host.name")
+              - delete_key(attributes, "http.url")
+              - delete_key(resource.attributes, "http.url")
+              - delete_key(attributes, "k8s.container.name")
+              - delete_key(resource.attributes, "k8s.container.name")
+              - delete_key(attributes, "k8s.pod.ip")
+              - delete_key(resource.attributes, "k8s.pod.ip")
+              - delete_key(attributes, "k8s.pod.name")
+              - delete_key(resource.attributes, "k8s.pod.name")
+              - delete_key(attributes, "k8s.pod.uid")
+              - delete_key(resource.attributes, "k8s.pod.uid")
+              - delete_key(attributes, "k8s.node.name")
+              - delete_key(resource.attributes, "k8s.node.name")
+              - delete_key(attributes, "network.local.address")
+              - delete_key(resource.attributes, "network.local.address")
+              - delete_key(attributes, "network.local.port")
+              - delete_key(resource.attributes, "network.local.port")
+              - delete_key(attributes, "network.peer.address")
+              - delete_key(resource.attributes, "network.peer.address")
+              - delete_key(attributes, "network.peer.port")
+              - delete_key(resource.attributes, "network.peer.port")
+              - delete_key(attributes, "process.pid")
+              - delete_key(resource.attributes, "process.pid")
+              - delete_key(attributes, "server.address")
+              - delete_key(resource.attributes, "server.address")
+              - delete_key(attributes, "server.port")
+              - delete_key(resource.attributes, "server.port")
+              - delete_key(attributes, "service.instance.id")
+              - delete_key(resource.attributes, "service.instance.id")
+              - delete_key(attributes, "url.full")
+              - delete_key(resource.attributes, "url.full")
+              - delete_key(attributes, "url.scheme")
+              - delete_key(resource.attributes, "url.scheme")
+              - delete_key(attributes, "user_agent.original")
+              - delete_key(resource.attributes, "user_agent.original")
       tail_sampling:
         decision_wait: 40s
         num_traces: 50000

--- a/infra/observability/runtime/overlay/patches/gateway-config.yaml
+++ b/infra/observability/runtime/overlay/patches/gateway-config.yaml
@@ -47,11 +47,11 @@ spec:
           exporters: [routing/metrics]
         metrics/control_plane:
           receivers: [routing/metrics]
-          processors: [batch]
+          processors: [filter/metrics_allowlist, cumulativetodelta/metrics, transform/metrics_cost_control, batch]
           exporters: [azuremonitor/control_plane]
         metrics/data_plane:
           receivers: [routing/metrics]
-          processors: [batch]
+          processors: [filter/metrics_allowlist, cumulativetodelta/metrics, transform/metrics_cost_control, batch]
           exporters: [azuremonitor/data_plane]
         logs/in:
           receivers: [otlp]

--- a/infra/observability/studio/overlay/patches/gateway-config.yaml
+++ b/infra/observability/studio/overlay/patches/gateway-config.yaml
@@ -17,7 +17,7 @@ spec:
           exporters: [azuremonitor]
         metrics:
           receivers: [otlp]
-          processors: [batch]
+          processors: [filter/metrics_allowlist, cumulativetodelta/metrics, transform/metrics_cost_control, batch]
           exporters: [azuremonitor]
         logs:
           receivers: [otlp]


### PR DESCRIPTION
## Description

`AppMetrics` is now the largest cost on the Studio side, and Azure Monitor doesnt handle cumulative "temporality preference", so adding processor for this. 

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented metric filtering to focus on relevant system data sources and reduce noise.
  * Enhanced data sanitisation removes sensitive and unnecessary attributes from observability metrics to protect privacy.
  * Added metric normalisation for improved consistency across analytics platforms.

* **Improvements**
  * Optimised metrics processing pipeline for improved efficiency and reduced data transmission volume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->