### PR TITLE
feat: pdf - enable pdf/a for ikta in prod

### DIFF
--- a/src/Runtime/pdf3/internal/config/config.go
+++ b/src/Runtime/pdf3/internal/config/config.go
@@ -24,6 +24,7 @@ const (
 var defaultPDFAConversionConfig = PDFAConversionConfig{
 	Targets: []PDFATarget{
 		{Environment: "tt02", ServiceOwner: "ikta"},
+		{Environment: "prod", ServiceOwner: "ikta"},
 	},
 }
 

--- a/src/Runtime/pdf3/internal/config/config_test.go
+++ b/src/Runtime/pdf3/internal/config/config_test.go
@@ -79,7 +79,7 @@ func TestPDFAConversionConfigEnabledFor(t *testing.T) {
 		},
 		{
 			name:         "wrong environment disabled",
-			environment:  "prod",
+			environment:  "proda",
 			serviceOwner: "ikta",
 			cfg:          defaultPDFAConversionConfig,
 			want:         false,
@@ -149,7 +149,7 @@ func TestConfigShouldConvertToPDFA(t *testing.T) {
 		},
 		{
 			name:         "wrong environment disabled",
-			environment:  "prod",
+			environment:  "proda",
 			serviceOwner: "ikta",
 			pdfa:         defaultPDFAConversionConfig,
 			want:         false,


### PR DESCRIPTION
## Description

Ronny talked to IKTA, they cant test in tt02 so lets enable in prod

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF/A conversion is now enabled for production environments when the service owner is ikta.

* **Tests**
  * Updated test cases to validate the new conversion configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->