### PR TITLE
chore: group non-major deps for python and go

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,13 @@
       "minimumReleaseAge": null
     },
     {
+      "matchManagers": ["gomod", "pep621"],
+      "groupName": "{{manager}} non-major dependencies",
+      "matchPackageNames": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupSlug": "{{manager}}-minor-patch"
+    },
+    {
       "groupName": "LibGit2Sharp dependency",
       "groupSlug": "LibGit2Sharp",
       "matchPackageNames": ["LibGit2Sharp"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Our base [renovate.json](https://github.com/Altinn/renovate-config/blob/main/default.json) includes grouping for non-major dependencies for a bunch of managers, but not go or python. These generate a lot of individual PRs that could easily have been grouped.

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to consolidate non-major updates for Go modules and Python-based packages. Minor and patch updates will now be grouped together, streamlining the review and deployment process for routine dependency maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->