### PR TITLE
fix: operator - k8s api transport preserve raw error

### DIFF
--- a/src/Runtime/operator/internal/telemetry/telemetry.go
+++ b/src/Runtime/operator/internal/telemetry/telemetry.go
@@ -98,6 +98,7 @@ type kubernetesAPITransport struct {
 	base http.RoundTripper
 }
 
+//nolint:wrapcheck // Preserve the exact transport error so callers can keep type-based handling.
 func (t *kubernetesAPITransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.base == nil {
 		t.base = http.DefaultTransport
@@ -105,10 +106,7 @@ func (t *kubernetesAPITransport) RoundTrip(req *http.Request) (*http.Response, e
 
 	res, err := t.base.RoundTrip(req)
 	if err != nil || res == nil || res.StatusCode != http.StatusNotFound || !isExpectedNotFoundKubernetesRequest(req) {
-		if err != nil {
-			return res, fmt.Errorf("round trip kubernetes API request: %w", err)
-		}
-		return res, nil
+		return res, err
 	}
 
 	const azureMonitorExpected404Attribute = "azuremonitor.expected_404"


### PR DESCRIPTION
## Description

some types of error checking might not work with `%w`, returning the raw error without wrapping in this case

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error propagation in telemetry operations to deliver more precise error information to callers, enabling improved diagnostics and troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->