### PR TITLE
fix: Avoid concurrent navigation when entering sub form with active validation

### DIFF
--- a/src/App/frontend/monorepo-changed-paths.txt
+++ b/src/App/frontend/monorepo-changed-paths.txt
@@ -38,6 +38,7 @@ src/features/form/layoutSets/
 src/features/form/layoutSettings/
 src/features/form/rules/RulesContext.tsx
 src/features/formData/LegacyRules.ts
+src/features/instantiate/containers/InstantiateContainer.tsx
 src/features/instantiate/useInstantiation.tsx
 src/features/language/LangDataSourcesProvider.tsx
 src/features/language/LangToolsStore.tsx

--- a/src/App/frontend/src/components/form/Form.tsx
+++ b/src/App/frontend/src/components/form/Form.tsx
@@ -47,18 +47,23 @@ export function FormPage({ currentPageId }: { currentPageId: string | undefined 
   const [searchParams, setSearchParams] = useSearchParams();
   const shouldValidateFormPage = searchParams.get(SearchParams.Validate);
   const onFormSubmitValidation = useOnFormSubmitValidation();
+  const { isValidPageId } = useNavigatePage();
+  const shouldNavigateToStart = !currentPageId || !isValidPageId(currentPageId);
 
   useEffect(() => {
-    if (shouldValidateFormPage) {
+    if (shouldValidateFormPage && !shouldNavigateToStart) {
       onFormSubmitValidation();
-      setSearchParams((params) => {
-        params.delete(SearchParams.Validate);
-        return searchParams;
-      });
+      setSearchParams(
+        (params) => {
+          const nextParams = new URLSearchParams(params);
+          nextParams.delete(SearchParams.Validate);
+          return nextParams;
+        },
+        { replace: true },
+      );
     }
-  }, [onFormSubmitValidation, searchParams, setSearchParams, shouldValidateFormPage]);
+  }, [onFormSubmitValidation, searchParams, setSearchParams, shouldValidateFormPage, shouldNavigateToStart]);
 
-  const { isValidPageId } = useNavigatePage();
   const appName = useAppName();
   const appOwner = useAppOwner();
   const { langAsString } = useLanguage();
@@ -76,7 +81,7 @@ export function FormPage({ currentPageId }: { currentPageId: string | undefined 
   useRedirectToStoredPage();
   useSetExpandedWidth();
 
-  if (!currentPageId || !isValidPageId(currentPageId)) {
+  if (shouldNavigateToStart) {
     return <NavigateToStartUrl forceCurrentTask={false} />;
   }
 


### PR DESCRIPTION
When opening a subform with valid activation (searchParam validate set), then From component did two concurrent navigation. This might create race condition, and they made a cypress test subform.ts fail in #18358 

## Description

The race condition was reproduced in #18358 by the test "subform validation" in subform.ts.
In this test there is an validation error in the subform. The user tries to click next in the main form, and this triggers the validation error.
Then then user opens then subform by pressing the edit button. This opens the subform with validation activated. Its done through the code enterSubform() with validate parameter set to true.

This causes two navigations to happen at the same time in Form.tsx
The first is directly through a useEffect which removes the validate search param from the current page.
The second is done indirectly in a useEffect by rendering the NavigateToStartUrl-component. This component adds the first page of the form to the url (through useStartUrl it adds firstPage to url)

This PR also include a fix to change such that back navigation from opening a subform with validation works as expected. Since removal of the validation search parameter did not use the replace option. pressing back in the browser would not navigate back from the subform to the main form.

Before : 
https://github.com/user-attachments/assets/4cb4595b-4cfa-486e-bfba-26bcd8472f73
After : 
https://github.com/user-attachments/assets/30d0cb98-95b6-4d3f-961a-96357fc17ff6

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced form validation to prevent unintended navigation on invalid pages; validation only runs for the correct page and clears validation state from the URL during submission.

* **Refactor**
  * Optimised form page initialisation and navigation gating for more reliable behaviour and improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->