### PR TITLE
fix: set correct production env name for app rr-publish

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/EnvironmentsService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/EnvironmentsService.cs
@@ -125,18 +125,13 @@ public class EnvironmentsService : IEnvironmentsService
                     throw new InvalidOperationException("Failed to deserialize response content or content was empty.");
                 }
 
-                /*
-                TEMPORARILY COMMENTED OUT THIS BLOCK TO ALLOW TO TEST DEPLOY TO PRODUCTION FROM DEV ENV.
-                DO NOT MERGE WITH THIS COMMENTED OUT!!
-                ENSURE TO UNCOMMENT BEFORE MERGING!!
-                */
-                // // Pretend that production environment does not exist in dev/staging, there is very limited access anyway
-                // if (_generalSettings.HostName.StartsWith("dev.") || _generalSettings.HostName.StartsWith("staging."))
-                // {
-                //     return environmentsModel
-                //         .Environments.Where(env => !env.Name.Contains("prod", StringComparison.OrdinalIgnoreCase))
-                //         .ToList();
-                // }
+                // Pretend that production environment does not exist in dev/staging, there is very limited access anyway
+                if (_generalSettings.HostName.StartsWith("dev.") || _generalSettings.HostName.StartsWith("staging."))
+                {
+                    return environmentsModel
+                        .Environments.Where(env => !env.Name.Contains("prod", StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+                }
 
                 return environmentsModel.Environments;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Publishing to resource registry fails when deploying apps to production.
This is caused by a mismatch between the production env name in apps (`production`) and the production env name in resource admin config (`PROD`).
We should probably decide on a single representation of these environments within Designer, f.ex. https://github.com/Altinn/altinn-cdn/blob/master/config/environments.json.
In the mean time, I have added a workaround that ensures we pass the expected env name to resource-admin when deploying apps.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure "production" environment is consistently mapped to the canonical production identifier when publishing services.
* **Improvements**
  * Environment listings now return the full set of environments regardless of runtime hostname, ensuring all environments are visible in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->