### PR TITLE
chore: workflow grouping and cancellation

### DIFF
--- a/.github/workflows/app-backend-codeql.yml
+++ b/.github/workflows/app-backend-codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '5 1 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/app-backend-formatting.yml
+++ b/.github/workflows/app-backend-formatting.yml
@@ -7,6 +7,10 @@ on:
       - 'src/App/backend/**'
       - '.github/workflows/app-backend-formatting.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   verify-no-changes:
     if: |

--- a/.github/workflows/app-codelists-codeql.yml
+++ b/.github/workflows/app-codelists-codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '15 1 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/app-codelists-tests.yml
+++ b/.github/workflows/app-codelists-tests.yml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/app-codelists-tests.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     strategy:

--- a/.github/workflows/app-fileanalyzers-codeql.yml
+++ b/.github/workflows/app-fileanalyzers-codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '25 1 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/app-fileanalyzers-tests.yml
+++ b/.github/workflows/app-fileanalyzers-tests.yml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/app-fileanalyzers-tests.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     strategy:

--- a/.github/workflows/app-frontend-codeql.yml
+++ b/.github/workflows/app-frontend-codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '35 1 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/app-frontend-lighthouse-ci.yml
+++ b/.github/workflows/app-frontend-lighthouse-ci.yml
@@ -17,6 +17,11 @@ on:
       - 'src/Runtime/localtest/**'
       - 'src/test/apps/component-library/**'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-frontend:
     timeout-minutes: 10

--- a/.github/workflows/app-template-build-on-pr.yaml
+++ b/.github/workflows/app-template-build-on-pr.yaml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/app-template-build-on-pr.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     strategy:

--- a/.github/workflows/app-template-test.yml
+++ b/.github/workflows/app-template-test.yml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/app-template-test.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     strategy:

--- a/.github/workflows/cli-build-test.yaml
+++ b/.github/workflows/cli-build-test.yaml
@@ -9,6 +9,10 @@ on:
       - .github/workflows/cli-build-test.yaml
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   detect-changelog-change:
     name: Detect changelog changes

--- a/.github/workflows/codeowners-validate.yaml
+++ b/.github/workflows/codeowners-validate.yaml
@@ -9,6 +9,10 @@ on:
       - ".github/workflows/codeowners-validate.yaml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/construct-environments-script-test.yaml
+++ b/.github/workflows/construct-environments-script-test.yaml
@@ -9,6 +9,10 @@ on:
       - ".github/workflows/construct-environments-script-test.yaml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run node tests

--- a/.github/workflows/deployer-check.yaml
+++ b/.github/workflows/deployer-check.yaml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/deployer-check.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Run make check

--- a/.github/workflows/designer-backend-check-quartz-update.yml
+++ b/.github/workflows/designer-backend-check-quartz-update.yml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/designer-backend-check-quartz-update.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check-quartz-update:
     name: Check Quartz update
@@ -97,4 +101,3 @@ jobs:
           else
             echo "Tables file is up to date"
           fi
-

--- a/.github/workflows/designer-backend-codeql.yml
+++ b/.github/workflows/designer-backend-codeql.yml
@@ -21,6 +21,10 @@ on:
   schedule:
     - cron: '45 1 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/designer-backend-dotnet-format.yaml
+++ b/.github/workflows/designer-backend-dotnet-format.yaml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/designer-backend-dotnet-format.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   dotnet-format-check:
     name: Format check

--- a/.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml
+++ b/.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   ensure-migrations-compatibility:
     name: Try to generate script and to add a new migrations

--- a/.github/workflows/designer-backend-dotnet-test.yaml
+++ b/.github/workflows/designer-backend-dotnet-test.yaml
@@ -10,6 +10,10 @@ on:
       - '.github/workflows/designer-backend-dotnet-test.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     strategy:

--- a/.github/workflows/designer-backend-gitea-and-db-integration-tests.yaml
+++ b/.github/workflows/designer-backend-gitea-and-db-integration-tests.yaml
@@ -11,6 +11,10 @@ on:
       - '.github/workflows/designer-backend-gitea-and-db-integration-tests.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   gitea-and-db-integration-tests:
     name: Run integration tests against actual gitea and dbs

--- a/.github/workflows/designer-frontend-codeql.yml
+++ b/.github/workflows/designer-frontend-codeql.yml
@@ -29,6 +29,10 @@ on:
   schedule:
     - cron: '55 1 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/designer-frontend-config-coverage.yml
+++ b/.github/workflows/designer-frontend-config-coverage.yml
@@ -9,6 +9,10 @@ on:
     - 'src/Designer/frontend/scripts/configurationStats/**'
     - '.github/workflows/designer-frontend-config-coverage.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   stats:
     name: 'Generate stats on configuration coverage'

--- a/.github/workflows/gitea-check-texts-file.yml
+++ b/.github/workflows/gitea-check-texts-file.yml
@@ -9,6 +9,10 @@ on:
       - '.github/workflows/gitea-check-texts-file.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check-gitea-texts-file:
     name: Check Gitea texts file
@@ -89,4 +93,3 @@ jobs:
           else
             echo "All custom US locale keys exist in Gitea v${{ steps.get-gitea-version.outputs.gitea-version }}."
           fi
-

--- a/.github/workflows/gitea-runner-test.yml
+++ b/.github/workflows/gitea-runner-test.yml
@@ -7,6 +7,10 @@ on:
       - 'src/gitea-runner/**'
       - '.github/workflows/gitea-runner-test.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/mcp-build.yaml
+++ b/.github/workflows/mcp-build.yaml
@@ -5,6 +5,10 @@ on:
     paths:
       - 'src/AI/mcp/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/mcp-test.yaml
+++ b/.github/workflows/mcp-test.yaml
@@ -5,6 +5,10 @@ on:
     paths:
       - 'src/AI/mcp/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/runtime-devenv-build.yml
+++ b/.github/workflows/runtime-devenv-build.yml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/runtime-devenv-build.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Check formatting and lint

--- a/.github/workflows/runtime-gateway-tests.yaml
+++ b/.github/workflows/runtime-gateway-tests.yaml
@@ -10,6 +10,10 @@ on:
       - '.github/workflows/runtime-gateway-tests.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: Build and test

--- a/.github/workflows/runtime-health-build.yml
+++ b/.github/workflows/runtime-health-build.yml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/runtime-health-build.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Check formatting and lint

--- a/.github/workflows/runtime-kubernetes-wrapper-build.yaml
+++ b/.github/workflows/runtime-kubernetes-wrapper-build.yaml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/runtime-kubernetes-wrapper-integrationtests-kind.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Build and test

--- a/.github/workflows/runtime-localtest-build.yml
+++ b/.github/workflows/runtime-localtest-build.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'src/Runtime/localtest/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/runtime-operator-build.yml
+++ b/.github/workflows/runtime-operator-build.yml
@@ -10,6 +10,10 @@ on:
       - 'src/App/azure-pipelines/deploy-app.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Build and test

--- a/.github/workflows/runtime-pdf3-build.yml
+++ b/.github/workflows/runtime-pdf3-build.yml
@@ -9,6 +9,10 @@ on:
       - '.github/workflows/runtime-pdf3-build.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and test

--- a/.github/workflows/runtime-workflow-engine-app-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-app-tests.yaml
@@ -16,6 +16,10 @@ on:
       - '.github/workflows/runtime-workflow-engine-app-tests.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: Build and test

--- a/.github/workflows/runtime-workflow-engine-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-tests.yaml
@@ -12,6 +12,10 @@ on:
       - '.github/workflows/runtime-workflow-engine-tests.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: Build and test

--- a/.github/workflows/validate-renovate.yaml
+++ b/.github/workflows/validate-renovate.yaml
@@ -5,6 +5,10 @@ on:
       - "renovate.json"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Description

add concurrency blocks with grouping and cancellation to more worklofs in an effort to save on CI time

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added concurrency configuration to GitHub Actions workflows, ensuring only the latest workflow run executes for each group (pull request, branch, or run ID). Older in-progress runs are automatically cancelled when new runs are triggered, improving resource utilisation and reducing unnecessary parallel execution across the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->