### PR TITLE
build: Include setting FEATUREFLAGS_STUDIOOIDC env variable in setup script

### DIFF
--- a/src/Designer/development/utils/ensure-dot-env.js
+++ b/src/Designer/development/utils/ensure-dot-env.js
@@ -26,6 +26,7 @@ const defaultEnvVars = {
   POSTGRES_PASSWORD: randomPass(),
   CLIENT_ID: '',
   CLIENT_SECRET: '',
+  FEATUREFLAGS_STUDIOOIDC: true,
 };
 
 module.exports = () => {


### PR DESCRIPTION
## Description
The Studio OIDC feature flag must be activated for Playwright tests to run locally. This pull request makes sure that the setup script sets this variable in the `.env` file.

## Verification
- No related issues
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- No need to add tests as there are no user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Studio OIDC authentication is now enabled by default, providing seamless identity verification for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->