### PR TITLE
fix: correct routing between pdf and app across all localtest harnesses

### DIFF
--- a/src/Runtime/localtest/docker-compose.yml
+++ b/src/Runtime/localtest/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - TZ=Europe/Oslo
       - PDF3_ENVIRONMENT=localtest
       - PDF3_QUEUE_SIZE=3
+      - PDF3_LOCALTEST_PUBLIC_BASE_URL=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-80}
     extra_hosts:
       - '${TEST_DOMAIN:-local.altinn.cloud}:host-gateway'
       - 'host.containers.internal:host-gateway'

--- a/src/Runtime/localtest/podman-compose.yml
+++ b/src/Runtime/localtest/podman-compose.yml
@@ -20,6 +20,7 @@ services:
       - TZ=Europe/Oslo
       - PDF3_ENVIRONMENT=localtest
       - PDF3_QUEUE_SIZE=3
+      - PDF3_LOCALTEST_PUBLIC_BASE_URL=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-8000}
 
   altinn_localtest:
     container_name: localtest

--- a/src/Runtime/pdf3/cmd/worker/localtest_url_test.go
+++ b/src/Runtime/pdf3/cmd/worker/localtest_url_test.go
@@ -1,0 +1,81 @@
+package main
+
+import "testing"
+
+func TestNormalizeLocaltestURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		requestURL       string
+		localtestBaseURL string
+		wantURL          string
+		wantReason       string
+		wantErr          bool
+	}{
+		{
+			name:             "no configured base url leaves request unchanged",
+			requestURL:       "http://local.altinn.cloud/ttd/app/instance",
+			localtestBaseURL: "",
+			wantURL:          "http://local.altinn.cloud/ttd/app/instance",
+		},
+		{
+			name:             "non matching host leaves request unchanged",
+			requestURL:       "http://example.com/ttd/app/instance",
+			localtestBaseURL: "http://local.altinn.cloud:8000",
+			wantURL:          "http://example.com/ttd/app/instance",
+		},
+		{
+			name:             "missing port is rewritten to canonical",
+			requestURL:       "http://local.altinn.cloud/ttd/app/instance?x=1#frag",
+			localtestBaseURL: "http://local.altinn.cloud:8000",
+			wantURL:          "http://local.altinn.cloud:8000/ttd/app/instance?x=1#frag",
+			wantReason:       "missing_port",
+		},
+		{
+			name:             "port mismatch is rewritten to canonical",
+			requestURL:       "http://local.altinn.cloud:80/ttd/app/instance",
+			localtestBaseURL: "http://local.altinn.cloud:8000",
+			wantURL:          "http://local.altinn.cloud:8000/ttd/app/instance",
+			wantReason:       "port_mismatch",
+		},
+		{
+			name:             "scheme mismatch is rewritten to canonical",
+			requestURL:       "https://local.altinn.cloud:8000/ttd/app/instance",
+			localtestBaseURL: "http://local.altinn.cloud:8000",
+			wantURL:          "http://local.altinn.cloud:8000/ttd/app/instance",
+			wantReason:       "scheme_mismatch",
+		},
+		{
+			name:             "invalid canonical base returns error",
+			requestURL:       "http://local.altinn.cloud/ttd/app/instance",
+			localtestBaseURL: "://bad",
+			wantURL:          "http://local.altinn.cloud/ttd/app/instance",
+			wantErr:          true,
+		},
+		{
+			name:             "invalid request url returns error",
+			requestURL:       "://bad",
+			localtestBaseURL: "http://local.altinn.cloud:8000",
+			wantURL:          "://bad",
+			wantErr:          true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotURL, gotReason, err := normalizeLocaltestURL(tc.requestURL, tc.localtestBaseURL)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("normalizeLocaltestURL() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if gotURL != tc.wantURL {
+				t.Fatalf("normalizeLocaltestURL() url = %q, want %q", gotURL, tc.wantURL)
+			}
+			if gotReason != tc.wantReason {
+				t.Fatalf("normalizeLocaltestURL() reason = %q, want %q", gotReason, tc.wantReason)
+			}
+		})
+	}
+}

--- a/src/Runtime/pdf3/internal/config/config.go
+++ b/src/Runtime/pdf3/internal/config/config.go
@@ -14,6 +14,8 @@ var logger = log.NewComponent("config")
 const (
 	// EnvironmentLocaltest identifies localtest execution mode.
 	EnvironmentLocaltest = "localtest"
+	// LocaltestPublicBaseURLEnv provides the canonical public base URL used for localtest URL rewriting.
+	LocaltestPublicBaseURLEnv = "PDF3_LOCALTEST_PUBLIC_BASE_URL"
 )
 
 type Config struct {
@@ -21,6 +23,7 @@ type Config struct {
 
 	QueueSize              int
 	BrowserRestartInterval time.Duration
+	LocaltestPublicBaseURL string
 }
 
 func ReadConfig() *Config {
@@ -64,6 +67,7 @@ func ReadConfig() *Config {
 		Environment:            environment,
 		QueueSize:              queueSize,
 		BrowserRestartInterval: browserRestartInterval,
+		LocaltestPublicBaseURL: os.Getenv(LocaltestPublicBaseURLEnv),
 	}
 }
 

--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- PDF connectivity when running `env localtest` (#17959)
+- Handle partial "up" state in `env up` (#17959)
+
 ## [0.1.0-preview.1] - 2026-02-25
 
 ### Added

--- a/src/cli/internal/cmd/env/localtest/env.go
+++ b/src/cli/internal/cmd/env/localtest/env.go
@@ -143,6 +143,7 @@ func (e *Env) Status(ctx context.Context) (*Status, error) {
 		state, err := e.client.ContainerState(ctx, name)
 		if err != nil {
 			if errors.Is(err, containertypes.ErrContainerNotFound) {
+				status.Containers = append(status.Containers, newContainerStatus(name, "not found"))
 				continue
 			}
 			return nil, fmt.Errorf("get state for container %q: %w", name, err)
@@ -156,6 +157,7 @@ func (e *Env) Status(ctx context.Context) (*Status, error) {
 		}
 	}
 	status.Running = runningCoreContainers == len(containers)
+	status.AnyRunning = runningCoreContainers > 0
 
 	return &status, nil
 }

--- a/src/cli/internal/cmd/env/localtest/env_test.go
+++ b/src/cli/internal/cmd/env/localtest/env_test.go
@@ -20,32 +20,37 @@ func TestStatus_RunningRequiresAllCoreContainers(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		states      map[string]types.ContainerState
-		wantRunning bool
+		states         map[string]types.ContainerState
+		wantRunning    bool
+		wantAnyRunning bool
 	}{
 		"all core containers running": {
 			states: map[string]types.ContainerState{
 				localtest.ContainerLocaltest: {Status: "running", Running: true},
 				localtest.ContainerPDF3:      {Status: "running", Running: true},
 			},
-			wantRunning: true,
+			wantRunning:    true,
+			wantAnyRunning: true,
 		},
 		"one running one exited": {
 			states: map[string]types.ContainerState{
 				localtest.ContainerLocaltest: {Status: "running", Running: true},
 				localtest.ContainerPDF3:      {Status: "exited", Running: false},
 			},
-			wantRunning: false,
+			wantRunning:    false,
+			wantAnyRunning: true,
 		},
 		"one running one missing": {
 			states: map[string]types.ContainerState{
 				localtest.ContainerLocaltest: {Status: "running", Running: true},
 			},
-			wantRunning: false,
+			wantRunning:    false,
+			wantAnyRunning: true,
 		},
 		"none running": {
-			states:      map[string]types.ContainerState{},
-			wantRunning: false,
+			states:         map[string]types.ContainerState{},
+			wantRunning:    false,
+			wantAnyRunning: false,
 		},
 	}
 
@@ -69,6 +74,9 @@ func TestStatus_RunningRequiresAllCoreContainers(t *testing.T) {
 			}
 			if status.Running != tt.wantRunning {
 				t.Fatalf("Status().Running = %v, want %v", status.Running, tt.wantRunning)
+			}
+			if status.AnyRunning != tt.wantAnyRunning {
+				t.Fatalf("Status().AnyRunning = %v, want %v", status.AnyRunning, tt.wantAnyRunning)
 			}
 		})
 	}

--- a/src/cli/internal/cmd/env/localtest/resources.go
+++ b/src/cli/internal/cmd/env/localtest/resources.go
@@ -36,7 +36,7 @@ var ErrInvalidResourceLayout = errors.New("invalid localtest resource layout")
 // RuntimeConfig holds runtime-specific configuration for localtest.
 type RuntimeConfig struct {
 	HostGateway      string                        // resolved host gateway IP (e.g., "172.17.0.1")
-	LoadBalancerPort string                        // port for localtest (default: "80" for Docker, "8000" for Podman)
+	LoadBalancerPort string                        // port for localtest (default: "8000")
 	User             string                        // "uid:gid" to run containers as (prevents root-owned bind mount files)
 	Installation     container.RuntimeInstallation // container runtime installation type
 }
@@ -62,6 +62,7 @@ type ContainerStatus struct {
 type Status struct {
 	Containers []ContainerStatus `json:"containers"`
 	Running    bool              `json:"running"`
+	AnyRunning bool              `json:"anyRunning"`
 }
 
 func newPort(hostPort, containerPort string) types.PortMapping {
@@ -103,6 +104,7 @@ func newStatus() Status {
 	return Status{
 		Containers: []ContainerStatus{},
 		Running:    false,
+		AnyRunning: false,
 	}
 }
 
@@ -146,9 +148,10 @@ func coreContainers(dataDir string, cfg RuntimeConfig) []ContainerSpec {
 			ContainerPDF3,
 			[]types.PortMapping{newPort("5300", "5031")},
 			map[string]string{
-				"TZ":               "Europe/Oslo",
-				"PDF3_ENVIRONMENT": "localtest",
-				"PDF3_QUEUE_SIZE":  "3",
+				"TZ":                             "Europe/Oslo",
+				"PDF3_ENVIRONMENT":               "localtest",
+				"PDF3_QUEUE_SIZE":                "3",
+				"PDF3_LOCALTEST_PUBLIC_BASE_URL": "http://" + networking.LocalDomain + ":" + cfg.LoadBalancerPort,
 			},
 			nil,
 			extraHosts,

--- a/src/cli/internal/cmd/env/localtest/runtime_config_resolver.go
+++ b/src/cli/internal/cmd/env/localtest/runtime_config_resolver.go
@@ -12,7 +12,8 @@ import (
 	"altinn.studio/studioctl/internal/networking"
 )
 
-const defaultLoadBalancerPort = 8000
+// DefaultLoadBalancerPort is the default localtest load balancer port.
+const DefaultLoadBalancerPort = 8000
 
 type runtimeConfigResolver struct {
 	cfg    *config.Config
@@ -57,7 +58,7 @@ func (r *runtimeConfigResolver) Build(ctx context.Context, portFlag int) (Runtim
 
 func resolveLoadBalancerPort(portFlag int) int {
 	if portFlag == 0 {
-		return defaultLoadBalancerPort
+		return DefaultLoadBalancerPort
 	}
 	return portFlag
 }


### PR DESCRIPTION
## Description

- let pdf3 automatically reroute to the correct port for local.altinn.cloud independent of localtest harness (cli, docker/podman compose)
- fix `studioctl env status` when env is only partially running

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic URL rewriting for the PDF service in localtest to handle scheme, host and port mismatches.
  * Localtest PDF handling now validates and applies a canonical public base URL when configured.

* **Bug Fixes / Improvements**
  * Improved localtest status reporting to distinguish fully running vs partially running states.

* **Chores**
  * Added environment variable for configuring the localtest public base URL.
  * Command help now shows a dynamic default port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->