### PR TITLE
fix: operator - inactivity scaler pdf invalid 0 minReplicas

### DIFF
--- a/src/Runtime/operator/internal/controller/inactivityscaler/__snapshots__/controller_test.snap
+++ b/src/Runtime/operator/internal/controller/inactivityscaler/__snapshots__/controller_test.snap
@@ -234,7 +234,7 @@
   },
   "kind": "HorizontalPodAutoscaler",
   "managed": "true",
-  "minReplicas": 0,
+  "minReplicas": 1,
   "name": "pdf3-proxy-hpa",
   "namespace": "runtime-pdf3",
   "reconcile": "disabled"
@@ -251,7 +251,7 @@
   },
   "kind": "HorizontalPodAutoscaler",
   "managed": "true",
-  "minReplicas": 0,
+  "minReplicas": 1,
   "name": "pdf3-worker-hpa",
   "namespace": "runtime-pdf3",
   "reconcile": "disabled"
@@ -289,7 +289,7 @@
   },
   "kind": "HorizontalPodAutoscaler",
   "managed": "true",
-  "minReplicas": 0,
+  "minReplicas": 1,
   "name": "pdf3-proxy-hpa",
   "namespace": "runtime-pdf3",
   "reconcile": "disabled"
@@ -306,7 +306,7 @@
   },
   "kind": "HorizontalPodAutoscaler",
   "managed": "true",
-  "minReplicas": 0,
+  "minReplicas": 1,
   "name": "pdf3-worker-hpa",
   "namespace": "runtime-pdf3",
   "reconcile": "disabled"

--- a/src/Runtime/operator/internal/controller/inactivityscaler/controller.go
+++ b/src/Runtime/operator/internal/controller/inactivityscaler/controller.go
@@ -39,7 +39,6 @@ const (
 	pdf3ProxyHpaName      = "pdf3-proxy-hpa"
 	pdf3WorkerHpaName     = "pdf3-worker-hpa"
 
-	scaleDownReplicaZero    = int32(0)
 	scaleDownReplicaOne     = int32(1)
 	desiredWorkdayStartHour = 6
 	desiredWorkdayEndHour   = 18
@@ -67,8 +66,9 @@ var (
 // Scaling paths:
 // - normal: restore app deployments/HPAs, gateway, and pdf3 to baseline.
 // - ttd_offhours: scale apps/gateway/pdf3 to 1 outside workhours for targeted ttd environments.
-// - no_apps: keep gateway at 1 and scale pdf3 to 0 until an app deployment appears.
-// - ttd_offhours_no_apps: same as no_apps for pdf3 (0), while app/gateway logic follows offhours/no-app rules.
+// - no_apps: same as above for now.
+// - ttd_offhours_no_apps: same as above for now.
+// NOTE: we cant scale to 0 atm with HPA
 type clusterState string
 
 const (
@@ -86,15 +86,8 @@ func (s clusterState) scaleGateway() bool {
 	return s == stateTTDOffhours || s == stateNoApps || s == stateTTDOffhoursNoApps
 }
 
-func (s clusterState) pdf3ScaleTarget() (bool, int32) {
-	switch s {
-	case stateNoApps, stateTTDOffhoursNoApps:
-		return true, scaleDownReplicaZero
-	case stateTTDOffhours:
-		return true, scaleDownReplicaOne
-	default:
-		return false, scaleDownReplicaOne
-	}
+func (s clusterState) scalePdf3() bool {
+	return s == stateTTDOffhours || s == stateNoApps || s == stateTTDOffhoursNoApps
 }
 
 type optionalInt32 struct {
@@ -250,13 +243,12 @@ func (r *InactivityScalerReconciler) SyncAll(ctx context.Context) error {
 		span.SetStatus(codes.Error, "reconcile gateway")
 		return err
 	}
-	pdf3ShouldScale, pdf3Target := state.pdf3ScaleTarget()
-	if err := r.reconcileHpa(ctx, client.ObjectKey{Name: pdf3ProxyHpaName, Namespace: runtimePdf3Namespace}, pdf3ShouldScale, pdf3Target); err != nil {
+	if err := r.reconcileHpa(ctx, client.ObjectKey{Name: pdf3ProxyHpaName, Namespace: runtimePdf3Namespace}, state.scalePdf3(), scaleDownReplicaOne); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "reconcile pdf3-proxy")
 		return err
 	}
-	if err := r.reconcileHpa(ctx, client.ObjectKey{Name: pdf3WorkerHpaName, Namespace: runtimePdf3Namespace}, pdf3ShouldScale, pdf3Target); err != nil {
+	if err := r.reconcileHpa(ctx, client.ObjectKey{Name: pdf3WorkerHpaName, Namespace: runtimePdf3Namespace}, state.scalePdf3(), scaleDownReplicaOne); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "reconcile pdf3-worker")
 		return err

--- a/src/Runtime/operator/internal/controller/inactivityscaler/controller_test.go
+++ b/src/Runtime/operator/internal/controller/inactivityscaler/controller_test.go
@@ -256,7 +256,7 @@ func assertNoAppsComputedStateApplied(g *WithT, h *testHarness) {
 		err = h.k8sClient.Get(h.ctx, client.ObjectKey{Name: name, Namespace: runtimePdf3Namespace}, hpa)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(hpa.Spec.MinReplicas).NotTo(BeNil())
-		g.Expect(*hpa.Spec.MinReplicas).To(Equal(scaleDownReplicaZero))
+		g.Expect(*hpa.Spec.MinReplicas).To(Equal(scaleDownReplicaOne))
 		g.Expect(annotation(hpa, reconcileAnnotationKey)).To(Equal(reconcileDisabledValue))
 		g.Expect(annotation(hpa, scalerManagedAnnotationKey)).To(Equal("true"))
 		g.Expect(annotation(hpa, scalerBaselineAnnotationKey)).NotTo(BeEmpty())


### PR DESCRIPTION
## Description

I tried to scale pdf to 0 for clusters that have no apps yet, but that is invalid: 


```
HorizontalPodAutoscaler.autoscaling "pdf3-proxy-hpa" is invalid: [spec.minReplicas: Invalid value: 0:
```

so sticking to 1

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PDF3 services no longer scale down to zero during inactivity or off‑hours; a minimum of one replica is maintained to avoid invalid auto‑scaler states and preserve availability.

* **Tests**
  * Updated tests to expect and verify the minimum‑one‑replica behaviour for PDF3 components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->