### PR TITLE
fix: remove trivy action

### DIFF
--- a/.github/workflows/deploy-runtime-gateway.yaml
+++ b/.github/workflows/deploy-runtime-gateway.yaml
@@ -64,16 +64,6 @@ jobs:
         working-directory: src
         run: docker build -t ${{ env.IMAGE_REPO }} -f Runtime/gateway/Dockerfile .
 
-      - name: scan image
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
-        with:
-          image-ref: '${{ env.IMAGE_REPO }}'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-
       - name: push image
         run: docker push ${{ env.IMAGE_REPO }}
 

--- a/.github/workflows/deploy-runtime-localtest.yaml
+++ b/.github/workflows/deploy-runtime-localtest.yaml
@@ -54,15 +54,5 @@ jobs:
       - name: Build image
         run: docker build --platform linux/amd64,linux/arm64 -t ${{ steps.vars.outputs.image }} .
 
-      - name: Scan image
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
-        with:
-          image-ref: '${{ steps.vars.outputs.image }}'
-          format: 'table'
-          exit-code: '0'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL'
-
       - name: Push image
         run: docker push ${{ steps.vars.outputs.image }}

--- a/.github/workflows/deploy-runtime-operator.yaml
+++ b/.github/workflows/deploy-runtime-operator.yaml
@@ -91,16 +91,6 @@ jobs:
       - name: docker build
         run: docker build --platform linux/amd64,linux/arm64 -t ${{ steps.vars.outputs.ghcr-image-repo }} -f Dockerfile .
 
-      - name: scan image - proxy
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
-        with:
-          image-ref: '${{ steps.vars.outputs.ghcr-image-repo }}'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-
       - name: push images
         run: docker push ${{ steps.vars.outputs.ghcr-image-repo }}
 

--- a/.github/workflows/deploy-runtime-pdf3.yaml
+++ b/.github/workflows/deploy-runtime-pdf3.yaml
@@ -100,27 +100,6 @@ jobs:
           wait $PROXY_PID
           wait $WORKER_PID
 
-      - name: scan image - proxy
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
-        with:
-          image-ref: '${{ steps.vars.outputs.ghcr-image-proxy-repo }}'
-          format: 'table'
-          exit-code: '0'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL'
-
-      - name: scan image - worker
-        if: success() || failure()
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
-        with:
-          image-ref: '${{ steps.vars.outputs.ghcr-image-worker-repo }}'
-          format: 'table'
-          exit-code: '0'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL'
-
       - name: push images
         run: |
           set -e

--- a/.github/workflows/deploy-runtime-workflow-engine.yaml
+++ b/.github/workflows/deploy-runtime-workflow-engine.yaml
@@ -58,16 +58,6 @@ jobs:
           fi
           docker build --platform linux/amd64,linux/arm64 $TAGS -f Runtime/workflow-engine/Dockerfile .
 
-      - name: Scan image
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
-        with:
-          image-ref: '${{ steps.vars.outputs.image }}'
-          format: 'table'
-          exit-code: '0'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL'
-
       - name: Push image
         run: |
           docker push ${{ steps.vars.outputs.image }}

--- a/.github/workflows/deploy-studio-mcp-server.yaml
+++ b/.github/workflows/deploy-studio-mcp-server.yaml
@@ -62,16 +62,6 @@ jobs:
       - name: docker build
         run: docker build -t ${{ env.IMAGE_REPO }} -f dockerfile .
 
-      # - name: scan image
-      #   uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
-      #   with:
-      #     image-ref: '${{ env.IMAGE_REPO }}'
-      #     format: 'table'
-      #     exit-code: '1'
-      #     ignore-unfixed: true
-      #     vuln-type: 'os,library'
-      #     severity: 'CRITICAL,HIGH'
-
       - name: push image
         run: docker push ${{ env.IMAGE_REPO }}
 


### PR DESCRIPTION
## Description

We were presumably using a safe version, but removing just in case

See `https://github.com/aquasecurity/trivy-action/issues/541`  and related news

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automated container image vulnerability scanning from deployment pipelines. Container images are now built and pushed to registries directly without intermediate security checks. These scans were previously configured to identify critical and high-severity vulnerabilities in operating system and library dependencies across multiple services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->