### PR TITLE
fix:visible/delegable should default to true if no value is set

### DIFF
--- a/src/Designer/backend/src/Designer/Services/Implementation/Validation/AltinnAppServiceResourceService.cs
+++ b/src/Designer/backend/src/Designer/Services/Implementation/Validation/AltinnAppServiceResourceService.cs
@@ -164,8 +164,8 @@ public static class ApplicationMetadataMapper
             Description = applicationmetadata?.Description?.ToDictionary(),
             ContactPoints = applicationmetadata?.ContactPoints?.ToServiceContactPoints(),
             RightDescription = applicationmetadata?.Access?.RightDescription?.ToDictionary(),
-            Delegable = applicationmetadata?.Access?.Delegable ?? false,
-            Visible = applicationmetadata?.Access?.Visible ?? false,
+            Delegable = applicationmetadata?.Access?.Delegable ?? true,
+            Visible = applicationmetadata?.Access?.Visible ?? true,
             AvailableForType = applicationmetadata?.Access?.AvailableForType,
         };
     }

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/AppConfigForm.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/AppConfigForm.test.tsx
@@ -136,6 +136,33 @@ describe('AppConfigForm', () => {
     expect(delegableSwitch).toBeChecked();
   });
 
+  it('displays correct default values for visibility and delegation when access is not defined, and updates the values on change', async () => {
+    const user = userEvent.setup();
+    renderAppConfigForm({
+      appConfig: { ...mockAppConfig, access: undefined },
+    });
+
+    const visibleSwitch = getSwitch(
+      textMock('app_settings.about_tab_visibility_and_delegation_visible_label'),
+    );
+    const delegableSwitch = getSwitch(
+      textMock('app_settings.about_tab_visibility_and_delegation_delegable_label'),
+    );
+
+    expect(visibleSwitch).toBeChecked();
+    expect(delegableSwitch).toBeChecked();
+
+    await user.click(visibleSwitch);
+
+    expect(visibleSwitch).not.toBeChecked();
+    expect(delegableSwitch).toBeChecked();
+
+    await user.click(delegableSwitch);
+
+    expect(visibleSwitch).not.toBeChecked();
+    expect(delegableSwitch).not.toBeChecked();
+  });
+
   it('updates "keywords" input field with correct value on change', async () => {
     const user = userEvent.setup();
     renderAppConfigForm();

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/AppConfigForm.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/AppConfigForm.tsx
@@ -180,8 +180,8 @@ export function AppConfigForm({ appConfig, saveAppConfig }: AppConfigFormProps):
           onUnsavedValueChange={handleUnsavedValueChange('homepage')}
         />
         <AppVisibilityAndDelegationCard
-          visible={updatedAppConfig.access?.visible ?? false}
-          delegable={updatedAppConfig.access?.delegable ?? false}
+          visible={updatedAppConfig.access?.visible ?? true}
+          delegable={updatedAppConfig.access?.delegable ?? true}
           descriptionValue={updatedAppConfig.access?.rightDescription ?? defaultDescriptionValue}
           onChangeVisible={onChangeVisible}
           onChangeDelegable={onChangeDelegable}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

See title.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for default app visibility and delegation settings.

* **Changes**
  * App visibility and delegation settings now default to enabled when access configuration is not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->