### PR TITLE
fix: remove injected default config for appmetadata in about app form

### DIFF
--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/AppConfigForm.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/AppConfigForm.test.tsx
@@ -120,21 +120,6 @@ describe('AppConfigForm', () => {
     expect(homepage).toHaveValue(`${mockHomepage}${newText}`);
   });
 
-  it('defaults visibility and delegation to true when not set', () => {
-    renderAppConfigForm();
-
-    const visibleSwitch = getSwitch(
-      textMock('app_settings.about_tab_visibility_and_delegation_visible_label'),
-    );
-    expect(visibleSwitch).toBeChecked();
-
-    const delegableSwitch = getSwitch(
-      textMock('app_settings.about_tab_visibility_and_delegation_delegable_label'),
-    );
-    expect(delegableSwitch).toBeChecked();
-    expect(delegableSwitch).toBeDisabled();
-  });
-
   it('displays correct value in delegation when app is hidden, and updates the value on change', async () => {
     const user = userEvent.setup();
     renderAppConfigForm({

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/AppConfigForm.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/AppConfigForm.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import type { ChangeEvent, MutableRefObject, ReactElement } from 'react';
 import classes from './AppConfigForm.module.css';
 import { useTranslation } from 'react-i18next';
@@ -22,22 +22,10 @@ export type AppConfigFormProps = {
 
 export function AppConfigForm({ appConfig, saveAppConfig }: AppConfigFormProps): ReactElement {
   const { t } = useTranslation();
-  const appConfigWithDefaults: ApplicationMetadata = useMemo(
-    () => ({
-      ...appConfig,
-      access: {
-        ...appConfig.access,
-        visible: appConfig.access?.visible ?? true,
-        delegable: appConfig.access?.delegable ?? true,
-      },
-    }),
-    [appConfig],
-  );
 
   const defaultDescriptionValue = { nb: '', nn: '', en: '' };
 
-  const [updatedAppConfig, setUpdatedAppConfig] =
-    useState<ApplicationMetadata>(appConfigWithDefaults);
+  const [updatedAppConfig, setUpdatedAppConfig] = useState<ApplicationMetadata>(appConfig);
   const [showAppConfigErrors, setShowAppConfigErrors] = useState<boolean>(false);
   const [keywordsInputValue, setKeywordsInputValue] = useState(
     mapKeywordsArrayToString(updatedAppConfig.keywords ?? []),
@@ -49,7 +37,7 @@ export function AppConfigForm({ appConfig, saveAppConfig }: AppConfigFormProps):
 
   useScrollIntoView(showAppConfigErrors, errorSummaryRef);
 
-  const hasUnsavedChanges = !ObjectUtils.areObjectsEqual(updatedAppConfig, appConfigWithDefaults);
+  const hasUnsavedChanges = !ObjectUtils.areObjectsEqual(updatedAppConfig, appConfig);
   useUnsavedChangesWarning(
     hasUnsavedChanges,
     t('app_settings.about_tab_unsaved_changes_navigation_warning'),
@@ -67,8 +55,8 @@ export function AppConfigForm({ appConfig, saveAppConfig }: AppConfigFormProps):
 
   const resetAppConfig = (): void => {
     if (confirm(t('app_settings.about_tab_reset_confirmation'))) {
-      setUpdatedAppConfig(appConfigWithDefaults);
-      setKeywordsInputValue(mapKeywordsArrayToString(appConfigWithDefaults.keywords ?? []));
+      setUpdatedAppConfig(appConfig);
+      setKeywordsInputValue(mapKeywordsArrayToString(appConfig.keywords ?? []));
       setShowAppConfigErrors(false);
     }
   };
@@ -133,11 +121,12 @@ export function AppConfigForm({ appConfig, saveAppConfig }: AppConfigFormProps):
 
   const onChangeVisible = (e: ChangeEvent<HTMLInputElement>): void => {
     const isVisible = e.target.checked;
-    setUpdatedAppConfig((oldVal: ApplicationMetadata) => ({
-      ...oldVal,
-      visible: isVisible,
-      access: { ...oldVal.access, ...(isVisible ? { delegable: true } : {}) },
-    }));
+    setUpdatedAppConfig(
+      (oldVal: ApplicationMetadata): ApplicationMetadata => ({
+        ...oldVal,
+        access: { ...oldVal.access, visible: isVisible, ...(isVisible ? { delegable: true } : {}) },
+      }),
+    );
   };
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This caused some issues where the form would visually look like "visible" and "delegable" was set to true, even if it actually was false.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
- Optimised app settings form state management by streamlining initialisation logic and improving maintainability.
- Simplified configuration reset and visibility controls with cleaner internal patterns.
- Enhanced button state comparison logic for more reliable form behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->