### PR TITLE
fix: always restart fake-ansattporten when restarting docker

### DIFF
--- a/src/Designer/compose.yaml
+++ b/src/Designer/compose.yaml
@@ -12,6 +12,7 @@ services:
   fake_ansattporten:
     container_name: fake-ansattporten
     image: fake-ansattporten:${COMMIT:-latest}
+    restart: always
     build:
       context: ./development/fake-ansattporten
     ports:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds `restart: always` to the Fake Ansattporten service in Designer's `compose.yml`, so that we don't have to start it manually when restarting Docker.

The same rule was already in place for Loadbalancer, Designer, Gitea Proxy, Repositories, DB, and Redis.

We could add the rule to Azure Mock as well, but it's only required when developing the deploy page (not as critical as Fake Ansattporten), so I let it be to save on memory.

## Verification

- [ ] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced service reliability by implementing automatic restart functionality for improved availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->