### PR TITLE
fix: Update agents .env.example

### DIFF
--- a/src/AI/agents/.env.example
+++ b/src/AI/agents/.env.example
@@ -1,5 +1,5 @@
 # Altinity Agent Configuration
-# Copy to .env (local) or .env.docker (Docker)
+# Copy to .env.docker (Docker) or .env (local)
 
 # =============================================================================
 # REQUIRED: Azure OpenAI
@@ -8,14 +8,14 @@ AZURE_API_KEY=your_azure_api_key
 # AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/  # Optional - default set in base_config.py
 
 # =============================================================================
-# REQUIRED: Gitea (for cloning and pushing branches)
+# OPTIONAL: Gitea proxy (for cloning and pushing branches)
 # =============================================================================
-GITEA_BASE_URL=http://studio.localhost/repos  # Docker: http://host.docker.internal/repos
+# GITEA_BASE_URL=http://host.docker.internal:3001 # Local: http://localhost:3001
 
 # =============================================================================
-# REQUIRED: MCP Server
+# Optional: MCP Server
 # =============================================================================
-MCP_SERVER_URL=http://localhost:8069/sse  # Docker: http://host.docker.internal:8069/sse
+# MCP_SERVER_URL=http://host.docker.internal:8070/sse # Local: http://localhost:8070/sse
 
 # =============================================================================
 # OPTIONAL: Model Overrides (defaults are set in base_config.py)

--- a/src/AI/agents/shared/config/base_config.py
+++ b/src/AI/agents/shared/config/base_config.py
@@ -39,7 +39,7 @@ class BaseConfig:
     ]
 
     # External integrations
-    MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://localhost:8069/sse")
+    MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://host.docker.internal:8070/sse")
     MCP_SERVER_EXPECTED_VERSION = os.getenv("MCP_SERVER_EXPECTED_VERSION")  # Optional: if set, checks for exact version match
 
     # LLM configuration - Azure OpenAI preferred


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since #18071, we now connect with Gitea Proxy directly instead of Loadbalancer, and use port 8070 for MCP.

This PR fixes a path in `base_config.py`, and makes `GITEA_BASE_URL` and `MCP_SERVER_URL` optional in `.env.example`, since they are defined for Docker in `base_config.py`.

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment configuration guidance to prioritise Docker setup instructions

* **Chores**
  * Updated default integration endpoint URLs for consistency across environments
  * Reclassified optional configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->