### PR TITLE
chore: pdf3 - handle 429 worker spans as 299 instead

### DIFF
--- a/infra/observability/base/gateway.yaml
+++ b/infra/observability/base/gateway.yaml
@@ -54,6 +54,17 @@ spec:
               - set(span.attributes["http.host"], resource.attributes["service.name"]) where resource.attributes["linkerd.io/proxy-deployment"] != nil
               - set(span.attributes["http.target"], resource.attributes["service.name"]) where resource.attributes["linkerd.io/proxy-deployment"] != nil
               - set(span.attributes["server.address"], resource.attributes["service.name"]) where resource.attributes["linkerd.io/proxy-deployment"] != nil
+      transform/pdf3_expected_429_success:
+        error_mode: ignore
+        trace_statements:
+          - context: span
+            statements:
+              # Queue-full retries are expected in pdf3 worker. Re-map 429 to 299 so
+              # Azure Monitor request success stays true, while retaining original code.
+              - set(span.attributes["altinn.original_http.response.status_code"], span.attributes["http.response.status_code"]) where resource.attributes["service.name"] == "pdf3-worker" and name == "POST /generate" and span.attributes["http.response.status_code"] == 429
+              - set(span.attributes["altinn.original_http.status_code"], span.attributes["http.status_code"]) where resource.attributes["service.name"] == "pdf3-worker" and name == "POST /generate" and span.attributes["http.status_code"] == 429
+              - set(span.attributes["http.response.status_code"], 299) where resource.attributes["service.name"] == "pdf3-worker" and name == "POST /generate" and span.attributes["http.response.status_code"] == 429
+              - set(span.attributes["http.status_code"], 299) where resource.attributes["service.name"] == "pdf3-worker" and name == "POST /generate" and span.attributes["http.status_code"] == 429
       filter/metrics_allowlist:
         error_mode: ignore
         metrics:

--- a/infra/observability/runtime/overlay/patches/gateway-config.yaml
+++ b/infra/observability/runtime/overlay/patches/gateway-config.yaml
@@ -36,11 +36,11 @@ spec:
           exporters: [routing/traces]
         traces/control_plane:
           receivers: [routing/traces]
-          processors: [transform/azuremonitor, tail_sampling, batch]
+          processors: [transform/azuremonitor, transform/pdf3_expected_429_success, tail_sampling, batch]
           exporters: [azuremonitor/control_plane]
         traces/data_plane:
           receivers: [routing/traces]
-          processors: [transform/azuremonitor, tail_sampling, batch]
+          processors: [transform/azuremonitor, transform/pdf3_expected_429_success, tail_sampling, batch]
           exporters: [azuremonitor/data_plane]
         metrics/in:
           receivers: [otlp]


### PR DESCRIPTION
## Description

Ive had a previous attempt at this in #17790 - but apparantly there is Azure Monitor specific mapping in the azuremonitorexporter that treats 429 as error ("Successful request" = false), so with this change we just remap it entirely and add the original as alternate attribute

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error tracking and monitoring infrastructure for rate-limited requests to improve platform observability and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->