### PR TITLE
chore: Enable new jsx transform "react-jsx"

### DIFF
--- a/src/App/frontend/eslint.config.mjs
+++ b/src/App/frontend/eslint.config.mjs
@@ -130,6 +130,7 @@ export default defineConfig([
         { checkFragmentShorthand: true, checkKeyMustBeforeSpread: true, warnOnDuplicates: true },
       ],
       'react/prop-types': ['off'],
+      'react/react-in-jsx-scope': ['off'],
 
       'sonarjs/no-duplicate-string': ['off'],
       'sonarjs/cognitive-complexity': ['off'],

--- a/src/App/frontend/monorepo-changed-paths.txt
+++ b/src/App/frontend/monorepo-changed-paths.txt
@@ -38,6 +38,7 @@ src/features/form/layoutSets/
 src/features/form/layoutSettings/
 src/features/form/rules/RulesContext.tsx
 src/features/formData/LegacyRules.ts
+src/features/instantiate/containers/InstantiateContainer.tsx
 src/features/instantiate/useInstantiation.tsx
 src/features/language/LangDataSourcesProvider.tsx
 src/features/language/LangToolsStore.tsx

--- a/src/App/frontend/src/AppComponentsBridge.tsx
+++ b/src/App/frontend/src/AppComponentsBridge.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { AppComponentsProvider } from 'src/app-components/AppComponentsProvider';

--- a/src/App/frontend/src/AppLayout.tsx
+++ b/src/App/frontend/src/AppLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router';
 import { Slide, ToastContainer } from 'react-toastify';
 

--- a/src/App/frontend/src/app-components/Accordion/AccordionItem.tsx
+++ b/src/App/frontend/src/app-components/Accordion/AccordionItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Details } from '@digdir/designsystemet-react';
 import cn from 'classnames';

--- a/src/App/frontend/src/app-components/AppComponentsProvider.tsx
+++ b/src/App/frontend/src/app-components/AppComponentsProvider.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
+import * as React from 'react';
 import type { PropsWithChildren } from 'react';
 
 // Minimal interface — only what app-components actually need

--- a/src/App/frontend/src/app-components/Button/Button.tsx
+++ b/src/App/frontend/src/app-components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Button as DesignSystemButton } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/app-components/Card/Card.tsx
+++ b/src/App/frontend/src/app-components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Card, Heading, Paragraph } from '@digdir/designsystemet-react';
 

--- a/src/App/frontend/src/app-components/ConditionalWrapper/ConditionalWrapper.test.tsx
+++ b/src/App/frontend/src/app-components/ConditionalWrapper/ConditionalWrapper.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { screen } from '@testing-library/react';
 

--- a/src/App/frontend/src/app-components/Date/DisplayDate.tsx
+++ b/src/App/frontend/src/app-components/Date/DisplayDate.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { useTranslation } from 'src/app-components/AppComponentsProvider';
 import classes from 'src/app-components/Date/Date.module.css';

--- a/src/App/frontend/src/app-components/Datepicker/DatePickerCalendar.tsx
+++ b/src/App/frontend/src/app-components/Datepicker/DatePickerCalendar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { DayPicker } from 'react-day-picker';
 import type { Matcher, MonthCaption } from 'react-day-picker';
 

--- a/src/App/frontend/src/app-components/Datepicker/DatePickerInput.tsx
+++ b/src/App/frontend/src/app-components/Datepicker/DatePickerInput.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import * as React from 'react';
 import { PatternFormat } from 'react-number-format';
 import type { Ref } from 'react';
 

--- a/src/App/frontend/src/app-components/Datepicker/Datepicker.tsx
+++ b/src/App/frontend/src/app-components/Datepicker/Datepicker.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+import * as React from 'react';
 import type { MonthCaption } from 'react-day-picker';
 
 import { CalendarIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/app-components/Datepicker/DatepickerDialog.tsx
+++ b/src/App/frontend/src/app-components/Datepicker/DatepickerDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import type { PropsWithChildren, ReactNode } from 'react';
 
 import { Dialog, Popover } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/app-components/Dropzone/Dropzone.tsx
+++ b/src/App/frontend/src/app-components/Dropzone/Dropzone.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useDropzone } from 'react-dropzone';
 import type { HTMLAttributes } from 'react';
 import type { FileRejection } from 'react-dropzone';

--- a/src/App/frontend/src/app-components/DynamicForm/DynamicForm.tsx
+++ b/src/App/frontend/src/app-components/DynamicForm/DynamicForm.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import * as React from 'react';
 import type { MonthCaption } from 'react-day-picker';
 
 import { Radio, Textfield } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/app-components/Flex/Flex.tsx
+++ b/src/App/frontend/src/app-components/Flex/Flex.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
+import * as React from 'react';
 import type { CSSProperties, ElementType, PropsWithChildren } from 'react';
 
 import cn from 'classnames';

--- a/src/App/frontend/src/app-components/FullWidthWrapper/FullWidthWrapper.tsx
+++ b/src/App/frontend/src/app-components/FullWidthWrapper/FullWidthWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { HTMLProps } from 'react';
 
 import cn from 'classnames';

--- a/src/App/frontend/src/app-components/HelpText/HelpText.test.tsx
+++ b/src/App/frontend/src/app-components/HelpText/HelpText.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/App/frontend/src/app-components/HelpText/HelpText.tsx
+++ b/src/App/frontend/src/app-components/HelpText/HelpText.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from 'react';
+import { forwardRef, useState } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Popover } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/app-components/HelpText/HelpTextIcon.test.tsx
+++ b/src/App/frontend/src/app-components/HelpText/HelpTextIcon.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { HelpTextIcon } from 'src/app-components/HelpText/HelpTextIcon';

--- a/src/App/frontend/src/app-components/HelpText/HelpTextIcon.tsx
+++ b/src/App/frontend/src/app-components/HelpText/HelpTextIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export type HelpTextIconProps = {
   className: string;
   filled?: boolean;

--- a/src/App/frontend/src/app-components/Input/FormattedInput.tsx
+++ b/src/App/frontend/src/app-components/Input/FormattedInput.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { PatternFormat } from 'react-number-format';
 import type { PatternFormatProps } from 'react-number-format';
 

--- a/src/App/frontend/src/app-components/Input/Input.tsx
+++ b/src/App/frontend/src/app-components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { InputHTMLAttributes, ReactNode } from 'react';
 
 import { Paragraph, Textfield } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/app-components/Input/NumericInput.tsx
+++ b/src/App/frontend/src/app-components/Input/NumericInput.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { NumericFormat, type NumericFormatProps } from 'react-number-format';
 
 import { Input, type InputProps } from 'src/app-components/Input/Input';

--- a/src/App/frontend/src/app-components/Label/Fieldset.test.tsx
+++ b/src/App/frontend/src/app-components/Label/Fieldset.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { Fieldset } from 'src/app-components/Label/Fieldset';

--- a/src/App/frontend/src/app-components/Label/Fieldset.tsx
+++ b/src/App/frontend/src/app-components/Label/Fieldset.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { JSX, PropsWithChildren, ReactElement } from 'react';
 
 import { Fieldset as DesignsystemetFieldset, Label as DesignsystemetLabel } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/app-components/Label/Label.tsx
+++ b/src/App/frontend/src/app-components/Label/Label.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX, PropsWithChildren, ReactElement } from 'react';
 
 import { Label as DesignsystemetLabel } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/app-components/Number/DisplayNumber.tsx
+++ b/src/App/frontend/src/app-components/Number/DisplayNumber.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { numericFormatter, patternFormatter } from 'react-number-format';
 import type { NumericFormatProps, PatternFormatProps } from 'react-number-format';
 

--- a/src/App/frontend/src/app-components/Pagination/Pagination.tsx
+++ b/src/App/frontend/src/app-components/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import {
   Field,

--- a/src/App/frontend/src/app-components/Panel/Panel.test.tsx
+++ b/src/App/frontend/src/app-components/Panel/Panel.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { PANEL_VARIANT } from 'src/app-components/Panel/constants';

--- a/src/App/frontend/src/app-components/Panel/Panel.tsx
+++ b/src/App/frontend/src/app-components/Panel/Panel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Heading } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/app-components/Table/Table.test.tsx
+++ b/src/App/frontend/src/app-components/Table/Table.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { fireEvent, screen } from '@testing-library/react';
 import type { JSONSchema7 } from 'json-schema';
 

--- a/src/App/frontend/src/app-components/Table/Table.tsx
+++ b/src/App/frontend/src/app-components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Button, Table } from '@digdir/designsystemet-react';
 import cn from 'classnames';

--- a/src/App/frontend/src/app-components/Text/DisplayText.tsx
+++ b/src/App/frontend/src/app-components/Text/DisplayText.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useTranslation } from 'src/app-components/AppComponentsProvider';
 import classes from 'src/app-components/Text/Text.module.css';
 import type { TranslationKey } from 'src/app-components/types';

--- a/src/App/frontend/src/app-components/TextArea/TextArea.tsx
+++ b/src/App/frontend/src/app-components/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Field, Textarea } from '@digdir/designsystemet-react';
 import type { FieldCounterProps } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/app-components/TimePicker/TimePicker.responsive.test.tsx
+++ b/src/App/frontend/src/app-components/TimePicker/TimePicker.responsive.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/App/frontend/src/app-components/TimePicker/TimePicker.tsx
+++ b/src/App/frontend/src/app-components/TimePicker/TimePicker.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+import * as React from 'react';
 
 import { Popover } from '@digdir/designsystemet-react';
 import { ClockIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/app-components/TimePicker/TimeSegment/TimeSegment.test.tsx
+++ b/src/App/frontend/src/app-components/TimePicker/TimeSegment/TimeSegment.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/app-components/TimePicker/TimeSegment/TimeSegment.tsx
+++ b/src/App/frontend/src/app-components/TimePicker/TimeSegment/TimeSegment.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Textfield } from '@digdir/designsystemet-react';
 

--- a/src/App/frontend/src/app-components/error/FatalError/FatalError.tsx
+++ b/src/App/frontend/src/app-components/error/FatalError/FatalError.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { HTMLAttributes, PropsWithChildren } from 'react';
 
 /**

--- a/src/App/frontend/src/app-components/error/FatalErrorEmpty/FatalErrorEmpty.tsx
+++ b/src/App/frontend/src/app-components/error/FatalErrorEmpty/FatalErrorEmpty.tsx
@@ -1,8 +1,3 @@
-import React from 'react';
-
-/**
- * The `data-fatal-error` signals that some unrecoverable error occured which should prevent PDF generation from happening as it would not include necessary information.
- */
 export function FatalErrorEmpty() {
   return (
     <div

--- a/src/App/frontend/src/app-components/loading/AltinnContentLoader/AltinnContentIcon.tsx
+++ b/src/App/frontend/src/app-components/loading/AltinnContentLoader/AltinnContentIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export function AltinnContentIcon() {
   return (
     <>

--- a/src/App/frontend/src/app-components/loading/AltinnContentLoader/AltinnContentIconFormData.tsx
+++ b/src/App/frontend/src/app-components/loading/AltinnContentLoader/AltinnContentIconFormData.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export function AltinnContentIconFormData() {
   return (
     <>

--- a/src/App/frontend/src/app-components/loading/AltinnContentLoader/AltinnContentIconReceipt.tsx
+++ b/src/App/frontend/src/app-components/loading/AltinnContentLoader/AltinnContentIconReceipt.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export function AltinnContentIconReceipt() {
   return (
     <>

--- a/src/App/frontend/src/app-components/loading/AltinnContentLoader/AltinnContentLoader.test.tsx
+++ b/src/App/frontend/src/app-components/loading/AltinnContentLoader/AltinnContentLoader.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import {

--- a/src/App/frontend/src/app-components/loading/AltinnContentLoader/AltinnContentLoader.tsx
+++ b/src/App/frontend/src/app-components/loading/AltinnContentLoader/AltinnContentLoader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ContentLoader from 'react-content-loader';
 
 import { AltinnContentIcon } from 'src/app-components/loading/AltinnContentLoader/AltinnContentIcon';

--- a/src/App/frontend/src/app-components/loading/LoadingEmpty/LoadingEmpty.tsx
+++ b/src/App/frontend/src/app-components/loading/LoadingEmpty/LoadingEmpty.tsx
@@ -1,8 +1,3 @@
-import React from 'react';
-
-/**
- * The `data-loading` signals that something is pending and we should not print PDF yet.
- */
 export function LoadingEmpty() {
   return (
     <div

--- a/src/App/frontend/src/app-components/loading/LoadingWrapper/LoadingWrapper.tsx
+++ b/src/App/frontend/src/app-components/loading/LoadingWrapper/LoadingWrapper.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { HTMLAttributes, PropsWithChildren } from 'react';
 
 /**

--- a/src/App/frontend/src/app-components/loading/Spinner/Spinner.tsx
+++ b/src/App/frontend/src/app-components/loading/Spinner/Spinner.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Spinner as DesignSystemSpinner } from '@digdir/designsystemet-react';
 
 /**

--- a/src/App/frontend/src/app-components/test/renderWithAppComponentsProvider.tsx
+++ b/src/App/frontend/src/app-components/test/renderWithAppComponentsProvider.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 
 import { render, RenderOptions } from '@testing-library/react';
 

--- a/src/App/frontend/src/components/AltinnCollapsible.test.tsx
+++ b/src/App/frontend/src/components/AltinnCollapsible.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/App/frontend/src/components/AltinnCollapsible.tsx
+++ b/src/App/frontend/src/components/AltinnCollapsible.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import cn from 'classnames';

--- a/src/App/frontend/src/components/AltinnLoader.test.tsx
+++ b/src/App/frontend/src/components/AltinnLoader.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { render as rtlRender, screen } from '@testing-library/react';
 
 import { AltinnLoader } from 'src/components/AltinnLoader';

--- a/src/App/frontend/src/components/AltinnLoader.tsx
+++ b/src/App/frontend/src/components/AltinnLoader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { CSSProperties } from 'react';
 
 import classes from 'src/components/AltinnLoader.module.css';

--- a/src/App/frontend/src/components/AltinnSpinner.test.tsx
+++ b/src/App/frontend/src/components/AltinnSpinner.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, waitFor } from '@testing-library/react';
 
 import { AltinnSpinner } from 'src/components/AltinnSpinner';

--- a/src/App/frontend/src/components/AltinnSpinner.tsx
+++ b/src/App/frontend/src/components/AltinnSpinner.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Paragraph } from '@digdir/designsystemet-react';
 import classNames from 'classnames';
 import type { ArgumentArray } from 'classnames';

--- a/src/App/frontend/src/components/CircleIcon.tsx
+++ b/src/App/frontend/src/components/CircleIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import cn from 'classnames';
 

--- a/src/App/frontend/src/components/ErrorBoundary.tsx
+++ b/src/App/frontend/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { DisplayError } from 'src/core/errorHandling/DisplayError';
 

--- a/src/App/frontend/src/components/LandmarkShortcuts.test.tsx
+++ b/src/App/frontend/src/components/LandmarkShortcuts.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/components/LandmarkShortcuts.tsx
+++ b/src/App/frontend/src/components/LandmarkShortcuts.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import cn from 'classnames';
 

--- a/src/App/frontend/src/components/PDFGeneratorPreview/PDFGeneratorPreview.tsx
+++ b/src/App/frontend/src/components/PDFGeneratorPreview/PDFGeneratorPreview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment, useRef, useState } from 'react';
 
 import { Dialog, Heading } from '@digdir/designsystemet-react';
 import { FilePdfIcon } from '@navikt/aksel-icons';
@@ -18,11 +18,11 @@ export function PDFGeneratorPreview({
   buttonTitle?: string;
   showErrorDetails?: boolean;
 }) {
-  const modalRef = React.useRef<HTMLDialogElement>(null);
-  const abortRef = React.useRef<AbortController | null>(null);
+  const modalRef = useRef<HTMLDialogElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
-  const [blobUrl, setBlobUrl] = React.useState<string | null>(null);
-  const [errorText, setErrorText] = React.useState<string | null>(null);
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [errorText, setErrorText] = useState<string | null>(null);
 
   const instanceId = useLaxInstanceId();
   const language = useCurrentLanguage();
@@ -90,10 +90,10 @@ export function PDFGeneratorPreview({
             <Heading id='pdfPreview.error' />
             {showErrorDetails &&
               errorText.split('\n').map((line) => (
-                <React.Fragment key={line}>
+                <Fragment key={line}>
                   {line}
                   <br />
-                </React.Fragment>
+                </Fragment>
               ))}
           </div>
         ) : (

--- a/src/App/frontend/src/components/ReadyForPrint.tsx
+++ b/src/App/frontend/src/components/ReadyForPrint.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState, useTransition } from 'react';
+import { useEffect, useState, useTransition } from 'react';
+import * as React from 'react';
 
 import { useIsFetching } from '@tanstack/react-query';
 

--- a/src/App/frontend/src/components/ViewportWrapper.tsx
+++ b/src/App/frontend/src/components/ViewportWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useLayoutEffect } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
@@ -16,7 +16,7 @@ export const ViewportWrapper = ({ children }: PropsWithChildren) => {
   // Using a layout effect to make sure the whole app is re-rendered as we want it before taking screenshots
   // for visual testing. This is needed because the visual testing library takes screenshots as soon as the viewport
   // is resized and these classes are set.
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     document.documentElement.lang = selectedLanguage;
     document.documentElement.dir = direction;
 

--- a/src/App/frontend/src/components/altinnError.tsx
+++ b/src/App/frontend/src/components/altinnError.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import cn from 'classnames';
 

--- a/src/App/frontend/src/components/altinnParty.test.tsx
+++ b/src/App/frontend/src/components/altinnParty.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/components/altinnParty.tsx
+++ b/src/App/frontend/src/components/altinnParty.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Paragraph } from '@digdir/designsystemet-react';
 import { Buildings3Icon, ChevronRightCircleFillIcon, PersonIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/components/atoms/AltinnAttachments.test.tsx
+++ b/src/App/frontend/src/components/atoms/AltinnAttachments.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { render, screen } from '@testing-library/react';
 

--- a/src/App/frontend/src/components/atoms/AltinnAttachments.tsx
+++ b/src/App/frontend/src/components/atoms/AltinnAttachments.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Link, List } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/components/atoms/AttachmentHeader.tsx
+++ b/src/App/frontend/src/components/atoms/AttachmentHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Heading } from '@digdir/designsystemet-react';
 

--- a/src/App/frontend/src/components/form/Description.tsx
+++ b/src/App/frontend/src/components/form/Description.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { HTMLAttributes } from 'react';
 
 import cn from 'classnames';

--- a/src/App/frontend/src/components/form/Form.test.tsx
+++ b/src/App/frontend/src/components/form/Form.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/components/form/Form.tsx
+++ b/src/App/frontend/src/components/form/Form.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
+import * as React from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router';
 
 import { Flex } from 'src/app-components/Flex/Flex';

--- a/src/App/frontend/src/components/form/FormInfectedFiles.test.tsx
+++ b/src/App/frontend/src/components/form/FormInfectedFiles.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, waitFor } from '@testing-library/react';
 
 import { getAttachmentDataMock, getAttachmentMock } from 'src/__mocks__/getAttachmentsMock';

--- a/src/App/frontend/src/components/form/HelpTextContainer.test.tsx
+++ b/src/App/frontend/src/components/form/HelpTextContainer.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { HelpTextContainer } from 'src/components/form/HelpTextContainer';

--- a/src/App/frontend/src/components/form/HelpTextContainer.tsx
+++ b/src/App/frontend/src/components/form/HelpTextContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { HelpText } from 'src/app-components/HelpText/HelpText';
 import { translationKey } from 'src/AppComponentsBridge';

--- a/src/App/frontend/src/components/form/LinkToPotentialNode.tsx
+++ b/src/App/frontend/src/components/form/LinkToPotentialNode.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Link } from 'react-router';
 import type { LinkProps } from 'react-router';
 

--- a/src/App/frontend/src/components/form/LinkToPotentialPage.tsx
+++ b/src/App/frontend/src/components/form/LinkToPotentialPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Link } from 'react-router';
 import type { LinkProps } from 'react-router';
 

--- a/src/App/frontend/src/components/form/MessageBanner.tsx
+++ b/src/App/frontend/src/components/form/MessageBanner.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import classNames from 'classnames';
 
 import classes from 'src/components/form/MessageBanner.module.css';

--- a/src/App/frontend/src/components/form/OptionalIndicator.tsx
+++ b/src/App/frontend/src/components/form/OptionalIndicator.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useLanguage } from 'src/features/language/useLanguage';
 import { AltinnPalette } from 'src/theme/altinnAppTheme';
 

--- a/src/App/frontend/src/components/form/RadioButton.test.tsx
+++ b/src/App/frontend/src/components/form/RadioButton.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 
 import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
@@ -14,7 +14,7 @@ const defaultProps = {
 };
 
 const ControlledRadioButton = (props: Partial<IRadioButtonProps> = {}) => {
-  const [value, setValue] = React.useState<string | undefined>(undefined);
+  const [value, setValue] = useState<string | undefined>(undefined);
 
   return (
     <RadioButton

--- a/src/App/frontend/src/components/form/RadioButton.tsx
+++ b/src/App/frontend/src/components/form/RadioButton.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useRef } from 'react';
+import { forwardRef, useRef } from 'react';
+import * as React from 'react';
 
 import { Radio } from '@digdir/designsystemet-react';
 import cn from 'classnames';

--- a/src/App/frontend/src/components/form/RequiredIndicator.tsx
+++ b/src/App/frontend/src/components/form/RequiredIndicator.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Lang } from 'src/features/language/Lang';
 
 export interface IRequiredIndicatorProps {

--- a/src/App/frontend/src/components/form/caption/Caption.test.tsx
+++ b/src/App/frontend/src/components/form/caption/Caption.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { Caption } from 'src/components/form/caption/Caption';

--- a/src/App/frontend/src/components/form/caption/Caption.tsx
+++ b/src/App/frontend/src/components/form/caption/Caption.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { HtmlHTMLAttributes } from 'react';
 
 import { Label as DesignsystemetLabel } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/components/label/Label.tsx
+++ b/src/App/frontend/src/components/label/Label.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Label as DesignsystemetLabel } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/components/label/LabelContent.tsx
+++ b/src/App/frontend/src/components/label/LabelContent.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
+import * as React from 'react';
 
 import cn from 'classnames';
 

--- a/src/App/frontend/src/components/logo/AltinnLogo.tsx
+++ b/src/App/frontend/src/components/logo/AltinnLogo.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useQuery } from '@tanstack/react-query';
 import cn from 'classnames';
 

--- a/src/App/frontend/src/components/message/ErrorPaper.test.tsx
+++ b/src/App/frontend/src/components/message/ErrorPaper.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { render, screen } from '@testing-library/react';
 
 import { ErrorPaper } from 'src/components/message/ErrorPaper';

--- a/src/App/frontend/src/components/message/ErrorPaper.tsx
+++ b/src/App/frontend/src/components/message/ErrorPaper.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 
 import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/components/message/ErrorReport.tsx
+++ b/src/App/frontend/src/components/message/ErrorReport.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
+import * as React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { ErrorSummary } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/components/molecules/AltinnCollapsibleAttachments.test.tsx
+++ b/src/App/frontend/src/components/molecules/AltinnCollapsibleAttachments.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/App/frontend/src/components/molecules/AltinnCollapsibleAttachments.tsx
+++ b/src/App/frontend/src/components/molecules/AltinnCollapsibleAttachments.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import * as React from 'react';
 
 import { CaretDownFillIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';

--- a/src/App/frontend/src/components/molecules/AltinnSubstatus.test.tsx
+++ b/src/App/frontend/src/components/molecules/AltinnSubstatus.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { AltinnSubstatus } from 'src/components/molecules/AltinnSubstatus';

--- a/src/App/frontend/src/components/molecules/AltinnSubstatus.tsx
+++ b/src/App/frontend/src/components/molecules/AltinnSubstatus.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Paragraph } from '@digdir/designsystemet-react';
 

--- a/src/App/frontend/src/components/organisms/AltinnReceipt.test.tsx
+++ b/src/App/frontend/src/components/organisms/AltinnReceipt.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { IReceiptComponentProps, ReceiptComponent } from 'src/components/organisms/AltinnReceipt';

--- a/src/App/frontend/src/components/organisms/AltinnReceipt.tsx
+++ b/src/App/frontend/src/components/organisms/AltinnReceipt.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { JSX } from 'react';
 
 import { Heading } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/components/organisms/AltinnReceiptSimple.tsx
+++ b/src/App/frontend/src/components/organisms/AltinnReceiptSimple.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { JSX } from 'react';
 
 import { Heading, Paragraph } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/components/organisms/AttachmentGroupings.test.tsx
+++ b/src/App/frontend/src/components/organisms/AttachmentGroupings.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { render, screen } from '@testing-library/react';
 
 import { AttachmentGroupings } from 'src/components/organisms/AttachmentGroupings';

--- a/src/App/frontend/src/components/organisms/AttachmentGroupings.tsx
+++ b/src/App/frontend/src/components/organisms/AttachmentGroupings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { JSX } from 'react';
 
 import cn from 'classnames';

--- a/src/App/frontend/src/components/presentation/AppHeader/AppHeader.test.tsx
+++ b/src/App/frontend/src/components/presentation/AppHeader/AppHeader.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { act, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/components/presentation/AppHeader/AppHeader.tsx
+++ b/src/App/frontend/src/components/presentation/AppHeader/AppHeader.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { LandmarkShortcuts } from 'src/components/LandmarkShortcuts';
 import { AltinnLogo } from 'src/components/logo/AltinnLogo';
 import classes from 'src/components/presentation/AppHeader/AppHeader.module.css';

--- a/src/App/frontend/src/components/presentation/AppHeader/AppHeaderMenu.tsx
+++ b/src/App/frontend/src/components/presentation/AppHeader/AppHeaderMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Button, Dropdown } from '@digdir/designsystemet-react';
 import { Buildings3Icon, PersonIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/components/presentation/BackNavigationButton.tsx
+++ b/src/App/frontend/src/components/presentation/BackNavigationButton.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ArrowLeftIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';
 

--- a/src/App/frontend/src/components/presentation/ExpandWidthButton.tsx
+++ b/src/App/frontend/src/components/presentation/ExpandWidthButton.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from '@digdir/designsystemet-react';
 import { ExpandIcon, ShrinkIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';

--- a/src/App/frontend/src/components/presentation/Header.test.tsx
+++ b/src/App/frontend/src/components/presentation/Header.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { Header } from 'src/components/presentation/Header';

--- a/src/App/frontend/src/components/presentation/Header.tsx
+++ b/src/App/frontend/src/components/presentation/Header.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Heading } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/components/presentation/LanguageSelector.tsx
+++ b/src/App/frontend/src/components/presentation/LanguageSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Dropdown, RovingFocusItem, RovingFocusRoot } from '@digdir/designsystemet-react';
 import { CheckmarkIcon, ChevronDownIcon, GlobeIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/components/presentation/NavBar.test.tsx
+++ b/src/App/frontend/src/components/presentation/NavBar.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 import mockAxios from 'jest-mock-axios';
 

--- a/src/App/frontend/src/components/presentation/NavBar.tsx
+++ b/src/App/frontend/src/components/presentation/NavBar.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { BackNavigationButton } from 'src/components/presentation/BackNavigationButton';
 import { ExpandWidthButton } from 'src/components/presentation/ExpandWidthButton';
 import classes from 'src/components/presentation/NavBar.module.css';

--- a/src/App/frontend/src/components/presentation/OrganisationLogo/OrganisationLogo.test.tsx
+++ b/src/App/frontend/src/components/presentation/OrganisationLogo/OrganisationLogo.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';

--- a/src/App/frontend/src/components/presentation/OrganisationLogo/OrganisationLogo.tsx
+++ b/src/App/frontend/src/components/presentation/OrganisationLogo/OrganisationLogo.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import cn from 'classnames';
 
 import classes from 'src/components/presentation/OrganisationLogo/OrganisationLogo.module.css';

--- a/src/App/frontend/src/components/presentation/Presentation.test.tsx
+++ b/src/App/frontend/src/components/presentation/Presentation.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getPartyMock } from 'src/__mocks__/getPartyMock';

--- a/src/App/frontend/src/components/presentation/Presentation.tsx
+++ b/src/App/frontend/src/components/presentation/Presentation.tsx
@@ -1,4 +1,5 @@
-import React, { useLayoutEffect } from 'react';
+import { useLayoutEffect } from 'react';
+import * as React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import cn from 'classnames';

--- a/src/App/frontend/src/components/presentation/Progress.test.tsx
+++ b/src/App/frontend/src/components/presentation/Progress.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { defaultDataTypeMock, getUiConfigMock } from 'src/__mocks__/getUiConfigMock';

--- a/src/App/frontend/src/components/presentation/Progress.tsx
+++ b/src/App/frontend/src/components/presentation/Progress.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { getLabelId } from 'src/components/label/Label';
 import classes from 'src/components/presentation/Progress.module.css';

--- a/src/App/frontend/src/components/table/AltinnSummaryTable.tsx
+++ b/src/App/frontend/src/components/table/AltinnSummaryTable.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import cn from 'classnames';
 
 import classes from 'src/components/table/AltinnSummaryTable.module.css';

--- a/src/App/frontend/src/components/wrappers/ProcessWrapper.tsx
+++ b/src/App/frontend/src/components/wrappers/ProcessWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import type { PropsWithChildren } from 'react';
 

--- a/src/App/frontend/src/core/auth/KeepAliveProvider.tsx
+++ b/src/App/frontend/src/core/auth/KeepAliveProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { useQuery } from '@tanstack/react-query';

--- a/src/App/frontend/src/core/contexts/ApiProvider.tsx
+++ b/src/App/frontend/src/core/contexts/ApiProvider.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { type InstanceApi, instanceApi } from 'src/core/api-client/instance.api';

--- a/src/App/frontend/src/core/contexts/AppQueriesProvider.tsx
+++ b/src/App/frontend/src/core/contexts/AppQueriesProvider.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
+import * as React from 'react';
 
 import { QueryClientProvider } from '@tanstack/react-query';
 import type { QueryClient } from '@tanstack/react-query';

--- a/src/App/frontend/src/core/contexts/TaskOverrides.tsx
+++ b/src/App/frontend/src/core/contexts/TaskOverrides.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
 import type { PropsWithChildren } from 'react';
 
 interface TaskOverridesContext {

--- a/src/App/frontend/src/core/contexts/context.tsx
+++ b/src/App/frontend/src/core/contexts/context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext as createReactContext, memo, useContext } from 'react';
+import { createContext as createReactContext, memo, useContext } from 'react';
 import type { Provider } from 'react';
 
 interface ContextProvider<T> {

--- a/src/App/frontend/src/core/contexts/hookContext.tsx
+++ b/src/App/frontend/src/core/contexts/hookContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
+import * as React from 'react';
 import type { PropsWithChildren } from 'react';
 
 type HookContextProps = {

--- a/src/App/frontend/src/core/contexts/queryContext.tsx
+++ b/src/App/frontend/src/core/contexts/queryContext.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import type { UseQueryResult } from '@tanstack/react-query';

--- a/src/App/frontend/src/core/contexts/zustandContext.tsx
+++ b/src/App/frontend/src/core/contexts/zustandContext.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import deepEqual from 'fast-deep-equal';

--- a/src/App/frontend/src/core/errorHandling/DisplayError.tsx
+++ b/src/App/frontend/src/core/errorHandling/DisplayError.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { AxiosError } from 'axios';
 
 import { InvalidSubformLayoutException } from 'src/features/formData/InvalidSubformLayoutException';

--- a/src/App/frontend/src/core/loading/Loader.test.tsx
+++ b/src/App/frontend/src/core/loading/Loader.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { Loader } from 'src/core/loading/Loader';

--- a/src/App/frontend/src/core/loading/Loader.tsx
+++ b/src/App/frontend/src/core/loading/Loader.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { AltinnContentLoader } from 'src/app-components/loading/AltinnContentLoader/AltinnContentLoader';
 import { PresentationComponent, useHasPresentation } from 'src/components/presentation/Presentation';
 import { LoadingProvider } from 'src/core/loading/LoadingContext';

--- a/src/App/frontend/src/core/loading/LoadingContext.tsx
+++ b/src/App/frontend/src/core/loading/LoadingContext.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { createContext } from 'src/core/contexts/context';

--- a/src/App/frontend/src/core/texts/appTexts.test.tsx
+++ b/src/App/frontend/src/core/texts/appTexts.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';

--- a/src/App/frontend/src/core/ui/RenderStart.tsx
+++ b/src/App/frontend/src/core/ui/RenderStart.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useLocation } from 'react-router';
 import type { PropsWithChildren } from 'react';
 

--- a/src/App/frontend/src/features/alertOnChange/DeleteWarningPopover.tsx
+++ b/src/App/frontend/src/features/alertOnChange/DeleteWarningPopover.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Popover } from '@digdir/designsystemet-react';
 

--- a/src/App/frontend/src/features/attachments/StoreAttachmentsInNode.tsx
+++ b/src/App/frontend/src/features/attachments/StoreAttachmentsInNode.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import deepEqual from 'fast-deep-equal';
 

--- a/src/App/frontend/src/features/devtools/DevTools.tsx
+++ b/src/App/frontend/src/features/devtools/DevTools.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { OpenDevToolsButton } from 'src/features/devtools/components/OpenDevToolsButton/OpenDevToolsButton';
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';

--- a/src/App/frontend/src/features/devtools/DevToolsControls.tsx
+++ b/src/App/frontend/src/features/devtools/DevToolsControls.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Tabs } from '@digdir/designsystemet-react';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 

--- a/src/App/frontend/src/features/devtools/DevToolsPanel.tsx
+++ b/src/App/frontend/src/features/devtools/DevToolsPanel.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-import React, { useState } from 'react';
+import { useState } from 'react';
+import * as React from 'react';
 import type { ErrorInfo, PropsWithChildren } from 'react';
 
 import { XMarkIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/features/devtools/components/DevHiddenFunctionality/DevHiddenFunctionality.tsx
+++ b/src/App/frontend/src/features/devtools/components/DevHiddenFunctionality/DevHiddenFunctionality.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Fieldset, ToggleGroup } from '@digdir/designsystemet-react';
 
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';

--- a/src/App/frontend/src/features/devtools/components/DevLanguageSelector/DevLanguageSelector.tsx
+++ b/src/App/frontend/src/features/devtools/components/DevLanguageSelector/DevLanguageSelector.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Fieldset } from '@digdir/designsystemet-react';
 
 import { LanguageSelector } from 'src/components/presentation/LanguageSelector';

--- a/src/App/frontend/src/features/devtools/components/DevNavigationButtons/DevNavigationButtons.tsx
+++ b/src/App/frontend/src/features/devtools/components/DevNavigationButtons/DevNavigationButtons.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Chip, EXPERIMENTAL_Suggestion as Suggestion, Fieldset } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 

--- a/src/App/frontend/src/features/devtools/components/DevToolsLogs/DevToolsLogs.tsx
+++ b/src/App/frontend/src/features/devtools/components/DevToolsLogs/DevToolsLogs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { Fragment, useState } from 'react';
 
 import {
   DownloadIcon,
@@ -123,7 +123,7 @@ export const DevToolsLogs = () => {
                 const urlRegex = /(https?:\/\/[^\s]+)/g;
                 const split = line.split(urlRegex);
                 return (
-                  <React.Fragment key={line}>
+                  <Fragment key={line}>
                     {split.map((part, index) => {
                       if (part.match(urlRegex)) {
                         return (
@@ -140,7 +140,7 @@ export const DevToolsLogs = () => {
                       return part;
                     })}
                     <br />
-                  </React.Fragment>
+                  </Fragment>
                 );
               })}
             </pre>

--- a/src/App/frontend/src/features/devtools/components/DownloadXMLButton/DownloadXMLButton.tsx
+++ b/src/App/frontend/src/features/devtools/components/DownloadXMLButton/DownloadXMLButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Dropzone from 'react-dropzone';
 
 import { EXPERIMENTAL_Suggestion as Suggestion, Fieldset } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
+++ b/src/App/frontend/src/features/devtools/components/ExpressionPlayground/ExpressionPlayground.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { Checkbox, EXPERIMENTAL_Suggestion as Suggestion, Fieldset, Tabs } from '@digdir/designsystemet-react';
 import cn from 'classnames';

--- a/src/App/frontend/src/features/devtools/components/LayoutInspector/ComponentSelector.tsx
+++ b/src/App/frontend/src/features/devtools/components/LayoutInspector/ComponentSelector.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import * as React from 'react';
 
 import { FingerButtonIcon } from '@navikt/aksel-icons';
 

--- a/src/App/frontend/src/features/devtools/components/LayoutInspector/LayoutInspector.tsx
+++ b/src/App/frontend/src/features/devtools/components/LayoutInspector/LayoutInspector.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import * as React from 'react';
 
 import { Alert } from '@digdir/designsystemet-react';
 import { XMarkIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/features/devtools/components/LayoutInspector/LayoutInspectorItem.tsx
+++ b/src/App/frontend/src/features/devtools/components/LayoutInspector/LayoutInspectorItem.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';

--- a/src/App/frontend/src/features/devtools/components/NodeInspector/DefaultNodeInspector.tsx
+++ b/src/App/frontend/src/features/devtools/components/NodeInspector/DefaultNodeInspector.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import cn from 'classnames';
 
 import classes from 'src/features/devtools/components/NodeInspector/NodeInspector.module.css';

--- a/src/App/frontend/src/features/devtools/components/NodeInspector/NodeHierarchy.tsx
+++ b/src/App/frontend/src/features/devtools/components/NodeInspector/NodeHierarchy.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { EyeSlashIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';

--- a/src/App/frontend/src/features/devtools/components/NodeInspector/NodeInspector.tsx
+++ b/src/App/frontend/src/features/devtools/components/NodeInspector/NodeInspector.tsx
@@ -1,6 +1,4 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React from 'react';
-
 import { Tabs } from '@digdir/designsystemet-react';
 import { XMarkIcon } from '@navikt/aksel-icons';
 

--- a/src/App/frontend/src/features/devtools/components/NodeInspector/NodeInspectorDataField.tsx
+++ b/src/App/frontend/src/features/devtools/components/NodeInspector/NodeInspectorDataField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import cn from 'classnames';
 import dot from 'dot-object';

--- a/src/App/frontend/src/features/devtools/components/NodeInspector/NodeInspectorDataModelBindings.tsx
+++ b/src/App/frontend/src/features/devtools/components/NodeInspector/NodeInspectorDataModelBindings.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useBindingSchema } from 'src/features/datamodel/useBindingSchema';
 import classes from 'src/features/devtools/components/NodeInspector/NodeInspector.module.css';
 import { Value } from 'src/features/devtools/components/NodeInspector/NodeInspectorDataField';

--- a/src/App/frontend/src/features/devtools/components/NodeInspector/NodeInspectorTextResourceBindings.tsx
+++ b/src/App/frontend/src/features/devtools/components/NodeInspector/NodeInspectorTextResourceBindings.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import classes from 'src/features/devtools/components/NodeInspector/NodeInspector.module.css';
 import { Value } from 'src/features/devtools/components/NodeInspector/NodeInspectorDataField';
 import { canBeExpression } from 'src/features/expressions/validation';

--- a/src/App/frontend/src/features/devtools/components/NodeInspector/ValidationInspector.tsx
+++ b/src/App/frontend/src/features/devtools/components/NodeInspector/ValidationInspector.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { EyeSlashIcon } from '@navikt/aksel-icons';
 
 import { isAttachmentUploaded } from 'src/features/attachments';

--- a/src/App/frontend/src/features/devtools/components/OpenDevToolsButton/OpenDevToolsButton.tsx
+++ b/src/App/frontend/src/features/devtools/components/OpenDevToolsButton/OpenDevToolsButton.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { CodeIcon, XMarkOctagonFillIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';
 

--- a/src/App/frontend/src/features/devtools/components/PDFPreviewButton/PDFPreviewButton.tsx
+++ b/src/App/frontend/src/features/devtools/components/PDFPreviewButton/PDFPreviewButton.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Fieldset } from '@digdir/designsystemet-react';
 import { FilePdfIcon } from '@navikt/aksel-icons';
 

--- a/src/App/frontend/src/features/devtools/components/PermissionsEditor/PermissionsEditor.tsx
+++ b/src/App/frontend/src/features/devtools/components/PermissionsEditor/PermissionsEditor.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Checkbox, Fieldset } from '@digdir/designsystemet-react';
 
 import classes from 'src/features/devtools/components/PermissionsEditor/PermissionsEditor.module.css';

--- a/src/App/frontend/src/features/devtools/components/SplitView/SplitView.tsx
+++ b/src/App/frontend/src/features/devtools/components/SplitView/SplitView.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-import React, { Children, createRef, useEffect, useMemo, useState } from 'react';
+import { Children, createRef, useEffect, useMemo, useState } from 'react';
+import * as React from 'react';
 
 import classes from 'src/features/devtools/components/SplitView/SplitView.module.css';
 

--- a/src/App/frontend/src/features/devtools/components/VersionSwitcher/VersionSwitcher.tsx
+++ b/src/App/frontend/src/features/devtools/components/VersionSwitcher/VersionSwitcher.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 
 import { EXPERIMENTAL_Suggestion as Suggestion, Fieldset } from '@digdir/designsystemet-react';
 import { useQuery } from '@tanstack/react-query';
@@ -11,7 +11,7 @@ import { optionFilter } from 'src/utils/options';
 import { appPath, getAppFrontendCDNPath, getFrontendVersionsCDN } from 'src/utils/urls/appUrlHelper';
 
 export const VersionSwitcher = () => {
-  const [selectedVersion, setSelectedVersion] = React.useState<string | undefined>(undefined);
+  const [selectedVersion, setSelectedVersion] = useState<string | undefined>(undefined);
   const {
     data: versions,
     isLoading: isVersionsLoading,

--- a/src/App/frontend/src/features/expressions/shared-context.test.tsx
+++ b/src/App/frontend/src/features/expressions/shared-context.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';

--- a/src/App/frontend/src/features/expressions/shared-functions.test.tsx
+++ b/src/App/frontend/src/features/expressions/shared-functions.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { screen } from '@testing-library/react';
 

--- a/src/App/frontend/src/features/footer/Footer.tsx
+++ b/src/App/frontend/src/features/footer/Footer.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import cn from 'classnames';
 
 import { AltinnLogo, LogoColor } from 'src/components/logo/AltinnLogo';

--- a/src/App/frontend/src/features/footer/components/FooterComponentWrapper.tsx
+++ b/src/App/frontend/src/features/footer/components/FooterComponentWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import type { JSX } from 'react';
 
 import classes from 'src/features/footer/components/FooterComponentWrapper.module.css';
@@ -11,5 +11,5 @@ interface IFooterComponentWrapper {
 }
 
 export const FooterComponentWrapper = ({ props, childRenderer }: IFooterComponentWrapper) => (
-  <div className={classes.wrapper}>{React.createElement(childRenderer, props)}</div>
+  <div className={classes.wrapper}>{createElement(childRenderer, props)}</div>
 );

--- a/src/App/frontend/src/features/footer/components/FooterEmail.tsx
+++ b/src/App/frontend/src/features/footer/components/FooterEmail.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FooterGenericLink } from 'src/features/footer/components/shared/FooterGenericLink';
 import { useLanguage } from 'src/features/language/useLanguage';
 import type { IFooterBaseComponent } from 'src/features/footer/types';

--- a/src/App/frontend/src/features/footer/components/FooterLink.tsx
+++ b/src/App/frontend/src/features/footer/components/FooterLink.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FooterGenericLink } from 'src/features/footer/components/shared/FooterGenericLink';
 import { useLanguage } from 'src/features/language/useLanguage';
 import type { IFooterBaseComponent, IFooterIcon } from 'src/features/footer/types';

--- a/src/App/frontend/src/features/footer/components/FooterPhone.tsx
+++ b/src/App/frontend/src/features/footer/components/FooterPhone.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FooterGenericLink } from 'src/features/footer/components/shared/FooterGenericLink';
 import { useLanguage } from 'src/features/language/useLanguage';
 import type { IFooterBaseComponent } from 'src/features/footer/types';

--- a/src/App/frontend/src/features/footer/components/FooterText.tsx
+++ b/src/App/frontend/src/features/footer/components/FooterText.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Lang } from 'src/features/language/Lang';
 import type { IFooterBaseComponent } from 'src/features/footer/types';
 

--- a/src/App/frontend/src/features/footer/components/index.ts
+++ b/src/App/frontend/src/features/footer/components/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import type { JSX } from 'react';
 
 import { v4 as uuidv4 } from 'uuid';
@@ -19,7 +19,7 @@ export abstract class FooterComponent<T extends IFooterBaseComponent<IFooterComp
   }
 
   public render() {
-    return React.createElement(FooterComponent.wrapper, {
+    return createElement(FooterComponent.wrapper, {
       key: this.id,
       props: this.props,
       childRenderer: this.renderComponent,

--- a/src/App/frontend/src/features/footer/components/shared/FooterGenericLink.tsx
+++ b/src/App/frontend/src/features/footer/components/shared/FooterGenericLink.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Link } from '@digdir/designsystemet-react';
 
 import { FooterIcon } from 'src/features/footer/components/shared/FooterIcon';

--- a/src/App/frontend/src/features/footer/components/shared/FooterIcon.tsx
+++ b/src/App/frontend/src/features/footer/components/shared/FooterIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { EnvelopeClosedIcon, InformationSquareIcon, PhoneIcon } from '@navikt/aksel-icons';
 
 import type { IFooterIcon } from 'src/features/footer/types';

--- a/src/App/frontend/src/features/form/FormProvider.tsx
+++ b/src/App/frontend/src/features/form/FormProvider.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+import * as React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { createStore } from 'zustand';

--- a/src/App/frontend/src/features/form/layout/UiConfigContext.tsx
+++ b/src/App/frontend/src/features/form/layout/UiConfigContext.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import * as React from 'react';
 
 import { createContext } from 'src/core/contexts/context';
 

--- a/src/App/frontend/src/features/formData/FormData.test.tsx
+++ b/src/App/frontend/src/features/formData/FormData.test.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import * as React from 'react';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
 import type { PropsWithChildren } from 'react';
 

--- a/src/App/frontend/src/features/formData/FormDataReaders.test.tsx
+++ b/src/App/frontend/src/features/formData/FormDataReaders.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, waitFor } from '@testing-library/react';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/src/App/frontend/src/features/formData/FormDataReaders.tsx
+++ b/src/App/frontend/src/features/formData/FormDataReaders.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import dot from 'dot-object';

--- a/src/App/frontend/src/features/formData/FormDataWrite.tsx
+++ b/src/App/frontend/src/features/formData/FormDataWrite.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { useIsMutating, useMutation, useQueryClient } from '@tanstack/react-query';
 import dot from 'dot-object';

--- a/src/App/frontend/src/features/formData/MissingRowIdView.tsx
+++ b/src/App/frontend/src/features/formData/MissingRowIdView.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ALTINN_ROW_ID } from 'src/features/formData/types';
 import { InstantiationErrorPage } from 'src/features/instantiate/containers/InstantiationErrorPage';
 import { Lang } from 'src/features/language/Lang';

--- a/src/App/frontend/src/features/formData/useDataModelBindings.test.tsx
+++ b/src/App/frontend/src/features/formData/useDataModelBindings.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/features/instance/InstanceContext.tsx
+++ b/src/App/frontend/src/features/instance/InstanceContext.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import { createContext, useCallback, useMemo } from 'react';
 import { useNavigation } from 'react-router';
 import type { PropsWithChildren } from 'react';
 
@@ -21,7 +21,7 @@ import { buildInstanceDataSources } from 'src/utils/instanceDataSources';
 import type { IData, IInstance, IInstanceDataSources } from 'src/types/shared';
 
 const emptyArray: never[] = [];
-const InstanceContext = React.createContext<IInstance | null>(null);
+const InstanceContext = createContext<IInstance | null>(null);
 
 export const InstanceProvider = ({ children }: PropsWithChildren) => {
   const instanceOwnerPartyId = useNavigationParam('instanceOwnerPartyId');

--- a/src/App/frontend/src/features/instance/useProcessNext.tsx
+++ b/src/App/frontend/src/features/instance/useProcessNext.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { toast } from 'react-toastify';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';

--- a/src/App/frontend/src/features/instantiate/InstantiationError.tsx
+++ b/src/App/frontend/src/features/instantiate/InstantiationError.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useParams } from 'react-router';
 
 import { InstantiateValidationError } from 'src/features/instantiate/containers/InstantiateValidationError';

--- a/src/App/frontend/src/features/instantiate/InstantiationValidation.tsx
+++ b/src/App/frontend/src/features/instantiate/InstantiationValidation.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Lang } from 'src/features/language/Lang';
 import type { IParty } from 'src/types/shared';
 

--- a/src/App/frontend/src/features/instantiate/containers/ForbiddenError.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/ForbiddenError.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { InstantiationErrorPage } from 'src/features/instantiate/containers/InstantiationErrorPage';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';

--- a/src/App/frontend/src/features/instantiate/containers/InstantiateValidationError.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/InstantiateValidationError.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { InstantiationErrorPage } from 'src/features/instantiate/containers/InstantiationErrorPage';
 import {
   InstantiationValidation,

--- a/src/App/frontend/src/features/instantiate/containers/InstantiationContainer.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/InstantiationContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
 import { RenderStart } from 'src/core/ui/RenderStart';

--- a/src/App/frontend/src/features/instantiate/containers/InstantiationErrorPage.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/InstantiationErrorPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Flex } from 'src/app-components/Flex/Flex';
 import { AltinnError } from 'src/components/altinnError';

--- a/src/App/frontend/src/features/instantiate/containers/InvalidSubformLayoutError.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/InvalidSubformLayoutError.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from 'src/app-components/Button/Button';
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
 import { DevToolsTab } from 'src/features/devtools/data/types';

--- a/src/App/frontend/src/features/instantiate/containers/MissingRolesError.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/MissingRolesError.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router';
 
 import { InstantiationErrorPage } from 'src/features/instantiate/containers/InstantiationErrorPage';

--- a/src/App/frontend/src/features/instantiate/containers/NoValidPartiesError.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/NoValidPartiesError.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { getApplicationMetadata } from 'src/features/applicationMetadata';
 import { InstantiationErrorPage } from 'src/features/instantiate/containers/InstantiationErrorPage';
 import { Lang } from 'src/features/language/Lang';

--- a/src/App/frontend/src/features/instantiate/containers/PartySelection.test.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/PartySelection.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { screen, waitFor } from '@testing-library/react';

--- a/src/App/frontend/src/features/instantiate/containers/PartySelection.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/PartySelection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useMatch, useNavigate } from 'react-router';
 
 import { Checkbox, Heading, Paragraph } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/features/instantiate/containers/UnknownError.test.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/UnknownError.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { UnknownError } from 'src/features/instantiate/containers/UnknownError';

--- a/src/App/frontend/src/features/instantiate/containers/UnknownError.tsx
+++ b/src/App/frontend/src/features/instantiate/containers/UnknownError.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from 'src/app-components/Button/Button';
 import { useDevToolsStore } from 'src/features/devtools/data/DevToolsStore';
 import { DevToolsTab } from 'src/features/devtools/data/types';

--- a/src/App/frontend/src/features/instantiate/instantiateHeader/InstantiateHeader.test.tsx
+++ b/src/App/frontend/src/features/instantiate/instantiateHeader/InstantiateHeader.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getOrganisationMock } from 'src/__mocks__/getOrganisationMock';

--- a/src/App/frontend/src/features/instantiate/instantiateHeader/InstantiateHeader.tsx
+++ b/src/App/frontend/src/features/instantiate/instantiateHeader/InstantiateHeader.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Buildings3Icon, PersonIcon } from '@navikt/aksel-icons';
 
 import { CircleIcon } from 'src/components/CircleIcon';

--- a/src/App/frontend/src/features/instantiate/selection/ActiveInstancesProvider.tsx
+++ b/src/App/frontend/src/features/instantiate/selection/ActiveInstancesProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { useQuery } from '@tanstack/react-query';

--- a/src/App/frontend/src/features/instantiate/selection/InstanceSelection.test.tsx
+++ b/src/App/frontend/src/features/instantiate/selection/InstanceSelection.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/features/instantiate/selection/InstanceSelection.tsx
+++ b/src/App/frontend/src/features/instantiate/selection/InstanceSelection.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import * as React from 'react';
 import { useNavigate } from 'react-router';
 
 import { Heading, Paragraph, Table } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/features/language/Lang.test.tsx
+++ b/src/App/frontend/src/features/language/Lang.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { Lang } from 'src/features/language/Lang';

--- a/src/App/frontend/src/features/language/Lang.tsx
+++ b/src/App/frontend/src/features/language/Lang.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Paragraph } from '@digdir/designsystemet-react';
 
 import { useLanguage } from 'src/features/language/useLanguage';

--- a/src/App/frontend/src/features/language/useLanguage.test.tsx
+++ b/src/App/frontend/src/features/language/useLanguage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getApplicationSettingsMock } from 'src/__mocks__/getApplicationSettingsMock';

--- a/src/App/frontend/src/features/navigation/AppNavigation.test.tsx
+++ b/src/App/frontend/src/features/navigation/AppNavigation.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/App/frontend/src/features/navigation/AppNavigation.tsx
+++ b/src/App/frontend/src/features/navigation/AppNavigation.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Heading } from '@digdir/designsystemet-react';
 import { XMarkIcon } from '@navikt/aksel-icons';
 

--- a/src/App/frontend/src/features/navigation/NavigationEffectContext.tsx
+++ b/src/App/frontend/src/features/navigation/NavigationEffectContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { createContext } from 'src/core/contexts/context';
@@ -20,7 +20,7 @@ const { useCtx, Provider } = createContext<Context>({
 });
 
 export function NavigationEffectProvider({ children }: PropsWithChildren) {
-  const [effect, setEffect] = React.useState<Context['effect']>(null);
+  const [effect, setEffect] = useState<Context['effect']>(null);
   return <Provider value={{ effect, setEffect }}>{children}</Provider>;
 }
 export const useNavigationEffect = () => useCtx().effect;

--- a/src/App/frontend/src/features/navigation/PopoverNavigation.tsx
+++ b/src/App/frontend/src/features/navigation/PopoverNavigation.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import * as React from 'react';
 import type { CSSProperties } from 'react';
 
 import { Dialog, Dropdown } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/features/navigation/SidebarNavigation.tsx
+++ b/src/App/frontend/src/features/navigation/SidebarNavigation.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useUiConfigContext } from 'src/features/form/layout/UiConfigContext';
 import { AppNavigation, AppNavigationHeading, appNavigationHeadingId } from 'src/features/navigation/AppNavigation';
 import classes from 'src/features/navigation/SidebarNavigation.module.css';

--- a/src/App/frontend/src/features/navigation/components/Page.tsx
+++ b/src/App/frontend/src/features/navigation/components/Page.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { CheckmarkIcon, XMarkIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';
 

--- a/src/App/frontend/src/features/navigation/components/PageGroup.tsx
+++ b/src/App/frontend/src/features/navigation/components/PageGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
 import { CheckmarkIcon, ChevronDownIcon, InformationIcon, XMarkIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';

--- a/src/App/frontend/src/features/navigation/components/SubformsForPage.tsx
+++ b/src/App/frontend/src/features/navigation/components/SubformsForPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { ChevronDownIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';

--- a/src/App/frontend/src/features/navigation/components/TaskGroup.tsx
+++ b/src/App/frontend/src/features/navigation/components/TaskGroup.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import cn from 'classnames';
 
 import { Lang } from 'src/features/language/Lang';

--- a/src/App/frontend/src/features/options/RunOptionsEffects.tsx
+++ b/src/App/frontend/src/features/options/RunOptionsEffects.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FormStore } from 'src/features/form/FormContext';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { EffectPreselectedOptionIndex } from 'src/features/options/effects/EffectPreselectedOptionIndex';

--- a/src/App/frontend/src/features/options/useGetOptions.test.tsx
+++ b/src/App/frontend/src/features/options/useGetOptions.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { jest } from '@jest/globals';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';

--- a/src/App/frontend/src/features/party/PartiesProvider.tsx
+++ b/src/App/frontend/src/features/party/PartiesProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { createContext } from 'src/core/contexts/context';

--- a/src/App/frontend/src/features/payment/PaymentProvider.tsx
+++ b/src/App/frontend/src/features/payment/PaymentProvider.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useEffect } from 'react';
+import { createContext, useContext, useEffect } from 'react';
+import * as React from 'react';
 import type { ReactNode } from 'react';
 
 import type { AxiosError } from 'axios';

--- a/src/App/frontend/src/features/pdf/PDFWrapper.test.tsx
+++ b/src/App/frontend/src/features/pdf/PDFWrapper.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Form } from 'react-router';
 
 import { screen, waitFor } from '@testing-library/react';

--- a/src/App/frontend/src/features/pdf/PdfFromLayout.tsx
+++ b/src/App/frontend/src/features/pdf/PdfFromLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import type { PropsWithChildren } from 'react';
 

--- a/src/App/frontend/src/features/pdf/PdfWrapper.tsx
+++ b/src/App/frontend/src/features/pdf/PdfWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import cn from 'classnames';

--- a/src/App/frontend/src/features/process/confirm/containers/Confirm.test.tsx
+++ b/src/App/frontend/src/features/process/confirm/containers/Confirm.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getInstanceDataMock } from 'src/__mocks__/getInstanceDataMock';

--- a/src/App/frontend/src/features/process/confirm/containers/Confirm.tsx
+++ b/src/App/frontend/src/features/process/confirm/containers/Confirm.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { AltinnContentLoader } from 'src/app-components/loading/AltinnContentLoader/AltinnContentLoader';
 import { useAppName } from 'src/core/texts/appTexts';
 import { getApplicationMetadata } from 'src/features/applicationMetadata';

--- a/src/App/frontend/src/features/process/confirm/containers/ConfirmPage.test.tsx
+++ b/src/App/frontend/src/features/process/confirm/containers/ConfirmPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AxiosResponse } from 'axios';

--- a/src/App/frontend/src/features/process/confirm/containers/ConfirmPage.tsx
+++ b/src/App/frontend/src/features/process/confirm/containers/ConfirmPage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from 'src/app-components/Button/Button';
 import { ReceiptComponent } from 'src/components/organisms/AltinnReceipt';
 import { ReadyForPrint } from 'src/components/ReadyForPrint';

--- a/src/App/frontend/src/features/process/feedback/Feedback.tsx
+++ b/src/App/frontend/src/features/process/feedback/Feedback.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { ReadyForPrint } from 'src/components/ReadyForPrint';
 import { useAppName, useAppOwner } from 'src/core/texts/appTexts';

--- a/src/App/frontend/src/features/process/service/ServiceTask.tsx
+++ b/src/App/frontend/src/features/process/service/ServiceTask.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Heading, Paragraph } from '@digdir/designsystemet-react';
 
 import { Button } from 'src/app-components/Button/Button';

--- a/src/App/frontend/src/features/receipt/FixWrongReceiptType.tsx
+++ b/src/App/frontend/src/features/receipt/FixWrongReceiptType.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Loader } from 'src/core/loading/Loader';

--- a/src/App/frontend/src/features/receipt/ReceiptContainer.test.tsx
+++ b/src/App/frontend/src/features/receipt/ReceiptContainer.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';

--- a/src/App/frontend/src/features/receipt/ReceiptContainer.tsx
+++ b/src/App/frontend/src/features/receipt/ReceiptContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { formatDate } from 'date-fns';
 

--- a/src/App/frontend/src/features/stateless/getAllowAnonymous.test.tsx
+++ b/src/App/frontend/src/features/stateless/getAllowAnonymous.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';

--- a/src/App/frontend/src/features/validation/ComponentValidations.tsx
+++ b/src/App/frontend/src/features/validation/ComponentValidations.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Alert, ValidationMessage } from '@digdir/designsystemet-react';
 
 import { Lang } from 'src/features/language/Lang';

--- a/src/App/frontend/src/features/validation/StoreValidationsInNode.tsx
+++ b/src/App/frontend/src/features/validation/StoreValidationsInNode.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import deepEqual from 'fast-deep-equal';
 

--- a/src/App/frontend/src/features/validation/ValidationPlugin.test.tsx
+++ b/src/App/frontend/src/features/validation/ValidationPlugin.test.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { screen, waitFor, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';

--- a/src/App/frontend/src/features/validation/expressionValidation/ExpressionValidation.tsx
+++ b/src/App/frontend/src/features/validation/expressionValidation/ExpressionValidation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { FrontendValidationSource, ValidationMask } from '..';
 import type { FieldValidations, IExpressionValidation } from '..';

--- a/src/App/frontend/src/features/validation/schemaValidation/SchemaValidation.test.tsx
+++ b/src/App/frontend/src/features/validation/schemaValidation/SchemaValidation.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { render } from '@testing-library/react';
 import type { JSONSchema7 } from 'json-schema';
 

--- a/src/App/frontend/src/features/validation/validationContext.tsx
+++ b/src/App/frontend/src/features/validation/validationContext.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useEffect, useMemo, useRef } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import deepEqual from 'fast-deep-equal';
 import type { Draft } from 'immer';

--- a/src/App/frontend/src/hooks/delayedSelectors.test.tsx
+++ b/src/App/frontend/src/hooks/delayedSelectors.test.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';

--- a/src/App/frontend/src/hooks/useCookieState.test.tsx
+++ b/src/App/frontend/src/hooks/useCookieState.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { act, renderHook, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/hooks/useStateDeepEqual.test.tsx
+++ b/src/App/frontend/src/hooks/useStateDeepEqual.test.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { act, renderHook, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';

--- a/src/App/frontend/src/hooks/useWaitForState.test.tsx
+++ b/src/App/frontend/src/hooks/useWaitForState.test.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 
 import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
@@ -254,7 +254,7 @@ function ChildComponentInner(_props: { wait: () => Promise<string> }) {
   return <div data-testid='childRenderCount'>{renderCount.current}</div>;
 }
 
-const ChildComponent = React.memo(ChildComponentInner);
+const ChildComponent = memo(ChildComponentInner);
 
 function SetterComponent({ store, setToValue }: { store: StoreApi<string>; setToValue: string }) {
   const setStore = useCallback(() => store.setState(setToValue), [store, setToValue]);

--- a/src/App/frontend/src/index.tsx
+++ b/src/App/frontend/src/index.tsx
@@ -2,7 +2,6 @@
 // all the polyfills we need and inject them here
 import 'core-js';
 
-import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router';
 

--- a/src/App/frontend/src/language/sharedLanguage.ts
+++ b/src/App/frontend/src/language/sharedLanguage.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 
 import { Heading } from '@digdir/designsystemet-react';
 import DOMPurify from 'dompurify';
@@ -76,52 +76,48 @@ const parserOptions: HTMLReactParserOptions = {
      * Replace p tag with Paragraph component from design system
      */
     if (isElement(domNode) && domNode.name === 'p') {
-      return React.createElement(
-        'p',
-        { style: { margin: 0 } },
-        domToReact(domNode.children as DOMNode[], parserOptions),
-      );
+      return createElement('p', { style: { margin: 0 } }, domToReact(domNode.children as DOMNode[], parserOptions));
     }
     /**
      * Replace h1-h6 tags with Heading component from design system
      */
     if (isElement(domNode) && domNode.name === 'h1') {
-      return React.createElement(
+      return createElement(
         Heading,
         { level: 1, 'data-size': 'lg' },
         domToReact(domNode.children as DOMNode[], parserOptions),
       );
     }
     if (isElement(domNode) && domNode.name === 'h2') {
-      return React.createElement(
+      return createElement(
         Heading,
         { level: 2, 'data-size': 'md' },
         domToReact(domNode.children as DOMNode[], parserOptions),
       );
     }
     if (isElement(domNode) && domNode.name === 'h3') {
-      return React.createElement(
+      return createElement(
         Heading,
         { level: 3, 'data-size': 'sm' },
         domToReact(domNode.children as DOMNode[], parserOptions),
       );
     }
     if (isElement(domNode) && domNode.name === 'h4') {
-      return React.createElement(
+      return createElement(
         Heading,
         { level: 4, 'data-size': 'xs' },
         domToReact(domNode.children as DOMNode[], parserOptions),
       );
     }
     if (isElement(domNode) && domNode.name === 'h5') {
-      return React.createElement(
+      return createElement(
         Heading,
         { level: 5, 'data-size': 'xs' },
         domToReact(domNode.children as DOMNode[], parserOptions),
       );
     }
     if (isElement(domNode) && domNode.name === 'h6') {
-      return React.createElement(
+      return createElement(
         Heading,
         { level: 6, 'data-size': 'xs' },
         domToReact(domNode.children as DOMNode[], parserOptions),
@@ -131,14 +127,14 @@ const parserOptions: HTMLReactParserOptions = {
      * Internal links
      */
     if (isElement(domNode) && domNode.name === 'a' && domNode.attribs['data-link-type'] === 'LinkToPotentialNode') {
-      return React.createElement(
+      return createElement(
         LinkToPotentialNode,
         { to: domNode.attribs.href, preventScrollReset: true },
         domToReact(domNode.children as DOMNode[], parserOptions),
       );
     }
     if (isElement(domNode) && domNode.name === 'a' && domNode.attribs['data-link-type'] === 'LinkToPotentialPage') {
-      return React.createElement(
+      return createElement(
         LinkToPotentialPage,
         { to: domNode.attribs.href, preventScrollReset: true },
         domToReact(domNode.children as DOMNode[], parserOptions),

--- a/src/App/frontend/src/layout/Accordion/Accordion.test.tsx
+++ b/src/App/frontend/src/layout/Accordion/Accordion.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { Accordion } from 'src/layout/Accordion/Accordion';

--- a/src/App/frontend/src/layout/Accordion/Accordion.tsx
+++ b/src/App/frontend/src/layout/Accordion/Accordion.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Card } from '@digdir/designsystemet-react';
 
 import { AccordionItem } from 'src/app-components/Accordion/AccordionItem';

--- a/src/App/frontend/src/layout/Accordion/SummaryAccordion.tsx
+++ b/src/App/frontend/src/layout/Accordion/SummaryAccordion.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import cn from 'classnames';
 
 import { useLanguage } from 'src/features/language/useLanguage';

--- a/src/App/frontend/src/layout/Accordion/index.tsx
+++ b/src/App/frontend/src/layout/Accordion/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
+import * as React from 'react';
 
 import { Accordion as AccordionComponent } from 'src/layout/Accordion/Accordion';
 import { AccordionDef } from 'src/layout/Accordion/config.def.generated';

--- a/src/App/frontend/src/layout/AccordionGroup/AccordionGroup.tsx
+++ b/src/App/frontend/src/layout/AccordionGroup/AccordionGroup.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Card } from '@digdir/designsystemet-react';
 
 import { AccordionGroupProvider } from 'src/layout/AccordionGroup/AccordionGroupContext';

--- a/src/App/frontend/src/layout/AccordionGroup/AccordionGroupContext.tsx
+++ b/src/App/frontend/src/layout/AccordionGroup/AccordionGroupContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { createContext } from 'src/core/contexts/context';
 

--- a/src/App/frontend/src/layout/AccordionGroup/SummaryAccordionGroupComponent.tsx
+++ b/src/App/frontend/src/layout/AccordionGroup/SummaryAccordionGroupComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { SummaryAccordionComponent, SummaryAccordionComponent2 } from 'src/layout/Accordion/SummaryAccordion';
 import { EmptyChildrenBoundary } from 'src/layout/Summary2/isEmpty/EmptyChildrenContext';
 import { SummaryFlexForContainer } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';

--- a/src/App/frontend/src/layout/AccordionGroup/index.tsx
+++ b/src/App/frontend/src/layout/AccordionGroup/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { AccordionGroup as AccordionGroupComponent } from 'src/layout/AccordionGroup/AccordionGroup';

--- a/src/App/frontend/src/layout/ActionButton/ActionButtonComponent.tsx
+++ b/src/App/frontend/src/layout/ActionButton/ActionButtonComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { PropsFromGenericComponent } from '..';
 
 import { Button, type ButtonColor, type ButtonVariant } from 'src/app-components/Button/Button';

--- a/src/App/frontend/src/layout/ActionButton/index.tsx
+++ b/src/App/frontend/src/layout/ActionButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { ActionButtonComponent } from 'src/layout/ActionButton/ActionButtonComponent';

--- a/src/App/frontend/src/layout/AddToList/AddToList.tsx
+++ b/src/App/frontend/src/layout/AddToList/AddToList.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import * as React from 'react';
 import type { MonthCaption } from 'react-day-picker';
 
 import { Button, Dialog } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/AddToList/index.tsx
+++ b/src/App/frontend/src/layout/AddToList/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
+import * as React from 'react';
 import type { JSX } from 'react';
 
 import { AddToListComponent } from 'src/layout/AddToList/AddToList';

--- a/src/App/frontend/src/layout/Address/AddressComponent.test.tsx
+++ b/src/App/frontend/src/layout/Address/AddressComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/layout/Address/AddressComponent.tsx
+++ b/src/App/frontend/src/layout/Address/AddressComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { Flex } from 'src/app-components/Flex/Flex';
 import { Input } from 'src/app-components/Input/Input';

--- a/src/App/frontend/src/layout/Address/AddressSummary/AddressSummary.tsx
+++ b/src/App/frontend/src/layout/Address/AddressSummary/AddressSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';
 import { Lang } from 'src/features/language/Lang';
 import { ComponentValidations } from 'src/features/validation/ComponentValidations';

--- a/src/App/frontend/src/layout/Address/index.tsx
+++ b/src/App/frontend/src/layout/Address/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';

--- a/src/App/frontend/src/layout/Alert/Alert.test.tsx
+++ b/src/App/frontend/src/layout/Alert/Alert.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { Alert } from 'src/layout/Alert/Alert';

--- a/src/App/frontend/src/layout/Alert/Alert.tsx
+++ b/src/App/frontend/src/layout/Alert/Alert.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { AlertBaseComponent } from 'src/layout/Alert/AlertBaseComponent';

--- a/src/App/frontend/src/layout/Alert/AlertBaseComponent.test.tsx
+++ b/src/App/frontend/src/layout/Alert/AlertBaseComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { render as rtlRender, screen } from '@testing-library/react';
 
 import { AlertBaseComponent } from 'src/layout/Alert/AlertBaseComponent';

--- a/src/App/frontend/src/layout/Alert/AlertBaseComponent.tsx
+++ b/src/App/frontend/src/layout/Alert/AlertBaseComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Alert as AlertDesignSystem } from '@digdir/designsystemet-react';
 

--- a/src/App/frontend/src/layout/Alert/index.tsx
+++ b/src/App/frontend/src/layout/Alert/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { Alert as AlertComponent } from 'src/layout/Alert/Alert';

--- a/src/App/frontend/src/layout/AttachmentList/AttachmentListComponent.tsx
+++ b/src/App/frontend/src/layout/AttachmentList/AttachmentListComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { AltinnAttachments } from 'src/components/atoms/AltinnAttachments';
 import { MainAttachmentHeader } from 'src/components/atoms/AttachmentHeader';
 import { AttachmentGroupings } from 'src/components/organisms/AttachmentGroupings';

--- a/src/App/frontend/src/layout/AttachmentList/index.tsx
+++ b/src/App/frontend/src/layout/AttachmentList/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { AttachmentListComponent } from 'src/layout/AttachmentList/AttachmentListComponent';

--- a/src/App/frontend/src/layout/Audio/Audio.tsx
+++ b/src/App/frontend/src/layout/Audio/Audio.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useParentCard } from 'src/layout/Cards/CardContext';

--- a/src/App/frontend/src/layout/Audio/index.tsx
+++ b/src/App/frontend/src/layout/Audio/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { AudioComponent } from 'src/layout/Audio/Audio';

--- a/src/App/frontend/src/layout/Button/ButtonComponent.tsx
+++ b/src/App/frontend/src/layout/Button/ButtonComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from 'src/app-components/Button/Button';
 import { useAttachmentState } from 'src/features/attachments/hooks';
 import { FormStore } from 'src/features/form/FormContext';

--- a/src/App/frontend/src/layout/Button/index.tsx
+++ b/src/App/frontend/src/layout/Button/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { ButtonComponent } from 'src/layout/Button/ButtonComponent';

--- a/src/App/frontend/src/layout/ButtonGroup/ButtonGroupComponent.tsx
+++ b/src/App/frontend/src/layout/ButtonGroup/ButtonGroupComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { PropsFromGenericComponent } from '..';
 
 import { Flex } from 'src/app-components/Flex/Flex';

--- a/src/App/frontend/src/layout/ButtonGroup/index.tsx
+++ b/src/App/frontend/src/layout/ButtonGroup/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import type { PropsFromGenericComponent } from '..';

--- a/src/App/frontend/src/layout/Cards/CardContext.tsx
+++ b/src/App/frontend/src/layout/Cards/CardContext.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { createContext } from 'src/core/contexts/context';

--- a/src/App/frontend/src/layout/Cards/Cards.tsx
+++ b/src/App/frontend/src/layout/Cards/Cards.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { CSSProperties } from 'react';
 
 import { AppCard } from 'src/app-components/Card/Card';

--- a/src/App/frontend/src/layout/Cards/CardsSummary.tsx
+++ b/src/App/frontend/src/layout/Cards/CardsSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';
 import { EmptyChildrenBoundary } from 'src/layout/Summary2/isEmpty/EmptyChildrenContext';
 import { ComponentSummary, SummaryFlexForContainer } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';

--- a/src/App/frontend/src/layout/Cards/index.tsx
+++ b/src/App/frontend/src/layout/Cards/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
+import * as React from 'react';
 import type { JSX } from 'react';
 
 import { Cards as CardsComponent } from 'src/layout/Cards/Cards';

--- a/src/App/frontend/src/layout/Checkboxes/CheckboxesContainerComponent.test.tsx
+++ b/src/App/frontend/src/layout/Checkboxes/CheckboxesContainerComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import type { AxiosResponse } from 'axios';

--- a/src/App/frontend/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
+++ b/src/App/frontend/src/layout/Checkboxes/CheckboxesContainerComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Fieldset, useCheckboxGroup } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 

--- a/src/App/frontend/src/layout/Checkboxes/CheckboxesSummary.tsx
+++ b/src/App/frontend/src/layout/Checkboxes/CheckboxesSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import {

--- a/src/App/frontend/src/layout/Checkboxes/MultipleChoiceSummary.tsx
+++ b/src/App/frontend/src/layout/Checkboxes/MultipleChoiceSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import dot from 'dot-object';
 
 import { Flex } from 'src/app-components/Flex/Flex';

--- a/src/App/frontend/src/layout/Checkboxes/WrappedCheckbox.tsx
+++ b/src/App/frontend/src/layout/Checkboxes/WrappedCheckbox.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 
 import { Checkbox } from '@digdir/designsystemet-react';
 import cn from 'classnames';

--- a/src/App/frontend/src/layout/Checkboxes/index.tsx
+++ b/src/App/frontend/src/layout/Checkboxes/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import dot from 'dot-object';

--- a/src/App/frontend/src/layout/ComponentStructureWrapper.tsx
+++ b/src/App/frontend/src/layout/ComponentStructureWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Flex } from 'src/app-components/Flex/Flex';

--- a/src/App/frontend/src/layout/Custom/CustomWebComponent.test.tsx
+++ b/src/App/frontend/src/layout/Custom/CustomWebComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { CustomWebComponent } from 'src/layout/Custom/CustomWebComponent';

--- a/src/App/frontend/src/layout/Custom/CustomWebComponent.tsx
+++ b/src/App/frontend/src/layout/Custom/CustomWebComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { isValidElement, useLayoutEffect, useMemo, useRef } from 'react';
 import ReactDOMServer from 'react-dom/server';
 
 import dot from 'dot-object';
@@ -53,10 +53,10 @@ export function CustomWebComponent({
 
   const HtmlTag = tagName;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const wcRef = React.useRef<any>(null);
+  const wcRef = useRef<any>(null);
   const { formData, setValue } = useDataModelBindings(dataModelBindings);
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     const { current } = wcRef;
     if (current) {
       const handleChange = (customEvent: CustomEvent) => {
@@ -80,7 +80,7 @@ export function CustomWebComponent({
     }
   }, [dataModelBindings?.simpleBinding, setValue, wcRef]);
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     const { current } = wcRef;
     if (current) {
       current.texts = getTextsForComponent(textResourceBindings, langTools);
@@ -89,7 +89,7 @@ export function CustomWebComponent({
     }
   }, [wcRef, textResourceBindings, dataModelBindings, langTools, legacyLanguage]);
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     const { current } = wcRef;
     if (current) {
       current.formData = formData;
@@ -106,7 +106,7 @@ export function CustomWebComponent({
   const propsAsAttributes: any = {};
   Object.keys(passThroughProps).forEach((key) => {
     let prop = passThroughProps[key];
-    if (React.isValidElement(prop)) {
+    if (isValidElement(prop)) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       prop = ReactDOMServer.renderToStaticMarkup(prop as any);
     } else if (['object', 'array'].includes(typeof prop) && key !== 'containerDivRef') {

--- a/src/App/frontend/src/layout/Custom/index.tsx
+++ b/src/App/frontend/src/layout/Custom/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { createRef, forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
@@ -48,7 +48,7 @@ export class Custom extends CustomDef {
           summaryMode={true}
           formData={formData}
           baseComponentId={props.targetBaseComponentId}
-          containerDivRef={React.createRef()}
+          containerDivRef={createRef()}
         />
       </SummaryFlex>
     );

--- a/src/App/frontend/src/layout/CustomButton/CustomButtonComponent.test.tsx
+++ b/src/App/frontend/src/layout/CustomButton/CustomButtonComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { CustomButtonComponent } from 'src/layout/CustomButton/CustomButtonComponent';

--- a/src/App/frontend/src/layout/CustomButton/CustomButtonComponent.tsx
+++ b/src/App/frontend/src/layout/CustomButton/CustomButtonComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useParams } from 'react-router';
 import { toast } from 'react-toastify';
 
@@ -213,7 +213,7 @@ export const CustomButtonComponent = ({ baseComponentId }: PropsFromGenericCompo
   const isAnyProcessing = useIsAnyProcessing();
   const layoutLookups = FormBootstrap.useLayoutLookups();
 
-  const getScrollPosition = React.useCallback(
+  const getScrollPosition = useCallback(
     () => document.querySelector(`[data-componentid="${id}"]`)?.getClientRects().item(0)?.y,
     [id],
   );

--- a/src/App/frontend/src/layout/CustomButton/index.tsx
+++ b/src/App/frontend/src/layout/CustomButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { CustomButtonDef } from 'src/layout/CustomButton/config.def.generated';

--- a/src/App/frontend/src/layout/Date/DateComponent.tsx
+++ b/src/App/frontend/src/layout/Date/DateComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import cn from 'classnames';
 import { isValid, parseISO } from 'date-fns';
 

--- a/src/App/frontend/src/layout/Date/DateSummary.tsx
+++ b/src/App/frontend/src/layout/Date/DateSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';

--- a/src/App/frontend/src/layout/Date/index.tsx
+++ b/src/App/frontend/src/layout/Date/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { formatDate, isValid, parseISO } from 'date-fns';

--- a/src/App/frontend/src/layout/Datepicker/DatepickerComponent.test.tsx
+++ b/src/App/frontend/src/layout/Datepicker/DatepickerComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/layout/Datepicker/DatepickerComponent.tsx
+++ b/src/App/frontend/src/layout/Datepicker/DatepickerComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { DatePickerControl } from 'src/app-components/Datepicker/Datepicker';
 import { getDateConstraint, getDateFormat } from 'src/app-components/Datepicker/utils/dateHelpers';
 import { Flex } from 'src/app-components/Flex/Flex';

--- a/src/App/frontend/src/layout/Datepicker/DatepickerSummary.tsx
+++ b/src/App/frontend/src/layout/Datepicker/DatepickerSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';

--- a/src/App/frontend/src/layout/Datepicker/DropdownCaption.tsx
+++ b/src/App/frontend/src/layout/Datepicker/DropdownCaption.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { formatMonthDropdown, useDayPicker } from 'react-day-picker';
 import type { MonthCaptionProps } from 'react-day-picker';
 

--- a/src/App/frontend/src/layout/Datepicker/index.tsx
+++ b/src/App/frontend/src/layout/Datepicker/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { formatISOString, getDateFormat } from 'src/app-components/Datepicker/utils/dateHelpers';

--- a/src/App/frontend/src/layout/Divider/DividerComponent.tsx
+++ b/src/App/frontend/src/layout/Divider/DividerComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Divider } from '@digdir/designsystemet-react';
 
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';

--- a/src/App/frontend/src/layout/Divider/index.tsx
+++ b/src/App/frontend/src/layout/Divider/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { createRef, forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import type { PropsFromGenericComponent } from '..';
@@ -23,7 +23,7 @@ export class Divider extends DividerDef {
       >
         <DividerComponent
           baseComponentId={props.targetBaseComponentId}
-          containerDivRef={React.createRef()}
+          containerDivRef={createRef()}
         />
       </SummaryFlex>
     );

--- a/src/App/frontend/src/layout/Dropdown/DropdownComponent.test.tsx
+++ b/src/App/frontend/src/layout/Dropdown/DropdownComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { act, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import type { AxiosResponse } from 'axios';

--- a/src/App/frontend/src/layout/Dropdown/DropdownComponent.tsx
+++ b/src/App/frontend/src/layout/Dropdown/DropdownComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 
 import { EXPERIMENTAL_Suggestion as Suggestion, Label as DSLabel } from '@digdir/designsystemet-react';
 import cn from 'classnames';

--- a/src/App/frontend/src/layout/Dropdown/DropdownSummary.tsx
+++ b/src/App/frontend/src/layout/Dropdown/DropdownSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';

--- a/src/App/frontend/src/layout/Dropdown/index.tsx
+++ b/src/App/frontend/src/layout/Dropdown/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';

--- a/src/App/frontend/src/layout/FileUpload/AttachmentSummaryComponent2.tsx
+++ b/src/App/frontend/src/layout/FileUpload/AttachmentSummaryComponent2.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Paragraph } from '@digdir/designsystemet-react';
 
 import { Label } from 'src/components/label/Label';

--- a/src/App/frontend/src/layout/FileUpload/Error/FailedAttachments.tsx
+++ b/src/App/frontend/src/layout/FileUpload/Error/FailedAttachments.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Alert, Button } from '@digdir/designsystemet-react';
 import { XMarkIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/layout/FileUpload/Error/InfectedFileAlert.tsx
+++ b/src/App/frontend/src/layout/FileUpload/Error/InfectedFileAlert.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Alert } from '@digdir/designsystemet-react';
 
 import { isAttachmentUploaded } from 'src/features/attachments';

--- a/src/App/frontend/src/layout/FileUpload/FileUploadComponent.test.tsx
+++ b/src/App/frontend/src/layout/FileUpload/FileUploadComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { v4 as uuidv4 } from 'uuid';

--- a/src/App/frontend/src/layout/FileUpload/FileUploadComponent.tsx
+++ b/src/App/frontend/src/layout/FileUpload/FileUploadComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useNavigation } from 'react-router';
 import { toast } from 'react-toastify';
 import type { FileRejection } from 'react-dropzone';

--- a/src/App/frontend/src/layout/FileUpload/FileUploadTable/AttachmentFileName.tsx
+++ b/src/App/frontend/src/layout/FileUpload/FileUploadTable/AttachmentFileName.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Link } from '@digdir/designsystemet-react';
 import { FileCsvIcon, FileExcelIcon, FileIcon, FilePdfIcon, FileWordIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';

--- a/src/App/frontend/src/layout/FileUpload/FileUploadTable/FileTable.tsx
+++ b/src/App/frontend/src/layout/FileUpload/FileUploadTable/FileTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { isAttachmentUploaded } from 'src/features/attachments';
 import { Lang } from 'src/features/language/Lang';

--- a/src/App/frontend/src/layout/FileUpload/FileUploadTable/FileTableButtons.tsx
+++ b/src/App/frontend/src/layout/FileUpload/FileUploadTable/FileTableButtons.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { PencilIcon, TrashIcon } from '@navikt/aksel-icons';
 
 import { Button } from 'src/app-components/Button/Button';

--- a/src/App/frontend/src/layout/FileUpload/FileUploadTable/FileTableRow.tsx
+++ b/src/App/frontend/src/layout/FileUpload/FileUploadTable/FileTableRow.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import classNames from 'classnames';
 
 import { AltinnLoader } from 'src/components/AltinnLoader';

--- a/src/App/frontend/src/layout/FileUpload/Summary/AttachmentSummaryComponent.tsx
+++ b/src/App/frontend/src/layout/FileUpload/Summary/AttachmentSummaryComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { isAttachmentUploaded } from 'src/features/attachments';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';

--- a/src/App/frontend/src/layout/FileUpload/Summary/AttachmentWithTagSummaryComponent.test.tsx
+++ b/src/App/frontend/src/layout/FileUpload/Summary/AttachmentWithTagSummaryComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getApplicationMetadataMock } from 'src/__mocks__/getApplicationMetadataMock';

--- a/src/App/frontend/src/layout/FileUpload/index.tsx
+++ b/src/App/frontend/src/layout/FileUpload/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useAttachmentsFor } from 'src/features/attachments/hooks';

--- a/src/App/frontend/src/layout/FileUploadWithTag/EditWindowComponent.tsx
+++ b/src/App/frontend/src/layout/FileUploadWithTag/EditWindowComponent.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import * as React from 'react';
 
 import { EXPERIMENTAL_Suggestion as Suggestion } from '@digdir/designsystemet-react';
 import deepEqual from 'fast-deep-equal';

--- a/src/App/frontend/src/layout/FileUploadWithTag/index.tsx
+++ b/src/App/frontend/src/layout/FileUploadWithTag/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, type JSX } from 'react';
+import { forwardRef } from 'react';
+import type { type JSX } from 'react';
 
 import { useAttachmentsFor } from 'src/features/attachments/hooks';
 import { AttachmentSummaryComponent2 } from 'src/layout/FileUpload/AttachmentSummaryComponent2';

--- a/src/App/frontend/src/layout/GenericComponent.test.tsx
+++ b/src/App/frontend/src/layout/GenericComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, waitFor } from '@testing-library/react';
 
 import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';

--- a/src/App/frontend/src/layout/GenericComponent.tsx
+++ b/src/App/frontend/src/layout/GenericComponent.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+import * as React from 'react';
 import { useSearchParams } from 'react-router';
 import type { SetURLSearchParams } from 'react-router';
 

--- a/src/App/frontend/src/layout/Grid/GridComponent.tsx
+++ b/src/App/frontend/src/layout/Grid/GridComponent.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Table } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/Grid/GridSummary.tsx
+++ b/src/App/frontend/src/layout/Grid/GridSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import type { JSX, PropsWithChildren } from 'react';
 
 import { Heading, Table, ValidationMessage } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/Grid/GridSummaryComponent.tsx
+++ b/src/App/frontend/src/layout/Grid/GridSummaryComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { getComponentDef } from 'src/layout';
 import { useBaseIdsFromGrid } from 'src/layout/Grid/tools';
 import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';

--- a/src/App/frontend/src/layout/Grid/index.tsx
+++ b/src/App/frontend/src/layout/Grid/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import type { ErrorObject } from 'ajv';

--- a/src/App/frontend/src/layout/Group/GroupComponent.tsx
+++ b/src/App/frontend/src/layout/Group/GroupComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { JSX } from 'react';
 
 import { Heading } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/Group/GroupSummary.tsx
+++ b/src/App/frontend/src/layout/Group/GroupSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Heading } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 import type { HeadingProps } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/Group/SummaryGroupComponent.test.tsx
+++ b/src/App/frontend/src/layout/Group/SummaryGroupComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';
 import { defaultDataTypeMock } from 'src/__mocks__/getUiConfigMock';
 import { SummaryGroupComponent } from 'src/layout/Group/SummaryGroupComponent';

--- a/src/App/frontend/src/layout/Group/SummaryGroupComponent.tsx
+++ b/src/App/frontend/src/layout/Group/SummaryGroupComponent.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
+import * as React from 'react';
 
 import { ErrorPaper } from 'src/components/message/ErrorPaper';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';

--- a/src/App/frontend/src/layout/Group/index.tsx
+++ b/src/App/frontend/src/layout/Group/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { GenericComponent } from 'src/layout/GenericComponent';

--- a/src/App/frontend/src/layout/Header/HeaderComponent.test.tsx
+++ b/src/App/frontend/src/layout/Header/HeaderComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { fireEvent, screen } from '@testing-library/react';
 import ResizeObserverModule from 'resize-observer-polyfill';
 

--- a/src/App/frontend/src/layout/Header/HeaderComponent.tsx
+++ b/src/App/frontend/src/layout/Header/HeaderComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Heading } from '@digdir/designsystemet-react';
 
 import { HelpTextContainer } from 'src/components/form/HelpTextContainer';

--- a/src/App/frontend/src/layout/Header/index.tsx
+++ b/src/App/frontend/src/layout/Header/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { createRef, forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { HeaderDef } from 'src/layout/Header/config.def.generated';
@@ -22,7 +22,7 @@ export class Header extends HeaderDef {
       >
         <HeaderComponent
           baseComponentId={props.targetBaseComponentId}
-          containerDivRef={React.createRef()}
+          containerDivRef={createRef()}
         />
       </SummaryFlex>
     );

--- a/src/App/frontend/src/layout/IFrame/IFrameComponent.tsx
+++ b/src/App/frontend/src/layout/IFrame/IFrameComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { JSX } from 'react';
 
 import { PANEL_VARIANT } from 'src/app-components/Panel/constants';

--- a/src/App/frontend/src/layout/IFrame/index.tsx
+++ b/src/App/frontend/src/layout/IFrame/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { IFrameDef } from 'src/layout/IFrame/config.def.generated';

--- a/src/App/frontend/src/layout/Image/ImageComponent.tsx
+++ b/src/App/frontend/src/layout/Image/ImageComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Flex } from 'src/app-components/Flex/Flex';
 import { HelpTextContainer } from 'src/components/form/HelpTextContainer';
 import { Lang } from 'src/features/language/Lang';

--- a/src/App/frontend/src/layout/Image/index.tsx
+++ b/src/App/frontend/src/layout/Image/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { ImageDef } from 'src/layout/Image/config.def.generated';

--- a/src/App/frontend/src/layout/ImageUpload/ImageCanvas/ImageCanvas.tsx
+++ b/src/App/frontend/src/layout/ImageUpload/ImageCanvas/ImageCanvas.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
+import * as React from 'react';
 
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useImageFile } from 'src/layout/ImageUpload/hooks/useImageFile';

--- a/src/App/frontend/src/layout/ImageUpload/ImageCanvas/ImagePreview.tsx
+++ b/src/App/frontend/src/layout/ImageUpload/ImageCanvas/ImagePreview.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Spinner } from 'src/app-components/loading/Spinner/Spinner';
 import { useLanguage } from 'src/features/language/useLanguage';
 import classes from 'src/layout/ImageUpload/ImageCanvas/ImagePreview.module.css';

--- a/src/App/frontend/src/layout/ImageUpload/ImageControllers.tsx
+++ b/src/App/frontend/src/layout/ImageUpload/ImageControllers.tsx
@@ -1,4 +1,5 @@
-import React, { useId, useRef } from 'react';
+import { useId, useRef } from 'react';
+import * as React from 'react';
 
 import { Button, Input, Label } from '@digdir/designsystemet-react';
 import { ArrowUndoIcon, TrashIcon, UploadIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/layout/ImageUpload/ImageCropper.tsx
+++ b/src/App/frontend/src/layout/ImageUpload/ImageCropper.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { ValidationMessage } from '@digdir/designsystemet-react';
 

--- a/src/App/frontend/src/layout/ImageUpload/ImageDropzone.tsx
+++ b/src/App/frontend/src/layout/ImageUpload/ImageDropzone.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import cn from 'classnames';
 

--- a/src/App/frontend/src/layout/ImageUpload/ImageUploadComponent.test.tsx
+++ b/src/App/frontend/src/layout/ImageUpload/ImageUploadComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/App/frontend/src/layout/ImageUpload/ImageUploadComponent.tsx
+++ b/src/App/frontend/src/layout/ImageUpload/ImageUploadComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Label } from 'src/app-components/Label/Label';
 import { getApplicationMetadata } from 'src/features/applicationMetadata';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';

--- a/src/App/frontend/src/layout/ImageUpload/ImageUploadSummary2/ImageUploadSummary2.test.tsx
+++ b/src/App/frontend/src/layout/ImageUpload/ImageUploadSummary2/ImageUploadSummary2.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getAttachmentsMock } from 'src/__mocks__/getAttachmentsMock';

--- a/src/App/frontend/src/layout/ImageUpload/ImageUploadSummary2/ImageUploadSummary2.tsx
+++ b/src/App/frontend/src/layout/ImageUpload/ImageUploadSummary2/ImageUploadSummary2.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Lang } from 'src/features/language/Lang';
 import { useUploaderSummaryData } from 'src/layout/FileUpload/Summary/summary';
 import { useImageFile } from 'src/layout/ImageUpload/hooks/useImageFile';

--- a/src/App/frontend/src/layout/ImageUpload/index.tsx
+++ b/src/App/frontend/src/layout/ImageUpload/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useAttachmentsFor } from 'src/features/attachments/hooks';

--- a/src/App/frontend/src/layout/Input/InputComponent.test.tsx
+++ b/src/App/frontend/src/layout/Input/InputComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/layout/Input/InputComponent.tsx
+++ b/src/App/frontend/src/layout/Input/InputComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { FormattedInput } from 'src/app-components/Input/FormattedInput';
 import { Input } from 'src/app-components/Input/Input';

--- a/src/App/frontend/src/layout/Input/InputSummary.tsx
+++ b/src/App/frontend/src/layout/Input/InputSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';

--- a/src/App/frontend/src/layout/Input/index.tsx
+++ b/src/App/frontend/src/layout/Input/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';

--- a/src/App/frontend/src/layout/InstanceInformation/InstanceInformationComponent.tsx
+++ b/src/App/frontend/src/layout/InstanceInformation/InstanceInformationComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { formatDate, formatISO } from 'date-fns';
 
 import type { PropsFromGenericComponent } from '..';

--- a/src/App/frontend/src/layout/InstanceInformation/index.tsx
+++ b/src/App/frontend/src/layout/InstanceInformation/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { InstanceInformationDef } from 'src/layout/InstanceInformation/config.def.generated';

--- a/src/App/frontend/src/layout/InstantiationButton/InstantiationButton.test.tsx
+++ b/src/App/frontend/src/layout/InstantiationButton/InstantiationButton.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 
 import { screen, waitFor } from '@testing-library/react';

--- a/src/App/frontend/src/layout/InstantiationButton/InstantiationButton.tsx
+++ b/src/App/frontend/src/layout/InstantiationButton/InstantiationButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useNavigate } from 'react-router';
 
 import { Button } from 'src/app-components/Button/Button';

--- a/src/App/frontend/src/layout/InstantiationButton/InstantiationButtonComponent.tsx
+++ b/src/App/frontend/src/layout/InstantiationButton/InstantiationButtonComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { Lang } from 'src/features/language/Lang';
 import { ComponentStructureWrapper } from 'src/layout/ComponentStructureWrapper';

--- a/src/App/frontend/src/layout/InstantiationButton/index.tsx
+++ b/src/App/frontend/src/layout/InstantiationButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { InstantiationButtonDef } from 'src/layout/InstantiationButton/config.def.generated';

--- a/src/App/frontend/src/layout/LayoutComponent.tsx
+++ b/src/App/frontend/src/layout/LayoutComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { JSX } from 'react';
 
 import type { ErrorObject } from 'ajv';

--- a/src/App/frontend/src/layout/Likert/Generator/LikertGeneratorChildren.tsx
+++ b/src/App/frontend/src/layout/Likert/Generator/LikertGeneratorChildren.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 
 import { FormStore } from 'src/features/form/FormContext';
 import { makeLikertChildId } from 'src/layout/Likert/Generator/makeLikertChildId';
@@ -54,7 +54,7 @@ interface GenerateRowProps {
   questionsBinding: IDataModelReference;
 }
 
-const GenerateLikertRow = React.memo((props: GenerateRowProps) => (
+const GenerateLikertRow = memo((props: GenerateRowProps) => (
   <DataModelLocationProvider
     groupBinding={props.questionsBinding}
     rowIndex={props.rowIndex}
@@ -64,7 +64,7 @@ const GenerateLikertRow = React.memo((props: GenerateRowProps) => (
 ));
 GenerateLikertRow.displayName = 'GenerateLikertRow';
 
-const GenerateLikertRowInner = React.memo(function ({ rowIndex, questionsBinding }: GenerateRowProps) {
+const GenerateLikertRowInner = memo(function ({ rowIndex, questionsBinding }: GenerateRowProps) {
   const parentItem = GeneratorInternal.useIntermediateItem() as CompIntermediate<'Likert'>;
   const depth = GeneratorInternal.useDepth();
 

--- a/src/App/frontend/src/layout/Likert/LikertComponent.tsx
+++ b/src/App/frontend/src/layout/Likert/LikertComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Heading, Table } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 

--- a/src/App/frontend/src/layout/Likert/LikertTestUtils.tsx
+++ b/src/App/frontend/src/layout/Likert/LikertTestUtils.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { jest } from '@jest/globals';
 import { v4 as uuidv4 } from 'uuid';
 import type { AxiosResponse } from 'axios';

--- a/src/App/frontend/src/layout/Likert/Summary/LargeLikertSummaryContainer.tsx
+++ b/src/App/frontend/src/layout/Likert/Summary/LargeLikertSummaryContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { JSX } from 'react';
 
 import { Heading } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/Likert/Summary/LikertSummaryComponent.tsx
+++ b/src/App/frontend/src/layout/Likert/Summary/LikertSummaryComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ErrorPaper } from 'src/components/message/ErrorPaper';
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';

--- a/src/App/frontend/src/layout/Likert/Summary2/LikertSummary.tsx
+++ b/src/App/frontend/src/layout/Likert/Summary2/LikertSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Heading, ValidationMessage } from '@digdir/designsystemet-react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';

--- a/src/App/frontend/src/layout/Likert/index.tsx
+++ b/src/App/frontend/src/layout/Likert/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import type { PropsFromGenericComponent } from '..';

--- a/src/App/frontend/src/layout/LikertItem/LikertItemComponent.tsx
+++ b/src/App/frontend/src/layout/LikertItem/LikertItemComponent.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 
 import { Label, Radio, Table } from '@digdir/designsystemet-react';
 import cn from 'classnames';

--- a/src/App/frontend/src/layout/LikertItem/index.tsx
+++ b/src/App/frontend/src/layout/LikertItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';

--- a/src/App/frontend/src/layout/Link/LinkComponent.test.tsx
+++ b/src/App/frontend/src/layout/Link/LinkComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { LinkComponent } from 'src/layout/Link/LinkComponent';

--- a/src/App/frontend/src/layout/Link/LinkComponent.tsx
+++ b/src/App/frontend/src/layout/Link/LinkComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { PropsFromGenericComponent } from '..';
 
 import { Button, type ButtonColor, type ButtonVariant } from 'src/app-components/Button/Button';

--- a/src/App/frontend/src/layout/Link/index.tsx
+++ b/src/App/frontend/src/layout/Link/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import type { PropsFromGenericComponent } from '..';

--- a/src/App/frontend/src/layout/List/ListComponent.test.tsx
+++ b/src/App/frontend/src/layout/List/ListComponent.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useRef } from 'react';
 
 import { act, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
@@ -55,7 +55,7 @@ const countries = [
 ];
 
 function RenderCounter({ baseComponentId }: { baseComponentId: string }) {
-  const renderCount = React.useRef(0);
+  const renderCount = useRef(0);
   const dataModelBindings = useDataModelBindingsFor(baseComponentId, 'List');
 
   // This simulates the List component data model fetching. It will trigger a re-render of the component once every

--- a/src/App/frontend/src/layout/List/ListComponent.tsx
+++ b/src/App/frontend/src/layout/List/ListComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { AriaAttributes } from 'react';
 
 import {

--- a/src/App/frontend/src/layout/List/ListSummary.tsx
+++ b/src/App/frontend/src/layout/List/ListSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Heading, Table } from '@digdir/designsystemet-react';
 import dot from 'dot-object';
 

--- a/src/App/frontend/src/layout/List/index.tsx
+++ b/src/App/frontend/src/layout/List/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import dot from 'dot-object';

--- a/src/App/frontend/src/layout/Map/Map.tsx
+++ b/src/App/frontend/src/layout/Map/Map.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { AttributionControl, MapContainer } from 'react-leaflet';
 import type { RefObject } from 'react';
 

--- a/src/App/frontend/src/layout/Map/MapComponent.tsx
+++ b/src/App/frontend/src/layout/Map/MapComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import cn from 'classnames';
 
 import { useIsValid } from 'src/features/validation/selectors/isValid';

--- a/src/App/frontend/src/layout/Map/MapComponentSummary.tsx
+++ b/src/App/frontend/src/layout/Map/MapComponentSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FormStore } from 'src/features/form/FormContext';
 import { Lang } from 'src/features/language/Lang';
 import { MarkerLocationText } from 'src/layout/Map/features/singleMarker/MarkerLocationText';

--- a/src/App/frontend/src/layout/Map/Summary2/MapSummary.tsx
+++ b/src/App/frontend/src/layout/Map/Summary2/MapSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Paragraph, ValidationMessage } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 

--- a/src/App/frontend/src/layout/Map/features/geometries/editable/MapEditGeometries.tsx
+++ b/src/App/frontend/src/layout/Map/features/geometries/editable/MapEditGeometries.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { FeatureGroup } from 'react-leaflet';
 import { EditControl } from 'react-leaflet-draw';
 

--- a/src/App/frontend/src/layout/Map/features/geometries/fixed/MapGeometries.tsx
+++ b/src/App/frontend/src/layout/Map/features/geometries/fixed/MapGeometries.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { GeoJSON, Tooltip } from 'react-leaflet';
 
 import { icon, marker } from 'leaflet';

--- a/src/App/frontend/src/layout/Map/features/layers/MapLayers.tsx
+++ b/src/App/frontend/src/layout/Map/features/layers/MapLayers.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { TileLayer, WMSTileLayer } from 'react-leaflet';
 
 import { DefaultMapLayers } from 'src/layout/Map/utils';

--- a/src/App/frontend/src/layout/Map/features/singleMarker/MapSingleMarker.tsx
+++ b/src/App/frontend/src/layout/Map/features/singleMarker/MapSingleMarker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { Marker, useMapEvent } from 'react-leaflet';
 
 import { icon } from 'leaflet';

--- a/src/App/frontend/src/layout/Map/features/singleMarker/MarkerLocationText.tsx
+++ b/src/App/frontend/src/layout/Map/features/singleMarker/MarkerLocationText.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Paragraph } from '@digdir/designsystemet-react';
 
 import { Lang } from 'src/features/language/Lang';

--- a/src/App/frontend/src/layout/Map/index.tsx
+++ b/src/App/frontend/src/layout/Map/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';

--- a/src/App/frontend/src/layout/MultipleSelect/MultipleSelectComponent.test.tsx
+++ b/src/App/frontend/src/layout/MultipleSelect/MultipleSelectComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { defaultDataTypeMock } from 'src/__mocks__/getUiConfigMock';

--- a/src/App/frontend/src/layout/MultipleSelect/MultipleSelectComponent.tsx
+++ b/src/App/frontend/src/layout/MultipleSelect/MultipleSelectComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 
 import { EXPERIMENTAL_Suggestion as Suggestion, Field, Label as DSLabel } from '@digdir/designsystemet-react';
 

--- a/src/App/frontend/src/layout/MultipleSelect/MultipleSelectSummary.tsx
+++ b/src/App/frontend/src/layout/MultipleSelect/MultipleSelectSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import {

--- a/src/App/frontend/src/layout/MultipleSelect/index.tsx
+++ b/src/App/frontend/src/layout/MultipleSelect/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import dot from 'dot-object';

--- a/src/App/frontend/src/layout/NavigationBar/NavigationBarComponent.test.tsx
+++ b/src/App/frontend/src/layout/NavigationBar/NavigationBarComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/layout/NavigationBar/NavigationBarComponent.tsx
+++ b/src/App/frontend/src/layout/NavigationBar/NavigationBarComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { CaretDownFillIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';

--- a/src/App/frontend/src/layout/NavigationBar/index.tsx
+++ b/src/App/frontend/src/layout/NavigationBar/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { NavigationBarDef } from 'src/layout/NavigationBar/config.def.generated';

--- a/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx
+++ b/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';

--- a/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
+++ b/src/App/frontend/src/layout/NavigationButtons/NavigationButtonsComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useCallback } from 'react';
 import { useSearchParams } from 'react-router';
 
 import { Button } from 'src/app-components/Button/Button';
@@ -102,7 +102,7 @@ function NavigationButtonsComponentInner({
 
   const attachmentsPending = useHasPendingAttachments();
 
-  const getScrollPosition = React.useCallback(
+  const getScrollPosition = useCallback(
     () => document.querySelector(`[data-componentid="${id}"]`)?.getClientRects().item(0)?.y,
     [id],
   );

--- a/src/App/frontend/src/layout/NavigationButtons/index.tsx
+++ b/src/App/frontend/src/layout/NavigationButtons/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { NavigationButtonsDef } from 'src/layout/NavigationButtons/config.def.generated';

--- a/src/App/frontend/src/layout/Number/NumberComponent.tsx
+++ b/src/App/frontend/src/layout/Number/NumberComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import cn from 'classnames';
 
 import { DisplayNumber } from 'src/app-components/Number/DisplayNumber';

--- a/src/App/frontend/src/layout/Number/NumberSummary.tsx
+++ b/src/App/frontend/src/layout/Number/NumberSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';

--- a/src/App/frontend/src/layout/Number/index.tsx
+++ b/src/App/frontend/src/layout/Number/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';

--- a/src/App/frontend/src/layout/Option/OptionComponent.tsx
+++ b/src/App/frontend/src/layout/Option/OptionComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import cn from 'classnames';
 
 import { HelpText } from 'src/app-components/HelpText/HelpText';

--- a/src/App/frontend/src/layout/Option/OptionSummary.tsx
+++ b/src/App/frontend/src/layout/Option/OptionSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';

--- a/src/App/frontend/src/layout/Option/index.tsx
+++ b/src/App/frontend/src/layout/Option/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useLanguage } from 'src/features/language/useLanguage';

--- a/src/App/frontend/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
+++ b/src/App/frontend/src/layout/OrganisationLookup/OrganisationLookupComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Field, Paragraph, ValidationMessage } from '@digdir/designsystemet-react';
 import { queryOptions, useQuery } from '@tanstack/react-query';

--- a/src/App/frontend/src/layout/OrganisationLookup/OrganisationLookupSummary.tsx
+++ b/src/App/frontend/src/layout/OrganisationLookup/OrganisationLookupSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Heading } from '@digdir/designsystemet-react';
 
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';

--- a/src/App/frontend/src/layout/OrganisationLookup/index.tsx
+++ b/src/App/frontend/src/layout/OrganisationLookup/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import type { PropsFromGenericComponent } from '..';

--- a/src/App/frontend/src/layout/PDFPreviewButton/PDFPreviewButtonComponent.tsx
+++ b/src/App/frontend/src/layout/PDFPreviewButton/PDFPreviewButtonComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import type { PropsFromGenericComponent } from '..';
 

--- a/src/App/frontend/src/layout/PDFPreviewButton/index.tsx
+++ b/src/App/frontend/src/layout/PDFPreviewButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { PDFPreviewButtonDef } from 'src/layout/PDFPreviewButton/config.def.generated';

--- a/src/App/frontend/src/layout/Panel/PanelComponent.tsx
+++ b/src/App/frontend/src/layout/Panel/PanelComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { PANEL_VARIANT } from 'src/app-components/Panel/constants';
 import { Panel } from 'src/app-components/Panel/Panel';
 import { translationKey } from 'src/AppComponentsBridge';

--- a/src/App/frontend/src/layout/Panel/index.tsx
+++ b/src/App/frontend/src/layout/Panel/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { PanelDef } from 'src/layout/Panel/config.def.generated';

--- a/src/App/frontend/src/layout/Paragraph/ParagraphComponent.test.tsx
+++ b/src/App/frontend/src/layout/Paragraph/ParagraphComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { ParagraphComponent } from 'src/layout/Paragraph/ParagraphComponent';

--- a/src/App/frontend/src/layout/Paragraph/ParagraphComponent.tsx
+++ b/src/App/frontend/src/layout/Paragraph/ParagraphComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { HelpTextContainer } from 'src/components/form/HelpTextContainer';
 import { Lang, LangAsParagraph } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';

--- a/src/App/frontend/src/layout/Paragraph/index.tsx
+++ b/src/App/frontend/src/layout/Paragraph/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { createRef, forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { ParagraphDef } from 'src/layout/Paragraph/config.def.generated';
@@ -22,7 +22,7 @@ export class Paragraph extends ParagraphDef {
       >
         <ParagraphComponent
           baseComponentId={props.targetBaseComponentId}
-          containerDivRef={React.createRef()}
+          containerDivRef={createRef()}
         />
       </SummaryFlex>
     );

--- a/src/App/frontend/src/layout/Payment/PaymentComponent.tsx
+++ b/src/App/frontend/src/layout/Payment/PaymentComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Alert } from '@digdir/designsystemet-react';
 
 import { Button } from 'src/app-components/Button/Button';

--- a/src/App/frontend/src/layout/Payment/PaymentReceiptDetails/PaymentReceiptDetails.tsx
+++ b/src/App/frontend/src/layout/Payment/PaymentReceiptDetails/PaymentReceiptDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Label, Paragraph } from '@digdir/designsystemet-react';
 

--- a/src/App/frontend/src/layout/Payment/PaymentSummary.tsx
+++ b/src/App/frontend/src/layout/Payment/PaymentSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { PaymentReceiptDetails } from 'src/layout/Payment/PaymentReceiptDetails/PaymentReceiptDetails';
 import { SummaryContains, SummaryFlex } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';

--- a/src/App/frontend/src/layout/Payment/SummaryPaymentComponent.tsx
+++ b/src/App/frontend/src/layout/Payment/SummaryPaymentComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { PaymentReceiptDetails } from 'src/layout/Payment/PaymentReceiptDetails/PaymentReceiptDetails';
 import { useItemWhenType } from 'src/utils/layout/useNodeItem';
 import type { SummaryRendererProps } from 'src/layout/LayoutComponent';

--- a/src/App/frontend/src/layout/Payment/index.tsx
+++ b/src/App/frontend/src/layout/Payment/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
+import * as React from 'react';
 import type { JSX } from 'react';
 
 import { PaymentDef } from 'src/layout/Payment/config.def.generated';

--- a/src/App/frontend/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
+++ b/src/App/frontend/src/layout/PaymentDetails/PaymentDetailsComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import deepEqual from 'fast-deep-equal';
 

--- a/src/App/frontend/src/layout/PaymentDetails/PaymentDetailsTable.tsx
+++ b/src/App/frontend/src/layout/PaymentDetails/PaymentDetailsTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Label, Table } from '@digdir/designsystemet-react';
 import cn from 'classnames';

--- a/src/App/frontend/src/layout/PaymentDetails/index.tsx
+++ b/src/App/frontend/src/layout/PaymentDetails/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { PaymentDetailsDef } from 'src/layout/PaymentDetails/config.def.generated';

--- a/src/App/frontend/src/layout/PersonLookup/PersonLookupComponent.tsx
+++ b/src/App/frontend/src/layout/PersonLookup/PersonLookupComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Field, ValidationMessage } from '@digdir/designsystemet-react';
 import { queryOptions, useQuery } from '@tanstack/react-query';

--- a/src/App/frontend/src/layout/PersonLookup/PersonLookupSummary.tsx
+++ b/src/App/frontend/src/layout/PersonLookup/PersonLookupSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Heading } from '@digdir/designsystemet-react';
 
 import { useDataModelBindings } from 'src/features/formData/useDataModelBindings';

--- a/src/App/frontend/src/layout/PersonLookup/index.tsx
+++ b/src/App/frontend/src/layout/PersonLookup/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';

--- a/src/App/frontend/src/layout/PrintButton/PrintButtonComponent.test.tsx
+++ b/src/App/frontend/src/layout/PrintButton/PrintButtonComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { PrintButtonComponent } from 'src/layout/PrintButton/PrintButtonComponent';

--- a/src/App/frontend/src/layout/PrintButton/PrintButtonComponent.tsx
+++ b/src/App/frontend/src/layout/PrintButton/PrintButtonComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { PropsFromGenericComponent } from '..';
 
 import { Button } from 'src/app-components/Button/Button';

--- a/src/App/frontend/src/layout/PrintButton/index.tsx
+++ b/src/App/frontend/src/layout/PrintButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import type { PropsFromGenericComponent } from '..';

--- a/src/App/frontend/src/layout/RadioButtons/ControlledRadioGroup.test.tsx
+++ b/src/App/frontend/src/layout/RadioButtons/ControlledRadioGroup.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import type { AxiosResponse } from 'axios';

--- a/src/App/frontend/src/layout/RadioButtons/ControlledRadioGroup.tsx
+++ b/src/App/frontend/src/layout/RadioButtons/ControlledRadioGroup.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Fieldset, useRadioGroup } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 

--- a/src/App/frontend/src/layout/RadioButtons/RadioButtonsSummary.tsx
+++ b/src/App/frontend/src/layout/RadioButtons/RadioButtonsSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';

--- a/src/App/frontend/src/layout/RadioButtons/index.tsx
+++ b/src/App/frontend/src/layout/RadioButtons/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';

--- a/src/App/frontend/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.test.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, waitFor, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { v4 as uuidv4 } from 'uuid';

--- a/src/App/frontend/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Container/RepeatingGroupContainer.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
+import * as React from 'react';
 import type { JSX } from 'react';
 
 import { PlusIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/layout/RepeatingGroup/EditContainer/RepeatingGroupEditContainer.test.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/EditContainer/RepeatingGroupEditContainer.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/layout/RepeatingGroup/EditContainer/RepeatingGroupEditContext.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/EditContainer/RepeatingGroupEditContext.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import type { PropsWithChildren } from 'react';
 

--- a/src/App/frontend/src/layout/RepeatingGroup/EditContainer/RepeatingGroupsEditContainer.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/EditContainer/RepeatingGroupsEditContainer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { JSX } from 'react';
 
 import { ChevronLeftIcon, ChevronRightIcon, TrashIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/layout/RepeatingGroup/Pagination/RepeatingGroupPagination.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Pagination/RepeatingGroupPagination.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+import * as React from 'react';
 
 import { Pagination, Table, usePagination } from '@digdir/designsystemet-react';
 import type { UsePaginationProps } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/RepeatingGroup/Providers/RepeatingGroupContext.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Providers/RepeatingGroupContext.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { v4 as uuidv4 } from 'uuid';

--- a/src/App/frontend/src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Providers/RepeatingGroupFocusContext.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useSearchParams } from 'react-router';
 import type { PropsWithChildren } from 'react';
 

--- a/src/App/frontend/src/layout/RepeatingGroup/Summary/LargeRowSummaryContainer.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Summary/LargeRowSummaryContainer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { JSX } from 'react';
 
 import { Fieldset, Heading } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.test.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';
 import { defaultDataTypeMock } from 'src/__mocks__/getUiConfigMock';
 import { ALTINN_ROW_ID } from 'src/features/formData/types';

--- a/src/App/frontend/src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Summary/SummaryRepeatingGroup.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ErrorPaper } from 'src/components/message/ErrorPaper';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { Lang } from 'src/features/language/Lang';

--- a/src/App/frontend/src/layout/RepeatingGroup/Summary2/RepGroupSummaryEditableContext.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Summary2/RepGroupSummaryEditableContext.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { createContext } from 'src/core/contexts/context';

--- a/src/App/frontend/src/layout/RepeatingGroup/Summary2/RepeatingGroupSummary.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Summary2/RepeatingGroupSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Heading, ValidationMessage } from '@digdir/designsystemet-react';
 import cn from 'classnames';
 

--- a/src/App/frontend/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.test.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/App/frontend/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Summary2/RepeatingGroupTableSummary/RepeatingGroupTableSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Table, ValidationMessage } from '@digdir/designsystemet-react';
 import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';

--- a/src/App/frontend/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Table/RepeatingGroupTable.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import ResizeObserverModule from 'resize-observer-polyfill';

--- a/src/App/frontend/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Table/RepeatingGroupTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Table } from '@digdir/designsystemet-react';
 import cn from 'classnames';

--- a/src/App/frontend/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Table/RepeatingGroupTableRow.tsx
@@ -1,4 +1,5 @@
-import React, { useLayoutEffect } from 'react';
+import { useLayoutEffect } from 'react';
+import * as React from 'react';
 import type { JSX } from 'react';
 
 import { Table } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/Table/RepeatingGroupTableTitle.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ExprVal } from 'src/features/expressions/types';
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { Lang } from 'src/features/language/Lang';

--- a/src/App/frontend/src/layout/RepeatingGroup/index.tsx
+++ b/src/App/frontend/src/layout/RepeatingGroup/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import type { PropsFromGenericComponent, ValidateComponent, ValidationFilter, ValidationFilterFunction } from '..';

--- a/src/App/frontend/src/layout/SigneeList/SigneeListComponent.test.tsx
+++ b/src/App/frontend/src/layout/SigneeList/SigneeListComponent.test.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import { createRef, ReactElement } from 'react';
 import { useParams } from 'react-router';
 
 import { screen } from '@testing-library/dom';
@@ -100,7 +100,7 @@ describe('SigneeListComponent', () => {
     render(
       <SigneeListComponent
         baseComponentId='whatever'
-        containerDivRef={React.createRef()}
+        containerDivRef={createRef()}
       />,
     );
 
@@ -127,7 +127,7 @@ describe('SigneeListComponent', () => {
     render(
       <SigneeListComponent
         baseComponentId='whatever'
-        containerDivRef={React.createRef()}
+        containerDivRef={createRef()}
       />,
     );
 
@@ -144,7 +144,7 @@ describe('SigneeListComponent', () => {
     render(
       <SigneeListComponent
         baseComponentId='whatever'
-        containerDivRef={React.createRef()}
+        containerDivRef={createRef()}
       />,
     );
 

--- a/src/App/frontend/src/layout/SigneeList/SigneeListComponent.tsx
+++ b/src/App/frontend/src/layout/SigneeList/SigneeListComponent.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useParams } from 'react-router';
 
 import { AppTable } from 'src/app-components/Table/Table';

--- a/src/App/frontend/src/layout/SigneeList/SigneeListError.tsx
+++ b/src/App/frontend/src/layout/SigneeList/SigneeListError.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { isAxiosError } from 'axios';
 import { z, ZodError } from 'zod';
 

--- a/src/App/frontend/src/layout/SigneeList/SigneeListSummary.tsx
+++ b/src/App/frontend/src/layout/SigneeList/SigneeListSummary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useParams } from 'react-router';
 import type { PropsWithChildren, ReactElement } from 'react';
 

--- a/src/App/frontend/src/layout/SigneeList/SigneeStateTag.test.tsx
+++ b/src/App/frontend/src/layout/SigneeList/SigneeStateTag.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/dom';
 import { render } from '@testing-library/react';
 

--- a/src/App/frontend/src/layout/SigneeList/SigneeStateTag.tsx
+++ b/src/App/frontend/src/layout/SigneeList/SigneeStateTag.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Tag } from '@digdir/designsystemet-react';
 import type { TagProps } from '@digdir/designsystemet-react';
 

--- a/src/App/frontend/src/layout/SigneeList/index.tsx
+++ b/src/App/frontend/src/layout/SigneeList/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, type JSX } from 'react';
+import { forwardRef } from 'react';
+import type { type JSX } from 'react';
 
 import { SigneeListDef } from 'src/layout/SigneeList/config.def.generated';
 import { SigneeListComponent } from 'src/layout/SigneeList/SigneeListComponent';

--- a/src/App/frontend/src/layout/SigningActions/OnBehalfOfChooser.tsx
+++ b/src/App/frontend/src/layout/SigningActions/OnBehalfOfChooser.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ChangeEvent } from 'react';
 
 import { ValidationMessage } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/SigningActions/PanelAwaitingCurrentUserSignature.tsx
+++ b/src/App/frontend/src/layout/SigningActions/PanelAwaitingCurrentUserSignature.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 
 import { Checkbox, Heading, ValidationMessage } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/SigningActions/PanelAwaitingOtherSignatures.tsx
+++ b/src/App/frontend/src/layout/SigningActions/PanelAwaitingOtherSignatures.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Button } from 'src/app-components/Button/Button';
 import { Lang } from 'src/features/language/Lang';

--- a/src/App/frontend/src/layout/SigningActions/PanelNoActionRequired.tsx
+++ b/src/App/frontend/src/layout/SigningActions/PanelNoActionRequired.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Link } from '@digdir/designsystemet-react';
 
 import { Button } from 'src/app-components/Button/Button';

--- a/src/App/frontend/src/layout/SigningActions/PanelSigning.tsx
+++ b/src/App/frontend/src/layout/SigningActions/PanelSigning.tsx
@@ -1,4 +1,5 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
+import * as React from 'react';
 import type { PropsWithChildren, ReactElement } from 'react';
 
 import { Dialog, Heading, Paragraph, ValidationMessage } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/SigningActions/PanelSubmit.tsx
+++ b/src/App/frontend/src/layout/SigningActions/PanelSubmit.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Lang } from 'src/features/language/Lang';
 import { SigningPanel } from 'src/layout/SigningActions/PanelSigning';
 import { SubmitSigningButton } from 'src/layout/SigningActions/SubmitSigningButton';

--- a/src/App/frontend/src/layout/SigningActions/SigningActionsComponent.test.tsx
+++ b/src/App/frontend/src/layout/SigningActions/SigningActionsComponent.test.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import { createRef, ReactElement } from 'react';
 import { useParams } from 'react-router';
 
 import { screen } from '@testing-library/dom';
@@ -148,7 +148,7 @@ describe('SigningActionsComponent', () => {
     render(
       <SigningActionsComponent
         baseComponentId='whatever'
-        containerDivRef={React.createRef()}
+        containerDivRef={createRef()}
       />,
     );
 
@@ -165,7 +165,7 @@ describe('SigningActionsComponent', () => {
     render(
       <SigningActionsComponent
         baseComponentId='whatever'
-        containerDivRef={React.createRef()}
+        containerDivRef={createRef()}
       />,
     );
 
@@ -183,7 +183,7 @@ describe('SigningActionsComponent', () => {
     render(
       <SigningActionsComponent
         baseComponentId='whatever'
-        containerDivRef={React.createRef()}
+        containerDivRef={createRef()}
       />,
     );
 
@@ -201,7 +201,7 @@ describe('SigningActionsComponent', () => {
     render(
       <SigningActionsComponent
         baseComponentId='whatever'
-        containerDivRef={React.createRef()}
+        containerDivRef={createRef()}
       />,
     );
 
@@ -219,7 +219,7 @@ describe('SigningActionsComponent', () => {
     render(
       <SigningActionsComponent
         baseComponentId='whatever'
-        containerDivRef={React.createRef()}
+        containerDivRef={createRef()}
       />,
     );
 
@@ -234,7 +234,7 @@ describe('SigningActionsComponent', () => {
     render(
       <SigningActionsComponent
         baseComponentId='whatever'
-        containerDivRef={React.createRef()}
+        containerDivRef={createRef()}
       />,
     );
 
@@ -249,7 +249,7 @@ describe('SigningActionsComponent', () => {
     render(
       <SigningActionsComponent
         baseComponentId='whatever'
-        containerDivRef={React.createRef()}
+        containerDivRef={createRef()}
       />,
     );
 
@@ -268,7 +268,7 @@ describe('SigningActionsComponent', () => {
     render(
       <SigningActionsComponent
         baseComponentId='whatever'
-        containerDivRef={React.createRef()}
+        containerDivRef={createRef()}
       />,
     );
 
@@ -287,7 +287,7 @@ describe('SigningActionsComponent', () => {
     render(
       <SigningActionsComponent
         baseComponentId='whatever'
-        containerDivRef={React.createRef()}
+        containerDivRef={createRef()}
       />,
     );
 
@@ -308,7 +308,7 @@ describe('SigningActionsComponent', () => {
       render(
         <SigningActionsComponent
           baseComponentId='whatever'
-          containerDivRef={React.createRef()}
+          containerDivRef={createRef()}
         />,
       );
 

--- a/src/App/frontend/src/layout/SigningActions/SigningActionsComponent.tsx
+++ b/src/App/frontend/src/layout/SigningActions/SigningActionsComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useParams } from 'react-router';
 
 import { FatalError } from 'src/app-components/error/FatalError/FatalError';

--- a/src/App/frontend/src/layout/SigningActions/SubmitSigningButton.tsx
+++ b/src/App/frontend/src/layout/SigningActions/SubmitSigningButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 

--- a/src/App/frontend/src/layout/SigningActions/index.tsx
+++ b/src/App/frontend/src/layout/SigningActions/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { SigningActionsDef } from 'src/layout/SigningActions/config.def.generated';

--- a/src/App/frontend/src/layout/SigningDocumentList/SigningDocumentListComponent.test.tsx
+++ b/src/App/frontend/src/layout/SigningDocumentList/SigningDocumentListComponent.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { screen } from '@testing-library/dom';
 import { render as renderRtl } from '@testing-library/react';

--- a/src/App/frontend/src/layout/SigningDocumentList/SigningDocumentListComponent.tsx
+++ b/src/App/frontend/src/layout/SigningDocumentList/SigningDocumentListComponent.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useParams } from 'react-router';
 
 import { Link } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/SigningDocumentList/SigningDocumentListError.tsx
+++ b/src/App/frontend/src/layout/SigningDocumentList/SigningDocumentListError.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { isAxiosError } from 'axios';
 import { ZodError } from 'zod';
 

--- a/src/App/frontend/src/layout/SigningDocumentList/index.tsx
+++ b/src/App/frontend/src/layout/SigningDocumentList/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, type JSX } from 'react';
+import { forwardRef } from 'react';
+import type { type JSX } from 'react';
 
 import { ValidateSigningTaskType } from 'src/layout/SigningActions/ValidateSigningTaskType';
 import { SigningDocumentListDef } from 'src/layout/SigningDocumentList/config.def.generated';

--- a/src/App/frontend/src/layout/SimpleTable/ApiTable.tsx
+++ b/src/App/frontend/src/layout/SimpleTable/ApiTable.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Link } from '@digdir/designsystemet-react';
 import { pick } from 'dot-object';
 

--- a/src/App/frontend/src/layout/SimpleTable/ApiTableSummary.tsx
+++ b/src/App/frontend/src/layout/SimpleTable/ApiTableSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { pick } from 'dot-object';
 
 import { AppTable } from 'src/app-components/Table/Table';

--- a/src/App/frontend/src/layout/SimpleTable/SimpleTableComponent.tsx
+++ b/src/App/frontend/src/layout/SimpleTable/SimpleTableComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Link } from '@digdir/designsystemet-react';
 import { PencilIcon, TrashIcon } from '@navikt/aksel-icons';

--- a/src/App/frontend/src/layout/SimpleTable/SimpleTableSummary.tsx
+++ b/src/App/frontend/src/layout/SimpleTable/SimpleTableSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { AppTable } from 'src/app-components/Table/Table';
 import { translationKey } from 'src/AppComponentsBridge';
 import { Caption } from 'src/components/form/caption/Caption';

--- a/src/App/frontend/src/layout/SimpleTable/index.tsx
+++ b/src/App/frontend/src/layout/SimpleTable/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
+import * as React from 'react';
 
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';
 import { ApiTable } from 'src/layout/SimpleTable/ApiTable';

--- a/src/App/frontend/src/layout/Subform/SubformCellContent.tsx
+++ b/src/App/frontend/src/layout/Subform/SubformCellContent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import dot from 'dot-object';
 
 import { evalExpr } from 'src/features/expressions';

--- a/src/App/frontend/src/layout/Subform/SubformComponent.tsx
+++ b/src/App/frontend/src/layout/Subform/SubformComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useNavigation } from 'react-router';
 
 import { Table } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/Subform/SubformWrapper.tsx
+++ b/src/App/frontend/src/layout/Subform/SubformWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Form } from 'src/components/form/Form';

--- a/src/App/frontend/src/layout/Subform/Summary/SubformSummaryComponent.tsx
+++ b/src/App/frontend/src/layout/Subform/Summary/SubformSummaryComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { ReactNode } from 'react';
 
 import { FatalError } from 'src/app-components/error/FatalError/FatalError';

--- a/src/App/frontend/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
+++ b/src/App/frontend/src/layout/Subform/Summary/SubformSummaryComponent2.tsx
@@ -1,4 +1,6 @@
-import React, { Fragment, type PropsWithChildren } from 'react';
+import { Fragment } from 'react';
+import * as React from 'react';
+import type { type PropsWithChildren } from 'react';
 
 import { Heading, Paragraph } from '@digdir/designsystemet-react';
 

--- a/src/App/frontend/src/layout/Subform/Summary/SubformSummaryTable.tsx
+++ b/src/App/frontend/src/layout/Subform/Summary/SubformSummaryTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useNavigate, useNavigation } from 'react-router';
 
 import { Paragraph, Table } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/Subform/index.tsx
+++ b/src/App/frontend/src/layout/Subform/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX, ReactNode } from 'react';
 
 import { type ComponentValidation } from 'src/features/validation';

--- a/src/App/frontend/src/layout/Summary/EditButton.tsx
+++ b/src/App/frontend/src/layout/Summary/EditButton.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { PencilIcon } from '@navikt/aksel-icons';
 
 import { Button } from 'src/app-components/Button/Button';

--- a/src/App/frontend/src/layout/Summary/SummaryComponent.test.tsx
+++ b/src/App/frontend/src/layout/Summary/SummaryComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { act, fireEvent, screen } from '@testing-library/react';
 
 import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';

--- a/src/App/frontend/src/layout/Summary/SummaryComponent.tsx
+++ b/src/App/frontend/src/layout/Summary/SummaryComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import cn from 'classnames';
 

--- a/src/App/frontend/src/layout/Summary/SummaryContent.tsx
+++ b/src/App/frontend/src/layout/Summary/SummaryContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import cn from 'classnames';
 

--- a/src/App/frontend/src/layout/Summary/SummaryItemCompact.tsx
+++ b/src/App/frontend/src/layout/Summary/SummaryItemCompact.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Lang } from 'src/features/language/Lang';
 import { useLanguage } from 'src/features/language/useLanguage';
 import classes from 'src/layout/Summary/SummaryItemCompact.module.css';

--- a/src/App/frontend/src/layout/Summary/SummaryItemSimple.tsx
+++ b/src/App/frontend/src/layout/Summary/SummaryItemSimple.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import cn from 'classnames';
 
 import { Lang } from 'src/features/language/Lang';

--- a/src/App/frontend/src/layout/Summary/index.tsx
+++ b/src/App/frontend/src/layout/Summary/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
+import * as React from 'react';
 import type { JSX } from 'react';
 
 import { SummaryDef } from 'src/layout/Summary/config.def.generated';

--- a/src/App/frontend/src/layout/Summary2/CommonSummaryComponents/EditButton.test.tsx
+++ b/src/App/frontend/src/layout/Summary2/CommonSummaryComponents/EditButton.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';

--- a/src/App/frontend/src/layout/Summary2/CommonSummaryComponents/EditButton.tsx
+++ b/src/App/frontend/src/layout/Summary2/CommonSummaryComponents/EditButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { PencilIcon } from '@navikt/aksel-icons';
 

--- a/src/App/frontend/src/layout/Summary2/CommonSummaryComponents/LayoutSetSummaryAccordion.tsx
+++ b/src/App/frontend/src/layout/Summary2/CommonSummaryComponents/LayoutSetSummaryAccordion.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { AccordionItem } from 'src/app-components/Accordion/AccordionItem';
 import { Flex } from 'src/app-components/Flex/Flex';
 import { translationKey } from 'src/AppComponentsBridge';

--- a/src/App/frontend/src/layout/Summary2/CommonSummaryComponents/MultipleValueSummary.tsx
+++ b/src/App/frontend/src/layout/Summary2/CommonSummaryComponents/MultipleValueSummary.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Label, List, Paragraph, ValidationMessage } from '@digdir/designsystemet-react';
 import cn from 'classnames';

--- a/src/App/frontend/src/layout/Summary2/CommonSummaryComponents/SingleValueSummary.tsx
+++ b/src/App/frontend/src/layout/Summary2/CommonSummaryComponents/SingleValueSummary.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Label, Paragraph, ValidationMessage } from '@digdir/designsystemet-react';
 import cn from 'classnames';

--- a/src/App/frontend/src/layout/Summary2/SummaryComponent2/ComponentSummary.tsx
+++ b/src/App/frontend/src/layout/Summary2/SummaryComponent2/ComponentSummary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { JSX, PropsWithChildren } from 'react';
 
 import cn from 'classnames';

--- a/src/App/frontend/src/layout/Summary2/SummaryComponent2/LayoutSetSummary.tsx
+++ b/src/App/frontend/src/layout/Summary2/SummaryComponent2/LayoutSetSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { usePageOrder } from 'src/hooks/useNavigatePage';
 import { LayoutSetSummaryAccordion } from 'src/layout/Summary2/CommonSummaryComponents/LayoutSetSummaryAccordion';
 import { EmptyChildrenBoundary } from 'src/layout/Summary2/isEmpty/EmptyChildrenContext';

--- a/src/App/frontend/src/layout/Summary2/SummaryComponent2/PageSummary.tsx
+++ b/src/App/frontend/src/layout/Summary2/SummaryComponent2/PageSummary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { CSSProperties } from 'react';
 
 import { Flex } from 'src/app-components/Flex/Flex';

--- a/src/App/frontend/src/layout/Summary2/SummaryComponent2/SummaryComponent2.test.tsx
+++ b/src/App/frontend/src/layout/Summary2/SummaryComponent2/SummaryComponent2.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { getFormBootstrapMock } from 'src/__mocks__/getFormBootstrapMock';

--- a/src/App/frontend/src/layout/Summary2/SummaryComponent2/SummaryComponent2.tsx
+++ b/src/App/frontend/src/layout/Summary2/SummaryComponent2/SummaryComponent2.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { memo } from 'react';
 
 import { ComponentSummary } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';
 import { LayoutSetSummary } from 'src/layout/Summary2/SummaryComponent2/LayoutSetSummary';
@@ -36,5 +36,5 @@ function SummaryComponent2Inner({ baseComponentId }: Pick<PropsFromGenericCompon
   );
 }
 
-export const SummaryComponent2 = React.memo(SummaryComponent2Inner);
+export const SummaryComponent2 = memo(SummaryComponent2Inner);
 SummaryComponent2.displayName = 'SummaryComponent2';

--- a/src/App/frontend/src/layout/Summary2/SummaryComponent2/TaskSummaryWrapper.tsx
+++ b/src/App/frontend/src/layout/Summary2/SummaryComponent2/TaskSummaryWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { TaskOverrides } from 'src/core/contexts/TaskOverrides';
 import { FormProvider } from 'src/features/form/FormProvider';

--- a/src/App/frontend/src/layout/Summary2/index.tsx
+++ b/src/App/frontend/src/layout/Summary2/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
+import * as React from 'react';
 import type { JSX } from 'react';
 
 import { Summary2Def } from 'src/layout/Summary2/config.def.generated';

--- a/src/App/frontend/src/layout/Summary2/isEmpty/EmptyChildrenContext.tsx
+++ b/src/App/frontend/src/layout/Summary2/isEmpty/EmptyChildrenContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useLayoutEffect, useReducer, useRef } from 'react';
+import { createContext, useLayoutEffect, useReducer, useRef } from 'react';
+import * as React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { SummaryContains } from 'src/layout/Summary2/SummaryComponent2/ComponentSummary';

--- a/src/App/frontend/src/layout/Summary2/summaryStoreContext.tsx
+++ b/src/App/frontend/src/layout/Summary2/summaryStoreContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { FormBootstrap } from 'src/features/formBootstrap/FormBootstrap';

--- a/src/App/frontend/src/layout/Tabs/Tabs.tsx
+++ b/src/App/frontend/src/layout/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
 
 import { Tabs as DesignsystemetTabs } from '@digdir/designsystemet-react';

--- a/src/App/frontend/src/layout/Tabs/TabsSummary.tsx
+++ b/src/App/frontend/src/layout/Tabs/TabsSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Heading } from '@digdir/designsystemet-react';
 
 import { Flex } from 'src/app-components/Flex/Flex';

--- a/src/App/frontend/src/layout/Tabs/TabsSummaryComponent.tsx
+++ b/src/App/frontend/src/layout/Tabs/TabsSummaryComponent.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { JSX } from 'react';
 
 import { SummaryComponentFor } from 'src/layout/Summary/SummaryComponent';

--- a/src/App/frontend/src/layout/Tabs/index.tsx
+++ b/src/App/frontend/src/layout/Tabs/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, type JSX } from 'react';
+import { forwardRef } from 'react';
+import type { type JSX } from 'react';
 
 import type { PropsFromGenericComponent } from '..';
 

--- a/src/App/frontend/src/layout/Text/TextComponent.tsx
+++ b/src/App/frontend/src/layout/Text/TextComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import cn from 'classnames';
 
 import { DisplayText } from 'src/app-components/Text/DisplayText';

--- a/src/App/frontend/src/layout/Text/TextSummary.tsx
+++ b/src/App/frontend/src/layout/Text/TextSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';

--- a/src/App/frontend/src/layout/Text/index.tsx
+++ b/src/App/frontend/src/layout/Text/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { TextDef } from 'src/layout/Text/config.def.generated';

--- a/src/App/frontend/src/layout/TextArea/TextAreaComponent.test.tsx
+++ b/src/App/frontend/src/layout/TextArea/TextAreaComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/App/frontend/src/layout/TextArea/TextAreaComponent.tsx
+++ b/src/App/frontend/src/layout/TextArea/TextAreaComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Label } from 'src/app-components/Label/Label';
 import { TextArea } from 'src/app-components/TextArea/TextArea';
 import { translationKey } from 'src/AppComponentsBridge';

--- a/src/App/frontend/src/layout/TextArea/TextAreaSummary.tsx
+++ b/src/App/frontend/src/layout/TextArea/TextAreaSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';

--- a/src/App/frontend/src/layout/TextArea/index.tsx
+++ b/src/App/frontend/src/layout/TextArea/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';

--- a/src/App/frontend/src/layout/TimePicker/TimePickerComponent.test.tsx
+++ b/src/App/frontend/src/layout/TimePicker/TimePickerComponent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 
 import { defaultDataTypeMock } from 'src/__mocks__/getUiConfigMock';

--- a/src/App/frontend/src/layout/TimePicker/TimePickerComponent.tsx
+++ b/src/App/frontend/src/layout/TimePicker/TimePickerComponent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Flex } from 'src/app-components/Flex/Flex';
 import { Label } from 'src/app-components/Label/Label';
 import { TimePicker as TimePickerControl } from 'src/app-components/TimePicker/TimePicker';

--- a/src/App/frontend/src/layout/TimePicker/TimePickerSummary.tsx
+++ b/src/App/frontend/src/layout/TimePicker/TimePickerSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useDisplayData } from 'src/features/displayData/useDisplayData';
 import { Lang } from 'src/features/language/Lang';
 import { useUnifiedValidationsForNode } from 'src/features/validation/selectors/unifiedValidationsForNode';

--- a/src/App/frontend/src/layout/TimePicker/index.tsx
+++ b/src/App/frontend/src/layout/TimePicker/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { useDisplayData } from 'src/features/displayData/useDisplayData';

--- a/src/App/frontend/src/layout/Video/Video.tsx
+++ b/src/App/frontend/src/layout/Video/Video.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useCurrentLanguage } from 'src/features/language/LanguageProvider';
 import { useLanguage } from 'src/features/language/useLanguage';
 import { useParentCard } from 'src/layout/Cards/CardContext';

--- a/src/App/frontend/src/layout/Video/index.tsx
+++ b/src/App/frontend/src/layout/Video/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { JSX } from 'react';
 
 import { VideoDef } from 'src/layout/Video/config.def.generated';

--- a/src/App/frontend/src/router.tsx
+++ b/src/App/frontend/src/router.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createBrowserRouter, Navigate } from 'react-router';
 
 import type { QueryClient } from '@tanstack/react-query';

--- a/src/App/frontend/src/routes/index/index.route.tsx
+++ b/src/App/frontend/src/routes/index/index.route.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Outlet, useLoaderData } from 'react-router';
 
 import { DisplayError } from 'src/core/errorHandling/DisplayError';

--- a/src/App/frontend/src/routes/instance-selection/instance-selection.route.tsx
+++ b/src/App/frontend/src/routes/instance-selection/instance-selection.route.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useLoaderData } from 'react-router';
 
 import { DisplayError } from 'src/core/errorHandling/DisplayError';

--- a/src/App/frontend/src/routes/instance/instance.route.tsx
+++ b/src/App/frontend/src/routes/instance/instance.route.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Outlet } from 'react-router';
 
 import { InstanceProvider } from 'src/features/instance/InstanceContext';

--- a/src/App/frontend/src/routes/page/page.route.tsx
+++ b/src/App/frontend/src/routes/page/page.route.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Form } from 'src/components/form/Form';
 import { PresentationComponent } from 'src/components/presentation/Presentation';
 import { PdfWrapper } from 'src/features/pdf/PdfWrapper';

--- a/src/App/frontend/src/routes/task/task.route.tsx
+++ b/src/App/frontend/src/routes/task/task.route.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Outlet } from 'react-router';
 
 import { ProcessWrapper } from 'src/components/wrappers/ProcessWrapper';

--- a/src/App/frontend/src/test/renderWithProviders.tsx
+++ b/src/App/frontend/src/test/renderWithProviders.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes, useLocation } from 'react-router';
 import type { PropsWithChildren } from 'react';
 

--- a/src/App/frontend/src/test/routerUtils.tsx
+++ b/src/App/frontend/src/test/routerUtils.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 
 export const PageNavigationRouter =

--- a/src/App/frontend/src/utils/formattingUtils.test.tsx
+++ b/src/App/frontend/src/utils/formattingUtils.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { NumericFormatProps, PatternFormatProps } from 'react-number-format';
 
 import { render as renderRtl, screen } from '@testing-library/react';

--- a/src/App/frontend/src/utils/layout/ComponentErrorBoundary.tsx
+++ b/src/App/frontend/src/utils/layout/ComponentErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import React, { Component, useEffect } from 'react';
+import { Component, useEffect } from 'react';
+import * as React from 'react';
 
 import { FormStore } from 'src/features/form/FormContext';
 

--- a/src/App/frontend/src/utils/layout/DataModelLocation.tsx
+++ b/src/App/frontend/src/utils/layout/DataModelLocation.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+import * as React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { createContext } from 'src/core/contexts/context';

--- a/src/App/frontend/src/utils/layout/NodesContext.tsx
+++ b/src/App/frontend/src/utils/layout/NodesContext.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import type { PropsWithChildren, RefObject } from 'react';
 
 import deepEqual from 'fast-deep-equal';

--- a/src/App/frontend/src/utils/layout/all.test.tsx
+++ b/src/App/frontend/src/utils/layout/all.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { screen } from '@testing-library/react';

--- a/src/App/frontend/src/utils/layout/generator/GeneratorContext.tsx
+++ b/src/App/frontend/src/utils/layout/generator/GeneratorContext.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import type { PropsWithChildren, RefObject } from 'react';
 
 import { ContextNotProvided, createContext } from 'src/core/contexts/context';
@@ -155,7 +155,7 @@ function GeneratorRowProviderInner({
   return <Provider value={value}>{children}</Provider>;
 }
 
-export const GeneratorRowProvider = React.memo(GeneratorRowProviderInner);
+export const GeneratorRowProvider = memo(GeneratorRowProviderInner);
 GeneratorRowProvider.displayName = 'GeneratorRowProvider';
 
 export function GeneratorGlobalProvider({ children, ...rest }: PropsWithChildren<GlobalProviderProps>) {

--- a/src/App/frontend/src/utils/layout/generator/GeneratorErrorBoundary.tsx
+++ b/src/App/frontend/src/utils/layout/generator/GeneratorErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { Component, useEffect } from 'react';
+import { Component, createContext, useContext, useEffect } from 'react';
 import type { PropsWithChildren, RefObject } from 'react';
 
 import { FormStore } from 'src/features/form/FormContext';
@@ -40,12 +40,12 @@ interface ContextData {
   ref: RefObject<Ref>;
 }
 
-const Context = React.createContext<ContextData>({
+const Context = createContext<ContextData>({
   ref: { current: undefined },
 });
 
 export function useGeneratorErrorBoundaryNodeRef() {
-  return React.useContext(Context).ref;
+  return useContext(Context).ref;
 }
 
 function StoreErrorAndBail({ error, ref }: { error: Error; ref: Ref }) {

--- a/src/App/frontend/src/utils/layout/generator/LayoutSetGenerator.tsx
+++ b/src/App/frontend/src/utils/layout/generator/LayoutSetGenerator.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { FormStore } from 'src/features/form/FormContext';
 import { usePdfLayoutName, useRawPageOrder } from 'src/features/form/layoutSettings/processLayoutSettings';

--- a/src/App/frontend/src/utils/layout/generator/NodeRepeatingChildren.tsx
+++ b/src/App/frontend/src/utils/layout/generator/NodeRepeatingChildren.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo } from 'react';
+import { Fragment, memo, useMemo } from 'react';
 
 import dot from 'dot-object';
 
@@ -64,7 +64,7 @@ interface GenerateRowProps {
   multiPageMapping: MultiPageMapping | undefined;
 }
 
-const GenerateRow = React.memo((props: GenerateRowProps) => (
+const GenerateRow = memo((props: GenerateRowProps) => (
   <DataModelLocationProvider
     groupBinding={props.groupBinding}
     rowIndex={props.rowIndex}

--- a/src/App/frontend/src/utils/layout/generator/validation/GenerationValidationContext.tsx
+++ b/src/App/frontend/src/utils/layout/generator/validation/GenerationValidationContext.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
+import * as React from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 import type { ErrorObject } from 'ajv';

--- a/src/App/frontend/src/utils/layout/generator/validation/NodePropertiesValidation.tsx
+++ b/src/App/frontend/src/utils/layout/generator/validation/NodePropertiesValidation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import type { FC } from 'react';
 
 import { formatLayoutSchemaValidationError } from 'src/features/devtools/utils/layoutSchemaValidation';

--- a/src/App/frontend/src/utils/layout/useLabel.tsx
+++ b/src/App/frontend/src/utils/layout/useLabel.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Description } from 'src/components/form/Description';
 import { HelpTextContainer } from 'src/components/form/HelpTextContainer';
 import { OptionalIndicator } from 'src/components/form/OptionalIndicator';

--- a/src/App/frontend/tsconfig.json
+++ b/src/App/frontend/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["es6", "dom", "es7", "esnext"],
     "sourceMap": true,
     "allowJs": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "moduleResolution": "node",
     "rootDir": "./",
     "noEmit": true,


### PR DESCRIPTION
Update the jsx-transform from "react" to "react-jsx". Avoid the need to import React just for using jsx.

## Description
- Update the value of "jsx" in compiler options of tsconfig.json to "react-jsx"
- Run npx react-codemod update-react-imports
- Turn off eslint rule react/react-in-jsx-scope

## Verification

- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
