### PR TITLE
fix(resource-adm): refactor to remove imports from designsystemet-react in resourceadm

### DIFF
--- a/src/Designer/frontend/resourceadm/pages/ListAdminPage/ListAdminPage.tsx
+++ b/src/Designer/frontend/resourceadm/pages/ListAdminPage/ListAdminPage.tsx
@@ -1,8 +1,13 @@
 import React, { useRef, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ToggleGroup } from '@digdir/designsystemet-react';
-import { StudioSpinner, StudioButton, StudioLink, StudioHeading } from '@studio/components';
+import {
+  StudioSpinner,
+  StudioButton,
+  StudioLink,
+  StudioHeading,
+  StudioToggleGroup,
+} from '@studio/components';
 import { PencilWritingIcon, PlusIcon } from '@studio/icons';
 import classes from './ListAdminPage.module.css';
 import { useGetAccessListsQuery } from '../../hooks/queries/useGetAccessListsQuery';
@@ -59,15 +64,18 @@ export const ListAdminPage = (): React.JSX.Element => {
         {t('resourceadm.listadmin_header')}
       </StudioHeading>
       <div className={classes.environmentSelectorWrapper}>
-        <ToggleGroup size='sm' onChange={navigateToListEnv} value={selectedEnv}>
+        <StudioToggleGroup
+          onChange={(value) => navigateToListEnv(value as EnvId)}
+          value={selectedEnv}
+        >
           {getAvailableEnvironments(org).map((environment) => {
             return (
-              <ToggleGroup.Item key={environment.id} value={environment.id}>
+              <StudioToggleGroup.Item key={environment.id} value={environment.id}>
                 {t(environment.label)}
-              </ToggleGroup.Item>
+              </StudioToggleGroup.Item>
             );
           })}
-        </ToggleGroup>
+        </StudioToggleGroup>
         {selectedEnv && (
           <>
             <NewAccessListModal


### PR DESCRIPTION
## Description
- Use StudioToggleGroup from `@studio/components` instead of ToggleGroup from `@digdir/designsystemet-react`. This removes any direct import of `@digdir/designsystemet-react` in resource admin

## Verification

- [ ] Related issues are connected (if applicable)
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
