### PR TITLE
chore: pdf3 - make localtest OTel export opt-in

### DIFF
--- a/src/Runtime/pdf3/internal/config/config.go
+++ b/src/Runtime/pdf3/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 var logger = log.NewComponent("config")
 
 const (
+	// EnvironmentLocaltest identifies localtest execution mode.
 	EnvironmentLocaltest = "localtest"
 )
 
@@ -64,6 +65,26 @@ func ReadConfig() *Config {
 		QueueSize:              queueSize,
 		BrowserRestartInterval: browserRestartInterval,
 	}
+}
+
+// ShouldConfigureOTel reports whether PDF3 should initialize OpenTelemetry exporters.
+// In localtest, exporters are opt-in to avoid noisy connection errors in default setup.
+func ShouldConfigureOTel(environment string) bool {
+	if environment != EnvironmentLocaltest {
+		return true
+	}
+
+	for _, key := range []string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+	} {
+		if val := os.Getenv(key); val != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 // HostParameters contains timeout values for runtime.NewHost

--- a/src/Runtime/pdf3/internal/config/config_test.go
+++ b/src/Runtime/pdf3/internal/config/config_test.go
@@ -1,0 +1,56 @@
+package config
+
+import "testing"
+
+func TestShouldConfigureOTel(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment string
+		endpoint    string
+		traces      string
+		metrics     string
+		want        bool
+	}{
+		{
+			name:        "non localtest always enabled",
+			environment: "production",
+			want:        true,
+		},
+		{
+			name:        "localtest disabled by default",
+			environment: EnvironmentLocaltest,
+			want:        false,
+		},
+		{
+			name:        "localtest enabled when generic endpoint is set",
+			environment: EnvironmentLocaltest,
+			endpoint:    "http://collector:4317",
+			want:        true,
+		},
+		{
+			name:        "localtest enabled when traces endpoint is set",
+			environment: EnvironmentLocaltest,
+			traces:      "http://collector-traces:4317",
+			want:        true,
+		},
+		{
+			name:        "localtest enabled when metrics endpoint is set",
+			environment: EnvironmentLocaltest,
+			metrics:     "http://collector-metrics:4317",
+			want:        true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", tc.endpoint)
+			t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", tc.traces)
+			t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", tc.metrics)
+
+			got := ShouldConfigureOTel(tc.environment)
+			if got != tc.want {
+				t.Fatalf("ShouldConfigureOTel() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Monitoring/OTel is opt in during localtest, OTel SDK for Go emits error/warning logs if it cant reach a OTLP exporter by default, so we conditionally enable OTLP export here based on environment and OTLP

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
