### PR TITLE
fix: WorkflowEngine.Core.Tests permanently hangs

### DIFF
--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/CancellationWatcherServiceTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/CancellationWatcherServiceTests.cs
@@ -76,7 +76,8 @@ public class CancellationWatcherServiceTests
 
         cts.Cancel();
         tracker.TryRemove(id, out _);
-        await service.StopAsync(CancellationToken.None);
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await service.StopAsync(stopCts.Token);
     }
 
     [Fact]
@@ -105,7 +106,8 @@ public class CancellationWatcherServiceTests
         );
 
         cts.Cancel();
-        await service.StopAsync(CancellationToken.None);
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await service.StopAsync(stopCts.Token);
     }
 
     [Fact]
@@ -151,6 +153,7 @@ public class CancellationWatcherServiceTests
 
         cts.Cancel();
         tracker.TryRemove(id, out _);
-        await service.StopAsync(CancellationToken.None);
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await service.StopAsync(stopCts.Token);
     }
 }

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/HeartbeatServiceTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/HeartbeatServiceTests.cs
@@ -78,7 +78,8 @@ public class HeartbeatServiceTests
         cts.Cancel();
         tracker.TryRemove(id1, out _);
         tracker.TryRemove(id2, out _);
-        await service.StopAsync(CancellationToken.None);
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await service.StopAsync(stopCts.Token);
     }
 
     [Fact]
@@ -121,7 +122,8 @@ public class HeartbeatServiceTests
 
         // Now empty the tracker — service should exit
         tracker.TryRemove(id, out _);
-        await service.StopAsync(CancellationToken.None);
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await service.StopAsync(stopCts.Token);
     }
 
     [Fact]
@@ -150,7 +152,8 @@ public class HeartbeatServiceTests
         );
 
         cts.Cancel();
-        await service.StopAsync(CancellationToken.None);
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await service.StopAsync(stopCts.Token);
     }
 
     [Fact]
@@ -192,6 +195,7 @@ public class HeartbeatServiceTests
 
         cts.Cancel();
         tracker.TryRemove(id, out _);
-        await service.StopAsync(CancellationToken.None);
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await service.StopAsync(stopCts.Token);
     }
 }

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowUpdateBufferTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowUpdateBufferTests.cs
@@ -150,7 +150,8 @@ public class WorkflowUpdateBufferTests
         var (buffer, repo) = CreateBuffer();
         SetupMockSuccess(repo);
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -168,7 +169,8 @@ public class WorkflowUpdateBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -189,7 +191,8 @@ public class WorkflowUpdateBufferTests
             )
             .Returns(Task.CompletedTask);
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -206,7 +209,8 @@ public class WorkflowUpdateBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -236,7 +240,8 @@ public class WorkflowUpdateBufferTests
                 }
             );
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -259,7 +264,8 @@ public class WorkflowUpdateBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -277,7 +283,8 @@ public class WorkflowUpdateBufferTests
             )
             .ThrowsAsync(expectedException);
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -290,7 +297,8 @@ public class WorkflowUpdateBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -300,7 +308,8 @@ public class WorkflowUpdateBufferTests
         var (buffer, repo) = CreateBuffer();
         SetupMockSuccess(repo);
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -317,7 +326,8 @@ public class WorkflowUpdateBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -331,7 +341,8 @@ public class WorkflowUpdateBufferTests
         var gate = new TaskCompletionSource();
         SetupMockSuccess(repo, gate);
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -353,7 +364,8 @@ public class WorkflowUpdateBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -375,7 +387,8 @@ public class WorkflowUpdateBufferTests
             )
             .Returns(Task.CompletedTask);
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         var tasks = Enumerable
             .Range(1, 5)
@@ -383,7 +396,8 @@ public class WorkflowUpdateBufferTests
             .ToList();
 
         // Stop should drain all pending items
-        await buffer.StopAsync(CancellationToken.None);
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await buffer.StopAsync(stopCts.Token);
 
         await Task.WhenAll(tasks);
 

--- a/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowWriteBufferTests.cs
+++ b/src/Runtime/workflow-engine/tests/WorkflowEngine.Core.Tests/WorkflowWriteBufferTests.cs
@@ -148,7 +148,8 @@ public class WorkflowWriteBufferTests
                     reqs.Select(_ => BatchEnqueueResult.Created(workflowIds)).ToArray()
             );
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -167,7 +168,8 @@ public class WorkflowWriteBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -198,7 +200,8 @@ public class WorkflowWriteBufferTests
                 }
             );
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -228,7 +231,8 @@ public class WorkflowWriteBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -259,7 +263,8 @@ public class WorkflowWriteBufferTests
                 }
             );
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -280,7 +285,8 @@ public class WorkflowWriteBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -298,7 +304,8 @@ public class WorkflowWriteBufferTests
             )
             .ThrowsAsync(expectedException);
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -311,7 +318,8 @@ public class WorkflowWriteBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -321,7 +329,8 @@ public class WorkflowWriteBufferTests
         var (buffer, repo, _) = CreateBuffer();
         SetupMockCreated(repo);
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -339,7 +348,8 @@ public class WorkflowWriteBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -365,7 +375,8 @@ public class WorkflowWriteBufferTests
                 }
             );
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -390,7 +401,8 @@ public class WorkflowWriteBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -400,7 +412,8 @@ public class WorkflowWriteBufferTests
         var (buffer, repo, signal) = CreateBuffer();
         SetupMockCreated(repo);
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -413,7 +426,8 @@ public class WorkflowWriteBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -434,7 +448,8 @@ public class WorkflowWriteBufferTests
                     reqs.Select(_ => BatchEnqueueResult.Duplicate(existingIds)).ToArray()
             );
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         try
         {
@@ -446,7 +461,8 @@ public class WorkflowWriteBufferTests
         }
         finally
         {
-            await buffer.StopAsync(CancellationToken.None);
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await buffer.StopAsync(stopCts.Token);
         }
     }
 
@@ -471,7 +487,8 @@ public class WorkflowWriteBufferTests
                 }
             );
 
-        await buffer.StartAsync(TestContext.Current.CancellationToken);
+        using var serviceCts = new CancellationTokenSource();
+        await buffer.StartAsync(serviceCts.Token);
 
         // Enqueue several items
         var tasks = Enumerable
@@ -484,7 +501,8 @@ public class WorkflowWriteBufferTests
             .ToList();
 
         // Stop the buffer — it should drain all remaining items
-        await buffer.StopAsync(CancellationToken.None);
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await buffer.StopAsync(stopCts.Token);
 
         // All tasks should complete (not hang or fault)
         await Task.WhenAll(tasks);


### PR DESCRIPTION
## Summary
- Replace all unbounded `StopAsync(CancellationToken.None)` calls with 10-second timeouts in buffer and background service tests
- Decouple buffer service lifetime from `TestContext.Current.CancellationToken` by using dedicated `CancellationTokenSource` instances for `StartAsync`
- Prevents linked-token cascade from xUnit v3 test runner cancellation into the service's drain code, which can cause the semaphore-based drain to wait indefinitely

## Context
The "Runtime Workflow Engine - Build and test" CI runner hangs indefinitely on `WorkflowEngine.Core.Tests`. The root cause is that `BackgroundService.StartAsync(ct)` creates a linked `CancellationTokenSource` from the passed token. When `TestContext.Current.CancellationToken` is used, any xUnit runner-level cancellation propagates into the service's stopping token, triggering the drain code path. The drain code then waits on `flushSemaphore.WaitAsync(CancellationToken.None)` with no timeout — a permanent hang if any in-flight flush hasn't completed.

## Test plan
- [ ] Verify CI pipeline completes without hanging
- [ ] All existing tests should still pass (no behavioral changes, only timeout safety)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test shutdown procedures with bounded cancellation timeouts across service lifecycle tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->