### PR TITLE
fix: replace stringify comparison with objectUtils

### DIFF
--- a/src/Designer/frontend/packages/ux-editor/src/components/Settings/SettingsNavigation/ValidateNavigation/utils/ValidateNavigationUtils.ts
+++ b/src/Designer/frontend/packages/ux-editor/src/components/Settings/SettingsNavigation/ValidateNavigation/utils/ValidateNavigationUtils.ts
@@ -2,6 +2,7 @@ import type { ExternalConfigState, InternalConfigState } from './ValidateNavigat
 import { properties } from '../../../../../testing/schemas/json/layout/layout-sets.schema.v1.json';
 import type { LayoutSet } from 'app-shared/types/api/LayoutSetsResponse';
 import type { IFormLayouts } from '@altinn/ux-editor/types/global';
+import { ObjectUtils } from '@studio/pure-functions';
 
 export enum Scope {
   AllTasks = 'allTasks',
@@ -99,7 +100,7 @@ type ValidateFormProps = {
 };
 
 export const validateForm = ({ scope, config, newConfig }: ValidateFormProps): boolean => {
-  const noChangesMade = !newConfig || JSON.stringify(config) === JSON.stringify(newConfig);
+  const noChangesMade = !newConfig || ObjectUtils.areObjectsEqual(config, newConfig);
   if (noChangesMade) {
     return false;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Utilize `ObjectUtils.areObjectsEqual` instead of `JSON.stringify` for comparison. JSON.stringify is order-sensitive, which can cause identical configs with different key order to be treated as different. This could incorrectly enable the save button even when no changes were made.

### Video presentation

<details><summary> Before fix </summary>

https://github.com/user-attachments/assets/bfd000df-10fb-44e6-ba96-6a3046ad7c7d
</details>

<details><summary> After fix </summary>

https://github.com/user-attachments/assets/4d413664-a4e7-440e-aaed-2ec72c6be7b7
</details>



<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
