### PR TITLE
fix: add missing studio root in compose

### DIFF
--- a/src/Designer/compose.yaml
+++ b/src/Designer/compose.yaml
@@ -53,6 +53,7 @@ services:
         [ "$$DEVELOP_PREVIEW" = "1" ] && export PREVIEW_HOST="host.docker.internal:2005" && disable_rewrite preview
         [ "$$DEVELOP_ADMIN" = "1" ] && export ADMIN_HOST="host.docker.internal:2006" && disable_rewrite admin
         [ "$$DEVELOP_RESOURCE_ADMIN" = "1" ] && export RESOURCEADM_HOST="host.docker.internal:2023" && disable_rewrite resourceadm
+        [ "$$DEVELOP_STUDIO_ROOT" = "1" ] && export INFO_HOST="host.docker.internal:2002" && disable_rewrite info
         [ "$$DEVELOP_USER_SETTINGS" = "1" ] && export USER_SETTINGS_HOST="host.docker.internal:2007" && disable_rewrite settings
         exec /entrypoint.sh
     environment:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Re-add `DEVELOP_STUDIO_ROOT` entry in `compose.yaml`, accidentally removed in  #18035

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved development environment configuration for the studio load balancer service to enhance local development workflows and developer experience. New conditional routing capabilities enable better service integration when using alternative development server configurations. These enhancements provide more flexible and streamlined local development options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->