### PR TITLE
chore: Removing cypress dscheck and dsuncheck commands

### DIFF
--- a/src/App/frontend/test/e2e/integration/expression-validation-test/expression-validation.ts
+++ b/src/App/frontend/test/e2e/integration/expression-validation-test/expression-validation.ts
@@ -73,27 +73,27 @@ describe('Expression validation', () => {
     cy.findByText(/basert på stilling/i).should('be.visible');
 
     cy.get(appFrontend.errorReport).should('contain.text', 'Du må fylle ut fornavn');
-    cy.findByRole('checkbox', { name: /fornavn/i }).dsCheck();
+    cy.findByRole('checkbox', { name: /fornavn/i }).check();
     cy.get(appFrontend.errorReport).should('not.contain.text', 'Du må fylle ut fornavn');
 
     cy.get(appFrontend.errorReport).should('contain.text', 'Du må fylle ut etternavn');
-    cy.findByRole('checkbox', { name: /etternavn/i }).dsCheck();
+    cy.findByRole('checkbox', { name: /etternavn/i }).check();
     cy.get(appFrontend.errorReport).should('not.contain.text', 'Du må fylle ut etternavn');
 
     cy.get(appFrontend.errorReport).should('contain.text', 'Du må fylle ut kjønn');
-    cy.findByRole('checkbox', { name: /kjønn/i }).dsCheck();
+    cy.findByRole('checkbox', { name: /kjønn/i }).check();
     cy.get(appFrontend.errorReport).should('not.contain.text', 'Du må fylle ut kjønn');
 
     cy.get(appFrontend.errorReport).should('contain.text', "E-post må slutte med '@altinn.no'");
-    cy.findByRole('checkbox', { name: /e-post/i }).dsCheck();
+    cy.findByRole('checkbox', { name: /e-post/i }).check();
     cy.get(appFrontend.errorReport).should('not.contain.text', "E-post må slutte med '@altinn.no'");
 
     cy.get(appFrontend.errorReport).should('contain.text', "Telefonnummer må starte med '9'");
-    cy.findByRole('checkbox', { name: /telefon/i }).dsCheck();
+    cy.findByRole('checkbox', { name: /telefon/i }).check();
     cy.get(appFrontend.errorReport).should('not.contain.text', "Telefonnummer må starte med '9'");
 
     cy.get(appFrontend.errorReport).should('contain.text', 'Du må fylle ut bosted');
-    cy.findByRole('checkbox', { name: /bosted/i }).dsCheck();
+    cy.findByRole('checkbox', { name: /bosted/i }).check();
     cy.get(appFrontend.errorReport).should('not.exist');
 
     cy.findByRole('button', { name: /send inn/i }).click();
@@ -103,13 +103,13 @@ describe('Expression validation', () => {
   it('should show validation messages for repeating groups', () => {
     cy.gotoNavPage('Skjul felter');
 
-    cy.findByRole('checkbox', { name: /fornavn/i }).dsCheck();
-    cy.findByRole('checkbox', { name: /etternavn/i }).dsCheck();
-    cy.findByRole('checkbox', { name: /alder/i }).dsCheck();
-    cy.findByRole('checkbox', { name: /kjønn/i }).dsCheck();
-    cy.findByRole('checkbox', { name: /e-post/i }).dsCheck();
-    cy.findByRole('checkbox', { name: /telefon/i }).dsCheck();
-    cy.findByRole('checkbox', { name: /bosted/i }).dsCheck();
+    cy.findByRole('checkbox', { name: /fornavn/i }).check();
+    cy.findByRole('checkbox', { name: /etternavn/i }).check();
+    cy.findByRole('checkbox', { name: /alder/i }).check();
+    cy.findByRole('checkbox', { name: /kjønn/i }).check();
+    cy.findByRole('checkbox', { name: /e-post/i }).check();
+    cy.findByRole('checkbox', { name: /telefon/i }).check();
+    cy.findByRole('checkbox', { name: /bosted/i }).check();
 
     cy.gotoNavPage('CV');
 
@@ -169,13 +169,13 @@ describe('Expression validation', () => {
       }
     });
 
-    cy.findByRole('checkbox', { name: /fornavn/i }).dsCheck();
-    cy.findByRole('checkbox', { name: /etternavn/i }).dsCheck();
-    cy.findByRole('checkbox', { name: /alder/i }).dsCheck();
-    cy.findByRole('checkbox', { name: /kjønn/i }).dsCheck();
-    cy.findByRole('checkbox', { name: /e-post/i }).dsCheck();
-    cy.findByRole('checkbox', { name: /telefon/i }).dsCheck();
-    cy.findByRole('checkbox', { name: /bosted/i }).dsCheck();
+    cy.findByRole('checkbox', { name: /fornavn/i }).check();
+    cy.findByRole('checkbox', { name: /etternavn/i }).check();
+    cy.findByRole('checkbox', { name: /alder/i }).check();
+    cy.findByRole('checkbox', { name: /kjønn/i }).check();
+    cy.findByRole('checkbox', { name: /e-post/i }).check();
+    cy.findByRole('checkbox', { name: /telefon/i }).check();
+    cy.findByRole('checkbox', { name: /bosted/i }).check();
 
     cy.gotoNavPage('CV');
 
@@ -297,7 +297,7 @@ describe('Expression validation', () => {
     cy.get(appFrontend.errorReport).should('contain.text', 'Startdatoen må være før sluttdato');
     cy.get(appFrontend.errorReport).should('contain.text', 'Sluttdato må være etter startdato');
 
-    cy.findByRole('checkbox', { name: /jeg er fortsatt ansatt her/i }).dsCheck();
+    cy.findByRole('checkbox', { name: /jeg er fortsatt ansatt her/i }).check();
     cy.findByRole('button', { name: /lagre og lukk/i }).click();
     cy.get(appFrontend.errorReport).findAllByRole('listitem').should('have.length', 1);
 

--- a/src/App/frontend/test/e2e/integration/expression-validation-test/tags-validation.ts
+++ b/src/App/frontend/test/e2e/integration/expression-validation-test/tags-validation.ts
@@ -13,7 +13,7 @@ describe('Attachment tags validation', () => {
     cy.findByRole('textbox', { name: /alder/i }).type('17');
 
     // Opt-in to attachment type validation
-    cy.findByRole('radio', { name: /ja/i }).dsCheck();
+    cy.findByRole('radio', { name: /ja/i }).check();
 
     cy.get(appFrontend.errorReport).should('contain.text', "Du må laste opp 'Vitnemål'");
     cy.get(appFrontend.errorReport).should('contain.text', "Du må laste opp 'Søknad'");

--- a/src/App/frontend/test/e2e/integration/frontend-test/auto-save-behavior.ts
+++ b/src/App/frontend/test/e2e/integration/frontend-test/auto-save-behavior.ts
@@ -236,7 +236,7 @@ describe('Auto save behavior', () => {
       cy.gotoNavPage('form');
       cy.navPage('form').should('have.attr', 'aria-current', 'page');
 
-      cy.get(appFrontend.changeOfName.confirmChangeName).find('input').dsCheck();
+      cy.get(appFrontend.changeOfName.confirmChangeName).find('input').check();
       cy.get(appFrontend.changeOfName.reasonRelationship).click();
       cy.get(appFrontend.changeOfName.reasonRelationship).type('hello world');
       cy.findByRole('button', { name: appFrontend.changeOfName.datePickerButton }).click();

--- a/src/App/frontend/test/e2e/integration/frontend-test/components.ts
+++ b/src/App/frontend/test/e2e/integration/frontend-test/components.ts
@@ -938,10 +938,10 @@ describe('UI Components', () => {
     cy.get(component('mapSummary')).findByRole('img', { description: /hankabakken 8/i }).should('be.visible');
     }
 
-    cy.findByRole('checkbox', { name: /hankabakken 2/i }).dsUncheck();
-    cy.findByRole('checkbox', { name: /hankabakken 4/i }).dsUncheck();
-    cy.findByRole('checkbox', { name: /hankabakken 7/i }).dsUncheck();
-    cy.findByRole('checkbox', { name: /hankabakken 8/i }).dsUncheck();
+    cy.findByRole('checkbox', { name: /hankabakken 2/i }).uncheck();
+    cy.findByRole('checkbox', { name: /hankabakken 4/i }).uncheck();
+    cy.findByRole('checkbox', { name: /hankabakken 7/i }).uncheck();
+    cy.findByRole('checkbox', { name: /hankabakken 8/i }).uncheck();
     cy.waitUntilSaved();
 
     // prettier-ignore

--- a/src/App/frontend/test/e2e/integration/frontend-test/options.ts
+++ b/src/App/frontend/test/e2e/integration/frontend-test/options.ts
@@ -353,7 +353,7 @@ describe('Options', () => {
   it('optionsFilter should remove options based on a condition', () => {
     cy.gotoHiddenPage('filtered-options');
 
-    cy.findByRole('checkbox', { name: 'Blåbær' }).dsCheck();
+    cy.findByRole('checkbox', { name: 'Blåbær' }).check();
     cy.findByRole('checkbox', { name: 'Druer' }).should('not.exist'); // Filtered out
     cy.findByRole('checkbox', { name: 'Banan' }).should('not.exist'); // Filtered out
 
@@ -376,7 +376,7 @@ describe('Options', () => {
     cy.get('[data-componentid="ingredientId-1"]').should('have.text', '5');
 
     // Disliking 'vannmelon' will remove the selection and not allow it to be re-selected
-    cy.findByRole('checkbox', { name: 'Vannmelon' }).dsCheck();
+    cy.findByRole('checkbox', { name: 'Vannmelon' }).check();
     cy.get('[data-componentid="ingredientId-0"]').should('have.text', '');
     cy.get('[data-componentid="ingredientId-1"]').should('have.text', '5');
     cy.get('[data-componentid="ingredientType-0"]').findByRole('combobox').click();

--- a/src/App/frontend/test/e2e/integration/frontend-test/party-selection.ts
+++ b/src/App/frontend/test/e2e/integration/frontend-test/party-selection.ts
@@ -16,9 +16,9 @@ describe('Party selection', () => {
     cy.findByText('underenhet').click();
     cy.contains(appFrontend.partySelection.subUnits, 'Bergen').should('be.visible');
     cy.contains(appFrontend.partySelection.party, 'slettet').should('not.exist');
-    cy.findByRole('checkbox', { name: /Vis slettede/i }).dsCheck();
+    cy.findByRole('checkbox', { name: /Vis slettede/i }).check();
     cy.contains(appFrontend.partySelection.party, 'slettet').should('be.visible');
-    cy.findByRole('checkbox', { name: /Vis underenheter/i }).dsCheck();
+    cy.findByRole('checkbox', { name: /Vis underenheter/i }).check();
     cy.findByText('underenhet').click();
     cy.get(appFrontend.partySelection.search).type('DDG');
     cy.get(appFrontend.partySelection.party).should('have.length', 1).contains('DDG');

--- a/src/App/frontend/test/e2e/integration/multiple-datamodels-test/fetching.ts
+++ b/src/App/frontend/test/e2e/integration/multiple-datamodels-test/fetching.ts
@@ -41,7 +41,7 @@ describe('fetching new data from models', () => {
     });
 
     cy.gotoNavPage('Side6');
-    cy.findByRole('radio', { name: /kåre/i }).dsCheck();
+    cy.findByRole('radio', { name: /kåre/i }).check();
     cy.waitUntilSaved();
     cy.findByText(/Du må rette disse feilene før du kan gå videre/i).should('not.exist');
 

--- a/src/App/frontend/test/e2e/integration/multiple-datamodels-test/readonly.ts
+++ b/src/App/frontend/test/e2e/integration/multiple-datamodels-test/readonly.ts
@@ -45,7 +45,7 @@ describe('readonly data models', () => {
 
     const errorReportTitle = /Du må rette disse feilene før du kan gå videre/i;
     cy.gotoNavPage('Side6');
-    cy.findByRole('radio', { name: /kåre/i }).dsCheck();
+    cy.findByRole('radio', { name: /kåre/i }).check();
     cy.findByText(errorReportTitle).should('not.exist');
     cy.waitUntilSaved();
     cy.findByRole('button', { name: /send inn/i }).click();

--- a/src/App/frontend/test/e2e/integration/multiple-datamodels-test/saving.ts
+++ b/src/App/frontend/test/e2e/integration/multiple-datamodels-test/saving.ts
@@ -191,7 +191,7 @@ describe('saving multiple data models', () => {
     cy.findByRole('searchbox', { name: /søk/i }).clear();
     cy.findByRole('searchbox', { name: /søk/i }).type('Utvikler');
     cy.findAllByRole('radio').should('have.length', 2);
-    cy.findByRole('radio', { name: /johanne/i }).dsCheck();
+    cy.findByRole('radio', { name: /johanne/i }).check();
     cy.findByRole('radio', { name: /johanne/i }).should('be.checked');
     cy.findByRole('searchbox', { name: /søk/i }).clear();
     cy.findAllByRole('radio').should('have.length', 5);

--- a/src/App/frontend/test/e2e/integration/multiple-datamodels-test/validation.ts
+++ b/src/App/frontend/test/e2e/integration/multiple-datamodels-test/validation.ts
@@ -51,7 +51,7 @@ describe('validating multiple data models', () => {
     cy.gotoNavPage('Side3');
     cy.findByRole('button', { name: /legg til ny/i }).click();
     cy.gotoNavPage('Side6');
-    cy.findByRole('radio', { name: /kåre/i }).dsCheck();
+    cy.findByRole('radio', { name: /kåre/i }).check();
     cy.get(appFrontend.errorReport).should('not.exist');
     cy.findByRole('button', { name: /send inn/i }).click();
     cy.findByRole('heading', { name: /fra forrige steg/i }).should('be.visible');

--- a/src/App/frontend/test/e2e/integration/navigation-test-subform/navigation.ts
+++ b/src/App/frontend/test/e2e/integration/navigation-test-subform/navigation.ts
@@ -229,7 +229,7 @@ describe('navigation', () => {
       cy.navGroup(/Innsending/, /Oppsummering/).should('be.visible');
       cy.gotoNavGroup(/Utfylling/, device, /Ekstra/);
 
-      cy.findByRole('checkbox', { name: 'Skjul tilbakemelding' }).dsCheck();
+      cy.findByRole('checkbox', { name: 'Skjul tilbakemelding' }).check();
 
       isUsingMobile && cy.showNavGroupsMobile();
       isUsingTablet && cy.showNavGroupsTablet();
@@ -238,7 +238,7 @@ describe('navigation', () => {
       cy.navGroup(/Innsending/, /Oppsummering/).should('be.visible');
       isUsingMobile && cy.hideNavGroupsMobile();
       isUsingTablet && cy.hideNavGroupsTablet();
-      cy.findByRole('checkbox', { name: 'Skjul oppsummering' }).dsCheck();
+      cy.findByRole('checkbox', { name: 'Skjul oppsummering' }).check();
       isUsingMobile && cy.showNavGroupsMobile();
       isUsingTablet && cy.showNavGroupsTablet();
       cy.navGroup(/Innsending/).should('not.exist');
@@ -249,7 +249,7 @@ describe('navigation', () => {
       cy.findByRole('heading', { name: 'Viktig informasjon' }).should('be.visible');
       cy.findByRole('button', { name: 'Neste' }).should('not.exist');
       cy.findByRole('button', { name: 'Forrige' }).clickAndGone();
-      cy.findByRole('checkbox', { name: 'Skjul oppsummering' }).dsUncheck();
+      cy.findByRole('checkbox', { name: 'Skjul oppsummering' }).uncheck();
       cy.findByRole('button', { name: 'Neste' }).clickAndGone();
       cy.findByRole('heading', { name: 'Viktig informasjon' }).should('be.visible');
       cy.findByRole('button', { name: 'Neste' }).clickAndGone();

--- a/src/App/frontend/test/e2e/support/custom.ts
+++ b/src/App/frontend/test/e2e/support/custom.ts
@@ -28,20 +28,6 @@ Cypress.Commands.add('isVisible', { prevSubject: true }, (subject) => {
   expect(isVisible(subject[0])).to.be.true;
 });
 
-Cypress.Commands.add('dsCheck', { prevSubject: true }, (subject: JQueryWithSelector | undefined) => {
-  cy.log('Checking');
-  if (subject && !subject.is(':checked')) {
-    cy.wrap(subject).parent().click();
-  }
-});
-
-Cypress.Commands.add('dsUncheck', { prevSubject: true }, (subject: JQueryWithSelector | undefined) => {
-  cy.log('Unchecking');
-  if (subject && subject.is(':checked')) {
-    cy.wrap(subject).parent().click();
-  }
-});
-
 Cypress.Commands.add('waitUntilSaved', () => {
   // If the data-unsaved-changes attribute does not exist, the page is not in a data/form state, and we should not
   // wait for it to be saved.

--- a/src/App/frontend/test/e2e/support/global.ts
+++ b/src/App/frontend/test/e2e/support/global.ts
@@ -176,19 +176,6 @@ declare global {
       waitUntilSaved(): Chainable<null>;
 
       /**
-       * Check a checkbox/radio from the design system.
-       * Our design system radios/checkboxes are a little special, as they hide the HTML input element and provide
-       * their own stylized variant. Cypress can't check/uncheck a hidden input field, and although we can tell
-       * cypress to force it, that just circumvents a lot of other checks that we want cypress to run.
-       */
-      dsCheck(): Chainable<null>;
-
-      /**
-       * Uncheck a checkbox/radio from the design system. See the comment above for dsCheck()
-       */
-      dsUncheck(): Chainable<null>;
-
-      /**
        * Waits until a design system element (Combobox, etc) is ready to be clicked.
        */
       dsReady(selector: string): Chainable<null>;


### PR DESCRIPTION
## Description

These are flaky in `expression-validation.ts` after the call to `cy.changeLayout()`. Since the design system now supports calling `check()` and `uncheck()` directly, we don't need these anymore.

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modernised end-to-end test suite by replacing custom checkbox and radio interaction helpers with standard testing library APIs across multiple test scenarios.
  * Removed obsolete custom test support commands from the test infrastructure.
  * All test assertions and validation logic remain functionally equivalent; test coverage unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->