### PR TITLE
build: Fix Storybook problems in legacy component library

### DIFF
--- a/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioProperty/StudioProperties.mdx
+++ b/src/Designer/frontend/libs/studio-components-legacy/src/components/StudioProperty/StudioProperties.mdx
@@ -1,38 +1,37 @@
 import { Canvas, Meta } from '@storybook/addon-docs/blocks';
 import * as StudioPropertyStories from './StudioProperty.stories';
-import { StudioHeading } from '../StudioHeading';
+import { Heading, List } from '@digdir/designsystemet-react';
 import { StudioParagraph } from '../StudioParagraph';
-import { StudioList } from '@studio/components';
 import { PlusCircleIcon } from '@studio/icons';
 
 <Meta of={StudioPropertyStories} />
 
-<StudioHeading level={1} size='small'>
+<Heading level={1} size='small'>
   StudioProperty
-</StudioHeading>
+</Heading>
 <StudioParagraph>
   StudioProperty is a composed component designed to present configurable content. It may be used to
   let the user view and edit complex data structures.
 </StudioParagraph>
 <StudioParagraph>
   It provides the following elements:
-  <StudioList.Root>
-    <StudioList.Unordered>
-      <StudioList.Item>
+  <List.Root>
+    <List.Unordered>
+      <List.Item>
         `StudioProperty.Group`: Groups the list of `Fieldset` and `Button` components together,
         providing proper spacing between the components.
-      </StudioList.Item>
-      <StudioList.Item>
+      </List.Item>
+      <List.Item>
         `StudioProperty.Fieldset`: Editable state of a property. Its children should be form
         elements to set up the given property. It may also contain a nested `StudioProperty.Group`
         component.
-      </StudioList.Item>
-      <StudioList.Item>
+      </List.Item>
+      <List.Item>
         `StudioProperty.Button`: A button element to represent a given property. When no value is
         given, it defaults to only show the property name with a <PlusCircleIcon /> icon.
-      </StudioList.Item>
-    </StudioList.Unordered>
-  </StudioList.Root>
+      </List.Item>
+    </List.Unordered>
+  </List.Root>
 </StudioParagraph>
 <StudioParagraph>
   The `StudioProperty.Fieldset` and `StudioProperty.Button` are designed to switch between each


### PR DESCRIPTION
## Description
There are errors while building the Storybook instance for the legacy component library. This apparantly comes from bad imports in an MDX file, which is not covered by our type and lint checks.
- `StudioHeading` is imported from within the same library, but does not exist anymore.
- `StudioList` is imported from the new library, of which the legacy library should be independent

This pull request fixes this by importing the components of interest directly fra The Design System.

## Verification
- No related issues
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- No need to add new tests, as these changes do not impact user-facing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation with clearer explanations of property control interactions and user-triggered switching behaviour in form elements.
  * Modernised documentation structure to align with current design system standards and updated component conventions.
  * Refined descriptive content for improved clarity in developer guidance materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->