### PR TITLE
chore: otel - more aggressive metric filtering

### DIFF
--- a/infra/observability/base/gateway.yaml
+++ b/infra/observability/base/gateway.yaml
@@ -60,7 +60,7 @@ spec:
           include:
             match_type: regexp
             metric_names:
-              - '^(altinn|http|dotnet|go)([._].*)?$'
+              - '^(altinn|http)([._].*)?$'
       cumulativetodelta/metrics:
         include:
           metric_types: [sum, histogram, exponentialhistogram]


### PR DESCRIPTION
## Description

since we are cost focused and don't use them right now.
After looking at results from

```
let lookback = 7d;
AppMetrics
| where TimeGenerated >= ago(lookback)
| where isnotempty(Name)
| summarize IngestGB = round(sum(toreal(_BilledSize)) / 1024.0 / 1024.0 / 1024.0, 3), Rows = count() by Name
| order by IngestGB desc
```

Go metrics were pretty large

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metrics filtering configuration to adjust which metric types are collected during trace processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->