### PR TITLE
fix: ensure correct orgnr for ttd

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/ApplicationInformationService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/ApplicationInformationService.cs
@@ -123,9 +123,9 @@ namespace Altinn.Studio.Designer.Services.Implementation
                 Org orgListOrg = await _orgService.GetOrg(org);
                 if (org == "ttd")
                 {
-                    // Ensure we have the correct org number for ttd, which is needed for the 
-                    // competent authority information in the service resource sent to Resource Registry. 
-                    // We get this from the environments service which has the established logic for handling 
+                    // Ensure we have the correct org number for ttd, which is needed for the
+                    // competent authority information in the service resource sent to Resource Registry.
+                    // We get this from the environments service which has the established logic for handling
                     // ttd's org number situation (see EnvironmentsService.GetAltinnOrgNumber and related comments).
                     orgListOrg.Orgnr = await _environmentsService.GetAltinnOrgNumber(org);
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use established method to fetch orgnr with custom logic for handling ttd org.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Application publishing updated to obtain organisation numbers from environment configuration for certain organisation contexts, ensuring published service resources include environment-resolved organisation information.
  * Service initialisation now accepts an environment-resolution capability to support the above behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->