### PR TITLE
chore: kubernetes-wrapper - add OTel

### DIFF
--- a/src/Runtime/kubernetes-wrapper/Directory.Packages.props
+++ b/src/Runtime/kubernetes-wrapper/Directory.Packages.props
@@ -6,6 +6,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="KubernetesClient" Version="18.0.13" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.2" />
 
     <!-- Static analysis, formatting -->

--- a/src/Runtime/kubernetes-wrapper/src/Altinn.Studio.KubernetesWrapper.csproj
+++ b/src/Runtime/kubernetes-wrapper/src/Altinn.Studio.KubernetesWrapper.csproj
@@ -8,6 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="KubernetesClient" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 

--- a/src/Runtime/kubernetes-wrapper/src/Hosting/OpenTelemetryExtensions.cs
+++ b/src/Runtime/kubernetes-wrapper/src/Hosting/OpenTelemetryExtensions.cs
@@ -1,0 +1,44 @@
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Altinn.Studio.KubernetesWrapper.Hosting;
+
+internal static class OpenTelemetryExtensions
+{
+    public static WebApplicationBuilder AddOpenTelemetry(this WebApplicationBuilder builder)
+    {
+        builder
+            .Services.AddOpenTelemetry()
+            .WithTracing(tracing =>
+            {
+                tracing
+                    .AddAspNetCoreInstrumentation(options =>
+                    {
+                        options.RecordException = true;
+                        options.Filter = ctx =>
+                            !ctx.Request.Path.StartsWithSegments("/health", StringComparison.OrdinalIgnoreCase);
+                    })
+                    .AddHttpClientInstrumentation(options => options.RecordException = true)
+                    .AddOtlpExporter();
+            })
+            .WithMetrics(metrics =>
+            {
+                metrics
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation()
+                    .AddOtlpExporter();
+            });
+
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+            logging.ParseStateValues = true;
+            logging.AddOtlpExporter();
+        });
+
+        return builder;
+    }
+}

--- a/src/Runtime/kubernetes-wrapper/src/Program.cs
+++ b/src/Runtime/kubernetes-wrapper/src/Program.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Altinn.Studio.KubernetesWrapper.Hosting;
 using Altinn.Studio.KubernetesWrapper.Services.Implementation;
 using Altinn.Studio.KubernetesWrapper.Services.Interfaces;
 using Microsoft.OpenApi;
@@ -7,6 +8,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 var builder = WebApplication.CreateBuilder(args);
 
 RegisterServices(builder.Services);
+builder.AddOpenTelemetry();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Description

To get some visibility when we deploy this version

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added OpenTelemetry instrumentation packages (v1.15.0) to project dependencies.
  * Configured OpenTelemetry for application observability, enabling automatic tracing of web requests and external calls, runtime metrics collection, and structured logging with OpenTelemetry Protocol export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->