### PR TITLE
fix: normalize app hostname in integration test snapshots

### DIFF
--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=True_useNewEndpoint=False_0_UploadResponse.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=True_useNewEndpoint=False_0_UploadResponse.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>
       ],
       Transfer-Encoding: [
         chunked

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=True_useNewEndpoint=True_0_UploadResponse.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=True_useNewEndpoint=True_0_UploadResponse.verified.txt
@@ -79,7 +79,7 @@
       AppId: ttd/basic,
       Org: ttd,
       SelfLinks: {
-        Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+        Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
         Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
       },
       VisibleAfter: DateTime_1,
@@ -109,7 +109,7 @@
           ContentType: application/xml,
           BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
           SelfLinks: {
-            Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+            Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
             Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
           },
           Size: 146,
@@ -128,7 +128,7 @@
           ContentType: application/pdf,
           BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
           SelfLinks: {
-            Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+            Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
             Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
           },
           Size: 25,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=MultipartNoPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=MultipartNoPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -68,7 +68,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -97,7 +97,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 146,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=MultipartNoPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=MultipartNoPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -88,7 +88,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -107,7 +107,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=MultipartXmlPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=MultipartXmlPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -68,7 +68,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -97,7 +97,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=MultipartXmlPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=MultipartXmlPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -88,7 +88,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -107,7 +107,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -106,7 +106,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 146,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedNoPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedNoPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -88,7 +88,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -107,7 +107,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -106,7 +106,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedWithPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedWithPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -88,7 +88,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -107,7 +107,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=MultipartNoPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=MultipartNoPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -68,7 +68,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -98,7 +98,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 146,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=MultipartNoPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=MultipartNoPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -89,7 +89,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -108,7 +108,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=MultipartXmlPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=MultipartXmlPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -68,7 +68,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -98,7 +98,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=MultipartXmlPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=MultipartXmlPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -89,7 +89,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -108,7 +108,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -107,7 +107,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 146,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedNoPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedNoPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -89,7 +89,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -108,7 +108,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -107,7 +107,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedWithPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedWithPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -89,7 +89,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -108,7 +108,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -68,7 +68,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -97,7 +97,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 146,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -88,7 +88,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -107,7 +107,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -68,7 +68,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -97,7 +97,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -88,7 +88,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -107,7 +107,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -106,7 +106,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 146,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -88,7 +88,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -107,7 +107,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -106,7 +106,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -88,7 +88,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -107,7 +107,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -68,7 +68,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -98,7 +98,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 146,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -89,7 +89,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -108,7 +108,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -68,7 +68,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -98,7 +98,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -89,7 +89,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -108,7 +108,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -107,7 +107,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 146,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -89,7 +89,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -108,7 +108,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -107,7 +107,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_4_Download-Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_4_Download-Instance.verified.txt
@@ -64,7 +64,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -89,7 +89,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: {Scrubbed},
@@ -108,7 +108,7 @@
         ContentType: application/pdf,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
         },
         Size: {Scrubbed},

--- a/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=ServiceOwner_scope=custom-serviceowner-instances.read-custom-serviceowner-instances.write_1_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=ServiceOwner_scope=custom-serviceowner-instances.read-custom-serviceowner-instances.write_1_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -106,7 +106,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=SystemUser_scope=custom-instances.read-custom-instances.write_1_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=SystemUser_scope=custom-instances.read-custom-instances.write_1_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -107,7 +107,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=User_scope=altinn-portal-enduser_1_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=User_scope=altinn-portal-enduser_1_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -107,7 +107,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=User_scope=custom-instances.read-custom-instances.write_1_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=User_scope=custom-instances.read-custom-instances.write_1_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -107,7 +107,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesWithPlaceholderTests.Full_auth=ServiceOwner_scope=custom-basic-serviceowner-instances.read-custom-basic-serviceowner-instances.write_1_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesWithPlaceholderTests.Full_auth=ServiceOwner_scope=custom-basic-serviceowner-instances.read-custom-basic-serviceowner-instances.write_1_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -106,7 +106,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesWithPlaceholderTests.Full_auth=SystemUser_scope=custom-basic-instances.read-custom-basic-instances.write_1_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesWithPlaceholderTests.Full_auth=SystemUser_scope=custom-basic-instances.read-custom-basic-instances.write_1_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -107,7 +107,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesWithPlaceholderTests.Full_auth=User_scope=custom-basic-instances.read-custom-basic-instances.write_1_Instantiation.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesWithPlaceholderTests.Full_auth=User_scope=custom-basic-instances.read-custom-basic-instances.write_1_Instantiation.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/501337/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -107,7 +107,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 200,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.Instantiate_partyId=500002_0_Instance.verified.txt
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.Instantiate_partyId=500002_0_Instance.verified.txt
@@ -19,7 +19,7 @@
         no-store, no-cache
       ],
       Location: [
-        https://app:5005/ttd/basic/instances/500002/<instanceGuid>
+        https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/500002/<instanceGuid>
       ],
       Transfer-Encoding: [
         chunked
@@ -77,7 +77,7 @@
     AppId: ttd/basic,
     Org: ttd,
     SelfLinks: {
-      Apps: https://app:5005/ttd/basic/instances/500002/<instanceGuid>,
+      Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/500002/<instanceGuid>,
       Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/500002/<instanceGuid>
     },
     VisibleAfter: DateTime_1,
@@ -107,7 +107,7 @@
         ContentType: application/xml,
         BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
         SelfLinks: {
-          Apps: https://app:5005/ttd/basic/instances/500002/<instanceGuid>/data/<dataElementId[0]>,
+          Apps: https://local.altinn.cloud:<localtestPort>/ttd/basic/instances/500002/<instanceGuid>/data/<dataElementId[0]>,
           Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/500002/<instanceGuid>/data/<dataElementId[0]>
         },
         Size: 146,

--- a/src/App/backend/test/Altinn.App.Integration.Tests/_fixture/AppFixture.ApiResponse.cs
+++ b/src/App/backend/test/Altinn.App.Integration.Tests/_fixture/AppFixture.ApiResponse.cs
@@ -120,6 +120,14 @@ public sealed partial class AppFixture
         }
     }
 
+    private static string NormalizeAppHost(string value)
+    {
+        // The app container may respond with either the internal Docker hostname (app:5005)
+        // or the forwarded host header (local.altinn.cloud:<port>) depending on platform
+        // and proxy configuration. Normalize to the forwarded host form for consistency.
+        return value.Replace($"{AppHostname}:{AppPort}", $"local.altinn.cloud:<localtestPort>");
+    }
+
     private sealed class StringConverter(string _appPort, string _localtestPort, Scrubbers? _scrubbers)
         : WriteOnlyJsonConverter<string>
     {
@@ -129,6 +137,7 @@ public sealed partial class AppFixture
                 value = scrubber(value);
             value = value.Replace(_appPort, "<appPort>");
             value = value.Replace(_localtestPort, "<localtestPort>");
+            value = NormalizeAppHost(value);
             writer.WriteValue(value);
         }
     }
@@ -177,6 +186,7 @@ public sealed partial class AppFixture
                                 v = scrubber(v);
                             v = v.Replace(_appPort, "<appPort>");
                             v = v.Replace(_localtestPort, "<localtestPort>");
+                            v = NormalizeAppHost(v);
                             writer.WriteValue(v);
                         }
                         writer.WriteEndArray();
@@ -197,6 +207,7 @@ public sealed partial class AppFixture
                 uri = scrubber(uri);
             uri = uri.Replace(_appPort, "<appPort>");
             uri = uri.Replace(_localtestPort, "<localtestPort>");
+            uri = NormalizeAppHost(uri);
             writer.WriteValue(uri);
         }
     }


### PR DESCRIPTION
## Summary
- After the YARP migration (#17839), the localtest proxy forwards the original `Host` header to the app container, causing it to generate URLs with `local.altinn.cloud:<port>` instead of `app:5005`
- Due to Docker networking differences between macOS and Linux, the behavior is inconsistent across platforms, breaking snapshot tests on Ubuntu CI
- Adds `NormalizeAppHost()` to the snapshot converters to replace the internal Docker hostname (`app:5005`) with the forwarded host form (`local.altinn.cloud:<localtestPort>`) for consistent snapshots across platforms

## Test plan
- [x] Integration tests pass locally (53 passed, 1 skipped)
- [ ] CI passes on Ubuntu
- [ ] CI passes on macOS

cc @martinothamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration to use local test endpoints instead of the previous app host references, ensuring test snapshots and validation reflect the current testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->