### PR TITLE
fix: wrap text label when overflow

### DIFF
--- a/src/Designer/frontend/libs/studio-components/src/components/StudioInlineTextField/StudioInlineTextField.module.css
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioInlineTextField/StudioInlineTextField.module.css
@@ -4,3 +4,7 @@
   align-items: flex-end;
   gap: var(--ds-size-3);
 }
+
+.propertyButton span {
+  white-space: normal;
+}

--- a/src/Designer/frontend/libs/studio-components/src/components/StudioInlineTextField/StudioInlineTextField.tsx
+++ b/src/Designer/frontend/libs/studio-components/src/components/StudioInlineTextField/StudioInlineTextField.tsx
@@ -34,7 +34,14 @@ export const StudioInlineTextField = ({
   const openEditMode = (): void => setIsEditMode(true);
 
   if (!isEditMode) {
-    return <StudioProperty.Button property={label} value={value} onClick={openEditMode} />;
+    return (
+      <StudioProperty.Button
+        property={label}
+        value={value}
+        onClick={openEditMode}
+        className={classes.propertyButton}
+      />
+    );
   }
 
   const handleSaveFieldInput = (newValue: string): void => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix so that label is always visible in "About app" page. Alternativ is to shorten the long label or make the container wider, since user can't adjust the width like they can do in config panel in utforming page.

Before:
<img width="997" height="801" alt="image" src="https://github.com/user-attachments/assets/adc66341-efa1-4464-bc34-52b90814f859" />



After:
<img width="910" height="727" alt="image" src="https://github.com/user-attachments/assets/8ce723f7-bd65-4eea-a021-cf0d4e27bf2e" />


<!--- Describe your changes in detail -->

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Property button text now wraps onto multiple lines instead of being constrained to a single line, improving readability and layout flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->