### PR TITLE
feat: default enable inactivity undeploy for new apps

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/RepositoryService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/RepositoryService.cs
@@ -39,6 +39,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
         // Using Norwegian name of initial page to be consistent
         // with automatic naming from frontend when adding new page
         private const string InitialLayout = "Side1";
+        private const bool DefaultUndeployOnInactivity = true;
 
         private readonly string _resourceIdentifierRegex = "^[a-z0-9_æøå-]*$";
 
@@ -51,6 +52,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
         private readonly IAltinnGitRepositoryFactory _altinnGitRepositoryFactory;
         private readonly IApplicationMetadataService _applicationMetadataService;
         private readonly ITextsService _textsService;
+        private readonly IAppSettingsService _appSettingsService;
         private readonly IResourceRegistry _resourceRegistryService;
         private readonly ICustomTemplateService _templateService;
         private readonly IAuthorizationPolicyService _authorizationPolicyService;
@@ -72,6 +74,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
         /// <param name="altinnGitRepositoryFactory">Factory class that knows how to create types of <see cref="AltinnGitRepository"/></param>
         /// <param name="applicationMetadataService">The service for handling the application metadata file</param>
         /// <param name="textsService">The service for handling texts</param>
+        /// <param name="appSettingsService">The service for handling app settings</param>
         /// <param name="resourceRegistryService">The service for publishing resource in the ResourceRegistry</param>
         /// <param name="templateService">The service for handling custom templates</param>
         /// <param name="authorizationPolicyService">The service for policy files</param>
@@ -85,6 +88,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             IAltinnGitRepositoryFactory altinnGitRepositoryFactory,
             IApplicationMetadataService applicationMetadataService,
             ITextsService textsService,
+            IAppSettingsService appSettingsService,
             IResourceRegistry resourceRegistryService,
             ICustomTemplateService templateService,
             IAuthorizationPolicyService authorizationPolicyService
@@ -99,6 +103,7 @@ namespace Altinn.Studio.Designer.Services.Implementation
             _altinnGitRepositoryFactory = altinnGitRepositoryFactory;
             _applicationMetadataService = applicationMetadataService;
             _textsService = textsService;
+            _appSettingsService = appSettingsService;
             _resourceRegistryService = resourceRegistryService;
             _templateService = templateService;
             _authorizationPolicyService = authorizationPolicyService;
@@ -307,6 +312,10 @@ namespace Altinn.Studio.Designer.Services.Implementation
                         Message = "App created",
                     };
                     _sourceControl.PushChangesForRepository(authenticatedContext, commitInfo);
+                    await _appSettingsService.UpsertAsync(
+                        AltinnRepoEditingContext.FromOrgRepoDeveloper(org, serviceConfig.RepositoryName, developer),
+                        DefaultUndeployOnInactivity
+                    );
                 }
                 catch (Exception)
                 {

--- a/src/Designer/backend/tests/Designer.Tests/Services/RepositoryServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/RepositoryServiceTests.cs
@@ -13,6 +13,7 @@ using Altinn.Studio.Designer.Configuration;
 using Altinn.Studio.Designer.Enums;
 using Altinn.Studio.Designer.Factories;
 using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Repository.Models.AppSettings;
 using Altinn.Studio.Designer.RepositoryClient.Model;
 using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
@@ -136,6 +137,67 @@ namespace Designer.Tests.Services
                 Thread.Sleep(400);
                 Directory.Delete(repositoryDirectory, true);
                 Directory.Delete(repositoryRemoteDirectory, true);
+            }
+        }
+
+        [Fact]
+        public async Task CreateRepository_DoesNotExists_ShouldEnableUndeployOnInactivityByDefault()
+        {
+            string org = "ttd";
+            string repositoryName = TestDataHelper.GenerateTestRepoName();
+            string developer = "testUser";
+
+            var repositoryDirectory = TestDataHelper.GetTestDataRepositoryDirectory(org, repositoryName, developer);
+            var repositoryRemoteDirectory = TestDataHelper.GetTestDataRemoteRepository(org, repositoryName);
+
+            Mock<IAppSettingsService> appSettingsServiceMock = new();
+            appSettingsServiceMock
+                .Setup(m =>
+                    m.UpsertAsync(
+                        It.IsAny<AltinnRepoEditingContext>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<string>(),
+                        It.IsAny<CancellationToken>()
+                    )
+                )
+                .ReturnsAsync(
+                    new AppSettingsEntity
+                    {
+                        Org = org,
+                        App = repositoryName,
+                        Environment = null,
+                        UndeployOnInactivity = true,
+                    }
+                );
+
+            var repositoryService = GetServiceForTest(developer, appSettingsServiceMock: appSettingsServiceMock.Object);
+
+            try
+            {
+                await repositoryService.CreateService(
+                    org,
+                    new ServiceConfiguration() { RepositoryName = repositoryName, ServiceName = repositoryName },
+                    []
+                );
+
+                appSettingsServiceMock.Verify(
+                    m =>
+                        m.UpsertAsync(
+                            It.Is<AltinnRepoEditingContext>(c =>
+                                c.Org == org && c.Repo == repositoryName && c.Developer == developer
+                            ),
+                            true,
+                            null,
+                            It.IsAny<CancellationToken>()
+                        ),
+                    Times.Once
+                );
+            }
+            finally
+            {
+                Thread.Sleep(400);
+                TestDataHelper.DeleteDirectory(repositoryDirectory);
+                TestDataHelper.DeleteDirectory(repositoryRemoteDirectory);
             }
         }
 
@@ -609,7 +671,8 @@ namespace Designer.Tests.Services
         private static RepositoryService GetServiceForTest(
             string developer,
             ISourceControl sourceControlMock = null,
-            ICustomTemplateService customTemplateServiceMock = null
+            ICustomTemplateService customTemplateServiceMock = null,
+            IAppSettingsService appSettingsServiceMock = null
         )
         {
             HttpContext ctx = GetHttpContextForTestUser(developer);
@@ -619,6 +682,7 @@ namespace Designer.Tests.Services
 
             sourceControlMock ??= new ISourceControlMock();
             customTemplateServiceMock ??= new Mock<ICustomTemplateService>().Object;
+            appSettingsServiceMock ??= new Mock<IAppSettingsService>().Object;
             string unitTestFolder = Path.GetDirectoryName(
                 new Uri(typeof(RepositoryServiceTests).Assembly.Location).LocalPath
             );
@@ -688,6 +752,7 @@ namespace Designer.Tests.Services
                 altinnGitRepositoryFactory,
                 applicationInformationService,
                 textsService,
+                appSettingsServiceMock,
                 resourceRegistryService,
                 customTemplateServiceMock,
                 authorizationPolicyServiceMock


### PR DESCRIPTION
## Description

Enables the new config for all apps, might be a little surprising? Shold be communicated. Could possibly also make it ttd-only.
app_settings and app_scopes are not copied as part of copying an app, not sure if that is unexpected

For https://github.com/Altinn/altinn-studio/issues/17719

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New applications created via the repository now have "undeploy on inactivity" enabled by default, helping automatically clean up inactive deployments and optimise resource usage.

* **Tests**
  * Added unit test coverage to verify undeploy-on-inactivity is enabled by default for newly created applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->