### PR TITLE
chore: cancel closed workflows

### DIFF
--- a/.github/workflows/app-backend-codeql.yml
+++ b/.github/workflows/app-backend-codeql.yml
@@ -9,7 +9,7 @@ on:
       - '.github/codeql/**'
       - '.github/workflows/app-backend-codeql.yml'
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/backend/**'
       - '.github/actions/codeql-config/**'
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/app-backend-tests.yml
+++ b/.github/workflows/app-backend-tests.yml
@@ -2,7 +2,7 @@ name: App Backend - Build and test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/backend/**'
       - 'src/Runtime/localtest/**'
@@ -10,19 +10,19 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   build-frontend:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/app-build-frontend
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     needs: build-frontend
     strategy:
       matrix:

--- a/.github/workflows/app-codelists-codeql.yml
+++ b/.github/workflows/app-codelists-codeql.yml
@@ -9,7 +9,7 @@ on:
       - '.github/codeql/**'
       - '.github/workflows/app-codelists-codeql.yml'
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/codelists/**'
       - '.github/actions/codeql-config/**'
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/app-codelists-tests.yml
+++ b/.github/workflows/app-codelists-tests.yml
@@ -2,7 +2,7 @@ name: App Codelists - Build and test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/codelists/**'
       - '.github/workflows/app-codelists-tests.yml'
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     strategy:
       matrix:
         os:

--- a/.github/workflows/app-fileanalyzers-codeql.yml
+++ b/.github/workflows/app-fileanalyzers-codeql.yml
@@ -9,7 +9,7 @@ on:
       - '.github/codeql/**'
       - '.github/workflows/app-fileanalyzers-codeql.yml'
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/fileanalyzers/**'
       - '.github/actions/codeql-config/**'
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/app-fileanalyzers-tests.yml
+++ b/.github/workflows/app-fileanalyzers-tests.yml
@@ -2,7 +2,7 @@ name: App Fileanalyzers - Build and test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/fileanalyzers/**'
       - '.github/workflows/app-fileanalyzers-tests.yml'
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     strategy:
       matrix:
         os:

--- a/.github/workflows/app-frontend-codeql.yml
+++ b/.github/workflows/app-frontend-codeql.yml
@@ -9,7 +9,7 @@ on:
       - '.github/codeql/**'
       - '.github/workflows/app-frontend-codeql.yml'
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/frontend/**'
       - '.github/actions/codeql-config/**'
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/app-frontend-compare-repos.yml
+++ b/.github/workflows/app-frontend-compare-repos.yml
@@ -2,18 +2,18 @@ name: App Frontend - Compare Repos
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/frontend/**'
       - '.github/workflows/app-frontend-compare-repos.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   verify-monorepo-changed-paths:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Verify monorepo changed paths

--- a/.github/workflows/app-frontend-cypress.yml
+++ b/.github/workflows/app-frontend-cypress.yml
@@ -2,7 +2,7 @@ name: App Frontend - Cypress
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/backend/**'
       - 'src/App/codelists/**'
@@ -17,12 +17,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   build-frontend:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build Frontend
     runs-on: ubuntu-latest
     container:
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/app-build-frontend
 
   build-docker-images:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build Docker Images
     runs-on: ubuntu-latest
     container:
@@ -52,7 +52,7 @@ jobs:
   cypress-run-internal:
     name: Cypress Run Internal
     if: |
-      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      (github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft)) &&
       github.repository_owner == 'Altinn' &&
       (
         (github.event_name != 'pull_request' && github.event.repository.fork == false) ||
@@ -134,7 +134,7 @@ jobs:
   cypress-run-external:
     name: Cypress Run External
     if: |
-      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      (github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft)) &&
       github.repository_owner == 'Altinn' &&
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
 

--- a/.github/workflows/app-frontend-k6-browser.yml
+++ b/.github/workflows/app-frontend-k6-browser.yml
@@ -2,7 +2,7 @@ name: App Frontend - K6 Browser Tests
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/backend/**'
       - 'src/App/codelists/**'
@@ -17,11 +17,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   build-frontend:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build Frontend
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/app-build-frontend
 
   build-localtest:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build Localtest
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -45,7 +45,7 @@ jobs:
           docker-profile: 'test-apps'
 
   k6-browser:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: K6 Browser
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/app-frontend-lighthouse-ci.yml
+++ b/.github/workflows/app-frontend-lighthouse-ci.yml
@@ -10,7 +10,7 @@ on:
       - 'src/Runtime/localtest/**'
       - 'src/test/apps/component-library/**'
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - '.github/workflows/app-frontend-lighthouse-ci.yml'
       - './.github/actions/**'
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   build-frontend:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/app-build-frontend
 
   build-localtest:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -47,7 +47,7 @@ jobs:
           docker-profile: 'test-apps'
 
   lighthouse:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Lighthouse CI
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/app-frontend-unit-tests.yml
+++ b/.github/workflows/app-frontend-unit-tests.yml
@@ -2,19 +2,19 @@ name: App Frontend - Unit tests
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/frontend/src/**'
       - 'src/App/frontend/package.json'
       - '.github/workflows/app-frontend-unit-tests.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   unit-tests:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Type-checks, eslint, unit tests and SonarCloud

--- a/.github/workflows/app-template-build-on-pr.yaml
+++ b/.github/workflows/app-template-build-on-pr.yaml
@@ -2,7 +2,7 @@ name: App Template - docker build on PR
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/template/**'
       - '.github/workflows/app-template-build-on-pr.yaml'
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/app-template-test.yml
+++ b/.github/workflows/app-template-test.yml
@@ -2,7 +2,7 @@ name: App Template - Build and test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/App/template/**'
       - '.github/workflows/app-template-test.yml'
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     strategy:
       matrix:
         os: [macos-latest,windows-latest,ubuntu-latest]

--- a/.github/workflows/cli-build-test.yaml
+++ b/.github/workflows/cli-build-test.yaml
@@ -2,7 +2,7 @@ name: CLI - Build and test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - "src/cli/**"
       - "src/tools/releaser/**"
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   detect-changelog-change:
     name: Detect changelog changes
-    if: github.event_name == 'pull_request' && !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -37,7 +37,7 @@ jobs:
 
   validate-changelog:
     name: Validate changelog
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.detect-changelog-change.outputs.changed == 'true'
+    if: (github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft)) && needs.detect-changelog-change.outputs.changed == 'true'
     needs: detect-changelog-change
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -59,7 +59,7 @@ jobs:
           go run . validate-changelog -component studioctl -base "${{ github.event.pull_request.base.sha }}" -head "${{ github.event.pull_request.head.sha }}"
 
   verify-release-artifacts:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Verify studioctl release artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -91,7 +91,7 @@ jobs:
           retention-days: 1
 
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     strategy:
       matrix:
         os: [macos-latest,windows-latest,ubuntu-latest]

--- a/.github/workflows/construct-environments-script-test.yaml
+++ b/.github/workflows/construct-environments-script-test.yaml
@@ -2,7 +2,7 @@ name: Construct Environments Script - Test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - ".github/scripts/construct-environments.mjs"
       - ".github/scripts/construct-environments.test.mjs"
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Run node tests
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/designer-backend-check-quartz-update.yml
+++ b/.github/workflows/designer-backend-check-quartz-update.yml
@@ -2,7 +2,7 @@ name: Designer Backend - Verify Quartz migrations
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Designer/backend/**'
       - '.github/workflows/designer-backend-check-quartz-update.yml'
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-quartz-update:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Check Quartz update
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/designer-backend-codeql.yml
+++ b/.github/workflows/designer-backend-codeql.yml
@@ -10,7 +10,7 @@ on:
       - '.github/codeql/**'
       - '.github/workflows/designer-backend-codeql.yml'
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Designer/testdata/**'
       - 'src/Designer/backend/**'
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml
+++ b/.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml
@@ -2,7 +2,7 @@ name: Designer Backend - Ensure Migrations Compatibility
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Designer/backend/**'
       - '.github/workflows/designer-backend-dotnet-migrations-ensure-compatibility.yaml'
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   ensure-migrations-compatibility:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Try to generate script and to add a new migrations
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/designer-backend-dotnet-test.yaml
+++ b/.github/workflows/designer-backend-dotnet-test.yaml
@@ -2,7 +2,7 @@ name: Designer Backend - Build and test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Designer/backend/**'
       - 'src/Designer/testdata/**'
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     strategy:
       matrix:
         os: [ubuntu-latest,windows-latest,macos-latest]

--- a/.github/workflows/designer-backend-gitea-and-db-integration-tests.yaml
+++ b/.github/workflows/designer-backend-gitea-and-db-integration-tests.yaml
@@ -2,7 +2,7 @@ name: Designer Backend - Gitea and Db integration tests
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Designer/backend/**'
       - 'src/Designer/testdata/**'
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   gitea-and-db-integration-tests:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Run integration tests against actual gitea and dbs
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/designer-frontend-codeql.yml
+++ b/.github/workflows/designer-frontend-codeql.yml
@@ -14,7 +14,7 @@ on:
       - 'package.json'
       - 'yarn.lock'
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Designer/frontend/**'
       - 'src/Designer/frontend/testing/cypress/**'
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/designer-frontend-config-coverage.yml
+++ b/.github/workflows/designer-frontend-config-coverage.yml
@@ -2,7 +2,7 @@ name: Designer Frontend - Configuration coverage stats
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
     - 'src/Designer/frontend/app-development/**'
     - 'src/Designer/frontend/packages/ux-editor/**'
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   stats:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: 'Generate stats on configuration coverage'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
+++ b/.github/workflows/designer-frontend-run-playwright-on-pr.yaml
@@ -2,7 +2,7 @@ name: Designer Frontend - Playwright tests on PR
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Designer/frontend/**'
       - '!src/Designer/frontend/stats/**'
@@ -18,12 +18,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   playwright-tests:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Playwright (${{ matrix.studio-oidc-mode && 'StudioOidc' || 'GiteaOidc' }})
     timeout-minutes: 25
     runs-on: ubuntu-latest

--- a/.github/workflows/designer-frontend-unit-tests.yml
+++ b/.github/workflows/designer-frontend-unit-tests.yml
@@ -2,7 +2,7 @@ name: Designer Frontend - Unit tests
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Designer/frontend/**'
       - 'src/Designer/frontend/testing/cypress/**'
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -22,7 +22,7 @@ env:
 
 jobs:
   typecheck:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: 'Typechecking and linting'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -56,7 +56,7 @@ jobs:
         run: yarn run codestyle:check
 
   test:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: 'Testing'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/gitea-check-texts-file.yml
+++ b/.github/workflows/gitea-check-texts-file.yml
@@ -2,7 +2,7 @@ name: Gitea check local gitea locale files
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/gitea/Dockerfile'
       - 'src/gitea/files/locale/**'
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   check-gitea-texts-file:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Check Gitea texts file
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/gitea-runner-test.yml
+++ b/.github/workflows/gitea-runner-test.yml
@@ -2,7 +2,7 @@ name: Gitea Runner - Test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/gitea-runner/**'
       - '.github/workflows/gitea-runner-test.yml'
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   test:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/mcp-build.yaml
+++ b/.github/workflows/mcp-build.yaml
@@ -2,7 +2,7 @@ name: MCP - Build
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/AI/mcp/**'
 
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/mcp-test.yaml
+++ b/.github/workflows/mcp-test.yaml
@@ -2,7 +2,7 @@ name: MCP - Test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/AI/mcp/**'
 
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   test:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/releaser-build-test.yml
+++ b/.github/workflows/releaser-build-test.yml
@@ -2,7 +2,7 @@ name: Releaser - Build and test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - "src/tools/releaser/**"
       - ".github/workflows/releaser-build-test.yml"
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build, lint and unit tests
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/run-playwright-resourceadm-on-pr.yml
+++ b/.github/workflows/run-playwright-resourceadm-on-pr.yml
@@ -2,19 +2,19 @@ name: Resource admin playwright tests on pr
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Designer/frontend/resourceadm/**'
       - '.github/workflows/run-playwright-resourceadm-on-pr.yaml'
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   playwright-tests:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Playwright (${{ matrix.studio-oidc-mode && 'StudioOidc' || 'GiteaOidc' }})
     timeout-minutes: 25
     runs-on: ubuntu-latest

--- a/.github/workflows/runtime-gateway-tests.yaml
+++ b/.github/workflows/runtime-gateway-tests.yaml
@@ -2,7 +2,7 @@ name: Runtime Gateway - Build and test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/common/**'
       - 'src/Runtime/gateway/**'
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/runtime-kubernetes-wrapper-build.yaml
+++ b/.github/workflows/runtime-kubernetes-wrapper-build.yaml
@@ -2,7 +2,7 @@ name: Runtime kubernetes-wrapper - Build and test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Runtime/kubernetes-wrapper/**'
       - '.github/workflows/runtime-kubernetes-wrapper-integrationtests-kind.yaml'
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/runtime-localtest-build.yml
+++ b/.github/workflows/runtime-localtest-build.yml
@@ -2,7 +2,7 @@ name: Localtest - Build
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Runtime/localtest/**'
 
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/runtime-operator-build.yml
+++ b/.github/workflows/runtime-operator-build.yml
@@ -2,7 +2,7 @@ name: operator - Build
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Runtime/operator/**'
       - 'src/Runtime/devenv/**'
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   test:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -51,7 +51,7 @@ jobs:
         run: make test
 
   test-e2e:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test - e2e
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/runtime-pdf3-build.yml
+++ b/.github/workflows/runtime-pdf3-build.yml
@@ -2,7 +2,7 @@ name: pdf3 - Build
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/Runtime/pdf3/**'
       - 'src/Runtime/devenv/**'
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/runtime-workflow-engine-app-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-app-tests.yaml
@@ -2,7 +2,7 @@ name: Runtime Workflow Engine App - Build and test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/common/**'
       - 'src/Runtime/workflow-engine/src/**'
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/runtime-workflow-engine-tests.yaml
+++ b/.github/workflows/runtime-workflow-engine-tests.yaml
@@ -2,7 +2,7 @@ name: Runtime Workflow Engine - Build and test
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - 'src/common/**'
       - 'src/Runtime/workflow-engine/src/**'
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Build and test
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/validate-renovate.yaml
+++ b/.github/workflows/validate-renovate.yaml
@@ -1,7 +1,7 @@
 name: Validate Renovate config
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed]
     paths:
       - "renovate.json"
   workflow_dispatch:
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   validate:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Validate renovate.json
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Description

- mostly adding `closed` event so that we can trigger cancellation through the concurrency group when closing PRs while workflows are running
- github.ref changes between running PR and merged/closed PR so thats why some of the concurrency groups are changing

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflows to handle pull request lifecycle events more efficiently. These changes optimise CI/CD infrastructure and do not affect product functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->