### PR TITLE
fix: prevent warning message to be present when navigation between languages

### DIFF
--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/InputfieldsWithTranslation/InputfieldsWithTranslation.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/InputfieldsWithTranslation/InputfieldsWithTranslation.test.tsx
@@ -45,7 +45,7 @@ describe('InputfieldsWithTranslation', () => {
     const user = userEvent.setup();
     renderInputfieldsWithTranslation({ route: '/?focus=test-id-nb' });
     await user.click(screen.getByRole('tab', { name: `${textMock('language.nn')} ${label}` }));
-    expect(getLocationSearch()).toHaveTextContent('');
+    expect(getLocationSearch()).toBeEmptyDOMElement();
   });
 });
 

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/InputfieldsWithTranslation/InputfieldsWithTranslation.test.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/InputfieldsWithTranslation/InputfieldsWithTranslation.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { InputfieldsWithTranslation } from './InputfieldsWithTranslation';
 import type { InputfieldsWithTranslationProps } from './InputfieldsWithTranslation';
 import userEvent from '@testing-library/user-event';
@@ -40,6 +40,13 @@ describe('InputfieldsWithTranslation', () => {
       nb: value.nb + newText,
     });
   });
+
+  it('clears focus query param when switching language tab', async () => {
+    const user = userEvent.setup();
+    renderInputfieldsWithTranslation({ route: '/?focus=test-id-nb' });
+    await user.click(screen.getByRole('tab', { name: `${textMock('language.nn')} ${label}` }));
+    expect(getLocationSearch()).toHaveTextContent('');
+  });
 });
 
 const label = textMock('label');
@@ -57,13 +64,27 @@ const defaultProps: InputfieldsWithTranslationProps = {
   required: true,
 };
 
-function renderInputfieldsWithTranslation(props: Partial<InputfieldsWithTranslationProps> = {}) {
+type RenderInputfieldsWithTranslationArgs = Partial<InputfieldsWithTranslationProps> & {
+  route?: string;
+};
+
+function renderInputfieldsWithTranslation({
+  route = '/',
+  ...props
+}: RenderInputfieldsWithTranslationArgs = {}) {
   return render(
-    <MemoryRouter initialEntries={['/']}>
+    <MemoryRouter initialEntries={[route]}>
       <InputfieldsWithTranslation {...defaultProps} {...props} />
+      <TestLocationSearch />
     </MemoryRouter>,
   );
 }
 
 const getTextbox = (name: string): HTMLInputElement => screen.getByRole('textbox', { name });
 const getText = (name: string): HTMLElement => screen.getByText(name);
+const getLocationSearch = (): HTMLElement => screen.getByTestId('location-search');
+
+function TestLocationSearch() {
+  const location = useLocation();
+  return <div data-testid='location-search'>{location.search}</div>;
+}

--- a/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/InputfieldsWithTranslation/InputfieldsWithTranslation.tsx
+++ b/src/Designer/frontend/app-development/features/appSettings/components/TabsContent/Tabs/AboutTab/AppConfigForm/InputfieldsWithTranslation/InputfieldsWithTranslation.tsx
@@ -57,9 +57,11 @@ export function InputfieldsWithTranslation({
 
   const handleTabChange = (newValue: string): void => {
     setSelectedLanguage(newValue as ValidLanguage);
-    const next = new URLSearchParams(searchParams);
-    next.delete('focus');
-    setSearchParams(next);
+    if (searchParams.has('focus')) {
+      const next = new URLSearchParams(searchParams);
+      next.delete('focus');
+      setSearchParams(next, { replace: true });
+    }
   };
 
   const languageTabs = LANGUAGES.map((language) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

CLOSES BEFORE; #18331 


<details><summary>AFTER</summary> 

https://github.com/user-attachments/assets/b59f955b-7e1b-4e9f-84cb-825a08c6f4b4


 </details>


## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * URL parameter handling for the form's focus state now clears the parameter only when present and updates the URL using a replace operation to avoid adding a new browser history entry, improving navigation behaviour.

* **Tests**
  * Added test coverage that exposes the current location.search, allows specifying an initial route, and verifies the focus query parameter is cleared when switching language tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->