### PR TITLE
chore: release studioctl v0.1.0-preview.2

### DIFF
--- a/src/cli/CHANGELOG.md
+++ b/src/cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-preview.2] - 2026-02-27
+
 ### Added
 
 - Support `self update` and `self uninstall` for Linux, macOS


### PR DESCRIPTION
## Description

Prepare release v0.1.0-preview.2

- [Added] Support `self update` and `self uninstall` for Linux, macOS
- [Fixed] PDF connectivity when running `env localtest` (#17959)
- [Fixed] Handle partial "up" state in `env up` (#17959)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for self-update and self-uninstall functionality on Linux and macOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->