### PR TITLE
chore: Combining zustand stores

### DIFF
--- a/.github/workflows/app-frontend-unit-tests.yml
+++ b/.github/workflows/app-frontend-unit-tests.yml
@@ -55,8 +55,8 @@ jobs:
           strict_error_count="$(yarn tsc-strict:error-count)"
           echo "Strict TypeScript error count: ${strict_error_count}"
 
-          if (( strict_error_count >= 302 )); then
-            echo "Strict TypeScript error count is ${strict_error_count}, expected less than 302."
+          if (( strict_error_count >= 301 )); then
+            echo "Strict TypeScript error count is ${strict_error_count}, expected less than 301."
             exit 1
           fi
 

--- a/src/App/frontend/monorepo-changed-paths.txt
+++ b/src/App/frontend/monorepo-changed-paths.txt
@@ -22,6 +22,7 @@ src/core/loading/LoadingRegistry.tsx
 src/core/queries/useQueryWithStaleData.ts
 src/features/applicationMetadata/
 src/features/applicationSettings/ApplicationSettingsProvider.tsx
+src/features/attachments/hooks.ts
 src/features/customValidation/useCustomValidationQuery.ts
 src/features/datamodel/DataElementIdsForCypress.tsx
 src/features/datamodel/DataModelsProvider.tsx
@@ -31,6 +32,7 @@ src/features/entrypoint/Entrypoint.tsx
 src/features/form/FormContext.tsx
 src/features/form/dynamics/
 src/features/form/layout/LayoutsContext.tsx
+src/features/form/layout/PageNavigationContext.tsx
 src/features/form/layout/quirks.ts
 src/features/form/layoutSets/
 src/features/form/layoutSettings/
@@ -45,6 +47,10 @@ src/features/navigation/useNavigateToPageWithValidation.ts
 src/features/options/CodeListsProvider.tsx
 src/features/orgs/OrgsProvider.tsx
 src/features/profile/ProfileProvider.tsx
+src/features/validation/backendValidation/BackendValidation.tsx
+src/features/validation/backendValidation/useUpdateIncrementalValidations.ts
+src/features/validation/nodeValidation/waitForNodesToValidate.ts
+src/features/validation/validationContext.tsx
 src/hooks/usePageValidation.ts
 src/hooks/useWaitForState.ts
 src/index.tsx

--- a/src/App/frontend/src/components/form/Form.tsx
+++ b/src/App/frontend/src/components/form/Form.tsx
@@ -12,6 +12,7 @@ import { useAppName, useAppOwner } from 'src/core/texts/appTexts';
 import { getApplicationMetadata } from 'src/features/applicationMetadata';
 import { useAllAttachments } from 'src/features/attachments/hooks';
 import { FileScanResults } from 'src/features/attachments/types';
+import { FormStore } from 'src/features/form/FormContext';
 import { useUiConfigContext } from 'src/features/form/layout/UiConfigContext';
 import { usePageSettings } from 'src/features/form/layoutSettings/processLayoutSettings';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
@@ -26,7 +27,6 @@ import { useCurrentView, useNavigatePage } from 'src/hooks/useNavigatePage';
 import { getComponentCapabilities } from 'src/layout';
 import { GenericComponent } from 'src/layout/GenericComponent';
 import { getPageTitle } from 'src/utils/getPageTitle';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { AnyValidation, BaseValidation, NodeRefValidation } from 'src/features/validation';
 
 interface FormState {
@@ -63,7 +63,7 @@ export function FormPage({ currentPageId }: { currentPageId: string | undefined 
   const appOwner = useAppOwner();
   const { langAsString } = useLanguage();
   const { hasRequired, mainIds, errorReportIds, formErrors, taskErrors } = useFormState(currentPageId);
-  const requiredFieldsMissing = NodesInternal.usePageHasVisibleRequiredValidations(currentPageId);
+  const requiredFieldsMissing = FormStore.nodes.usePageHasVisibleRequiredValidations(currentPageId);
   const allAttachments = useAllAttachments();
   const textResources = useTextResources();
 

--- a/src/App/frontend/src/components/message/ErrorReport.test.tsx
+++ b/src/App/frontend/src/components/message/ErrorReport.test.tsx
@@ -82,7 +82,8 @@ describe('ErrorReport', () => {
               customTextKey: 'some unmapped error',
               source: 'taskValidator',
               severity: BackendValidationSeverity.Error,
-            } as BackendValidationIssue,
+              dataElementId: defaultMockDataElementId,
+            } satisfies BackendValidationIssue,
           ],
         },
       };

--- a/src/App/frontend/src/core/contexts/zustandContext.tsx
+++ b/src/App/frontend/src/core/contexts/zustandContext.tsx
@@ -27,29 +27,26 @@ type ObjectOrArraySelectorFuncLax<T> = <U extends ObjectOrArray>(
   selector: Selector<T, U>,
 ) => U | typeof ContextNotProvided;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function createZustandContext<Store extends StoreApi<Type>, Type = ExtractFromStoreApi<Store>, Props = any>(
-  props: CreateContextProps<Store> & {
-    initialCreateStore: (props: Props) => Store;
-    onReRender?: (store: Store, props: Props) => void;
-  },
-) {
-  const { initialCreateStore, onReRender, ...rest } = props;
-  const { Provider, useCtx, useLaxCtx, useHasProvider } = createContext<Store>(rest);
-
+export function createZustandHooks<Store extends StoreApi<Type>, Type = ExtractFromStoreApi<Store>>({
+  useStore: useStoreHook,
+  useLaxStore: useLaxStoreHook,
+}: {
+  useStore: () => Store;
+  useLaxStore: () => Store | typeof ContextNotProvided;
+}) {
   /**
    * A hook that can be used to select values from the store. The selector function will be called whenever the store
    * changes, and the component will re-render if the selected value changes when compared with the previous value.
    */
-  const useSelector: SelectorFunc<Type> = (selector) => useStore(useCtx(), selector);
+  const useSelector: SelectorFunc<Type> = (selector) => useStore(useStoreHook(), selector);
 
   /**
    * A light weight hook that can be used to select static values from the store like update functions which are never changed.
    */
-  const useStaticSelector: SelectorFunc<Type> = (selector) => selector(useCtx().getState());
+  const useStaticSelector: SelectorFunc<Type> = (selector) => selector(useStoreHook().getState());
 
   const useSelectorAsRef: SelectorRefFunc<Type> = (selector) => {
-    const store = useCtx();
+    const store = useStoreHook();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ref = useRef<any>(selector(store.getState()));
 
@@ -68,7 +65,7 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
   };
 
   const useLaxSelectorAsRef: SelectorRefFuncLax<Type> = (selector) => {
-    const store = useLaxCtx();
+    const store = useLaxStoreHook();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ref = useRef<any>(store === ContextNotProvided ? ContextNotProvided : selector(store.getState() as Type));
 
@@ -104,7 +101,7 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
   };
 
   const useLaxMemoSelector: SelectorFuncLax<Type> = (selector) => {
-    const _store = useLaxCtx();
+    const _store = useLaxStoreHook();
     const store = _store === ContextNotProvided ? dummyStore : _store;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const prev = useRef<any>(undefined);
@@ -128,7 +125,7 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
    * is not present, the hook will return the ContextNotProvided value instead.
    */
   const useLaxSelector: SelectorFuncLax<Type> = (_selector) => {
-    const _store = useLaxCtx();
+    const _store = useLaxStoreHook();
     const store = _store === ContextNotProvided ? dummyStore : _store;
     const selector = _store === ContextNotProvided ? () => ContextNotProvided : _selector;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -140,10 +137,11 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
    * Will use shallow comparison to keep stable object references as long as the things inside don't change.
    * See: https://zustand.docs.pmnd.rs/hooks/use-shallow
    */
-  const useShallowSelector: ObjectOrArraySelectorFunc<Type> = (selector) => useStore(useCtx(), useShallow(selector));
+  const useShallowSelector: ObjectOrArraySelectorFunc<Type> = (selector) =>
+    useStore(useStoreHook(), useShallow(selector));
 
   const useLaxShallowSelector: ObjectOrArraySelectorFuncLax<Type> = (_selector) => {
-    const _store = useLaxCtx();
+    const _store = useLaxStoreHook();
     const store = _store === ContextNotProvided ? dummyStore : _store;
     const selector = _store === ContextNotProvided ? () => ContextNotProvided : _selector;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any,react-compiler/react-compiler
@@ -151,6 +149,78 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
     // eslint-disable-next-line @typescript-eslint/no-explicit-any,react-compiler/react-compiler
     return useStore(store, _useShallow(selector as any));
   };
+
+  const useLaxDS = <Mode extends DSMode<Type>>(
+    mode: Mode,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    deps?: any[],
+  ): DSReturn<DSConfig<Type, Mode, SelectorStrictness.returnWhenNotProvided>> =>
+    useDelayedSelector({
+      store: useLaxStoreHook(),
+      strictness: SelectorStrictness.returnWhenNotProvided,
+      mode,
+      deps,
+    });
+
+  const useDS = <Mode extends DSMode<Type>>(
+    mode: Mode,
+    deps?: unknown[],
+  ): DSReturn<DSConfig<Type, Mode, SelectorStrictness.throwWhenNotProvided>> =>
+    useDelayedSelector({
+      store: useStoreHook(),
+      strictness: SelectorStrictness.throwWhenNotProvided,
+      mode,
+      deps,
+    });
+
+  const useDSProps = <Mode extends DSMode<Type>>(
+    mode: Mode,
+    deps?: unknown[],
+  ): DSProps<DSConfig<Type, Mode, SelectorStrictness.throwWhenNotProvided>> => ({
+    store: useStoreHook(),
+    strictness: SelectorStrictness.throwWhenNotProvided,
+    mode,
+    deps,
+  });
+
+  const useLaxDSProps = <Mode extends DSMode<Type>>(
+    mode: Mode,
+    deps?: unknown[],
+  ): DSProps<DSConfig<Type, Mode, SelectorStrictness.returnWhenNotProvided>> => ({
+    store: useLaxStoreHook(),
+    strictness: SelectorStrictness.returnWhenNotProvided,
+    mode,
+    deps,
+  });
+
+  return {
+    useSelector,
+    useSelectorAsRef,
+    useLaxSelectorAsRef,
+    useMemoSelector,
+    useLaxMemoSelector,
+    useShallowSelector,
+    useLaxShallowSelector,
+    useLaxSelector,
+    useDelayedSelector: useDS,
+    useLaxDelayedSelector: useLaxDS,
+    useDelayedSelectorProps: useDSProps,
+    useLaxDelayedSelectorProps: useLaxDSProps,
+    useStore: useStoreHook,
+    useLaxStore: useLaxStoreHook,
+    useStaticSelector,
+  };
+}
+
+export function createZustandContext<Store extends StoreApi<Type>, Type = ExtractFromStoreApi<Store>, Props = unknown>(
+  props: CreateContextProps<Store> & {
+    initialCreateStore: (props: Props) => Store;
+    onReRender?: (store: Store, props: Props) => void;
+  },
+) {
+  const { initialCreateStore, onReRender, ...rest } = props;
+  const { Provider, useCtx, useLaxCtx, useHasProvider } = createContext<Store>(rest);
+  const hooks = createZustandHooks<Store, Type>({ useStore: useCtx, useLaxStore: useLaxCtx });
 
   function MyProvider({ children, ...props }: PropsWithChildren<Props>) {
     const storeRef = useRef<Store>(undefined);
@@ -167,66 +237,9 @@ export function createZustandContext<Store extends StoreApi<Type>, Type = Extrac
     return <Provider value={storeRef.current}>{children}</Provider>;
   }
 
-  const useLaxDS = <Mode extends DSMode<Type>>(
-    mode: Mode,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    deps?: any[],
-  ): DSReturn<DSConfig<Type, Mode, SelectorStrictness.returnWhenNotProvided>> =>
-    useDelayedSelector({
-      store: useLaxCtx(),
-      strictness: SelectorStrictness.returnWhenNotProvided,
-      mode,
-      deps,
-    });
-
-  const useDS = <Mode extends DSMode<Type>>(
-    mode: Mode,
-    deps?: unknown[],
-  ): DSReturn<DSConfig<Type, Mode, SelectorStrictness.throwWhenNotProvided>> =>
-    useDelayedSelector({
-      store: useCtx(),
-      strictness: SelectorStrictness.throwWhenNotProvided,
-      mode,
-      deps,
-    });
-
-  const useDSProps = <Mode extends DSMode<Type>>(
-    mode: Mode,
-    deps?: unknown[],
-  ): DSProps<DSConfig<Type, Mode, SelectorStrictness.throwWhenNotProvided>> => ({
-    store: useCtx(),
-    strictness: SelectorStrictness.throwWhenNotProvided,
-    mode,
-    deps,
-  });
-
-  const useLaxDSProps = <Mode extends DSMode<Type>>(
-    mode: Mode,
-    deps?: unknown[],
-  ): DSProps<DSConfig<Type, Mode, SelectorStrictness.returnWhenNotProvided>> => ({
-    store: useLaxCtx(),
-    strictness: SelectorStrictness.returnWhenNotProvided,
-    mode,
-    deps,
-  });
-
   return {
     Provider: MyProvider,
-    useSelector,
-    useSelectorAsRef,
-    useLaxSelectorAsRef,
-    useMemoSelector,
-    useLaxMemoSelector,
-    useShallowSelector,
-    useLaxShallowSelector,
-    useLaxSelector,
-    useDelayedSelector: useDS,
-    useLaxDelayedSelector: useLaxDS,
-    useDelayedSelectorProps: useDSProps,
-    useLaxDelayedSelectorProps: useLaxDSProps,
+    ...hooks,
     useHasProvider,
-    useStore: useCtx,
-    useLaxStore: useLaxCtx,
-    useStaticSelector,
   };
 }

--- a/src/App/frontend/src/features/attachments/AttachmentsStorePlugin.tsx
+++ b/src/App/frontend/src/features/attachments/AttachmentsStorePlugin.tsx
@@ -13,7 +13,7 @@ import { sortAttachmentsByName } from 'src/features/attachments/sortAttachments'
 import { attachmentSelector } from 'src/features/attachments/tools';
 import { FileScanResults } from 'src/features/attachments/types';
 import { hasPendingAttachments } from 'src/features/attachments/utils';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { dataModelPairsToObject } from 'src/features/formData/types';
 import {
   useLaxInstanceId,
@@ -26,7 +26,7 @@ import { backendValidationIssueGroupListToObject } from 'src/features/validation
 import { useUpdateIncrementalValidations } from 'src/features/validation/backendValidation/useUpdateIncrementalValidations';
 import { useWaitForState } from 'src/hooks/useWaitForState';
 import { doUpdateAttachmentTags } from 'src/queries/queries';
-import { nodesProduce } from 'src/utils/layout/NodesContext';
+import { nodesProduce } from 'src/utils/layout/nodesProduce';
 import { NodeDataPlugin } from 'src/utils/layout/plugins/NodeDataPlugin';
 import { splitDashedKey } from 'src/utils/splitDashedKey';
 import type {
@@ -39,6 +39,7 @@ import type {
 } from 'src/features/attachments/index';
 import type { AttachmentsSelector } from 'src/features/attachments/tools';
 import type { AttachmentStateInfo } from 'src/features/attachments/types';
+import type { FormStoreSet, FormStoreState } from 'src/features/form/FormContext';
 import type { FDActionResult } from 'src/features/formData/FormDataWriteStateMachine';
 import type { DSPropsForSimpleSelector } from 'src/hooks/delayedSelectors';
 import type { IDataModelBindingsList, IDataModelBindingsSimple } from 'src/layout/common.generated';
@@ -46,8 +47,6 @@ import type { RejectedFileError } from 'src/layout/FileUpload/RejectedFileError'
 import type { CompWithBehavior } from 'src/layout/layout';
 import type { SetTagsRequest } from 'src/queries/queries';
 import type { IData } from 'src/types/shared';
-import type { NodesContext, NodesStoreFull } from 'src/utils/layout/NodesContext';
-import type { NodeDataPluginSetState } from 'src/utils/layout/plugins/NodeDataPlugin';
 import type { NodeData } from 'src/utils/layout/types';
 
 type AttachmentUploadSuccess = {
@@ -128,7 +127,7 @@ export interface AttachmentsStorePluginConfig {
     useAttachments: (nodeId: string) => IAttachment[];
     useFailedAttachments: (nodeId: string) => IFailedAttachment[];
     useAttachmentsSelector: () => AttachmentsSelector;
-    useAttachmentsSelectorProps: () => DSPropsForSimpleSelector<NodesContext, AttachmentsSelector>;
+    useAttachmentsSelectorProps: () => DSPropsForSimpleSelector<FormStoreState, AttachmentsSelector>;
     useWaitUntilUploaded: () => (nodeId: string, attachment: TemporaryAttachment) => Promise<IData | false>;
 
     useHasPendingAttachments: () => boolean;
@@ -149,7 +148,7 @@ const ATTACHMENT_STATE_RESULTS = {
 type ProperData = NodeData<CompWithBehavior<'canHaveAttachments'>>;
 
 export class AttachmentsStorePlugin extends NodeDataPlugin<AttachmentsStorePluginConfig> {
-  extraFunctions(set: NodeDataPluginSetState): AttachmentsStorePluginConfig['extraFunctions'] {
+  extraFunctions(set: FormStoreSet): AttachmentsStorePluginConfig['extraFunctions'] {
     return {
       attachmentUpload: ({ files, nodeId }) => {
         set(
@@ -287,16 +286,16 @@ export class AttachmentsStorePlugin extends NodeDataPlugin<AttachmentsStorePlugi
       },
     };
   }
-  extraHooks(store: NodesStoreFull): AttachmentsStorePluginConfig['extraHooks'] {
+  extraHooks(): AttachmentsStorePluginConfig['extraHooks'] {
     return {
       useAttachmentsUpload() {
-        const upload = store.useSelector((state) => state.attachmentUpload);
-        const uploadFinished = store.useSelector((state) => state.attachmentUploadFinished);
+        const upload = FormStore.raw.useSelector((state) => state.nodes.attachmentUpload);
+        const uploadFinished = FormStore.raw.useSelector((state) => state.nodes.attachmentUploadFinished);
 
         const { mutateAsync: uploadAttachment } = useAttachmentsUploadMutation();
 
         const setAttachmentsInDataModel = useSetAttachmentInDataModel();
-        const lock = FD.useLocking('__attachment__upload__');
+        const lock = FormStore.data.useLocking('__attachment__upload__');
 
         return useCallback(
           async (action) => {
@@ -347,9 +346,9 @@ export class AttachmentsStorePlugin extends NodeDataPlugin<AttachmentsStorePlugi
         const { mutateAsync: updateTags } = useAttachmentUpdateTagsMutation();
         const optimisticallyUpdateDataElement = useOptimisticallyUpdateDataElement();
         const { lang } = useLanguage();
-        const update = store.useSelector((state) => state.attachmentUpdate);
-        const fulfill = store.useSelector((state) => state.attachmentUpdateFulfilled);
-        const reject = store.useSelector((state) => state.attachmentUpdateRejected);
+        const update = FormStore.raw.useSelector((state) => state.nodes.attachmentUpdate);
+        const fulfill = FormStore.raw.useSelector((state) => state.nodes.attachmentUpdateFulfilled);
+        const reject = FormStore.raw.useSelector((state) => state.nodes.attachmentUpdateRejected);
 
         return useCallback(
           async (action: AttachmentActionUpdate) => {
@@ -382,11 +381,11 @@ export class AttachmentsStorePlugin extends NodeDataPlugin<AttachmentsStorePlugi
       useAttachmentsRemove() {
         const { mutateAsync: removeAttachment } = useAttachmentsRemoveMutation();
         const { lang } = useLanguage();
-        const remove = store.useSelector((state) => state.attachmentRemove);
-        const fulfill = store.useSelector((state) => state.attachmentRemoveFulfilled);
-        const reject = store.useSelector((state) => state.attachmentRemoveRejected);
-        const setLeafValue = FD.useSetLeafValue();
-        const removeValueFromList = FD.useRemoveValueFromList();
+        const remove = FormStore.raw.useSelector((state) => state.nodes.attachmentRemove);
+        const fulfill = FormStore.raw.useSelector((state) => state.nodes.attachmentRemoveFulfilled);
+        const reject = FormStore.raw.useSelector((state) => state.nodes.attachmentRemoveRejected);
+        const setLeafValue = FormStore.data.useSetLeafValue();
+        const removeValueFromList = FormStore.data.useRemoveValueFromList();
 
         return useCallback(
           async (action: AttachmentActionRemove) => {
@@ -418,8 +417,8 @@ export class AttachmentsStorePlugin extends NodeDataPlugin<AttachmentsStorePlugi
         );
       },
       useAttachments(nodeId) {
-        return store.useShallowSelector((state) => {
-          const nodeData = state.nodeData[nodeId];
+        return FormStore.raw.useShallowSelector((state) => {
+          const nodeData = state.nodes.nodeData[nodeId];
           if (nodeData && 'attachments' in nodeData) {
             return Object.values(nodeData.attachments).sort(sortAttachmentsByName);
           }
@@ -428,25 +427,25 @@ export class AttachmentsStorePlugin extends NodeDataPlugin<AttachmentsStorePlugi
         });
       },
       useAttachmentsSelector() {
-        return store.useDelayedSelector({
+        return FormStore.raw.useDelayedSelector({
           mode: 'simple',
           selector: attachmentSelector,
-        }) satisfies AttachmentsSelector;
+        });
       },
       useAttachmentsSelectorProps() {
-        return store.useDelayedSelectorProps({
+        return FormStore.raw.useDelayedSelectorProps({
           mode: 'simple',
           selector: attachmentSelector,
         });
       },
       useWaitUntilUploaded() {
-        const zustandStore = store.useStore();
-        const waitFor = useWaitForState<IData | false, NodesContext>(zustandStore);
+        const zustandStore = FormStore.raw.useStore();
+        const waitFor = useWaitForState<IData | false, FormStoreState>(zustandStore);
 
         return useCallback(
           (nodeId, attachment) =>
             waitFor((state, setReturnValue) => {
-              const nodeData = state.nodeData[nodeId];
+              const nodeData = state.nodes.nodeData[nodeId];
               if (!nodeData || !('attachments' in nodeData) || !('attachmentsFailedToUpload' in nodeData)) {
                 setReturnValue(false);
                 return true;
@@ -475,13 +474,13 @@ export class AttachmentsStorePlugin extends NodeDataPlugin<AttachmentsStorePlugi
         );
       },
       useHasPendingAttachments() {
-        const out = store.useLaxSelector(hasPendingAttachments);
+        const out = FormStore.raw.useLaxSelector((state) => hasPendingAttachments(state));
         return out === ContextNotProvided ? false : out;
       },
       useAttachmentState(): AttachmentStateInfo {
-        const out = store.useLaxSelector((state): AttachmentStateInfo => {
-          for (const id of Object.keys(state.nodeData)) {
-            const nodeData = state.nodeData[id];
+        const out = FormStore.raw.useLaxSelector((state): AttachmentStateInfo => {
+          for (const id of Object.keys(state.nodes.nodeData)) {
+            const nodeData = state.nodes.nodeData[id];
             if (!nodeData || !('attachments' in nodeData)) {
               continue;
             }
@@ -507,10 +506,10 @@ export class AttachmentsStorePlugin extends NodeDataPlugin<AttachmentsStorePlugi
         return out === ContextNotProvided ? ATTACHMENT_STATE_RESULTS.ready : out;
       },
       useAllAttachments() {
-        return store.useMemoSelector((state) => {
+        return FormStore.raw.useMemoSelector((state) => {
           const map: IAttachmentsMap = {};
-          for (const id of Object.keys(state.nodeData)) {
-            const nodeData = state.nodeData[id];
+          for (const id of Object.keys(state.nodes.nodeData)) {
+            const nodeData = state.nodes.nodeData[id];
             if (!nodeData || !('attachments' in nodeData)) {
               continue;
             }
@@ -522,8 +521,8 @@ export class AttachmentsStorePlugin extends NodeDataPlugin<AttachmentsStorePlugi
         });
       },
       useFailedAttachments(nodeId) {
-        return store.useShallowSelector((state) => {
-          const nodeData = state.nodeData[nodeId];
+        return FormStore.raw.useShallowSelector((state) => {
+          const nodeData = state.nodes.nodeData[nodeId];
           if (nodeData && 'attachmentsFailedToUpload' in nodeData) {
             return Object.values(nodeData.attachmentsFailedToUpload).sort(sortAttachmentsByName);
           }
@@ -532,10 +531,10 @@ export class AttachmentsStorePlugin extends NodeDataPlugin<AttachmentsStorePlugi
         });
       },
       useDeleteFailedAttachment() {
-        return store.useStaticSelector((state) => state.deleteFailedAttachment);
+        return FormStore.raw.useStaticSelector((state) => state.nodes.deleteFailedAttachment);
       },
       useAddRejectedAttachments() {
-        const addFailedAttachments = store.useStaticSelector((state) => state.addFailedAttachments);
+        const addFailedAttachments = FormStore.raw.useStaticSelector((state) => state.nodes.addFailedAttachments);
         return useCallback(
           (nodeId: string, errors: RejectedFileError[]) => {
             const attachments: IFailedAttachment[] = errors.map((error) => ({
@@ -566,9 +565,9 @@ export class AttachmentsStorePlugin extends NodeDataPlugin<AttachmentsStorePlugi
  * @see MaintainSimpleDataModelBinding
  */
 function useSetAttachmentInDataModel() {
-  const setLeafValue = FD.useSetLeafValue();
-  const appendToListUnique = FD.useAppendToListUnique();
-  const debounce = FD.useDebounceImmediately();
+  const setLeafValue = FormStore.data.useSetLeafValue();
+  const appendToListUnique = FormStore.data.useAppendToListUnique();
+  const debounce = FormStore.data.useDebounceImmediately();
 
   return useCallback(
     (attachmentIds: string[], dataModelBindings: IDataModelBindingsSimple | IDataModelBindingsList | undefined) => {

--- a/src/App/frontend/src/features/attachments/StoreAttachmentsInNode.tsx
+++ b/src/App/frontend/src/features/attachments/StoreAttachmentsInNode.tsx
@@ -5,6 +5,7 @@ import deepEqual from 'fast-deep-equal';
 import { useTaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { getApplicationMetadata } from 'src/features/applicationMetadata';
 import { isAttachmentUploaded } from 'src/features/attachments/index';
+import { FormStore } from 'src/features/form/FormContext';
 import { DEFAULT_DEBOUNCE_TIMEOUT } from 'src/features/formData/types';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { useInstanceDataElements } from 'src/features/instance/InstanceContext';
@@ -12,7 +13,6 @@ import { useProcessQuery } from 'src/features/instance/useProcessQuery';
 import { useMemoDeepEqual } from 'src/hooks/useStateDeepEqual';
 import { GeneratorInternal } from 'src/utils/layout/generator/GeneratorContext';
 import { WhenParentAdded } from 'src/utils/layout/generator/GeneratorStages';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useFormDataFor } from 'src/utils/layout/useNodeItem';
 import type { ApplicationMetadata } from 'src/features/applicationMetadata/types';
 import type { IAttachment } from 'src/features/attachments/index';
@@ -46,10 +46,10 @@ function StoreAttachmentsInNodeWorker() {
   }
   const item = GeneratorInternal.useIntermediateItem();
   const attachments = useNodeAttachments();
-  const errors = NodesInternal.useNodeErrors(parent.indexedId);
+  const errors = FormStore.nodes.useNodeErrors(parent.indexedId);
   const hasErrors = errors && Object.values(errors).length > 0;
 
-  const hasBeenSet = NodesInternal.useNodeData(parent.indexedId, undefined, (data) =>
+  const hasBeenSet = FormStore.nodes.useNodeData(parent.indexedId, undefined, (data) =>
     deepEqual('attachments' in data ? data.attachments : undefined, attachments),
   );
 
@@ -100,7 +100,7 @@ function useNodeAttachments(): AttachmentRecord {
     return mapAttachments(indexedId, baseId, data, application, taskId, nodeData);
   }, [indexedId, baseId, data, application, currentTask, nodeData, overriddenTaskId]);
 
-  const prev = NodesInternal.useNodeData(indexedId, undefined, (data) =>
+  const prev = FormStore.nodes.useNodeData(indexedId, undefined, (data) =>
     'attachments' in data ? data.attachments : undefined,
   );
 

--- a/src/App/frontend/src/features/attachments/hooks.ts
+++ b/src/App/frontend/src/features/attachments/hooks.ts
@@ -1,22 +1,22 @@
+import { FormStore } from 'src/features/form/FormContext';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 
-export const useAttachmentsUploader = () => NodesInternal.useAttachmentsUpload();
-export const useAttachmentsUpdater = () => NodesInternal.useAttachmentsUpdate();
-export const useAttachmentsRemover = () => NodesInternal.useAttachmentsRemove();
-export const useAttachmentsAwaiter = () => NodesInternal.useWaitUntilUploaded();
-export const useAddRejectedAttachments = () => NodesInternal.useAddRejectedAttachments();
-export const useDeleteFailedAttachment = () => NodesInternal.useDeleteFailedAttachment();
+export const useAttachmentsUploader = () => FormStore.nodes.useAttachmentsUpload();
+export const useAttachmentsUpdater = () => FormStore.nodes.useAttachmentsUpdate();
+export const useAttachmentsRemover = () => FormStore.nodes.useAttachmentsRemove();
+export const useAttachmentsAwaiter = () => FormStore.nodes.useWaitUntilUploaded();
+export const useAddRejectedAttachments = () => FormStore.nodes.useAddRejectedAttachments();
+export const useDeleteFailedAttachment = () => FormStore.nodes.useDeleteFailedAttachment();
 
 export const useAttachmentsFor = (baseComponentId: string) => {
   const indexedId = useIndexedId(baseComponentId);
-  return NodesInternal.useAttachments(indexedId);
+  return FormStore.nodes.useAttachments(indexedId);
 };
 export const useFailedAttachmentsFor = (baseComponentId: string) => {
   const indexedId = useIndexedId(baseComponentId);
-  return NodesInternal.useFailedAttachments(indexedId);
+  return FormStore.nodes.useFailedAttachments(indexedId);
 };
 
-export const useHasPendingAttachments = () => NodesInternal.useHasPendingAttachments();
-export const useAttachmentState = () => NodesInternal.useAttachmentState();
-export const useAllAttachments = () => NodesInternal.useAllAttachments();
+export const useHasPendingAttachments = () => FormStore.nodes.useHasPendingAttachments();
+export const useAttachmentState = () => FormStore.nodes.useAttachmentState();
+export const useAllAttachments = () => FormStore.nodes.useAllAttachments();

--- a/src/App/frontend/src/features/attachments/tools.ts
+++ b/src/App/frontend/src/features/attachments/tools.ts
@@ -1,12 +1,12 @@
 import { sortAttachmentsByName } from 'src/features/attachments/sortAttachments';
 import type { IAttachment } from 'src/features/attachments/index';
-import type { NodesContext } from 'src/utils/layout/NodesContext';
+import type { FormStoreState } from 'src/features/form/FormContext';
 
 const emptyArray = [];
 
 export type AttachmentsSelector = (nodeId: string) => IAttachment[];
-export const attachmentSelector = (nodeId: string) => (state: NodesContext) => {
-  const nodeData = state.nodeData[nodeId];
+export const attachmentSelector = (nodeId: string) => (state: FormStoreState) => {
+  const nodeData = state.nodes.nodeData[nodeId];
   if (!nodeData) {
     return emptyArray;
   }

--- a/src/App/frontend/src/features/attachments/useAttachmentDeletionInRepGroups.ts
+++ b/src/App/frontend/src/features/attachments/useAttachmentDeletionInRepGroups.ts
@@ -4,12 +4,13 @@ import { AttachmentsPlugin } from 'src/features/attachments/AttachmentsPlugin';
 import { useAttachmentsAwaiter, useAttachmentsRemover } from 'src/features/attachments/hooks';
 import { isAttachmentUploaded } from 'src/features/attachments/index';
 import { attachmentSelector } from 'src/features/attachments/tools';
+import { FormStore } from 'src/features/form/FormContext';
 import { useAsRef } from 'src/hooks/useAsRef';
 import { getComponentDef } from 'src/layout';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
+import type { FormStoreState } from 'src/features/form/FormContext';
 import type { CompWithPlugin, IDataModelBindings } from 'src/layout/layout';
-import type { NodesContext } from 'src/utils/layout/NodesContext';
+import type { NodeData } from 'src/utils/layout/types';
 
 /**
  * When deleting a row in a repeating group, we need to find any attachments that are uploaded
@@ -25,13 +26,13 @@ export function useAttachmentDeletionInRepGroups(baseComponentId: string) {
   const remove = useAsRef(useAttachmentsRemover());
   const awaiter = useAttachmentsAwaiter();
   const idRef = useAsRef(useIndexedId(baseComponentId));
-  const nodesStore = NodesInternal.useStore();
+  const formStore = FormStore.raw.useStore();
 
   return useCallback(
     async (restriction: number | undefined): Promise<boolean> => {
-      const state = nodesStore.getState();
+      const state = formStore.getState();
       const recursiveChildren = new Set<string>(recursivelyFindChildren(idRef.current, state, restriction));
-      const uploaderNodeIds = Object.values(state.nodeData)
+      const uploaderNodeIds = (Object.values(state.nodes.nodeData) as NodeData[])
         .filter((n) => {
           if (!recursiveChildren.has(n.id)) {
             return false;
@@ -44,7 +45,7 @@ export function useAttachmentDeletionInRepGroups(baseComponentId: string) {
       // This code is intentionally not parallelized, as especially LocalTest can't handle parallel requests to
       // delete attachments. It might return a 500 if you try. To be safe, we do them one by one.
       for (const uploaderId of uploaderNodeIds) {
-        const nodeData = state.nodeData[uploaderId];
+        const nodeData = state.nodes.nodeData[uploaderId];
         const dataModelBindings = nodeData?.dataModelBindings as IDataModelBindings<
           CompWithPlugin<typeof AttachmentsPlugin>
         >;
@@ -86,12 +87,12 @@ export function useAttachmentDeletionInRepGroups(baseComponentId: string) {
 
       return true;
     },
-    [nodesStore, idRef, remove, awaiter],
+    [formStore, idRef, remove, awaiter],
   );
 }
 
-function recursivelyFindChildren(parentId: string, state: NodesContext, restriction?: number): string[] {
-  const children = Object.values(state.nodeData)
+function recursivelyFindChildren(parentId: string, state: FormStoreState, restriction?: number): string[] {
+  const children = Object.values(state.nodes.nodeData)
     .filter((n) => n.parentId === parentId && (restriction === undefined || n.rowIndex === restriction))
     .map((n) => n.id);
 

--- a/src/App/frontend/src/features/attachments/utils.ts
+++ b/src/App/frontend/src/features/attachments/utils.ts
@@ -1,13 +1,13 @@
 import { FileScanResults } from 'src/features/attachments/types';
-import type { NodesContext } from 'src/utils/layout/NodesContext';
+import type { FormStoreState } from 'src/features/form/FormContext';
 
 /**
  * Checks if there are any pending attachments (uploading, updating, deleting, or infected).
  * This is a pure function that can be used both in hooks and as a selector.
  */
-export function hasPendingAttachments(state: NodesContext): boolean {
-  for (const id of Object.keys(state.nodeData)) {
-    const nodeData = state.nodeData[id];
+export function hasPendingAttachments(state: FormStoreState): boolean {
+  for (const id of Object.keys(state.nodes.nodeData)) {
+    const nodeData = state.nodes.nodeData[id];
     if (!nodeData || !('attachments' in nodeData)) {
       continue;
     }

--- a/src/App/frontend/src/features/dataLists/useDataListQuery.tsx
+++ b/src/App/frontend/src/features/dataLists/useDataListQuery.tsx
@@ -4,8 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useLaxInstanceId } from 'src/features/instance/InstanceContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { getDataListsUrl } from 'src/utils/urls/appUrlHelper';
@@ -31,7 +31,7 @@ export const useDataListQuery = (
   const { fetchDataList } = useAppQueries();
   const selectedLanguage = useCurrentLanguage();
   const instanceId = useLaxInstanceId();
-  const mappingResult = FD.useMapping(mapping, FormBootstrap.useDefaultDataType());
+  const mappingResult = FormStore.data.useMapping(mapping, FormBootstrap.useDefaultDataType());
   const { pageSize, pageNumber, sortColumn, sortDirection } = filter || {};
 
   const url = getDataListsUrl({

--- a/src/App/frontend/src/features/devtools/components/DownloadXMLButton/DownloadXMLButton.tsx
+++ b/src/App/frontend/src/features/devtools/components/DownloadXMLButton/DownloadXMLButton.tsx
@@ -7,9 +7,8 @@ import axios from 'axios';
 
 import { Button } from 'src/app-components/Button/Button';
 import { useIsStateless } from 'src/features/applicationMetadata';
-import { FormProviderHooks } from 'src/features/form/FormContext';
+import { FormProviderHooks, FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useLaxInstanceId } from 'src/features/instance/InstanceContext';
 import comboboxClasses from 'src/styles/combobox.module.css';
 import { optionFilter } from 'src/utils/options';
@@ -32,7 +31,7 @@ const InnerDownloadXMLButton = () => {
   const [selectedDataType, setSelectedDataType] = useState(writableDataTypes?.at(0));
   const disabled = !selectedDataType;
 
-  const lock = FD.useLocking('__dev_tools__');
+  const lock = FormStore.data.useLocking('__dev_tools__');
 
   const downloadXML = async () => {
     const dataElementId = selectedDataType ? getDataElementIdForDataType(selectedDataType) : undefined;

--- a/src/App/frontend/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
+++ b/src/App/frontend/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
@@ -10,11 +10,11 @@ import { DevToolsTab } from 'src/features/devtools/data/types';
 import { evalExpr } from 'src/features/expressions';
 import { ExprVal } from 'src/features/expressions/types';
 import { ExprValidation } from 'src/features/expressions/validation';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { useNavigationParam } from 'src/hooks/navigation';
 import comboboxClasses from 'src/styles/combobox.module.css';
 import { DataModelLocationProviderFromNode } from 'src/utils/layout/DataModelLocation';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 import { optionFilter } from 'src/utils/options';
 import { splitDashedKey } from 'src/utils/splitDashedKey';
@@ -63,8 +63,8 @@ export const ExpressionPlayground = () => {
   // populating the output history with a fresh value.
   const resetOutputHistory = () => setOutputs([]);
 
-  const componentOptions = NodesInternal.useMemoSelector((state) =>
-    Object.values(state.nodeData).map((nodeData) => ({
+  const componentOptions = FormStore.raw.useMemoSelector((state) =>
+    Object.values(state.nodes.nodeData).map((nodeData) => ({
       label: nodeData.id,
       value: nodeData.id,
     })),

--- a/src/App/frontend/src/features/devtools/components/NodeInspector/NodeInspectorDataModelBindings.tsx
+++ b/src/App/frontend/src/features/devtools/components/NodeInspector/NodeInspectorDataModelBindings.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useBindingSchema } from 'src/features/datamodel/useBindingSchema';
 import classes from 'src/features/devtools/components/NodeInspector/NodeInspector.module.css';
 import { Value } from 'src/features/devtools/components/NodeInspector/NodeInspectorDataField';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import type { IDataModelReference } from 'src/layout/common.generated';
 import type { IDataModelBindings } from 'src/layout/layout';
 
@@ -14,7 +14,7 @@ interface Props {
 export function NodeInspectorDataModelBindings({ dataModelBindings }: Props) {
   const schema = useBindingSchema(dataModelBindings);
   const bindings = dataModelBindings as Record<string, IDataModelReference>;
-  const results = FD.useFreshBindings(bindings, 'raw');
+  const results = FormStore.data.useFreshBindings(bindings, 'raw');
   return (
     <Value
       property='dataModelBindings'

--- a/src/App/frontend/src/features/devtools/components/NodeInspector/ValidationInspector.tsx
+++ b/src/App/frontend/src/features/devtools/components/NodeInspector/ValidationInspector.tsx
@@ -5,13 +5,13 @@ import { EyeSlashIcon } from '@navikt/aksel-icons';
 import { isAttachmentUploaded } from 'src/features/attachments';
 import { useAttachmentsFor } from 'src/features/attachments/hooks';
 import classes from 'src/features/devtools/components/NodeInspector/ValidationInspector.module.css';
+import { FormStore } from 'src/features/form/FormContext';
 import { Lang } from 'src/features/language/Lang';
 import { ValidationMask } from 'src/features/validation';
 import { isValidationVisible } from 'src/features/validation/utils';
 import { getComponentDef, implementsAnyValidation } from 'src/layout';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useDataModelBindingsFor, useExternalItem } from 'src/utils/layout/hooks';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { AttachmentValidation, NodeRefValidation, ValidationSeverity } from 'src/features/validation';
 
 interface ValidationInspectorProps {
@@ -29,8 +29,8 @@ const categories = [
 
 export const ValidationInspector = ({ baseComponentId }: ValidationInspectorProps) => {
   const indexedId = useIndexedId(baseComponentId);
-  const validations = NodesInternal.useRawValidations(indexedId);
-  const nodeVisibility = NodesInternal.useRawValidationVisibility(indexedId);
+  const validations = FormStore.nodes.useRawValidations(indexedId);
+  const nodeVisibility = FormStore.nodes.useRawValidationVisibility(indexedId);
   const dataModelBindings = useDataModelBindingsFor(baseComponentId);
   const type = useExternalItem(baseComponentId).type;
   const attachments = useAttachmentsFor(baseComponentId);

--- a/src/App/frontend/src/features/expressions/shared-context.test.tsx
+++ b/src/App/frontend/src/features/expressions/shared-context.test.tsx
@@ -8,11 +8,10 @@ import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';
 import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
 import { defaultDataTypeMock } from 'src/__mocks__/getUiConfigMock';
 import { getSharedTests } from 'src/features/expressions/shared';
+import { FormStore, FormStoreState } from 'src/features/form/FormContext';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { splitDashedKey } from 'src/utils/splitDashedKey';
 import type { SharedTestContext, SharedTestContextList } from 'src/features/expressions/shared';
-import type { NodesContext } from 'src/utils/layout/NodesContext';
 
 function contextSorter(a: SharedTestContext, b: SharedTestContext): -1 | 0 | 1 {
   if (a.component === b.component) {
@@ -22,13 +21,13 @@ function contextSorter(a: SharedTestContext, b: SharedTestContext): -1 | 0 | 1 {
   return a.component > b.component ? 1 : -1;
 }
 
-function recurse(state: NodesContext, nodeId: string, pageKey: string): SharedTestContextList {
+function recurse(state: FormStoreState, nodeId: string, pageKey: string): SharedTestContextList {
   const splitKey = splitDashedKey(nodeId);
   const context: SharedTestContextList = {
     component: splitKey.baseComponentId,
     currentLayout: pageKey,
   };
-  const children = Object.values(state.nodeData)
+  const children = Object.values(state.nodes.nodeData)
     .filter((n) => n.parentId === nodeId)
     .map((n) => recurse(state, n.id, pageKey));
   if (children.length) {
@@ -42,13 +41,13 @@ function recurse(state: NodesContext, nodeId: string, pageKey: string): SharedTe
 }
 
 function TestContexts() {
-  const contexts = NodesInternal.useMemoSelector((state) => {
+  const contexts = FormStore.raw.useMemoSelector((state) => {
     const contexts: SharedTestContextList[] = [];
-    for (const page of Object.values(state.pagesData.pages)) {
+    for (const page of Object.values(state.nodes.pagesData.pages)) {
       contexts.push({
         component: page.pageKey,
         currentLayout: page.pageKey,
-        children: Object.values(state.nodeData)
+        children: Object.values(state.nodes.nodeData)
           .filter((n) => n.pageKey === page.pageKey && n.parentId === undefined)
           .map((n) => recurse(state, n.id, page.pageKey)),
       });

--- a/src/App/frontend/src/features/form/FormContext.tsx
+++ b/src/App/frontend/src/features/form/FormContext.tsx
@@ -1,5 +1,17 @@
+import type { StoreApi } from 'zustand';
+
 import { ContextNotProvided, createContext } from 'src/core/contexts/context';
+import { createZustandHooks } from 'src/core/contexts/zustandContext';
+import { pageNavigationHooks } from 'src/features/form/layout/PageNavigationContext';
+import { formDataHooks } from 'src/features/formData/FormDataWrite';
+import { validationHooks } from 'src/features/validation/validationContext';
+import { nodesHooks } from 'src/utils/layout/NodesContext';
+import type { PageNavigationSliceState } from 'src/features/form/layout/PageNavigationContext';
 import type { FormBootstrapContextValue } from 'src/features/formBootstrap/types';
+import type { FormDataMethods, FormDataSliceState } from 'src/features/formData/FormDataWriteStateMachine';
+import type { ValidationSliceState } from 'src/features/validation';
+import type { ValidationInternals } from 'src/features/validation/validationContext';
+import type { NodesSliceState } from 'src/utils/layout/NodesContext';
 
 export interface FormContext {
   // Set this if this form context is provided somewhere it's not expected we should write data to the data model.
@@ -9,6 +21,7 @@ export interface FormContext {
   // prevent automatic effects from happening.
   readOnly?: boolean;
   bootstrap: FormBootstrapContextValue;
+  store: FormStoreApi;
 }
 
 const { Provider, useLaxCtx, useCtx } = createContext<FormContext>({
@@ -36,3 +49,36 @@ export const FormProviderHooks = {
     return ctx.bootstrap;
   },
 };
+
+const formStoreHooks = createZustandHooks<FormStoreApi, FormStoreState>({
+  useStore: () => useCtx().store,
+  useLaxStore: () => {
+    const ctx = useLaxCtx();
+    return ctx === ContextNotProvided ? ContextNotProvided : ctx.store;
+  },
+});
+
+export const FormStore = {
+  raw: formStoreHooks,
+  data: formDataHooks,
+  validation: validationHooks,
+  nodes: nodesHooks,
+  pageNavigation: pageNavigationHooks,
+};
+
+export interface FormStoreState {
+  data: FormDataSliceState & FormDataMethods;
+  validation: ValidationSliceState & ValidationInternals;
+  nodes: NodesSliceState;
+  pageNavigation: PageNavigationSliceState;
+}
+
+export type FormStoreApi = StoreApi<FormStoreState>;
+
+export type FormStoreSet = (
+  partial:
+    | FormStoreState
+    | Partial<FormStoreState>
+    | ((state: FormStoreState) => FormStoreState | Partial<FormStoreState> | void),
+  replace?: boolean,
+) => void;

--- a/src/App/frontend/src/features/form/FormProvider.tsx
+++ b/src/App/frontend/src/features/form/FormProvider.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import type { PropsWithChildren } from 'react';
 
+import { createStore } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+
 import { useTaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { DisplayError } from 'src/core/errorHandling/DisplayError';
 import { Loader } from 'src/core/loading/Loader';
@@ -11,22 +14,32 @@ import { getPrefillFromSessionStorage } from 'src/features/form/getPrefillFromSe
 import { useLayoutOverrides } from 'src/features/form/layout/layoutOverrides';
 import { processLayouts } from 'src/features/form/layout/LayoutsContext';
 import { makeLayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
-import { PageNavigationProvider } from 'src/features/form/layout/PageNavigationContext';
+import { createPageNavigationSlice } from 'src/features/form/layout/PageNavigationContext';
+import { usePageSettings } from 'src/features/form/layoutSettings/processLayoutSettings';
 import { getUiFolderSettings } from 'src/features/form/ui';
 import { useCurrentUiFolderNameFromUrl } from 'src/features/form/ui/hooks';
 import { useFormBootstrapQuery } from 'src/features/formBootstrap/useFormBootstrapQuery';
-import { FormDataWriteProvider } from 'src/features/formData/FormDataWrite';
+import { FormDataWriteEffects } from 'src/features/formData/FormDataWrite';
+import { useFormDataWriteProxies } from 'src/features/formData/FormDataWriteProxies';
+import { createFormDataWriteSlice } from 'src/features/formData/FormDataWriteStateMachine';
+import {
+  useOptimisticallyUpdateCachedInstance,
+  useSelectFromInstanceData,
+} from 'src/features/instance/InstanceContext';
 import { MissingRolesError } from 'src/features/instantiate/containers/MissingRolesError';
 import { OrderDetailsProvider } from 'src/features/payment/OrderDetailsProvider';
 import { PaymentInformationProvider } from 'src/features/payment/PaymentInformationProvider';
 import { PaymentProvider } from 'src/features/payment/PaymentProvider';
-import { ValidationProvider } from 'src/features/validation/validationContext';
+import { useGetCachedInitialValidations } from 'src/features/validation/backendValidation/backendValidationQuery';
+import { createValidationSlice, ValidationEffects } from 'src/features/validation/validationContext';
 import { useNavigationParam } from 'src/hooks/navigation';
 import { isAxiosError } from 'src/utils/isAxiosError';
-import { NodesProvider } from 'src/utils/layout/NodesContext';
+import { createNodesSlice, NodesProvider } from 'src/utils/layout/NodesContext';
 import { HttpStatusCodes } from 'src/utils/network/networking';
-import type { FormContext } from 'src/features/form/FormContext';
+import type { FormContext, FormStoreApi, FormStoreSet, FormStoreState } from 'src/features/form/FormContext';
 import type { FormBootstrapBase, FormBootstrapContextValue } from 'src/features/formBootstrap/types';
+import type { FormDataSliceProps } from 'src/features/formData/FormDataWrite';
+import type { NodesSliceProps } from 'src/utils/layout/NodesContext';
 
 interface FormProviderProps {
   uiFolderOverride?: string;
@@ -62,6 +75,10 @@ export function FormProvider({
     return null;
   }, [bootstrapBase, layouts]);
 
+  const dataSliceProps = useFormDataSliceProps(bootstrap);
+  const bootstrapBaseRef = useRef(bootstrapBase);
+  const storeRef = useRef<FormStoreApi | undefined>(undefined);
+
   if (!enabled) {
     // No point in trying to render a form here, but this can still happen when FormProvider is applied for all tasks
     // without actually checking the task type (such as in src/index.tsx). Only data-tasks, subforms, custom receipt and
@@ -77,29 +94,30 @@ export function FormProvider({
     return <DisplayError error={error} />;
   }
 
-  if (!bootstrap) {
+  if (!bootstrap || !dataSliceProps) {
     return <Loader reason='bootstrap-form' />;
   }
 
+  if (!storeRef.current || bootstrapBaseRef.current !== bootstrapBase) {
+    // When the bootstrap query changes, or if it's the first render, we should wipe the store and restart. This usually
+    // means we're moved to another task while keeping a similar enough render-tree to cause this to be re-used. The
+    // layouts can change without all of this being reset, however.
+    storeRef.current = createFormStore({ nodes: { isEmbedded, readOnly }, data: dataSliceProps, bootstrap });
+    bootstrapBaseRef.current = bootstrapBase;
+  }
+
   return (
-    <FormProviderInternal value={{ readOnly, bootstrap }}>
+    <FormProviderInternal value={{ readOnly, bootstrap, store: storeRef.current }}>
       {window.Cypress && <UpdateDataElementIdsForCypress />}
-      <FormDataWriteProvider>
-        <ValidationProvider>
-          <NodesProvider
-            readOnly={readOnly}
-            isEmbedded={isEmbedded}
-          >
-            <PageNavigationProvider>
-              <PaymentInformationProvider>
-                <OrderDetailsProvider>
-                  <MaybePaymentProvider hasProcess={hasProcess}>{children}</MaybePaymentProvider>
-                </OrderDetailsProvider>
-              </PaymentInformationProvider>
-            </PageNavigationProvider>
-          </NodesProvider>
-        </ValidationProvider>
-      </FormDataWriteProvider>
+      <FormDataWriteEffects />
+      <ValidationEffects />
+      <NodesProvider>
+        <PaymentInformationProvider>
+          <OrderDetailsProvider>
+            <MaybePaymentProvider hasProcess={hasProcess}>{children}</MaybePaymentProvider>
+          </OrderDetailsProvider>
+        </PaymentInformationProvider>
+      </NodesProvider>
     </FormProviderInternal>
   );
 }
@@ -150,10 +168,51 @@ function useBoostrapQuery({ uiFolderOverride, dataElementIdOverride }: FormProvi
             dataModels: data.dataModels,
             staticOptions: data.staticOptions,
             validationIssues: data.validationIssues,
+            allInitialValidations: data.allInitialValidations,
           }
         : null,
     [data, uiFolder],
   );
 
   return { error, bootstrap, layouts: data?.layouts, enabled };
+}
+
+function createFormStore({
+  data,
+  nodes,
+  bootstrap,
+}: {
+  data: FormDataSliceProps;
+  nodes: NodesSliceProps;
+  bootstrap: FormBootstrapContextValue;
+}): FormStoreApi {
+  return createStore<FormStoreState>()(
+    immer((set: FormStoreSet) => ({
+      data: createFormDataWriteSlice(data, set),
+      validation: createValidationSlice(bootstrap, set),
+      nodes: createNodesSlice(nodes, set),
+      pageNavigation: createPageNavigationSlice(set),
+    })),
+  );
+}
+
+export function useFormDataSliceProps(bootstrap: FormBootstrapContextValue | null): FormDataSliceProps | undefined {
+  const proxies = useFormDataWriteProxies();
+  const selectFromInstance = useSelectFromInstanceData();
+  const autoSaveBehavior = usePageSettings().autoSaveBehavior;
+  const changeInstance = useOptimisticallyUpdateCachedInstance();
+  const getCachedInitialValidations = useGetCachedInitialValidations();
+
+  if (!bootstrap) {
+    return undefined;
+  }
+
+  return {
+    dataModels: bootstrap.dataModels,
+    autoSaving: !autoSaveBehavior || autoSaveBehavior === 'onChangeFormData',
+    proxies,
+    changeInstance,
+    selectFromInstance,
+    getCachedInitialValidations,
+  };
 }

--- a/src/App/frontend/src/features/form/layout/PageNavigationContext.tsx
+++ b/src/App/frontend/src/features/form/layout/PageNavigationContext.tsx
@@ -1,11 +1,7 @@
-import React, { useState } from 'react';
-
-import { createStore } from 'zustand';
-
 import { ContextNotProvided } from 'src/core/contexts/context';
-import { createZustandContext } from 'src/core/contexts/zustandContext';
+import { FormStore, type FormStoreSet, type FormStoreState } from 'src/features/form/FormContext';
 
-export type PageNavigationContext = {
+export type PageNavigationSliceState = {
   /**
    * Keeps track of which view to return to when the user has navigated
    * with the summary component buttons.
@@ -20,52 +16,39 @@ export type PageNavigationContext = {
   setSummaryNodeOfOrigin: (componentOrigin?: string) => void;
 };
 
-function initialCreateStore() {
-  return createStore<PageNavigationContext>((set) => ({
+export function createPageNavigationSlice(set: FormStoreSet): FormStoreState['pageNavigation'] {
+  return {
     returnToView: undefined,
-    setReturnToView: (returnToView) => set({ returnToView }),
+    setReturnToView: (returnToView) =>
+      set((state) => {
+        state.pageNavigation.returnToView = returnToView;
+      }),
     summaryNodeOfOrigin: undefined,
-    setSummaryNodeOfOrigin: (summaryNodeOfOrigin) => set({ summaryNodeOfOrigin }),
-  }));
+    setSummaryNodeOfOrigin: (summaryNodeOfOrigin) =>
+      set((state) => {
+        state.pageNavigation.summaryNodeOfOrigin = summaryNodeOfOrigin;
+      }),
+  };
 }
 
-const { Provider, useLaxSelector } = createZustandContext({
-  name: 'PageNavigationContext',
-  required: true,
-  initialCreateStore,
-});
+export const pageNavigationHooks = {
+  useReturnToView: () => {
+    const returnToView = FormStore.raw.useLaxSelector((s) => s.pageNavigation.returnToView);
+    return returnToView === ContextNotProvided ? undefined : returnToView;
+  },
 
-export function PageNavigationProvider({ children }: React.PropsWithChildren) {
-  const [returnToView, setReturnToView] = useState<string>();
+  useSetReturnToView: () => {
+    const func = FormStore.raw.useLaxSelector((s) => s.pageNavigation.setReturnToView);
+    return func === ContextNotProvided ? undefined : func;
+  },
 
-  return (
-    <Provider
-      value={{
-        returnToView,
-        setReturnToView,
-      }}
-    >
-      {children}
-    </Provider>
-  );
-}
+  useSummaryNodeIdOfOrigin: (): string | undefined => {
+    const ref = FormStore.raw.useLaxSelector((s) => s.pageNavigation.summaryNodeOfOrigin);
+    return ref === ContextNotProvided ? undefined : ref;
+  },
 
-export const useReturnToView = () => {
-  const returnToView = useLaxSelector((ctx) => ctx.returnToView);
-  return returnToView === ContextNotProvided ? undefined : returnToView;
-};
-
-export const useSetReturnToView = () => {
-  const func = useLaxSelector((ctx) => ctx.setReturnToView);
-  return func === ContextNotProvided ? undefined : func;
-};
-
-export const useSummaryNodeIdOfOrigin = (): string | undefined => {
-  const ref = useLaxSelector((ctx) => ctx.summaryNodeOfOrigin);
-  return ref === ContextNotProvided ? undefined : ref;
-};
-
-export const useSetSummaryNodeOfOrigin = () => {
-  const func = useLaxSelector((ctx) => ctx.setSummaryNodeOfOrigin);
-  return func === ContextNotProvided ? undefined : func;
+  useSetSummaryNodeOfOrigin: () => {
+    const func = FormStore.raw.useLaxSelector((s) => s.pageNavigation.setSummaryNodeOfOrigin);
+    return func === ContextNotProvided ? undefined : func;
+  },
 };

--- a/src/App/frontend/src/features/formBootstrap/FormBootstrap.tsx
+++ b/src/App/frontend/src/features/formBootstrap/FormBootstrap.tsx
@@ -10,12 +10,10 @@ export const FormBootstrap = {
   useLayouts: () => FormProviderHooks.useBootstrap().layouts,
   useLaxLayouts: () => FormProviderHooks.useLaxBootstrap()?.layouts,
   useLayoutLookups: () => FormProviderHooks.useBootstrap().layoutLookups,
-  useLaxLayoutLookups: () => FormProviderHooks.useLaxBootstrap()?.layoutLookups,
   useHiddenLayoutsExpressions: () => FormProviderHooks.useBootstrap().hiddenLayoutsExpressions,
   useLaxHiddenLayoutsExpressions: () => FormProviderHooks.useLaxBootstrap()?.hiddenLayoutsExpressions,
   useExpandedWidthLayouts: () => FormProviderHooks.useBootstrap().expandedWidthLayouts,
 
-  useDataModels: () => FormProviderHooks.useBootstrap().dataModels,
   useDefaultDataType: () => {
     const uiFolder = FormProviderHooks.useBootstrap().uiFolder;
     return getUiFolderSettings(uiFolder)?.defaultDataType;
@@ -48,13 +46,6 @@ export const FormBootstrap = {
       }).data ?? Object.keys(dataModels)
     );
   },
-  useInitialData: () => {
-    const dataModels = FormProviderHooks.useBootstrap().dataModels;
-    return useMemo(
-      () => Object.fromEntries(Object.entries(dataModels).map(([dataType, info]) => [dataType, info.initialData])),
-      [dataModels],
-    );
-  },
   useDataModelSchema: (dataType: string) => FormProviderHooks.useBootstrap().dataModels[dataType]?.schemaResult,
   useSchemaLookup: () => {
     const dataModels = FormProviderHooks.useBootstrap().dataModels;
@@ -79,11 +70,7 @@ export const FormBootstrap = {
   },
   useExpressionValidationConfig: (dataType: string) =>
     FormProviderHooks.useBootstrap().dataModels[dataType]?.expressionValidationConfig,
-  useDefaultDataElementId: () => {
-    const { dataModels, uiFolder } = FormProviderHooks.useBootstrap();
-    const defaultDataType = getUiFolderSettings(uiFolder)?.defaultDataType;
-    return defaultDataType ? (dataModels[defaultDataType]?.dataElementId ?? null) : null;
-  },
+
   useDataElementIdForDataType: (dataType: string) =>
     FormProviderHooks.useBootstrap().dataModels[dataType]?.dataElementId,
   useGetDataElementIdForDataType: () => {
@@ -99,5 +86,5 @@ export const FormBootstrap = {
   },
 
   useStaticOptionsMap: () => FormProviderHooks.useBootstrap().staticOptions,
-  useInitialValidationIssues: () => FormProviderHooks.useBootstrap().validationIssues,
+  useAllInitialValidationIssues: () => FormProviderHooks.useLaxBootstrap()?.allInitialValidations,
 };

--- a/src/App/frontend/src/features/formBootstrap/types.ts
+++ b/src/App/frontend/src/features/formBootstrap/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema7 } from 'json-schema';
 
 import type { DataModelSchemaResult } from 'src/features/datamodel/SchemaLookupTool';
 import type { LayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
+import type { FormBootstrapQueryResponse } from 'src/features/formBootstrap/useFormBootstrapQuery';
 import type { IOptionInternal } from 'src/features/options/castOptionsToStrings';
 import type {
   BackendValidationIssue,
@@ -36,11 +37,9 @@ export interface ProcessedDataModelInfo extends Omit<RawDataModelInfo, 'expressi
   schemaResult: DataModelSchemaResult;
 }
 
-export interface FormBootstrapBase {
+export interface FormBootstrapBase extends Omit<FormBootstrapQueryResponse, 'staticOptions' | 'layouts'> {
   uiFolder: string;
-  dataModels: Record<string, ProcessedDataModelInfo>;
   staticOptions: Record<string, StaticOptionSet>;
-  validationIssues?: BackendValidationIssue[] | null;
 }
 
 export interface FormBootstrapContextValue extends FormBootstrapBase {

--- a/src/App/frontend/src/features/formBootstrap/useFormBootstrapQuery.ts
+++ b/src/App/frontend/src/features/formBootstrap/useFormBootstrapQuery.ts
@@ -16,6 +16,7 @@ import type {
   RawDataModelInfo,
   StaticOptionSet,
 } from 'src/features/formBootstrap/types';
+import type { BackendValidationIssue } from 'src/features/validation';
 
 export interface FormBootstrapQueryOptions {
   enabled: boolean;
@@ -27,6 +28,7 @@ export interface FormBootstrapQueryOptions {
 export interface FormBootstrapQueryResponse extends Omit<FormBootstrapResponse, 'dataModels' | 'staticOptions'> {
   dataModels: ReturnType<typeof processDataModels>;
   staticOptions: ReturnType<typeof processStaticOptions>;
+  allInitialValidations: BackendValidationIssue[];
 }
 
 export function useFormBootstrapQuery(options: FormBootstrapQueryOptions) {
@@ -56,6 +58,10 @@ export function useFormBootstrapQuery(options: FormBootstrapQueryOptions) {
             ...raw,
             dataModels: processDataModels(raw.dataModels),
             staticOptions: processStaticOptions(raw.staticOptions),
+            allInitialValidations: [
+              ...(raw.validationIssues ?? []),
+              ...Object.values(raw.dataModels).flatMap((dataModel) => dataModel.initialValidationIssues ?? []),
+            ],
           };
         }
       : skipToken,

--- a/src/App/frontend/src/features/formData/FormData.test.tsx
+++ b/src/App/frontend/src/features/formData/FormData.test.tsx
@@ -11,9 +11,9 @@ import { getApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadata
 import { getDataModelBootstrapMock, getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';
 import { defaultMockDataElementId, getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
 import { defaultDataTypeMock, statelessDataTypeMock } from 'src/__mocks__/getUiConfigMock';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormProvider } from 'src/features/form/FormProvider';
 import { GlobalFormDataReadersProvider } from 'src/features/formData/FormDataReaders';
-import { FD, FormDataWriteProvider } from 'src/features/formData/FormDataWrite';
 import { FormDataWriteProxyProvider } from 'src/features/formData/FormDataWriteProxies';
 import { IDataModelMultiPatchRequest, IDataModelMultiPatchResponse } from 'src/features/formData/types';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
@@ -128,11 +128,9 @@ async function statelessRender(props: RenderProps) {
       ),
       renderer: () => (
         <GlobalFormDataReadersProvider>
-          <FormProvider uiFolderOverride='stateless'>
-            <FormDataWriteProxyProvider value={formDataProxies}>
-              <FormDataWriteProvider>{props.renderer}</FormDataWriteProvider>
-            </FormDataWriteProxyProvider>
-          </FormProvider>
+          <FormDataWriteProxyProvider value={formDataProxies}>
+            <FormProvider uiFolderOverride='stateless'>{props.renderer}</FormProvider>
+          </FormDataWriteProxyProvider>
         </GlobalFormDataReadersProvider>
       ),
       queries: {
@@ -320,7 +318,7 @@ describe('FormData', () => {
   }
 
   function HasUnsavedChanges() {
-    const hasUnsavedChanges = FD.useHasUnsavedChanges();
+    const hasUnsavedChanges = FormStore.data.useHasUnsavedChanges();
     return <div data-testid='hasUnsavedChanges'>{hasUnsavedChanges ? 'true' : 'false'}</div>;
   }
 
@@ -341,8 +339,8 @@ describe('FormData', () => {
     });
 
     function LockActionButton({ lockId, renderInfo }: { lockId: string; renderInfo: boolean }) {
-      const lock = FD.useLocking(lockId);
-      const { isLocked, lockedBy } = FD.useLockStatus();
+      const lock = FormStore.data.useLocking(lockId);
+      const { isLocked, lockedBy } = FormStore.data.useLockStatus();
       const [currentLock, setCurrentLock] = useState<Awaited<ReturnType<typeof lock>> | undefined>();
 
       return (
@@ -753,8 +751,8 @@ describe('FormData', () => {
       } = useDataModelBindings({
         simpleBinding: { field: path, dataType },
       });
-      const validValue = dot.pick(path, FD.useDebounced(dataType));
-      const invalidValue = dot.pick(path, FD.useInvalidDebounced(dataType));
+      const validValue = dot.pick(path, FormStore.data.useDebounced(dataType));
+      const invalidValue = dot.pick(path, FormStore.data.useInvalidDebounced(dataType));
 
       return (
         <>

--- a/src/App/frontend/src/features/formData/FormDataWrite.test.ts
+++ b/src/App/frontend/src/features/formData/FormDataWrite.test.ts
@@ -1,20 +1,14 @@
 import { describe, expect, it } from '@jest/globals';
 
+import { FormStoreState } from 'src/features/form/FormContext';
 import { selectAllPaths } from 'src/features/formData/FormDataWrite';
-import type { FormDataContext } from 'src/features/formData/FormDataWriteStateMachine';
 
 const dataType = 'default';
 
-function makeContext(formData?: object): FormDataContext {
+function makeContext(formData?: object): FormStoreState {
   return {
-    dataModels: formData
-      ? {
-          [dataType]: {
-            debouncedCurrentData: formData,
-          },
-        }
-      : {},
-  } as FormDataContext;
+    data: { models: formData ? { [dataType]: { debouncedCurrentData: formData } } : {} },
+  } as FormStoreState;
 }
 
 describe('selectAllPaths', () => {

--- a/src/App/frontend/src/features/formData/FormDataWrite.tsx
+++ b/src/App/frontend/src/features/formData/FormDataWrite.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import type { PropsWithChildren } from 'react';
 
 import { useIsMutating, useMutation, useQueryClient } from '@tanstack/react-query';
 import dot from 'dot-object';
@@ -8,21 +7,14 @@ import type { AxiosRequestConfig } from 'axios';
 
 import { useAppMutations } from 'src/core/contexts/AppQueriesProvider';
 import { ContextNotProvided } from 'src/core/contexts/context';
-import { createZustandContext } from 'src/core/contexts/zustandContext';
 import { useIsStateless } from 'src/features/applicationMetadata';
 import { useGetDataModelUrl } from 'src/features/datamodel/useBindingSchema';
-import { usePageSettings } from 'src/features/form/layoutSettings/processLayoutSettings';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { useFormDataWriteProxies } from 'src/features/formData/FormDataWriteProxies';
-import { createFormDataWriteStore } from 'src/features/formData/FormDataWriteStateMachine';
 import { createPatch } from 'src/features/formData/jsonPatch/createPatch';
 import { ALTINN_ROW_ID } from 'src/features/formData/types';
 import { getFormDataQueryKey } from 'src/features/formData/useFormDataQuery';
-import {
-  useLaxInstanceId,
-  useOptimisticallyUpdateCachedInstance,
-  useSelectFromInstanceData,
-} from 'src/features/instance/InstanceContext';
+import { useLaxInstanceId } from 'src/features/instance/InstanceContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useSelectedParty } from 'src/features/party/PartiesProvider';
 import {
@@ -35,17 +27,13 @@ import { useAsRef } from 'src/hooks/useAsRef';
 import { useWaitForState } from 'src/hooks/useWaitForState';
 import { getMultiPatchUrl } from 'src/utils/urls/appUrlHelper';
 import { getUrlWithLanguage } from 'src/utils/urls/urlHelper';
-import type { SchemaLookupTool } from 'src/features/datamodel/SchemaLookupTool';
+import type { FormStoreState } from 'src/features/form/FormContext';
+import type { FormBootstrapQueryResponse } from 'src/features/formBootstrap/useFormBootstrapQuery';
 import type { FormDataWriteProxies } from 'src/features/formData/FormDataWriteProxies';
-import type {
-  DataModelState,
-  FDActionResult,
-  FDSaveFinished,
-  FormDataContext,
-  UpdatedDataModel,
-} from 'src/features/formData/FormDataWriteStateMachine';
+import type { FDActionResult, FDSaveFinished, UpdatedDataModel } from 'src/features/formData/FormDataWriteStateMachine';
 import type { DebounceReason, IPatchListItem } from 'src/features/formData/types';
 import type { ChangeInstanceData, InstanceDataSelector } from 'src/features/instance/InstanceContext';
+import type { useGetCachedInitialValidations } from 'src/features/validation/backendValidation/backendValidationQuery';
 import type { FormDataRowsSelector, FormDataSelector } from 'src/layout';
 import type { IDataModelReference, IMapping } from 'src/layout/common.generated';
 import type { IDataModelBindings } from 'src/layout/layout';
@@ -54,41 +42,14 @@ import type { BaseRow } from 'src/utils/layout/types';
 export type FDLeafValue = string | number | boolean | null | undefined | string[];
 export type FDValue = FDLeafValue | object | FDValue[];
 
-interface FormDataContextInitialProps {
-  initialDataModels: { [dataType: string]: DataModelState };
+export interface FormDataSliceProps {
+  dataModels: FormBootstrapQueryResponse['dataModels'];
   autoSaving: boolean;
   proxies: FormDataWriteProxies;
-  schemaLookup: { [dataType: string]: SchemaLookupTool };
   changeInstance: ChangeInstanceData;
   selectFromInstance: InstanceDataSelector;
+  getCachedInitialValidations: ReturnType<typeof useGetCachedInitialValidations>;
 }
-
-const {
-  Provider,
-  useSelector,
-  useStaticSelector,
-  useShallowSelector,
-  useMemoSelector,
-  useLaxMemoSelector,
-  useLaxDelayedSelector,
-  useDelayedSelector,
-  useLaxDelayedSelectorProps,
-  useLaxSelector,
-  useLaxStore,
-  useStore,
-} = createZustandContext({
-  name: 'FormDataWrite',
-  required: true,
-  initialCreateStore: ({
-    initialDataModels,
-    autoSaving,
-    proxies,
-    schemaLookup,
-    changeInstance,
-    selectFromInstance,
-  }: FormDataContextInitialProps) =>
-    createFormDataWriteStore(initialDataModels, autoSaving, proxies, schemaLookup, changeInstance, selectFromInstance),
-});
 
 const saveFormDataMutationKey = ['saveFormData'] as const;
 
@@ -98,16 +59,16 @@ function useFormDataSaveMutation() {
   const instanceId = useLaxInstanceId();
   const multiPatchUrl = instanceId ? getMultiPatchUrl(instanceId) : undefined;
   const currentLanguage = useAsRef(useCurrentLanguage());
-  const dataModelsRef = useAsRef(useSelector((state) => state.dataModels));
-  const saveFinished = useSelector((s) => s.saveFinished);
-  const cancelSave = useSelector((s) => s.cancelSave);
+  const dataModelsRef = useAsRef(FormStore.raw.useSelector((state) => state.data.models));
+  const saveFinished = FormStore.raw.useSelector((s) => s.data.saveFinished);
+  const cancelSave = FormStore.raw.useSelector((s) => s.data.cancelSave);
   const isStateless = useIsStateless();
-  const debounce = useSelector((s) => s.debounce);
+  const debounce = FormStore.raw.useSelector((s) => s.data.debounce);
   const selectedPartyId = useSelectedParty()?.partyId;
   const waitFor = useWaitForState<
     { prev: { [dataType: string]: object }; next: { [dataType: string]: object } },
-    FormDataContext
-  >(useStore());
+    FormStoreState
+  >(FormStore.raw.useStore());
   const queryClient = useQueryClient();
 
   // This updates the query cache with the new data models every time a save has finished. This means we won't have to
@@ -198,7 +159,7 @@ function useFormDataSaveMutation() {
         // navigating away from the form context.
         debounce('beforeSave');
         return await waitFor((state, setReturnValue) => {
-          const dataModels = state.dataModels;
+          const dataModels = state.data.models;
           const hasUnDebouncedChanges = Object.values(dataModels).some(
             ({ debouncedCurrentData, currentData }) => debouncedCurrentData !== currentData,
           );
@@ -329,55 +290,21 @@ function useIsSavingFormData() {
   );
 }
 
-export function FormDataWriteProvider({ children }: PropsWithChildren) {
-  const proxies = useFormDataWriteProxies();
-  const allDataTypes = FormBootstrap.useReadableDataTypes();
-  const instanceDataSelector = useSelectFromInstanceData();
-  const initialData = FormBootstrap.useInitialData();
-  const dataElementIds = FormBootstrap.useDataElementIds();
-  const schemaLookup = FormBootstrap.useSchemaLookup();
-  const autoSaveBehavior = usePageSettings().autoSaveBehavior;
-  const changeInstance = useOptimisticallyUpdateCachedInstance();
-
-  if (!allDataTypes) {
-    throw new Error('FormDataWriteProvider failed because data types have not been loaded, see FormBootstrapProvider');
-  }
-
-  const initialDataModels = allDataTypes.reduce((dm, dt) => {
-    const emptyInvalidData = {};
-    dm[dt] = {
-      currentData: initialData[dt],
-      invalidCurrentData: emptyInvalidData,
-      debouncedCurrentData: initialData[dt],
-      invalidDebouncedCurrentData: emptyInvalidData,
-      lastSavedData: initialData[dt],
-      dataElementId: dataElementIds[dt],
-    } satisfies DataModelState;
-    return dm;
-  }, {});
-
+export function FormDataWriteEffects() {
   return (
-    <Provider
-      initialDataModels={initialDataModels}
-      autoSaving={!autoSaveBehavior || autoSaveBehavior === 'onChangeFormData'}
-      proxies={proxies}
-      schemaLookup={schemaLookup}
-      changeInstance={changeInstance}
-      selectFromInstance={instanceDataSelector}
-    >
+    <>
       <FormDataEffects />
       <LockingEffects />
-      {children}
-    </Provider>
+    </>
   );
 }
 
 function FormDataEffects() {
-  const [autoSaving, lockedBy, debounceTimeout, manualSaveRequested] = useShallowSelector((s) => [
-    s.autoSaving,
-    s.lockedBy,
-    s.debounceTimeout,
-    s.manualSaveRequested,
+  const [autoSaving, lockedBy, debounceTimeout, manualSaveRequested] = FormStore.raw.useShallowSelector((s) => [
+    s.data.autoSaving,
+    s.data.lockedBy,
+    s.data.debounceTimeout,
+    s.data.manualSaveRequested,
   ]);
   const hasUnsavedChanges = useHasUnsavedChanges();
   const setUnsavedAttrTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -417,7 +344,7 @@ function FormDataEffects() {
 
   // Debounce the data model when the user stops typing. This has the effect of triggering the useEffect below,
   // saving the data model to the backend. Freezing can also be triggered manually, when a manual save is requested.
-  const shouldDebounce = useSelector(hasUnDebouncedChanges);
+  const shouldDebounce = FormStore.raw.useSelector((state) => hasUnDebouncedChanges(state));
   useEffect(() => {
     const timer = shouldDebounce
       ? setTimeout(() => {
@@ -429,7 +356,7 @@ function FormDataEffects() {
   });
 
   // Save the data model when the data has been frozen/debounced, and we're ready
-  const needsToSave = useSelector(hasDebouncedUnsavedChanges);
+  const needsToSave = FormStore.raw.useSelector((state) => hasDebouncedUnsavedChanges(state));
   const canSaveNow = !isSaving && !lockedBy && !isUpdatingInitialValidations;
   const shouldSave = needsToSave && (autoSaving || manualSaveRequested);
 
@@ -456,10 +383,10 @@ function FormDataEffects() {
   );
 
   // Sets the debounced data in the window object, so that Cypress tests can access it.
-  useSelector((state) => {
+  FormStore.raw.useSelector((state) => {
     if (window.Cypress) {
       const formData: { [key: string]: unknown } = {};
-      for (const [dataType, { debouncedCurrentData }] of Object.entries(state.dataModels)) {
+      for (const [dataType, { debouncedCurrentData }] of Object.entries(state.data.models)) {
         formData[dataType] = debouncedCurrentData;
       }
 
@@ -471,8 +398,8 @@ function FormDataEffects() {
 }
 
 function LockingEffects() {
-  const store = useStore();
-  const hasNext = useSelector((s) => (s.lockedBy ? false : s.lockQueue.length > 0));
+  const store = FormStore.raw.useStore();
+  const hasNext = FormStore.raw.useSelector((s) => (s.data.lockedBy ? false : s.data.lockQueue.length > 0));
 
   const hasUnsavedChangesNow = useHasUnsavedChangesNow();
   const waitForSave = useWaitForSave();
@@ -480,11 +407,12 @@ function LockingEffects() {
   useEffect(() => {
     (async () => {
       const state = store.getState();
-      if (!state.lockedBy && state.lockQueue.length > 0) {
+      const dataState = state.data;
+      if (!dataState.lockedBy && dataState.lockQueue.length > 0) {
         if (hasUnsavedChangesNow()) {
           await waitForSave(true);
         }
-        state.nextLock();
+        dataState.nextLock();
       }
     })().then();
   }, [hasNext, hasUnsavedChangesNow, store, waitForSave]);
@@ -493,7 +421,7 @@ function LockingEffects() {
 }
 
 const useRequestManualSave = () => {
-  const requestSave = useLaxSelector((s) => s.requestManualSave);
+  const requestSave = FormStore.raw.useLaxSelector((s) => s.data.requestManualSave);
   return useCallback(
     (setTo = true) => {
       if (requestSave !== ContextNotProvided) {
@@ -505,7 +433,7 @@ const useRequestManualSave = () => {
 };
 
 const useDebounceImmediately = () => {
-  const debounce = useLaxSelector((s) => s.debounce);
+  const debounce = FormStore.raw.useLaxSelector((s) => s.data.debounce);
   return useCallback(
     (reason: DebounceReason) => {
       if (debounce !== ContextNotProvided) {
@@ -516,21 +444,21 @@ const useDebounceImmediately = () => {
   );
 };
 
-function hasDebouncedUnsavedChanges(state: FormDataContext) {
-  return Object.values(state.dataModels).some(
+function hasDebouncedUnsavedChanges(state: FormStoreState) {
+  return Object.values(state.data.models).some(
     ({ debouncedCurrentData, lastSavedData }) => debouncedCurrentData !== lastSavedData,
   );
 }
 
-function hasUnDebouncedChanges(state: FormDataContext) {
-  return Object.values(state.dataModels).some(
+function hasUnDebouncedChanges(state: FormStoreState) {
+  return Object.values(state.data.models).some(
     ({ currentData, debouncedCurrentData, invalidCurrentData, invalidDebouncedCurrentData }) =>
       currentData !== debouncedCurrentData || invalidCurrentData !== invalidDebouncedCurrentData,
   );
 }
 
-function hasUnsavedChanges(state: FormDataContext) {
-  return Object.values(state.dataModels).some(
+function hasUnsavedChanges(state: FormStoreState) {
+  return Object.values(state.data.models).some(
     ({ currentData, lastSavedData, debouncedCurrentData }) =>
       currentData !== lastSavedData || debouncedCurrentData !== lastSavedData,
   );
@@ -538,7 +466,7 @@ function hasUnsavedChanges(state: FormDataContext) {
 
 const useHasUnsavedChanges = () => {
   const isSaving = useIsSavingFormData();
-  const result = useLaxMemoSelector((state) => hasUnsavedChanges(state));
+  const result = FormStore.raw.useLaxMemoSelector((state) => hasUnsavedChanges(state));
   if (result === ContextNotProvided) {
     return false;
   }
@@ -546,7 +474,7 @@ const useHasUnsavedChanges = () => {
 };
 
 const useHasUnsavedChangesNow = () => {
-  const store = useStore();
+  const store = FormStore.raw.useStore();
   const queryClient = useQueryClient();
 
   return useCallback(() => {
@@ -565,47 +493,35 @@ const useHasUnsavedChangesNow = () => {
 
 const useWaitForSave = () => {
   const requestSave = useRequestManualSave();
-  const dataTypes = useLaxMemoSelector((s) => Object.keys(s.dataModels));
-  const waitFor = useWaitForState<
-    BackendValidationIssueGroups | undefined,
-    FormDataContext | typeof ContextNotProvided
-  >(useLaxStore());
+  const waitFor = useWaitForState<undefined, FormStoreState | typeof ContextNotProvided>(FormStore.raw.useLaxStore());
 
   return useCallback(
-    async (requestManualSave = false): Promise<BackendValidationIssueGroups | undefined> => {
-      if (dataTypes === ContextNotProvided) {
-        return Promise.resolve(undefined);
-      }
-
-      return await waitFor((state, setReturnValue) => {
+    async (
+      requestManualSave = false,
+      extraReady?: (state: FormStoreState) => boolean,
+    ): Promise<BackendValidationIssueGroups | undefined> =>
+      await waitFor((state) => {
         if (state === ContextNotProvided) {
-          setReturnValue(undefined);
           return true;
         }
 
-        if (requestManualSave && !state.manualSaveRequested && hasDebouncedUnsavedChanges(state)) {
+        if (requestManualSave && !state.data.manualSaveRequested && hasDebouncedUnsavedChanges(state)) {
           requestSave();
           return false;
         }
 
-        if (hasUnsavedChanges(state)) {
-          return false;
-        }
-
-        setReturnValue(state.validationIssues);
-        return true;
-      });
-    },
-    [requestSave, dataTypes, waitFor],
+        return !hasUnsavedChanges(state) && (extraReady ? extraReady(state) : true);
+      }),
+    [requestSave, waitFor],
   );
 };
 
-function getFreshNumRows(state: FormDataContext, reference: IDataModelReference | undefined) {
+function getFreshNumRows(state: FormStoreState, reference: IDataModelReference | undefined) {
   if (!reference) {
     return 0;
   }
 
-  const model = state.dataModels[reference.dataType];
+  const model = state.data.models[reference.dataType];
   if (!model) {
     return 0;
   }
@@ -658,7 +574,7 @@ function collectMatchingFieldPaths(
 }
 
 export function selectAllPaths(reference: IDataModelReference | undefined, noRepGroup: boolean | undefined) {
-  return (v: FormDataContext) => {
+  return (v: FormStoreState) => {
     if (!reference) {
       return emptyArray;
     }
@@ -669,7 +585,7 @@ export function selectAllPaths(reference: IDataModelReference | undefined, noRep
 
     // If lookupTool is not available (e.g., in tests), or if there's a missingRepeatingGroup error,
     // we need to check the actual data to find all matching paths.
-    const formData = v.dataModels[reference.dataType]?.debouncedCurrentData;
+    const formData = v.data.models[reference.dataType]?.debouncedCurrentData;
     if (!formData) {
       return [];
     }
@@ -680,15 +596,15 @@ export function selectAllPaths(reference: IDataModelReference | undefined, noRep
   };
 }
 
-const currentSelector = (reference: IDataModelReference) => (state: FormDataContext) =>
-  dot.pick(reference.field, state.dataModels[reference.dataType]?.currentData);
-const debouncedSelector = (reference: IDataModelReference) => (state: FormDataContext) =>
-  dot.pick(reference.field, state.dataModels[reference.dataType]?.debouncedCurrentData);
-const invalidDebouncedSelector = (reference: IDataModelReference) => (state: FormDataContext) =>
-  dot.pick(reference.field, state.dataModels[reference.dataType]?.invalidDebouncedCurrentData);
+const currentSelector = (reference: IDataModelReference) => (state: FormStoreState) =>
+  dot.pick(reference.field, state.data.models[reference.dataType]?.currentData);
+const debouncedSelector = (reference: IDataModelReference) => (state: FormStoreState) =>
+  dot.pick(reference.field, state.data.models[reference.dataType]?.debouncedCurrentData);
+const invalidDebouncedSelector = (reference: IDataModelReference) => (state: FormStoreState) =>
+  dot.pick(reference.field, state.data.models[reference.dataType]?.invalidDebouncedCurrentData);
 
-const debouncedRowSelector = (reference: IDataModelReference) => (state: FormDataContext) => {
-  const rawRows = dot.pick(reference.field, state.dataModels[reference.dataType]?.debouncedCurrentData);
+const debouncedRowSelector = (reference: IDataModelReference) => (state: FormStoreState) => {
+  const rawRows = dot.pick(reference.field, state.data.models[reference.dataType]?.debouncedCurrentData);
   if (!Array.isArray(rawRows) || !rawRows.length) {
     return emptyArray;
   }
@@ -696,13 +612,13 @@ const debouncedRowSelector = (reference: IDataModelReference) => (state: FormDat
   return rawRows.map((row: any, index: number) => ({ uuid: row[ALTINN_ROW_ID], index }));
 };
 
-export const FD = {
+export const formDataHooks = {
   /**
    * Gives you a selector function that can be used to look up paths in the current datamodel (not the slower debounced
    * model).
    */
   useCurrentSelector(): FormDataSelector {
-    return useDelayedSelector({
+    return FormStore.raw.useDelayedSelector({
       mode: 'simple',
       selector: currentSelector,
     });
@@ -715,14 +631,14 @@ export const FD = {
    * pretend to have the full data model available to look up values from.
    */
   useDebouncedSelector(): FormDataSelector {
-    return useDelayedSelector({
+    return FormStore.raw.useDelayedSelector({
       mode: 'simple',
       selector: debouncedSelector,
     });
   },
 
   useLaxDebouncedSelectorProps() {
-    return useLaxDelayedSelectorProps({
+    return FormStore.raw.useLaxDelayedSelectorProps({
       mode: 'simple',
       selector: debouncedSelector,
     });
@@ -734,7 +650,7 @@ export const FD = {
    * inside them (and re-render if that data changes).
    */
   useDebouncedRowsSelector(): FormDataRowsSelector {
-    return useDelayedSelector({
+    return FormStore.raw.useDelayedSelector({
       mode: 'simple',
       selector: debouncedRowSelector,
     });
@@ -744,7 +660,7 @@ export const FD = {
    * Same as useDebouncedSelector(), but for invalid data.
    */
   useInvalidDebouncedSelector(): FormDataSelector {
-    return useDelayedSelector({
+    return FormStore.raw.useDelayedSelector({
       mode: 'simple',
       selector: invalidDebouncedSelector,
     });
@@ -755,7 +671,7 @@ export const FD = {
    * This will always give you the debounced data, which may or may not be saved to the backend yet.
    */
   useDebounced(dataType: string): object {
-    return useSelector((v) => v.dataModels[dataType]?.debouncedCurrentData);
+    return FormStore.raw.useSelector((v) => v.data.models[dataType]?.debouncedCurrentData);
   },
 
   /**
@@ -763,9 +679,9 @@ export const FD = {
    * select a value from the data model, and then process it in some way before returning it.
    */
   useDebouncedSelect<O>(selector: (pick: (reference: IDataModelReference) => FDValue) => O): O {
-    return useMemoSelector((v) =>
+    return FormStore.raw.useMemoSelector((v) =>
       selector((reference: IDataModelReference) =>
-        dot.pick(reference.field, v.dataModels[reference.dataType]?.debouncedCurrentData),
+        dot.pick(reference.field, v.data.models[reference.dataType]?.debouncedCurrentData),
       ),
     );
   },
@@ -775,7 +691,7 @@ export const FD = {
    * provider is not present.
    */
   useLaxDebouncedSelector(): FormDataSelector | typeof ContextNotProvided {
-    return useLaxDelayedSelector({
+    return FormStore.raw.useLaxDelayedSelector({
       mode: 'simple',
       selector: debouncedSelector,
     });
@@ -785,8 +701,8 @@ export const FD = {
    * This behaves the same as useDebouncedPick(), but selects from the current data
    */
   useCurrentPick(reference: IDataModelReference | undefined): FDValue {
-    return useSelector((v) =>
-      reference ? dot.pick(reference.field, v.dataModels[reference.dataType]?.currentData) : undefined,
+    return FormStore.raw.useSelector((v) =>
+      reference ? dot.pick(reference.field, v.data.models[reference.dataType]?.currentData) : undefined,
     );
   },
 
@@ -796,8 +712,8 @@ export const FD = {
    * the value is explicitly set to null.
    */
   useDebouncedPick(reference: IDataModelReference | undefined): FDValue {
-    return useSelector((v) =>
-      reference ? dot.pick(reference.field, v.dataModels[reference.dataType]?.debouncedCurrentData) : undefined,
+    return FormStore.raw.useSelector((v) =>
+      reference ? dot.pick(reference.field, v.data.models[reference.dataType]?.debouncedCurrentData) : undefined,
     );
   },
 
@@ -817,7 +733,7 @@ export const FD = {
       (!lookupErr || lookupErr.error !== 'missingProperty') &&
       (!lookupErr || lookupErr.error !== 'missingRepeatingGroup');
 
-    return useShallowSelector(selectAllPaths(reference, noRepGroup));
+    return FormStore.raw.useShallowSelector(selectAllPaths(reference, noRepGroup));
   },
 
   /**
@@ -830,7 +746,7 @@ export const FD = {
     bindings: T,
     dataAs: O,
   ): T extends undefined ? Record<string, never> : { [key in keyof T]: O extends 'raw' ? FDValue : string } =>
-    useMemoSelector((s) => {
+    FormStore.raw.useMemoSelector((s) => {
       if (!bindings || Object.keys(bindings).length === 0) {
         return emptyObject;
       }
@@ -839,13 +755,13 @@ export const FD = {
       for (const key of Object.keys(bindings)) {
         const field = bindings[key].field;
         const dataType = bindings[key].dataType;
-        const invalidValue = dot.pick(field, s.dataModels[dataType]?.invalidCurrentData);
+        const invalidValue = dot.pick(field, s.data.models[dataType]?.invalidCurrentData);
         if (invalidValue !== undefined) {
           out[key] = invalidValue;
           continue;
         }
 
-        const value = dot.pick(field, s.dataModels[dataType]?.currentData);
+        const value = dot.pick(field, s.data.models[dataType]?.currentData);
         if (dataAs === 'raw') {
           out[key] = value;
         } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
@@ -869,7 +785,7 @@ export const FD = {
    * and warn the user if it is not.
    */
   useBindingsAreValid: <T extends IDataModelBindings | undefined>(bindings: T): { [key in keyof T]: boolean } =>
-    useMemoSelector((s) => {
+    FormStore.raw.useMemoSelector((s) => {
       if (!bindings || Object.keys(bindings).length === 0) {
         return emptyObject;
       }
@@ -878,7 +794,7 @@ export const FD = {
       for (const key of Object.keys(bindings)) {
         const field = bindings[key].field;
         const dataType = bindings[key].dataType;
-        out[key] = dot.pick(field, s.dataModels[dataType]?.invalidCurrentData) === undefined;
+        out[key] = dot.pick(field, s.data.models[dataType]?.invalidCurrentData) === undefined;
       }
       return out;
     }),
@@ -890,15 +806,15 @@ export const FD = {
    * while, so that this model can be used for i.e. validation messages.
    */
   useInvalidDebounced(dataType: string): object {
-    return useSelector((v) => v.dataModels[dataType]?.invalidDebouncedCurrentData);
+    return FormStore.raw.useSelector((v) => v.data.models[dataType]?.invalidDebouncedCurrentData);
   },
 
   /**
    * This returns the current invalid data which cannot be saved to backend
    */
   useInvalidDebouncedPick(reference: IDataModelReference | undefined): FDValue {
-    return useSelector((v) =>
-      reference ? dot.pick(reference.field, v.dataModels[reference.dataType]?.invalidDebouncedCurrentData) : undefined,
+    return FormStore.raw.useSelector((v) =>
+      reference ? dot.pick(reference.field, v.data.models[reference.dataType]?.invalidDebouncedCurrentData) : undefined,
     );
   },
 
@@ -915,14 +831,14 @@ export const FD = {
     defaultDataType: string | undefined,
     dataAs?: D,
   ): D extends 'raw' ? { [key: string]: FDValue } : { [key: string]: string } =>
-    useMemoSelector((s) => {
+    FormStore.raw.useMemoSelector((s) => {
       const realDataAs = dataAs || 'string';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const out: any = {};
       if (mapping && defaultDataType) {
         for (const key of Object.keys(mapping)) {
           const outputKey = mapping[key];
-          const value = dot.pick(key, s.dataModels[defaultDataType]?.debouncedCurrentData);
+          const value = dot.pick(key, s.data.models[defaultDataType]?.debouncedCurrentData);
 
           if (realDataAs === 'raw') {
             out[outputKey] = value;
@@ -944,7 +860,7 @@ export const FD = {
    * consider using something like useDataModelBindings() instead.
    * @see useDataModelBindings
    */
-  useSetLeafValue: () => useStaticSelector((s) => s.setLeafValue),
+  useSetLeafValue: () => FormStore.raw.useStaticSelector((s) => s.data.setLeafValue),
 
   /**
    * This returns the raw method for setting multiple leaf values in the form data at once. This is
@@ -952,7 +868,7 @@ export const FD = {
    * for what you really want to do, so consider using something like useDataModelBindings() instead.
    * @see useDataModelBindings
    */
-  useSetMultiLeafValues: () => useStaticSelector((s) => s.setMultiLeafValues),
+  useSetMultiLeafValues: () => FormStore.raw.useStaticSelector((s) => s.data.setMultiLeafValues),
 
   /**
    * The locking functionality allows you to prevent form data from saving, even if the user stops typing (or navigates
@@ -961,13 +877,13 @@ export const FD = {
    * @see LockingEffects
    */
   useLocking(lockId: string) {
-    const store = useStore();
+    const store = FormStore.raw.useStore();
 
     const hasUnsavedChangesNow = useHasUnsavedChangesNow();
     const waitForSave = useWaitForSave();
 
     return useCallback(async () => {
-      const { lock: rawLock, unlock: rawUnlock, lockedBy } = store.getState();
+      const { lock: rawLock, unlock: rawUnlock, lockedBy } = store.getState().data;
 
       if (!lockedBy && hasUnsavedChangesNow()) {
         // Always save before locking. If the lock is not acquired immediately, LockingEffects will do that for us.
@@ -981,8 +897,8 @@ export const FD = {
         }),
       );
 
-      const isLockedByMe = () => store.getState().lockedBy === `${lockId} (${uuid})`;
-      const isLocked = () => store.getState().lockedBy !== undefined;
+      const isLockedByMe = () => store.getState().data.lockedBy === `${lockId} (${uuid})`;
+      const isLocked = () => store.getState().data.lockedBy !== undefined;
       const unlock = (actionResult?: FDActionResult) => rawUnlock(lockId, uuid, actionResult);
 
       return { unlock, isLocked, isLockedByMe };
@@ -990,7 +906,7 @@ export const FD = {
   },
 
   useLockStatus() {
-    const lockedBy = useSelector((s) => s.lockedBy);
+    const lockedBy = FormStore.raw.useSelector((s) => s.data.lockedBy);
     const isLocked = lockedBy !== undefined;
 
     return { lockedBy, isLocked };
@@ -1001,12 +917,12 @@ export const FD = {
    * objects). This will always be 'fresh', meaning it will update immediately when a new row is added/removed.
    */
   useFreshRows: (reference: IDataModelReference | undefined): BaseRow[] =>
-    useMemoSelector((s) => {
+    FormStore.raw.useMemoSelector((s) => {
       if (!reference) {
         return emptyArray;
       }
 
-      const rawRows = dot.pick(reference.field, s.dataModels[reference.dataType]?.currentData);
+      const rawRows = dot.pick(reference.field, s.data.models[reference.dataType]?.currentData);
       if (!Array.isArray(rawRows) || !rawRows.length) {
         return emptyArray;
       }
@@ -1018,24 +934,25 @@ export const FD = {
    * Returns the number of rows in a repeating group. This will always be 'fresh', meaning it will update immediately
    * when a new row is added/removed.
    */
-  useFreshNumRows: (ref: IDataModelReference | undefined) => useMemoSelector((s) => getFreshNumRows(s, ref)),
+  useFreshNumRows: (ref: IDataModelReference | undefined) =>
+    FormStore.raw.useMemoSelector((s) => getFreshNumRows(s, ref)),
 
   /**
    * Same as the above, but returns a non-reactive function you can call to check the number of rows.
    */
   useGetFreshNumRows: (): ((reference: IDataModelReference | undefined) => number) => {
-    const store = useStore();
+    const store = FormStore.raw.useStore();
     return useCallback((reference) => getFreshNumRows(store.getState(), reference), [store]);
   },
 
   useGetFreshRows: (): ((reference: IDataModelReference | undefined) => BaseRow[]) => {
-    const store = useStore();
+    const store = FormStore.raw.useStore();
     return useCallback(
       (reference) => {
         if (!reference) {
           return emptyArray;
         }
-        const rawRows = dot.pick(reference.field, store.getState().dataModels[reference.dataType]?.currentData);
+        const rawRows = dot.pick(reference.field, store.getState().data.models[reference.dataType]?.currentData);
         if (!Array.isArray(rawRows) || !rawRows.length) {
           return emptyArray;
         }
@@ -1051,12 +968,12 @@ export const FD = {
    * a new row is added/removed.
    */
   useFreshRowUuid: (reference: IDataModelReference | undefined, index: number | undefined): string | undefined =>
-    useMemoSelector((s) => {
+    FormStore.raw.useMemoSelector((s) => {
       if (!reference || index === undefined) {
         return undefined;
       }
 
-      const model = s.dataModels[reference.dataType];
+      const model = s.data.models[reference.dataType];
       if (!model) {
         return undefined;
       }
@@ -1070,13 +987,13 @@ export const FD = {
 
   /**
    * Returns a function you can use to debounce saved form data
-   * This will work (and return immediately) even if there is no FormDataWriteProvider in the tree.
+   * This will work (and return immediately) even if there is no form store in the tree.
    */
   useDebounceImmediately,
 
   /**
    * Returns a function you can use to wait until the form data is saved.
-   * This will work (and return immediately) even if there is no FormDataWriteProvider in the tree.
+   * This will work (and return immediately) even if there is no form store in the tree.
    */
   useWaitForSave,
 
@@ -1087,7 +1004,7 @@ export const FD = {
 
   /**
    * Returns true if the form data has unsaved changes
-   * This will work (and return false) even if there is no FormDataWriteProvider in the tree.
+   * This will work (and return false) even if there is no form store in the tree.
    */
   useHasUnsavedChanges,
 
@@ -1100,38 +1017,31 @@ export const FD = {
    * Returns a function to append a value to a list. It checks if the value is already in the list, and if not,
    * it will append it. If the value is already in the list, it will not be appended.
    */
-  useAppendToListUnique: () => useStaticSelector((s) => s.appendToListUnique),
+  useAppendToListUnique: () => FormStore.raw.useStaticSelector((s) => s.data.appendToListUnique),
 
   /**
    * Returns a function to append a value to a list. It will always append the value, even if it is already in the list.
    */
-  useAppendToList: () => useStaticSelector((s) => s.appendToList),
+  useAppendToList: () => FormStore.raw.useStaticSelector((s) => s.data.appendToList),
 
   /**
    * Returns a function to remove a value from a list, by use of a callback that lets you find the correct row to
    * remove. When the callback returns true, that row will be removed.
    */
-  useRemoveFromListCallback: () => useStaticSelector((s) => s.removeFromListCallback),
+  useRemoveFromListCallback: () => FormStore.raw.useStaticSelector((s) => s.data.removeFromListCallback),
 
   /**
    * Returns a function to remove a value from a list, by value. If your list contains unique values, this is the
    * safer alternative to useRemoveIndexFromList().
    */
-  useRemoveValueFromList: () => useStaticSelector((s) => s.removeValueFromList),
+  useRemoveValueFromList: () => FormStore.raw.useStaticSelector((s) => s.data.removeValueFromList),
 
-  /**
-   * Returns the latest validation issues from the backend, from the last time the form data was saved.
-   */
-  useLastSaveValidationIssues: () => useSelector((s) => s.validationIssues),
-
-  useSetLastValidationIssues: () => useStaticSelector((s) => s.setLastValidationIssues),
-
-  useRemoveIndexFromList: () => useStaticSelector((s) => s.removeIndexFromList),
+  useRemoveIndexFromList: () => FormStore.raw.useStaticSelector((s) => s.data.removeIndexFromList),
 
   useGetDataTypeForElementId: () => {
-    const map: Record<string, string | undefined> = useMemoSelector((s) =>
+    const map: Record<string, string | undefined> = FormStore.raw.useMemoSelector((s) =>
       Object.fromEntries(
-        Object.entries(s.dataModels)
+        Object.entries(s.data.models)
           .filter(([_, dataModel]) => dataModel.dataElementId)
           .map(([dataType, dataModel]) => [dataModel.dataElementId, dataType]),
       ),

--- a/src/App/frontend/src/features/formData/FormDataWriteProxies.tsx
+++ b/src/App/frontend/src/features/formData/FormDataWriteProxies.tsx
@@ -45,7 +45,6 @@ const { Provider, useCtx } = createContext<FormDataWriteProxies>({
     lock: defaultProxy as Proxy<'lock'>,
     nextLock: defaultProxy as Proxy<'nextLock'>,
     requestManualSave: defaultProxy as Proxy<'requestManualSave'>,
-    setLastValidationIssues: defaultProxy as Proxy<'setLastValidationIssues'>,
   },
 });
 

--- a/src/App/frontend/src/features/formData/FormDataWriteStateMachine.tsx
+++ b/src/App/frontend/src/features/formData/FormDataWriteStateMachine.tsx
@@ -2,18 +2,18 @@ import dot from 'dot-object';
 import deepEqual from 'fast-deep-equal';
 import { applyPatch } from 'fast-json-patch';
 import { v4 as uuidv4 } from 'uuid';
-import { createStore } from 'zustand';
-import { immer } from 'zustand/middleware/immer';
 
 import { convertData } from 'src/features/formData/convertData';
 import { createPatch } from 'src/features/formData/jsonPatch/createPatch';
 import { DEFAULT_DEBOUNCE_TIMEOUT } from 'src/features/formData/types';
 import { getFeature } from 'src/features/toggles';
-import type { SchemaLookupTool } from 'src/features/datamodel/SchemaLookupTool';
-import type { FDLeafValue } from 'src/features/formData/FormDataWrite';
-import type { FormDataWriteProxies, Proxy } from 'src/features/formData/FormDataWriteProxies';
+import { updateIncrementalValidations } from 'src/features/validation/backendValidation/useUpdateIncrementalValidations';
+import { updateBackendValidations } from 'src/features/validation/validationContext';
+import type { FormStoreSet, FormStoreState } from 'src/features/form/FormContext';
+import type { FDLeafValue, FormDataSliceProps } from 'src/features/formData/FormDataWrite';
+import type { Proxy } from 'src/features/formData/FormDataWriteProxies';
 import type { DebounceReason } from 'src/features/formData/types';
-import type { ChangeInstanceData, InstanceDataSelector } from 'src/features/instance/InstanceContext';
+import type { InstanceDataSelector } from 'src/features/instance/InstanceContext';
 import type { BackendValidationIssueGroups } from 'src/features/validation';
 import type { IDataModelReference } from 'src/layout/common.generated';
 import type { IInstance } from 'src/types/shared';
@@ -58,9 +58,9 @@ interface LockRequest {
   whenAcquired: (uuid: string) => void;
 }
 
-type FormDataState = {
+export type FormDataSliceState = {
   // Data model state
-  dataModels: { [dataType: string]: DataModelState };
+  models: { [dataType: string]: DataModelState };
 
   // Auto-saving is turned on by default, and will automatically save the data model to the server whenever the
   // debouncedCurrentData model changes. This can be turned off when, for example, you want to save the data model
@@ -76,9 +76,6 @@ type FormDataState = {
   // the way we track when to save the data model to the server. It can also be used to trigger a manual save
   // as a way to immediately save the data model to the server, for example before locking the data model.
   manualSaveRequested: boolean;
-
-  // This contains the validation issues we receive from the server last time we saved the data model.
-  validationIssues: BackendValidationIssueGroups | undefined;
 
   // This is used to track which component is currently blocking the auto-saving feature. If this is set to a string
   // value, auto-saving will be disabled, even if the autoSaving flag is set to true. This is useful when you want
@@ -200,21 +197,16 @@ export interface FormDataMethods {
   lock: (request: LockRequest) => void;
   nextLock: () => void;
   unlock: (key: string, uuid: string, saveResult?: FDActionResult) => void;
-  setLastValidationIssues: (issues: BackendValidationIssueGroups | undefined) => void;
 }
 
-export type FormDataContext = FormDataState & FormDataMethods;
-
 function makeActions(
-  set: (fn: (state: FormDataContext) => void) => void,
-  changeInstance: ChangeInstanceData,
-  selectFromInstance: InstanceDataSelector,
-  schemaLookup: { [dataType: string]: SchemaLookupTool },
+  set: FormStoreSet,
+  { selectFromInstance, dataModels, changeInstance, getCachedInitialValidations }: FormDataSliceProps,
 ): FormDataMethods {
   const debounceOnBlur = getFeature('saveOnBlur').value;
 
-  function setDebounceTimeout(state: FormDataContext, change: FDChange) {
-    state.debounceTimeout = change.debounceTimeout ?? DEFAULT_DEBOUNCE_TIMEOUT;
+  function setDebounceTimeout(state: FormStoreState, change: FDChange) {
+    state.data.debounceTimeout = change.debounceTimeout ?? DEFAULT_DEBOUNCE_TIMEOUT;
   }
 
   /**
@@ -223,8 +215,8 @@ function makeActions(
    * as deepEqual is a fairly expensive operation, and the object references has to be the same for hasUnsavedChanges
    * to work properly.
    */
-  function deduplicateModels(state: FormDataContext) {
-    for (const [dataType, { currentData, debouncedCurrentData, lastSavedData }] of Object.entries(state.dataModels)) {
+  function deduplicateModels(state: FormStoreState) {
+    for (const [dataType, { currentData, debouncedCurrentData, lastSavedData }] of Object.entries(state.data.models)) {
       const models = [
         { key: 'currentData', model: currentData },
         { key: 'debouncedCurrentData', model: debouncedCurrentData },
@@ -244,7 +236,7 @@ function makeActions(
             continue;
           }
           if (deepEqual(modelA.model, modelB.model)) {
-            state.dataModels[dataType][modelB.key] = modelA.model;
+            state.data.models[dataType][modelB.key] = modelA.model;
             modelB.model = modelA.model;
           }
         }
@@ -252,16 +244,23 @@ function makeActions(
     }
   }
 
-  function processChanges(state: FormDataContext, toProcess: FDSaveFinished) {
+  function processChanges(state: FormStoreState, toProcess: FDSaveFinished) {
     const { validationIssues, savedData, newDataModels, instance } = toProcess;
-    state.manualSaveRequested = false;
-    state.validationIssues = validationIssues;
+    state.data.manualSaveRequested = false;
+
+    if (validationIssues) {
+      updateIncrementalValidations(
+        validationIssues,
+        getCachedInitialValidations().cachedInitialValidations,
+        updateBackendValidations(state),
+      );
+    }
 
     if (instance) {
       changeInstance(() => instance);
     }
 
-    for (const [dataType, { dataElementId }] of Object.entries(state.dataModels)) {
+    for (const [dataType, { dataElementId }] of Object.entries(state.data.models)) {
       const next = dataElementId
         ? newDataModels.find((m) => m.dataElementId === dataElementId)?.data // Stateful apps
         : newDataModels.find((m) => m.dataType === dataType)?.data; // Stateless apps
@@ -269,10 +268,10 @@ function makeActions(
         const backendChangesPatch = createPatch({
           prev: savedData[dataType],
           next,
-          current: state.dataModels[dataType].currentData,
+          current: state.data.models[dataType].currentData,
         });
-        applyPatch(state.dataModels[dataType].currentData, backendChangesPatch);
-        state.dataModels[dataType].lastSavedData = next;
+        applyPatch(state.data.models[dataType].currentData, backendChangesPatch);
+        state.data.models[dataType].lastSavedData = next;
 
         // When we've copied over changes into the current model from the backend, we should also debounce this
         // immediately. Some selectors run on the debounced model (such as 'mapping', which should never run on the
@@ -283,57 +282,58 @@ function makeActions(
           debounce(state, `backendChanges`);
         }
       } else {
-        state.dataModels[dataType].lastSavedData = savedData[dataType];
+        state.data.models[dataType].lastSavedData = savedData[dataType];
       }
     }
     deduplicateModels(state);
   }
 
-  function debounce(state: FormDataContext, reason: DebounceReason) {
+  function debounce(state: FormStoreState, reason: DebounceReason) {
     if (reason === 'blur' && !debounceOnBlur) {
       return;
     }
 
-    for (const dataType of Object.keys(state.dataModels)) {
-      state.dataModels[dataType].invalidDebouncedCurrentData = state.dataModels[dataType].invalidCurrentData;
-      if (deepEqual(state.dataModels[dataType].debouncedCurrentData, state.dataModels[dataType].currentData)) {
-        state.dataModels[dataType].debouncedCurrentData = state.dataModels[dataType].currentData;
+    for (const dataType of Object.keys(state.data.models)) {
+      state.data.models[dataType].invalidDebouncedCurrentData = state.data.models[dataType].invalidCurrentData;
+      if (deepEqual(state.data.models[dataType].debouncedCurrentData, state.data.models[dataType].currentData)) {
+        state.data.models[dataType].debouncedCurrentData = state.data.models[dataType].currentData;
         continue;
       }
 
-      state.dataModels[dataType].debouncedCurrentData = state.dataModels[dataType].currentData;
+      state.data.models[dataType].debouncedCurrentData = state.data.models[dataType].currentData;
     }
   }
 
   function setValue(props: {
     reference: IDataModelReference;
     newValue: FDLeafValue;
-    state: FormDataContext;
+    state: FormStoreState;
   }): FDSetValueSuccessful | typeof FDSetValueUnset {
     const { reference, newValue, state } = props;
     if (newValue === '' || newValue === null || newValue === undefined) {
-      const prevValue = dot.pick(reference.field, state.dataModels[reference.dataType].currentData);
-      const prevInvalidValue = dot.pick(reference.field, state.dataModels[reference.dataType].invalidCurrentData);
+      const prevValue = dot.pick(reference.field, state.data.models[reference.dataType].currentData);
+      const prevInvalidValue = dot.pick(reference.field, state.data.models[reference.dataType].invalidCurrentData);
 
       // We conflate null and undefined, so no need to set to null or undefined if the value is
       // already null or undefined
       if (prevValue !== null && prevValue !== undefined) {
-        dot.delete(reference.field, state.dataModels[reference.dataType].currentData);
+        dot.delete(reference.field, state.data.models[reference.dataType].currentData);
       }
       if (prevInvalidValue !== null && prevInvalidValue !== undefined) {
-        dot.delete(reference.field, state.dataModels[reference.dataType].invalidCurrentData);
+        dot.delete(reference.field, state.data.models[reference.dataType].invalidCurrentData);
       }
       return FDSetValueUnset;
     } else {
-      const hadError = dot.pick(reference.field, state.dataModels[reference.dataType].invalidCurrentData) !== undefined;
-      const schema = schemaLookup[reference.dataType].getSchemaForPath(reference.field)[0];
+      const hadError =
+        dot.pick(reference.field, state.data.models[reference.dataType].invalidCurrentData) !== undefined;
+      const schema = dataModels[reference.dataType].schemaResult.lookupTool.getSchemaForPath(reference.field)[0];
       const { newValue: convertedValue, error } = convertData(newValue, schema);
       if (error) {
-        dot.delete(reference.field, state.dataModels[reference.dataType].currentData);
-        dot.str(reference.field, newValue, state.dataModels[reference.dataType].invalidCurrentData);
+        dot.delete(reference.field, state.data.models[reference.dataType].currentData);
+        dot.str(reference.field, newValue, state.data.models[reference.dataType].invalidCurrentData);
       } else {
-        dot.delete(reference.field, state.dataModels[reference.dataType].invalidCurrentData);
-        dot.str(reference.field, convertedValue, state.dataModels[reference.dataType].currentData);
+        dot.delete(reference.field, state.data.models[reference.dataType].invalidCurrentData);
+        dot.str(reference.field, convertedValue, state.data.models[reference.dataType].currentData);
       }
       return { newValue, convertedValue, error, hadError };
     }
@@ -346,7 +346,7 @@ function makeActions(
       }),
     cancelSave: () =>
       set((state) => {
-        state.manualSaveRequested = false;
+        state.data.manualSaveRequested = false;
         deduplicateModels(state);
       }),
     saveFinished: (props) =>
@@ -355,12 +355,12 @@ function makeActions(
       }),
     setLeafValue: ({ reference, newValue, callback, ...rest }) =>
       set((state) => {
-        if (!isWritable(state.dataModels[reference.dataType].dataElementId, selectFromInstance)) {
+        if (!isWritable(state.data.models[reference.dataType].dataElementId, selectFromInstance)) {
           window.logError(`Tried to write to readOnly dataType "${reference.dataType}"`);
           callback?.(FDSetValueReadOnly);
           return;
         }
-        const existingValue = dot.pick(reference.field, state.dataModels[reference.dataType].currentData);
+        const existingValue = dot.pick(reference.field, state.data.models[reference.dataType].currentData);
         if (existingValue === newValue) {
           callback?.(FDSetValueEqual);
           return;
@@ -375,11 +375,12 @@ function makeActions(
     // list items are immediate.
     appendToListUnique: ({ reference, newValue }) =>
       set((state) => {
-        if (!isWritable(state.dataModels[reference.dataType].dataElementId, selectFromInstance)) {
+        const dataState = state.data;
+        if (!isWritable(dataState.models[reference.dataType].dataElementId, selectFromInstance)) {
           window.logError(`Tried to write to readOnly dataType "${reference.dataType}"`);
           return;
         }
-        const existingValue = dot.pick(reference.field, state.dataModels[reference.dataType].currentData);
+        const existingValue = dot.pick(reference.field, dataState.models[reference.dataType].currentData);
         if (Array.isArray(existingValue) && existingValue.includes(newValue)) {
           return;
         }
@@ -387,17 +388,17 @@ function makeActions(
         if (Array.isArray(existingValue)) {
           existingValue.push(newValue);
         } else {
-          dot.str(reference.field, [newValue], state.dataModels[reference.dataType].currentData);
+          dot.str(reference.field, [newValue], dataState.models[reference.dataType].currentData);
         }
       }),
     appendToList: ({ reference, newValue }) =>
       set((state) => {
-        if (!isWritable(state.dataModels[reference.dataType].dataElementId, selectFromInstance)) {
+        if (!isWritable(state.data.models[reference.dataType].dataElementId, selectFromInstance)) {
           window.logError(`Tried to write to readOnly dataType "${reference.dataType}"`);
           return;
         }
         if (typeof newValue === 'object') {
-          const model = state.dataModels[reference.dataType].currentData;
+          const model = state.data.models[reference.dataType].currentData;
           const existingValue = dot.pick(reference.field, model);
           const nextIndex = Array.isArray(existingValue) ? existingValue.length : 0;
           const flatObject = dot.dot(newValue);
@@ -411,8 +412,8 @@ function makeActions(
         }
 
         const models = [
-          state.dataModels[reference.dataType].currentData,
-          state.dataModels[reference.dataType].debouncedCurrentData,
+          state.data.models[reference.dataType].currentData,
+          state.data.models[reference.dataType].debouncedCurrentData,
         ];
 
         for (const model of models) {
@@ -426,11 +427,11 @@ function makeActions(
       }),
     removeIndexFromList: ({ reference, index }) =>
       set((state) => {
-        if (!isWritable(state.dataModels[reference.dataType].dataElementId, selectFromInstance)) {
+        if (!isWritable(state.data.models[reference.dataType].dataElementId, selectFromInstance)) {
           window.logError(`Tried to write to readOnly dataType "${reference.dataType}"`);
           return;
         }
-        const existingValue = dot.pick(reference.field, state.dataModels[reference.dataType].currentData);
+        const existingValue = dot.pick(reference.field, state.data.models[reference.dataType].currentData);
         if (index >= existingValue.length) {
           return;
         }
@@ -440,11 +441,11 @@ function makeActions(
 
     removeValueFromList: ({ reference, value }) =>
       set((state) => {
-        if (!isWritable(state.dataModels[reference.dataType].dataElementId, selectFromInstance)) {
+        if (!isWritable(state.data.models[reference.dataType].dataElementId, selectFromInstance)) {
           window.logError(`Tried to write to readOnly dataType "${reference.dataType}"`);
           return;
         }
-        const existingValue = dot.pick(reference.field, state.dataModels[reference.dataType].currentData);
+        const existingValue = dot.pick(reference.field, state.data.models[reference.dataType].currentData);
         if (!existingValue.includes(value)) {
           return;
         }
@@ -453,7 +454,7 @@ function makeActions(
       }),
     removeFromListCallback: ({ reference, startAtIndex, callback }) =>
       set((state) => {
-        if (!isWritable(state.dataModels[reference.dataType].dataElementId, selectFromInstance)) {
+        if (!isWritable(state.data.models[reference.dataType].dataElementId, selectFromInstance)) {
           window.logError(`Tried to write to readOnly dataType "${reference.dataType}"`);
           return;
         }
@@ -462,8 +463,8 @@ function makeActions(
           // and debounced data models, the row would linger for a while in the UI, and we'd have intricate problems
           // to solve, like fetching options (which use the debounced data model when mapping form data into the URL),
           // which then would stall updating options and might cause deletion of stale option values before debounce.
-          state.dataModels[reference.dataType].currentData,
-          state.dataModels[reference.dataType].debouncedCurrentData,
+          state.data.models[reference.dataType].currentData,
+          state.data.models[reference.dataType].debouncedCurrentData,
         ];
         for (const model of models) {
           const existingValue = dot.pick(reference.field, model);
@@ -497,12 +498,12 @@ function makeActions(
       set((state) => {
         const changedTypes = new Set<string>();
         for (const { reference, newValue } of changes) {
-          if (!isWritable(state.dataModels[reference.dataType].dataElementId, selectFromInstance)) {
+          if (!isWritable(state.data.models[reference.dataType].dataElementId, selectFromInstance)) {
             window.logError(`Tried to write to readOnly dataType "${reference.dataType}"`);
             continue;
           }
 
-          const existingValue = dot.pick(reference.field, state.dataModels[reference.dataType].currentData);
+          const existingValue = dot.pick(reference.field, state.data.models[reference.dataType].currentData);
           if (existingValue === newValue) {
             continue;
           }
@@ -513,33 +514,33 @@ function makeActions(
       }),
     requestManualSave: (setTo = true) =>
       set((state) => {
-        state.manualSaveRequested = setTo;
+        state.data.manualSaveRequested = setTo;
       }),
     lock: (request) =>
       set((state) => {
-        if (state.lockedBy) {
-          state.lockQueue.push(request);
+        if (state.data.lockedBy) {
+          state.data.lockQueue.push(request);
           return;
         }
         const uuid = uuidv4();
-        state.lockedBy = `${request.key} (${uuid})`;
+        state.data.lockedBy = `${request.key} (${uuid})`;
         request.whenAcquired(uuid);
       }),
     nextLock: () =>
       set((state) => {
-        const next = state.lockQueue.shift();
+        const next = state.data.lockQueue.shift();
         if (next) {
           const uuid = uuidv4();
-          state.lockedBy = `${next.key} (${uuid})`;
+          state.data.lockedBy = `${next.key} (${uuid})`;
           next.whenAcquired(uuid);
         }
       }),
     unlock: (key, uuid, actionResult) =>
       set((state) => {
         const expected = `${key} (${uuid})`;
-        if (state.lockedBy !== expected) {
+        if (state.data.lockedBy !== expected) {
           throw new Error(
-            `Tried to unlock with an invalid UUID (state is locked by ${state.lockedBy}, but ${expected} tried to unlock)`,
+            `Tried to unlock with an invalid UUID (state is locked by ${state.data.lockedBy}, but ${expected} tried to unlock)`,
           );
         }
 
@@ -547,8 +548,8 @@ function makeActions(
         if (actionResult?.updatedDataModels) {
           const newDataModels: UpdatedDataModel[] = [];
           for (const dataElementId of Object.keys(actionResult.updatedDataModels)) {
-            const dataType = Object.keys(state.dataModels).find(
-              (dt) => state.dataModels[dt].dataElementId === dataElementId,
+            const dataType = Object.keys(state.data.models).find(
+              (dt) => state.data.models[dt].dataElementId === dataElementId,
             );
             if (dataType) {
               const data = actionResult.updatedDataModels[dataElementId];
@@ -559,7 +560,7 @@ function makeActions(
           processChanges(state, {
             instance: actionResult.instance,
             newDataModels,
-            savedData: Object.entries(state.dataModels).reduce((savedData, [dataType, { lastSavedData }]) => {
+            savedData: Object.entries(state.data.models).reduce((savedData, [dataType, { lastSavedData }]) => {
               savedData[dataType] = lastSavedData;
               return savedData;
             }, {}),
@@ -570,50 +571,48 @@ function makeActions(
         /** Unlock. If there are more locks in the queue, the next one will be processed by
          * @see FormDataEffects
          */
-        state.lockedBy = undefined;
-      }),
-    setLastValidationIssues: (issues) =>
-      set((state) => {
-        state.validationIssues = issues;
+        state.data.lockedBy = undefined;
       }),
   };
 }
 
-export const createFormDataWriteStore = (
-  initialDataModels: { [dataType: string]: DataModelState },
-  autoSaving: boolean,
-  proxies: FormDataWriteProxies,
-  schemaLookup: { [dataType: string]: SchemaLookupTool },
-  changeInstance: ChangeInstanceData,
-  selectFromInstance: InstanceDataSelector,
-) =>
-  createStore<FormDataContext>()(
-    immer((set) => {
-      const actions = makeActions(set, changeInstance, selectFromInstance, schemaLookup);
-      for (const name of Object.keys(actions)) {
-        const fnName = name as keyof FormDataMethods;
-        const original = actions[fnName];
-        const proxyFn = proxies[fnName] as Proxy<keyof FormDataMethods>;
-        const { proxy, method } = proxyFn(original);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        actions[fnName] = (...args: any[]) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          proxy({ args: args as any, toCall: method });
-        };
-      }
+export function createFormDataWriteSlice(props: FormDataSliceProps, set: FormStoreSet): FormStoreState['data'] {
+  const actions = makeActions(set, props);
+  for (const name of Object.keys(actions)) {
+    const fnName = name as keyof FormDataMethods;
+    const original = actions[fnName];
+    const proxyFn = props.proxies[fnName] as Proxy<keyof FormDataMethods>;
+    const { proxy, method } = proxyFn(original);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    actions[fnName] = (...args: any[]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      proxy({ args: args as any, toCall: method });
+    };
+  }
 
-      return {
-        dataModels: initialDataModels,
-        autoSaving,
-        lockedBy: undefined,
-        lockQueue: [],
-        debounceTimeout: DEFAULT_DEBOUNCE_TIMEOUT,
-        manualSaveRequested: false,
-        validationIssues: undefined,
-        ...actions,
-      };
-    }),
-  );
+  const models = Object.keys(props.dataModels).reduce((dm, dt) => {
+    const emptyInvalidData = {};
+    dm[dt] = {
+      currentData: props.dataModels[dt].initialData,
+      invalidCurrentData: emptyInvalidData,
+      debouncedCurrentData: props.dataModels[dt].initialData,
+      invalidDebouncedCurrentData: emptyInvalidData,
+      lastSavedData: props.dataModels[dt].initialData,
+      dataElementId: props.dataModels[dt].dataElementId,
+    } satisfies DataModelState;
+    return dm;
+  }, {});
+
+  return {
+    models,
+    autoSaving: props.autoSaving,
+    lockedBy: undefined,
+    lockQueue: [],
+    debounceTimeout: DEFAULT_DEBOUNCE_TIMEOUT,
+    manualSaveRequested: false,
+    ...actions,
+  };
+}
 
 function isWritable(dataElementId: string | null, selectFromInstance: InstanceDataSelector) {
   if (!dataElementId) {

--- a/src/App/frontend/src/features/formData/useDataModelBindings.test.tsx
+++ b/src/App/frontend/src/features/formData/useDataModelBindings.test.tsx
@@ -6,7 +6,7 @@ import { userEvent } from '@testing-library/user-event';
 import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';
 import { defaultMockDataElementId, getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
 import { defaultDataTypeMock } from 'src/__mocks__/getUiConfigMock';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { IDataModelMultiPatchResponse } from 'src/features/formData/types';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
@@ -21,7 +21,7 @@ describe('useDataModelBindings', () => {
   });
 
   function DummyComponent() {
-    const debounce = FD.useDebounceImmediately();
+    const debounce = FormStore.data.useDebounceImmediately();
     const { formData, setValue, setValues, isValid } = useDataModelBindings({
       stringy: { field: 'stringyField', dataType: defaultDataTypeMock },
       decimal: { field: 'decimalField', dataType: defaultDataTypeMock },

--- a/src/App/frontend/src/features/formData/useDataModelBindings.ts
+++ b/src/App/frontend/src/features/formData/useDataModelBindings.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { DEFAULT_DEBOUNCE_TIMEOUT } from 'src/features/formData/types';
 import { useMemoDeepEqual } from 'src/hooks/useStateDeepEqual';
 import type { FDLeafValue } from 'src/features/formData/FormDataWrite';
@@ -46,8 +46,8 @@ export function useDataModelBindings<B extends IDataModelBindings | undefined, D
 ): Output<B, DA> {
   const bindings = useMemoDeepEqual(() => (_bindings || defaultBindings) as Exclude<B, undefined>, [_bindings]);
 
-  const formData = FD.useFreshBindings(bindings, dataAs);
-  const isValid = FD.useBindingsAreValid(bindings);
+  const formData = FormStore.data.useFreshBindings(bindings, dataAs);
+  const isValid = FormStore.data.useBindingsAreValid(bindings);
   const { setValue, setValues } = useSaveDataModelBindings(bindings, debounceTimeout);
 
   return useMemo(
@@ -62,8 +62,8 @@ export function useSaveDataModelBindings<B extends IDataModelBindings | undefine
 ): SaveOutput<B> {
   const bindings = useMemoDeepEqual(() => (_bindings || defaultBindings) as Exclude<B, undefined>, [_bindings]);
 
-  const setLeafValue = FD.useSetLeafValue();
-  const setMultiLeafValue = FD.useSetMultiLeafValues();
+  const setLeafValue = FormStore.data.useSetLeafValue();
+  const setMultiLeafValue = FormStore.data.useSetMultiLeafValues();
 
   const saveOptions: SaveOptions = useMemo(
     () =>

--- a/src/App/frontend/src/features/instance/useProcessNext.tsx
+++ b/src/App/frontend/src/features/instance/useProcessNext.tsx
@@ -3,7 +3,7 @@ import { toast } from 'react-toastify';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { ContextNotProvided } from 'src/core/contexts/context';
+import { FormStore } from 'src/features/form/FormContext';
 import { invalidateFormDataQueries } from 'src/features/formData/useFormDataQuery';
 import { useHasPendingScans, useInstanceDataQuery, useLaxInstanceId } from 'src/features/instance/InstanceContext';
 import { useOptimisticallyUpdateProcess, useProcessQuery } from 'src/features/instance/useProcessQuery';
@@ -11,7 +11,6 @@ import { Lang } from 'src/features/language/Lang';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useUpdateInitialValidations } from 'src/features/validation/backendValidation/backendValidationQuery';
 import { useOnFormSubmitValidation } from 'src/features/validation/callbacks/onFormSubmitValidation';
-import { Validation } from 'src/features/validation/validationContext';
 import { useNavigateToTask } from 'src/hooks/useNavigatePage';
 import { doProcessNext } from 'src/queries/queries';
 import { TaskKeys } from 'src/routesBuilder';
@@ -23,6 +22,11 @@ interface ProcessNextProps {
   action?: IActionType;
 }
 
+interface ProcessNextInternalProps extends ProcessNextProps {
+  beforeProcessNext?: () => Promise<boolean>;
+  onValidationIssues?: (validationIssues: BackendValidationIssue[]) => Promise<void>;
+}
+
 export function getProcessNextMutationKey(action?: IActionType) {
   if (!action) {
     return ['processNext'] as const;
@@ -30,16 +34,12 @@ export function getProcessNextMutationKey(action?: IActionType) {
   return ['processNext', action] as const;
 }
 
-export function useProcessNext({ action }: ProcessNextProps = {}) {
+function useProcessNextInternal({ action, beforeProcessNext, onValidationIssues }: ProcessNextInternalProps = {}) {
   const reFetchInstanceData = useInstanceDataQuery({ enabled: false }).refetch;
   const language = useCurrentLanguage();
   const { data: process, refetch: refetchProcessData } = useProcessQuery();
   const navigateToTask = useNavigateToTask();
   const instanceId = useLaxInstanceId();
-  const onFormSubmitValidation = useOnFormSubmitValidation();
-  const updateInitialValidations = useUpdateInitialValidations();
-  const setShowAllBackendErrors = Validation.useSetShowAllBackendErrors();
-  const onSubmitFormValidation = useOnFormSubmitValidation();
   const queryClient = useQueryClient();
   const hasPendingScans = useHasPendingScans();
   const optimisticallyUpdateProcess = useOptimisticallyUpdateProcess();
@@ -52,8 +52,7 @@ export function useProcessNext({ action }: ProcessNextProps = {}) {
         await reFetchInstanceData();
       }
 
-      const hasErrors = await onFormSubmitValidation();
-      if (hasErrors) {
+      if (await beforeProcessNext?.()) {
         return [null, null];
       }
 
@@ -88,13 +87,13 @@ export function useProcessNext({ action }: ProcessNextProps = {}) {
         }
         navigateToTask(task);
       } else if (validationIssues) {
-        // Set initial validation to validation issues from process/next and make all errors visible
-        updateInitialValidations(validationIssues);
-
-        const hasValidationErrors = await onSubmitFormValidation(true);
-        if (!hasValidationErrors) {
-          setShowAllBackendErrors !== ContextNotProvided && setShowAllBackendErrors();
+        if (!onValidationIssues) {
+          throw new Error(
+            'Process next returned validation issues outside a form context. This task cannot represent validation issues without a FormProvider.',
+          );
         }
+
+        await onValidationIssues(validationIssues);
       }
     },
     onError: async (error: HttpClientError<ProblemDetails | undefined>) => {
@@ -114,6 +113,30 @@ export function useProcessNext({ action }: ProcessNextProps = {}) {
       });
     },
   });
+}
+
+export function useProcessNext({ action }: ProcessNextProps = {}) {
+  const onFormSubmitValidation = useOnFormSubmitValidation();
+  const updateInitialValidations = useUpdateInitialValidations();
+  const setShowAllBackendErrors = FormStore.validation.useSetShowAllBackendErrors();
+
+  return useProcessNextInternal({
+    action,
+    beforeProcessNext: async () => await onFormSubmitValidation(),
+    onValidationIssues: async (validationIssues) => {
+      // Set initial validation to validation issues from process/next and make all errors visible
+      updateInitialValidations(validationIssues);
+
+      const hasValidationErrors = await onFormSubmitValidation(true);
+      if (!hasValidationErrors) {
+        await setShowAllBackendErrors();
+      }
+    },
+  });
+}
+
+export function useProcessNextOutsideFormProvider({ action }: ProcessNextProps = {}) {
+  return useProcessNextInternal({ action });
 }
 
 export function getTargetTaskFromProcess(processData: IProcess | undefined) {

--- a/src/App/frontend/src/features/language/useLanguage.ts
+++ b/src/App/frontend/src/features/language/useLanguage.ts
@@ -2,9 +2,9 @@ import { Children, isValidElement, useCallback, useMemo } from 'react';
 import type { JSX, ReactNode } from 'react';
 
 import { ContextNotProvided } from 'src/core/contexts/context';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { DataModelReaders } from 'src/features/formData/FormDataReaders';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { Lang } from 'src/features/language/Lang';
 import { useLangToolsDataSources } from 'src/features/language/useLangToolsDataSources';
 import { type FixedLanguageList, getLanguageFromCode } from 'src/language/languages';
@@ -93,7 +93,7 @@ export function useLanguageWithForcedPath(dataModelPath: IDataModelReference | u
   const sources = useLangToolsDataSources();
   const defaultDataType = FormBootstrap.useLaxDefaultDataType();
   const formDataTypes = FormBootstrap.useLaxReadableDataTypes();
-  const formDataSelector = FD.useLaxDebouncedSelector();
+  const formDataSelector = FormStore.data.useLaxDebouncedSelector();
 
   return useMemo(() => {
     const { textResources, language, selectedLanguage, ...dataSources } = sources;

--- a/src/App/frontend/src/features/navigation/AppNavigation.test.tsx
+++ b/src/App/frontend/src/features/navigation/AppNavigation.test.tsx
@@ -4,6 +4,7 @@ import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';
+import { defaultMockDataElementId } from 'src/__mocks__/getInstanceDataMock';
 import { defaultDataTypeMock, getUiConfigMock } from 'src/__mocks__/getUiConfigMock';
 import { NavigationReceipt, NavigationTask } from 'src/features/form/ui/types';
 import { AppNavigation } from 'src/features/navigation/AppNavigation';
@@ -110,6 +111,7 @@ describe('AppNavigation', () => {
                 severity: BackendValidationSeverity.Error,
                 source: 'SomeCustomValidator',
                 field: `field-${page}`,
+                dataElementId: defaultMockDataElementId,
               })) ?? [];
             obj.dataModels[defaultDataTypeMock].initialData = Object.fromEntries(
               rawOrder.map((page) => [`field-${page}`, 'some value']),

--- a/src/App/frontend/src/features/navigation/utils.ts
+++ b/src/App/frontend/src/features/navigation/utils.ts
@@ -11,12 +11,12 @@ import {
 
 import { ContextNotProvided } from 'src/core/contexts/context';
 import { useIsReceiptPage } from 'src/core/routing/useIsReceiptPage';
+import { FormStore } from 'src/features/form/FormContext';
 import { usePageGroups, usePageSettings } from 'src/features/form/layoutSettings/processLayoutSettings';
 import { useGetAltinnTaskType } from 'src/features/instance/useProcessQuery';
 import { ValidationMask } from 'src/features/validation';
 import { useVisitedPages } from 'src/hooks/useNavigatePage';
 import { useHiddenPages } from 'src/utils/layout/hidden';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { NavigationReceipt, NavigationTask } from 'src/features/form/ui/types';
 
 export function useHasGroupedNavigation() {
@@ -87,12 +87,12 @@ export function getTaskIcon(taskType: string | undefined) {
  * 4. A group is marked as completed if all of its pages have no nodes with any validations errors (visible or not), and all of the pages are marked as 'visited'.
  */
 export function useValidationsForPages(order: string[], shouldMarkWhenCompleted = false) {
-  const validationsSelector = NodesInternal.useLaxValidationsSelector();
+  const validationsSelector = FormStore.nodes.useLaxValidationsSelector();
   const [visitedPages] = useVisitedPages();
 
-  const allNodeIds = NodesInternal.useLaxMemoSelector((state) => {
+  const allNodeIds = FormStore.raw.useLaxMemoSelector((state) => {
     const allNodeIds = Object.fromEntries<string[]>(order.map((page) => [page, []]));
-    Object.values(state.nodeData).forEach((node) => allNodeIds[node.pageKey]?.push(node.id));
+    Object.values(state.nodes.nodeData).forEach((node) => allNodeIds[node.pageKey]?.push(node.id));
     return allNodeIds;
   });
 

--- a/src/App/frontend/src/features/options/RunOptionsEffects.tsx
+++ b/src/App/frontend/src/features/options/RunOptionsEffects.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { EffectPreselectedOptionIndex } from 'src/features/options/effects/EffectPreselectedOptionIndex';
 import { EffectRemoveStaleValues } from 'src/features/options/effects/EffectRemoveStaleValues';
@@ -9,7 +10,6 @@ import { EffectStoreLabelInGroup } from 'src/features/options/effects/EffectStor
 import { useFetchOptions, useFilteredAndSortedOptions } from 'src/features/options/useGetOptions';
 import { GeneratorInternal } from 'src/utils/layout/generator/GeneratorContext';
 import { WhenParentAdded } from 'src/utils/layout/generator/GeneratorStages';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { OptionsValueType } from 'src/features/options/useGetOptions';
 import type { IDataModelBindingsForGroupCheckbox } from 'src/layout/Checkboxes/config.generated';
 import type { IDataModelBindingsOptionsSimple } from 'src/layout/common.generated';
@@ -21,7 +21,7 @@ interface RunOptionEffectsProps {
 }
 
 export function RunOptionsEffects({ valueType }: RunOptionEffectsProps) {
-  const isReadOnly = NodesInternal.useIsReadOnly();
+  const isReadOnly = FormStore.nodes.useIsReadOnly();
   const item = GeneratorInternal.useIntermediateItem() as CompIntermediate<CompWithBehavior<'canHaveOptions'>>;
   const parent = GeneratorInternal.useParent();
   const lookups = FormBootstrap.useLayoutLookups();

--- a/src/App/frontend/src/features/options/effects/EffectStoreLabelInGroup.tsx
+++ b/src/App/frontend/src/features/options/effects/EffectStoreLabelInGroup.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'react';
 import dot from 'dot-object';
 import deepEqual from 'fast-deep-equal';
 
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { toRelativePath } from 'src/features/saveToGroup/useSaveToGroup';
 import { GeneratorInternal } from 'src/utils/layout/generator/GeneratorContext';
@@ -27,13 +27,13 @@ export function EffectStoreLabelInGroup({ options }: Props) {
   const parent = GeneratorInternal.useParent();
   const isHidden = useIsHidden(parent.baseId);
   const { langAsString } = useLanguage();
-  const setLeafValue = FD.useSetLeafValue();
-  const formDataSelector = FD.useCurrentSelector();
+  const setLeafValue = FormStore.data.useSetLeafValue();
+  const formDataSelector = FormStore.data.useCurrentSelector();
 
   const bindings = item.dataModelBindings as IDataModelBindingsForGroupCheckbox | IDataModelBindingsForGroupMultiselect;
 
   const groupBinding = bindings.group;
-  const groupRows = FD.useDebouncedPick(groupBinding) as Row[];
+  const groupRows = FormStore.data.useDebouncedPick(groupBinding) as Row[];
 
   const checkedPath = toRelativePath(groupBinding, bindings.checked);
   const valuePath = toRelativePath(groupBinding, bindings.simpleBinding);

--- a/src/App/frontend/src/features/options/useGetOptionsQuery.ts
+++ b/src/App/frontend/src/features/options/useGetOptionsQuery.ts
@@ -3,8 +3,8 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import type { AxiosResponse } from 'axios';
 
 import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useLaxInstanceId } from 'src/features/instance/InstanceContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { castOptionsToStrings } from 'src/features/options/castOptionsToStrings';
@@ -42,7 +42,7 @@ export const useGetOptionsUrl = (
   queryParameters?: IQueryParameters,
   secure?: boolean,
 ): string | undefined => {
-  const mappingResult = FD.useMapping(mapping, FormBootstrap.useDefaultDataType());
+  const mappingResult = FormStore.data.useMapping(mapping, FormBootstrap.useDefaultDataType());
   const language = useCurrentLanguage();
   const instanceId = useLaxInstanceId();
   const resolvedQueryParameters = useResolvedQueryParameters(queryParameters);

--- a/src/App/frontend/src/features/options/useSourceOptions.ts
+++ b/src/App/frontend/src/features/options/useSourceOptions.ts
@@ -3,8 +3,8 @@ import dot from 'dot-object';
 import { evalExpr } from 'src/features/expressions';
 import { ExprVal } from 'src/features/expressions/types';
 import { ExprValidation } from 'src/features/expressions/validation';
+import { FormStore } from 'src/features/form/FormContext';
 import { useCurrentUiFolderSettings } from 'src/features/form/ui/hooks';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useMemoDeepEqual } from 'src/hooks/useStateDeepEqual';
 import { getKeyWithoutIndexIndicators } from 'src/utils/databindings';
@@ -20,7 +20,7 @@ export const useSourceOptions = (source: IOptionSource): IOptionInternal[] => {
   const langTools = useLanguage();
   const groupReference = useGroupReference(source);
   const valueSubPath = getValueSubPath(source);
-  const rawValues = FD.useDebouncedSelect((pick) => {
+  const rawValues = FormStore.data.useDebouncedSelect((pick) => {
     if (!groupReference || !valueSubPath) {
       return [];
     }

--- a/src/App/frontend/src/features/pdf/PdfFromLayout.tsx
+++ b/src/App/frontend/src/features/pdf/PdfFromLayout.tsx
@@ -30,7 +30,6 @@ import { SummaryComponent2 } from 'src/layout/Summary2/SummaryComponent2/Summary
 import { TaskSummaryWrapper } from 'src/layout/Summary2/SummaryComponent2/TaskSummaryWrapper';
 import { useIsHiddenMulti } from 'src/utils/layout/hidden';
 import { useExternalItem } from 'src/utils/layout/hooks';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useItemIfType } from 'src/utils/layout/useNodeItem';
 import type { IPdfFormat } from 'src/features/pdf/types';
 
@@ -162,10 +161,9 @@ function PdfWrapping({ children }: PropsWithChildren) {
 }
 
 function PlainPage({ pageKey }: { pageKey: string }) {
-  const pageExists = NodesInternal.useSelector((state) =>
-    Object.values(state.pagesData.pages).some((data) => data.pageKey === pageKey),
-  );
-  const children = FormBootstrap.useLayoutLookups().topLevelComponents[pageKey] ?? [];
+  const lookups = FormBootstrap.useLayoutLookups();
+  const pageExists = lookups.allPerPage[pageKey] ?? false;
+  const children = lookups.topLevelComponents[pageKey] ?? [];
 
   if (!pageExists) {
     const message = `Error using: "pdfLayoutName": ${JSON.stringify(pageKey)}, could not find a layout with that name.`;

--- a/src/App/frontend/src/features/process/confirm/containers/ConfirmPage.tsx
+++ b/src/App/frontend/src/features/process/confirm/containers/ConfirmPage.tsx
@@ -4,7 +4,7 @@ import { Button } from 'src/app-components/Button/Button';
 import { ReceiptComponent } from 'src/components/organisms/AltinnReceipt';
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
 import { useAppOwner } from 'src/core/texts/appTexts';
-import { useProcessNext } from 'src/features/instance/useProcessNext';
+import { useProcessNextOutsideFormProvider } from 'src/features/instance/useProcessNext';
 import { useIsAuthorized } from 'src/features/instance/useProcessQuery';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -75,7 +75,9 @@ export const ConfirmPage = ({ instance, instanceOwnerParty, appName, application
 
 const ConfirmButton = () => {
   const canConfirm = useIsAuthorized()('confirm');
-  const { mutateAsync: processConfirm, isPending: isConfirming } = useProcessNext({ action: 'confirm' });
+  const { mutateAsync: processConfirm, isPending: isConfirming } = useProcessNextOutsideFormProvider({
+    action: 'confirm',
+  });
 
   return (
     <div style={{ marginTop: 'var(--button-margin-top)' }}>

--- a/src/App/frontend/src/features/process/service/ServiceTask.tsx
+++ b/src/App/frontend/src/features/process/service/ServiceTask.tsx
@@ -5,7 +5,7 @@ import { Heading, Paragraph } from '@digdir/designsystemet-react';
 import { Button } from 'src/app-components/Button/Button';
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
 import { useAppOwner } from 'src/core/texts/appTexts';
-import { useProcessNext } from 'src/features/instance/useProcessNext';
+import { useProcessNextOutsideFormProvider } from 'src/features/instance/useProcessNext';
 import { useIsAuthorized } from 'src/features/instance/useProcessQuery';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -56,7 +56,7 @@ export function ServiceTask() {
 
 const RetryButton = () => {
   const canRetry = useIsAuthorized()('write');
-  const { mutateAsync: processRetry, isPending: isRetrying } = useProcessNext();
+  const { mutateAsync: processRetry, isPending: isRetrying } = useProcessNextOutsideFormProvider();
 
   return (
     <Button
@@ -73,7 +73,9 @@ const RetryButton = () => {
 
 const BackButton = () => {
   const canReject = useIsAuthorized()('reject');
-  const { mutateAsync: processReject, isPending: isRejecting } = useProcessNext({ action: 'reject' });
+  const { mutateAsync: processReject, isPending: isRejecting } = useProcessNextOutsideFormProvider({
+    action: 'reject',
+  });
 
   if (!canReject) {
     return null;

--- a/src/App/frontend/src/features/saveToGroup/ObjectToGroupLayoutValidator.tsx
+++ b/src/App/frontend/src/features/saveToGroup/ObjectToGroupLayoutValidator.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { NodeValidationProps } from 'src/layout/layout';
 
 export function ObjectToGroupLayoutValidator(props: NodeValidationProps<'List' | 'Checkboxes' | 'MultipleSelect'>) {
@@ -11,7 +11,7 @@ export function ObjectToGroupLayoutValidator(props: NodeValidationProps<'List' |
   const deletionStrategy = externalItem.deletionStrategy;
   const checkedBinding = externalItem.dataModelBindings?.checked;
 
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
 
   useEffect(() => {
     let error: string | null = null;

--- a/src/App/frontend/src/features/saveToGroup/useSaveToGroup.ts
+++ b/src/App/frontend/src/features/saveToGroup/useSaveToGroup.ts
@@ -1,7 +1,7 @@
 import dot from 'dot-object';
 import { v4 as uuidv4 } from 'uuid';
 
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { ALTINN_ROW_ID } from 'src/features/formData/types';
 import type { IDataModelBindingsForGroupCheckbox } from 'src/layout/Checkboxes/config.generated';
 import type { IDataModelReference } from 'src/layout/common.generated';
@@ -51,10 +51,10 @@ function findRowInFormData(
 
 function useSaveToGroup(bindings: Bindings) {
   const { group, checked, values } = bindings;
-  const formDataSelector = FD.useCurrentSelector();
-  const setLeafValue = FD.useSetLeafValue();
-  const appendToList = FD.useAppendToList();
-  const removeFromList = FD.useRemoveFromListCallback();
+  const formDataSelector = FormStore.data.useCurrentSelector();
+  const setLeafValue = FormStore.data.useSetLeafValue();
+  const appendToList = FormStore.data.useAppendToList();
+  const removeFromList = FormStore.data.useRemoveFromListCallback();
   const checkedPath = toRelativePath(group, checked);
 
   function toggle(row: Row): void {
@@ -114,7 +114,7 @@ export function useSaveObjectToGroup(listBindings: IDataModelBindingsForList) {
     }
   }
   const bindings: Bindings = { group: listBindings.group, checked: listBindings.checked, values };
-  const formDataSelector = FD.useCurrentSelector();
+  const formDataSelector = FormStore.data.useCurrentSelector();
   const { enabled, toggle, checkedPath } = useSaveToGroup(bindings);
 
   function isChecked(row: Row): boolean {
@@ -148,7 +148,7 @@ export function useSaveValueToGroup(
   });
   const valuePath = toRelativePath(bindings.group, bindings.simpleBinding);
 
-  const formData = FD.useFreshBindings(bindings.group ? { group: bindings.group } : {}, 'raw').group as
+  const formData = FormStore.data.useFreshBindings(bindings.group ? { group: bindings.group } : {}, 'raw').group as
     | Row[]
     | undefined;
 

--- a/src/App/frontend/src/features/saveToGroup/useValidateGroupIsEmpty.ts
+++ b/src/App/frontend/src/features/saveToGroup/useValidateGroupIsEmpty.ts
@@ -1,6 +1,6 @@
 import dot from 'dot-object';
 
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { toRelativePath } from 'src/features/saveToGroup/useSaveToGroup';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getFieldNameKey } from 'src/utils/formComponentUtils';
@@ -17,7 +17,7 @@ export function useValidateGroupIsEmpty<T extends 'Checkboxes' | 'MultipleSelect
   const textResourceBindings = item.textResourceBindings;
   const formData = useNodeFormDataWhenType(baseComponentId, type);
 
-  const invalidDataSelector = FD.useInvalidDebouncedSelector();
+  const invalidDataSelector = FormStore.data.useInvalidDebouncedSelector();
   if (!required || !dataModelBindings) {
     return [];
   }

--- a/src/App/frontend/src/features/validation/StoreValidationsInNode.tsx
+++ b/src/App/frontend/src/features/validation/StoreValidationsInNode.tsx
@@ -2,12 +2,12 @@ import React, { useEffect } from 'react';
 
 import deepEqual from 'fast-deep-equal';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { useNodeValidation } from 'src/features/validation/nodeValidation/useNodeValidation';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { GeneratorInternal } from 'src/utils/layout/generator/GeneratorContext';
 import { WhenParentAdded } from 'src/utils/layout/generator/GeneratorStages';
 import { useIsHidden } from 'src/utils/layout/hidden';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { AnyValidation, AttachmentValidation } from 'src/features/validation/index';
 import type { CompExternal, CompIntermediate } from 'src/layout/layout';
 
@@ -42,7 +42,7 @@ function useStoreValidations(baseComponentId: string) {
   const freshValidations = useNodeValidation(baseComponentId);
   const validations = useUpdatedValidations(freshValidations, indexedId);
 
-  const shouldSetValidations = NodesInternal.useNodeData(
+  const shouldSetValidations = FormStore.nodes.useNodeData(
     indexedId,
     undefined,
     (data) => !deepEqual('validations' in data ? data.validations : undefined, validations),
@@ -54,7 +54,7 @@ function useStoreValidations(baseComponentId: string) {
   }, [indexedId, setNodeProp, shouldSetValidations, validations]);
 
   // Reduce visibility as validations are fixed
-  const visibilityToSet = NodesInternal.useNodeData(indexedId, undefined, (data) => {
+  const visibilityToSet = FormStore.nodes.useNodeData(indexedId, undefined, (data) => {
     if (!('validationVisibility' in data)) {
       return undefined;
     }
@@ -73,7 +73,7 @@ function useStoreValidations(baseComponentId: string) {
 
   // Hidden state needs to be set for validations as a temporary solution
   const hidden = useIsHidden(baseComponentId, { respectPageOrder: true });
-  const shouldSetHidden = NodesInternal.useNodeData(indexedId, undefined, (data) =>
+  const shouldSetHidden = FormStore.nodes.useNodeData(indexedId, undefined, (data) =>
     'hidden' in data ? data.hidden !== hidden : true,
   );
 
@@ -83,7 +83,7 @@ function useStoreValidations(baseComponentId: string) {
 }
 
 function useUpdatedValidations(validations: AnyValidation[], nodeId: string) {
-  return NodesInternal.useNodeData(nodeId, undefined, (data) => {
+  return FormStore.nodes.useNodeData(nodeId, undefined, (data) => {
     if (!('validations' in data) || !data.validations) {
       return validations;
     }

--- a/src/App/frontend/src/features/validation/ValidationPlugin.test.tsx
+++ b/src/App/frontend/src/features/validation/ValidationPlugin.test.tsx
@@ -9,12 +9,12 @@ import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';
 import { defaultMockDataElementId } from 'src/__mocks__/getInstanceDataMock';
 import { defaultDataTypeMock, getUiConfigMock } from 'src/__mocks__/getUiConfigMock';
 import { Form } from 'src/components/form/Form';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
 import type { AllowedValidationMasks } from 'src/layout/common.generated';
 
 function FormDataValue() {
-  const formDataValue = FD.useDebouncedPick({ dataType: defaultDataTypeMock, field: 'TextField' });
+  const formDataValue = FormStore.data.useDebouncedPick({ dataType: defaultDataTypeMock, field: 'TextField' });
   const [delayedValue, setDelayedValue] = useState(formDataValue);
 
   // This will ensure that the validation state gets updated in the error report by the time this value gets written to the DOM

--- a/src/App/frontend/src/features/validation/ValidationStorePlugin.test.ts
+++ b/src/App/frontend/src/features/validation/ValidationStorePlugin.test.ts
@@ -1,11 +1,11 @@
 import { defaultDataTypeMock } from 'src/__mocks__/getUiConfigMock';
+import { FormStoreState } from 'src/features/form/FormContext';
 import { makeLayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getRecursiveValidations, makeComponentIdIndex } from 'src/features/validation/ValidationStorePlugin';
 import { NodeData } from 'src/utils/layout/types';
 import type { NodeRefValidation } from 'src/features/validation';
 import type { ILayouts } from 'src/layout/layout';
-import type { NodesContext } from 'src/utils/layout/NodesContext';
 
 function createNodeWithValidation(id: string, baseId: string, errorMessage: string): NodeData {
   return {
@@ -69,13 +69,13 @@ describe('ValidationStorePlugin', () => {
       };
 
       const lookups = makeLayoutLookups(layouts);
-      const nodeData: NodesContext['nodeData'] = {};
+      const nodeData: FormStoreState['nodes']['nodeData'] = {};
       for (let i = 1; i <= 200; i++) {
         nodeData[`myGroup-${i}`] = createParentNode(`myGroup-${i}`, 'myGroup');
         nodeData[`field1-${i}`] = createNodeWithValidation(`field1-${i}`, 'field1', `Error in row ${i}`);
       }
 
-      const state = { nodeData } as NodesContext;
+      const state = { nodes: { nodeData } } as FormStoreState;
       const baseToIndexedMap = makeComponentIdIndex(state);
       const output: NodeRefValidation[] = [];
 
@@ -133,7 +133,7 @@ describe('ValidationStorePlugin', () => {
       };
 
       const lookups = makeLayoutLookups(layouts);
-      const nodeData: NodesContext['nodeData'] = {};
+      const nodeData: FormStoreState['nodes']['nodeData'] = {};
       for (let parentRow = 1; parentRow <= 20; parentRow++) {
         nodeData[`mainGroup-${parentRow}`] = createParentNode(`mainGroup-${parentRow}`, 'mainGroup');
 
@@ -150,7 +150,7 @@ describe('ValidationStorePlugin', () => {
         }
       }
 
-      const state = { nodeData } as NodesContext;
+      const state = { nodes: { nodeData } } as FormStoreState;
       const baseToIndexedMap = makeComponentIdIndex(state);
       const output: NodeRefValidation[] = [];
 

--- a/src/App/frontend/src/features/validation/ValidationStorePlugin.tsx
+++ b/src/App/frontend/src/features/validation/ValidationStorePlugin.tsx
@@ -1,12 +1,14 @@
 import { useCallback } from 'react';
 
-import { ContextNotProvided } from 'src/core/contexts/context';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation/index';
 import { selectValidations } from 'src/features/validation/utils';
-import { nodesProduce } from 'src/utils/layout/NodesContext';
+import { nodesProduce } from 'src/utils/layout/nodesProduce';
 import { NodeDataPlugin } from 'src/utils/layout/plugins/NodeDataPlugin';
 import { splitDashedKey } from 'src/utils/splitDashedKey';
+import type { ContextNotProvided } from 'src/core/contexts/context';
+import type { FormStoreSet, FormStoreState } from 'src/features/form/FormContext';
 import type { LayoutLookups } from 'src/features/form/layout/makeLayoutLookups';
 import type {
   AnyValidation,
@@ -15,8 +17,6 @@ import type {
   NodeVisibility,
   ValidationSeverity,
 } from 'src/features/validation/index';
-import type { NodesContext, NodesStoreFull } from 'src/utils/layout/NodesContext';
-import type { NodeDataPluginSetState } from 'src/utils/layout/plugins/NodeDataPlugin';
 
 export type ValidationsSelector = (
   nodeId: string,
@@ -39,9 +39,6 @@ export interface ValidationStorePluginConfig {
   };
   extraHooks: {
     useSetNodeVisibility: () => ValidationStorePluginConfig['extraFunctions']['setNodeVisibility'];
-    useLaxSetNodeVisibility: () =>
-      | ValidationStorePluginConfig['extraFunctions']['setNodeVisibility']
-      | typeof ContextNotProvided;
     useSetAttachmentVisibility: () => ValidationStorePluginConfig['extraFunctions']['setAttachmentVisibility'];
     useRawValidationVisibility: (nodeId: string | undefined) => number;
     useRawValidations: (nodeId: string | undefined) => AnyValidation[];
@@ -59,12 +56,12 @@ export interface ValidationStorePluginConfig {
       mask: NodeVisibility,
       severity?: ValidationSeverity,
       includeHidden?: boolean, // Defaults to false
-    ) => NodeRefValidation[] | typeof ContextNotProvided;
+    ) => NodeRefValidation[];
     useGetNodesWithErrors: () => (
       mask: NodeVisibility,
       severity?: ValidationSeverity,
       includeHidden?: boolean, // Defaults to false
-    ) => [string[], AnyValidation[]] | typeof ContextNotProvided;
+    ) => [string[], AnyValidation[]];
     usePageHasVisibleRequiredValidations: (pageKey: string | undefined) => boolean;
   };
 }
@@ -72,7 +69,7 @@ export interface ValidationStorePluginConfig {
 const emptyArray: never[] = [];
 
 export class ValidationStorePlugin extends NodeDataPlugin<ValidationStorePluginConfig> {
-  extraFunctions(set: NodeDataPluginSetState) {
+  extraFunctions(set: FormStoreSet) {
     const out: ValidationStorePluginConfig['extraFunctions'] = {
       setNodeVisibility: (nodes, newVisibility) => {
         set(
@@ -106,28 +103,28 @@ export class ValidationStorePlugin extends NodeDataPlugin<ValidationStorePluginC
     return { ...out };
   }
 
-  extraHooks(store: NodesStoreFull): ValidationStorePluginConfig['extraHooks'] {
+  extraHooks(): ValidationStorePluginConfig['extraHooks'] {
     return {
-      useSetNodeVisibility: () => store.useSelector((state) => state.setNodeVisibility),
-      useLaxSetNodeVisibility: () => store.useLaxSelector((state) => state.setNodeVisibility),
-      useSetAttachmentVisibility: () => store.useSelector((state) => state.setAttachmentVisibility),
+      useSetNodeVisibility: () => FormStore.raw.useSelector((state) => state.nodes.setNodeVisibility),
+      useSetAttachmentVisibility: () => FormStore.raw.useSelector((state) => state.nodes.setAttachmentVisibility),
       useRawValidationVisibility: (nodeId) =>
-        store.useSelector((state) => {
+        FormStore.raw.useSelector((state) => {
+          const nodes = state.nodes;
           if (!nodeId) {
             return 0;
           }
-          const nodeData = state.nodeData[nodeId];
+          const nodeData = nodes.nodeData[nodeId];
           if (!nodeData) {
             return 0;
           }
           return 'validationVisibility' in nodeData ? nodeData.validationVisibility : 0;
         }),
       useRawValidations: (nodeId) =>
-        store.useShallowSelector((state) => {
+        FormStore.raw.useShallowSelector((state) => {
           if (!nodeId) {
             return emptyArray;
           }
-          const nodeData = state.nodeData[nodeId];
+          const nodeData = state.nodes.nodeData[nodeId];
           if (!nodeData) {
             return emptyArray;
           }
@@ -136,7 +133,7 @@ export class ValidationStorePlugin extends NodeDataPlugin<ValidationStorePluginC
         }),
       useVisibleValidations: (indexedId, showAll) => {
         const lookups = FormBootstrap.useLayoutLookups();
-        return store.useShallowSelector((state) => {
+        return FormStore.raw.useShallowSelector((state) => {
           if (!indexedId) {
             return emptyArray;
           }
@@ -152,7 +149,7 @@ export class ValidationStorePlugin extends NodeDataPlugin<ValidationStorePluginC
       },
       useVisibleValidationsDeep: (indexedId, mask, includeSelf, restriction, severity) => {
         const lookups = FormBootstrap.useLayoutLookups();
-        return store.useMemoSelector((state) => {
+        return FormStore.raw.useMemoSelector((state) => {
           const { baseComponentId } = splitDashedKey(indexedId);
           const output: NodeRefValidation[] = [];
           getRecursiveValidations({
@@ -172,11 +169,11 @@ export class ValidationStorePlugin extends NodeDataPlugin<ValidationStorePluginC
       },
       useValidationsSelector: () => {
         const lookups = FormBootstrap.useLayoutLookups();
-        return store.useDelayedSelector({
+        return FormStore.raw.useDelayedSelector({
           mode: 'simple',
           selector:
             (nodeId: string, mask: NodeVisibility, severity?: ValidationSeverity, includeHidden: boolean = false) =>
-            (state: NodesContext) => {
+            (state: FormStoreState) => {
               const { baseComponentId } = splitDashedKey(nodeId);
               return getValidations({
                 state,
@@ -188,15 +185,15 @@ export class ValidationStorePlugin extends NodeDataPlugin<ValidationStorePluginC
                 lookups,
               });
             },
-        }) satisfies ValidationsSelector;
+        });
       },
       useLaxValidationsSelector: () => {
         const lookups = FormBootstrap.useLayoutLookups();
-        return store.useLaxDelayedSelector({
+        return FormStore.raw.useLaxDelayedSelector({
           mode: 'simple',
           selector:
             (nodeId: string, mask: NodeVisibility, severity?: ValidationSeverity, includeHidden: boolean = false) =>
-            (state: NodesContext) => {
+            (state: FormStoreState) => {
               const { baseComponentId } = splitDashedKey(nodeId);
               return getValidations({
                 state,
@@ -208,13 +205,13 @@ export class ValidationStorePlugin extends NodeDataPlugin<ValidationStorePluginC
                 lookups,
               });
             },
-        }) satisfies ValidationsSelector;
+        });
       },
       useAllValidations: (mask, severity, includeHidden) => {
         const lookups = FormBootstrap.useLayoutLookups();
-        return store.useLaxMemoSelector((state) => {
+        return FormStore.raw.useMemoSelector((state) => {
           const out: NodeRefValidation[] = [];
-          for (const nodeData of Object.values(state.nodeData)) {
+          for (const nodeData of Object.values(state.nodes.nodeData)) {
             const id = nodeData.id;
             const validations = getValidations({
               state,
@@ -234,22 +231,18 @@ export class ValidationStorePlugin extends NodeDataPlugin<ValidationStorePluginC
         });
       },
       useGetNodesWithErrors: () => {
-        const zustand = store.useLaxStore();
-        const lookups = FormBootstrap.useLaxLayoutLookups();
+        const zustand = FormStore.raw.useStore();
+        const lookups = FormBootstrap.useLayoutLookups();
         return useCallback(
           (mask, severity, includeHidden = false) => {
-            if (zustand === ContextNotProvided) {
-              return ContextNotProvided;
-            }
-
             // This is intentionally not reactive, as it is used once when a function is called. There's no need to
             // constantly recompute this.
             const state = zustand.getState();
 
             const outNodes: string[] = [];
             const outValidations: AnyValidation[] = [];
-            for (const id of Object.keys(state.nodeData)) {
-              const data = state.nodeData[id];
+            for (const id of Object.keys(state.nodes.nodeData)) {
+              const data = state.nodes.nodeData[id];
               const validations = getValidations({
                 state,
                 id,
@@ -271,12 +264,12 @@ export class ValidationStorePlugin extends NodeDataPlugin<ValidationStorePluginC
       },
       usePageHasVisibleRequiredValidations: (pageKey) => {
         const lookups = FormBootstrap.useLayoutLookups();
-        return store.useSelector((state) => {
+        return FormStore.raw.useSelector((state) => {
           if (!pageKey) {
             return false;
           }
 
-          for (const nodeData of Object.values(state.nodeData)) {
+          for (const nodeData of Object.values(state.nodes.nodeData)) {
             if (!nodeData || nodeData.pageKey !== pageKey) {
               continue;
             }
@@ -305,7 +298,7 @@ export class ValidationStorePlugin extends NodeDataPlugin<ValidationStorePluginC
 }
 
 interface GetValidationsProps {
-  state: NodesContext;
+  state: FormStoreState;
   id: string;
   baseId: string;
   mask: NodeVisibility;
@@ -322,7 +315,7 @@ function getValidations({
   includeHidden = false,
   lookups,
 }: GetValidationsProps): AnyValidation[] {
-  const nodeData = state.nodeData[id];
+  const nodeData = state.nodes.nodeData[id];
   if (!nodeData || !('validations' in nodeData) || !('validationVisibility' in nodeData) || !nodeData.isValid) {
     return emptyArray;
   }
@@ -385,7 +378,7 @@ function getChildren(props: GetDeepValidationsProps): { id: string; baseId: stri
     const childId = `${childBaseId}${lookForSuffix}`;
 
     for (const idToCheck of props.baseToIndexedMap.get(childBaseId) ?? []) {
-      const childData = props.state.nodeData[idToCheck];
+      const childData = props.state.nodes.nodeData[idToCheck];
       if (!childData || (idToCheck !== childId && !idToCheck.startsWith(`${childId}-`))) {
         continue;
       }
@@ -396,10 +389,10 @@ function getChildren(props: GetDeepValidationsProps): { id: string; baseId: stri
   return children;
 }
 
-export function makeComponentIdIndex(state: NodesContext) {
+export function makeComponentIdIndex(state: FormStoreState) {
   const out = new Map<string, string[]>();
-  for (const id of Object.keys(state.nodeData)) {
-    const data = state.nodeData[id];
+  for (const id of Object.keys(state.nodes.nodeData)) {
+    const data = state.nodes.nodeData[id];
     if (!data) {
       continue;
     }

--- a/src/App/frontend/src/features/validation/backendValidation/BackendValidation.tsx
+++ b/src/App/frontend/src/features/validation/backendValidation/BackendValidation.tsx
@@ -1,93 +1,26 @@
 import { useEffect } from 'react';
 
-import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
-import {
-  useBackendValidationQuery,
-  useUpdateInitialValidations,
-} from 'src/features/validation/backendValidation/backendValidationQuery';
+import { FormStore } from 'src/features/form/FormContext';
+import { useBackendValidationQuery } from 'src/features/validation/backendValidation/backendValidationQuery';
 import {
   mapBackendIssuesToTaskValidations,
   mapBackendValidationsToValidatorGroups,
   mapValidatorGroupsToDataModelValidations,
-  useShouldValidateInitial,
 } from 'src/features/validation/backendValidation/backendValidationUtils';
-import { useUpdateIncrementalValidations } from 'src/features/validation/backendValidation/useUpdateIncrementalValidations';
-import { Validation } from 'src/features/validation/validationContext';
-import type { BackendValidationIssue } from 'src/features/validation';
-
-const emptyArray: BackendValidationIssue[] = [];
 
 export function BackendValidation() {
-  const updateBackendValidations = Validation.useUpdateBackendValidations();
-  const defaultDataElementId = FormBootstrap.useDefaultDataElementId();
-  const taskLevelBootstrapIssues = FormBootstrap.useInitialValidationIssues() ?? emptyArray;
-  const bootstrapDataModels = FormBootstrap.useDataModels();
-  const updateInitialValidations = useUpdateInitialValidations();
-  const lastSaveValidations = FD.useLastSaveValidationIssues();
-  const enabled = useShouldValidateInitial();
-  const { data: queriedInitialValidations, isFetching: isFetchingInitial } = useBackendValidationQuery({
-    enabled: false,
-  });
-  const updateIncrementalValidations = useUpdateIncrementalValidations(false);
+  const updateBackendValidations = FormStore.validation.useUpdateBackendValidations();
+  const { data: queriedInitialValidations } = useBackendValidationQuery({ enabled: false });
 
-  // Initial validation
+  // This ensures manual refetches (used by subform validation, clicking on a submit button) are reflected in state.
   useEffect(() => {
-    // Ensure each issue has dataElementId set from its data model.
-    // This is critical for incremental updates to correctly match and replace issues.
-    const initialFieldIssues = Object.values(bootstrapDataModels).flatMap((dataModel) =>
-      (dataModel.initialValidationIssues ?? []).map((issue) => ({
-        ...issue,
-        dataElementId: issue.dataElementId ?? dataModel.dataElementId ?? undefined,
-      })),
-    );
-    const initialValidations = [...taskLevelBootstrapIssues, ...initialFieldIssues];
-
-    const initialTaskValidations = mapBackendIssuesToTaskValidations(taskLevelBootstrapIssues);
-    const initialValidatorGroups = Object.values(bootstrapDataModels).reduce(
-      (acc, dataModel) => {
-        const groups = mapBackendValidationsToValidatorGroups(
-          dataModel.initialValidationIssues ?? undefined,
-          dataModel.dataElementId,
-        );
-        for (const [source, issues] of Object.entries(groups)) {
-          if (!acc[source]) {
-            acc[source] = [];
-          }
-          acc[source].push(...issues);
-        }
-        return acc;
-      },
-      {} as ReturnType<typeof mapBackendValidationsToValidatorGroups>,
-    );
-
-    const backendValidations = mapValidatorGroupsToDataModelValidations(initialValidatorGroups);
-    updateInitialValidations(initialValidations);
-    updateBackendValidations(backendValidations, { initial: initialValidations }, initialTaskValidations);
-  }, [bootstrapDataModels, taskLevelBootstrapIssues, updateBackendValidations, updateInitialValidations]);
-
-  // Keep initial validations in sync with /validate query results (main-like behavior).
-  // This ensures manual refetches (used by subform validation flow) are reflected in state.
-  useEffect(() => {
-    if (!enabled || isFetchingInitial) {
-      return;
+    if (queriedInitialValidations) {
+      const initialTaskValidations = mapBackendIssuesToTaskValidations(queriedInitialValidations);
+      const initialValidatorGroups = mapBackendValidationsToValidatorGroups(queriedInitialValidations);
+      const backendValidations = mapValidatorGroupsToDataModelValidations(initialValidatorGroups);
+      updateBackendValidations(backendValidations, { initial: queriedInitialValidations }, initialTaskValidations);
     }
-
-    const initialTaskValidations = mapBackendIssuesToTaskValidations(queriedInitialValidations);
-    const initialValidatorGroups = mapBackendValidationsToValidatorGroups(
-      queriedInitialValidations,
-      defaultDataElementId,
-    );
-    const backendValidations = mapValidatorGroupsToDataModelValidations(initialValidatorGroups);
-    updateBackendValidations(backendValidations, { initial: queriedInitialValidations }, initialTaskValidations);
-  }, [defaultDataElementId, queriedInitialValidations, enabled, isFetchingInitial, updateBackendValidations]);
-
-  // Incremental validation: Update validators and propagate changes to validation context
-  useEffect(() => {
-    if (lastSaveValidations) {
-      updateIncrementalValidations(lastSaveValidations);
-    }
-  }, [lastSaveValidations, updateIncrementalValidations]);
+  }, [queriedInitialValidations, updateBackendValidations]);
 
   return null;
 }

--- a/src/App/frontend/src/features/validation/backendValidation/backendValidationQuery.ts
+++ b/src/App/frontend/src/features/validation/backendValidation/backendValidationQuery.ts
@@ -6,6 +6,7 @@ import type { UseQueryOptions } from '@tanstack/react-query';
 import { type BackendValidationIssue } from '..';
 
 import { useAppQueries } from 'src/core/contexts/AppQueriesProvider';
+import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { useLaxInstanceId } from 'src/features/instance/InstanceContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useAsRef } from 'src/hooks/useAsRef';
@@ -20,15 +21,16 @@ function useBackendValidationQueryKey() {
 }
 
 export function useGetCachedInitialValidations() {
+  const bootstrapInitial = FormBootstrap.useAllInitialValidationIssues() ?? undefined;
   const queryKey = useBackendValidationQueryKey();
   const client = useQueryClient();
 
   return useCallback(
     () => ({
       isFetching: client.isFetching({ queryKey }),
-      cachedInitialValidations: client.getQueryData<BackendValidationIssue[] | undefined>(queryKey),
+      cachedInitialValidations: client.getQueryData<BackendValidationIssue[] | undefined>(queryKey) ?? bootstrapInitial,
     }),
-    [client, queryKey],
+    [bootstrapInitial, client, queryKey],
   );
 }
 

--- a/src/App/frontend/src/features/validation/backendValidation/backendValidationUtils.ts
+++ b/src/App/frontend/src/features/validation/backendValidation/backendValidationUtils.ts
@@ -1,12 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { useIsStateless } from 'src/features/applicationMetadata';
-import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { useProcessTaskId } from 'src/features/instance/useProcessTaskId';
 import { BackendValidationSeverity, BuiltInValidationIssueSources, ValidationMask } from 'src/features/validation';
 import { validationTexts } from 'src/features/validation/backendValidation/validationTexts';
-import { useIsPdf } from 'src/hooks/useIsPdf';
-import { TaskKeys } from 'src/routesBuilder';
 import type { TextReference } from 'src/features/language/useLanguage';
 import type {
   BackendFieldValidatorGroups,
@@ -27,14 +22,6 @@ const severityMap: { [s in BackendValidationSeverity]: ValidationSeverity } = {
   [BackendValidationSeverity.Success]: 'success',
 };
 
-export function useShouldValidateInitial(): boolean {
-  const isCustomReceipt = useProcessTaskId() === TaskKeys.CustomReceipt;
-  const isPDF = useIsPdf();
-  const isStateless = useIsStateless();
-  const writableDataTypes = FormBootstrap.useWritableDataTypes();
-  return !isCustomReceipt && !isPDF && !isStateless && !!writableDataTypes?.length;
-}
-
 export function getValidationIssueSeverity(issue: BackendValidationIssue): ValidationSeverity {
   return severityMap[issue.severity];
 }
@@ -52,19 +39,14 @@ function isStandardBackend(rawSource: string): boolean {
  * Extracts field validations from a list of validation issues and assigns the correct data type based on the dataElementId
  * Will skip over any validations that are missing a field and/or dataElementId
  */
-export function mapBackendIssuesToFieldValidations(
-  issues: BackendValidationIssue[],
-  defaultDataElementId: string | null,
-): FieldValidation[] {
+export function mapBackendIssuesToFieldValidations(issues: BackendValidationIssue[]): FieldValidation[] {
   const fieldValidations: FieldValidation[] = [];
   for (const issue of issues) {
-    const { field, source, noIncrementalUpdates, dataElementId: _dataElementId } = issue;
+    const { field, source, noIncrementalUpdates, dataElementId } = issue;
 
     if (!field) {
       continue;
     }
-
-    const dataElementId = _dataElementId ?? defaultDataElementId;
 
     if (!dataElementId) {
       continue;
@@ -128,14 +110,13 @@ export function mapBackendIssuesToTaskValidations(issues: BackendValidationIssue
 
 export function mapBackendValidationsToValidatorGroups(
   validations: BackendValidationIssue[] | undefined,
-  defaultDataElementId: string | null,
 ): BackendFieldValidatorGroups {
   if (!validations) {
     return emptyObject;
   }
   // Note that we completely ignore task validations (validations not related to form data) on initial validations,
   // this is because validations like minimum number of attachments in application metadata is not really useful to show initially
-  const fieldValidations = mapBackendIssuesToFieldValidations(validations, defaultDataElementId);
+  const fieldValidations = mapBackendIssuesToFieldValidations(validations);
   const validatorGroups: BackendFieldValidatorGroups = {};
   for (const validation of fieldValidations) {
     if (!validatorGroups[validation.source]) {

--- a/src/App/frontend/src/features/validation/backendValidation/useUpdateIncrementalValidations.ts
+++ b/src/App/frontend/src/features/validation/backendValidation/useUpdateIncrementalValidations.ts
@@ -2,52 +2,53 @@ import { useCallback } from 'react';
 
 import deepEqual from 'fast-deep-equal';
 
-import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { useGetCachedInitialValidations } from 'src/features/validation/backendValidation/backendValidationQuery';
 import {
   mapBackendIssuesToFieldValidations,
   mapBackendValidationsToValidatorGroups,
   mapValidatorGroupsToDataModelValidations,
 } from 'src/features/validation/backendValidation/backendValidationUtils';
-import { Validation } from 'src/features/validation/validationContext';
-import type { BackendValidationIssueGroups } from 'src/features/validation';
+import type { FormStoreState } from 'src/features/form/FormContext';
+import type { BackendValidationIssue, BackendValidationIssueGroups } from 'src/features/validation';
 
 /**
  * Hook for updating incremental validations from various sources (usually the validations updated from last saved data)
  */
-export function useUpdateIncrementalValidations(setInFormData = true) {
-  const updateBackendValidations = Validation.useUpdateBackendValidations();
-  const defaultDataElementId = FormBootstrap.useDefaultDataElementId();
+export function useUpdateIncrementalValidations() {
+  const updateBackendValidations = FormStore.validation.useUpdateBackendValidations();
   const getCachedInitialValidations = useGetCachedInitialValidations();
-  const updateInFormData = FD.useSetLastValidationIssues();
 
   return useCallback(
     (lastSaveValidations: BackendValidationIssueGroups) => {
-      const { cachedInitialValidations } = getCachedInitialValidations();
-      const initialValidatorGroups = mapBackendValidationsToValidatorGroups(
-        cachedInitialValidations,
-        defaultDataElementId,
+      updateIncrementalValidations(
+        lastSaveValidations,
+        getCachedInitialValidations().cachedInitialValidations,
+        updateBackendValidations,
       );
-
-      const newValidatorGroups = structuredClone(initialValidatorGroups);
-      for (const [group, validationIssues] of Object.entries(lastSaveValidations)) {
-        newValidatorGroups[group] = mapBackendIssuesToFieldValidations(validationIssues, defaultDataElementId);
-      }
-
-      if (setInFormData) {
-        updateInFormData(lastSaveValidations);
-      }
-
-      if (deepEqual(initialValidatorGroups, newValidatorGroups)) {
-        // Don't update any validations, only set last saved validations
-        updateBackendValidations(undefined, { incremental: lastSaveValidations });
-        return;
-      }
-
-      const backendValidations = mapValidatorGroupsToDataModelValidations(newValidatorGroups);
-      updateBackendValidations(backendValidations, { incremental: lastSaveValidations });
     },
-    [defaultDataElementId, getCachedInitialValidations, updateBackendValidations, setInFormData, updateInFormData],
+    [getCachedInitialValidations, updateBackendValidations],
   );
+}
+
+export function updateIncrementalValidations(
+  lastSaveValidations: BackendValidationIssueGroups,
+  cachedInitialValidations: BackendValidationIssue[] | undefined,
+  updateBackendValidations: FormStoreState['validation']['updateBackendValidations'],
+) {
+  const initialValidatorGroups = mapBackendValidationsToValidatorGroups(cachedInitialValidations);
+
+  const newValidatorGroups = structuredClone(initialValidatorGroups);
+  for (const [group, validationIssues] of Object.entries(lastSaveValidations)) {
+    newValidatorGroups[group] = mapBackendIssuesToFieldValidations(validationIssues);
+  }
+
+  if (deepEqual(initialValidatorGroups, newValidatorGroups)) {
+    // Don't update any validations, only set last saved validations
+    updateBackendValidations(undefined, { incremental: lastSaveValidations });
+    return;
+  }
+
+  const backendValidations = mapValidatorGroupsToDataModelValidations(newValidatorGroups);
+  updateBackendValidations(backendValidations, { incremental: lastSaveValidations });
 }

--- a/src/App/frontend/src/features/validation/callbacks/onAttachmentSave.ts
+++ b/src/App/frontend/src/features/validation/callbacks/onAttachmentSave.ts
@@ -1,16 +1,16 @@
 import { useCallback } from 'react';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { getVisibilityMask } from 'src/features/validation/utils';
-import { Validation } from 'src/features/validation/validationContext';
+import { useWaitForValidation } from 'src/features/validation/validationContext';
 import { useComponentIdMutator } from 'src/utils/layout/DataModelLocation';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 
 /**
  * Sets attachment validations as visible for when an attachment is saved (tag is changed).
  */
 export function useOnAttachmentSave() {
-  const validating = Validation.useValidating();
-  const setAttachmentVisibility = NodesInternal.useSetAttachmentVisibility();
+  const validating = useWaitForValidation();
+  const setAttachmentVisibility = FormStore.nodes.useSetAttachmentVisibility();
   const idMutator = useComponentIdMutator();
 
   return useCallback(

--- a/src/App/frontend/src/features/validation/callbacks/onFormSubmitValidation.ts
+++ b/src/App/frontend/src/features/validation/callbacks/onFormSubmitValidation.ts
@@ -2,10 +2,9 @@ import { useCallback } from 'react';
 
 import { ValidationMask } from '..';
 
-import { ContextNotProvided } from 'src/core/contexts/context';
-import { Validation } from 'src/features/validation/validationContext';
+import { FormStore } from 'src/features/form/FormContext';
+import { useWaitForValidation } from 'src/features/validation/validationContext';
 import { useOurEffectEvent } from 'src/hooks/useOurEffectEvent';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 
 /**
  * Checks for any validation errors before submitting the form.
@@ -16,24 +15,15 @@ import { NodesInternal } from 'src/utils/layout/NodesContext';
  * We should however show them after we get the results of process/next.
  */
 export function useOnFormSubmitValidation() {
-  const validation = Validation.useLaxRef();
-  const setNodeVisibility = NodesInternal.useLaxSetNodeVisibility();
-  const getNodesWithErrors = NodesInternal.useGetNodesWithErrors();
+  const validate = useWaitForValidation();
+  const setNodeVisibility = FormStore.nodes.useSetNodeVisibility();
+  const getNodesWithErrors = FormStore.nodes.useGetNodesWithErrors();
 
   const callback = useOurEffectEvent((includeNonIncrementalValidations: boolean): boolean => {
-    if (validation.current === ContextNotProvided || setNodeVisibility === ContextNotProvided) {
-      // If the validation context or nodes context is not provided, we cannot validate
-      return false;
-    }
-
     /*
      * Check if there are any frontend validation errors, and if so, show them now and block submit
      */
     const nodesWithFrontendErrors = getNodesWithErrors(ValidationMask.All, 'error', false);
-    if (nodesWithFrontendErrors === ContextNotProvided) {
-      // If the nodes are not provided, we cannot validate them
-      return false;
-    }
 
     const [nodes, validations] = nodesWithFrontendErrors;
     if (
@@ -54,15 +44,9 @@ export function useOnFormSubmitValidation() {
 
   return useCallback(
     async (includeNonIncrementalValidations = false) => {
-      const validateFn = validation.current === ContextNotProvided ? undefined : validation.current?.validating;
-      if (!validateFn) {
-        // If the validation context is not provided, we cannot validate
-        return false;
-      }
-
-      await validateFn();
+      await validate();
       return callback(includeNonIncrementalValidations);
     },
-    [callback, validation],
+    [callback, validate],
   );
 }

--- a/src/App/frontend/src/features/validation/callbacks/onGroupCloseValidation.ts
+++ b/src/App/frontend/src/features/validation/callbacks/onGroupCloseValidation.ts
@@ -1,10 +1,10 @@
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { getVisibilityMask } from 'src/features/validation/utils';
-import { Validation } from 'src/features/validation/validationContext';
+import { useWaitForValidation } from 'src/features/validation/validationContext';
 import { getRecursiveValidations, makeComponentIdIndex } from 'src/features/validation/ValidationStorePlugin';
 import { useOurEffectEvent } from 'src/hooks/useOurEffectEvent';
 import { useComponentIdMutator } from 'src/utils/layout/DataModelLocation';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { NodeRefValidation } from 'src/features/validation';
 import type { AllowedValidationMasks } from 'src/layout/common.generated';
 
@@ -13,9 +13,9 @@ import type { AllowedValidationMasks } from 'src/layout/common.generated';
  * If there are errors, the visibility is set, and will return true, indicating that the row should not be closed.
  */
 export function useOnGroupCloseValidation() {
-  const setNodeVisibility = NodesInternal.useSetNodeVisibility();
-  const validating = Validation.useValidating();
-  const nodeStore = NodesInternal.useStore();
+  const setNodeVisibility = FormStore.nodes.useSetNodeVisibility();
+  const validating = useWaitForValidation();
+  const formStore = FormStore.raw.useStore();
   const lookups = FormBootstrap.useLayoutLookups();
   const idMutator = useComponentIdMutator(true);
 
@@ -23,7 +23,7 @@ export function useOnGroupCloseValidation() {
   const callback = useOurEffectEvent(
     (baseComponentId: string, restriction: number | undefined, masks: AllowedValidationMasks): boolean => {
       const mask = getVisibilityMask(masks);
-      const state = nodeStore.getState();
+      const state = formStore.getState();
       const errors: NodeRefValidation[] = [];
       getRecursiveValidations({
         id: idMutator(baseComponentId),

--- a/src/App/frontend/src/features/validation/callbacks/onPageNavigationValidation.ts
+++ b/src/App/frontend/src/features/validation/callbacks/onPageNavigationValidation.ts
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { useRefetchInitialValidations } from 'src/features/validation/backendValidation/backendValidationQuery';
 import { getVisibilityMask } from 'src/features/validation/utils';
-import { Validation } from 'src/features/validation/validationContext';
+import { useWaitForValidation } from 'src/features/validation/validationContext';
 import { usePageOrder } from 'src/hooks/useNavigatePage';
 import { useOurEffectEvent } from 'src/hooks/useOurEffectEvent';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { PageValidation } from 'src/layout/common.generated';
 
 /**
@@ -14,11 +14,11 @@ import type { PageValidation } from 'src/layout/common.generated';
  *
  */
 export function useOnPageNavigationValidation() {
-  const setNodeVisibility = NodesInternal.useSetNodeVisibility();
-  const getNodeValidations = NodesInternal.useValidationsSelector();
-  const validating = Validation.useValidating();
+  const setNodeVisibility = FormStore.nodes.useSetNodeVisibility();
+  const getNodeValidations = FormStore.nodes.useValidationsSelector();
+  const validating = useWaitForValidation();
   const pageOrder = usePageOrder();
-  const nodeStore = NodesInternal.useStore();
+  const formStore = FormStore.raw.useStore();
   const refetchInitialValidations = useRefetchInitialValidations();
 
   /* Ensures the callback will have the latest state */
@@ -36,7 +36,7 @@ export function useOnPageNavigationValidation() {
       currentOrPreviousPages.add(pageKey);
     }
 
-    const state = nodeStore.getState();
+    const state = formStore.getState();
     const nodeIds: string[] = [];
     const nodesOnCurrentOrPreviousPages = new Set<string>();
     let hasSubform = false;
@@ -48,7 +48,7 @@ export function useOnPageNavigationValidation() {
       shouldCheckPage = (pageKey: string) => currentOrPreviousPages.has(pageKey);
     }
 
-    for (const nodeData of Object.values(state.nodeData)) {
+    for (const nodeData of Object.values(state.nodes.nodeData)) {
       if (currentOrPreviousPages.has(nodeData.pageKey)) {
         nodesOnCurrentOrPreviousPages.add(nodeData.id);
       }

--- a/src/App/frontend/src/features/validation/expressionValidation/ExpressionValidation.test.tsx
+++ b/src/App/frontend/src/features/validation/expressionValidation/ExpressionValidation.test.tsx
@@ -5,10 +5,9 @@ import fs from 'node:fs';
 import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';
 import { defaultMockDataElementId } from 'src/__mocks__/getInstanceDataMock';
 import { defaultDataTypeMock } from 'src/__mocks__/getUiConfigMock';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { ExpressionValidation } from 'src/features/validation/expressionValidation/ExpressionValidation';
-import { Validation } from 'src/features/validation/validationContext';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
 import type { IRawTextResource } from 'src/features/language/textResources';
 import type { FieldValidations, IExpressionValidationConfig } from 'src/features/validation';
@@ -70,9 +69,9 @@ function getSharedTests() {
 
 describe('Expression validation shared tests', () => {
   beforeEach(() => {
-    jest.spyOn(FD, 'useDebounced').mockRestore();
+    jest.spyOn(FormStore.data, 'useDebounced').mockRestore();
     jest.spyOn(FormBootstrap, 'useExpressionValidationConfig').mockRestore();
-    jest.spyOn(Validation, 'useUpdateDataModelValidations').mockRestore();
+    jest.spyOn(FormStore.validation, 'useUpdateDataModelValidations').mockRestore();
   });
 
   const sharedTests = getSharedTests();
@@ -82,7 +81,9 @@ describe('Expression validation shared tests', () => {
     const updateDataModelValidations = jest.fn((_key, _dataType, validations: FieldValidations) => {
       result = validations;
     });
-    jest.spyOn(Validation, 'useUpdateDataModelValidations').mockImplementation(() => updateDataModelValidations);
+    jest
+      .spyOn(FormStore.validation, 'useUpdateDataModelValidations')
+      .mockImplementation(() => updateDataModelValidations);
     window.altinnAppGlobalData.textResources!.resources = textResources ?? [];
 
     await renderWithInstanceAndLayout({

--- a/src/App/frontend/src/features/validation/expressionValidation/ExpressionValidation.tsx
+++ b/src/App/frontend/src/features/validation/expressionValidation/ExpressionValidation.tsx
@@ -5,9 +5,8 @@ import type { FieldValidations, IExpressionValidation } from '..';
 
 import { evalExpr } from 'src/features/expressions';
 import { ExprVal } from 'src/features/expressions/types';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
-import { Validation } from 'src/features/validation/validationContext';
 import { NestedDataModelLocationProviders } from 'src/utils/layout/DataModelLocation';
 import { useExpressionDataSources } from 'src/utils/layout/useExpressionDataSources';
 import type { ExprValToActualOrExpr, ExprValueArgs } from 'src/features/expressions/types';
@@ -36,7 +35,7 @@ export function ExpressionValidation() {
 }
 
 function DataTypeValidation({ dataType }: { dataType: string }) {
-  const updateDataModelValidations = Validation.useUpdateDataModelValidations();
+  const updateDataModelValidations = FormStore.validation.useUpdateDataModelValidations();
   const dataElementId = FormBootstrap.useDataElementIdForDataType(dataType);
   const expressionValidationConfig = FormBootstrap.useExpressionValidationConfig(dataType);
 
@@ -88,7 +87,7 @@ function BaseFieldExpressionValidation({
   reference: IDataModelReference;
   collector: ValidationCollectorApi;
 }) {
-  const allPaths = FD.useDebouncedAllPaths(reference);
+  const allPaths = FormStore.data.useDebouncedAllPaths(reference);
 
   return (
     <>

--- a/src/App/frontend/src/features/validation/index.ts
+++ b/src/App/frontend/src/features/validation/index.ts
@@ -68,9 +68,8 @@ export type NodeVisibility = 'visible' | 'showAll' | number;
 
 export type WaitForValidation = (forceSave?: boolean) => Promise<void>;
 
-export type ValidationContext = {
+export type ValidationSliceState = {
   state: ValidationState;
-  validating: WaitForValidation | undefined;
 
   /**
    * If there are no frontend errors, but process next still returns validation errors,
@@ -206,7 +205,7 @@ export interface BackendValidationIssue {
   code?: string;
   description?: string;
   field?: string;
-  dataElementId?: string;
+  dataElementId: string;
   severity: BackendValidationSeverity;
   source: string;
   noIncrementalUpdates?: boolean; // true if it will not be validated on PATCH, should be ignored when trying to submit

--- a/src/App/frontend/src/features/validation/invalidDataValidation/InvalidDataValidation.tsx
+++ b/src/App/frontend/src/features/validation/invalidDataValidation/InvalidDataValidation.tsx
@@ -4,17 +4,16 @@ import dot from 'dot-object';
 
 import { FrontendValidationSource, ValidationMask } from '..';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
-import { Validation } from 'src/features/validation/validationContext';
 
 function isScalar(value: unknown): value is string | number | boolean {
   return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
 }
 
 export function InvalidDataValidation({ dataType }: { dataType: string }) {
-  const updateDataModelValidations = Validation.useUpdateDataModelValidations();
-  const invalidData = FD.useInvalidDebounced(dataType);
+  const updateDataModelValidations = FormStore.validation.useUpdateDataModelValidations();
+  const invalidData = FormStore.data.useInvalidDebounced(dataType);
   const dataElementId = FormBootstrap.useDataElementIdForDataType(dataType) ?? dataType; // stateless does not have dataElementId
 
   useEffect(() => {

--- a/src/App/frontend/src/features/validation/nodeValidation/emptyFieldValidation.ts
+++ b/src/App/frontend/src/features/validation/nodeValidation/emptyFieldValidation.ts
@@ -1,4 +1,4 @@
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { type ComponentValidation, FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getFieldNameKey } from 'src/utils/formComponentUtils';
 import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
@@ -19,8 +19,8 @@ export function useEmptyFieldValidationAllBindings<Type extends CompTypes>(
   const item = useItemFor(baseComponentId);
   const required = 'required' in item ? item.required : false;
   const trb = item.textResourceBindings;
-  const formDataSelector = FD.useDebouncedSelector();
-  const invalidDataSelector = FD.useInvalidDebouncedSelector();
+  const formDataSelector = FormStore.data.useDebouncedSelector();
+  const invalidDataSelector = FormStore.data.useInvalidDebouncedSelector();
   if (!required || !dataModelBindings) {
     return [];
   }
@@ -62,8 +62,8 @@ export function useEmptyFieldValidationOnlyOneBinding<Binding extends string>(
   const required = 'required' in item ? item.required : false;
   const reference = item.dataModelBindings?.[binding as string] as IDataModelReference | undefined;
   const trb = item.textResourceBindings;
-  const validData = FD.useDebouncedPick(reference);
-  const invalidData = FD.useInvalidDebouncedPick(reference);
+  const validData = FormStore.data.useDebouncedPick(reference);
+  const invalidData = FormStore.data.useInvalidDebouncedPick(reference);
   const data = validData ?? invalidData;
   if (!required || !reference) {
     return [];

--- a/src/App/frontend/src/features/validation/nodeValidation/useNodeValidation.ts
+++ b/src/App/frontend/src/features/validation/nodeValidation/useNodeValidation.ts
@@ -1,5 +1,5 @@
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { Validation } from 'src/features/validation/validationContext';
 import {
   type CompDef,
   getComponentDef,
@@ -44,11 +44,11 @@ export function useNodeValidation(baseComponentId: string): AnyValidation[] {
   }
 
   const getDataElementIdForDataType = FormBootstrap.useGetDataElementIdForDataType();
-  const fieldValidations = Validation.useFullState((state) => {
+  const fieldValidations = FormStore.raw.useMemoSelector((state) => {
     const validations: BaseValidation[] = [];
     for (const [bindingKey, { dataType, field }] of bindings) {
       const dataElementId = getDataElementIdForDataType(dataType) ?? dataType; // stateless does not have dataElementId
-      const fieldValidations = state.state.dataModels[dataElementId]?.[field];
+      const fieldValidations = state.validation.state.dataModels[dataElementId]?.[field];
       if (fieldValidations) {
         validations.push(...fieldValidations.map((v) => ({ ...v, bindingKey })));
       }
@@ -58,7 +58,7 @@ export function useNodeValidation(baseComponentId: string): AnyValidation[] {
     // If we set this during render, all components using this hook would have to re-render after saving data, but now
     // they only have to re-run the selector. The downside here is that empty validations and component validations will
     // run outside the selector, so they _may_ have new validations that are not yet processed.
-    registry.current.validationsProcessed[indexedId] = state.processedLast;
+    registry.current.validationsProcessed[indexedId] = state.validation.processedLast;
     return validations;
   });
 

--- a/src/App/frontend/src/features/validation/nodeValidation/waitForNodesToValidate.ts
+++ b/src/App/frontend/src/features/validation/nodeValidation/waitForNodesToValidate.ts
@@ -1,60 +1,58 @@
 import { useCallback } from 'react';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { shouldValidateNode } from 'src/features/validation/StoreValidationsInNode';
 import { GeneratorInternal } from 'src/utils/layout/generator/GeneratorContext';
-import { NodesStore } from 'src/utils/layout/NodesContext';
-import type { ValidationsProcessedLast } from 'src/features/validation';
 import type { CompExternal, CompTypes } from 'src/layout/layout';
 import type { NodeData } from 'src/utils/layout/types';
 
 export function useWaitForNodesToValidate() {
   const registry = GeneratorInternal.useRegistry();
-  const nodesStore = NodesStore.useStore();
+  const formStore = FormStore.raw.useStore();
   const lookups = FormBootstrap.useLayoutLookups();
 
-  return useCallback(
-    async (processedLast: ValidationsProcessedLast): Promise<void> => {
-      let callbackId: ReturnType<typeof requestIdleCallback | typeof requestAnimationFrame> | undefined;
-      const request = window.requestIdleCallback || window.requestAnimationFrame;
-      const cancel = window.cancelIdleCallback || window.cancelAnimationFrame;
+  return useCallback(async (): Promise<void> => {
+    let callbackId: ReturnType<typeof requestIdleCallback | typeof requestAnimationFrame> | undefined;
+    const request = window.requestIdleCallback || window.requestAnimationFrame;
+    const cancel = window.cancelIdleCallback || window.cancelAnimationFrame;
 
-      function check(): boolean {
-        const allNodeData = nodesStore.getState().nodeData;
-        const nodeIds = Object.keys(allNodeData);
-        for (const nodeId of nodeIds) {
-          const nodeData = allNodeData[nodeId];
-          const layout = lookups.getComponent(nodeData.baseId);
-          if (!doesNodeSupportValidation(nodeData, layout)) {
-            continue;
-          }
-
-          const lastValidations = registry.current.validationsProcessed[nodeId];
-          const initialIsLatest = lastValidations?.initial === processedLast.initial;
-          const incrementalIsLatest = lastValidations?.incremental === processedLast.incremental;
-          if (!(lastValidations && initialIsLatest && incrementalIsLatest)) {
-            return false;
-          }
+    function check(): boolean {
+      const state = formStore.getState();
+      const processedLast = state.validation.processedLast;
+      const allNodeData = state.nodes.nodeData;
+      const nodeIds = Object.keys(allNodeData);
+      for (const nodeId of nodeIds) {
+        const nodeData = allNodeData[nodeId];
+        const layout = lookups.getComponent(nodeData.baseId);
+        if (!doesNodeSupportValidation(nodeData, layout)) {
+          continue;
         }
 
-        return true;
+        const lastValidations = registry.current.validationsProcessed[nodeId];
+        const initialIsLatest = lastValidations?.initial === processedLast.initial;
+        const incrementalIsLatest = lastValidations?.incremental === processedLast.incremental;
+        if (!(lastValidations && initialIsLatest && incrementalIsLatest)) {
+          return false;
+        }
       }
 
-      return new Promise<void>((resolve) => {
-        function checkAndResolve() {
-          if (check()) {
-            resolve();
-            callbackId && cancel(callbackId);
-          } else {
-            callbackId = request(checkAndResolve);
-          }
-        }
+      return true;
+    }
 
-        checkAndResolve();
-      });
-    },
-    [lookups, nodesStore, registry],
-  );
+    return new Promise<void>((resolve) => {
+      function checkAndResolve() {
+        if (check()) {
+          resolve();
+          callbackId && cancel(callbackId);
+        } else {
+          callbackId = request(checkAndResolve);
+        }
+      }
+
+      checkAndResolve();
+    });
+  }, [lookups, formStore, registry]);
 }
 
 function doesNodeSupportValidation<T extends CompTypes>(nodeData: NodeData, layout: CompExternal<T>): boolean {

--- a/src/App/frontend/src/features/validation/schemaValidation/SchemaValidation.test.tsx
+++ b/src/App/frontend/src/features/validation/schemaValidation/SchemaValidation.test.tsx
@@ -6,20 +6,19 @@ import type { JSONSchema7 } from 'json-schema';
 import { defaultMockDataElementId } from 'src/__mocks__/getInstanceDataMock';
 import { DataModelSchemaResult } from 'src/features/datamodel/SchemaLookupTool';
 import * as UseBindingSchema from 'src/features/datamodel/useBindingSchema';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { SchemaValidation } from 'src/features/validation/schemaValidation/SchemaValidation';
 import { createValidator } from 'src/features/validation/schemaValidation/schemaValidationUtils';
-import { Validation } from 'src/features/validation/validationContext';
 import type { IDataType } from 'src/types/shared';
 
 describe('SchemaValidation', () => {
   describe('format validation', () => {
     beforeEach(() => {
-      jest.spyOn(FD, 'useDebounced').mockRestore();
+      jest.spyOn(FormStore.data, 'useDebounced').mockRestore();
       jest.spyOn(FormBootstrap, 'useDataModelSchema').mockRestore();
       jest.spyOn(UseBindingSchema, 'useDataModelType').mockRestore();
-      jest.spyOn(Validation, 'useUpdateDataModelValidations').mockRestore();
+      jest.spyOn(FormStore.validation, 'useUpdateDataModelValidations').mockRestore();
     });
 
     const formatTests = [
@@ -258,7 +257,7 @@ describe('SchemaValidation', () => {
             const rootElementPath = '';
             const validator = createValidator(schema);
 
-            jest.spyOn(FD, 'useDebounced').mockReturnValue(formData);
+            jest.spyOn(FormStore.data, 'useDebounced').mockReturnValue(formData);
             jest
               .spyOn(FormBootstrap, 'useDataModelSchema')
               .mockReturnValue({ schema, rootElementPath, validator } as DataModelSchemaResult);
@@ -267,7 +266,7 @@ describe('SchemaValidation', () => {
 
             const updateDataModelValidations = jest.fn();
             jest
-              .spyOn(Validation, 'useUpdateDataModelValidations')
+              .spyOn(FormStore.validation, 'useUpdateDataModelValidations')
               .mockImplementation(() => updateDataModelValidations);
 
             render(<SchemaValidation dataType='mockDataType' />);

--- a/src/App/frontend/src/features/validation/schemaValidation/SchemaValidation.tsx
+++ b/src/App/frontend/src/features/validation/schemaValidation/SchemaValidation.tsx
@@ -4,21 +4,20 @@ import { FrontendValidationSource } from '..';
 import type { FieldValidations } from '..';
 
 import { pointerToDotNotation } from 'src/features/datamodel/notations';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import {
   getErrorCategory,
   getErrorParams,
   getErrorTextKey,
 } from 'src/features/validation/schemaValidation/schemaValidationUtils';
-import { Validation } from 'src/features/validation/validationContext';
 import { getSchemaPart, getSchemaPartOldGenerator } from 'src/utils/schemaUtils';
 import type { TextReference } from 'src/features/language/useLanguage';
 
 export function SchemaValidation({ dataType }: { dataType: string }) {
-  const updateDataModelValidations = Validation.useUpdateDataModelValidations();
+  const updateDataModelValidations = FormStore.validation.useUpdateDataModelValidations();
 
-  const formData = FD.useDebounced(dataType);
+  const formData = FormStore.data.useDebounced(dataType);
   const { validator, rootElementPath, schema } = FormBootstrap.useDataModelSchema(dataType) ?? {};
   const dataElementId = FormBootstrap.useDataElementIdForDataType(dataType) ?? dataType; // stateless does not have dataElementId
 

--- a/src/App/frontend/src/features/validation/selectors/attachmentValidations.ts
+++ b/src/App/frontend/src/features/validation/selectors/attachmentValidations.ts
@@ -2,9 +2,8 @@ import { useMemo } from 'react';
 
 import type { AttachmentValidation, NodeRefValidation } from '..';
 
-import { Validation } from 'src/features/validation/validationContext';
+import { FormStore } from 'src/features/form/FormContext';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 
 /**
  * Returns the validations for the given attachment.
@@ -13,9 +12,9 @@ export function useAttachmentValidations(
   baseComponentId: string,
   attachmentId: string | undefined,
 ): NodeRefValidation<AttachmentValidation>[] {
-  const showAll = Validation.useShowAllBackendErrors();
+  const showAll = FormStore.validation.useShowAllBackendErrors();
   const indexedId = useIndexedId(baseComponentId);
-  const validations = NodesInternal.useVisibleValidations(indexedId, showAll);
+  const validations = FormStore.nodes.useVisibleValidations(indexedId, showAll);
 
   return useMemo(() => {
     if (!attachmentId) {

--- a/src/App/frontend/src/features/validation/selectors/bindingValidationsForNode.ts
+++ b/src/App/frontend/src/features/validation/selectors/bindingValidationsForNode.ts
@@ -2,10 +2,9 @@ import { useMemo } from 'react';
 
 import type { ComponentValidation, FieldValidation, NodeRefValidation } from '..';
 
-import { Validation } from 'src/features/validation/validationContext';
+import { FormStore } from 'src/features/form/FormContext';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { CompTypes, IDataModelBindings } from 'src/layout/layout';
 
 type OutValues = NodeRefValidation<ComponentValidation | FieldValidation>[];
@@ -17,8 +16,8 @@ type OutValues = NodeRefValidation<ComponentValidation | FieldValidation>[];
 export function useBindingValidationsFor<T extends CompTypes>(
   baseComponentId: string,
 ): { [binding in keyof NonNullable<IDataModelBindings<T>>]: OutValues } | undefined {
-  const showAll = Validation.useShowAllBackendErrors();
-  const component = NodesInternal.useVisibleValidations(baseComponentId, showAll);
+  const showAll = FormStore.validation.useShowAllBackendErrors();
+  const component = FormStore.nodes.useVisibleValidations(baseComponentId, showAll);
   const dataModelBindings = useDataModelBindingsFor(baseComponentId);
   const indexedId = useIndexedId(baseComponentId);
 

--- a/src/App/frontend/src/features/validation/selectors/componentValidationsForNode.ts
+++ b/src/App/frontend/src/features/validation/selectors/componentValidationsForNode.ts
@@ -1,17 +1,16 @@
 import { useMemo } from 'react';
 
-import { Validation } from 'src/features/validation/validationContext';
+import { FormStore } from 'src/features/form/FormContext';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { ComponentValidation, NodeRefValidation } from 'src/features/validation/index';
 
 /**
  * Get only the component validations which are not bound to any data model fields.
  */
 export function useComponentValidationsFor(baseComponentId: string): NodeRefValidation<ComponentValidation>[] {
-  const showAll = Validation.useShowAllBackendErrors();
+  const showAll = FormStore.validation.useShowAllBackendErrors();
   const indexedId = useIndexedId(baseComponentId);
-  const component = NodesInternal.useVisibleValidations(indexedId, showAll);
+  const component = FormStore.nodes.useVisibleValidations(indexedId, showAll);
 
   return useMemo(
     () =>

--- a/src/App/frontend/src/features/validation/selectors/deepValidationsForNode.ts
+++ b/src/App/frontend/src/features/validation/selectors/deepValidationsForNode.ts
@@ -1,6 +1,5 @@
-import { Validation } from 'src/features/validation/validationContext';
+import { FormStore } from 'src/features/form/FormContext';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { NodeRefValidation } from 'src/features/validation/index';
 
 /**
@@ -12,8 +11,8 @@ export function useDeepValidationsForNode(
   restriction?: number | undefined,
   skipLastIdMutator = false,
 ): NodeRefValidation[] {
-  const showAll = Validation.useShowAllBackendErrors();
+  const showAll = FormStore.validation.useShowAllBackendErrors();
   const mask = showAll ? 'showAll' : 'visible';
   const indexedId = useIndexedId(baseComponentId, skipLastIdMutator);
-  return NodesInternal.useVisibleValidationsDeep(indexedId, mask, includeSelf, restriction);
+  return FormStore.nodes.useVisibleValidationsDeep(indexedId, mask, includeSelf, restriction);
 }

--- a/src/App/frontend/src/features/validation/selectors/isValid.ts
+++ b/src/App/frontend/src/features/validation/selectors/isValid.ts
@@ -1,9 +1,8 @@
+import { FormStore } from 'src/features/form/FormContext';
 import { hasValidationErrors } from 'src/features/validation/utils';
-import { Validation } from 'src/features/validation/validationContext';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 
 export function useIsValid(baseComponentId: string): boolean {
-  const showAll = Validation.useShowAllBackendErrors();
-  const validations = NodesInternal.useVisibleValidations(baseComponentId, showAll);
+  const showAll = FormStore.validation.useShowAllBackendErrors();
+  const validations = FormStore.nodes.useVisibleValidations(baseComponentId, showAll);
   return !hasValidationErrors(validations);
 }

--- a/src/App/frontend/src/features/validation/selectors/taskErrors.ts
+++ b/src/App/frontend/src/features/validation/selectors/taskErrors.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { ContextNotProvided } from 'src/core/contexts/context';
+import { FormStore } from 'src/features/form/FormContext';
 import {
   type AnyValidation,
   type BaseValidation,
@@ -10,8 +10,6 @@ import {
   ValidationMask,
 } from 'src/features/validation/index';
 import { selectValidations, validationsOfSeverity } from 'src/features/validation/utils';
-import { Validation } from 'src/features/validation/validationContext';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 
 const emptyArray: never[] = [];
 
@@ -23,14 +21,16 @@ export function useTaskErrors(): {
   formErrors: NodeRefValidation<AnyValidation<'error'>>[];
   taskErrors: BaseValidation<'error'>[];
 } {
-  const selector = Validation.useSelector();
-
-  const showAllBackendErrors = selector((state) => state.showAllBackendErrors, []);
+  const [dataModels, taskValidations, showAllBackendErrors] = FormStore.raw.useShallowSelector((state) => [
+    state.validation.state.dataModels,
+    state.validation.state.task,
+    state.validation.showAllBackendErrors,
+  ]);
 
   const formErrorVisibility: NodeVisibility = showAllBackendErrors ? 'showAll' : 'visible';
 
-  const _formErrors = NodesInternal.useAllValidations(formErrorVisibility, 'error');
-  const formErrors = _formErrors === ContextNotProvided || !_formErrors.length ? emptyArray : _formErrors;
+  const _formErrors = FormStore.nodes.useAllValidations(formErrorVisibility, 'error');
+  const formErrors = !_formErrors.length ? emptyArray : _formErrors;
 
   const taskErrors = useMemo(() => {
     if (!showAllBackendErrors) {
@@ -43,7 +43,6 @@ export function useTaskErrors(): {
     const boundErrorIds = new Set(formErrors.filter(hasBackendValidationId).map((v) => v.backendValidationId));
 
     // Unbound field errors
-    const dataModels = selector((state) => state.state.dataModels, []);
     for (const fields of Object.values(dataModels)) {
       for (const field of Object.values(fields)) {
         allBackendErrors.push(
@@ -56,15 +55,10 @@ export function useTaskErrors(): {
     }
 
     // Task errors
-    allBackendErrors.push(
-      ...validationsOfSeverity(
-        selector((state) => state.state.task, []),
-        'error',
-      ),
-    );
+    allBackendErrors.push(...validationsOfSeverity(taskValidations, 'error'));
 
     return allBackendErrors?.length ? allBackendErrors : emptyArray;
-  }, [formErrors, selector, showAllBackendErrors]);
+  }, [dataModels, formErrors, showAllBackendErrors, taskValidations]);
 
   return {
     formErrors,

--- a/src/App/frontend/src/features/validation/selectors/unifiedValidationsForNode.ts
+++ b/src/App/frontend/src/features/validation/selectors/unifiedValidationsForNode.ts
@@ -2,9 +2,8 @@ import { useMemo } from 'react';
 
 import type { NodeRefValidation } from '..';
 
-import { Validation } from 'src/features/validation/validationContext';
+import { FormStore } from 'src/features/form/FormContext';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 
 /**
  * Returns all validation messages for a given node.
@@ -14,8 +13,8 @@ import { NodesInternal } from 'src/utils/layout/NodesContext';
 const emptyArray = [];
 export function useUnifiedValidationsForNode(baseComponentId: string): NodeRefValidation[] {
   const nodeId = useIndexedId(baseComponentId);
-  const showAll = Validation.useShowAllBackendErrors();
-  const validations = NodesInternal.useVisibleValidations(nodeId, showAll);
+  const showAll = FormStore.validation.useShowAllBackendErrors();
+  const validations = FormStore.nodes.useVisibleValidations(nodeId, showAll);
 
   return useMemo(() => {
     if (!nodeId) {

--- a/src/App/frontend/src/features/validation/validationContext.tsx
+++ b/src/App/frontend/src/features/validation/validationContext.tsx
@@ -1,22 +1,16 @@
 import React, { Fragment, useCallback, useEffect, useMemo, useRef } from 'react';
-import type { PropsWithChildren } from 'react';
 
 import deepEqual from 'fast-deep-equal';
-import { createStore } from 'zustand';
-import { immer } from 'zustand/middleware/immer';
+import type { Draft } from 'immer';
 
-import { ContextNotProvided } from 'src/core/contexts/context';
-import { createZustandContext } from 'src/core/contexts/zustandContext';
-import { Loader } from 'src/core/loading/Loader';
 import { hasPendingAttachments } from 'src/features/attachments/utils';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useInstanceDataQuery } from 'src/features/instance/InstanceContext';
 import {
   type BaseValidation,
   type DataModelValidations,
   type FieldValidations,
-  type ValidationContext,
   ValidationMask,
   type ValidationsProcessedLast,
   type WaitForValidation,
@@ -26,16 +20,20 @@ import {
   useGetCachedInitialValidations,
   useRefetchInitialValidations,
 } from 'src/features/validation/backendValidation/backendValidationQuery';
-import { useShouldValidateInitial } from 'src/features/validation/backendValidation/backendValidationUtils';
+import {
+  mapBackendIssuesToTaskValidations,
+  mapBackendValidationsToValidatorGroups,
+  mapValidatorGroupsToDataModelValidations,
+} from 'src/features/validation/backendValidation/backendValidationUtils';
 import { InvalidDataValidation } from 'src/features/validation/invalidDataValidation/InvalidDataValidation';
 import { useWaitForNodesToValidate } from 'src/features/validation/nodeValidation/waitForNodesToValidate';
 import { SchemaValidation } from 'src/features/validation/schemaValidation/SchemaValidation';
 import { hasValidationErrors, mergeFieldValidations, selectValidations } from 'src/features/validation/utils';
 import { useWaitForState } from 'src/hooks/useWaitForState';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
-import type { NodesContext } from 'src/utils/layout/NodesContext';
+import type { FormStoreSet, FormStoreState } from 'src/features/form/FormContext';
+import type { FormBootstrapContextValue } from 'src/features/formBootstrap/types';
 
-interface Internals {
+export interface ValidationInternals {
   individualValidations: {
     backend: DataModelValidations;
     expression: DataModelValidations;
@@ -48,7 +46,7 @@ interface Internals {
    * if validations is undefined, nothing will be changed
    */
   updateDataModelValidations: (
-    key: Exclude<keyof Internals['individualValidations'], 'backend'>,
+    key: Exclude<keyof ValidationInternals['individualValidations'], 'backend'>,
     dataElementId: string,
     validations?: FieldValidations,
   ) => void;
@@ -57,110 +55,102 @@ interface Internals {
     processedLast?: Partial<ValidationsProcessedLast>,
     taskValidations?: BaseValidation[],
   ) => void;
-  updateValidating: (validating: WaitForValidation) => void;
 }
 
-function initialCreateStore() {
-  return createStore<ValidationContext & Internals>()(
-    immer((set) => ({
-      // =======
-      // Publicly exposed state
-      state: {
-        task: [],
-        dataModels: {},
-      },
-      setShowAllBackendErrors: (newValue) =>
-        set((state) => {
-          state.showAllBackendErrors = newValue;
-        }),
-      showAllBackendErrors: false,
-      validating: undefined,
+export function createValidationSlice(
+  bootstrap: FormBootstrapContextValue,
+  set: FormStoreSet,
+): FormStoreState['validation'] {
+  return {
+    // =======
+    // Publicly exposed state
+    state: {
+      task: mapBackendIssuesToTaskValidations(bootstrap.validationIssues ?? []),
+      dataModels: {},
+    },
+    setShowAllBackendErrors: (newValue) =>
+      set((state) => {
+        state.validation.showAllBackendErrors = newValue;
+      }),
+    showAllBackendErrors: false,
 
-      // =======
-      // Internal state
-      individualValidations: {
-        backend: {},
-        expression: {},
-        schema: {},
-        invalidData: {},
-      },
-      processedLast: {
-        initial: undefined,
-        incremental: undefined,
-      },
-      updateDataModelValidations: (key, dataElementId, validations) =>
-        set((state) => {
-          if (validations) {
-            state.individualValidations[key][dataElementId] = validations;
-            state.state.dataModels[dataElementId] = mergeFieldValidations(
-              state.individualValidations.backend[dataElementId],
-              state.individualValidations.invalidData[dataElementId],
-              state.individualValidations.schema[dataElementId],
-              state.individualValidations.expression[dataElementId],
-            );
-          }
-        }),
-      updateBackendValidations: (backendValidations, processedLast, taskValidations) =>
-        set((state) => {
-          if (processedLast?.incremental) {
-            state.processedLast.incremental = processedLast.incremental;
-          }
-          if (processedLast?.initial) {
-            state.processedLast.initial = processedLast.initial;
-          }
-          if (taskValidations) {
-            state.state.task = taskValidations;
-          }
-          if (backendValidations) {
-            /**
-             * If a data model no longer has any backend validations, the key will not exist in the new object,
-             * we therefore need to make sure we update data model validations for any model that
-             * previously had validations as well.
-             */
-            const keys = new Set([
-              ...Object.keys(backendValidations),
-              ...Object.keys(state.individualValidations.backend),
-            ]);
-
-            state.individualValidations.backend = backendValidations;
-            for (const dataElementId of keys) {
-              state.state.dataModels[dataElementId] = mergeFieldValidations(
-                state.individualValidations.backend[dataElementId],
-                state.individualValidations.invalidData[dataElementId],
-                state.individualValidations.schema[dataElementId],
-                state.individualValidations.expression[dataElementId],
-              );
-            }
-          }
-        }),
-      updateValidating: (newValidating) =>
-        set((state) => {
-          state.validating = newValidating;
-        }),
-    })),
-  );
+    // =======
+    // Internal state
+    individualValidations: {
+      backend: mapValidatorGroupsToDataModelValidations(
+        mapBackendValidationsToValidatorGroups(bootstrap.allInitialValidations),
+      ),
+      expression: {},
+      schema: {},
+      invalidData: {},
+    },
+    processedLast: {
+      initial: bootstrap.allInitialValidations,
+      incremental: undefined,
+    },
+    updateDataModelValidations: (key, dataElementId, validations) =>
+      set((state) => {
+        if (validations) {
+          state.validation.individualValidations[key][dataElementId] = validations;
+          state.validation.state.dataModels[dataElementId] = mergeFieldValidations(
+            state.validation.individualValidations.backend[dataElementId],
+            state.validation.individualValidations.invalidData[dataElementId],
+            state.validation.individualValidations.schema[dataElementId],
+            state.validation.individualValidations.expression[dataElementId],
+          );
+        }
+      }),
+    updateBackendValidations: (backendValidations, processedLast, taskValidations) =>
+      set((state) => {
+        updateBackendValidations(state)(backendValidations, processedLast, taskValidations);
+      }),
+  };
 }
 
-const {
-  Provider,
-  useSelector,
-  useStaticSelector,
-  useMemoSelector,
-  useLaxShallowSelector,
-  useSelectorAsRef,
-  useStore,
-  useLaxSelectorAsRef,
-  useDelayedSelector,
-} = createZustandContext({
-  name: 'Validation',
-  required: true,
-  initialCreateStore,
-});
+export function updateBackendValidations(
+  state: Draft<FormStoreState>,
+): ValidationInternals['updateBackendValidations'] {
+  return (backendValidations, processedLast, taskValidations) => {
+    if (
+      processedLast?.incremental &&
+      !deepEqual(state.validation.processedLast.incremental, processedLast.incremental)
+    ) {
+      state.validation.processedLast.incremental = processedLast.incremental;
+    }
+    if (processedLast?.initial) {
+      state.validation.processedLast.initial = processedLast.initial;
+    }
+    if (taskValidations) {
+      state.validation.state.task = taskValidations;
+    }
+    if (backendValidations) {
+      /**
+       * If a data model no longer has any backend validations, the key will not exist in the new object,
+       * we therefore need to make sure we update data model validations for any model that
+       * previously had validations as well.
+       */
+      const keys = new Set([
+        ...Object.keys(backendValidations),
+        ...Object.keys(state.validation.individualValidations.backend),
+      ]);
 
-export function ValidationProvider({ children }: PropsWithChildren) {
+      state.validation.individualValidations.backend = backendValidations;
+      for (const dataElementId of keys) {
+        state.validation.state.dataModels[dataElementId] = mergeFieldValidations(
+          state.validation.individualValidations.backend[dataElementId],
+          state.validation.individualValidations.invalidData[dataElementId],
+          state.validation.individualValidations.schema[dataElementId],
+          state.validation.individualValidations.expression[dataElementId],
+        );
+      }
+    }
+  };
+}
+
+export function ValidationEffects() {
   const writableDataTypes = FormBootstrap.useWritableDataTypes();
   return (
-    <Provider>
+    <>
       {writableDataTypes.map((dataType) => (
         <Fragment key={dataType}>
           <SchemaValidation dataType={dataType} />
@@ -169,64 +159,51 @@ export function ValidationProvider({ children }: PropsWithChildren) {
       ))}
       <BackendValidation />
       <ManageShowAllErrors />
-      {children}
-    </Provider>
+    </>
   );
 }
 
-function useWaitForValidation(): WaitForValidation {
-  const waitForNodesReady = NodesInternal.useWaitUntilReady();
-  const waitForSave = FD.useWaitForSave();
-  const waitForState = useWaitForState<ValidationsProcessedLast, ValidationContext & Internals>(useStore());
-  const nodesStore = NodesInternal.useStore();
-  const waitForAttachments = useWaitForState<void, NodesContext>(nodesStore);
+export function useWaitForValidation(): WaitForValidation {
+  const waitForNodesReady = FormStore.nodes.useWaitUntilReady();
+  const waitForSave = FormStore.data.useWaitForSave();
+  const waitForState = useWaitForState<undefined, FormStoreState>(FormStore.raw.useStore());
 
   const hasWritableDataTypes = !!FormBootstrap.useWritableDataTypes()?.length;
-  const enabled = useShouldValidateInitial();
   const getCachedInitialValidations = useGetCachedInitialValidations();
   const waitForNodesToValidate = useWaitForNodesToValidate();
 
   return useCallback(
     async (forceSave = true) => {
-      if (!enabled || !hasWritableDataTypes) {
+      if (!hasWritableDataTypes) {
         // Even when validation is not enabled, we may still have pending query data written by
         // updateInitialValidations() (e.g. from process/next returning task validation issues).
         // Wait for BackendValidation to process it into the zustand store before returning.
         await waitForState((state) => {
           const { isFetching, cachedInitialValidations } = getCachedInitialValidations();
-          return !isFetching && deepEqual(state.processedLast.initial, cachedInitialValidations);
+          return (
+            !isFetching &&
+            deepEqual(state.validation.processedLast.initial, cachedInitialValidations) &&
+            !hasPendingAttachments(state)
+          );
         });
         return;
       }
 
-      await waitForAttachments((state) => !hasPendingAttachments(state));
-
       // Wait until we've saved changed to backend, and we've processed the backend validations we got from that save
       await waitForNodesReady();
-      const validationsFromSave = await waitForSave(forceSave);
-      // If validationsFromSave is not defined, we check if initial validations are done processing
-      const processedLast = await waitForState((state, setReturnValue) => {
+      await waitForSave(forceSave, (state) => {
         const { isFetching, cachedInitialValidations } = getCachedInitialValidations();
-        const incrementalMatch = deepEqual(state.processedLast.incremental, validationsFromSave);
-        const initialMatch = deepEqual(state.processedLast.initial, cachedInitialValidations);
+        const initialMatch = deepEqual(state.validation.processedLast.initial, cachedInitialValidations);
+        const pendingAttachments = hasPendingAttachments(state);
 
-        const validationsReady = incrementalMatch && initialMatch && !isFetching;
-
-        if (validationsReady) {
-          setReturnValue(state.processedLast);
-          return true;
-        }
-
-        return false;
+        return initialMatch && !isFetching && !pendingAttachments;
       });
-      await waitForNodesToValidate(processedLast);
+      await waitForNodesToValidate();
       await waitForNodesReady();
     },
     [
-      enabled,
       getCachedInitialValidations,
       hasWritableDataTypes,
-      waitForAttachments,
       waitForNodesReady,
       waitForNodesToValidate,
       waitForSave,
@@ -235,35 +212,17 @@ function useWaitForValidation(): WaitForValidation {
   );
 }
 
-export function ProvideWaitForValidation() {
-  const validate = useWaitForValidation();
-  const updateValidating = useSelector((state) => state.updateValidating);
-
-  useEffect(() => {
-    updateValidating(validate);
-  }, [updateValidating, validate]);
-
-  return null;
-}
-
-export function LoadingBlockerWaitForValidation({ children }: PropsWithChildren) {
-  const validationFn = useSelector((state) => state.validating);
-  if (!validationFn) {
-    return <Loader reason='validation-awaiter' />;
-  }
-
-  return children;
-}
-
 function ManageShowAllErrors() {
-  const showAllErrors = useSelector((state) => state.showAllBackendErrors);
+  const showAllErrors = FormStore.raw.useSelector((state) => state.validation.showAllBackendErrors);
   return showAllErrors ? <UpdateShowAllErrors /> : null;
 }
 
 function UpdateShowAllErrors() {
-  const taskValidations = useSelector((state) => state.state.task);
-  const dataModelValidations = useSelector((state) => state.state.dataModels);
-  const setShowAllErrors = useSelector((state) => state.setShowAllBackendErrors);
+  const [taskValidations, dataModelValidations, setShowAllErrors] = FormStore.raw.useShallowSelector((state) => [
+    state.validation.state.task,
+    state.validation.state.dataModels,
+    state.validation.setShowAllBackendErrors,
+  ]);
 
   const isFirstRender = useRef(true);
 
@@ -273,7 +232,6 @@ function UpdateShowAllErrors() {
    * or if new data elements are added. Single-patch does not return updated instance data so for now we need to
    * also check useLastSaveValidationIssues which will change on each patch.
    */
-  const lastSaved = FD.useLastSaveValidationIssues();
   const instanceDataChanges = useInstanceDataQuery({
     select: (instance) => instance.data.map(({ id, lastChanged }) => ({ id, lastChanged })),
   }).data;
@@ -286,12 +244,13 @@ function UpdateShowAllErrors() {
       isFirstRender.current = false;
       return;
     }
+
     // Adding or deleting an attachment can lead to changes in both the data model and an update
     // in the attachments data elements, which can lead to two updates right after each other,
     // so debouncing a little so that we don't call validate too much as it can be heavy.
     const timer = setTimeout(() => refetchInitialValidations(), 1000);
     return () => clearTimeout(timer);
-  }, [refetchInitialValidations, instanceDataChanges, lastSaved]);
+  }, [refetchInitialValidations, instanceDataChanges]);
 
   /**
    * Hide unbound errors as soon as possible.
@@ -311,26 +270,12 @@ function UpdateShowAllErrors() {
   return null;
 }
 
-/**
- * This hook returns a function that lets you select one or more fields from the validation state. The hook will
- * only force a re-render if the selected fields have changed.
- */
-function useDS<U>(outerSelector: (state: ValidationContext) => U) {
-  return useDelayedSelector({
-    mode: 'innerSelector',
-    makeArgs: (state) => [outerSelector(state)],
-  });
-}
-
-export const Validation = {
-  // Selectors. These are memoized, so they won't cause a re-render unless the selected fields change.
-  useSelector: () => useDS((state) => state),
-
+export const validationHooks = {
   useDataElementsWithErrors: (elementIds: string[]) =>
-    useMemoSelector((state) => {
+    FormStore.raw.useMemoSelector((state) => {
       const out: string[] = [];
       for (const elementId of elementIds) {
-        const dataElementValidations = state.state.dataModels[elementId];
+        const dataElementValidations = state.validation.state.dataModels[elementId];
         for (const fieldValidations of Object.values(dataElementValidations ?? {})) {
           for (const validation of fieldValidations) {
             if (validation.severity === 'error') {
@@ -343,38 +288,24 @@ export const Validation = {
       return out;
     }),
 
-  useShowAllBackendErrors: () => useSelector((state) => state.showAllBackendErrors),
+  useShowAllBackendErrors: () => FormStore.raw.useSelector((state) => state.validation.showAllBackendErrors),
   useSetShowAllBackendErrors: () => {
-    const s = useLaxShallowSelector(({ validating, setShowAllBackendErrors }) => ({
-      validating,
-      setShowAllBackendErrors,
-    }));
+    const validating = useWaitForValidation();
+    const setShowAllBackendErrors = FormStore.raw.useShallowSelector((s) => s.validation.setShowAllBackendErrors);
 
-    return useMemo(() => {
-      if (s === ContextNotProvided) {
-        return ContextNotProvided;
-      }
-
-      return async () => {
+    return useMemo(
+      () => async () => {
         // Make sure we have finished processing validations before setting showAllErrors.
         // This is because we automatically turn off this state as soon as possible.
         // If the validations to show have not finished processing, this could get turned off before they ever became visible.
-        s.validating && (await s.validating());
-        s.setShowAllBackendErrors(true);
-      };
-    }, [s]);
+        await validating();
+        setShowAllBackendErrors(true);
+      },
+      [setShowAllBackendErrors, validating],
+    );
   },
-  useValidating: () => useSelector((state) => state.validating!),
-  useUpdateDataModelValidations: () => useStaticSelector((state) => state.updateDataModelValidations),
-  useUpdateBackendValidations: () => useStaticSelector((state) => state.updateBackendValidations),
-
-  useFullState: <U,>(selector: (state: ValidationContext & Internals) => U): U =>
-    useMemoSelector((state) => selector(state)),
-  useGetProcessedLast: () => {
-    const store = useStore();
-    return useCallback(() => store.getState().processedLast, [store]);
-  },
-
-  useRef: () => useSelectorAsRef((state) => state),
-  useLaxRef: () => useLaxSelectorAsRef((state) => state),
+  useUpdateDataModelValidations: () =>
+    FormStore.raw.useStaticSelector((state) => state.validation.updateDataModelValidations),
+  useUpdateBackendValidations: () =>
+    FormStore.raw.useStaticSelector((state) => state.validation.updateBackendValidations),
 };

--- a/src/App/frontend/src/hooks/useNavigatePage.ts
+++ b/src/App/frontend/src/hooks/useNavigatePage.ts
@@ -4,11 +4,10 @@ import type { NavigateOptions } from 'react-router';
 
 import { SearchParams } from 'src/core/routing/types';
 import { useIsStateless } from 'src/features/applicationMetadata';
-import { useSetReturnToView, useSetSummaryNodeOfOrigin } from 'src/features/form/layout/PageNavigationContext';
+import { FormStore } from 'src/features/form/FormContext';
 import { usePageSettings, useRawPageOrder } from 'src/features/form/layoutSettings/processLayoutSettings';
 import { getUiConfig } from 'src/features/form/ui';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useGetTaskTypeById, useProcessQuery } from 'src/features/instance/useProcessQuery';
 import { useSetNavigationEffect } from 'src/features/navigation/NavigationEffectContext';
 import { useRefetchInitialValidations } from 'src/features/validation/backendValidation/backendValidationQuery';
@@ -36,8 +35,8 @@ export interface NavigateToPageOptions {
 
 const useOurNavigate = () => {
   const storeCallback = useSetNavigationEffect();
-  const setReturnToView = useSetReturnToView();
-  const setSummaryNodeOfOrigin = useSetSummaryNodeOfOrigin();
+  const setReturnToView = FormStore.pageNavigation.useSetReturnToView();
+  const setSummaryNodeOfOrigin = FormStore.pageNavigation.useSetSummaryNodeOfOrigin();
   const navigate = useNavigate();
 
   return useCallback(
@@ -232,7 +231,7 @@ export function useNavigatePage() {
     }
   }, [isStateless, orderRef, navigate, isValidPageId, navParams, searchParamsRef]);
 
-  const waitForSave = FD.useWaitForSave();
+  const waitForSave = FormStore.data.useWaitForSave();
   const maybeSaveOnPageChange = useCallback(async () => {
     await waitForSave(autoSaveBehavior === 'onChangePage');
   }, [autoSaveBehavior, waitForSave]);

--- a/src/App/frontend/src/layout/AddToList/AddToList.tsx
+++ b/src/App/frontend/src/layout/AddToList/AddToList.tsx
@@ -7,8 +7,8 @@ import type { JSONSchema7 } from 'json-schema';
 
 import { DynamicForm } from 'src/app-components/DynamicForm/DynamicForm';
 import { translationKey } from 'src/AppComponentsBridge';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { ALTINN_ROW_ID } from 'src/features/formData/types';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { DropdownCaption } from 'src/layout/Datepicker/DropdownCaption';
@@ -54,7 +54,7 @@ export function AddToListModal({
   modalRef,
   DropdownCaption,
 }: ModalDynamicFormProps) {
-  const appendToList = FD.useAppendToList();
+  const appendToList = FormStore.data.useAppendToList();
   let addToListModalRef = useRef<HTMLDialogElement | null>(null);
   addToListModalRef = modalRef ?? addToListModalRef;
 
@@ -123,7 +123,7 @@ export function AddToListModal({
 export function AddToListComponent({ baseComponentId }: PropsFromGenericComponent<'AddToList'>) {
   const dataModelBindings = useDataModelBindingsFor(baseComponentId, 'AddToList');
   const { formData } = useDataModelBindings(dataModelBindings, 1, 'raw');
-  const setMultiLeafValues = FD.useSetMultiLeafValues();
+  const setMultiLeafValues = FormStore.data.useSetMultiLeafValues();
 
   const modalRef = useRef<HTMLDialogElement>(null);
   const [showForm, setShowForm] = useState(false);

--- a/src/App/frontend/src/layout/AddToList/AddToListFeatureFlagLayoutValidator.tsx
+++ b/src/App/frontend/src/layout/AddToList/AddToListFeatureFlagLayoutValidator.tsx
@@ -1,11 +1,11 @@
+import { FormStore } from 'src/features/form/FormContext';
 import { getFeature } from 'src/features/toggles';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { NodeValidationProps } from 'src/layout/layout';
 
 export function AddToListFeatureFlagLayoutValidator({ intermediateItem }: NodeValidationProps<'AddToList'>) {
   const simpleTableEnabled = getFeature('addToListEnabled');
 
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
   if (!simpleTableEnabled.value) {
     const error = `You need to enable the feature flag addToListEnabled to use this component. Please note that the component is experimental
     and the configuration is likely to change.`;

--- a/src/App/frontend/src/layout/Address/AddressComponent.tsx
+++ b/src/App/frontend/src/layout/Address/AddressComponent.tsx
@@ -6,7 +6,7 @@ import { Label } from 'src/app-components/Label/Label';
 import { HelpTextContainer } from 'src/components/form/HelpTextContainer';
 import { OptionalIndicator } from 'src/components/form/OptionalIndicator';
 import { RequiredIndicator } from 'src/components/form/RequiredIndicator';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -45,7 +45,7 @@ export function AddressComponent({ baseComponentId }: PropsFromGenericComponent<
   const bindingValidations = useBindingValidationsFor<'Address'>(baseComponentId);
   const componentValidations = useComponentValidationsFor(baseComponentId);
   const { formData, setValue } = useDataModelBindings(dataModelBindings, saveWhileTyping);
-  const debounce = FD.useDebounceImmediately();
+  const debounce = FormStore.data.useDebounceImmediately();
   const { address, careOf, postPlace, zipCode, houseNumber } = formData;
 
   const updatePostPlace = useOurEffectEvent((newPostPlace) => {
@@ -54,7 +54,7 @@ export function AddressComponent({ baseComponentId }: PropsFromGenericComponent<
     }
   });
 
-  const zipCodeDebounced = FD.useDebouncedPick(dataModelBindings.zipCode);
+  const zipCodeDebounced = FormStore.data.useDebouncedPick(dataModelBindings.zipCode);
   const slowZip = typeof zipCodeDebounced === 'string' ? zipCodeDebounced : undefined;
   const postPlaceQueryData = usePostPlace(slowZip, !hasValidationErrors(bindingValidations?.zipCode) && !readOnly);
   useEffect(() => updatePostPlace(postPlaceQueryData), [postPlaceQueryData, updatePostPlace]);

--- a/src/App/frontend/src/layout/Address/useAddressValidation.ts
+++ b/src/App/frontend/src/layout/Address/useAddressValidation.ts
@@ -1,12 +1,12 @@
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import type { ComponentValidation } from 'src/features/validation';
 
 export function useAddressValidation(baseComponentId: string): ComponentValidation[] {
   const dataModelBindings = useDataModelBindingsFor(baseComponentId, 'Address');
-  const zipCode = FD.useDebouncedPick(dataModelBindings?.zipCode);
-  const houseNumber = FD.useDebouncedPick(dataModelBindings?.houseNumber);
+  const zipCode = FormStore.data.useDebouncedPick(dataModelBindings?.zipCode);
+  const houseNumber = FormStore.data.useDebouncedPick(dataModelBindings?.houseNumber);
   if (!dataModelBindings) {
     return [];
   }

--- a/src/App/frontend/src/layout/Button/ButtonComponent.tsx
+++ b/src/App/frontend/src/layout/Button/ButtonComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Button } from 'src/app-components/Button/Button';
 import { useAttachmentState } from 'src/features/attachments/hooks';
-import { useSetReturnToView } from 'src/features/form/layout/PageNavigationContext';
+import { FormStore } from 'src/features/form/FormContext';
 import { getUiConfig } from 'src/features/form/ui';
 import { useProcessNext } from 'src/features/instance/useProcessNext';
 import { useProcessQuery, useTaskTypeFromBackend } from 'src/features/instance/useProcessQuery';
@@ -35,7 +35,7 @@ export const ButtonComponent = ({ baseComponentId, ...componentProps }: PropsFro
   const { mutate: processNext, isPending: isProcessingNext } = useProcessNext();
   const { mutate: processConfirm, isPending: isConfirming } = useProcessNext({ action: 'confirm' });
 
-  const setReturnToView = useSetReturnToView();
+  const setReturnToView = FormStore.pageNavigation.useSetReturnToView();
 
   if (useIsSubformPage()) {
     throw new Error('Cannot use process navigation in a subform');

--- a/src/App/frontend/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/App/frontend/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -8,8 +8,8 @@ import { isAxiosError } from 'axios';
 import { Button } from 'src/app-components/Button/Button';
 import { useAppMutations } from 'src/core/contexts/AppQueriesProvider';
 import { useResetScrollPosition } from 'src/core/ui/useResetScrollPosition';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useIsAuthorized } from 'src/features/instance/useProcessQuery';
 import { Lang } from 'src/features/language/Lang';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
@@ -41,7 +41,7 @@ type UpdatedValidationIssues = {
   [dataElementId: string]: BackendValidationIssueGroups;
 };
 
-type FormDataLocking = ReturnType<typeof FD.useLocking>;
+type FormDataLocking = ReturnType<typeof FormStore.data.useLocking>;
 type FormDataLock = Awaited<ReturnType<FormDataLocking>>;
 
 export type ActionResult = {
@@ -200,7 +200,7 @@ export const CustomButtonComponent = ({ baseComponentId }: PropsFromGenericCompo
     'CustomButton',
   );
 
-  const acquireLock = FD.useLocking(id);
+  const acquireLock = FormStore.data.useLocking(id);
   const isAuthorized = useIsAuthorized();
   const { handleClientActions } = useHandleClientActions();
   const { mutateAsync: handleServerAction, error } = useMutation({

--- a/src/App/frontend/src/layout/Datepicker/useDatepickerValidation.ts
+++ b/src/App/frontend/src/layout/Datepicker/useDatepickerValidation.ts
@@ -1,7 +1,7 @@
 import { isAfter, isBefore } from 'date-fns';
 
 import { getDateConstraint, getDateFormat, strictParseISO } from 'src/app-components/Datepicker/utils/dateHelpers';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { type ComponentValidation, FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { getDatepickerFormat } from 'src/utils/dateUtils';
@@ -12,7 +12,7 @@ export function useDatepickerValidation(baseComponentId: string): ComponentValid
   const currentLanguage = useCurrentLanguage();
   const field = useDataModelBindingsFor(baseComponentId, 'Datepicker')?.simpleBinding;
   const component = useItemWhenType(baseComponentId, 'Datepicker');
-  const data = FD.useDebouncedPick(field);
+  const data = FormStore.data.useDebouncedPick(field);
   const minDate = getDateConstraint(component?.minDate, 'min');
   const maxDate = getDateConstraint(component?.maxDate, 'max');
   const format = getDateFormat(component?.format, currentLanguage);

--- a/src/App/frontend/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/App/frontend/src/layout/Dropdown/DropdownComponent.tsx
@@ -9,7 +9,7 @@ import { AltinnSpinner } from 'src/components/AltinnSpinner';
 import { getDescriptionId } from 'src/components/label/Label';
 import { DeleteWarningPopover } from 'src/features/alertOnChange/DeleteWarningPopover';
 import { useAlertOnChange } from 'src/features/alertOnChange/useAlertOnChange';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useGetOptions } from 'src/features/options/useGetOptions';
@@ -36,7 +36,7 @@ export function DropdownComponent({ baseComponentId, overrideDisplay }: PropsFro
     useLabel({ baseComponentId, overrideDisplay });
 
   const { options, isFetching, selectedValues, setData } = useGetOptions(baseComponentId, 'single');
-  const debounce = FD.useDebounceImmediately();
+  const debounce = FormStore.data.useDebounceImmediately();
 
   const selectedLabels = selectedValues.map((value) => {
     const option = options.find((o) => o.value === value);

--- a/src/App/frontend/src/layout/FileUpload/FileUploadLayoutValidator.tsx
+++ b/src/App/frontend/src/layout/FileUpload/FileUploadLayoutValidator.tsx
@@ -1,10 +1,10 @@
 import { useEffect } from 'react';
 import type { JSX } from 'react';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useShallowMemo } from 'src/hooks/useShallowMemo';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { IDataModelReference } from 'src/layout/common.generated';
 import type { CompExternal, NodeValidationProps } from 'src/layout/layout';
 
@@ -15,7 +15,7 @@ export function FileUploadLayoutValidator(
   const allPages = FormBootstrap.useLayouts();
   const binding = extractBinding(externalItem);
   const { langAsString } = useLanguage();
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
 
   const othersWithSameBinding: string[] = [];
   if (binding) {

--- a/src/App/frontend/src/layout/FileUpload/useValidateMinNumberOfAttachments.ts
+++ b/src/App/frontend/src/layout/FileUpload/useValidateMinNumberOfAttachments.ts
@@ -1,14 +1,14 @@
+import { FormStore } from 'src/features/form/FormContext';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useExternalItem } from 'src/utils/layout/hooks';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { ComponentValidation } from 'src/features/validation';
 
 export function useValidateMinNumberOfAttachments(baseComponentId: string): ComponentValidation[] {
   const validations: ComponentValidation[] = [];
   const component = useExternalItem(baseComponentId);
-  const attachments = NodesInternal.useAttachments(useIndexedId(baseComponentId));
+  const attachments = FormStore.nodes.useAttachments(useIndexedId(baseComponentId));
   const minNumberOfAttachments = useItemWhenType<'FileUpload' | 'FileUploadWithTag'>(
     baseComponentId,
     (t) => t === 'FileUpload' || t === 'FileUploadWithTag',

--- a/src/App/frontend/src/layout/FileUploadWithTag/useValidateMissingTag.ts
+++ b/src/App/frontend/src/layout/FileUploadWithTag/useValidateMissingTag.ts
@@ -1,14 +1,14 @@
 import { isAttachmentUploaded } from 'src/features/attachments';
+import { FormStore } from 'src/features/form/FormContext';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { AttachmentValidation, ComponentValidation } from 'src/features/validation';
 
 export function useValidateMissingTag(baseComponentId: string): ComponentValidation[] {
   const item = useItemWhenType(baseComponentId, 'FileUploadWithTag');
   const tagKey = item?.textResourceBindings?.tagTitle;
-  const attachments = NodesInternal.useAttachments(useIndexedId(baseComponentId));
+  const attachments = FormStore.nodes.useAttachments(useIndexedId(baseComponentId));
   const validations: ComponentValidation[] = [];
 
   for (const attachment of attachments) {

--- a/src/App/frontend/src/layout/GenericComponent.tsx
+++ b/src/App/frontend/src/layout/GenericComponent.tsx
@@ -11,6 +11,7 @@ import { SearchParams } from 'src/core/routing/types';
 import { useIsNavigating } from 'src/core/routing/useIsNavigating';
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
 import { ExprVal } from 'src/features/expressions/types';
+import { FormStore } from 'src/features/form/FormContext';
 import { Lang } from 'src/features/language/Lang';
 import { FormComponentContextProvider } from 'src/layout/FormComponentContext';
 import classes from 'src/layout/GenericComponent.module.css';
@@ -23,7 +24,6 @@ import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useEvalExpression } from 'src/utils/layout/generator/useEvalExpression';
 import { useIsHidden } from 'src/utils/layout/hidden';
 import { useExternalItem } from 'src/utils/layout/hooks';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { EvalExprOptions } from 'src/features/expressions';
 import type { IGridStyling } from 'src/layout/common.generated';
 import type { GenericComponentOverrideDisplay, IFormComponentContext } from 'src/layout/FormComponentContext';
@@ -43,7 +43,7 @@ function NonMemoGenericComponent<Type extends CompTypes = CompTypes>({
   overrideDisplay,
 }: IGenericComponentProps<Type>) {
   const nodeId = useIndexedId(baseComponentId);
-  const generatorErrors = NodesInternal.useNodeData(nodeId, undefined, (node) => node.errors);
+  const generatorErrors = FormStore.nodes.useNodeData(nodeId, undefined, (node) => node.errors);
 
   if (generatorErrors && Object.keys(generatorErrors).length > 0) {
     return (

--- a/src/App/frontend/src/layout/Group/GroupComponent.tsx
+++ b/src/App/frontend/src/layout/Group/GroupComponent.tsx
@@ -7,12 +7,12 @@ import cn from 'classnames';
 import { ConditionalWrapper } from 'src/app-components/ConditionalWrapper/ConditionalWrapper';
 import { Fieldset } from 'src/app-components/Label/Fieldset';
 import { Panel } from 'src/app-components/Panel/Panel';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { Lang } from 'src/features/language/Lang';
 import classes from 'src/layout/Group/GroupComponent.module.css';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useIsHidden } from 'src/utils/layout/hidden';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { HeadingLevel } from 'src/layout/common.generated';
 
@@ -44,7 +44,7 @@ export function GroupComponent({
   const isHidden = useIsHidden(baseComponentId);
 
   const indexedId = useIndexedId(baseComponentId);
-  const depth = NodesInternal.useSelector((state) => state.nodeData?.[indexedId]?.depth);
+  const depth = FormStore.raw.useSelector((state) => state.nodes.nodeData?.[indexedId]?.depth);
   const layoutLookups = FormBootstrap.useLayoutLookups();
 
   if (isHidden || typeof depth !== 'number') {

--- a/src/App/frontend/src/layout/ImageUpload/hooks/useValidateRequiredImageUpload.tsx
+++ b/src/App/frontend/src/layout/ImageUpload/hooks/useValidateRequiredImageUpload.tsx
@@ -1,11 +1,11 @@
+import { FormStore } from 'src/features/form/FormContext';
 import { type ComponentValidation, FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 
 export function useValidateRequiredImageUpload(baseComponentId: string): ComponentValidation[] {
   const item = useItemWhenType(baseComponentId, 'ImageUpload');
-  const attachments = NodesInternal.useAttachments(useIndexedId(baseComponentId));
+  const attachments = FormStore.nodes.useAttachments(useIndexedId(baseComponentId));
 
   if (!item?.required || attachments.length > 0) {
     return [];

--- a/src/App/frontend/src/layout/Input/InputComponent.tsx
+++ b/src/App/frontend/src/layout/Input/InputComponent.tsx
@@ -6,7 +6,7 @@ import { NumericInput } from 'src/app-components/Input/NumericInput';
 import { Label } from 'src/app-components/Label/Label';
 import { translationKey } from 'src/AppComponentsBridge';
 import { getDescriptionId, getLabelId } from 'src/components/label/Label';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { useIsValid } from 'src/features/validation/selectors/isValid';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';
@@ -129,7 +129,7 @@ const InputVariant = ({
   const reactNumberFormatConfig = useMapToReactNumberConfig(formatting, formValue);
   const variant = getVariantWithFormat(inputVariant, reactNumberFormatConfig?.number);
   const { inputMode, pattern } = getMobileKeyboardProps(variant, autocomplete);
-  const debounce = FD.useDebounceImmediately();
+  const debounce = FormStore.data.useDebounceImmediately();
 
   const descriptionId = getDescriptionId(id);
   const validationsId = `${baseComponentId}-validations`;

--- a/src/App/frontend/src/layout/InstantiationButton/InstantiationButton.tsx
+++ b/src/App/frontend/src/layout/InstantiationButton/InstantiationButton.tsx
@@ -4,8 +4,8 @@ import { useNavigate } from 'react-router';
 import { Button } from 'src/app-components/Button/Button';
 import { ErrorListFromInstantiation, ErrorReport } from 'src/components/message/ErrorReport';
 import { parseInstanceId } from 'src/core/queries/instance';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useInstantiation } from 'src/features/instantiate/useInstantiation';
 import { useSetNavigationEffect } from 'src/features/navigation/NavigationEffectContext';
 import { useSelectedParty } from 'src/features/party/PartiesProvider';
@@ -23,7 +23,7 @@ export const InstantiationButton = ({ children, ...props }: Props) => {
   const performProcess = useProcessingMutation('instantiation');
   const isLoading = useIsThisProcessing('instantiation');
   const isAnyProcessing = useIsAnyProcessing();
-  const prefill = FD.useMapping(props.mapping, FormBootstrap.useDefaultDataType());
+  const prefill = FormStore.data.useMapping(props.mapping, FormBootstrap.useDefaultDataType());
   const party = useSelectedParty();
   const setNavigationEffect = useSetNavigationEffect();
   const navigate = useNavigate();

--- a/src/App/frontend/src/layout/Likert/Generator/LikertGeneratorChildren.tsx
+++ b/src/App/frontend/src/layout/Likert/Generator/LikertGeneratorChildren.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { makeLikertChildId } from 'src/layout/Likert/Generator/makeLikertChildId';
 import { getLikertStartStopIndex } from 'src/layout/Likert/rowUtils';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
@@ -28,7 +28,7 @@ export function LikertGeneratorChildren() {
 function LikertGeneratorChildrenWorker() {
   const item = GeneratorInternal.useIntermediateItem() as CompIntermediate<'Likert'>;
   const questionsBinding = item?.dataModelBindings?.questions;
-  const rows = FD.useFreshRows(questionsBinding);
+  const rows = FormStore.data.useFreshRows(questionsBinding);
 
   const lastIndex = rows.length - 1;
   const { startIndex, stopIndex } = getLikertStartStopIndex(lastIndex, item.filter);

--- a/src/App/frontend/src/layout/Likert/Summary/LargeLikertSummaryContainer.tsx
+++ b/src/App/frontend/src/layout/Likert/Summary/LargeLikertSummaryContainer.tsx
@@ -4,12 +4,12 @@ import type { JSX } from 'react';
 import { Heading } from '@digdir/designsystemet-react';
 
 import { Fieldset } from 'src/app-components/Label/Fieldset';
+import { FormStore } from 'src/features/form/FormContext';
 import { Lang } from 'src/features/language/Lang';
 import { makeLikertChildId } from 'src/layout/Likert/Generator/makeLikertChildId';
 import classes from 'src/layout/Likert/Summary/LikertSummaryComponent.module.css';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useIsHidden } from 'src/utils/layout/hidden';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { HeadingLevel } from 'src/layout/common.generated';
 
@@ -37,7 +37,7 @@ export function LargeLikertSummaryContainer({
   const container = useItemWhenType(likertBaseId, 'Likert');
   const { title, summaryTitle } = container.textResourceBindings ?? {};
   const indexedId = useIndexedId(likertBaseId, true);
-  const depth = NodesInternal.useSelector((state) => state.nodeData?.[indexedId]?.depth);
+  const depth = FormStore.raw.useSelector((state) => state.nodes.nodeData?.[indexedId]?.depth);
   const childId = makeLikertChildId(likertBaseId);
   const childIndexedId = useIndexedId(childId);
   const hidden = useIsHidden(childId);

--- a/src/App/frontend/src/layout/Likert/rowUtils.ts
+++ b/src/App/frontend/src/layout/Likert/rowUtils.ts
@@ -1,4 +1,4 @@
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { useDataModelBindingsFor, useExternalItem } from 'src/utils/layout/hooks';
 import { typedBoolean } from 'src/utils/typing';
 import type { ILikertFilter } from 'src/layout/Likert/config.generated';
@@ -21,7 +21,7 @@ export const getLikertStartStopIndex = (lastIndex: number, filters: ILikertFilte
 export function useLikertRows(baseComponentId: string) {
   const groupBinding = useDataModelBindingsFor(baseComponentId, 'Likert')?.questions;
   const filter = useExternalItem(baseComponentId, 'Likert').filter;
-  const rows = FD.useFreshRows(groupBinding);
+  const rows = FormStore.data.useFreshRows(groupBinding);
   const lastIndex = rows.length - 1;
   const { startIndex, stopIndex } = getLikertStartStopIndex(lastIndex, filter);
 

--- a/src/App/frontend/src/layout/Map/MapComponentSummary.tsx
+++ b/src/App/frontend/src/layout/Map/MapComponentSummary.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { Lang } from 'src/features/language/Lang';
 import { MarkerLocationText } from 'src/layout/Map/features/singleMarker/MarkerLocationText';
 import { Map } from 'src/layout/Map/Map';
@@ -11,7 +11,7 @@ import type { SummaryRendererProps } from 'src/layout/LayoutComponent';
 
 export function MapComponentSummary({ targetBaseComponentId }: SummaryRendererProps) {
   const markerBinding = useDataModelBindingsFor(targetBaseComponentId, 'Map').simpleBinding;
-  const formData = FD.useDebouncedPick(markerBinding);
+  const formData = FormStore.data.useDebouncedPick(markerBinding);
   const markerLocation = typeof formData === 'string' ? parseLocation(formData) : undefined;
   const markerLocationIsValid = isLocationValid(markerLocation);
 

--- a/src/App/frontend/src/layout/Map/features/geometries/editable/MapEditGeometries.tsx
+++ b/src/App/frontend/src/layout/Map/features/geometries/editable/MapEditGeometries.tsx
@@ -8,7 +8,7 @@ import L from 'leaflet';
 import { v4 as uuidv4 } from 'uuid';
 import type { Feature } from 'geojson';
 
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { ALTINN_ROW_ID } from 'src/features/formData/types';
 import { toRelativePath } from 'src/features/saveToGroup/useSaveToGroup';
 import { useLeafletDrawSpritesheetFix } from 'src/layout/Map/features/geometries/editable/useLeafletDrawSpritesheetFix';
@@ -39,9 +39,9 @@ export function MapEditGeometries({ baseComponentId }: MapEditGeometriesProps) {
 
   const geometryDataPath = toRelativePath(geometryBinding, geometryDataBinding);
 
-  const appendToList = FD.useAppendToList();
-  const setLeafValue = FD.useSetLeafValue();
-  const removeFromList = FD.useRemoveFromListCallback();
+  const appendToList = FormStore.data.useAppendToList();
+  const setLeafValue = FormStore.data.useSetLeafValue();
+  const removeFromList = FormStore.data.useRemoveFromListCallback();
 
   const { toolbar } = useItemWhenType(baseComponentId, 'Map');
 

--- a/src/App/frontend/src/layout/Map/features/geometries/fixed/hooks.ts
+++ b/src/App/frontend/src/layout/Map/features/geometries/fixed/hooks.ts
@@ -5,7 +5,7 @@ import dot from 'dot-object';
 import { geoJson, LatLngBounds } from 'leaflet';
 import type { GeoJSON } from 'geojson';
 
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { ALTINN_ROW_ID } from 'src/features/formData/types';
 import { toRelativePath } from 'src/features/saveToGroup/useSaveToGroup';
 import { useDataModelBindingsFor, useExternalItem } from 'src/utils/layout/hooks';
@@ -14,7 +14,7 @@ import type { Geometry, RawGeometry } from 'src/layout/Map/types';
 
 export function useMapRawGeometries(baseComponentId: string): RawGeometry[] | undefined {
   const dataModelBindings = useDataModelBindingsFor(baseComponentId, 'Map');
-  const formData = FD.useDebouncedPick(dataModelBindings?.geometries);
+  const formData = FormStore.data.useDebouncedPick(dataModelBindings?.geometries);
 
   return useMemo(() => {
     if (!formData || !Array.isArray(formData)) {

--- a/src/App/frontend/src/layout/Map/features/singleMarker/MapSingleMarker.tsx
+++ b/src/App/frontend/src/layout/Map/features/singleMarker/MapSingleMarker.tsx
@@ -6,7 +6,7 @@ import Icon from 'leaflet/dist/images/marker-icon.png';
 import RetinaIcon from 'leaflet/dist/images/marker-icon-2x.png';
 import IconShadow from 'leaflet/dist/images/marker-shadow.png';
 
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { useSingleMarker } from 'src/layout/Map/features/singleMarker/hooks';
 import { isLocationValid, locationToTuple } from 'src/layout/Map/utils';
 import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
@@ -40,7 +40,7 @@ export function MapSingleMarker({ baseComponentId, readOnly }: MapMarkerProps) {
   const markerLocation = useSingleMarker(baseComponentId);
   const markerLocationIsValid = isLocationValid(markerLocation);
   const dataModelBindings = useDataModelBindingsFor(baseComponentId, 'Map');
-  const setLeafValue = FD.useSetLeafValue();
+  const setLeafValue = FormStore.data.useSetLeafValue();
 
   const setMarkerLocation = useCallback(
     ({ latitude, longitude }: Location) => {

--- a/src/App/frontend/src/layout/Map/features/singleMarker/hooks.ts
+++ b/src/App/frontend/src/layout/Map/features/singleMarker/hooks.ts
@@ -1,10 +1,10 @@
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { parseLocation } from 'src/layout/Map/utils';
 import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 
 export function useSingleMarker(baseComponentId: string) {
   const dataModelBindings = useDataModelBindingsFor(baseComponentId, 'Map');
   const markerBinding = dataModelBindings.simpleBinding;
-  const rawLocation = FD.useCurrentPick(markerBinding);
+  const rawLocation = FormStore.data.useCurrentPick(markerBinding);
   return typeof rawLocation === 'string' ? parseLocation(rawLocation) : undefined;
 }

--- a/src/App/frontend/src/layout/MultipleSelect/MultipleSelectComponent.tsx
+++ b/src/App/frontend/src/layout/MultipleSelect/MultipleSelectComponent.tsx
@@ -7,7 +7,7 @@ import { AltinnSpinner } from 'src/components/AltinnSpinner';
 import { getDescriptionId } from 'src/components/label/Label';
 import { DeleteWarningPopover } from 'src/features/alertOnChange/DeleteWarningPopover';
 import { useAlertOnChange } from 'src/features/alertOnChange/useAlertOnChange';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useGetOptions } from 'src/features/options/useGetOptions';
@@ -37,7 +37,7 @@ export function MultipleSelectComponent({
   const groupBinding = useSaveValueToGroup(dataModelBindings);
   const selectedValues = groupBinding.enabled ? groupBinding.selectedValues : selectedFromSimpleBinding;
 
-  const debounce = FD.useDebounceImmediately();
+  const debounce = FormStore.data.useDebounceImmediately();
   const { langAsString, lang } = useLanguage();
 
   const selectedLabels = selectedValues.map((value) => {

--- a/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
+++ b/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
@@ -5,7 +5,7 @@ import { Button } from 'src/app-components/Button/Button';
 import { SearchParams } from 'src/core/routing/types';
 import { useResetScrollPosition } from 'src/core/ui/useResetScrollPosition';
 import { useHasPendingAttachments } from 'src/features/attachments/hooks';
-import { useReturnToView, useSummaryNodeIdOfOrigin } from 'src/features/form/layout/PageNavigationContext';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -27,7 +27,7 @@ import type { PropsFromGenericComponent } from 'src/layout';
 type Props = Pick<PropsFromGenericComponent<'NavigationButtons'>, 'baseComponentId'>;
 
 export function NavigationButtonsComponent({ baseComponentId }: Props) {
-  const summaryNodeId = useSummaryNodeIdOfOrigin();
+  const summaryNodeId = FormStore.pageNavigation.useSummaryNodeIdOfOrigin();
   const { baseComponentId: summaryBaseComponentId } = splitDashedKey(summaryNodeId ?? '');
   const layoutLookups = FormBootstrap.useLayoutLookups();
   const origin = summaryBaseComponentId ? layoutLookups.getComponent(summaryBaseComponentId) : undefined;
@@ -78,7 +78,7 @@ function NavigationButtonsComponentInner({
   const { navigateToNextPage, navigateToPreviousPage, navigateToPage, maybeSaveOnPageChange } = useNavigatePage();
   const hasNext = !!useNextPageKey();
   const hasPrevious = !!usePreviousPageKey();
-  const returnToView = useReturnToView();
+  const returnToView = FormStore.pageNavigation.useReturnToView();
   const { langAsString } = useLanguage();
 
   const [searchParams] = useSearchParams();

--- a/src/App/frontend/src/layout/PDFPreviewButton/PDFPreviewButtonComponent.tsx
+++ b/src/App/frontend/src/layout/PDFPreviewButton/PDFPreviewButtonComponent.tsx
@@ -3,14 +3,14 @@ import React, { useEffect } from 'react';
 import type { PropsFromGenericComponent } from '..';
 
 import { PDFGeneratorPreview } from 'src/components/PDFGeneratorPreview/PDFGeneratorPreview';
+import { FormStore } from 'src/features/form/FormContext';
 import { useStrictInstanceId } from 'src/features/instance/InstanceContext';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { NodeValidationProps } from 'src/layout/layout';
 
 export function PDFPreviewButtonRenderLayoutValidator({ intermediateItem }: NodeValidationProps<'PDFPreviewButton'>) {
   const instanceId = useStrictInstanceId();
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
 
   useEffect(() => {
     if (!instanceId) {

--- a/src/App/frontend/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
+++ b/src/App/frontend/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useRef } from 'react';
 
 import deepEqual from 'fast-deep-equal';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useOrderDetails, useRefetchOrderDetails } from 'src/features/payment/OrderDetailsProvider';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';
 import { PaymentDetailsTable } from 'src/layout/PaymentDetails/PaymentDetailsTable';
@@ -15,9 +15,9 @@ export function PaymentDetailsComponent({ baseComponentId }: PropsFromGenericCom
   const refetchOrderDetails = useRefetchOrderDetails();
   const { mapping, textResourceBindings } = useItemWhenType(baseComponentId, 'PaymentDetails');
   const { title, description } = textResourceBindings || {};
-  const hasUnsavedChanges = FD.useHasUnsavedChanges();
+  const hasUnsavedChanges = FormStore.data.useHasUnsavedChanges();
 
-  const mappedValues = FD.useMapping(mapping, FormBootstrap.useDefaultDataType());
+  const mappedValues = FormStore.data.useMapping(mapping, FormBootstrap.useDefaultDataType());
   const prevMappedValues = useRef<Record<string, unknown> | undefined>(undefined);
 
   // refetch data if we have configured mapping and the mapped values have changed

--- a/src/App/frontend/src/layout/RepeatingGroup/Pagination/RepeatingGroupPagination.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Pagination/RepeatingGroupPagination.tsx
@@ -5,6 +5,7 @@ import type { UsePaginationProps } from '@digdir/designsystemet-react';
 
 import { ConditionalWrapper } from 'src/app-components/ConditionalWrapper/ConditionalWrapper';
 import { useResetScrollPosition } from 'src/core/ui/useResetScrollPosition';
+import { FormStore } from 'src/features/form/FormContext';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useIsMini, useIsMobile, useIsMobileOrTablet } from 'src/hooks/useDeviceWidths';
 import classes from 'src/layout/RepeatingGroup/Pagination/RepeatingGroupPagination.module.css';
@@ -16,7 +17,6 @@ import {
 } from 'src/layout/RepeatingGroup/Providers/RepeatingGroupContext';
 import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { useIndexedId } from 'src/utils/layout/DataModelLocation';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import { splitDashedKey } from 'src/utils/splitDashedKey';
 interface RepeatingGroupPaginationProps {
@@ -188,7 +188,7 @@ function PaginationComponent({
  */
 function usePagesWithErrors(rowsPerPage: number | undefined, baseComponentId: string): number[] {
   const rows = RepGroupHooks.useAllRowsWithHidden(baseComponentId);
-  const deepValidations = NodesInternal.useVisibleValidationsDeep(
+  const deepValidations = FormStore.nodes.useVisibleValidationsDeep(
     baseComponentId,
     'visible',
     false,

--- a/src/App/frontend/src/layout/RepeatingGroup/Providers/OpenByDefaultProvider.test.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Providers/OpenByDefaultProvider.test.tsx
@@ -6,7 +6,7 @@ import { userEvent } from '@testing-library/user-event';
 import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';
 import { defaultMockDataElementId, getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';
 import { defaultDataTypeMock } from 'src/__mocks__/getUiConfigMock';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { ALTINN_ROW_ID, IDataModelMultiPatchResponse } from 'src/features/formData/types';
 import {
   RepeatingGroupProvider,
@@ -39,7 +39,7 @@ describe('openByDefault', () => {
     const deleteRow = RepGroupContext.useDeleteRow();
     const { visibleRows, hiddenRows } = useRepeatingGroupRowState();
 
-    const data = FD.useDebouncedPick({ field: 'MyGroup', dataType: defaultDataTypeMock });
+    const data = FormStore.data.useDebouncedPick({ field: 'MyGroup', dataType: defaultDataTypeMock });
     return (
       <>
         <div data-testid='state'>

--- a/src/App/frontend/src/layout/RepeatingGroup/Providers/RepeatingGroupContext.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Providers/RepeatingGroupContext.tsx
@@ -6,8 +6,8 @@ import { createStore } from 'zustand';
 
 import { createZustandContext } from 'src/core/contexts/zustandContext';
 import { useAttachmentDeletionInRepGroups } from 'src/features/attachments/useAttachmentDeletionInRepGroups';
+import { FormStore } from 'src/features/form/FormContext';
 import { usePageSettings } from 'src/features/form/layoutSettings/processLayoutSettings';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { ALTINN_ROW_ID } from 'src/features/formData/types';
 import { useOnGroupCloseValidation } from 'src/features/validation/callbacks/onGroupCloseValidation';
 import { OpenByDefaultProvider } from 'src/layout/RepeatingGroup/Providers/OpenByDefaultProvider';
@@ -502,8 +502,8 @@ export const RepGroupContext = {
 
     const groupBinding = useDataModelBindingsFor(baseComponentId, 'RepeatingGroup')?.group;
     const autoSaving = usePageSettings().autoSaveBehavior !== 'onChangePage';
-    const waitUntilSaved = FD.useWaitForSave();
-    const appendToList = FD.useAppendToList();
+    const waitUntilSaved = FormStore.data.useWaitForSave();
+    const appendToList = FormStore.data.useAppendToList();
     const getRows = RepGroupHooks.useGetFreshRowsWithButtons(baseComponentId);
     const getState = () => produceStateFromRows(getRows() ?? []);
 
@@ -553,7 +553,7 @@ export const RepGroupContext = {
     const rawEndDeletingRow = ZStore.useStaticSelector((state) => state.endDeletingRow);
 
     const groupBinding = useDataModelBindingsFor(baseComponentId, 'RepeatingGroup')?.group;
-    const removeFromList = FD.useRemoveFromListCallback();
+    const removeFromList = FormStore.data.useRemoveFromListCallback();
     const onBeforeRowDeletion = useAttachmentDeletionInRepGroups(baseComponentId);
     const getRows = RepGroupHooks.useGetFreshRowsWithButtons(baseComponentId);
     const getState = () => produceStateFromRows(getRows() ?? []);

--- a/src/App/frontend/src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext.tsx
@@ -4,9 +4,9 @@ import type { PropsWithChildren } from 'react';
 
 import { createContext } from 'src/core/contexts/context';
 import { SearchParams } from 'src/core/routing/types';
+import { FormStore } from 'src/features/form/FormContext';
 import { isRepeatingComponentType } from 'src/features/form/layout/utils/repeating';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import {
   RepGroupContext,
   useRepeatingGroupComponentId,
@@ -109,7 +109,7 @@ function useNavigateToRepeatingGroupPageAndFocusRow() {
   const openForEditing = RepGroupContext.useOpenForEditing();
   const changePageToRow = RepGroupContext.useChangePageToRow();
   const { dataModelBindings, pagination, tableColumns, edit } = useIntermediateItem(baseComponentId, 'RepeatingGroup');
-  const rowsSelector = FD.useDebouncedRowsSelector();
+  const rowsSelector = FormStore.data.useDebouncedRowsSelector();
   const layoutLookups = FormBootstrap.useLayoutLookups();
   const [searchParams] = useSearchParams();
 

--- a/src/App/frontend/src/layout/RepeatingGroup/Summary/LargeRowSummaryContainer.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Summary/LargeRowSummaryContainer.tsx
@@ -4,6 +4,7 @@ import type { JSX } from 'react';
 import { Fieldset, Heading } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { Lang } from 'src/features/language/Lang';
 import classes from 'src/layout/RepeatingGroup/Summary/LargeGroupSummaryContainer.module.css';
@@ -11,7 +12,6 @@ import { RepGroupHooks } from 'src/layout/RepeatingGroup/utils';
 import { pageBreakStyles } from 'src/utils/formComponentUtils';
 import { useComponentIdMutator, useIndexedId } from 'src/utils/layout/DataModelLocation';
 import { useIsHiddenMulti } from 'src/utils/layout/hidden';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { HeadingLevel } from 'src/layout/common.generated';
 
@@ -38,7 +38,7 @@ export function LargeRowSummaryContainer({
 }: IDisplayRepAsLargeGroup) {
   const item = useItemWhenType(baseComponentId, 'RepeatingGroup');
   const indexedId = useIndexedId(baseComponentId, true);
-  const depth = NodesInternal.useSelector((state) => state.nodeData?.[indexedId]?.depth);
+  const depth = FormStore.raw.useSelector((state) => state.nodes.nodeData?.[indexedId]?.depth);
   const layoutLookups = FormBootstrap.useLayoutLookups();
   const children = RepGroupHooks.useChildIds(baseComponentId);
   const isHidden = useIsHiddenMulti(children);

--- a/src/App/frontend/src/layout/RepeatingGroup/utils.ts
+++ b/src/App/frontend/src/layout/RepeatingGroup/utils.ts
@@ -3,8 +3,8 @@ import { useCallback, useMemo } from 'react';
 import { evalExpr } from 'src/features/expressions';
 import { ExprVal } from 'src/features/expressions/types';
 import { ExprValidation } from 'src/features/expressions/validation';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useMemoDeepEqual } from 'src/hooks/useStateDeepEqual';
 import { getComponentDef } from 'src/layout';
 import { CompCategory } from 'src/layout/common';
@@ -167,7 +167,7 @@ function collectEditableChildren(
 export const RepGroupHooks = {
   useAllBaseRows(baseComponentId: string) {
     const groupBinding = useDataModelBindingsFor(baseComponentId, 'RepeatingGroup')?.group;
-    return FD.useFreshRows(groupBinding);
+    return FormStore.data.useFreshRows(groupBinding);
   },
 
   useAllRowsWithHidden(baseComponentId: string): RepGroupRow[] {
@@ -221,7 +221,7 @@ export const RepGroupHooks = {
     const editButton = component?.edit?.editButton;
     const deleteButton = component?.edit?.deleteButton;
     const dataSources = useExpressionDataSources({ hiddenRow, editButton, deleteButton });
-    const getFreshRows = FD.useGetFreshRows();
+    const getFreshRows = FormStore.data.useGetFreshRows();
 
     return useCallback(() => {
       const freshRows = getFreshRows(groupBinding);

--- a/src/App/frontend/src/layout/SigningActions/ValidateSigningTaskType.tsx
+++ b/src/App/frontend/src/layout/SigningActions/ValidateSigningTaskType.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
 
 import { useTaskOverrides } from 'src/core/contexts/TaskOverrides';
+import { FormStore } from 'src/features/form/FormContext';
 import { useProcessQuery, useTaskTypeFromBackend } from 'src/features/instance/useProcessQuery';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useNavigationParam } from 'src/hooks/navigation';
 import { ProcessTaskType } from 'src/types';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { NodeValidationProps } from 'src/layout/layout';
 
 type Props = NodeValidationProps<'SigningActions' | 'SigningDocumentList' | 'SigneeList'>;
@@ -13,7 +13,7 @@ type Props = NodeValidationProps<'SigningActions' | 'SigningDocumentList' | 'Sig
 export function ValidateSigningTaskType(props: Props) {
   const currentTaskType = useTaskTypeFromBackend();
   const isInCurrentTask = useIsInCurrentTask();
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
   const { langAsString } = useLanguage();
   const error = langAsString('signing.wrong_task_error', [props.intermediateItem.type]);
 

--- a/src/App/frontend/src/layout/SimpleTable/SimpleTableComponent.tsx
+++ b/src/App/frontend/src/layout/SimpleTable/SimpleTableComponent.tsx
@@ -8,8 +8,8 @@ import { FieldRenderer } from 'src/app-components/DynamicForm/DynamicForm';
 import { AppTable } from 'src/app-components/Table/Table';
 import { translationKey } from 'src/AppComponentsBridge';
 import { Caption } from 'src/components/form/caption/Caption';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { Lang } from 'src/features/language/Lang';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
@@ -35,7 +35,7 @@ export function SimpleTableComponent({ baseComponentId, dataModelBindings }: Tab
     'SimpleTable',
   );
   const { formData } = useDataModelBindings(dataModelBindings, 1, 'raw');
-  const removeFromList = FD.useRemoveFromListCallback();
+  const removeFromList = FormStore.data.useRemoveFromListCallback();
   const { title, description, help } = textResourceBindings ?? {};
   const { elementAsString } = useLanguage();
   const accessibleTitle = elementAsString(title);
@@ -44,7 +44,7 @@ export function SimpleTableComponent({ baseComponentId, dataModelBindings }: Tab
   const schemaLookup = FormBootstrap.useSchemaLookup();
   const [showEdit, setShowEdit] = useState(false);
   const [editItemIndex, setEditItemIndex] = useState<number>(-1);
-  const setMultiLeafValues = FD.useSetMultiLeafValues();
+  const setMultiLeafValues = FormStore.data.useSetMultiLeafValues();
   const languageLocale = useCurrentLanguage();
   const { langAsString } = useLanguage();
 

--- a/src/App/frontend/src/layout/SimpleTable/SimpleTableFeatureFlagLayoutValidator.tsx
+++ b/src/App/frontend/src/layout/SimpleTable/SimpleTableFeatureFlagLayoutValidator.tsx
@@ -1,11 +1,11 @@
+import { FormStore } from 'src/features/form/FormContext';
 import { getFeature } from 'src/features/toggles';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { NodeValidationProps } from 'src/layout/layout';
 
 export function SimpleTableFeatureFlagLayoutValidator({ intermediateItem }: NodeValidationProps<'SimpleTable'>) {
   const simpleTableEnabled = getFeature('simpleTableEnabled');
 
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
   if (!simpleTableEnabled.value) {
     const error = `You need to enable the feature flag simpleTableEnabled to use this component. Please note that the component is experimental
 

--- a/src/App/frontend/src/layout/Subform/SubformComponent.tsx
+++ b/src/App/frontend/src/layout/Subform/SubformComponent.tsx
@@ -11,8 +11,8 @@ import { Flex } from 'src/app-components/Flex/Flex';
 import { Spinner } from 'src/app-components/loading/Spinner/Spinner';
 import { translationKey } from 'src/AppComponentsBridge';
 import { Caption } from 'src/components/form/caption/Caption';
+import { FormStore } from 'src/features/form/FormContext';
 import { getDefaultDataTypeFromUiFolder } from 'src/features/form/ui';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useInstanceDataElements } from 'src/features/instance/InstanceContext';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -58,7 +58,7 @@ export function SubformComponent({ baseComponentId }: PropsFromGenericComponent<
   const subformEntries = useInstanceDataElements(dataType);
 
   const { enterSubform } = useNavigatePage();
-  const lock = FD.useLocking(id);
+  const lock = FormStore.data.useLocking(id);
   const performProcess = useProcessingMutation('add-subform');
   const isAdding = useIsThisProcessing('add-subform');
   const isAddingDisabled = useIsAnyProcessing();

--- a/src/App/frontend/src/layout/Subform/SubformValidator.tsx
+++ b/src/App/frontend/src/layout/Subform/SubformValidator.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
 
 import { getApplicationMetadata } from 'src/features/applicationMetadata';
+import { FormStore } from 'src/features/form/FormContext';
 import { getDefaultDataTypeFromUiFolder } from 'src/features/form/ui';
 import { useLanguage } from 'src/features/language/useLanguage';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { NodeValidationProps } from 'src/layout/layout';
 
 export function SubformValidator(props: NodeValidationProps<'Subform'>) {
@@ -16,7 +16,7 @@ export function SubformValidator(props: NodeValidationProps<'Subform'>) {
     (x) => x.id.toLocaleLowerCase() === targetType?.toLocaleLowerCase(),
   );
 
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
 
   useEffect(() => {
     let error: string | null = null;

--- a/src/App/frontend/src/layout/Subform/useValidateSubform.ts
+++ b/src/App/frontend/src/layout/Subform/useValidateSubform.ts
@@ -1,8 +1,8 @@
 import { getApplicationMetadata } from 'src/features/applicationMetadata';
+import { FormStore } from 'src/features/form/FormContext';
 import { getUiFolderSettings } from 'src/features/form/ui';
 import { useInstanceDataElements } from 'src/features/instance/InstanceContext';
 import { FrontendValidationSource, ValidationMask } from 'src/features/validation';
-import { Validation } from 'src/features/validation/validationContext';
 import { useExternalItem } from 'src/utils/layout/hooks';
 import type { ComponentValidation, SubformValidation } from 'src/features/validation';
 
@@ -19,7 +19,7 @@ export function useValidateSubform(baseComponentId: string): ComponentValidation
     throw new Error(`Default data type not found for ui folder with name ${layoutSetName}`);
   }
   const elements = useInstanceDataElements(targetType);
-  const subformIdsWithError = Validation.useDataElementsWithErrors(elements.map((dE) => dE.id));
+  const subformIdsWithError = FormStore.validation.useDataElementsWithErrors(elements.map((dE) => dE.id));
   const dataTypeDefinition = applicationMetadata.dataTypes.find((x) => x.id === targetType);
   if (dataTypeDefinition === undefined) {
     return [];

--- a/src/App/frontend/src/layout/Subform/utils.ts
+++ b/src/App/frontend/src/layout/Subform/utils.ts
@@ -5,8 +5,8 @@ import dot from 'dot-object';
 import { evalExpr } from 'src/features/expressions';
 import { ExprVal } from 'src/features/expressions/types';
 import { ExprValidation } from 'src/features/expressions/validation';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useFormDataQuery } from 'src/features/formData/useFormDataQuery';
 import { useStrictInstanceId } from 'src/features/instance/InstanceContext';
 import { useInnerLanguageWithForcedPathSelector } from 'src/features/language/useLanguage';
@@ -42,7 +42,7 @@ function useDataModelNamesForSubform(dataType: string) {
 }
 
 function useFormDataSelectorForSubform(dataType: string, subformData: unknown) {
-  const formDataSelector = FD.useDebouncedSelector();
+  const formDataSelector = FormStore.data.useDebouncedSelector();
   return useCallback(
     (reference: IDataModelReference) => {
       if (reference.dataType !== dataType) {

--- a/src/App/frontend/src/layout/Summary/SummaryComponent.tsx
+++ b/src/App/frontend/src/layout/Summary/SummaryComponent.tsx
@@ -4,7 +4,7 @@ import cn from 'classnames';
 
 import { Flex } from 'src/app-components/Flex/Flex';
 import { ErrorPaper } from 'src/components/message/ErrorPaper';
-import { useSetReturnToView, useSetSummaryNodeOfOrigin } from 'src/features/form/layout/PageNavigationContext';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
@@ -136,8 +136,8 @@ const SummaryComponentInner = React.forwardRef(function (
   const errors = validationsOfSeverity(validations, 'error');
 
   const navigateToComponent = useNavigateToComponent();
-  const setReturnToView = useSetReturnToView();
-  const setNodeOfOrigin = useSetSummaryNodeOfOrigin();
+  const setReturnToView = FormStore.pageNavigation.useSetReturnToView();
+  const setNodeOfOrigin = FormStore.pageNavigation.useSetSummaryNodeOfOrigin();
 
   const onChangeClick = async () => {
     if (!targetView) {

--- a/src/App/frontend/src/layout/Summary/ValidateSummary.tsx
+++ b/src/App/frontend/src/layout/Summary/ValidateSummary.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { NodeValidationProps } from 'src/layout/layout';
 
 export function ValidateSummary({ intermediateItem, externalItem }: NodeValidationProps<'Summary'>) {
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
   const targetType = FormBootstrap.useLayoutLookups().allComponents[externalItem.componentRef]?.type;
 
   useEffect(() => {

--- a/src/App/frontend/src/layout/Summary2/CommonSummaryComponents/EditButton.tsx
+++ b/src/App/frontend/src/layout/Summary2/CommonSummaryComponents/EditButton.tsx
@@ -5,7 +5,7 @@ import { PencilIcon } from '@navikt/aksel-icons';
 import { Button } from 'src/app-components/Button/Button';
 import { translationKey } from 'src/AppComponentsBridge';
 import { useTaskOverrides } from 'src/core/contexts/TaskOverrides';
-import { useSetReturnToView, useSetSummaryNodeOfOrigin } from 'src/features/form/layout/PageNavigationContext';
+import { FormStore } from 'src/features/form/FormContext';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { usePdfModeActive } from 'src/features/pdf/PdfWrapper';
@@ -57,8 +57,8 @@ export function EditButton({
 }: EditButtonProps) {
   const navigateToComponent = useNavigateToComponent();
   const { langAsString } = useLanguage();
-  const setReturnToView = useSetReturnToView();
-  const setNodeOfOrigin = useSetSummaryNodeOfOrigin();
+  const setReturnToView = FormStore.pageNavigation.useSetReturnToView();
+  const setNodeOfOrigin = FormStore.pageNavigation.useSetSummaryNodeOfOrigin();
   const currentPageId = useCurrentView();
   const pdfModeActive = usePdfModeActive();
   const isMobile = useIsMobile();

--- a/src/App/frontend/src/layout/Summary2/SummaryComponent2/LayoutValidator.tsx
+++ b/src/App/frontend/src/layout/Summary2/SummaryComponent2/LayoutValidator.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo } from 'react';
 
-import { NodesInternal } from 'src/utils/layout/NodesContext';
+import { FormStore } from 'src/features/form/FormContext';
 import type { NodeValidationProps } from 'src/layout/layout';
 
 export function Summary2LayoutValidator({ intermediateItem, externalItem }: NodeValidationProps<'Summary2'>) {
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
 
   const errors = useMemo(() => {
     const errors: string[] = [];

--- a/src/App/frontend/src/layout/Summary2/isEmpty/isEmptyComponent.ts
+++ b/src/App/frontend/src/layout/Summary2/isEmpty/isEmptyComponent.ts
@@ -1,9 +1,9 @@
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 
 function useHasDataInBindings(baseComponentId: string) {
   const dataModelBindings = useDataModelBindingsFor(baseComponentId);
-  const formData = FD.useFreshBindings(dataModelBindings, 'raw');
+  const formData = FormStore.data.useFreshBindings(dataModelBindings, 'raw');
 
   // Checks if there is data in any of the data model binding
   return Object.values(formData).some((value) => value !== undefined && value !== null && value !== '');

--- a/src/App/frontend/src/layout/TextArea/TextAreaComponent.tsx
+++ b/src/App/frontend/src/layout/TextArea/TextAreaComponent.tsx
@@ -4,7 +4,7 @@ import { Label } from 'src/app-components/Label/Label';
 import { TextArea } from 'src/app-components/TextArea/TextArea';
 import { translationKey } from 'src/AppComponentsBridge';
 import { getDescriptionId } from 'src/components/label/Label';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { useIsValid } from 'src/features/validation/selectors/isValid';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';
@@ -36,7 +36,7 @@ export function TextAreaComponent({ baseComponentId, overrideDisplay }: ITextAre
     formData: { simpleBinding: value },
     setValue,
   } = useDataModelBindings(dataModelBindings, saveWhileTyping);
-  const debounce = FD.useDebounceImmediately();
+  const debounce = FormStore.data.useDebounceImmediately();
 
   const { labelText, getRequiredComponent, getOptionalComponent, getHelpTextComponent, getDescriptionComponent } =
     useLabel({ baseComponentId, overrideDisplay });

--- a/src/App/frontend/src/layout/TimePicker/useTimePickerValidation.ts
+++ b/src/App/frontend/src/layout/TimePicker/useTimePickerValidation.ts
@@ -1,5 +1,5 @@
 import { parseTimeString } from 'src/app-components/TimePicker/utils/timeConstraintUtils';
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { type ComponentValidation, FrontendValidationSource, ValidationMask } from 'src/features/validation';
 import { useDataModelBindingsFor } from 'src/utils/layout/hooks';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
@@ -56,7 +56,7 @@ const timeToSeconds = (time: TimeValue): number => time.hours * 3600 + time.minu
 export function useTimePickerValidation(baseComponentId: string): ComponentValidation[] {
   const field = useDataModelBindingsFor(baseComponentId, 'TimePicker')?.simpleBinding;
   const component = useItemWhenType(baseComponentId, 'TimePicker');
-  const data = FD.useDebouncedPick(field);
+  const data = FormStore.data.useDebouncedPick(field);
   const { minTime, maxTime, format = 'HH:mm' } = component || {};
 
   const timeString = typeof data === 'string' || typeof data === 'number' ? String(data) : undefined;

--- a/src/App/frontend/src/test/renderWithProviders.tsx
+++ b/src/App/frontend/src/test/renderWithProviders.tsx
@@ -22,7 +22,6 @@ import { ApiProvider } from 'src/core/contexts/ApiProvider';
 import { AppQueriesProvider } from 'src/core/contexts/AppQueriesProvider';
 import { RenderStart } from 'src/core/ui/RenderStart';
 import { FormProvider } from 'src/features/form/FormProvider';
-import { PageNavigationProvider } from 'src/features/form/layout/PageNavigationContext';
 import { UiConfigProvider } from 'src/features/form/layout/UiConfigContext';
 import { FormBootstrapResponse } from 'src/features/formBootstrap/types';
 import { GlobalFormDataReadersProvider } from 'src/features/formData/FormDataReaders';
@@ -200,7 +199,6 @@ export const makeFormDataMethodProxies = (
     lock: makeProxy('lock', ref),
     nextLock: makeProxy('nextLock', ref),
     requestManualSave: makeProxy('requestManualSave', ref),
-    setLastValidationIssues: makeProxy('setLastValidationIssues', ref),
   };
 
   const proxies: FormDataWriteProxies = Object.fromEntries(
@@ -323,17 +321,15 @@ function DefaultProviders({ children, queries, apis, queryClient, Router = Defau
         queryClient={queryClient}
       >
         <UiConfigProvider>
-          <PageNavigationProvider>
-            <Router>
-              <AppComponentsBridge>
-                <NavigationEffectProvider>
-                  <GlobalFormDataReadersProvider>
-                    <PartyProvider>{children}</PartyProvider>
-                  </GlobalFormDataReadersProvider>
-                </NavigationEffectProvider>
-              </AppComponentsBridge>
-            </Router>
-          </PageNavigationProvider>
+          <Router>
+            <AppComponentsBridge>
+              <NavigationEffectProvider>
+                <GlobalFormDataReadersProvider>
+                  <PartyProvider>{children}</PartyProvider>
+                </GlobalFormDataReadersProvider>
+              </NavigationEffectProvider>
+            </AppComponentsBridge>
+          </Router>
         </UiConfigProvider>
       </AppQueriesProvider>
     </ApiProvider>

--- a/src/App/frontend/src/utils/layout/ComponentErrorBoundary.tsx
+++ b/src/App/frontend/src/utils/layout/ComponentErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import React, { Component, useEffect } from 'react';
 
-import { NodesInternal } from 'src/utils/layout/NodesContext';
+import { FormStore } from 'src/features/form/FormContext';
 
 interface IErrorBoundary {
   lastError?: Error;
@@ -37,7 +37,7 @@ export class ComponentErrorBoundary extends Component<Props, IErrorBoundary> {
 }
 
 function StoreErrorAndBail({ error, nodeId }: { error: Error; nodeId: string }) {
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
 
   useEffect(() => {
     window.logError(`Exception thrown when rendering node "${nodeId}":\n`, error);

--- a/src/App/frontend/src/utils/layout/DataModelLocation.tsx
+++ b/src/App/frontend/src/utils/layout/DataModelLocation.tsx
@@ -2,8 +2,8 @@ import React, { useCallback, useMemo } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { createContext } from 'src/core/contexts/context';
+import { FormStore } from 'src/features/form/FormContext';
 import { getRepeatingBinding, isRepeatingComponentType } from 'src/features/form/layout/utils/repeating';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { IDataModelReference } from 'src/layout/common.generated';
 import type { IDataModelBindings } from 'src/layout/layout';
 
@@ -43,16 +43,16 @@ export function DataModelLocationProvider({ groupBinding, rowIndex, children }: 
 }
 
 function useDataModelLocationForNodeRaw(nodeId: string | undefined) {
-  return NodesInternal.useMemoSelector((state) => {
+  return FormStore.raw.useMemoSelector((state) => {
     if (!nodeId) {
       return { groupBinding: undefined, rowIndex: undefined };
     }
 
     let childId = nodeId;
-    let parentId = state.nodeData[childId]?.parentId;
+    let parentId = state.nodes.nodeData[childId]?.parentId;
     while (parentId) {
-      const child = state.nodeData[childId];
-      const parent = state.nodeData[parentId];
+      const child = state.nodes.nodeData[childId];
+      const parent = state.nodes.nodeData[parentId];
       const groupBinding = isRepeatingComponentType(parent.nodeType)
         ? getRepeatingBinding(parent.nodeType, parent.dataModelBindings as IDataModelBindings<typeof parent.nodeType>)
         : undefined;
@@ -61,7 +61,7 @@ function useDataModelLocationForNodeRaw(nodeId: string | undefined) {
       }
 
       childId = parentId;
-      parentId = state.nodeData[childId]?.parentId;
+      parentId = state.nodes.nodeData[childId]?.parentId;
     }
 
     return { groupBinding: undefined, rowIndex: undefined };

--- a/src/App/frontend/src/utils/layout/NodesContext.tsx
+++ b/src/App/frontend/src/utils/layout/NodesContext.tsx
@@ -2,23 +2,16 @@ import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react'
 import type { PropsWithChildren, RefObject } from 'react';
 
 import deepEqual from 'fast-deep-equal';
-import { produce } from 'immer';
-import { createStore } from 'zustand';
+import { current } from 'immer';
 import type { UnionToIntersection } from 'utility-types';
-import type { StoreApi } from 'zustand';
 
-import { createZustandContext } from 'src/core/contexts/zustandContext';
 import { Loader } from 'src/core/loading/Loader';
 import { AttachmentsStorePlugin } from 'src/features/attachments/AttachmentsStorePlugin';
 import { UpdateAttachmentsForCypress } from 'src/features/attachments/UpdateAttachmentsForCypress';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { useProcessQuery } from 'src/features/instance/useProcessQuery';
 import { ExpressionValidation } from 'src/features/validation/expressionValidation/ExpressionValidation';
-import {
-  LoadingBlockerWaitForValidation,
-  ProvideWaitForValidation,
-  Validation,
-} from 'src/features/validation/validationContext';
 import { ValidationStorePlugin } from 'src/features/validation/ValidationStorePlugin';
 import { useNavigationParam } from 'src/hooks/navigation';
 import { TaskKeys } from 'src/routesBuilder';
@@ -27,10 +20,10 @@ import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
 import { useRegistry } from 'src/utils/layout/generator/GeneratorStages';
 import { LayoutSetGenerator } from 'src/utils/layout/generator/LayoutSetGenerator';
 import { GeneratorValidationProvider } from 'src/utils/layout/generator/validation/GenerationValidationContext';
+import { nodesProduce } from 'src/utils/layout/nodesProduce';
 import type { AttachmentsStorePluginConfig } from 'src/features/attachments/AttachmentsStorePlugin';
-import type { ValidationsProcessedLast } from 'src/features/validation';
+import type { FormStoreSet, FormStoreState } from 'src/features/form/FormContext';
 import type { ValidationStorePluginConfig } from 'src/features/validation/ValidationStorePlugin';
-import type { ObjectOrArray } from 'src/hooks/useShallowMemo';
 import type { CompTypes, ILayouts } from 'src/layout/layout';
 import type { Registry } from 'src/utils/layout/generator/GeneratorStages';
 import type { NodeDataPlugin } from 'src/utils/layout/plugins/NodeDataPlugin';
@@ -83,7 +76,7 @@ export interface SetNodePropRequest {
   value: unknown;
 }
 
-export type NodesContext = {
+export type NodesSliceState = {
   hasErrors: boolean;
   pagesData: PagesData;
   nodeData: { [key: string]: NodeData };
@@ -95,52 +88,38 @@ export type NodesContext = {
 
   addPage: (pageKey: string) => void;
 
-  reset: (layouts: ILayouts, validationsProcessedLast: ValidationsProcessedLast) => void;
-} & NodesProviderProps &
+  reset: (layouts: ILayouts) => void;
+} & NodesSliceProps &
   ExtraFunctions;
 
-/**
- * Using the inferred types in the immer produce() function here introduces a lot of typescript overhead, which slows
- * down development. Using this instead short-circuits the type-checking to make it fast again.
- */
-export function nodesProduce(fn: (draft: NodesContext) => void) {
-  return produce(fn) as unknown as Partial<NodesContext>;
-}
+const defaultState = {
+  hasErrors: false,
+  pagesData: {
+    type: 'pages' as const,
+    pages: {},
+  },
+  nodeData: {},
+};
 
-interface CreateStoreProps extends NodesProviderProps {
-  validationsProcessedLast: ValidationsProcessedLast;
-}
-
-export type NodesContextStore = StoreApi<NodesContext>;
-export function createNodesDataStore({ validationsProcessedLast, ...props }: CreateStoreProps) {
-  const defaultState = {
-    hasErrors: false,
-    pagesData: {
-      type: 'pages' as const,
-      pages: {},
-    },
-    nodeData: {},
-    validationsProcessedLast,
-  };
-
-  return createStore<NodesContext>((set) => ({
-    ...defaultState,
+export function createNodesSlice(props: NodesSliceProps, set: FormStoreSet): FormStoreState['nodes'] {
+  return {
+    ...structuredClone(defaultState),
     ...props,
 
     layouts: undefined,
 
     addNodes: (requests) =>
       set((state) => {
-        const nodeData = { ...state.nodeData };
+        const nodeData = { ...state.nodes.nodeData };
         for (const { nodeId, targetState } of requests) {
           nodeData[nodeId] = targetState;
         }
 
-        return { nodeData };
+        return { nodes: { ...state.nodes, nodeData } };
       }),
     removeNodes: (requests) =>
       set((state) => {
-        const nodeData = { ...state.nodeData };
+        const nodeData = { ...state.nodes.nodeData };
 
         let count = 0;
         for (const { nodeId, layouts } of requests) {
@@ -148,7 +127,7 @@ export function createNodesDataStore({ validationsProcessedLast, ...props }: Cre
             continue;
           }
 
-          if (layouts !== state.layouts) {
+          if (layouts !== current(state.nodes.layouts)) {
             // The layouts have changed since the request was added, so there's no need to remove the node (it was
             // automatically removed when resetting the NodesContext state upon the layout change)
             continue;
@@ -162,12 +141,12 @@ export function createNodesDataStore({ validationsProcessedLast, ...props }: Cre
           return {};
         }
 
-        return { nodeData };
+        return { nodes: { ...state.nodes, nodeData } };
       }),
     setNodeProps: (requests) =>
       set((state) => {
         let changes = false;
-        const nodeData = { ...state.nodeData };
+        const nodeData = { ...state.nodes.nodeData };
         for (const { nodeId, prop, value } of requests) {
           if (!nodeData[nodeId]) {
             continue;
@@ -183,7 +162,7 @@ export function createNodesDataStore({ validationsProcessedLast, ...props }: Cre
             nodeData[nodeId] = thisNode;
           }
         }
-        return changes ? { nodeData } : {};
+        return changes ? { nodes: { ...state.nodes, nodeData } } : {};
       }),
     addError: (error, id, type) =>
       set(
@@ -215,65 +194,55 @@ export function createNodesDataStore({ validationsProcessedLast, ...props }: Cre
         }),
       ),
 
-    reset: (layouts, validationsProcessedLast: ValidationsProcessedLast) =>
-      set(() => ({ ...structuredClone(defaultState), layouts, validationsProcessedLast })),
+    reset: (layouts) =>
+      set((state) => ({
+        nodes: {
+          ...state.nodes,
+          ...structuredClone(defaultState),
+          ...props,
+          layouts,
+        },
+      })),
 
     ...(Object.values(StorePlugins)
       .map((plugin) => plugin.extraFunctions(set))
       .reduce((acc, val) => ({ ...acc, ...val }), {}) as ExtraFunctions),
-  }));
+  };
 }
 
-const Store = createZustandContext<NodesContextStore, NodesContext>({
-  name: 'Nodes',
-  required: true,
-  initialCreateStore: createNodesDataStore,
-});
-
-export const NodesStore = Store; // Should be considered internal, do not use unless you know what you're doing
-export type NodesStoreFull = typeof Store;
-
-interface NodesProviderProps extends PropsWithChildren {
+export interface NodesSliceProps {
   readOnly: boolean;
   isEmbedded: boolean;
 }
 
-export const NodesProvider = ({ children, ...props }: NodesProviderProps) => {
+export const NodesProvider = ({ children }: PropsWithChildren) => {
   const registry = useRegistry();
-  const getProcessedLast = Validation.useGetProcessedLast();
 
   return (
-    <Store.Provider
-      {...props}
-      validationsProcessedLast={getProcessedLast()}
-    >
-      <ProvideGlobalContext registry={registry}>
-        <GeneratorValidationProvider>
-          <GeneratorData.Provider>
-            <LayoutSetGenerator />
-          </GeneratorData.Provider>
-        </GeneratorValidationProvider>
-        {window.Cypress && <UpdateAttachmentsForCypress />}
-        <ProvideWaitForValidation />
-        <ExpressionValidation />
-        <LoadingBlockerWaitForValidation>{children}</LoadingBlockerWaitForValidation>
-      </ProvideGlobalContext>
-    </Store.Provider>
+    <ProvideGlobalContext registry={registry}>
+      <GeneratorValidationProvider>
+        <GeneratorData.Provider>
+          <LayoutSetGenerator />
+        </GeneratorData.Provider>
+      </GeneratorValidationProvider>
+      {window.Cypress && <UpdateAttachmentsForCypress />}
+      <ExpressionValidation />
+      {children}
+    </ProvideGlobalContext>
   );
 };
 
 function ProvideGlobalContext({ children, registry }: PropsWithChildren<{ registry: RefObject<Registry> }>) {
   const isInTaskTransition = useIsInTaskTransition();
   const latestLayouts = FormBootstrap.useLayouts();
-  const layouts = Store.useSelector((s) => s.layouts);
-  const reset = Store.useSelector((s) => s.reset);
-  const getProcessedLast = Validation.useGetProcessedLast();
+  const layouts = FormStore.raw.useSelector((state) => state.nodes.layouts);
+  const reset = FormStore.raw.useSelector((state) => state.nodes.reset);
 
   useEffect(() => {
     if (layouts !== latestLayouts) {
-      reset(latestLayouts, getProcessedLast());
+      reset(latestLayouts);
     }
-  }, [latestLayouts, layouts, reset, getProcessedLast]);
+  }, [latestLayouts, layouts, reset]);
 
   const addNode = useCallback(
     (req: AddNodeRequest) => {
@@ -335,9 +304,9 @@ function useIsInTaskTransition() {
 }
 
 function AutoCommit({ registry }: { registry: RefObject<Registry> }) {
-  const addNodes = Store.useStaticSelector((s) => s.addNodes);
-  const removeNodes = Store.useStaticSelector((s) => s.removeNodes);
-  const setNodeProps = Store.useStaticSelector((s) => s.setNodeProps);
+  const addNodes = FormStore.raw.useStaticSelector((state) => state.nodes.addNodes);
+  const removeNodes = FormStore.raw.useStaticSelector((state) => state.nodes.removeNodes);
+  const setNodeProps = FormStore.raw.useStaticSelector((state) => state.nodes.setNodeProps);
   const [renderCount, forceRender] = useState(0);
 
   const reg = registry.current;
@@ -372,26 +341,26 @@ function NodesLoader() {
 /**
  * A set of tools, selectors and functions to use internally in node generator components.
  */
-export const NodesInternal = {
+export const nodesHooks = {
   useIsReadOnly() {
-    return Store.useSelector((s) => s.readOnly);
+    return FormStore.raw.useSelector((state) => state.nodes.readOnly);
   },
   useIsEmbedded() {
-    return Store.useSelector((s) => s.isEmbedded);
+    return FormStore.raw.useSelector((state) => state.nodes.isEmbedded);
   },
   useFullErrorList() {
-    return Store.useMemoSelector((s) => {
+    return FormStore.raw.useMemoSelector((s) => {
       const errors: { [pageOrNode: string]: string[] } = {};
 
-      for (const pageKey in s.pagesData.pages) {
-        const page = s.pagesData.pages[pageKey];
+      for (const pageKey in s.nodes.pagesData.pages) {
+        const page = s.nodes.pagesData.pages[pageKey];
         if (page.errors) {
           errors[`page/${pageKey}`] = Object.keys(page.errors);
         }
       }
 
-      for (const nodeId in s.nodeData) {
-        const node = s.nodeData[nodeId];
+      for (const nodeId in s.nodes.nodeData) {
+        const node = s.nodes.nodeData[nodeId];
         if (node.errors) {
           errors[`node/${nodeId}`] = Object.keys(node.errors);
         }
@@ -419,11 +388,11 @@ export const NodesInternal = {
   },
 
   useNodeErrors(nodeId: string | undefined) {
-    return Store.useSelector((s) => {
+    return FormStore.raw.useSelector((s) => {
       if (!nodeId) {
         return undefined;
       }
-      return s.nodeData[nodeId]?.errors;
+      return s.nodes.nodeData[nodeId]?.errors;
     });
   },
   useNodeData<Id extends string | undefined, Type extends CompTypes, Out>(
@@ -431,12 +400,12 @@ export const NodesInternal = {
     type: Type | undefined,
     selector: (nodeData: NodeData<Type>) => Out,
   ) {
-    return Store.useMemoSelector((s) => {
+    return FormStore.raw.useMemoSelector((s) => {
       if (!nodeId) {
         return undefined;
       }
 
-      const data = s.nodeData[nodeId];
+      const data = s.nodes.nodeData[nodeId];
       if (data && type && data.nodeType !== type) {
         throw new Error(`Expected id ${nodeId} to be of type ${type}, but it is of type ${data.nodeType}`);
       }
@@ -445,7 +414,7 @@ export const NodesInternal = {
     }) as Id extends undefined ? Out | undefined : Out;
   },
   useIsAdded: (id: string | undefined, type: 'node' | 'page' | undefined) =>
-    Store.useSelector((s) => {
+    FormStore.raw.useSelector((s) => {
       if (!id) {
         return false;
       }
@@ -453,24 +422,16 @@ export const NodesInternal = {
         throw new Error('useIsAdded() requires an id and a type. When id is given, type has to be given too.');
       }
       if (type === 'page') {
-        return s.pagesData.pages[id] !== undefined;
+        return s.nodes.pagesData.pages[id] !== undefined;
       }
-      return s.nodeData[id] !== undefined;
+      return s.nodes.nodeData[id] !== undefined;
     }),
-  useHasErrors: () => Store.useSelector((s) => s.hasErrors),
+  useHasErrors: () => FormStore.raw.useSelector((state) => state.nodes.hasErrors),
 
-  // Raw selectors, used when there are no other hooks that match your needs
-  useSelector: <T,>(selector: (state: NodesContext) => T) => Store.useSelector(selector),
-  useShallowSelector: <T extends ObjectOrArray>(selector: (state: NodesContext) => T) =>
-    Store.useShallowSelector(selector),
-  useMemoSelector: <T,>(selector: (state: NodesContext) => T) => Store.useMemoSelector(selector),
-  useLaxMemoSelector: <T,>(selector: (state: NodesContext) => T) => Store.useLaxMemoSelector(selector),
-
-  useStore: () => Store.useStore(),
-  useAddPage: () => Store.useStaticSelector((s) => s.addPage),
-  useAddError: () => Store.useStaticSelector((s) => s.addError),
+  useAddPage: () => FormStore.raw.useStaticSelector((state) => state.nodes.addPage),
+  useAddError: () => FormStore.raw.useStaticSelector((state) => state.nodes.addError),
 
   ...(Object.values(StorePlugins)
-    .map((plugin) => plugin.extraHooks(Store))
+    .map((plugin) => plugin.extraHooks())
     .reduce((acc, val) => ({ ...acc, ...val }), {}) as ExtraHooks),
 };

--- a/src/App/frontend/src/utils/layout/all.test.tsx
+++ b/src/App/frontend/src/utils/layout/all.test.tsx
@@ -9,12 +9,12 @@ import type { JSONSchema7 } from 'json-schema';
 import { ignoredConsoleMessages } from 'test/e2e/support/fail-on-console-log';
 
 import { getDataModelBootstrapMock, getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';
+import { FormStore } from 'src/features/form/FormContext';
 import { GenericComponent } from 'src/layout/GenericComponent';
 import { SubformWrapper } from 'src/layout/Subform/SubformWrapper';
 import { fetchProcessState } from 'src/queries/queries';
 import { ensureAppsDirIsSet, getAllApps } from 'src/test/allApps';
 import { renderWithInstanceAndLayout } from 'src/test/renderWithProviders';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { ExternalAppUiFolder } from 'src/test/allApps';
 
 jest.mock('src/features/applicationMetadata');
@@ -42,7 +42,7 @@ const ignoreLogAndErrors = [
 ];
 
 function TestApp() {
-  const errors = NodesInternal.useFullErrorList();
+  const errors = FormStore.nodes.useFullErrorList();
   const filteredErrors: Record<string, string[]> = {};
 
   for (const key in errors) {
@@ -59,8 +59,8 @@ function TestApp() {
 }
 
 function RenderAllComponents() {
-  const state = NodesInternal.useStore().getState();
-  const all = Object.values(state.nodeData)
+  const state = FormStore.raw.useStore().getState();
+  const all = Object.values(state.nodes.nodeData)
     .filter((nodeData) => nodeData.isValid && nodeData.parentId === undefined)
     .map((nodeData) => nodeData.id);
 

--- a/src/App/frontend/src/utils/layout/generator/GeneratorErrorBoundary.tsx
+++ b/src/App/frontend/src/utils/layout/generator/GeneratorErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import React, { Component, useEffect } from 'react';
 import type { PropsWithChildren, RefObject } from 'react';
 
-import { NodesInternal } from 'src/utils/layout/NodesContext';
+import { FormStore } from 'src/features/form/FormContext';
 
 interface IErrorBoundary extends ContextData {
   lastError?: Error;
@@ -49,7 +49,7 @@ export function useGeneratorErrorBoundaryNodeRef() {
 }
 
 function StoreErrorAndBail({ error, ref }: { error: Error; ref: Ref }) {
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
 
   useEffect(() => {
     if (!ref) {

--- a/src/App/frontend/src/utils/layout/generator/GeneratorStages.tsx
+++ b/src/App/frontend/src/utils/layout/generator/GeneratorStages.tsx
@@ -1,8 +1,8 @@
 import { useRef } from 'react';
 import type { PropsWithChildren, SetStateAction } from 'react';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { GeneratorInternal } from 'src/utils/layout/generator/GeneratorContext';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { ValidationsProcessedLast } from 'src/features/validation';
 import type { AddNodeRequest, RemoveNodeRequest, SetNodePropRequest } from 'src/utils/layout/NodesContext';
 
@@ -46,7 +46,7 @@ export function useRegistry() {
  */
 export function WhenParentAdded({ children }: PropsWithChildren) {
   const parent = GeneratorInternal.useParent();
-  const ready = NodesInternal.useIsAdded(parent.indexedId, parent.type);
+  const ready = FormStore.nodes.useIsAdded(parent.indexedId, parent.type);
 
   return ready ? children : null;
 }

--- a/src/App/frontend/src/utils/layout/generator/LayoutSetGenerator.tsx
+++ b/src/App/frontend/src/utils/layout/generator/LayoutSetGenerator.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 
+import { FormStore } from 'src/features/form/FormContext';
 import { usePdfLayoutName, useRawPageOrder } from 'src/features/form/layoutSettings/processLayoutSettings';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { getComponentDef } from 'src/layout';
@@ -9,7 +10,6 @@ import {
   useGeneratorErrorBoundaryNodeRef,
 } from 'src/utils/layout/generator/GeneratorErrorBoundary';
 import { WhenParentAdded } from 'src/utils/layout/generator/GeneratorStages';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { CompExternalExact, CompTypes, ILayout } from 'src/layout/layout';
 import type { NodeGeneratorProps } from 'src/layout/LayoutComponent';
 import type { ChildClaims } from 'src/utils/layout/generator/GeneratorContext';
@@ -83,7 +83,7 @@ interface CommonProps {
 }
 
 function AddPage({ name }: CommonProps) {
-  const addPage = NodesInternal.useAddPage();
+  const addPage = FormStore.nodes.useAddPage();
 
   useEffect(() => {
     addPage(name);

--- a/src/App/frontend/src/utils/layout/generator/NodeGenerator.tsx
+++ b/src/App/frontend/src/utils/layout/generator/NodeGenerator.tsx
@@ -4,13 +4,13 @@ import type { PropsWithChildren } from 'react';
 import { evalExpr } from 'src/features/expressions';
 import { ExprVal } from 'src/features/expressions/types';
 import { ExprValidation } from 'src/features/expressions/validation';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { getComponentCapabilities, getComponentDef } from 'src/layout';
 import { GeneratorInternal, GeneratorNodeProvider } from 'src/utils/layout/generator/GeneratorContext';
 import { useGeneratorErrorBoundaryNodeRef } from 'src/utils/layout/generator/GeneratorErrorBoundary';
 import { WhenParentAdded } from 'src/utils/layout/generator/GeneratorStages';
 import { NodePropertiesValidation } from 'src/utils/layout/generator/validation/NodePropertiesValidation';
-import { NodesInternal, NodesStore } from 'src/utils/layout/NodesContext';
 import type { SimpleEval } from 'src/features/expressions';
 import type { ExprResolved, ExprValToActual, ExprValToActualOrExpr } from 'src/features/expressions/types';
 import type { FormComponentProps, SummarizableComponentProps } from 'src/layout/common.generated';
@@ -115,7 +115,7 @@ function AddRemoveNode<T extends CompTypes>({
     ],
   );
 
-  const isAdded = NodesInternal.useIsAdded(intermediateItem.id, 'node');
+  const isAdded = FormStore.nodes.useIsAdded(intermediateItem.id, 'node');
 
   const def = getComponentDef(intermediateItem.type);
   const addNode = GeneratorInternal.useAddNode();
@@ -123,7 +123,7 @@ function AddRemoveNode<T extends CompTypes>({
 
   // This state is intentionally not reactive, as we want to commit _what the layout was when this node was created_,
   // so that we don't accidentally remove a node with the same ID from a future/different layout.
-  const layoutsWas = NodesStore.useStaticSelector((s) => s.layouts!);
+  const layoutsWas = FormStore.raw.useStaticSelector((state) => state.nodes.layouts!);
 
   useEffect(() => {
     !isAdded &&

--- a/src/App/frontend/src/utils/layout/generator/NodeRepeatingChildren.tsx
+++ b/src/App/frontend/src/utils/layout/generator/NodeRepeatingChildren.tsx
@@ -2,7 +2,7 @@ import React, { Fragment, useMemo } from 'react';
 
 import dot from 'dot-object';
 
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { DataModelLocationProvider } from 'src/utils/layout/DataModelLocation';
 import { GeneratorInternal, GeneratorRowProvider } from 'src/utils/layout/generator/GeneratorContext';
 import { WhenParentAdded } from 'src/utils/layout/generator/GeneratorStages';
@@ -28,7 +28,7 @@ function NodeRepeatingChildrenWorker({ claims }: Props) {
   const multiPageSupport = 'edit.multiPage'; // Hardcoded for RepeatingGroup
   const item = GeneratorInternal.useIntermediateItem();
   const groupBinding = item?.dataModelBindings?.[binding];
-  const numRows = FD.useFreshNumRows(groupBinding);
+  const numRows = FormStore.data.useFreshNumRows(groupBinding);
   const multiPage = multiPageSupport && dot.pick(multiPageSupport, item) === true;
   const multiPageMapping = useMemo(
     () => (multiPage ? makeMultiPageMapping(item?.['children']) : undefined),

--- a/src/App/frontend/src/utils/layout/generator/validation/GenerationValidationContext.tsx
+++ b/src/App/frontend/src/utils/layout/generator/validation/GenerationValidationContext.tsx
@@ -12,8 +12,8 @@ import {
   EMPTY_SCHEMA_NAME,
   LAYOUT_SCHEMA_NAME,
 } from 'src/features/devtools/utils/layoutSchemaValidation';
+import { FormStore } from 'src/features/form/FormContext';
 import { isDev } from 'src/utils/isDev';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 
 interface Context {
   schemaValidator: ValidateFunc | undefined;
@@ -75,7 +75,7 @@ function FetchLayoutSchema({
 function useIsLayoutValidationEnabled() {
   const hasBeenEnabledBefore = useRef(false);
   const panelOpen = useDevToolsStore((s) => s.isOpen);
-  const hasErrors = NodesInternal.useHasErrors();
+  const hasErrors = FormStore.nodes.useHasErrors();
   const enabled = isDev() || hasErrors || panelOpen || hasBeenEnabledBefore.current;
   hasBeenEnabledBefore.current = enabled;
 

--- a/src/App/frontend/src/utils/layout/generator/validation/NodePropertiesValidation.tsx
+++ b/src/App/frontend/src/utils/layout/generator/validation/NodePropertiesValidation.tsx
@@ -2,9 +2,9 @@ import React, { useEffect } from 'react';
 import type { FC } from 'react';
 
 import { formatLayoutSchemaValidationError } from 'src/features/devtools/utils/layoutSchemaValidation';
+import { FormStore } from 'src/features/form/FormContext';
 import { getComponentDef, implementsDataModelBindingValidation } from 'src/layout';
 import { GeneratorValidation } from 'src/utils/layout/generator/validation/GenerationValidationContext';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import { duplicateStringFilter } from 'src/utils/stringHelper';
 import type { CompDef } from 'src/layout';
 import type { CompTypes, NodeValidationProps } from 'src/layout/layout';
@@ -27,7 +27,7 @@ export function NodePropertiesValidation<T extends CompTypes>(props: NodeValidat
 
 const emptyArray: never[] = [];
 function DataModelValidation<T extends CompTypes>({ externalItem, intermediateItem }: NodeValidationProps<T>) {
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
   const def = getComponentDef(intermediateItem.type);
   const errors =
     implementsDataModelBindingValidation(def, intermediateItem) && window.forceNodePropertiesValidation !== 'off'
@@ -53,7 +53,7 @@ function DataModelValidation<T extends CompTypes>({ externalItem, intermediateIt
 
 function SchemaValidation<T extends CompTypes>({ intermediateItem, externalItem }: NodeValidationProps<T>) {
   const validate = GeneratorValidation.useValidate();
-  const addError = NodesInternal.useAddError();
+  const addError = FormStore.nodes.useAddError();
 
   useEffect(() => {
     if (!validate) {

--- a/src/App/frontend/src/utils/layout/nodesProduce.ts
+++ b/src/App/frontend/src/utils/layout/nodesProduce.ts
@@ -1,0 +1,13 @@
+import { produce } from 'immer';
+
+import type { FormStoreState } from 'src/features/form/FormContext';
+
+/**
+ * Using the inferred types in the immer produce() function here introduces a lot of typescript overhead, which slows
+ * down development. Using this instead short-circuits the type-checking to make it fast again.
+ */
+export function nodesProduce(fn: (draft: FormStoreState['nodes']) => void) {
+  return produce((draft: FormStoreState) => {
+    fn(draft.nodes);
+  }) as unknown as (state: FormStoreState) => FormStoreState;
+}

--- a/src/App/frontend/src/utils/layout/plugins/NodeDataPlugin.tsx
+++ b/src/App/frontend/src/utils/layout/plugins/NodeDataPlugin.tsx
@@ -1,4 +1,4 @@
-import type { NodesContext, NodesStoreFull } from 'src/utils/layout/NodesContext';
+import type { FormStoreSet } from 'src/features/form/FormContext';
 
 interface NodeDataPluginConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -7,11 +7,7 @@ interface NodeDataPluginConfig {
   extraHooks?: Record<string, (...args: any[]) => any>;
 }
 
-export type NodeDataPluginSetState = (
-  fnOrState: ((state: NodesContext) => Partial<NodesContext>) | Partial<NodesContext>,
-) => void;
-
 export abstract class NodeDataPlugin<Config extends NodeDataPluginConfig> {
-  abstract extraFunctions(set: NodeDataPluginSetState): Config['extraFunctions'];
-  abstract extraHooks(store: NodesStoreFull): Config['extraHooks'];
+  abstract extraFunctions(set: FormStoreSet): Config['extraFunctions'];
+  abstract extraHooks(): Config['extraHooks'];
 }

--- a/src/App/frontend/src/utils/layout/useExpressionDataSources.ts
+++ b/src/App/frontend/src/utils/layout/useExpressionDataSources.ts
@@ -6,8 +6,8 @@ import { useApplicationSettings } from 'src/features/applicationSettings/Applica
 import { useDisplayDataFor } from 'src/features/displayData/useDisplayData';
 import { ExprFunctionDefinitions } from 'src/features/expressions/expression-functions';
 import { useExternalApis } from 'src/features/externalApi/useExternalApi';
+import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
-import { FD } from 'src/features/formData/FormDataWrite';
 import { useDataElementsSelectorProps, useInstanceDataSources } from 'src/features/instance/InstanceContext';
 import { useProcessQuery } from 'src/features/instance/useProcessQuery';
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
@@ -19,7 +19,6 @@ import { useCurrentDataModelLocation } from 'src/utils/layout/DataModelLocation'
 import { GeneratorInternal } from 'src/utils/layout/generator/GeneratorContext';
 import { GeneratorData } from 'src/utils/layout/generator/GeneratorDataSources';
 import { useIsHiddenMulti } from 'src/utils/layout/hidden';
-import { NodesInternal } from 'src/utils/layout/NodesContext';
 import type { AttachmentsSelector } from 'src/features/attachments/tools';
 import type { ExprFunctionName } from 'src/features/expressions/types';
 import type { ExternalApisResult } from 'src/features/externalApi/useExternalApi';
@@ -52,8 +51,8 @@ export interface ExpressionDataSources {
 }
 
 const multiSelectors = {
-  formDataSelector: () => FD.useLaxDebouncedSelectorProps(),
-  attachmentsSelector: () => NodesInternal.useAttachmentsSelectorProps(),
+  formDataSelector: () => FormStore.data.useLaxDebouncedSelectorProps(),
+  attachmentsSelector: () => FormStore.nodes.useAttachmentsSelectorProps(),
 } satisfies {
   [K in keyof Omit<ExpressionDataSources, 'dataElementSelector'>]?: DSPropsMatching<ExpressionDataSources[K]>;
 };
@@ -79,7 +78,7 @@ const directHooks = {
     useInnerLanguageWithForcedPathSelector(
       FormBootstrap.useDefaultDataType(),
       FormBootstrap.useReadableDataTypes(),
-      FD.useDebouncedSelector(),
+      FormStore.data.useDebouncedSelector(),
     ),
   currentPage: (_isInGenerator) => useNavigationParam('pageKey'),
 } satisfies {

--- a/src/App/frontend/src/utils/layout/useNodeItem.ts
+++ b/src/App/frontend/src/utils/layout/useNodeItem.ts
@@ -1,4 +1,4 @@
-import { FD } from 'src/features/formData/FormDataWrite';
+import { FormStore } from 'src/features/form/FormContext';
 import { getComponentDef } from 'src/layout';
 import { useCurrentDataModelLocation } from 'src/utils/layout/DataModelLocation';
 import { useExpressionResolverProps } from 'src/utils/layout/generator/NodeGenerator';
@@ -91,7 +91,9 @@ export function useFormDataFor<T extends CompTypes>(
   type?: T | ((type: CompTypes) => boolean),
 ): FormDataFromType<T> {
   const dataModelBindings = useDataModelBindingsFor(baseComponentId, type) as IDataModelBindings<T>;
-  return FD.useDebouncedSelect((pick) => getNodeFormDataInner(dataModelBindings, pick)) as FormDataFromType<T>;
+  return FormStore.data.useDebouncedSelect((pick) =>
+    getNodeFormDataInner(dataModelBindings, pick),
+  ) as FormDataFromType<T>;
 }
 
 export function useNodeFormDataWhenType<Type extends CompTypes>(
@@ -99,7 +101,7 @@ export function useNodeFormDataWhenType<Type extends CompTypes>(
   type: Type,
 ): IComponentFormData<Type> | undefined {
   const dataModelBindings = useDataModelBindingsFor(baseComponentId, type) as IDataModelBindings<Type> | undefined;
-  return FD.useDebouncedSelect((pick) => getNodeFormDataInner(dataModelBindings, pick));
+  return FormStore.data.useDebouncedSelect((pick) => getNodeFormDataInner(dataModelBindings, pick));
 }
 
 function getNodeFormDataInner<T extends CompTypes>(

--- a/src/App/frontend/test/e2e/integration/frontend-test/components.ts
+++ b/src/App/frontend/test/e2e/integration/frontend-test/components.ts
@@ -479,22 +479,15 @@ describe('UI Components', () => {
     cy.gotoHiddenPage('label-data-bindings');
 
     cy.get('#form-content-colorsCheckboxes').click();
-    cy.findByRole('option', { name: /blå/i }).click();
-    cy.findAllByRole('option', { name: /added blå, blå/i })
-      .last()
-      .should('have.attr', 'aria-selected', 'true');
-    cy.findByRole('option', { name: /cyan/i }).click();
-    cy.findAllByRole('option', { name: /added cyan, cyan/i })
-      .last()
-      .should('have.attr', 'aria-selected', 'true');
-    cy.findByRole('option', { name: /grønn/i }).click();
-    cy.findAllByRole('option', { name: /added grønn, grønn/i })
-      .last()
-      .should('have.attr', 'aria-selected', 'true');
-    cy.findByRole('option', { name: /gul/i }).click();
-    cy.findAllByRole('option', { name: /added gul, gul/i })
-      .last()
-      .should('have.attr', 'aria-selected', 'true');
+
+    cy.get('u-option[label="Blå"][aria-selected="false"]').click();
+    cy.get('u-option[label="Blå"][aria-selected="true"]').should('exist');
+    cy.get('u-option[label="Cyan"][aria-selected="false"]').click();
+    cy.get('u-option[label="Cyan"][aria-selected="true"]').should('exist');
+    cy.get('u-option[label="Grønn"][aria-selected="false"]').click();
+    cy.get('u-option[label="Grønn"][aria-selected="true"]').should('exist');
+    cy.get('u-option[label="Gul"][aria-selected="false"]').click();
+    cy.get('u-option[label="Gul"][aria-selected="true"]').should('exist');
 
     cy.findByRole('option', {
       name: /Grønn, Press to remove/i,

--- a/src/App/frontend/test/e2e/integration/frontend-test/validation.ts
+++ b/src/App/frontend/test/e2e/integration/frontend-test/validation.ts
@@ -5,6 +5,7 @@ import { interceptAltinnAppGlobalData } from 'test/e2e/support/intercept-global-
 
 import type { FormBootstrapResponse } from 'src/features/formBootstrap/types';
 import type { IDataModelMultiPatchResponse } from 'src/features/formData/types';
+import type { BackendValidationIssue } from 'src/features/validation';
 
 const appFrontend = new AppFrontend();
 const dataListPage = new Datalist();
@@ -920,19 +921,34 @@ describe('Validation', () => {
       });
     });
 
+    const validationIssue: Omit<BackendValidationIssue, 'dataElementId'> = {
+      severity: 1,
+      source: 'SomeCustomValidator',
+      field: 'NyttNavn-grp-9313.NyttNavn-grp-9314.PersonMellomnavnNytt-datadef-34759.value',
+      customTextKey: 'custom_error_too_long',
+      customTextParameters: {
+        max_length: '10',
+        current_length: '19',
+      },
+    };
+
     cy.intercept('GET', '**/bootstrap-form/**', (req) => {
       req.on('response', (res) => {
         const body = res.body as FormBootstrapResponse;
         body.dataModels['ServiceModel-test'].initialValidationIssues!.push({
-          severity: 1,
-          source: 'SomeCustomValidator',
-          field: 'NyttNavn-grp-9313.NyttNavn-grp-9314.PersonMellomnavnNytt-datadef-34759.value',
+          ...validationIssue,
           dataElementId: body.dataModels['ServiceModel-test'].dataElementId!,
-          customTextKey: 'custom_error_too_long',
-          customTextParameters: {
-            max_length: '10',
-            current_length: '19',
-          },
+        });
+        res.send(body);
+      });
+    });
+
+    cy.intercept('PATCH', '**/data**', (req) => {
+      req.on('response', (res) => {
+        const body = res.body as IDataModelMultiPatchResponse;
+        body.validationIssues[0].issues.push({
+          ...validationIssue,
+          dataElementId: body.validationIssues[0].issues[0].dataElementId,
         });
         res.send(body);
       });

--- a/src/App/frontend/test/e2e/integration/signing-test/validation.ts
+++ b/src/App/frontend/test/e2e/integration/signing-test/validation.ts
@@ -8,8 +8,7 @@ describe('Validation', () => {
     cy.intercept('**/active', []).as('noActiveInstances');
   });
 
-  // Temporary skip until fix is merged in https://github.com/Altinn/altinn-studio/pull/18344
-  it.skip('Task validations returned from process/next should be visible immediately', () => {
+  it('Task validations returned from process/next should be visible immediately', () => {
     // Regression test for: waitForValidation() must ensure task validations are processed before
     // returning. The manager's signing step is a natural test case because it has no writable data
     // models and no components that support component-level validation, which are the conditions

--- a/src/App/frontend/test/e2e/support/custom.ts
+++ b/src/App/frontend/test/e2e/support/custom.ts
@@ -502,47 +502,30 @@ Cypress.Commands.add('interceptLayout', (taskName, mutator, wholeLayoutMutator, 
 Cypress.Commands.add('changeLayout', (mutator, wholeLayoutMutator) => {
   cy.log('Changing current layout');
   cy.window().then((win) => {
-    const activeData = win.queryClient.getQueryCache().findAll({ type: 'active' });
-    let found = false;
-    for (const query of activeData) {
-      if (!Array.isArray(query.queryKey) || query.queryKey[0] !== 'formBootstrap') {
-        continue;
+    win.changeLayouts((current) => {
+      const nextLayouts = structuredClone(current);
+      const layouts = Object.fromEntries(
+        Object.entries(nextLayouts).map(([pageKey, page]) => [pageKey, page?.data?.layout ?? []]),
+      ) as ILayouts;
+
+      if (mutator) {
+        for (const page of Object.values(layouts)) {
+          for (const component of page || []) {
+            mutator(component);
+          }
+        }
+      }
+      if (wholeLayoutMutator) {
+        wholeLayoutMutator(layouts);
+      }
+      for (const [pageKey, layout] of Object.entries(layouts)) {
+        if (nextLayouts[pageKey]?.data) {
+          nextLayouts[pageKey].data.layout = layout!;
+        }
       }
 
-      found = true;
-      win.queryClient.setQueryData(query.queryKey, (current: { layouts?: Record<string, ILayoutFile> } | undefined) => {
-        if (!current?.layouts) {
-          throw new Error('Expected query to have layouts');
-        }
-
-        const nextLayouts = structuredClone(current.layouts);
-        const layouts = Object.fromEntries(
-          Object.entries(nextLayouts).map(([pageKey, page]) => [pageKey, page?.data?.layout ?? []]),
-        ) as ILayouts;
-
-        if (mutator) {
-          for (const page of Object.values(layouts)) {
-            for (const component of page || []) {
-              mutator(component);
-            }
-          }
-        }
-        if (wholeLayoutMutator) {
-          wholeLayoutMutator(layouts);
-        }
-        for (const [pageKey, layout] of Object.entries(layouts)) {
-          if (nextLayouts[pageKey]?.data) {
-            nextLayouts[pageKey].data.layout = layout!;
-          }
-        }
-
-        return { ...current, layouts: nextLayouts };
-      });
-    }
-
-    if (!found) {
-      throw new Error('Could not find active query (for cy.changeLayout)');
-    }
+      return nextLayouts;
+    });
   });
 
   cy.findByTestId('presentation').should('exist');


### PR DESCRIPTION
## Description

This combines 4 zustand stores into one:
1. FormDataWrite
2. Validations
3. Nodes
4. PageNavigation

These together become `FormStore`.

closes #18199

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated form state into a single unified store, simplifying providers and improving state consistency.

* **Improvements**
  * Streamlined validation and attachment flows for more reliable validation visibility and attachment handling.
  * Page-navigation and save flows now use the unified form store for more consistent behaviour.

* **Bug Fixes**
  * Tightened backend validation shape to reduce ambiguous validation data and improve error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->