### PR TITLE
chore: operator - larger leader election interval, control trace size

### DIFF
--- a/src/Runtime/operator/cmd/main.go
+++ b/src/Runtime/operator/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -128,6 +129,12 @@ func main() {
 	restConfig := ctrl.GetConfigOrDie()
 	telemetry.WrapTransport(restConfig)
 	syncPeriod := time.Hour * 5
+	const (
+		leaderElectionLeaseDuration = 30 * time.Second
+		leaderElectionRenewDeadline = 20 * time.Second
+		leaderElectionRetryPeriod   = 5 * time.Second
+	)
+	managerCtx := telemetry.WithoutSpan(ctx)
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -139,6 +146,14 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "ec156e4c.altinn.studio",
+		// Stretch the lease timings to reduce steady-state renewal chatter while
+		// keeping multiple renewal attempts before leadership is lost.
+		LeaseDuration: ptr.To(leaderElectionLeaseDuration),
+		RenewDeadline: ptr.To(leaderElectionRenewDeadline),
+		RetryPeriod:   ptr.To(leaderElectionRetryPeriod),
+		BaseContext: func() context.Context {
+			return managerCtx
+		},
 		Cache: cache.Options{
 			// SyncPeriod will force additional reconciliations periodically
 			SyncPeriod: &syncPeriod,
@@ -232,7 +247,7 @@ func main() {
 
 	setupLog.Info("starting manager")
 	span.End()
-	if err = mgr.Start(ctx); err != nil {
+	if err = mgr.Start(managerCtx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/src/Runtime/operator/internal/config/config.go
+++ b/src/Runtime/operator/internal/config/config.go
@@ -43,6 +43,7 @@ func (m *ConfigMonitor) Get() *Config {
 }
 
 func (m *ConfigMonitor) start(ctx context.Context) {
+	ctx = telemetry.WithoutSpan(ctx)
 	sighup := make(chan os.Signal, 1)
 	signal.Notify(sighup, syscall.SIGHUP)
 

--- a/src/Runtime/operator/internal/orgs/orgs.go
+++ b/src/Runtime/operator/internal/orgs/orgs.go
@@ -119,6 +119,7 @@ func (r *OrgRegistry) Get(serviceOwnerId string) (Org, bool) {
 }
 
 func (r *OrgRegistry) startPeriodicRefresh(ctx context.Context, interval time.Duration) {
+	ctx = telemetry.WithoutSpan(ctx)
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()

--- a/src/Runtime/operator/internal/telemetry/telemetry.go
+++ b/src/Runtime/operator/internal/telemetry/telemetry.go
@@ -30,6 +30,12 @@ func Meter() otelmetric.Meter {
 	return otel.Meter(scopeName)
 }
 
+// WithoutSpan keeps cancellation and context values while dropping active span parentage.
+// Use this when handing a request-scoped context to long-lived background loops.
+func WithoutSpan(ctx context.Context) context.Context {
+	return oteltrace.ContextWithSpanContext(ctx, oteltrace.SpanContext{})
+}
+
 func ConfigureOTel(ctx context.Context) (shutdown func(context.Context) error, err error) {
 	var shutdownFuncs []func(context.Context) error
 

--- a/src/Runtime/operator/internal/telemetry/telemetry_test.go
+++ b/src/Runtime/operator/internal/telemetry/telemetry_test.go
@@ -1,0 +1,67 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestWithoutSpan(t *testing.T) {
+	t.Parallel()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	tracer := provider.Tracer("test")
+
+	type contextKey string
+
+	baseCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	baseCtx = context.WithValue(baseCtx, contextKey("key"), "value")
+
+	parentCtx, parentSpan := tracer.Start(baseCtx, "parent")
+	detachedCtx := WithoutSpan(parentCtx)
+
+	if got := detachedCtx.Value(contextKey("key")); got != "value" {
+		t.Fatalf("detached context value mismatch, got %v", got)
+	}
+
+	cancel()
+	select {
+	case <-detachedCtx.Done():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("detached context did not preserve cancellation")
+	}
+
+	_, childSpan := tracer.Start(detachedCtx, "child")
+	childSpan.End()
+	parentSpan.End()
+
+	spans := recorder.Ended()
+	if len(spans) != 2 {
+		t.Fatalf("unexpected span count, got %d want 2", len(spans))
+	}
+
+	var parentRecorded, childRecorded sdktrace.ReadOnlySpan
+	for _, span := range spans {
+		switch span.Name() {
+		case "parent":
+			parentRecorded = span
+		case "child":
+			childRecorded = span
+		}
+	}
+
+	if parentRecorded == nil || childRecorded == nil {
+		t.Fatalf("missing recorded spans: parent=%v child=%v", parentRecorded != nil, childRecorded != nil)
+	}
+	if childRecorded.Parent().IsValid() {
+		t.Fatalf("child span unexpectedly had a parent: %s", childRecorded.Parent().SpanID())
+	}
+	if childRecorded.SpanContext().TraceID() == parentRecorded.SpanContext().TraceID() {
+		t.Fatal("child span unexpectedly reused parent trace")
+	}
+}


### PR DESCRIPTION
## Description

- seen in some cases app insights traces for operator be huge, because e.g. leader election interval/renew spans are included in one global startup span. This tries to fix that
- a lot of k8s API traffic is generated due to leader election, increasing the interval somewhat here

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refined operator leader-election timing configuration with explicit duration values for improved reliability.
  * Enhanced internal context handling to improve tracing and observability isolation across background processes.
  * Added comprehensive test coverage for context management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->