### PR TITLE
fix: deploy-app - use latest Azure Powershell version on host

### DIFF
--- a/src/App/azure-pipelines/deploy-app.yaml
+++ b/src/App/azure-pipelines/deploy-app.yaml
@@ -394,6 +394,7 @@ steps:
         # PLEASE DON'T USE PIPELINE VARIABLES PAST THIS LINE.
 
         Write-Host "`nPowerShell script output START`n"
+        Write-Host "Using Az.Accounts $((Get-Module -Name Az.Accounts).Version) from $((Get-Module -Name Az.Accounts).Path)"
 
         $apimSubscriptionId = "$appOwner-$appName"
 
@@ -434,7 +435,8 @@ steps:
 
         Write-Host "`nPowerShell script output END`n"
       FailOnStandardError: true
-      CustomTargetAzurePs: 12.1.0
+      azurePowerShellVersion: LatestVersion
+      TargetAzurePs: LatestVersion
       pwsh: true
 
   - task: AzurePowerShell@4
@@ -456,6 +458,7 @@ steps:
         # PLEASE DON'T USE PIPELINE VARIABLES PAST THIS LINE.
 
         Write-Host "`nPowerShell script output START`n"
+        Write-Host "Using Az.Accounts $((Get-Module -Name Az.Accounts).Version) from $((Get-Module -Name Az.Accounts).Path)"
 
         $apimSubscriptionId = "$appOwner-$appName"
 
@@ -496,7 +499,8 @@ steps:
 
         Write-Host "`nPowerShell script output END`n"
       FailOnStandardError: true
-      CustomTargetAzurePs: 12.1.0
+      azurePowerShellVersion: LatestVersion
+      TargetAzurePs: LatestVersion
       pwsh: true
 
   - task: AzurePowerShell@4
@@ -509,6 +513,7 @@ steps:
         # THIS SCRIPT WILL ONLY BE RUN IF DEPLOYING TO PROD ENV. SEE CONTROL OPTIONS.
 
         if ("$(APP_ENVIRONMENT)" -eq "production"){
+            Write-Host "Using Az.Accounts $((Get-Module -Name Az.Accounts).Version) from $((Get-Module -Name Az.Accounts).Path)"
 
             $apimContext = New-AzApiManagementContext -ResourceId $(APIM_RESOURCE_ID_PROD)
 
@@ -534,7 +539,8 @@ steps:
             Write-Host "##vso[task.setvariable variable=SUBSCRIPTION_KEY;]$subscriptionKey"
         }
       FailOnStandardError: true
-      CustomTargetAzurePs: 12.1.0
+      azurePowerShellVersion: LatestVersion
+      TargetAzurePs: LatestVersion
       pwsh: true
 
   - task: Bash@3


### PR DESCRIPTION
## Description

Since the slow part is downloading Azure Powershell... seeing if this improves things with the tradeoff of potential drift/breakage when the agents update these versions (already vulnerable to this in other steps, so we need to refactor away from this mess)

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated deployment pipeline to use the latest Azure PowerShell tooling
  * Enhanced diagnostic logging in deployment processes to provide better visibility into module versions and paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->