### PR TITLE
chore: pdf3 - localetest faster shutdown

### DIFF
--- a/src/Runtime/pdf3/internal/config/config.go
+++ b/src/Runtime/pdf3/internal/config/config.go
@@ -11,6 +11,10 @@ import (
 
 var logger = log.NewComponent("config")
 
+const (
+	EnvironmentLocaltest = "localtest"
+)
+
 type Config struct {
 	Environment string
 
@@ -72,7 +76,7 @@ type HostParameters struct {
 // ResolveHostParametersForEnvironment returns appropriate host parameters based on environment.
 // Localtest uses zero timeouts for fast restarts, production uses full graceful shutdown periods.
 func ResolveHostParametersForEnvironment(environment string) HostParameters {
-	if environment == "localtest" {
+	if environment == EnvironmentLocaltest {
 		// Minimal delays for local development - fast restarts
 		return HostParameters{
 			ReadinessDrainDelay: 0,
@@ -86,4 +90,13 @@ func ResolveHostParametersForEnvironment(environment string) HostParameters {
 		ShutdownPeriod:      45 * time.Second,
 		ShutdownHardPeriod:  3 * time.Second,
 	}
+}
+
+// ResolveTelemetryShutdownTimeoutForEnvironment returns how long to wait for OTel shutdown flush.
+// Localtest skips graceful flush to prioritize fast restarts.
+func ResolveTelemetryShutdownTimeoutForEnvironment(environment string) time.Duration {
+	if environment == EnvironmentLocaltest {
+		return 0
+	}
+	return 5 * time.Second
 }


### PR DESCRIPTION
## Description

regression on this when we introduced otel, it now spends 5s trying to flush, which can block during localtest

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimised application shutdown flow with environment-specific telemetry timeout configuration. Local testing environments now skip graceful telemetry flush for faster shutdown during development and testing cycles. Production and other environments continue to maintain a 5-second graceful shutdown timeout, ensuring complete telemetry data transmission before application termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->