### PR TITLE
fix: pin flux install through devenv for integration tests

### DIFF
--- a/src/Runtime/devenv/pkg/flux/flux.go
+++ b/src/Runtime/devenv/pkg/flux/flux.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -31,12 +32,20 @@ var (
 	kustomizationGVR = kustomizev1.GroupVersion.WithResource("kustomizations")
 	ociRepositoryGVR = sourcev1.GroupVersion.WithResource("ocirepositories")
 
-	errKubeClientRequired = errors.New("kubeClient is required")
-	errUnknownSourceKind  = errors.New("unknown source kind")
+	errKubeClientRequired       = errors.New("kubeClient is required")
+	errUnknownSourceKind        = errors.New("unknown source kind")
+	errFluxBuildInfoUnavailable = errors.New("resolve flux install version: Go build info unavailable")
+	errFluxVersionUnavailable   = errors.New(
+		"resolve flux install version: github.com/fluxcd/flux2/v2 version unavailable in Go build info",
+	)
+	errFluxModuleNotFound = errors.New(
+		"resolve flux install version: github.com/fluxcd/flux2/v2 not found in Go build info",
+	)
 )
 
 const (
 	fluxInstallConcurrency = 8
+	fluxModulePath         = "github.com/fluxcd/flux2/v2"
 	yamlDecoderBufferSize  = 4096
 )
 
@@ -96,8 +105,10 @@ func LocalTestInstallOptions() InstallOptions {
 
 // Install installs Flux to the cluster with the specified components and options.
 func (c *FluxClient) Install(components []string, installOpts InstallOptions) error {
-	opts := install.MakeDefaultOptions()
-	opts.Components = components
+	opts, err := defaultInstallOptions(components)
+	if err != nil {
+		return err
+	}
 
 	manifest, err := install.Generate(opts, "")
 	if err != nil {
@@ -116,6 +127,42 @@ func (c *FluxClient) Install(components []string, installOpts InstallOptions) er
 	}
 
 	return nil
+}
+
+func defaultInstallOptions(components []string) (install.Options, error) {
+	version, err := fluxInstallVersion()
+	if err != nil {
+		return install.Options{}, err
+	}
+
+	opts := install.MakeDefaultOptions()
+	opts.Version = version
+	opts.Components = components
+	return opts, nil
+}
+
+func fluxInstallVersion() (string, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", errFluxBuildInfoUnavailable
+	}
+
+	for _, dep := range info.Deps {
+		if dep.Path != fluxModulePath {
+			continue
+		}
+
+		version := dep.Version
+		if dep.Replace != nil && dep.Replace.Version != "" {
+			version = dep.Replace.Version
+		}
+		if version == "" || version == "(devel)" {
+			return "", errFluxVersionUnavailable
+		}
+		return version, nil
+	}
+
+	return "", errFluxModuleNotFound
 }
 
 func parseManifestYAML(content string) ([]*unstructured.Unstructured, error) {


### PR DESCRIPTION
## Description

this is failing CI now due to recent flux release and the install just grabbed latest, it should correlate to the installed library version. This wont be in sync automatically, have to figure something out, maybe renovate....

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal consistency in Flux installation configuration management and version control mechanisms to enhance code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->