### PR TITLE
feat: sanitize full name header

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/GiteaAuthHeadersProvider.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/GiteaAuthHeadersProvider.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
 using Altinn.Studio.Designer.Infrastructure.DeveloperSession;
 using Altinn.Studio.Designer.Services.Interfaces;
 
@@ -22,9 +25,34 @@ public class GiteaAuthHeadersProvider(IDeveloperContextProvider developerContext
         string fullName = $"{context.GivenName} {context.FamilyName}".Trim();
         if (!string.IsNullOrEmpty(fullName))
         {
-            headers["X-WEBAUTH-FULLNAME"] = fullName;
+            headers["X-WEBAUTH-FULLNAME"] = ToAscii(fullName);
         }
 
         return headers;
+    }
+
+    /// <summary>
+    /// Converts a string to ASCII for HTTP header compatibility.
+    /// Norwegian letters are explicitly transliterated (æ→ae, ø→oe, å→aa).
+    /// Other accented characters (e.g. ö, é, ñ) are normalized via Unicode decomposition,
+    /// which strips diacritical marks (ö→o, é→e, ñ→n).
+    /// </summary>
+    internal static string ToAscii(string value)
+    {
+        string replaced = value
+            .Replace("æ", "ae")
+            .Replace("Æ", "AE")
+            .Replace("ø", "oe")
+            .Replace("Ø", "OE")
+            .Replace("å", "aa")
+            .Replace("Å", "AA");
+
+        string normalized = replaced.Normalize(NormalizationForm.FormD);
+
+        return new string(
+            normalized
+                .Where(c => CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark && c <= 127)
+                .ToArray()
+        );
     }
 }

--- a/src/Designer/backend/tests/Designer.Tests/Services/GiteaAuthHeadersProviderTests.cs
+++ b/src/Designer/backend/tests/Designer.Tests/Services/GiteaAuthHeadersProviderTests.cs
@@ -1,0 +1,34 @@
+using Altinn.Studio.Designer.Services.Implementation;
+using Xunit;
+
+namespace Designer.Tests.Services;
+
+public class GiteaAuthHeadersProviderTests
+{
+    [Theory]
+    [InlineData("Hensynsløs Måke", "Hensynsloes Maake")]
+    [InlineData("Björk Söderström", "Bjork Soderstrom")]
+    [InlineData("Ola Nordmann", "Ola Nordmann")]
+    [InlineData("Ærlig Ødansen Åsheim", "AErlig OEdansen AAsheim")]
+    [InlineData("José García", "Jose Garcia")]
+    [InlineData("François Müller", "Francois Muller")]
+    [InlineData("", "")]
+    [InlineData("ASCII only 123", "ASCII only 123")]
+    public void ToAscii_ConvertsCorrectly(string input, string expected)
+    {
+        string result = GiteaAuthHeadersProvider.ToAscii(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ToAscii_ResultContainsOnlyAsciiCharacters()
+    {
+        string input = "Hensynsløs Måke Björk Söderström José García æøåÆØÅ";
+        string result = GiteaAuthHeadersProvider.ToAscii(input);
+
+        foreach (char c in result)
+        {
+            Assert.True(c <= 127, $"Non-ASCII character found: '{c}' (U+{(int)c:X4})");
+        }
+    }
+}

--- a/src/Designer/development/fake-ansattporten/main.go
+++ b/src/Designer/development/fake-ansattporten/main.go
@@ -31,6 +31,8 @@ var testUsers = []TestUser{
 	{PID: "15076500565", Sub: "sub-15076500565", GivenName: "Ingrid", FamilyName: "Berg"},
 	{PID: "02056260016", Sub: "sub-02056260016", GivenName: "Erik", FamilyName: "Larsen"},
 	{PID: "15841396828", Sub: "sub-15841396828", GivenName: "Ola", FamilyName: "Mellomnavn Test Lastname"},
+	{PID: "11830099391", Sub: "sub-11830099391", GivenName: "Hensynsløs", FamilyName: "Måke"},
+	{PID: "23837298312", Sub: "sub-23837298312", GivenName: "Björk", FamilyName: "Söderström"},
 }
 
 type pendingAuth struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Sanitize non-ASCII characters in X-WEBAUTH-FULLNAME header to prevent HttpClient crash. 
Norwegian letters are transliterated (æ→ae,ø→oe, å→aa), other accented characters are normalized by stripping diacritics (ö→o, é→e).

<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved compatibility of user names in authentication headers by converting them to ASCII format, ensuring special characters are properly handled across systems.

* **Tests**
  * Added comprehensive test coverage for ASCII character conversion validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->