### PR TITLE
fix: padding in undeploy dialogs

### DIFF
--- a/src/Designer/frontend/app-development/features/appPublish/components/ConfirmUndeployDialog/ConfirmUndeployDialog.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/components/ConfirmUndeployDialog/ConfirmUndeployDialog.tsx
@@ -60,36 +60,38 @@ export const ConfirmUndeployDialog = ({
             {t('app_deployment.undeploy_confirmation_dialog_title')}
           </StudioHeading>
         </StudioDialog.Block>
-        <StudioParagraph spacing>
-          {t('app_deployment.undeploy_confirmation_dialog_description')}
-        </StudioParagraph>
-        <StudioTextfield
-          label={t('app_deployment.undeploy_confirmation_input_label')}
-          description={t('app_deployment.undeploy_confirmation_input_description', {
-            appName,
-          })}
-          onChange={onAppNameInputChange}
-        />
-        {undeployError && (
-          <StudioAlert className={classes.errorContainer}>
-            <StudioParagraph>
-              <Trans
-                i18nKey={'app_deployment.error_unknown.message'}
-                components={{
-                  a: <StudioLink href='/info/contact'> </StudioLink>,
-                }}
-              />
-            </StudioParagraph>
-          </StudioAlert>
-        )}
-        <StudioButton
-          disabled={!isAppNameConfirmed || isPendingUndeploy}
-          data-color='danger'
-          className={classes.confirmUndeployButton}
-          onClick={onUndeployClicked}
-        >
-          {t('app_deployment.undeploy_confirmation_button')}
-        </StudioButton>
+        <StudioDialog.Block>
+          <StudioParagraph spacing>
+            {t('app_deployment.undeploy_confirmation_dialog_description')}
+          </StudioParagraph>
+          <StudioTextfield
+            label={t('app_deployment.undeploy_confirmation_input_label')}
+            description={t('app_deployment.undeploy_confirmation_input_description', {
+              appName,
+            })}
+            onChange={onAppNameInputChange}
+          />
+          {undeployError && (
+            <StudioAlert className={classes.errorContainer}>
+              <StudioParagraph>
+                <Trans
+                  i18nKey={'app_deployment.error_unknown.message'}
+                  components={{
+                    a: <StudioLink href='/info/contact'> </StudioLink>,
+                  }}
+                />
+              </StudioParagraph>
+            </StudioAlert>
+          )}
+          <StudioButton
+            disabled={!isAppNameConfirmed || isPendingUndeploy}
+            data-color='danger'
+            className={classes.confirmUndeployButton}
+            onClick={onUndeployClicked}
+          >
+            {t('app_deployment.undeploy_confirmation_button')}
+          </StudioButton>
+        </StudioDialog.Block>
       </StudioDialog>
     </>
   );

--- a/src/Designer/frontend/app-development/features/appPublish/components/UndeployConsequenceDialog/UndeployConsequenceDialog.tsx
+++ b/src/Designer/frontend/app-development/features/appPublish/components/UndeployConsequenceDialog/UndeployConsequenceDialog.tsx
@@ -24,7 +24,9 @@ export const UndeployConsequenceDialog = ({
             {t('app_deployment.unpublish_consequence_dialog_title')}
           </StudioHeading>
         </StudioDialog.Block>
-        <DialogContent environment={environment} />
+        <StudioDialog.Block>
+          <DialogContent environment={environment} />
+        </StudioDialog.Block>
       </StudioDialog>
     </>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds missing `<StudioDialog.Block>` elements to the undeploy dialogs.

Closes https://github.com/Altinn/altinn-studio/issues/17419.

## Screenshots
<img width="500" height="826" alt="bilde" src="https://github.com/user-attachments/assets/4ea9720f-b438-425e-b90e-2544e10f7a88" />

<img width="500" height="393" alt="bilde" src="https://github.com/user-attachments/assets/93d8693b-e097-433f-9cba-42aa96f49105" />

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal structure of dialog layouts to enhance component consistency and maintainability across undeploy-related dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->