### PR TITLE
fix: fix save`homepage` and `keyword` to applicationMetadata

### DIFF
--- a/src/Designer/backend/src/Designer/Models/App/ApplicationMetadata.cs
+++ b/src/Designer/backend/src/Designer/Models/App/ApplicationMetadata.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.Studio.Designer.Enums;
+using Altinn.Studio.Designer.Models;
 
 namespace Altinn.Studio.Designer.Models.App;
 
@@ -15,6 +16,10 @@ public class ApplicationMetadata(string id) : Altinn.App.Core.Models.Application
     /// Overrides the base class property to initialize with null value
     /// </summary>
     public new string? AltinnNugetVersion { get; set; }
+
+    public string? Homepage { get; set; }
+
+    public List<Keyword>? Keywords { get; set; }
 
     public AppMetadataTranslatedString? Description { get; set; }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

CLOSES: #17944 


https://github.com/user-attachments/assets/464285b5-039d-4d46-81fb-390e28d6aa8d




## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Applications now support enhanced metadata capabilities, including new fields for homepage information and keywords. These additions enable improved organisation and better discoverability of your application details, allowing you to categorise and describe your applications more comprehensively whilst maintaining full control over your application information across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->