### PR TITLE
fix(settings): update contact point icon and fix infinite spinner

### DIFF
--- a/src/Designer/frontend/settings/features/orgs/components/Menu/Menu.tsx
+++ b/src/Designer/frontend/settings/features/orgs/components/Menu/Menu.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { StudioContentMenu } from '@studio/components';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { ShieldLockIcon, RobotSmileIcon } from '@studio/icons';
+import { RobotSmileIcon, BellIcon } from '@studio/icons';
 import { useTranslation } from 'react-i18next';
 import { RoutePaths } from '../../routes/RoutePaths';
 
@@ -19,7 +19,7 @@ export function Menu(): ReactElement {
     {
       tabId: RoutePaths.ContactPoints,
       tabName: t('settings.orgs.contact_points.menu.contact_points'),
-      icon: <ShieldLockIcon />,
+      icon: <BellIcon />,
     },
   ];
   return (

--- a/src/Designer/frontend/settings/features/orgs/layout/PageLayout.test.tsx
+++ b/src/Designer/frontend/settings/features/orgs/layout/PageLayout.test.tsx
@@ -1,18 +1,15 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { PageLayout } from './PageLayout';
 import { renderWithProviders } from '../../../testing/mocks';
 import { textMock } from '@studio/testing/mocks/i18nMock';
-import { useOrganizationsQuery, useUserOrgPermissionsQuery } from 'app-shared/hooks/queries';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import type { QueryClient } from '@tanstack/react-query';
 
 jest.mock('../components/Menu/Menu', () => ({ Menu: () => <div>Menu</div> }));
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   Outlet: () => <div>Outlet</div>,
-}));
-jest.mock('app-shared/hooks/queries', () => ({
-  ...jest.requireActual('app-shared/hooks/queries'),
-  useOrganizationsQuery: jest.fn(),
-  useUserOrgPermissionsQuery: jest.fn(),
 }));
 
 const testOrg = 'ttd';
@@ -25,25 +22,20 @@ const organizationsMock = [
   },
 ];
 
-const renderPageLayout = (initialEntries = ['/orgs/ttd/contact-points']) => {
-  return renderWithProviders(<PageLayout />, { initialEntries });
-};
-
 describe('PageLayout', () => {
-  beforeEach(() => {
-    jest.mocked(useOrganizationsQuery).mockReturnValue({
-      data: organizationsMock,
-      isPending: false,
-      isError: false,
-    } as ReturnType<typeof useOrganizationsQuery>);
-    jest.mocked(useUserOrgPermissionsQuery).mockReturnValue({
-      data: { canCreateOrgRepo: true, isOrgOwner: true },
-      isPending: false,
-      isError: false,
-    } as ReturnType<typeof useUserOrgPermissionsQuery>);
-  });
+  let queryClient: QueryClient;
 
-  afterEach(() => jest.clearAllMocks());
+  const renderPageLayout = (initialEntries = ['/orgs/ttd/contact-points']) =>
+    renderWithProviders(<PageLayout />, { initialEntries, queryClient });
+
+  beforeEach(() => {
+    queryClient = createQueryClientMock();
+    queryClient.setQueryData([QueryKey.Organizations], organizationsMock);
+    queryClient.setQueryData([QueryKey.UserOrgPermissions, testOrg], {
+      canCreateOrgRepo: true,
+      isOrgOwner: true,
+    });
+  });
 
   it('renders the settings heading', () => {
     renderPageLayout();
@@ -62,12 +54,12 @@ describe('PageLayout', () => {
   });
 
   it('renders the loading spinner while data is pending', () => {
-    jest.mocked(useOrganizationsQuery).mockReturnValueOnce({
-      data: undefined,
-      isPending: true,
-      isError: false,
-    } as ReturnType<typeof useOrganizationsQuery>);
-    renderWithProviders(<PageLayout />, { initialEntries: ['/orgs/ttd/contact-points'] });
+    const localQueryClient = createQueryClientMock();
+    renderWithProviders(<PageLayout />, {
+      initialEntries: ['/orgs/ttd/contact-points'],
+      queryClient: localQueryClient,
+      queries: { getOrganizations: () => new Promise<never>(() => {}) },
+    });
     expect(screen.getByRole('img', { name: textMock('repo_status.loading') })).toBeInTheDocument();
   });
 
@@ -86,45 +78,46 @@ describe('PageLayout', () => {
   });
 
   it('renders the loading spinner while org permissions are pending', () => {
-    jest.mocked(useUserOrgPermissionsQuery).mockReturnValueOnce({
-      data: undefined,
-      isPending: true,
-      isError: false,
-    } as ReturnType<typeof useUserOrgPermissionsQuery>);
-    renderPageLayout();
+    const localQueryClient = createQueryClientMock();
+    localQueryClient.setQueryData([QueryKey.Organizations], organizationsMock);
+    renderWithProviders(<PageLayout />, {
+      initialEntries: ['/orgs/ttd/contact-points'],
+      queryClient: localQueryClient,
+      queries: { getUserOrgPermissions: () => new Promise<never>(() => {}) },
+    });
     expect(screen.getByRole('img', { name: textMock('repo_status.loading') })).toBeInTheDocument();
   });
 
-  it('renders error page when organizations query fails', () => {
-    jest.mocked(useOrganizationsQuery).mockReturnValueOnce({
-      data: undefined,
-      isPending: false,
-      isError: true,
-    } as ReturnType<typeof useOrganizationsQuery>);
-    renderPageLayout();
-    expect(
-      screen.queryByRole('heading', { name: textMock('settings.orgs.heading') }),
-    ).not.toBeInTheDocument();
+  it('renders error page when organizations query fails', async () => {
+    const localQueryClient = createQueryClientMock();
+    renderWithProviders(<PageLayout />, {
+      initialEntries: ['/orgs/ttd/contact-points'],
+      queryClient: localQueryClient,
+      queries: { getOrganizations: () => Promise.reject(new Error('error')) },
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', { name: textMock('settings.orgs.heading') }),
+      ).not.toBeInTheDocument();
+    });
   });
 
-  it('renders error page when org permissions query fails', () => {
-    jest.mocked(useUserOrgPermissionsQuery).mockReturnValueOnce({
-      data: undefined,
-      isPending: false,
-      isError: true,
-    } as ReturnType<typeof useUserOrgPermissionsQuery>);
-    renderPageLayout();
-    expect(
-      screen.queryByRole('heading', { name: textMock('settings.orgs.heading') }),
-    ).not.toBeInTheDocument();
+  it('renders error page when org permissions query fails', async () => {
+    const localQueryClient = createQueryClientMock();
+    localQueryClient.setQueryData([QueryKey.Organizations], organizationsMock);
+    renderWithProviders(<PageLayout />, {
+      initialEntries: ['/orgs/ttd/contact-points'],
+      queryClient: localQueryClient,
+      queries: { getUserOrgPermissions: () => Promise.reject(new Error('error')) },
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', { name: textMock('settings.orgs.heading') }),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('renders not-found page when org is not in the list and permissions are pending', () => {
-    jest.mocked(useUserOrgPermissionsQuery).mockReturnValueOnce({
-      data: undefined,
-      isPending: true,
-      isError: false,
-    } as ReturnType<typeof useUserOrgPermissionsQuery>);
     renderPageLayout(['/orgs/unknown-org/contact-points']);
     expect(
       screen.getByRole('heading', { name: textMock('not_found_page.heading') }),
@@ -132,11 +125,10 @@ describe('PageLayout', () => {
   });
 
   it('renders not-org-owner alert when user is not owner for selected org', () => {
-    jest.mocked(useUserOrgPermissionsQuery).mockReturnValueOnce({
-      data: { canCreateOrgRepo: true, isOrgOwner: false },
-      isPending: false,
-      isError: false,
-    } as ReturnType<typeof useUserOrgPermissionsQuery>);
+    queryClient.setQueryData([QueryKey.UserOrgPermissions, testOrg], {
+      canCreateOrgRepo: true,
+      isOrgOwner: false,
+    });
     renderPageLayout();
     expect(
       screen.getByText(
@@ -151,16 +143,11 @@ describe('PageLayout', () => {
 
   it('renders not-org-owner alert using username when org has no full name', () => {
     const orgWithoutFullName = { username: testOrg, full_name: '', avatar_url: '', id: 1 };
-    jest.mocked(useOrganizationsQuery).mockReturnValueOnce({
-      data: [orgWithoutFullName],
-      isPending: false,
-      isError: false,
-    } as ReturnType<typeof useOrganizationsQuery>);
-    jest.mocked(useUserOrgPermissionsQuery).mockReturnValueOnce({
-      data: { canCreateOrgRepo: true, isOrgOwner: false },
-      isPending: false,
-      isError: false,
-    } as ReturnType<typeof useUserOrgPermissionsQuery>);
+    queryClient.setQueryData([QueryKey.Organizations], [orgWithoutFullName]);
+    queryClient.setQueryData([QueryKey.UserOrgPermissions, testOrg], {
+      canCreateOrgRepo: true,
+      isOrgOwner: false,
+    });
     renderPageLayout();
     expect(
       screen.getByText(textMock('settings.orgs.not_org_owner_alert', { orgName: testOrg })),

--- a/src/Designer/frontend/settings/features/orgs/layout/PageLayout.test.tsx
+++ b/src/Designer/frontend/settings/features/orgs/layout/PageLayout.test.tsx
@@ -85,6 +85,16 @@ describe('PageLayout', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the loading spinner while org permissions are pending', () => {
+    jest.mocked(useUserOrgPermissionsQuery).mockReturnValueOnce({
+      data: undefined,
+      isPending: true,
+      isError: false,
+    } as ReturnType<typeof useUserOrgPermissionsQuery>);
+    renderPageLayout();
+    expect(screen.getByRole('img', { name: textMock('repo_status.loading') })).toBeInTheDocument();
+  });
+
   it('renders error page when organizations query fails', () => {
     jest.mocked(useOrganizationsQuery).mockReturnValueOnce({
       data: undefined,
@@ -94,6 +104,30 @@ describe('PageLayout', () => {
     renderPageLayout();
     expect(
       screen.queryByRole('heading', { name: textMock('settings.orgs.heading') }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders error page when org permissions query fails', () => {
+    jest.mocked(useUserOrgPermissionsQuery).mockReturnValueOnce({
+      data: undefined,
+      isPending: false,
+      isError: true,
+    } as ReturnType<typeof useUserOrgPermissionsQuery>);
+    renderPageLayout();
+    expect(
+      screen.queryByRole('heading', { name: textMock('settings.orgs.heading') }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show loading spinner when org is not in the list and permissions are pending', () => {
+    jest.mocked(useUserOrgPermissionsQuery).mockReturnValueOnce({
+      data: undefined,
+      isPending: true,
+      isError: false,
+    } as ReturnType<typeof useUserOrgPermissionsQuery>);
+    renderPageLayout(['/orgs/unknown-org/contact-points']);
+    expect(
+      screen.queryByRole('img', { name: textMock('repo_status.loading') }),
     ).not.toBeInTheDocument();
   });
 
@@ -113,5 +147,25 @@ describe('PageLayout', () => {
     ).toBeInTheDocument();
     expect(screen.queryByText('Menu')).not.toBeInTheDocument();
     expect(screen.queryByText('Outlet')).not.toBeInTheDocument();
+  });
+
+  it('renders not-org-owner alert using username when org has no full name', () => {
+    const orgWithoutFullName = { username: testOrg, full_name: '', avatar_url: '', id: 1 };
+    jest.mocked(useOrganizationsQuery).mockReturnValueOnce({
+      data: [orgWithoutFullName],
+      isPending: false,
+      isError: false,
+    } as ReturnType<typeof useOrganizationsQuery>);
+    jest.mocked(useUserOrgPermissionsQuery).mockReturnValueOnce({
+      data: { canCreateOrgRepo: true, isOrgOwner: false },
+      isPending: false,
+      isError: false,
+    } as ReturnType<typeof useUserOrgPermissionsQuery>);
+    renderPageLayout();
+    expect(
+      screen.getByText(
+        textMock('settings.orgs.not_org_owner_alert', { orgName: testOrg }),
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/src/Designer/frontend/settings/features/orgs/layout/PageLayout.test.tsx
+++ b/src/Designer/frontend/settings/features/orgs/layout/PageLayout.test.tsx
@@ -119,7 +119,7 @@ describe('PageLayout', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('does not show loading spinner when org is not in the list and permissions are pending', () => {
+  it('renders not-found page when org is not in the list and permissions are pending', () => {
     jest.mocked(useUserOrgPermissionsQuery).mockReturnValueOnce({
       data: undefined,
       isPending: true,
@@ -127,8 +127,8 @@ describe('PageLayout', () => {
     } as ReturnType<typeof useUserOrgPermissionsQuery>);
     renderPageLayout(['/orgs/unknown-org/contact-points']);
     expect(
-      screen.queryByRole('img', { name: textMock('repo_status.loading') }),
-    ).not.toBeInTheDocument();
+      screen.getByRole('heading', { name: textMock('not_found_page.heading') }),
+    ).toBeInTheDocument();
   });
 
   it('renders not-org-owner alert when user is not owner for selected org', () => {
@@ -163,9 +163,7 @@ describe('PageLayout', () => {
     } as ReturnType<typeof useUserOrgPermissionsQuery>);
     renderPageLayout();
     expect(
-      screen.getByText(
-        textMock('settings.orgs.not_org_owner_alert', { orgName: testOrg }),
-      ),
+      screen.getByText(textMock('settings.orgs.not_org_owner_alert', { orgName: testOrg })),
     ).toBeInTheDocument();
   });
 });

--- a/src/Designer/frontend/settings/features/orgs/layout/PageLayout.tsx
+++ b/src/Designer/frontend/settings/features/orgs/layout/PageLayout.tsx
@@ -20,7 +20,7 @@ export const PageLayout = () => {
     isError: isOrgPermissionsError,
   } = useUserOrgPermissionsQuery(org, { enabled: !!selectedOrg });
 
-  if (isOrgsPending || isOrgPermissionsPending) {
+  if (isOrgsPending || (isOrgPermissionsPending && !!selectedOrg)) {
     return (
       <StudioCenter>
         <StudioPageSpinner spinnerTitle={t('repo_status.loading')} />

--- a/src/Designer/frontend/settings/features/user/layout/PageLayout.test.tsx
+++ b/src/Designer/frontend/settings/features/user/layout/PageLayout.test.tsx
@@ -3,7 +3,9 @@ import { PageLayout } from './PageLayout';
 import { renderWithProviders } from '../../../testing/mocks';
 import { textMock } from '@studio/testing/mocks/i18nMock';
 import { user as userMock } from 'app-shared/mocks/mocks';
-import { useUserQuery } from 'app-shared/hooks/queries';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import type { QueryClient } from '@tanstack/react-query';
 
 jest.mock('../components/Menu/Menu', () => ({ Menu: () => <div>Menu</div> }));
 jest.mock('react-router-dom', () => ({
@@ -13,23 +15,17 @@ jest.mock('react-router-dom', () => ({
 jest.mock('app-shared/contexts/EnvironmentConfigContext', () => ({
   useEnvironmentConfig: () => ({ environment: {} }),
 }));
-jest.mock('app-shared/hooks/queries', () => ({
-  ...jest.requireActual('app-shared/hooks/queries'),
-  useUserQuery: jest.fn(),
-}));
-
-const renderPageLayout = (initialEntries = ['/user/profile']) =>
-  renderWithProviders(<PageLayout />, { initialEntries });
 
 describe('PageLayout', () => {
-  beforeEach(() => {
-    jest.mocked(useUserQuery).mockReturnValue({
-      data: userMock,
-      isPending: false,
-    } as ReturnType<typeof useUserQuery>);
-  });
+  let queryClient: QueryClient;
 
-  afterEach(() => jest.clearAllMocks());
+  const renderPageLayout = (initialEntries = ['/user/profile']) =>
+    renderWithProviders(<PageLayout />, { initialEntries, queryClient });
+
+  beforeEach(() => {
+    queryClient = createQueryClientMock();
+    queryClient.setQueryData([QueryKey.CurrentUser], userMock);
+  });
 
   it('renders the settings heading', () => {
     renderPageLayout();
@@ -48,19 +44,17 @@ describe('PageLayout', () => {
   });
 
   it('renders the loading spinner while data is pending', () => {
-    jest.mocked(useUserQuery).mockReturnValueOnce({
-      data: undefined,
-      isPending: true,
-    } as ReturnType<typeof useUserQuery>);
-    renderPageLayout();
+    const localQueryClient = createQueryClientMock();
+    renderWithProviders(<PageLayout />, {
+      initialEntries: ['/user/profile'],
+      queryClient: localQueryClient,
+      queries: { getUser: () => new Promise<never>(() => {}) },
+    });
     expect(screen.getByRole('img', { name: textMock('repo_status.loading') })).toBeInTheDocument();
   });
 
   it('does not render the settings heading when user data is missing', () => {
-    jest.mocked(useUserQuery).mockReturnValueOnce({
-      data: undefined,
-      isPending: false,
-    } as ReturnType<typeof useUserQuery>);
+    queryClient.setQueryData([QueryKey.CurrentUser], null);
     renderPageLayout();
     expect(
       screen.queryByRole('heading', { name: textMock('settings.user.heading') }),
@@ -71,10 +65,7 @@ describe('PageLayout', () => {
   });
 
   it('renders the error page when user data is missing after loading', () => {
-    jest.mocked(useUserQuery).mockReturnValueOnce({
-      data: undefined,
-      isPending: false,
-    } as ReturnType<typeof useUserQuery>);
+    queryClient.setQueryData([QueryKey.CurrentUser], null);
     renderPageLayout();
     expect(screen.queryByText('Menu')).not.toBeInTheDocument();
     expect(screen.queryByText('Outlet')).not.toBeInTheDocument();

--- a/src/Designer/frontend/settings/layout/NavigationTabs/NavigationTabs.test.tsx
+++ b/src/Designer/frontend/settings/layout/NavigationTabs/NavigationTabs.test.tsx
@@ -3,18 +3,15 @@ import userEvent from '@testing-library/user-event';
 import { NavigationTabs } from './NavigationTabs';
 import { renderWithProviders } from '../../testing/mocks';
 import { textMock } from '@studio/testing/mocks/i18nMock';
-import { useOrganizationsQuery } from 'app-shared/hooks/queries';
+import { createQueryClientMock } from 'app-shared/mocks/queryClientMock';
+import { QueryKey } from 'app-shared/types/QueryKey';
+import type { QueryClient } from '@tanstack/react-query';
 
 const mockNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
-}));
-
-jest.mock('app-shared/hooks/queries', () => ({
-  ...jest.requireActual('app-shared/hooks/queries'),
-  useOrganizationsQuery: jest.fn(),
 }));
 
 const organizationsMock = [
@@ -32,22 +29,21 @@ const organizationsMock = [
   },
 ];
 
-const renderNavigationTabs = (initialEntries = ['/user/api-keys']) =>
-  renderWithProviders(<NavigationTabs />, { initialEntries });
-
 describe('NavigationTabs', () => {
+  let queryClient: QueryClient;
+
+  const renderNavigationTabs = (initialEntries = ['/user/api-keys']) =>
+    renderWithProviders(<NavigationTabs />, { initialEntries, queryClient });
+
   beforeEach(() => {
-    jest.mocked(useOrganizationsQuery).mockReturnValue({
-      data: organizationsMock,
-    } as ReturnType<typeof useOrganizationsQuery>);
+    queryClient = createQueryClientMock();
+    queryClient.setQueryData([QueryKey.Organizations], organizationsMock);
   });
 
   afterEach(() => jest.clearAllMocks());
 
   it('does not render tabs when organizations list is empty', () => {
-    jest.mocked(useOrganizationsQuery).mockReturnValueOnce({
-      data: [],
-    } as ReturnType<typeof useOrganizationsQuery>);
+    queryClient.setQueryData([QueryKey.Organizations], []);
 
     renderNavigationTabs();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Update contact point icon to align with figma sketches (see: https://www.figma.com/design/EwgOyWb0up2OrnAzUzlclv/Publiserte-apper?node-id=484-20650)

| BEFORE | AFTER |
|--------|--------|
| <img width="251" height="57" alt="Screenshot 2026-04-10 at 18 31 53" src="https://github.com/user-attachments/assets/287c3dfe-3eda-4cbf-979e-397a0d106a08" /> | <img width="251" height="57" alt="Screenshot 2026-04-10 at 18 31 48" src="https://github.com/user-attachments/assets/b153e88f-9ea4-4b5a-b504-1f1de94859dd" /> | 

- Fix infinite spinner
- Fix tests

## Verification

- [x] Related issues are connected (if applicable)
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the icon for the ContactPoints tab in organisation settings.

* **Bug Fixes**
  * Spinner now appears only when organisations are loading or when permissions are loading for a selected organisation, avoiding unnecessary loading states.

* **Tests**
  * Reworked tests to use query-cache-backed setups and added coverage for permission-loading, permission errors, missing organisation name, and related heading/alert/spinner behaviours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->