### PR TITLE
chore: operator - treat 404 as OK

### DIFF
--- a/infra/observability/base/gateway.yaml
+++ b/infra/observability/base/gateway.yaml
@@ -65,6 +65,17 @@ spec:
               - set(span.attributes["altinn.original_http.status_code"], span.attributes["http.status_code"]) where resource.attributes["service.name"] == "pdf3-worker" and name == "POST /generate" and span.attributes["http.status_code"] == 429
               - set(span.attributes["http.response.status_code"], 299) where resource.attributes["service.name"] == "pdf3-worker" and name == "POST /generate" and span.attributes["http.response.status_code"] == 429
               - set(span.attributes["http.status_code"], 299) where resource.attributes["service.name"] == "pdf3-worker" and name == "POST /generate" and span.attributes["http.status_code"] == 429
+      transform/azuremonitor_expected_404:
+        error_mode: ignore
+        trace_statements:
+          - context: span
+            statements:
+              # Azure Monitor derives dependency success from HTTP status, not just span status.
+              - set(span.attributes["altinn.original_http.response.status_code"], span.attributes["http.response.status_code"]) where span.attributes["azuremonitor.expected_404"] == true and span.attributes["http.response.status_code"] == 404
+              - set(span.attributes["altinn.original_http.status_code"], span.attributes["http.status_code"]) where span.attributes["azuremonitor.expected_404"] == true and span.attributes["http.status_code"] == 404
+              - set(span.attributes["http.response.status_code"], 299) where span.attributes["azuremonitor.expected_404"] == true and span.attributes["http.response.status_code"] == 404
+              - set(span.attributes["http.status_code"], 299) where span.attributes["azuremonitor.expected_404"] == true and span.attributes["http.status_code"] == 404
+              - delete_key(span.attributes, "azuremonitor.expected_404") where span.attributes["azuremonitor.expected_404"] != nil
       filter/metrics_allowlist:
         error_mode: ignore
         metrics:

--- a/infra/observability/runtime/overlay/patches/gateway-config.yaml
+++ b/infra/observability/runtime/overlay/patches/gateway-config.yaml
@@ -38,11 +38,11 @@ spec:
           exporters: [routing/traces]
         traces/control_plane:
           receivers: [routing/traces]
-          processors: [transform/azuremonitor, transform/pdf3_expected_429_success, tail_sampling, batch]
+          processors: [transform/azuremonitor, transform/pdf3_expected_429_success, transform/azuremonitor_expected_404, tail_sampling, batch]
           exporters: [azuremonitor/control_plane]
         traces/data_plane:
           receivers: [routing/traces]
-          processors: [transform/azuremonitor, transform/pdf3_expected_429_success, tail_sampling, batch]
+          processors: [transform/azuremonitor, transform/pdf3_expected_429_success, transform/azuremonitor_expected_404, tail_sampling, batch]
           exporters: [azuremonitor/data_plane]
         metrics/in:
           receivers: [otlp]

--- a/infra/observability/studio/overlay/patches/gateway-config.yaml
+++ b/infra/observability/studio/overlay/patches/gateway-config.yaml
@@ -15,7 +15,7 @@ spec:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [transform/azuremonitor, tail_sampling, batch]
+          processors: [transform/azuremonitor, transform/azuremonitor_expected_404, tail_sampling, batch]
           exporters: [azuremonitor]
         metrics:
           receivers: [otlp]

--- a/src/Runtime/operator/internal/telemetry/telemetry.go
+++ b/src/Runtime/operator/internal/telemetry/telemetry.go
@@ -9,6 +9,8 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	otelmetric "go.opentelemetry.io/otel/metric"
@@ -20,7 +22,9 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const scopeName = "operator"
+const (
+	scopeName = "operator"
+)
 
 func Tracer() oteltrace.Tracer {
 	return otel.Tracer(scopeName)
@@ -83,9 +87,47 @@ func ConfigureOTel(ctx context.Context) (shutdown func(context.Context) error, e
 }
 
 func WrapTransport(config *rest.Config) {
-	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-		return otelhttp.NewTransport(rt)
-	})
+	config.Wrap(newKubernetesTransport)
+}
+
+func newKubernetesTransport(base http.RoundTripper) http.RoundTripper {
+	return otelhttp.NewTransport(&kubernetesAPITransport{base: base})
+}
+
+type kubernetesAPITransport struct {
+	base http.RoundTripper
+}
+
+func (t *kubernetesAPITransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.base == nil {
+		t.base = http.DefaultTransport
+	}
+
+	res, err := t.base.RoundTrip(req)
+	if err != nil || res == nil || res.StatusCode != http.StatusNotFound || !isExpectedNotFoundKubernetesRequest(req) {
+		if err != nil {
+			return res, fmt.Errorf("round trip kubernetes API request: %w", err)
+		}
+		return res, nil
+	}
+
+	const azureMonitorExpected404Attribute = "azuremonitor.expected_404"
+	span := oteltrace.SpanFromContext(req.Context())
+	span.SetAttributes(attribute.Bool(azureMonitorExpected404Attribute, true))
+	span.SetStatus(codes.Ok, "")
+
+	return res, nil
+}
+
+func isExpectedNotFoundKubernetesRequest(req *http.Request) bool {
+	const inactivityScalerOverrideConfigMapPath = "/api/v1/namespaces/runtime-operator/configmaps/" +
+		"inactivity-scaler-override"
+
+	if req == nil || req.URL == nil {
+		return false
+	}
+
+	return req.Method == http.MethodGet && req.URL.Path == inactivityScalerOverrideConfigMapPath
 }
 
 func newPropagator() propagation.TextMapPropagator {

--- a/src/Runtime/operator/internal/telemetry/telemetry_test.go
+++ b/src/Runtime/operator/internal/telemetry/telemetry_test.go
@@ -2,11 +2,24 @@ package telemetry
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	testAzureMonitorExpected404Attribute      = "azuremonitor.expected_404"
+	testInactivityScalerOverrideConfigMapPath = "/api/v1/namespaces/runtime-operator/configmaps/" +
+		"inactivity-scaler-override"
 )
 
 func TestWithoutSpan(t *testing.T) {
@@ -64,4 +77,150 @@ func TestWithoutSpan(t *testing.T) {
 	if childRecorded.SpanContext().TraceID() == parentRecorded.SpanContext().TraceID() {
 		t.Fatal("child span unexpectedly reused parent trace")
 	}
+}
+
+func TestKubernetesTransportTreats404AsSuccess(t *testing.T) {
+	t.Parallel()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() {
+		if err := provider.Shutdown(context.Background()); err != nil {
+			t.Fatalf("shutdown tracer provider: %v", err)
+		}
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != testInactivityScalerOverrideConfigMapPath {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := &http.Client{
+		Transport: otelhttpTransportForTest(server.Client().Transport, provider),
+	}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		server.URL+testInactivityScalerOverrideConfigMapPath,
+		http.NoBody,
+	)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client do: %v", err)
+	}
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			t.Fatalf("close response body: %v", err)
+		}
+	}()
+
+	if _, err := io.Copy(io.Discard, res.Body); err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+
+	span := singleEndedSpan(t, recorder)
+	if span.Status().Code != codes.Ok {
+		t.Fatalf("unexpected span status: got %s want %s", span.Status().Code, codes.Ok)
+	}
+
+	if got := findAttribute(span.Attributes(), testAzureMonitorExpected404Attribute); got != attribute.BoolValue(true) {
+		t.Fatalf("missing success override attribute: got %v", got)
+	}
+}
+
+func TestKubernetesTransportLeavesOther404AsError(t *testing.T) {
+	t.Parallel()
+
+	assertKubernetesTransportLeavesErrorStatus(t, http.StatusNotFound, "")
+}
+
+func TestKubernetesTransportLeaves500AsError(t *testing.T) {
+	t.Parallel()
+
+	assertKubernetesTransportLeavesErrorStatus(t, http.StatusInternalServerError, "")
+}
+
+func otelhttpTransportForTest(base http.RoundTripper, provider trace.TracerProvider) http.RoundTripper {
+	return otelhttp.NewTransport(&kubernetesAPITransport{base: base}, otelhttp.WithTracerProvider(provider))
+}
+
+func singleEndedSpan(t *testing.T, recorder *tracetest.SpanRecorder) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("unexpected ended span count: got %d want 1", len(spans))
+	}
+
+	return spans[0]
+}
+
+func assertKubernetesTransportLeavesErrorStatus(t *testing.T, statusCode int, path string) {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() {
+		if err := provider.Shutdown(context.Background()); err != nil {
+			t.Fatalf("shutdown tracer provider: %v", err)
+		}
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(statusCode)
+	}))
+	defer server.Close()
+
+	client := &http.Client{
+		Transport: otelhttpTransportForTest(server.Client().Transport, provider),
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+path, http.NoBody)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client do: %v", err)
+	}
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			t.Fatalf("close response body: %v", err)
+		}
+	}()
+
+	if _, err := io.Copy(io.Discard, res.Body); err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+
+	span := singleEndedSpan(t, recorder)
+	if span.Status().Code != codes.Error {
+		t.Fatalf("unexpected span status: got %s want %s", span.Status().Code, codes.Error)
+	}
+
+	if got := findAttribute(span.Attributes(), testAzureMonitorExpected404Attribute); got.Type() != attribute.INVALID {
+		t.Fatalf("unexpected success override attribute: got %v", got)
+	}
+}
+
+func findAttribute(attrs []attribute.KeyValue, key string) attribute.Value {
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr.Value
+		}
+	}
+
+	return attribute.Value{}
 }


### PR DESCRIPTION
## Description

we get a lot of error noise in monitoring due to 404s being reported as failed spans. This is completely normal for a lot of APIs though, one of which is this inactivity-scaler-override GET request

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced observability and telemetry pipelines to distinguish expected 404 responses from genuine errors in system monitoring, improving signal quality and alert accuracy.
  * Updated processor configurations across multiple runtime environments to handle anticipated infrastructure failures more effectively.

* **Tests**
  * Added comprehensive test coverage validating expected 404 response handling and observability behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->