### PR TITLE
feat: designer - dont undeploy inactive apps that have been recently deployed

### DIFF
--- a/src/Designer/backend/src/Designer/Repository/IDeploymentRepository.cs
+++ b/src/Designer/backend/src/Designer/Repository/IDeploymentRepository.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Repository.Models;
@@ -41,6 +42,15 @@ namespace Altinn.Studio.Designer.Repository
             string app,
             string environment,
             DocumentQueryModel query
+        );
+
+        /// <summary>
+        /// Gets app names with a recent deploy in the given environment.
+        /// </summary>
+        Task<IReadOnlyList<string>> GetAppsWithRecentDeployments(
+            string org,
+            string environment,
+            DateTimeOffset sinceUtc
         );
 
         /// <summary>

--- a/src/Designer/backend/src/Designer/Repository/ORMImplementation/DeploymentRepository.cs
+++ b/src/Designer/backend/src/Designer/Repository/ORMImplementation/DeploymentRepository.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -99,6 +100,28 @@ public class DeploymentRepository : IDeploymentRepository
 
         var dbObjects = await deploymentsQuery.ToListAsync();
         return DeploymentMapper.MapToModels(dbObjects);
+    }
+
+    public async Task<IReadOnlyList<string>> GetAppsWithRecentDeployments(
+        string org,
+        string environment,
+        DateTimeOffset sinceUtc
+    )
+    {
+        Guard.AssertArgumentNotNullOrWhiteSpace(environment, nameof(environment));
+        Guard.AssertArgumentNotNullOrWhiteSpace(org, nameof(org));
+
+        return await _dbContext
+            .Deployments.AsNoTracking()
+            .Where(d =>
+                d.Org == org
+                && d.EnvName == environment
+                && d.DeploymentType == Models.DeploymentType.Deploy
+                && d.Created >= sinceUtc.UtcDateTime
+            )
+            .Select(d => d.App)
+            .Distinct()
+            .ToArrayAsync();
     }
 
     public async Task Update(DeploymentEntity deploymentEntity)

--- a/src/Designer/backend/src/Designer/Services/Implementation/AppInactivityUndeployService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/AppInactivityUndeployService.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Helpers;
 using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Repository;
 using Altinn.Studio.Designer.Repository.Models.AppSettings;
 using Altinn.Studio.Designer.Scheduling;
 using Altinn.Studio.Designer.Services.Interfaces;
@@ -23,16 +24,19 @@ public class AppInactivityUndeployService : IAppInactivityUndeployService
     private readonly IEnvironmentsService _environmentsService;
     private readonly IRuntimeGatewayClient _runtimeGatewayClient;
     private readonly IAppSettingsService _appSettingsService;
+    private readonly IDeploymentRepository _deploymentRepository;
 
     public AppInactivityUndeployService(
         IEnvironmentsService environmentsService,
         IRuntimeGatewayClient runtimeGatewayClient,
-        IAppSettingsService appSettingsService
+        IAppSettingsService appSettingsService,
+        IDeploymentRepository deploymentRepository
     )
     {
         _environmentsService = environmentsService;
         _runtimeGatewayClient = runtimeGatewayClient;
         _appSettingsService = appSettingsService;
+        _deploymentRepository = deploymentRepository;
     }
 
     public async Task<IReadOnlyList<InactivityUndeployCandidate>> GetAppsForDecommissioningAsync(
@@ -58,6 +62,7 @@ public class AppInactivityUndeployService : IAppInactivityUndeployService
         activity?.SetTag("app", options.App);
         activity?.SetTag("environment.filter", options.Environment);
         activity?.SetTag("window.days", options.WindowDays);
+        var recentDeploymentCutoffUtc = DateTimeOffset.UtcNow.AddDays(-options.WindowDays);
 
         var settings = await _appSettingsService.GetAllAsync(cancellationToken);
         var enabledApps = BuildEnabledSettingsLookup(settings, options.Org);
@@ -80,6 +85,11 @@ public class AppInactivityUndeployService : IAppInactivityUndeployService
         foreach (var environmentName in environments)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            using var environmentActivity = ServiceTelemetry.Source.StartActivity(
+                $"{nameof(AppInactivityUndeployService)}.EvaluateEnvironment"
+            );
+            environmentActivity?.SetTag("environment", environmentName);
+
             var environment = AltinnEnvironment.FromName(environmentName);
 
             List<AppDeployment> deployments;
@@ -95,8 +105,9 @@ public class AppInactivityUndeployService : IAppInactivityUndeployService
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                activity?.AddException(ex);
-                activity?.AddEvent(
+                environmentActivity?.SetStatus(ActivityStatusCode.Error, "Failed to fetch deployments.");
+                environmentActivity?.AddException(ex);
+                environmentActivity?.AddEvent(
                     CreateSkippedEvaluationEvent(options.Org, environmentName, "deployments_fetch_failed")
                 );
                 continue;
@@ -119,8 +130,9 @@ public class AppInactivityUndeployService : IAppInactivityUndeployService
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                activity?.AddException(ex);
-                activity?.AddEvent(
+                environmentActivity?.SetStatus(ActivityStatusCode.Error, "Failed to fetch activity metrics.");
+                environmentActivity?.AddException(ex);
+                environmentActivity?.AddEvent(
                     CreateSkippedEvaluationEvent(options.Org, environmentName, "activity_metrics_fetch_failed")
                 );
                 continue;
@@ -128,7 +140,7 @@ public class AppInactivityUndeployService : IAppInactivityUndeployService
 
             if (!string.Equals(activityMetrics.Status, MetricsStatusOk, StringComparison.OrdinalIgnoreCase))
             {
-                activity?.AddEvent(
+                environmentActivity?.AddEvent(
                     CreateSkippedEvaluationEvent(
                         options.Org,
                         environmentName,
@@ -143,9 +155,39 @@ public class AppInactivityUndeployService : IAppInactivityUndeployService
                 StringComparer.Ordinal
             );
 
+            if (!deployments.Any(d => enabledApps.Contains(d.App) && !activeApps.Contains(d.App)))
+            {
+                continue;
+            }
+
+            HashSet<string> recentlyDeployedApps;
+            try
+            {
+                recentlyDeployedApps = (
+                    await _deploymentRepository.GetAppsWithRecentDeployments(
+                        options.Org,
+                        environmentName,
+                        recentDeploymentCutoffUtc
+                    )
+                ).ToHashSet(StringComparer.Ordinal);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                environmentActivity?.SetStatus(ActivityStatusCode.Error, "Failed to fetch recent deployments.");
+                environmentActivity?.AddException(ex);
+                environmentActivity?.AddEvent(
+                    CreateSkippedEvaluationEvent(options.Org, environmentName, "recent_deployments_fetch_failed")
+                );
+                continue;
+            }
+
             foreach (var deployment in deployments)
             {
-                if (!enabledApps.Contains(deployment.App) || activeApps.Contains(deployment.App))
+                if (
+                    !enabledApps.Contains(deployment.App)
+                    || activeApps.Contains(deployment.App)
+                    || recentlyDeployedApps.Contains(deployment.App)
+                )
                 {
                     continue;
                 }

--- a/src/Designer/backend/tests/Designer.Tests/Services/AppInactivityUndeployServiceTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/AppInactivityUndeployServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Studio.Designer.Models;
+using Altinn.Studio.Designer.Repository;
 using Altinn.Studio.Designer.Repository.Models.AppSettings;
 using Altinn.Studio.Designer.Services.Implementation;
 using Altinn.Studio.Designer.Services.Interfaces;
@@ -19,6 +20,7 @@ public class AppInactivityUndeployServiceTests
     private readonly Mock<IEnvironmentsService> _environmentsService = new();
     private readonly Mock<IRuntimeGatewayClient> _runtimeGatewayClient = new();
     private readonly Mock<IAppSettingsService> _appSettingsService = new();
+    private readonly Mock<IDeploymentRepository> _deploymentRepository = new();
 
     [Fact]
     public async Task GetAppsForDecommissioningAsync_WhenStatusIsUnavailable_ShouldReturnNoCandidates()
@@ -136,6 +138,44 @@ public class AppInactivityUndeployServiceTests
     }
 
     [Fact]
+    public async Task GetAppsForDecommissioningAsync_WhenAppIsRecentlyDeployed_ShouldReturnNoCandidates()
+    {
+        var service = CreateService();
+        _appSettingsService
+            .Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new AppSettingsEntity
+                {
+                    Org = "ttd",
+                    App = "app1",
+                    UndeployOnInactivity = true,
+                },
+            ]);
+
+        _runtimeGatewayClient
+            .Setup(c => c.GetAppDeployments("ttd", It.IsAny<AltinnEnvironment>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new AppDeployment("ttd", "at23", "app1", "dev", "1", "v1")]);
+
+        _runtimeGatewayClient
+            .Setup(c =>
+                c.GetAppActivityMetricsAsync("ttd", It.IsAny<AltinnEnvironment>(), 7, It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(
+                new AppActivityMetricsResponse("ok", new Dictionary<string, double>(), 7, DateTimeOffset.UtcNow)
+            );
+
+        _deploymentRepository
+            .Setup(r => r.GetAppsWithRecentDeployments("ttd", "at23", It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(["app1"]);
+
+        var result = await service.GetAppsForDecommissioningAsync(
+            new InactivityUndeployEvaluationOptions { Org = "ttd", Environment = "at23" }
+        );
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
     public async Task GetAppsForDecommissioningAsync_WhenOrgHasNoOptedInApps_ShouldSkipExternalCalls()
     {
         var service = CreateService();
@@ -171,6 +211,10 @@ public class AppInactivityUndeployServiceTests
                     It.IsAny<int>(),
                     It.IsAny<CancellationToken>()
                 ),
+            Times.Never
+        );
+        _deploymentRepository.Verify(
+            r => r.GetAppsWithRecentDeployments(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTimeOffset>()),
             Times.Never
         );
     }
@@ -218,11 +262,17 @@ public class AppInactivityUndeployServiceTests
         _environmentsService
             .Setup(e => e.GetOrganizationEnvironments(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([new EnvironmentModel { Name = "at23", PlatformUrl = "https://platform.at23.altinn.cloud" }]);
+        _deploymentRepository
+            .Setup(r =>
+                r.GetAppsWithRecentDeployments(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTimeOffset>())
+            )
+            .ReturnsAsync([]);
 
         return new AppInactivityUndeployService(
             _environmentsService.Object,
             _runtimeGatewayClient.Object,
-            _appSettingsService.Object
+            _appSettingsService.Object,
+            _deploymentRepository.Object
         );
     }
 }


### PR DESCRIPTION
## Description

Expand the "inactivity" heuristic to account for apps that have been recently deployed. Meaning if someone published an app yesterday but didnt send any requests (for instance just to see what happened in ressursregisteret) it will still take 7d for it to get unpublished again

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
  * Improved app inactivity undeployment logic to exclude recently deployed applications from being automatically undeployed, preventing unintended removal of newly deployed apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->