### PR TITLE
fix: designer - inactivity undeploy jobs handle optional jobdata, improve tracing

### DIFF
--- a/src/Designer/backend/src/Designer/Scheduling/AppInactivityUndeployJob.cs
+++ b/src/Designer/backend/src/Designer/Scheduling/AppInactivityUndeployJob.cs
@@ -62,6 +62,7 @@ public class AppInactivityUndeployJob : IJob
             )
         {
             activity?.SetStatus(ActivityStatusCode.Error, "Job timed out.");
+            activity?.AddException(ex);
             activity?.AddEvent(
                 new ActivityEvent(
                     "job_timeout",

--- a/src/Designer/backend/src/Designer/Scheduling/JobDataMapExtensions.cs
+++ b/src/Designer/backend/src/Designer/Scheduling/JobDataMapExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using Quartz;
+
+namespace Altinn.Studio.Designer.Scheduling;
+
+internal static class JobDataMapExtensions
+{
+    public static string? GetOptionalString(this JobDataMap jobDataMap, string key)
+    {
+        ArgumentNullException.ThrowIfNull(jobDataMap);
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(key));
+        }
+
+        if (!jobDataMap.TryGetValue(key, out var value) || value is null)
+        {
+            return null;
+        }
+
+        return value as string ?? value.ToString();
+    }
+
+    public static string GetRequiredString(this JobDataMap jobDataMap, string key)
+    {
+        var value = jobDataMap.GetOptionalString(key);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"Missing required Quartz job data key '{key}'.");
+        }
+
+        return value;
+    }
+}

--- a/src/Designer/backend/tests/Designer.Tests/Scheduling/AppInactivityUndeployPerOrgJobTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Scheduling/AppInactivityUndeployPerOrgJobTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.Studio.Designer.Configuration;
+using Altinn.Studio.Designer.Scheduling;
+using Altinn.Studio.Designer.Services.Interfaces;
+using Altinn.Studio.Designer.Services.Models;
+using Moq;
+using Quartz;
+using Xunit;
+
+namespace Designer.Tests.Scheduling;
+
+public class AppInactivityUndeployPerOrgJobTests
+{
+    [Fact]
+    public async Task Execute_WithoutEnvironmentFilter_ShouldPassNullToService()
+    {
+        var inactivityUndeployService = new Mock<IAppInactivityUndeployService>();
+        var jobQueue = new Mock<IAppInactivityUndeployJobQueue>();
+        var job = new AppInactivityUndeployPerOrgJob(
+            inactivityUndeployService.Object,
+            jobQueue.Object,
+            new SchedulingSettings()
+        );
+
+        inactivityUndeployService
+            .Setup(x =>
+                x.GetAppsForDecommissioningAsync(
+                    It.IsAny<InactivityUndeployEvaluationOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(Array.Empty<InactivityUndeployCandidate>());
+
+        var mergedJobDataMap = new JobDataMap { [AppInactivityUndeployJobConstants.JobDataOrgKey] = "ttd" };
+        var context = new Mock<IJobExecutionContext>();
+        context.Setup(c => c.CancellationToken).Returns(CancellationToken.None);
+        context.Setup(c => c.MergedJobDataMap).Returns(mergedJobDataMap);
+
+        await job.Execute(context.Object);
+
+        inactivityUndeployService.Verify(
+            x =>
+                x.GetAppsForDecommissioningAsync(
+                    It.Is<InactivityUndeployEvaluationOptions>(o => o.Org == "ttd" && o.Environment == null),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+        jobQueue.Verify(
+            x =>
+                x.QueuePerAppUndeployJobAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task Execute_WithoutOrg_ShouldThrowInvalidOperationException()
+    {
+        var inactivityUndeployService = new Mock<IAppInactivityUndeployService>();
+        var jobQueue = new Mock<IAppInactivityUndeployJobQueue>();
+        var job = new AppInactivityUndeployPerOrgJob(
+            inactivityUndeployService.Object,
+            jobQueue.Object,
+            new SchedulingSettings()
+        );
+
+        var context = new Mock<IJobExecutionContext>();
+        context.Setup(c => c.CancellationToken).Returns(CancellationToken.None);
+        context.Setup(c => c.MergedJobDataMap).Returns(new JobDataMap());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => job.Execute(context.Object));
+
+        Assert.Contains(AppInactivityUndeployJobConstants.JobDataOrgKey, exception.Message);
+        inactivityUndeployService.Verify(
+            x =>
+                x.GetAppsForDecommissioningAsync(
+                    It.IsAny<InactivityUndeployEvaluationOptions>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+    }
+}


### PR DESCRIPTION

## Description

Wasnt immediately obvious in App Insights, but there were some error logs tonight

```
  System.Collections.Generic.KeyNotFoundException: Key environment_filter not found
     at Quartz.Util.StringKeyDirtyFlagMap.GetString(String key)
     at Altinn.Studio.Designer.Scheduling.AppInactivityUndeployPerOrgJob.Execute(IJobExecutionContext context)
     at Quartz.Core.JobRunShell.Run(CancellationToken cancellationToken)
```

So this change
* handle optional jobdata, moves retrieval inside try catch
* start of activities/spans to start of methods
* make sure we `AddException` relevant places

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced monitoring and error tracking for deployment and scheduling operations with improved telemetry logging.
  * Strengthened timeout handling and error reporting to provide better visibility into system behaviour.
  * Improved validation of configuration parameters for more reliable job execution.

* **Tests**
  * Added comprehensive test coverage for scheduling operations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->