### PR TITLE
fix: Endringer i hjelpetekstene til komponentene

### DIFF
--- a/src/Designer/frontend/language/src/nb.json
+++ b/src/Designer/frontend/language/src/nb.json
@@ -1610,7 +1610,7 @@
   "ux_editor.component_help_text.Panel": "Bruk denne komponenten til å vise brukerne en melding med viktig informasjon.",
   "ux_editor.component_help_text.Paragraph": "Bruk Avsnitt til å sette opp tekstblokker i appen. Hver avsnitt har en ledetekst, som du kan bruke til å lage gode mellomtitler.",
   "ux_editor.component_help_text.PaymentDetails": "Viser en beskrivelse, antall og pris for det som betales.",
-  "ux_editor.component_help_text.PersonLookup": "Med Finn person kan brukerne søke etter person i folkeregisteret.",
+  "ux_editor.component_help_text.PersonLookup": "Med Finn person kan brukerne søke etter en person i folkeregisteret.",
   "ux_editor.component_help_text.PrintButton": "Knapp for å starte utskrift av siden fra nettleseren.",
   "ux_editor.component_help_text.RadioButtons": "Bruk radioknapper når du vil at brukerne bare skal velge ett av alternativene.",
   "ux_editor.component_help_text.RepeatingGroup": "Gir mulighet til å repetere felter som oppfattes som en gruppe, for eksempel feltene for navn, telefonnummer og adresse.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Issue: https://github.com/Altinn/altinn-studio/issues/17124
## Description
Har fikset:
✅ Vedlegg
✅ Send inn
✅ Finn virksomhet
✅ Finn person
✅Informativ melding: (endret til melding)
✅Informasjon om eksemplaret (endret hjelpeteksten til instans med eksemplar i parantes. Tittelen på komponenten er den samme)
✅ Bilde
✅ Navigasjonsknapper
🛑 start eksemplar (står som før)
✅ Vedlegg med merking
✅ Gruppe
🛑 Knappegruppe (står som før)

Spørsmål: Hva er forskjellen på hvordan vi bruker felter i komponenten Gruppe og i Repeterende gruppe? Kanskje legge inn et godt eksempel i den som heter Gruppe, hvis disse to brukes til forskjellige ting. (uvisst)

✅ Stedfeste i kart: Endret kun hjeloptekst (skulle komponenten endres?)
🛑Egendefinert (fant ikke komponenten i koden 😅)

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Norwegian user-facing text for clarity, consistency and grammar.
  * Harmonised punctuation (added trailing periods) and capitalization across help texts, tooltips and labels.
  * Refined wording for components such as map (“Stedfeste i kart”), panel (“Informativ melding”), file upload, person lookup, navigation and print to better reflect Norwegian terminology and improve usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->