### PR TITLE
chore: go - remove '-a -installsuffix cgo' from Dockerfiles

### DIFF
--- a/src/Runtime/operator/Dockerfile
+++ b/src/Runtime/operator/Dockerfile
@@ -25,7 +25,7 @@ COPY . ./
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/src/Runtime/operator/Dockerfile.fakes
+++ b/src/Runtime/operator/Dockerfile.fakes
@@ -25,7 +25,7 @@ COPY . ./
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o fakes cmd/fakes/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o fakes cmd/fakes/main.go
 
 # Use distroless as minimal base image to package the fakes binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/src/Runtime/pdf3/Dockerfile.proxy
+++ b/src/Runtime/pdf3/Dockerfile.proxy
@@ -15,7 +15,7 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -installsuffix cgo -o main ./cmd/proxy
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o main ./cmd/proxy
 
 FROM scratch
 

--- a/src/Runtime/pdf3/Dockerfile.worker
+++ b/src/Runtime/pdf3/Dockerfile.worker
@@ -15,7 +15,7 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -installsuffix cgo -o main ./cmd/worker
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o main ./cmd/worker
 
 FROM docker.io/chromedp/headless-shell:stable@sha256:43d8b0d7980c76aa9d9f8a8556d2d994073fdb9c755744cc27667e351e2fe9d5
 


### PR DESCRIPTION
## Description

Apparantly these flags are outdated not needed anymore, came in through kubebuilder scaffold

References: 

https://go.dev/src/cmd/go/alldocs.go
```
// If you have made changes to the C libraries on your system, you
// will need to clean the cache explicitly or else use the -a build flag
// (see 'go help build') to force rebuilding of packages that
// depend on the updated C libraries.
```

```
//	-installsuffix suffix
//		a suffix to use in the name of the package installation directory,
//		in order to keep output separate from default builds.
//		If using the -race flag, the install suffix is automatically set to race
//		or, if set explicitly, has _race appended to it. Likewise for the -msan
//		and -asan flags. Using a -buildmode option that requires non-default compile
//		flags has a similar effect.
```

Hoping to get faster builds out of this as operator builds in particular are fairly slow

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimised build commands for containerised runtime components to improve build efficiency and consistency across operator, proxy, and worker services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->